### PR TITLE
Passes error response through in spice train

### DIFF
--- a/pkg/cli/cmd/train.go
+++ b/pkg/cli/cmd/train.go
@@ -82,7 +82,7 @@ spice train logpruner.yaml
 
 		if response.StatusCode != 200 {
 			if response.StatusCode == 404 {
-				fmt.Printf("failed to start training.  the pod '%s' cannot be found.  has it been added?", podNameOrPath)
+				fmt.Printf("Failed to start training. The pod '%s' cannot be found. Has it been added?", podNameOrPath)
 				return
 			}
 


### PR DESCRIPTION
Error handling in `spice train` was returning simple status codes.  This presents more info to the user, if available.  Also adds a richer 404 experience related to #124 

Closes #152 