### PR TITLE
Mitigates race in dashboard build

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -53,7 +53,7 @@
     "test": "react-scripts test",
     "test-ci": "react-scripts test --watchAll=false",
     "tsc": "tsc",
-    "set-version": "cat src/constants.ts | sed s/SPICE_VERSION\\ =\\ .*$/SPICE_VERSION\\ =\\ \\'v$(cat ../version.txt)\\'/g > src/constants.ts&& sleep 1"
+    "set-version": "cat src/constants.ts | sed s/SPICE_VERSION\\ =\\ .*$/SPICE_VERSION\\ =\\ \\'v$(cat ../version.txt)\\'/g > src/constants.ts && sleep 3"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
We are still seeing [occasional dashboard build flakes](https://github.com/spiceai/spiceai/runs/3753618268?check_suite_focus=true#step:9:483) caused by a race between flushing constants.ts and consuming it in the next step.  There isn't really a good way of forcing flush in bash - increasing the sleep time is the next best thing.  Keeping flakes out of the build and only pushing on green is preferable to saving two seconds during the build, IMO.