### PR TITLE
Add API to get datasets - including sink datasets

### DIFF
--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -1,8 +1,11 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
-use axum::{routing::get, Router};
+use app::App;
 use snafu::prelude::*;
 use tokio::net::{TcpListener, ToSocketAddrs};
+
+mod routes;
+mod v1;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -15,13 +18,11 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub(crate) async fn start<A>(bind_address: A) -> Result<()>
+pub(crate) async fn start<A>(bind_address: A, app: Arc<App>) -> Result<()>
 where
     A: ToSocketAddrs + Debug,
 {
-    let routes = Router::new()
-        .route("/", get(|| async { "Hello, World!" }))
-        .route("/health", get(|| async { "ok\n" }));
+    let routes = routes::routes(app);
 
     let listener = TcpListener::bind(&bind_address)
         .await

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+use app::App;
+use axum::{
+    routing::{get, Router},
+    Extension,
+};
+
+use super::v1;
+
+pub(crate) fn routes(app: Arc<App>) -> Router {
+    Router::new()
+        .route("/health", get(|| async { "ok\n" }))
+        .route("/v1/datasets", get(v1::datasets::get))
+        .layer(Extension(app))
+}

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -1,0 +1,38 @@
+pub(crate) mod datasets {
+    use std::sync::Arc;
+
+    use app::App;
+    use axum::{extract::Query, Extension, Json};
+    use serde::Deserialize;
+    use spicepod::component::dataset::Dataset;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    pub(crate) enum DatasetSource {
+        Sink,
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub(crate) struct DatasetFilter {
+        source: Option<DatasetSource>,
+    }
+
+    pub(crate) async fn get(
+        Extension(app): Extension<Arc<App>>,
+        Query(filter): Query<DatasetFilter>,
+    ) -> Json<Vec<Dataset>> {
+        let datasets: Vec<Dataset> = match filter.source {
+            Some(source) => match source {
+                DatasetSource::Sink => app
+                    .datasets
+                    .iter()
+                    .filter(|d| d.source.is_none())
+                    .cloned()
+                    .collect(),
+            },
+            None => app.datasets.clone(),
+        };
+
+        Json(datasets)
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -29,7 +29,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct Runtime {
-    pub app: app::App,
+    pub app: Arc<app::App>,
     pub config: config::Config,
     pub df: Arc<DataFusion>,
 }
@@ -38,14 +38,14 @@ impl Runtime {
     #[must_use]
     pub fn new(config: Config, app: app::App, df: DataFusion) -> Self {
         Runtime {
-            app,
+            app: Arc::new(app),
             config,
             df: Arc::new(df),
         }
     }
 
     pub async fn start_servers(&self) -> Result<()> {
-        let http_server_future = http::start(self.config.http_bind_address);
+        let http_server_future = http::start(self.config.http_bind_address, self.app.clone());
         let flight_server_future = flight::start(self.config.flight_bind_address, self.df.clone());
 
         tokio::select! {

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -59,6 +59,8 @@ pub mod acceleration {
     pub struct Acceleration {
         #[serde(default)]
         pub enabled: bool,
-        pub refresh: String,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub refresh: Option<String>,
     }
 }


### PR DESCRIPTION
Adds a `GET /v1/datasets` API to retrieve the currently loaded datasets.

Supports a query parameter `source` that allows filtering the datasets to just the "sink" datasets - that is the datasets that allow pushing data via `DoPut`. This will be used by the publisher system to know which datasets it is allowed to publish into.