### PR TITLE
Adding 'Tags' to Observation struct

### DIFF
--- a/pkg/context/docker/docker.go
+++ b/pkg/context/docker/docker.go
@@ -234,5 +234,9 @@ func getDockerImageVersion() (string, error) {
 	// Most recent image
 	tag := strings.TrimSpace(lines[0])
 
+	if !strings.HasPrefix(tag, "v") {
+		return fmt.Sprintf("v%s", tag), nil
+	}
+
 	return tag, nil
 }

--- a/pkg/observations/observation.go
+++ b/pkg/observations/observation.go
@@ -8,6 +8,7 @@ import (
 type Observation struct {
 	Time int64
 	Data map[string]float64
+	Tags []string
 }
 
 func GetCsv(headers []string, observations []Observation, previewLines int) (string, string) {


### PR DESCRIPTION
Needed for #197 - the next change will come in data-components-contrib, and this is a first step to enable that.

Also fixes a minor bug with the Docker version not printing correctly