### PR TITLE
Accept either string or float64 as value for Observation json format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/phillipleblanc/spiceai
+module github.com/spiceai/spiceai
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	github.com/spiceai/data-components-contrib v0.0.0-20210914102419-cfcf22c1f438
+	github.com/spiceai/data-components-contrib v0.0.0-20210917025245-ab0478df3b90
 	github.com/stretchr/testify v1.7.0
 	github.com/valyala/fasthttp v1.28.0
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spiceai/spiceai
+module github.com/phillipleblanc/spiceai
 
 go 1.17
 

--- a/go.sum
+++ b/go.sum
@@ -975,10 +975,12 @@ github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spiceai/data-components-contrib v0.0.0-20210901070425-f99a2b678fa4/go.mod h1:G9HIuE/UNz7g2NT+LFwE9LtXeRe5NPQpTDrybB/qbDQ=
-github.com/spiceai/data-components-contrib v0.0.0-20210914102419-cfcf22c1f438 h1:y6DuLaUuJlofGw0evsmaMYUty0lzDFKIh1MpnZOOGjM=
 github.com/spiceai/data-components-contrib v0.0.0-20210914102419-cfcf22c1f438/go.mod h1:v2nEPZGDQ7s5IQd/c3tgO7khDSbKmRJm4ry77zF5bAk=
+github.com/spiceai/data-components-contrib v0.0.0-20210917025245-ab0478df3b90 h1:Ai3wD5J1A5ryZgictbWKYcRNXz+O32wo8bP6LayQtnc=
+github.com/spiceai/data-components-contrib v0.0.0-20210917025245-ab0478df3b90/go.mod h1:5wRs4oYYczprCga+OwqSpEnCohbrNrpAcUykX7KPJDE=
 github.com/spiceai/spiceai v0.1.0-alpha.5-rc-spiced.0.20210831052121-80234a1fb51a/go.mod h1:pb+hKV5zvpFuKiLlKJmIUF0jkpeb/eTfhHLapttiVPk=
 github.com/spiceai/spiceai v0.2.0-alpha-rc-spiced.0.20210914095457-91c82109b461/go.mod h1:SxCAf9FDi5GX8R22QKarckFsj3r1IDXWIqcmNs+B54c=
+github.com/spiceai/spiceai v0.2.0-alpha-rc-spiced.0.20210917015218-a50887cec3e9/go.mod h1:nK2cyAhXDAcwqNvFrczDbsIHJqQAf6Hm+GMx36W6utI=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/pkg/api/observation/observation.go
+++ b/pkg/api/observation/observation.go
@@ -3,6 +3,7 @@ package observation
 import (
 	_ "embed"
 
+	spice_json "github.com/spiceai/spiceai/pkg/json"
 	spice_time "github.com/spiceai/spiceai/pkg/time"
 )
 
@@ -11,12 +12,29 @@ var (
 	jsonSchema []byte
 )
 
+type ObservationValue struct {
+	String  *string
+	Float64 *float64
+}
+
 type Observation struct {
-	Time *spice_time.Time   `json:"time"`
-	Data map[string]float64 `json:"data"`
-	Tags []string           `json:"tags,omitempty"`
+	Time *spice_time.Time             `json:"time"`
+	Data map[string]*ObservationValue `json:"data"`
+	Tags []string                     `json:"tags,omitempty"`
 }
 
 func JsonSchema() []byte {
 	return jsonSchema
+}
+
+func (x *ObservationValue) UnmarshalJSON(data []byte) error {
+	err := spice_json.UnmarshalUnion(data, nil, &x.String, &x.Float64)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (x *ObservationValue) MarshalJSON() ([]byte, error) {
+	return spice_json.MarshalUnion(nil, x.String, x.Float64)
 }

--- a/pkg/json/union.go
+++ b/pkg/json/union.go
@@ -6,10 +6,11 @@ import (
 	"errors"
 )
 
-// Unmarshals from json a union data type that can contain either an int64 or a string
-func UnmarshalUnion(data []byte, pi **int64, ps **string) error {
+// Unmarshals from json a union data type that can contain either an int64, string or float64
+func UnmarshalUnion(data []byte, pi **int64, ps **string, pf **float64) error {
 	*pi = nil
 	*ps = nil
+	*pf = nil
 
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
@@ -25,21 +26,29 @@ func UnmarshalUnion(data []byte, pi **int64, ps **string) error {
 			*pi = &i
 			return nil
 		}
+		f, err := v.Float64()
+		if err == nil {
+			*pf = &f
+			return nil
+		}
 		return err
 	case string:
 		*ps = &v
 		return nil
 	}
-	return errors.New("cannot unmarshal Time")
+	return errors.New("cannot unmarshal union")
 }
 
-// Marshals to json a union data type that can contain either an int64 or a string
-func MarshalUnion(pi *int64, ps *string) ([]byte, error) {
+// Marshals to json a union data type that can contain either an int64, string or float64
+func MarshalUnion(pi *int64, ps *string, pf *float64) ([]byte, error) {
 	if pi != nil {
 		return json.Marshal(*pi)
 	}
 	if ps != nil {
 		return json.Marshal(*ps)
 	}
-	return nil, errors.New("time must not be null")
+	if pf != nil {
+		return json.Marshal(*pf)
+	}
+	return nil, errors.New("union must not be null")
 }

--- a/pkg/json/union.go
+++ b/pkg/json/union.go
@@ -8,9 +8,15 @@ import (
 
 // Unmarshals from json a union data type that can contain either an int64, string or float64
 func UnmarshalUnion(data []byte, pi **int64, ps **string, pf **float64) error {
-	*pi = nil
-	*ps = nil
-	*pf = nil
+	if pi != nil {
+		*pi = nil
+	}
+	if ps != nil {
+		*ps = nil
+	}
+	if pf != nil {
+		*pf = nil
+	}
 
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
@@ -21,17 +27,22 @@ func UnmarshalUnion(data []byte, pi **int64, ps **string, pf **float64) error {
 
 	switch v := tok.(type) {
 	case json.Number:
-		i, err := v.Int64()
-		if err == nil {
-			*pi = &i
-			return nil
+		if pi != nil {
+			i, err := v.Int64()
+			if err == nil {
+				*pi = &i
+				return nil
+			}
 		}
-		f, err := v.Float64()
-		if err == nil {
-			*pf = &f
-			return nil
+		if pf != nil {
+			f, err := v.Float64()
+			if err == nil {
+				*pf = &f
+				return nil
+			}
+			return errors.New("unparsable number")
 		}
-		return err
+		return errors.New("union does not contain number")
 	case string:
 		*ps = &v
 		return nil

--- a/pkg/json/union_test.go
+++ b/pkg/json/union_test.go
@@ -9,6 +9,7 @@ import (
 type Test struct {
 	Integer *int64
 	String  *string
+	Float   *float64
 }
 
 func TestUnion(t *testing.T) {
@@ -20,18 +21,29 @@ func testUnmarshalUnionFunc() func(*testing.T) {
 	return func(t *testing.T) {
 		test := &Test{}
 
-		err := UnmarshalUnion([]byte("24"), &test.Integer, &test.String)
+		err := UnmarshalUnion([]byte("24"), &test.Integer, &test.String, &test.Float)
 		assert.NoError(t, err)
 
 		assert.Equal(t, int64(24), *test.Integer)
 		assert.Nil(t, test.String)
+		assert.Nil(t, test.Float)
 
 		test = &Test{}
 
-		err = UnmarshalUnion([]byte("\"this is a string\""), &test.Integer, &test.String)
+		err = UnmarshalUnion([]byte("\"this is a string\""), &test.Integer, &test.String, &test.Float)
 		assert.NoError(t, err)
 
 		assert.Equal(t, "this is a string", *test.String)
+		assert.Nil(t, test.Integer)
+		assert.Nil(t, test.Float)
+
+		test = &Test{}
+
+		err = UnmarshalUnion([]byte("24.0"), &test.Integer, &test.String, &test.Float)
+		assert.NoError(t, err)
+
+		assert.Equal(t, float64(24.0), *test.Float)
+		assert.Nil(t, test.String)
 		assert.Nil(t, test.Integer)
 	}
 }
@@ -43,7 +55,7 @@ func testMarshalUnionFunc() func(*testing.T) {
 		val := int64(24)
 		test.Integer = &val
 
-		jsonBytes, err := MarshalUnion(test.Integer, test.String)
+		jsonBytes, err := MarshalUnion(test.Integer, test.String, test.Float)
 		assert.NoError(t, err)
 		assert.Equal(t, "24", string(jsonBytes))
 
@@ -52,8 +64,17 @@ func testMarshalUnionFunc() func(*testing.T) {
 		strVal := "this is a string"
 		test.String = &strVal
 
-		jsonBytes, err = MarshalUnion(test.Integer, test.String)
+		jsonBytes, err = MarshalUnion(test.Integer, test.String, test.Float)
 		assert.NoError(t, err)
 		assert.Equal(t, "\"this is a string\"", string(jsonBytes))
+
+		test = &Test{}
+
+		floatVal := float64(24.2)
+		test.Float = &floatVal
+
+		jsonBytes, err = MarshalUnion(test.Integer, test.String, test.Float)
+		assert.NoError(t, err)
+		assert.Equal(t, "24.2", string(jsonBytes))
 	}
 }

--- a/pkg/json/union_test.go
+++ b/pkg/json/union_test.go
@@ -45,6 +45,9 @@ func testUnmarshalUnionFunc() func(*testing.T) {
 		assert.Equal(t, float64(24.0), *test.Float)
 		assert.Nil(t, test.String)
 		assert.Nil(t, test.Integer)
+
+		err = UnmarshalUnion([]byte("24.0"), nil, nil, &test.Float)
+		assert.NoError(t, err)
 	}
 }
 
@@ -74,6 +77,10 @@ func testMarshalUnionFunc() func(*testing.T) {
 		test.Float = &floatVal
 
 		jsonBytes, err = MarshalUnion(test.Integer, test.String, test.Float)
+		assert.NoError(t, err)
+		assert.Equal(t, "24.2", string(jsonBytes))
+
+		jsonBytes, err = MarshalUnion(nil, nil, test.Float)
 		assert.NoError(t, err)
 		assert.Equal(t, "24.2", string(jsonBytes))
 	}

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -10,7 +10,7 @@ type Time struct {
 }
 
 func (x *Time) UnmarshalJSON(data []byte) error {
-	err := spice_json.UnmarshalUnion(data, &x.Integer, &x.String)
+	err := spice_json.UnmarshalUnion(data, &x.Integer, &x.String, nil)
 	if err != nil {
 		return err
 	}
@@ -18,5 +18,5 @@ func (x *Time) UnmarshalJSON(data []byte) error {
 }
 
 func (x *Time) MarshalJSON() ([]byte, error) {
-	return spice_json.MarshalUnion(x.Integer, x.String)
+	return spice_json.MarshalUnion(x.Integer, x.String, nil)
 }


### PR DESCRIPTION
In the JSON processor any string value will be converted into a float - but we don't want to fail the unmarshaling