### PR TITLE
Adds `lint` target to Makefile for AI Engine, handle graceful shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build:
 .PHONY: lint
 lint:
 	pushd dashboard && yarn lint && popd
-#	black --check --extend-exclude proto ai/src
+	pushd ai/src && make lint && popd
 	go vet ./...
 	golangci-lint run	
 
@@ -131,7 +131,7 @@ generate-acknowledgements:
 	pushd dashboard && yarn install && npx license-checker --csv 2>/dev/null >> ../$(ACKNOWLEDGEMENTS_PATH) && popd
 
 	# Apply Formatting
-	@if [[ $(UNAME) -eq "Darwin" ]]; then\
+	@if [[ "$(UNAME)" -eq "Darwin" ]]; then\
 		sed -i '' 's/\"//g' $(ACKNOWLEDGEMENTS_PATH); \
 		sed -i '' 's/,/, /g' $(ACKNOWLEDGEMENTS_PATH); \
 		sed -i '' 's/,  /, /g' $(ACKNOWLEDGEMENTS_PATH); \

--- a/ai/src/Makefile
+++ b/ai/src/Makefile
@@ -1,4 +1,5 @@
 UNAME := $(shell uname)
+SHELL := /bin/bash
 
 .PHONY: test
 test: venv
@@ -12,11 +13,7 @@ venv:
 
 .PHONY: lint
 lint: venv
-	@if [[ "$(UNAME)" -eq "Darwin" ]]; then\
-		find . -name '*.py' -not -path './proto/*' -and -not -path './venv/*' | xargs venv/bin/pylint; \
-	else\
-		find -name '*.py' -not -path './proto/*' -and -not -path './venv/*' | xargs venv/bin/pylint; \
-	fi
+	find . -name '*.py' -not -path './proto/*' -and -not -path './venv/*' | xargs venv/bin/pylint
 
 .PHONY: venv-dev
 venv-dev:

--- a/ai/src/Makefile
+++ b/ai/src/Makefile
@@ -1,3 +1,5 @@
+UNAME := $(shell uname)
+
 .PHONY: test
 test: venv
 	ALGORITHM="dql" venv/bin/python3 -m pytest --timeout 10
@@ -7,6 +9,14 @@ venv:
 	python3 -m venv venv
 	venv/bin/pip3 install --upgrade pip
 	venv/bin/pip3 install -r requirements/production.txt
+
+.PHONY: lint
+lint: venv
+	@if [[ "$(UNAME)" -eq "Darwin" ]]; then\
+		find . -name '*.py' -not -path './proto/*' -and -not -path './venv/*' | xargs venv/bin/pylint; \
+	else\
+		find -name '*.py' -not -path './proto/*' -and -not -path './venv/*' | xargs venv/bin/pylint; \
+	fi
 
 .PHONY: venv-dev
 venv-dev:

--- a/ai/src/cleanup.py
+++ b/ai/src/cleanup.py
@@ -1,12 +1,9 @@
 import shutil
-import sys
 
 directories_to_delete = []
 
 
-def cleanup_on_shutdown(signum=None, _frame=None):
+def cleanup_on_shutdown():
     for directory in directories_to_delete:
         shutil.rmtree(directory)
     directories_to_delete.clear()
-    if signum is not None:
-        sys.exit(signum)


### PR DESCRIPTION
- Adds a `lint` Makefile target for the AI Engine code
- Tweak the shutdown logic of the AI Engine to gracefully shutdown the gRPC server when a SIGINT signal is sent, as well as normally.