### PR TITLE
Update to TensorFlow 2.6.1 and freeze Keras to 2.6.0

### DIFF
--- a/ai/src/requirements/common.txt
+++ b/ai/src/requirements/common.txt
@@ -1,3 +1,4 @@
+## The following requirements were added by pip freeze:
 absl-py==0.13.0
 astunparse==1.6.3
 attrs==21.2.0
@@ -15,6 +16,8 @@ h5py==3.1.0
 humanize==3.11.0
 idna==3.2
 iniconfig==1.1.1
+keras==2.6.0
+Keras-Preprocessing==1.1.2
 Markdown==3.3.4
 numpy==1.19.5
 oauthlib==3.1.1
@@ -38,7 +41,7 @@ six==1.15.0
 tensorboard==2.6.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.0
-tensorflow==2.6.0
+tensorflow==2.6.1
 tensorflow-estimator==2.6.0
 termcolor==1.1.0
 toml==0.10.2

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -494,7 +494,7 @@ func TestTrainingOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runtime.waitForTrainingToComplete("trader", "1" /*flight*/, 10)
+	err = runtime.waitForTrainingToComplete("trader", "1" /*flight*/, 10, 120)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +547,7 @@ func TestTrainingWithExternalRewards(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runtime.waitForTrainingToComplete("trader-external-funcs", "1" /*flight*/, 10)
+	err = runtime.waitForTrainingToComplete("trader-external-funcs", "1" /*flight*/, 10, 120)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,7 +600,7 @@ func TestPodWithTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runtime.waitForTrainingToComplete("event-tags", "1" /*flight*/, 4)
+	err = runtime.waitForTrainingToComplete("event-tags", "1" /*flight*/, 4, 60)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -653,7 +653,7 @@ func TestPodWithCategories(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runtime.waitForTrainingToComplete("event-categories", "1" /*flight*/, 4)
+	err = runtime.waitForTrainingToComplete("event-categories", "1" /*flight*/, 4, 60)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -711,7 +711,7 @@ func TestImportExport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = runtime.waitForTrainingToComplete("trader", "1" /*flight*/, 10)
+	err = runtime.waitForTrainingToComplete("trader", "1" /*flight*/, 10, 300)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Also, tweak the waitForTrainingComplete timeout for ImportExport to fix flaky e2e test.

See Issue thread for details on 2.6.1 + Keras: https://github.com/tensorflow/tensorflow/issues/52922