### PR TITLE
Fix health endpoint

### DIFF
--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -21,7 +21,7 @@ where
 {
     let routes = Router::new()
         .route("/", get(|| async { "Hello, World!" }))
-        .route("/health", get(|| async { "OK" }));
+        .route("/health", get(|| async { "ok\n" }));
 
     let listener = TcpListener::bind(&bind_address)
         .await


### PR DESCRIPTION
Fixes the `/health` endpoint to return a lowercase `ok` with a newline - to match the convention we have for our other `/health` endpoints.