### PR TITLE
Add Dockerfile for spiceai-rust

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,3 +53,25 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - run: make build
+
+  build-docker:
+    name: Build Docker Image
+    runs-on: rust
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false
+          tags: |
+            ghcr.io/spiceai/spiceai-rust:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,5 +73,5 @@ jobs:
           push: false
           tags: |
             ghcr.io/spiceai/spiceai-rust:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/workspace/.buildx-cache
+          cache-to: type=local,dest=/workspace/.buildx-cache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN \
   --mount=type=cache,id=spiceai_target,sharing=locked,target=/spiceai/target \
   cargo build --target-dir /spiceai/target --release
 
+RUN ls -l /spiceai/target
+RUN ls -l /spiceai/target/release
+
 FROM debian:bookworm-slim
 
 RUN apt update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
+#syntax=docker/dockerfile:1.2
 ARG RUST_VERSION=1.75
 FROM rust:${RUST_VERSION}-slim-bookworm as build
+
+# cache mounts below may already exist and owned by root
+USER root
 
 RUN apt update \
     && apt install --yes pkg-config libssl-dev \
@@ -10,11 +14,9 @@ COPY . /build
 WORKDIR /build
 
 RUN \
-  --mount=type=cache,id=spiceai_rustup,sharing=locked,target=/usr/local/rustup \
   --mount=type=cache,id=spiceai_registry,sharing=locked,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=spiceai_git,sharing=locked,target=/usr/local/cargo/git \
-  --mount=type=cache,id=spiceai_target,sharing=locked,target=/build/target \
-  cargo build --release
+  --mount=type=cache,id=spiceai_target,sharing=locked,target=/spiceai/target \
+  cargo build --target-dir /spiceai/target --release
 
 FROM debian:bookworm-slim
 
@@ -22,7 +24,7 @@ RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
-COPY --from=build /build/target/release/spiced /usr/local/bin/spiced
+COPY --from=build /spiceai/target/release/spiced /usr/local/bin/spiced
 
 EXPOSE 3000 50051
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,15 @@ RUN apt update \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 COPY . /build
-
 WORKDIR /build
+
+ARG CARGO_INCREMENTAL=yes
+ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL
 
 RUN \
   --mount=type=cache,id=spiceai_registry,sharing=locked,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=spiceai_target,sharing=locked,target=/spiceai/target \
-  cargo build --target-dir /spiceai/target --release
-
-RUN ls -l /spiceai/target
-RUN ls -l /spiceai/target/release
+  --mount=type=cache,id=spiceai_target,sharing=locked,target=/build/target \
+  cargo build --release
 
 FROM debian:bookworm-slim
 
@@ -27,7 +26,7 @@ RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
-COPY --from=build /spiceai/target/release/spiced /usr/local/bin/spiced
+COPY --from=build /build/target/release/spiced /usr/local/bin/spiced
 
 EXPOSE 3000 50051
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,13 @@ COPY . /build
 WORKDIR /build
 
 ARG CARGO_INCREMENTAL=yes
-ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL
+ARG CARGO_NET_GIT_FETCH_WITH_CLI=false
+ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL \
+    CARGO_NET_GIT_FETCH_WITH_CLI=$CARGO_NET_GIT_FETCH_WITH_CLI
 
 RUN \
   --mount=type=cache,id=spiceai_registry,sharing=locked,target=/usr/local/cargo/registry \
+  --mount=type=cache,id=spiceai_git,sharing=locked,target=/usr/local/cargo/git \
   --mount=type=cache,id=spiceai_target,sharing=locked,target=/build/target \
   cargo build --release && \
   cp /build/target/release/spiced /root/spiced

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+ARG RUST_VERSION=1.75
+FROM rust:${RUST_VERSION}-slim-bookworm as build
+
+RUN apt update \
+    && apt install --yes pkg-config libssl-dev \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}
+
+COPY . /build
+
+WORKDIR /build
+
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+
+RUN apt update \
+    && apt install --yes ca-certificates libssl3 --no-install-recommends \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}
+
+COPY --from=build /build/target/release/spiced /usr/local/bin/spiced
+
+EXPOSE 3000 50051
+
+ENTRYPOINT ["/usr/local/bin/spiced"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ COPY . /build
 
 WORKDIR /build
 
-RUN cargo build --release
+RUN \
+  --mount=type=cache,id=spiceai_rustup,sharing=locked,target=/usr/local/rustup \
+  --mount=type=cache,id=spiceai_registry,sharing=locked,target=/usr/local/cargo/registry \
+  --mount=type=cache,id=spiceai_git,sharing=locked,target=/usr/local/cargo/git \
+  --mount=type=cache,id=spiceai_target,sharing=locked,target=/build/target \
+  cargo build --release
 
 FROM debian:bookworm-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ENV CARGO_INCREMENTAL=$CARGO_INCREMENTAL
 RUN \
   --mount=type=cache,id=spiceai_registry,sharing=locked,target=/usr/local/cargo/registry \
   --mount=type=cache,id=spiceai_target,sharing=locked,target=/build/target \
-  cargo build --release
+  cargo build --release && \
+  cp /build/target/release/spiced /root/spiced
 
 FROM debian:bookworm-slim
 
@@ -26,7 +27,7 @@ RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
-COPY --from=build /build/target/release/spiced /usr/local/bin/spiced
+COPY --from=build /root/spiced /usr/local/bin/spiced
 
 EXPOSE 3000 50051
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,15 @@ lint:
 		-Dclippy::unwrap_used \
 		-Dclippy::expect_used
 
+.PHONY: docker
+docker:
+	docker buildx build -t spiceai-rust:local-dev .
+
+.PHONY: docker-run
+docker-run:
+	docker stop spiceai && docker rm spiceai || true
+	docker run --name spiceai -p 3000:3000 -p 50051:50051 spiceai-rust:local-dev
+
 ################################################################################
 # Target: install                                                              #
 ################################################################################


### PR DESCRIPTION
Adds a Dockerfile for building the rust runtime into a container suitable for running in K8s.