### PR TITLE
Add broad exception catch for the AI training

### DIFF
--- a/ai/src/.gitignore
+++ b/ai/src/.gitignore
@@ -1,1 +1,2 @@
 *.model
+*.temp

--- a/ai/src/exception.py
+++ b/ai/src/exception.py
@@ -11,6 +11,12 @@ class AiEngineException(Exception):
         return f"{self.type} {self.message}"
 
 
+class UnexpectedException(AiEngineException):
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.type = "unexpected_error"
+
+
 class LawInvalidException(AiEngineException):
     def __init__(self, message: str):
         super().__init__(message)

--- a/ai/src/train.py
+++ b/ai/src/train.py
@@ -23,6 +23,7 @@ from utils import print_event
 class Trainer():
     TRAINING_LOCK = threading.Lock()
     SAVED_MODELS: Dict[str, Path] = {}
+    BASE_URL = "http://localhost:8000/api/v0.1/pods"
 
     def __init__(
             self, pod_name: str, data_manager: DataManager, connector_manager: ConnectorManager, algorithm: str,
@@ -37,7 +38,7 @@ class Trainer():
 
         self.action_size = len(data_manager.action_names)
 
-        self.request_url = f"http://localhost:8000/api/v0.1/pods/{pod_name}/training_runs/{flight}/episodes"
+        self.request_url = self.BASE_URL + f"/{pod_name}/training_runs/{flight}/episodes"
 
         self.training_episodes = number_episodes
         self.not_learning_threshold = 3


### PR DESCRIPTION
Adding a broad exception catch that post an error message to the client API. The traceback is also printed for easier debug session (could be an option latter).

Fixes #326 #378 