### PR TITLE
Fixes serving of acknowledgements

### DIFF
--- a/pkg/dashboard/embedded.go
+++ b/pkg/dashboard/embedded.go
@@ -63,7 +63,7 @@ func (d *DashboardEmbedded) fileHandler(ctx *fasthttp.RequestCtx, fs embed.FS, f
 	filePath := ctx.UserValue("file").(string)
 
 	subfolder := fileType
-	if fileType == "svg" || fileType == ".md" {
+	if fileType == "svg" || fileType == "md" {
 		subfolder = "media"
 	}
 


### PR DESCRIPTION
The acknowledgements page wasn't displaying correctly.  The logic to serve it from the `media` directory wasn't catching it correctly and it was defaulting to `md` instead - 

```
open build/static/md/acknowledgements.7ca6da38.md: file does not exist
```

