### PR TITLE
Fixes no data on missing epoch bug

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -379,7 +379,7 @@ func (pod *Pod) InitDataConnectors(handler state.StateHandler) error {
 		dsp := ds
 		errGroup.Go(func() error {
 			dsp.RegisterStateHandler(handler)
-			return dsp.InitDataConnector(pod.podParams.Epoch, pod.podParams.Period, pod.podParams.Interval)
+			return dsp.InitDataConnector(pod.Epoch(), pod.Period(), pod.Interval())
 		})
 	}
 


### PR DESCRIPTION
If no epoch is specified in the manifest, as is the case in the serverops sample (or any use case where you want to look back `period` from now), no data will be pushed to the AI engine.  This is due to a bypass of the logic in `pod.Epoch()` that checks for a zero epoch and sets it to now looking back `period`.