### PR TITLE
Interfaces: DataSource, Auth

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -54,11 +54,15 @@ pub async fn run(args: Args) -> Result<()> {
     //     )
     // }
 
+    let debug_source = datasource::debug::DebugSource {
+        sleep_duration: Duration::from_secs(1),
+    };
+    // Ok to leak here since we want it to live for the lifetime of the process anyway
+    let debug_source = Box::leak(Box::new(debug_source));
+
     df.attach(
         "test-stream",
-        datasource::debug::DebugSource {
-            sleep_duration: Duration::from_secs(1),
-        },
+        debug_source,
         databackend::DataBackendType::default(),
     )
     .context(UnableToAttachDataSourceSnafu)?;

--- a/crates/runtime/src/auth.rs
+++ b/crates/runtime/src/auth.rs
@@ -2,12 +2,14 @@ pub trait Auth {
     fn get_token(&self) -> String;
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct AuthProviders {}
 
 pub mod none;
 pub mod spiceai;
 
 impl AuthProviders {
+    #[must_use]
     pub fn get_auth(name: &str) -> Box<dyn Auth> {
         match name {
             "spiceai" => {

--- a/crates/runtime/src/auth.rs
+++ b/crates/runtime/src/auth.rs
@@ -1,0 +1,19 @@
+pub trait Auth {
+    fn get_token(&self) -> String;
+}
+
+pub struct AuthProviders {}
+
+pub mod none;
+pub mod spiceai;
+
+impl AuthProviders {
+    pub fn get_auth(name: &str) -> Box<dyn Auth> {
+        match name {
+            "spiceai" => {
+                todo!("SpiceAI auth not implemented yet")
+            }
+            _ => Box::new(none::NoneAuth::new()),
+        }
+    }
+}

--- a/crates/runtime/src/auth/none.rs
+++ b/crates/runtime/src/auth/none.rs
@@ -1,0 +1,16 @@
+use super::Auth;
+
+pub struct NoneAuth {}
+
+impl Auth for NoneAuth {
+    fn get_token(&self) -> String {
+        "".to_string()
+    }
+}
+
+impl NoneAuth {
+    #[must_use]
+    pub fn new() -> Self {
+        NoneAuth {}
+    }
+}

--- a/crates/runtime/src/auth/none.rs
+++ b/crates/runtime/src/auth/none.rs
@@ -1,10 +1,11 @@
 use super::Auth;
 
+#[allow(clippy::module_name_repetitions)]
 pub struct NoneAuth {}
 
 impl Auth for NoneAuth {
     fn get_token(&self) -> String {
-        "".to_string()
+        String::new()
     }
 }
 
@@ -12,5 +13,11 @@ impl NoneAuth {
     #[must_use]
     pub fn new() -> Self {
         NoneAuth {}
+    }
+}
+
+impl Default for NoneAuth {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/runtime/src/auth/spiceai.rs
+++ b/crates/runtime/src/auth/spiceai.rs
@@ -1,0 +1,11 @@
+use super::Auth;
+
+pub struct SpiceAuth {
+    api_key: String,
+}
+
+impl Auth for SpiceAuth {
+    fn get_token(&self) -> String {
+        self.api_key.clone()
+    }
+}

--- a/crates/runtime/src/databackend.rs
+++ b/crates/runtime/src/databackend.rs
@@ -1,4 +1,4 @@
-use arrow::record_batch::RecordBatch;
+use crate::dataupdate::DataUpdate;
 use datafusion::{error::DataFusionError, sql::sqlparser};
 use snafu::prelude::*;
 use std::{future::Future, pin::Pin};
@@ -28,7 +28,6 @@ pub enum DataBackendType {
 pub trait DataBackend: Send {
     fn add_data(
         &mut self,
-        log_sequence_number: u64,
-        data: Vec<RecordBatch>,
+        data_update: DataUpdate,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
 }

--- a/crates/runtime/src/datasource.rs
+++ b/crates/runtime/src/datasource.rs
@@ -1,13 +1,53 @@
 use arrow::record_batch::RecordBatch;
 use futures_core::stream::BoxStream;
 
+use crate::auth::Auth;
+
 pub mod debug;
 
-pub struct DataUpdate {
-    pub log_sequence_number: u64,
-    pub data: Vec<RecordBatch>,
+pub enum UpdateType {
+    Append,
+    Overwrite,
 }
 
+pub struct DataUpdate {
+    /// The unique identifier associated with this DataUpdate.
+    /// If the runtime sees two DataUpdates with the same log_sequence_number,
+    /// it will remove the data associated with the first DataUpdate, and replace it with the second.
+    ///
+    /// A None value will disable the de-duplication logic.
+    pub log_sequence_number: Option<u64>,
+    pub data: Vec<RecordBatch>,
+    /// The type of update to perform.
+    /// If UpdateType::Append, the runtime will append the data to the existing dataset.
+    /// If UpdateType::Overwrite, the runtime will overwrite the existing data with the new data.
+    pub update_type: UpdateType,
+}
+
+/// A DataSource knows how to retrieve data for a given dataset.
+///
+/// Implementing `get_all_data` is required, but `stream_data_updates` & `supports_data_streaming` is optional.
+/// If `stream_data_updates` is not supported for a dataset, the runtime will fall back to polling `get_all_data` and returning a
+/// DataUpdate that is constructed like:
+///
+/// ```rust
+/// DataUpdate {
+///    log_sequence_number: None,
+///    data: get_all_data(dataset),
+///    update_type: UpdateType::Overwrite,
+/// }
+/// ```
 pub trait DataSource {
-    fn get_data<'a>(&self) -> BoxStream<'a, DataUpdate>;
+    /// Create a new DataSource with the given Auth.
+    fn new<T: Auth>(auth: T) -> Self;
+    /// Returns true if the given dataset supports streaming by this DataSource.
+    fn supports_data_streaming(&self, dataset: &str) -> bool {
+        false
+    }
+    /// Returns a stream of DataUpdates for the given dataset.
+    fn stream_data_updates<'a>(&self, dataset: &str) -> BoxStream<'a, DataUpdate> {
+        panic!("stream_data_updates not implemented for {}", dataset)
+    }
+    /// Returns all data for the given dataset.
+    fn get_all_data(&self, dataset: &str) -> Vec<RecordBatch>;
 }

--- a/crates/runtime/src/datasource.rs
+++ b/crates/runtime/src/datasource.rs
@@ -1,34 +1,19 @@
+use std::time::Duration;
+
 use arrow::record_batch::RecordBatch;
+use async_stream::stream;
 use futures_core::stream::BoxStream;
 
 use crate::auth::Auth;
+use crate::dataupdate::{DataUpdate, UpdateType};
 
 pub mod debug;
 
-pub enum UpdateType {
-    Append,
-    Overwrite,
-}
-
-pub struct DataUpdate {
-    /// The unique identifier associated with this DataUpdate.
-    /// If the runtime sees two DataUpdates with the same log_sequence_number,
-    /// it will remove the data associated with the first DataUpdate, and replace it with the second.
-    ///
-    /// A None value will disable the de-duplication logic.
-    pub log_sequence_number: Option<u64>,
-    pub data: Vec<RecordBatch>,
-    /// The type of update to perform.
-    /// If UpdateType::Append, the runtime will append the data to the existing dataset.
-    /// If UpdateType::Overwrite, the runtime will overwrite the existing data with the new data.
-    pub update_type: UpdateType,
-}
-
-/// A DataSource knows how to retrieve data for a given dataset.
+/// A `DataSource` knows how to retrieve data for a given dataset.
 ///
 /// Implementing `get_all_data` is required, but `stream_data_updates` & `supports_data_streaming` is optional.
 /// If `stream_data_updates` is not supported for a dataset, the runtime will fall back to polling `get_all_data` and returning a
-/// DataUpdate that is constructed like:
+/// `DataUpdate` that is constructed like:
 ///
 /// ```rust
 /// DataUpdate {
@@ -37,17 +22,53 @@ pub struct DataUpdate {
 ///    update_type: UpdateType::Overwrite,
 /// }
 /// ```
-pub trait DataSource {
-    /// Create a new DataSource with the given Auth.
-    fn new<T: Auth>(auth: T) -> Self;
-    /// Returns true if the given dataset supports streaming by this DataSource.
-    fn supports_data_streaming(&self, dataset: &str) -> bool {
+pub trait DataSource: Send + Sync {
+    /// Create a new `DataSource` with the given `Auth`.
+    fn new<T: Auth>(auth: T) -> Self
+    where
+        Self: Sized;
+    /// Returns true if the given dataset supports streaming by this `DataSource`.
+    fn supports_data_streaming(&self, _dataset: &str) -> bool {
         false
     }
-    /// Returns a stream of DataUpdates for the given dataset.
+    /// Returns a stream of `DataUpdates` for the given dataset.
     fn stream_data_updates<'a>(&self, dataset: &str) -> BoxStream<'a, DataUpdate> {
-        panic!("stream_data_updates not implemented for {}", dataset)
+        panic!("stream_data_updates not implemented for {dataset}")
+    }
+    fn get_all_data_refresh_interval(&self, _dataset: &str) -> Option<Duration> {
+        None
     }
     /// Returns all data for the given dataset.
     fn get_all_data(&self, dataset: &str) -> Vec<RecordBatch>;
+}
+
+impl dyn DataSource + '_ {
+    pub fn get_data<'a>(&'a self, dataset: &'a str) -> BoxStream<'_, DataUpdate> {
+        if self.supports_data_streaming(dataset) {
+            return self.stream_data_updates(dataset);
+        }
+
+        // If a refresh_internal is defined, refresh the data on that interval.
+        if let Some(refresh_interval) = self.get_all_data_refresh_interval(dataset) {
+            return Box::pin(stream! {
+                loop {
+                    tokio::time::sleep(refresh_interval).await;
+                    yield DataUpdate {
+                        log_sequence_number: None,
+                        data: self.get_all_data(dataset),
+                        update_type: UpdateType::Overwrite,
+                    };
+                }
+            });
+        }
+
+        // Otherwise, just return the data once.
+        Box::pin(stream! {
+            yield DataUpdate {
+                log_sequence_number: None,
+                data: self.get_all_data(dataset),
+                update_type: UpdateType::Overwrite,
+            };
+        })
+    }
 }

--- a/crates/runtime/src/datasource/debug.rs
+++ b/crates/runtime/src/datasource/debug.rs
@@ -1,3 +1,4 @@
+use super::{DataSource, DataUpdate, UpdateType};
 use arrow::{
     array::{Int32Array, StringArray},
     datatypes::{DataType, Field, Schema},
@@ -12,8 +13,36 @@ pub struct DebugSource {
     pub sleep_duration: Duration,
 }
 
-impl super::DataSource for DebugSource {
-    fn get_data<'a>(&self) -> BoxStream<'a, super::DataUpdate> {
+impl DataSource for DebugSource {
+    fn new<T: crate::auth::Auth>(auth: T) -> Self {
+        Self {
+            sleep_duration: Duration::from_secs(1),
+        }
+    }
+
+    fn supports_data_streaming(&self, dataset: &str) -> bool {
+        true
+    }
+
+    fn get_all_data(&self, dataset: &str) -> Vec<RecordBatch> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Utf8, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        if let Ok(batch) = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "c", "d"])),
+                Arc::new(Int32Array::from(vec![1, 10, 10, 100])),
+            ],
+        ) {
+            vec![batch]
+        } else {
+            vec![]
+        }
+    }
+
+    fn stream_data_updates<'a>(&self, dataset: &str) -> BoxStream<'a, DataUpdate> {
         let sleep_duration = self.sleep_duration;
         Box::pin(stream! {
           loop {
@@ -31,8 +60,9 @@ impl super::DataSource for DebugSource {
                       Arc::new(Int32Array::from(vec![1, 10, 10, 100])),
                   ],
               ) {
-                yield super::DataUpdate {
-                  log_sequence_number: 0,
+                yield DataUpdate {
+                  log_sequence_number: None,
+                  update_type: UpdateType::Append,
                   data: vec![batch],
                 };
               };

--- a/crates/runtime/src/datasource/debug.rs
+++ b/crates/runtime/src/datasource/debug.rs
@@ -14,17 +14,21 @@ pub struct DebugSource {
 }
 
 impl DataSource for DebugSource {
-    fn new<T: crate::auth::Auth>(auth: T) -> Self {
+    fn new<T: crate::auth::Auth>(_auth: T) -> Self {
         Self {
             sleep_duration: Duration::from_secs(1),
         }
     }
 
-    fn supports_data_streaming(&self, dataset: &str) -> bool {
+    fn supports_data_streaming(&self, _dataset: &str) -> bool {
         true
     }
 
-    fn get_all_data(&self, dataset: &str) -> Vec<RecordBatch> {
+    fn get_all_data_refresh_interval(&self, _dataset: &str) -> Option<Duration> {
+        Some(self.sleep_duration)
+    }
+
+    fn get_all_data(&self, _dataset: &str) -> Vec<RecordBatch> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("a", DataType::Utf8, false),
             Field::new("b", DataType::Int32, false),
@@ -42,7 +46,7 @@ impl DataSource for DebugSource {
         }
     }
 
-    fn stream_data_updates<'a>(&self, dataset: &str) -> BoxStream<'a, DataUpdate> {
+    fn stream_data_updates<'a>(&self, _dataset: &str) -> BoxStream<'a, DataUpdate> {
         let sleep_duration = self.sleep_duration;
         Box::pin(stream! {
           loop {

--- a/crates/runtime/src/dataupdate.rs
+++ b/crates/runtime/src/dataupdate.rs
@@ -1,0 +1,20 @@
+use arrow::record_batch::RecordBatch;
+
+pub enum UpdateType {
+    Append,
+    Overwrite,
+}
+
+pub struct DataUpdate {
+    /// The unique identifier associated with this DataUpdate.
+    /// If the runtime sees two DataUpdates with the same log_sequence_number,
+    /// it will remove the data associated with the first DataUpdate, and replace it with the second.
+    ///
+    /// A None value will disable the de-duplication logic.
+    pub log_sequence_number: Option<u64>,
+    pub data: Vec<RecordBatch>,
+    /// The type of update to perform.
+    /// If UpdateType::Append, the runtime will append the data to the existing dataset.
+    /// If UpdateType::Overwrite, the runtime will overwrite the existing data with the new data.
+    pub update_type: UpdateType,
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod databackend;
 pub mod datafusion;
 pub mod datasource;
+pub mod dataupdate;
 mod flight;
 mod http;
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -8,6 +8,7 @@ use tokio::signal;
 
 use crate::datafusion::DataFusion;
 
+pub mod auth;
 pub mod config;
 pub mod databackend;
 pub mod datafusion;


### PR DESCRIPTION
Updates the `DataSource` interface to support both polling & streaming.

Adds an `Auth` interface that is passed to a `DataSource`.

Creates a `dataupdate` module and moves the `DataUpdate` type to it - it is referenced in the databackend now as well.