### PR TITLE
Don't prompt to add to profile

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -212,18 +212,11 @@ checkShell() {
 }
 
 addToProfile() {
-  echo -e "Add the line:\n"
+  echo -e "Adding the line:\n"
   echo -e "  ${white}$1${reset}\n"
-  echo -e "to your shell profile at '${blue}$SHELL_TO_USE${reset}' ?\n"
-  read -p "[y/n] " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    echo "Adding to PATH"
-    echo -e "$1" >> $SHELL_TO_USE
-    echo "Added! You may need to restart your shell to be able to run 'spice'"
-  else
-    echo "Not adding to PATH"
-  fi
+  echo -e "to your shell profile at '${blue}$SHELL_TO_USE${reset}'\n"
+  echo -e "$1" >> $SHELL_TO_USE
+  echo "Added! You may need to restart your shell to be able to run 'spice'"
 }
 
 installCompleted() {


### PR DESCRIPTION
When piping a script into bash over stdin (i.e. `curl https://install.spicai.org | bash`) the script is not connected to the pseudo terminal and thus cannot get input. This makes the current version of the script skip over the prompt and does not add the path export.

This is the simplest solution to get around this problem - a better solution might be to have a "bootstrap" script that the user curls that downloads the real install script to disk and runs that.