### PR TITLE
Add basic diagnostics API

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -11,6 +11,7 @@ import (
 )
 
 type RuntimeContext interface {
+	Name() string
 	Init() error
 	Version() (string, error)
 	IsRuntimeInstallRequired() bool

--- a/pkg/context/docker/docker.go
+++ b/pkg/context/docker/docker.go
@@ -40,6 +40,10 @@ func NewDockerContext() *DockerContext {
 	}
 }
 
+func (c *DockerContext) Name() string {
+	return "docker"
+}
+
 func (c *DockerContext) Version() (string, error) {
 	version, err := getDockerImageVersion()
 	if err != nil {

--- a/pkg/context/metal/metal.go
+++ b/pkg/context/metal/metal.go
@@ -40,6 +40,10 @@ func NewMetalContext() *MetalContext {
 	}
 }
 
+func (c *MetalContext) Name() string {
+	return "metal"
+}
+
 func (c *MetalContext) SpiceRuntimeDir() string {
 	return c.spiceRuntimeDir
 }

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -1,0 +1,40 @@
+package diagnostics
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spiceai/spiceai/pkg/context"
+)
+
+func GenerateReport() (string, error) {
+	body := strings.Builder{}
+
+	body.WriteString("## Diagnostics Report\n\n")
+	
+	body.WriteString("Runtime Context\n")
+	body.WriteString("---------------\n")
+	context := context.CurrentContext()
+	body.WriteString(fmt.Sprintf("name: %s\n", context.Name()))
+	body.WriteString(fmt.Sprintf("app_dir: %s\n", context.AppDir()))
+	body.WriteString(fmt.Sprintf("pods_dir: %s\n", context.PodsDir()))
+	body.WriteString("\n\n")
+
+	podsDirEntries, err := os.ReadDir(context.PodsDir())
+	if err != nil {
+		return "", err
+	}
+
+	body.WriteString(fmt.Sprintf("Pods Directory Contents (%d entries)\n", len(podsDirEntries)))
+	body.WriteString("---------------\n")
+
+	for _, entry := range podsDirEntries {
+		body.WriteString(entry.Name())
+		body.WriteString("\n")
+	}
+
+	body.WriteString("\n")
+
+	return body.String(), nil
+}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spiceai/spiceai/pkg/api"
 	"github.com/spiceai/spiceai/pkg/dashboard"
 	"github.com/spiceai/spiceai/pkg/dataspace"
+	"github.com/spiceai/spiceai/pkg/diagnostics"
 	"github.com/spiceai/spiceai/pkg/environment"
 	"github.com/spiceai/spiceai/pkg/flights"
 	"github.com/spiceai/spiceai/pkg/loggers"
@@ -493,6 +494,17 @@ func apiPostImportHandler(ctx *fasthttp.RequestCtx) {
 	ctx.Response.SetStatusCode(200)
 }
 
+func (server *server)apiGetDiagnosticsHandler(ctx *fasthttp.RequestCtx) {
+	report, err := diagnostics.GenerateReport()
+	if err != nil {
+		ctx.Response.SetStatusCode(500)
+		ctx.Response.SetBodyString(err.Error())
+		return
+	}
+
+	ctx.SetBodyString(report)
+}
+
 func NewServer(port uint) *server {
 	return &server{
 		config: ServerConfig{
@@ -533,6 +545,8 @@ func (server *server) Start() error {
 		// Interpretations
 		api.GET("/pods/{pod}/interpretations", apiGetInterpretationsHandler)
 		api.POST("/pods/{pod}/interpretations", apiPostInterpretationsHandler)
+
+		api.GET("/diagnostics", server.apiGetDiagnosticsHandler)
 	}
 
 	static := r.Group("/static")


### PR DESCRIPTION
Returns a basic report like so:

```txt
## Diagnostics Report

Runtime Context
---------------
name: metal
app_dir: /workspaces/spiceai/cmd/spiced
pods_dir: /workspaces/spiceai/cmd/spiced/spicepods


Pods Directory Contents (2 entries)
---------------
data
trader.yaml
```