### PR TITLE
CLI command to list currently loaded pods from runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/dghubble/go-twitter v0.0.0-20210609183100-2fdbf421508e // indirect
 	github.com/dghubble/oauth1 v0.7.0 // indirect
 	github.com/dghubble/sling v1.3.0 // indirect
+	github.com/gocarina/gocsv v0.0.0-20211020200912-82fc2684cc48 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/flatbuffers v2.0.0+incompatible // indirect
@@ -61,7 +62,9 @@ require (
 	github.com/influxdata/flux v0.131.0 // indirect
 	github.com/influxdata/influxdb-client-go v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gocarina/gocsv v0.0.0-20211020200912-82fc2684cc48 h1:hLeicZW4XBuaISuJPfjkprg0SP0xxsQmb31aJZ6lnIw=
+github.com/gocarina/gocsv v0.0.0-20211020200912-82fc2684cc48/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
@@ -382,6 +384,8 @@ github.com/mattn/go-isatty v0.0.13 h1:qdl+GuBjcsKKDco5BsxPJlId98mSWNKqYA+Co0SC1y
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 h1:d8RFOZ2IiFtFWBcKEHAFYJcPTf0wY5q0exFNJZVWa1U=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
@@ -408,6 +412,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/api/pod.go
+++ b/pkg/api/pod.go
@@ -2,11 +2,17 @@ package api
 
 import (
 	"github.com/spiceai/spiceai/pkg/pods"
-	"github.com/spiceai/spiceai/pkg/proto/runtime_pb"
 )
 
-func NewPod(f *pods.Pod) *runtime_pb.Pod {
-	return &runtime_pb.Pod{
+type Pod struct {
+	Name         string   `json:"name,omitempty" csv:"name"`
+	ManifestPath string   `json:"manifest_path,omitempty" csv:"manifest_path"`
+	Measurements []string `json:"measurements,omitempty" csv:"-"`
+	Categories   []string `json:"categories,omitempty" csv:"-"`
+}
+
+func NewPod(f *pods.Pod) *Pod {
+	return &Pod{
 		Name:         f.Name,
 		ManifestPath: f.ManifestPath(),
 		Measurements: f.MeasurementNames(),

--- a/pkg/cli/cmd/pods.go
+++ b/pkg/cli/cmd/pods.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/spiceai/spiceai/pkg/api"
+	"github.com/spiceai/spiceai/pkg/config"
+	"github.com/spiceai/spiceai/pkg/context"
+	"github.com/spiceai/spiceai/pkg/util"
+)
+
+var podsCmd = &cobra.Command{
+	Use:     "pods",
+	Aliases: []string{"pods"},
+	Short:   "Retrieve pods",
+	Example: `
+spice pods list
+`,
+}
+
+var podsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists currently loaded pods from the runtime",
+	Example: `
+spice pods list
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		v := viper.New()
+		appDir := context.CurrentContext().AppDir()
+		runtimeConfig, err := config.LoadRuntimeConfiguration(v, appDir)
+		if err != nil {
+			cmd.Println("failed to load runtime configuration")
+			return
+		}
+
+		serverBaseUrl := runtimeConfig.ServerBaseUrl()
+
+		err = util.IsRuntimeServerHealthy(serverBaseUrl, http.DefaultClient)
+		if err != nil {
+			cmd.Printf("failed to reach %s. is the spice runtime running?\n", serverBaseUrl)
+			return
+		}
+
+		listUrl := fmt.Sprintf("%s/api/v0.1/pods", serverBaseUrl)
+
+		response, err := http.DefaultClient.Get(listUrl)
+		if err != nil {
+			cmd.Printf("failed to get currently loaded pods from runtime: %s\n", err.Error())
+			return
+		}
+
+		if response.StatusCode != 200 {
+			cmd.Printf("failed to get currently loaded pods from runtime: %s\n", response.Status)
+			return
+		}
+
+		body, _ := ioutil.ReadAll(response.Body)
+		if err != nil {
+			cmd.Printf("failed to get currently loaded pods from runtime: %s\n", err.Error())
+			return
+		}
+
+		pods := make([]*api.Pod, 0)
+		err = json.Unmarshal(body, &pods)
+
+		if err != nil {
+			cmd.Printf("failed to get currently loaded pods from runtime: %s\n", err.Error())
+			return
+		}
+
+		defer response.Body.Close()
+
+		sort.SliceStable(pods, func(i, j int) bool {
+			return strings.Compare(pods[i].Name, pods[j].Name) == -1
+		})
+		err = util.MarshalAndPrintTable(cmd.OutOrStdout(), pods)
+
+		if err != nil {
+			cmd.Printf("failed to get currently loaded pods from runtime: %s\n", err.Error())
+			return
+		}
+	},
+}
+
+func init() {
+	podsCmd.AddCommand(podsListCmd)
+	podsCmd.Flags().BoolP("help", "h", false, "Prints this help message")
+	podsListCmd.Flags().BoolP("help", "h", false, "Prints this help message")
+	RootCmd.AddCommand(podsCmd)
+}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -151,7 +151,7 @@ func apiPostDataspaceHandler(ctx *fasthttp.RequestCtx) {
 func apiGetPodsHandler(ctx *fasthttp.RequestCtx) {
 	pods := pods.Pods()
 
-	data := make([]*runtime_pb.Pod, 0, len(pods))
+	data := make([]*api.Pod, 0, len(pods))
 
 	for _, f := range pods {
 		if f == nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,9 +1,48 @@
 package util
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/gob"
+	"io"
+	"strings"
+
+	"github.com/gocarina/gocsv"
+	"github.com/olekukonko/tablewriter"
 )
+
+func MarshalAndPrintTable(writer io.Writer, in interface{}) error {
+	csvContent, err := gocsv.MarshalString(in)
+	if err != nil {
+		return err
+	}
+
+	table := tablewriter.NewWriter(writer)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetBorder(false)
+	table.SetHeaderLine(false)
+	table.SetRowLine(false)
+	table.SetCenterSeparator("")
+	table.SetRowSeparator("")
+	table.SetColumnSeparator("")
+	scanner := bufio.NewScanner(strings.NewReader(csvContent))
+	header := true
+
+	for scanner.Scan() {
+		text := strings.Split(scanner.Text(), ",")
+
+		if header {
+			table.SetHeader(text)
+			header = false
+		} else {
+			table.Append(text)
+		}
+	}
+
+	table.Render()
+	return nil
+}
 
 func GetBytes(key interface{}) ([]byte, error) {
 	var buf bytes.Buffer

--- a/test/assets/snapshots/e2e/TestCLICmdPodsList
+++ b/test/assets/snapshots/e2e/TestCLICmdPodsList
@@ -1,0 +1,5 @@
+  customprocessor   /userapp/spicepods/customprocessor.yaml   
+  event-categories  /userapp/spicepods/event-categories.yaml  
+  event-tags        /userapp/spicepods/event-tags.yaml        
+  trader            /userapp/spicepods/trader.yaml            
+

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -37,3 +37,8 @@ func (c *cli) startCliCmd(args ...string) (*exec.Cmd, error) {
 
 	return cmd, nil
 }
+
+func (c *cli) runCliCmdForOutput(args ...string) ([]byte, error) {
+	cmd := exec.Command(c.cliPath, args...)
+	return cmd.Output()
+}

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -38,7 +38,7 @@ func (c *cli) startCliCmd(args ...string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-func (c *cli) runCliCmdForOutput(args ...string) ([]byte, error) {
+func (c *cli) runCliCmdOutput(args ...string) ([]byte, error) {
 	cmd := exec.Command(c.cliPath, args...)
 	return cmd.Output()
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -713,7 +713,7 @@ func TestCLICmdPodsList(t *testing.T) {
 		}
 	})
 
-	output, err := cliClient.runCliCmdForOutput("pods", "list")
+	output, err := cliClient.runCliCmdOutput("pods", "list")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -695,6 +695,43 @@ func TestImportExport(t *testing.T) {
 	}
 }
 
+func TestCLICmdPodsList(t *testing.T) {
+	if !shouldRunTest {
+		t.Skip("Specify '-e2e' to run e2e tests")
+		return
+	}
+
+	err := runtime.startRuntime()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err := runtime.shutdown()
+		if err != nil {
+			log.Fatalln(err.Error())
+		}
+	})
+
+	output, err := cliClient.runCliCmdForOutput("pods", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputStr := string(output)
+	assert.Contains(t, outputStr, "NAME")
+	assert.Contains(t, outputStr, "MANIFEST PATH")
+
+	// tablewriter adds padding to make columns uniform length so the header differs in
+	// padding length across metal/docker context as we are snapshotting after replacing
+	// 'testDir' and `testDir' is different across contexts
+	lines := strings.Split(outputStr, "\n")
+	partialOutput := strings.Join(lines[1:], "\n")
+
+	fixedOutput := strings.ReplaceAll(partialOutput, "/private", "")
+	fixedOutput = strings.ReplaceAll(fixedOutput, testDir, "/userapp")
+	snapshotter.SnapshotT(t, fixedOutput)
+}
+
 func validateRepoRoot(repoRoot string) error {
 	return validateExists(filepath.Join(repoRoot, "go.mod"))
 }


### PR DESCRIPTION
1) spice shows pods as a command

```bash
❯ ./spice
Spice.ai CLI

Usage:
  spice [command]

Available Commands:
  action      Maintains actions
  add         Add Pod - adds a pod to the project
  completion  generate the autocompletion script for the specified shell
  export      Export Pod - export a pod
  help        Help about any command
  import      Import Pod - import a pod
  init        Initialize Pod - initializes a new pod in the project
  pods        Retrieve pods
  reward      Maintains rewards
  run         Run Spice.ai - starts the Spice.ai runtime, installing if necessary
  train       Train Pod - start a pod training run
  upgrade     Upgrades Spice.ai runtime if necessary
  version     Spice CLI version

Flags:
  -h, --help   help for spice

Use "spice [command] --help" for more information about a command.
```
2) `spice pods -h` shows a help

```bash
❯ ./spice pods -h
Retrieve pods

Usage:
  spice pods [command]

Aliases:
  pods, pods

Examples:

spice pods list


Available Commands:
  list        Lists available pods in the runtime

Flags:
  -h, --help   Prints this help message

Use "spice pods [command] --help" for more information about a command.

```
3) `spice pods list -h` shows a help
```bash
❯ ./spice pods list -h
Lists available pods in the runtime

Usage:
  spice pods list [flags]

Examples:

spice pods list


Flags:
  -h, --help   Prints this help message
  
```
4) This is how the command lists the output
```bash  
  ❯ ./spice pods list
  NAME              MANIFEST PATH
  customprocessor   /userapp/spicepods/customprocessor.yaml
  event-categories  /userapp/spicepods/event-categories.yaml
  event-tags        /userapp/spicepods/event-tags.yaml
  trader            /userapp/spicepods/trader.yaml
```

5) if the runtime not running
```bash
❯ ./spice pods list
failed to reach http://localhost:8000. is the spice runtime running?
```

Closes #333 