### PR TITLE
Adds a better error message on 404 when starting a training run

### DIFF
--- a/pkg/cli/cmd/train.go
+++ b/pkg/cli/cmd/train.go
@@ -80,7 +80,12 @@ spice train logpruner.yaml
 		}
 
 		if response.StatusCode != 200 {
-			fmt.Printf("failed to start training: %s", response.Status)
+			if response.StatusCode == 404 {
+				fmt.Printf("failed to start training.  the pod '%s' cannot be found.  has it been added?", podNameOrPath)
+			} else {
+				fmt.Printf("failed to start training: %s", response.Status)
+			}
+			
 			return
 		}
 


### PR DESCRIPTION
Improves error message when a the runtime returns a 404 on `spice train podname`.