### PR TITLE
Silences debugging message during spice add

### DIFF
--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	net_http "net/http"
 	"runtime"
 
@@ -15,6 +17,7 @@ var client *retryablehttp.Client
 func RetryableClient() *retryablehttp.Client {
 	if client == nil {
 		client = retryablehttp.NewClient()
+		client.Logger = log.New(ioutil.Discard, "", 0)
 	}
 	return client
 }


### PR DESCRIPTION
Running `spice add` produces an unwanted debug message from within retryablehttp:

```
Lanes-MacBook-Air:spice laneharris$ ./spice add quickstarts/trader
Getting Pod quickstarts/trader ...
2021/10/21 21:42:26 [DEBUG] GET https://api.spicerack.org/api/v0.1/pods/quickstarts/trader
Added spicepods/trader.yaml
```