### PR TITLE
Fixes ordering of pod initialization

### DIFF
--- a/pkg/runtime/watcher.go
+++ b/pkg/runtime/watcher.go
@@ -101,12 +101,12 @@ func processNotifyEvent(event fsnotify.Event) error {
 func startNewPodTraining(pod *pods.Pod) error {
 	pods.CreateOrUpdatePod(pod)
 
-	err := environment.InitPodDataConnector(pod)
+	err := aiengine.InitializePod(pod)
 	if err != nil {
 		return err
 	}
 
-	err = aiengine.InitializePod(pod)
+	err = environment.InitPodDataConnector(pod)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`spice add` - ing a pod fails.  Repro steps:

spice run
spice pod add quickstarts/trader@v0.4.1 (any of them will fail)

Expected:

Training starts

Actual:

```
Spice.ai runtime starting...
Using latest 'local' runtime version.
Loading Spice runtime ...
- Runtime version: local
- Listening on http://localhost:8000

Use Ctrl-C to stop
2021/10/01 16:30:26 loading file 'spicepods/data/btcusd.csv' ...
2021/10/01 16:30:26 loaded file 'btcusd.csv' in 0.00 seconds ...
2021/10/01 16:30:26 failed to initialize data connector 'file': failed to post new data to pod trader: rpc error: code = Unknown desc = Exception calling application: 'trader'
```

This is due to the ordering of initialization and sending data being backward in the watcher.  `spice run`-ing when a pod manifest exists already seems to work correctly.  

There is some more follow on to this one - 

Each of the AIEngine methods in main.py (AddData, StartTraining, etc) assume there will be a `data_manager` for the pod specified.  They blow up ungracefully if not.  We should add a check around each of them and return a more meaningful error.