### PR TITLE
Only check for latest version once every 24 hours

### DIFF
--- a/pkg/aiengine/aiengine_test.go
+++ b/pkg/aiengine/aiengine_test.go
@@ -266,6 +266,9 @@ func testPythonCmdBareMetalContextFunc() func(*testing.T) {
 		rtcontext, err := context.NewContext("metal")
 		assert.NoError(t, err)
 
+		err = rtcontext.Init(true)
+		assert.NoError(t, err)
+
 		actual := rtcontext.AIEnginePythonCmdPath()
 		assert.Equal(t, expectedPython, actual)
 	}

--- a/pkg/cli/cmd/add.go
+++ b/pkg/cli/cmd/add.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/pkg/context"
@@ -38,9 +37,8 @@ spice add samples/LogPruner
 		cmd.Printf("Added %s\n", relativePath)
 
 		err = checkLatestCliReleaseVersion()
-		if err != nil {
-			cmd.Println(err.Error())
-			os.Exit(1)
+		if err != nil && IsDebug() {
+			cmd.PrintErrf("failed to check for latest CLI release version: %s\n", err.Error())
 		}
 	},
 }

--- a/pkg/cli/cmd/run.go
+++ b/pkg/cli/cmd/run.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -17,17 +16,15 @@ spice run
 # See more at: https://docs.spiceai.org/
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		
+
 		err := checkLatestCliReleaseVersion()
-		if err != nil {
-			cmd.Println(err.Error())
-			os.Exit(1)
+		if err != nil && IsDebug() {
+			cmd.PrintErrf("failed to check for latest CLI release version: %s\n", err.Error())
 		}
 
 		err = runtime.Run(contextFlag, "")
-
 		if err != nil {
-			log.Println(err.Error())
+			cmd.PrintErrln(err.Error())
 			os.Exit(1)
 		}
 	},

--- a/pkg/cli/cmd/util.go
+++ b/pkg/cli/cmd/util.go
@@ -1,0 +1,7 @@
+package cmd
+
+import "os"
+
+func IsDebug() bool {
+	return os.Getenv("SPICE_DEBUG") == "1"
+}

--- a/pkg/cli/cmd/version.go
+++ b/pkg/cli/cmd/version.go
@@ -2,8 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/pkg/context"
 	"github.com/spiceai/spiceai/pkg/github"
@@ -47,22 +52,51 @@ spice version
 		cmd.Printf("Runtime version: %s\n", rtversion)
 
 		err = checkLatestCliReleaseVersion()
-		if err != nil {
-			cmd.Println(err.Error())
-			os.Exit(1)
+		if err != nil && IsDebug() {
+			cmd.PrintErrf("failed to check for latest CLI release version: %s\n", err.Error())
 		}
 	},
 }
 
 func checkLatestCliReleaseVersion() error {
-	release, err := github.GetLatestCliRelease()
+	rtcontext, err := context.NewContext("metal") // CLI is always metal context
 	if err != nil {
 		return err
 	}
-	cliVersion := version.Version()
-	if cliVersion != release.TagName {
-		fmt.Printf("New CLI version %s is now available!\nRun \"spice upgrade\" to upgrade.\n", release.TagName)
+
+	err = rtcontext.Init(true)
+	if err != nil {
+		return err
 	}
+
+	var latestReleaseVersion string
+	versionFilePath := filepath.Join(rtcontext.SpiceRuntimeDir(), "cli_version.txt")
+	if stat, err := os.Stat(versionFilePath); !os.IsNotExist(err) {
+		if time.Until(stat.ModTime()) < 24*time.Hour {
+			versionData, err := os.ReadFile(versionFilePath)
+			if err == nil {
+				latestReleaseVersion = strings.TrimSpace(string(versionData))
+			}
+		}
+	}
+
+	if latestReleaseVersion == "" {
+		release, err := github.GetLatestCliRelease()
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(versionFilePath, []byte(release.TagName+"\n"), 0644)
+		if err != nil && IsDebug() {
+			log.Printf("failed to write version file: %s\n", err.Error())
+		}
+		latestReleaseVersion = release.TagName
+	}
+
+	cliVersion := version.Version()
+	if cliVersion != latestReleaseVersion {
+		fmt.Printf("\nCLI version %s is now available!\nTo upgrade, run \"spice upgrade\".\n", aurora.BrightGreen(latestReleaseVersion))
+	}
+
 	return nil
 }
 

--- a/pkg/context/metal/metal.go
+++ b/pkg/context/metal/metal.go
@@ -26,19 +26,7 @@ type MetalContext struct {
 }
 
 func NewMetalContext() *MetalContext {
-	homeDir := os.Getenv("HOME")
-
-	spiceRuntimeDir := filepath.Join(homeDir, constants.DotSpice)
-	spiceBinDir := filepath.Join(spiceRuntimeDir, "bin")
-	aiEngineDir := filepath.Join(spiceBinDir, "ai")
-	aiEnginePythonCmdPath := filepath.Join(aiEngineDir, "venv", "bin", constants.PythonCmd)
-
-	return &MetalContext{
-		spiceRuntimeDir:       spiceRuntimeDir,
-		spiceBinDir:           spiceBinDir,
-		aiEngineDir:           aiEngineDir,
-		aiEnginePythonCmdPath: aiEnginePythonCmdPath,
-	}
+	return &MetalContext{}
 }
 
 func (c *MetalContext) Name() string {
@@ -66,10 +54,21 @@ func (c *MetalContext) PodsDir() string {
 }
 
 func (c *MetalContext) Init(isDevelopmentMode bool) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	c.spiceRuntimeDir = filepath.Join(homeDir, constants.DotSpice)
+	c.spiceBinDir = filepath.Join(c.spiceRuntimeDir, "bin")
+	c.aiEngineDir = filepath.Join(c.spiceBinDir, "ai")
+	c.aiEnginePythonCmdPath = filepath.Join(c.aiEngineDir, "venv", "bin", constants.PythonCmd)
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
+
 	c.appDir = cwd
 	c.podsDir = filepath.Join(c.appDir, constants.SpicePodsDirectoryName)
 	c.isDevelopmentMode = isDevelopmentMode

--- a/pkg/context/metal/metal_test.go
+++ b/pkg/context/metal/metal_test.go
@@ -26,7 +26,7 @@ func TestMetaContext(t *testing.T) {
 		assert.NoError(t, err)
 
 		if assert.Len(t, cmd.Args, 2) {
-			assert.Equal(t, "/.spice/bin/spiced", strings.TrimPrefix(cmd.Args[0], homeDir))
+			assert.Equal(t, "spiced", strings.TrimPrefix(cmd.Args[0], homeDir))
 			assert.Equal(t, "test-manifest-path", cmd.Args[1])
 		}
 	})

--- a/pkg/github/runtime_release.go
+++ b/pkg/github/runtime_release.go
@@ -17,7 +17,6 @@ const (
 	runtimeRepo  = "spiceai"
 )
 
-
 func GetLatestRuntimeRelease() (*RepoRelease, error) {
 	fmt.Println("Checking for latest Spice runtime release...")
 


### PR DESCRIPTION
Closes #449 

We now store a file at `.spice/cli_version.txt` with the latest version and use that for the check. The file is only updated if it's last mod time is > 24 hours (once a day).