### PR TITLE
Change Docker image to `spiceai/spiceai` and push to DockerHub

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -169,7 +169,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: false
-          tags: ghcr.io/spiceai/spiced:local
+          tags: ghcr.io/spiceai/spiceai:local
 
       - name: Verify Docker images
         if: matrix.context == 'docker'
@@ -255,7 +255,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: false
-          tags: ghcr.io/spiceai/spiced:local
+          tags: ghcr.io/spiceai/spiceai:local
 
       - name: Verify Docker images
         if: matrix.context == 'docker'

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -52,7 +52,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           platforms: ${{ matrix.target_os }}/${{ matrix.target_arch }}
-          push: true # ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/trunk' }}
+          push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/trunk' }}
           build-args: |
             REL_VERSION=${{ env.REL_VERSION }}
           tags: |

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -57,11 +57,11 @@ jobs:
             REL_VERSION=${{ env.REL_VERSION }}
           tags: |
             ghcr.io/spiceai/spiceai:latest
-            ghcr.io/spiceai/spiceai:v${{ env.REL_VERSION }}
-            ghcr.io/spiceai/spiceai:v${{ env.REL_VERSION }}-${{ matrix.target_arch }}
+            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}
+            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}-${{ matrix.target_os }}-${{ matrix.target_arch }}
             spiceai/spiceai:latest
-            spiceai/spiceai:v${{ env.REL_VERSION }}
-            spiceai/spiceai:v${{ env.REL_VERSION }}-${{ matrix.target_arch }}
+            spiceai/spiceai:${{ env.REL_VERSION }}
+            spiceai/spiceai:${{ env.REL_VERSION }}-${{ matrix.target_os }}-${{ matrix.target_arch }}
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
 

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -39,6 +39,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and push Docker images
         id: docker_build
         uses: docker/build-push-action@v2.5.0
@@ -46,13 +52,16 @@ jobs:
           context: .
           file: docker/Dockerfile
           platforms: ${{ matrix.target_os }}/${{ matrix.target_arch }}
-          push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/trunk' }}
+          push: true # ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/trunk' }}
           build-args: |
             REL_VERSION=${{ env.REL_VERSION }}
           tags: |
             ghcr.io/spiceai/spiced:latest
             ghcr.io/spiceai/spiced:v${{ env.REL_VERSION }}
             ghcr.io/spiceai/spiced:v${{ env.REL_VERSION }}-${{ matrix.target_arch }}
+            spiceai/spiced:latest
+            spiceai/spiced:v${{ env.REL_VERSION }}
+            spiceai/spiced:v${{ env.REL_VERSION }}-${{ matrix.target_arch }}
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
 

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -56,12 +56,12 @@ jobs:
           build-args: |
             REL_VERSION=${{ env.REL_VERSION }}
           tags: |
-            ghcr.io/spiceai/spiced:latest
-            ghcr.io/spiceai/spiced:v${{ env.REL_VERSION }}
-            ghcr.io/spiceai/spiced:v${{ env.REL_VERSION }}-${{ matrix.target_arch }}
-            spiceai/spiced:latest
-            spiceai/spiced:v${{ env.REL_VERSION }}
-            spiceai/spiced:v${{ env.REL_VERSION }}-${{ matrix.target_arch }}
+            ghcr.io/spiceai/spiceai:latest
+            ghcr.io/spiceai/spiceai:v${{ env.REL_VERSION }}
+            ghcr.io/spiceai/spiceai:v${{ env.REL_VERSION }}-${{ matrix.target_arch }}
+            spiceai/spiceai:latest
+            spiceai/spiceai:v${{ env.REL_VERSION }}
+            spiceai/spiceai:v${{ env.REL_VERSION }}-${{ matrix.target_arch }}
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: build
 
 .PHONY: docker
 docker:
-	docker build -t ghcr.io/spiceai/spiced:local -f docker/Dockerfile .
+	docker build -t ghcr.io/spiceai/spiceai:local -f docker/Dockerfile .
 
 ################################################################################
 # Target: modtidy                                                              #

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,11 +2,11 @@
 
 ## Release environments
 
-|                     | Production                    | Development                | Local                        |
-| ------------------- | ----------------------------- | -------------------------- | ---------------------------- |
-| Short name          | prod                          | dev                        | local                        |
-| spiced Docker image | ghcr.io/spiceai/spiced:latest | ghcr.io/spiceai/spiced:dev | ghcr.io/spiceai/spiced:local |
-| Spice Rack URL      | https://api.spicerack.org     | https://dev.spicerack.org  | http://localhost:80          |
+|                     | Production                     | Development                 | Local                         |
+| ------------------- | ------------------------------ | --------------------------- | ----------------------------- |
+| Short name          | prod                           | dev                         | local                         |
+| spiced Docker image | ghcr.io/spiceai/spiceai:latest | ghcr.io/spiceai/spiceai:dev | ghcr.io/spiceai/spiceai:local |
+| Spice Rack URL      | https://api.spicerack.org      | https://dev.spicerack.org   | http://localhost:80           |
 
 ## Endgame issue
 

--- a/pkg/context/docker/docker.go
+++ b/pkg/context/docker/docker.go
@@ -204,6 +204,7 @@ func getDockerArgs(args string) []string {
 }
 
 func getDockerImage(version string) string {
+	version = strings.TrimPrefix(version, "v")
 	return fmt.Sprintf("%s:%s", spicedDockerImg, version)
 }
 

--- a/pkg/context/docker/docker.go
+++ b/pkg/context/docker/docker.go
@@ -23,7 +23,7 @@ type DockerContext struct {
 }
 
 const (
-	spicedDockerImg        = "ghcr.io/spiceai/spiced"
+	spicedDockerImg        = "ghcr.io/spiceai/spiceai"
 	spicedDockerCmd        = "run -p %d:%d %s --add-host=host.docker.internal:host-gateway -v %s:/userapp --rm %s"
 	dockerAppPath          = "/userapp"
 	dockerSpiceRuntimePath = "/.spice"


### PR DESCRIPTION
Adds dual publishing images to Dockerhub/Github Packages.  `spiceai/spiceai` is private for now on DockerHub.  Follow on issues should be to:

- Make that public
- Make our image [Docker official](https://docs.docker.com/docker-hub/official_images/#creating-a-docker-official-image) (if desired)

Closes #52 