### PR TITLE
Uses correct flag for pre-release

### DIFF
--- a/.github/workflows/spice.yml
+++ b/.github/workflows/spice.yml
@@ -172,5 +172,5 @@ jobs:
             --tag "v${{ env.REL_VERSION }}-spice" \
             --release-name "Spice CLI v${{ env.REL_VERSION }}" \
             --body "${RELEASE_BODY}" \
-            --prerelease true \
+            --pre-release \
             ${RELEASE_ARTIFACT[*]}

--- a/.github/workflows/spiced.yml
+++ b/.github/workflows/spiced.yml
@@ -171,5 +171,5 @@ jobs:
             --tag "v${{ env.REL_VERSION }}-spiced" \
             --release-name "Spice Runtime v${{ env.REL_VERSION }}" \
             --body "${RELEASE_BODY}" \
-            --prerelease true \
+            --pre-release \
             ${RELEASE_ARTIFACT[*]}


### PR DESCRIPTION
We were using the "pre-release" flag [incorrectly](https://github.com/github-release/github-release/search?q=pre-release) in github-release.  Follow on will be to actually set this based on the version ID.