### PR TITLE
Fix debug log to report aiengine data sending

### DIFF
--- a/pkg/aiengine/data.go
+++ b/pkg/aiengine/data.go
@@ -107,6 +107,9 @@ func SendData(pod *pods.Pod, podState ...*state.State) error {
 		if response.Error {
 			return fmt.Errorf("failed to post new data to pod %s: %s", pod.Name, response.Message)
 		}
+	 zaplog.Sugar().Debugf(
+		  "Posting data to AI engine:\n%s", aurora.BrightYellow(
+				fmt.Sprintf("record of length %d posted", record.NumRows())))
 
 		state.Sent()
 	}
@@ -120,9 +123,7 @@ func getAddDataRequest(pod *pods.Pod, s *state.State, ipcPath string) *aiengine_
 		return nil
 	}
 
-	zaplog.Sugar().Debugf(
-		"Posting data to AI engine:\n%s", aurora.BrightYellow(
-			fmt.Sprintf("record of lenght %d posted", (*s.Record()).NumRows())))
+
 	addDataRequest := &aiengine_pb.AddDataRequest{
 		Pod:        pod.Name,
 		UnixSocket: ipcPath,


### PR DESCRIPTION
Simple fix for benchmarking as the debug log should for "data posted" should be send after the arrow IPC finishe and not when the AddData gRPC request is ready (as it doesn't hold the information any more)