### PR TITLE
Bring back specific SpiceAI/Dremio datasources

### DIFF
--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -43,6 +43,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[derive(Debug, Clone)]
 pub struct FlightClient {
     token: Option<String>,
     flight_client: FlightServiceClient<Channel>,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -98,7 +98,7 @@ impl DataFusion {
                         Ok(()) => (),
                         Err(e) => tracing::error!("Error adding data: {e:?}"),
                     },
-                    None => continue,
+                    None => break,
                 };
             }
         });

--- a/crates/runtime/src/datasource.rs
+++ b/crates/runtime/src/datasource.rs
@@ -1,6 +1,8 @@
 use snafu::prelude::*;
 use spicepod::component::dataset::Dataset;
+use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
 use async_stream::stream;
@@ -11,7 +13,9 @@ use crate::auth::AuthProvider;
 use crate::dataupdate::{DataUpdate, UpdateType};
 
 pub mod debug;
+pub mod dremio;
 pub mod flight;
+pub mod spiceai;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -39,7 +43,7 @@ pub trait DataSource: Send + Sync {
     /// Create a new `DataSource` with the given `AuthProvider`.
     fn new(
         auth_provider: Box<dyn AuthProvider>,
-        url: String,
+        params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = Result<Self>>>>
     where
         Self: Sized;

--- a/crates/runtime/src/datasource/debug.rs
+++ b/crates/runtime/src/datasource/debug.rs
@@ -1,5 +1,6 @@
 use crate::auth::AuthProvider;
 
+use std::collections::HashMap;
 use std::{future::Future, pin::Pin};
 use std::{sync::Arc, time::Duration};
 
@@ -19,7 +20,7 @@ pub struct DebugSource {}
 impl DataSource for DebugSource {
     fn new(
         _auth_provider: Box<dyn AuthProvider>,
-        _url: String,
+        _params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>>>> {
         Box::pin(async move { Ok(Self {}) })
     }

--- a/crates/runtime/src/datasource/dremio.rs
+++ b/crates/runtime/src/datasource/dremio.rs
@@ -1,0 +1,45 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{collections::HashMap, future::Future};
+
+use spicepod::component::dataset::Dataset;
+
+use crate::auth::AuthProvider;
+
+use super::{flight::Flight, DataSource};
+
+pub struct Dremio {
+    flight: Flight,
+}
+
+impl DataSource for Dremio {
+    fn new(
+        auth_provider: Box<dyn AuthProvider>,
+        params: Arc<Option<HashMap<String, String>>>,
+    ) -> Pin<Box<dyn Future<Output = super::Result<Self>>>>
+    where
+        Self: Sized,
+    {
+        Box::pin(async move {
+            let url: String = params
+                .as_ref()
+                .as_ref()
+                .and_then(|params| params.get("url").cloned())
+                .ok_or_else(|| super::Error::UnableToCreateDataSource {
+                    source: "Missing required parameter: url".into(),
+                })?;
+            let flight = Flight::new(auth_provider, url);
+            let flight = flight.await?;
+            Ok(Self { flight })
+        })
+    }
+
+    fn get_all_data(
+        &self,
+        dataset: &Dataset,
+    ) -> Pin<Box<dyn Future<Output = Vec<arrow::record_batch::RecordBatch>> + Send>> {
+        let dremio_path = dataset.path();
+
+        self.flight.get_all_data(&dremio_path)
+    }
+}

--- a/crates/runtime/src/datasource/dremio.rs
+++ b/crates/runtime/src/datasource/dremio.rs
@@ -29,8 +29,9 @@ impl DataSource for Dremio {
                     source: "Missing required parameter: url".into(),
                 })?;
             let flight = Flight::new(auth_provider, url);
-            let flight = flight.await?;
-            Ok(Self { flight })
+            Ok(Self {
+                flight: flight.await?,
+            })
         })
     }
 

--- a/crates/runtime/src/datasource/dremio.rs
+++ b/crates/runtime/src/datasource/dremio.rs
@@ -22,8 +22,8 @@ impl DataSource for Dremio {
     {
         Box::pin(async move {
             let url: String = params
-                .as_ref()
-                .as_ref()
+                .as_ref() // &Option<HashMap<String, String>>
+                .as_ref() // Option<&HashMap<String, String>>
                 .and_then(|params| params.get("url").cloned())
                 .ok_or_else(|| super::Error::UnableToCreateDataSource {
                     source: "Missing required parameter: url".into(),

--- a/crates/runtime/src/datasource/spiceai.rs
+++ b/crates/runtime/src/datasource/spiceai.rs
@@ -31,8 +31,8 @@ impl DataSource for SpiceAI {
     {
         Box::pin(async move {
             let url: String = params
-                .as_ref()
-                .as_ref()
+                .as_ref() // &Option<HashMap<String, String>>
+                .as_ref() // Option<&HashMap<String, String>>
                 .and_then(|params| params.get("url").cloned())
                 .unwrap_or_else(|| "https://flight.spiceai.io".to_string());
             let flight = Flight::new(auth_provider, url);

--- a/crates/runtime/src/datasource/spiceai.rs
+++ b/crates/runtime/src/datasource/spiceai.rs
@@ -1,0 +1,87 @@
+use snafu::prelude::*;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{collections::HashMap, future::Future};
+
+use spicepod::component::dataset::Dataset;
+
+use crate::auth::AuthProvider;
+
+use super::{flight::Flight, DataSource};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to parse SpiceAI dataset path: {}", dataset_path))]
+    UnableToParseDatasetPath { dataset_path: String },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct SpiceAI {
+    flight: Flight,
+}
+
+impl DataSource for SpiceAI {
+    fn new(
+        auth_provider: Box<dyn AuthProvider>,
+        params: Arc<Option<HashMap<String, String>>>,
+    ) -> Pin<Box<dyn Future<Output = super::Result<Self>>>>
+    where
+        Self: Sized,
+    {
+        Box::pin(async move {
+            let url: String = params
+                .as_ref()
+                .as_ref()
+                .and_then(|params| params.get("url").cloned())
+                .unwrap_or_else(|| "https://flight.spiceai.io".to_string());
+            let flight = Flight::new(auth_provider, url);
+            let flight = flight.await?;
+            Ok(Self { flight })
+        })
+    }
+
+    fn get_all_data(
+        &self,
+        dataset: &Dataset,
+    ) -> Pin<Box<dyn Future<Output = Vec<arrow::record_batch::RecordBatch>> + Send>> {
+        let spice_dataset_path = match Self::spice_dataset_path(dataset) {
+            Ok(path) => path,
+            Err(error) => {
+                tracing::error!("Unable to parse SpiceAI dataset path: {:?}", error);
+                return Box::pin(async move { vec![] });
+            }
+        };
+
+        self.flight.get_all_data(&spice_dataset_path)
+    }
+}
+
+impl SpiceAI {
+    /// Parses a dataset path from a Spice AI dataset definition.
+    ///
+    /// Spice AI datasets have two possible formats for `dataset.path()`:
+    /// 1. `<org>/<app>/datasets/<dataset_name>`.
+    /// 2. `<org>/<app>`.
+    ///
+    /// The second format is a shorthand for the first format, where the dataset name
+    /// is the same as the local table name specified in `name`.
+    ///
+    /// This function returns the full dataset path for the given dataset as you would query for it in Spice.
+    /// i.e. `<org>.<app>.<dataset_name>`
+    fn spice_dataset_path(dataset: &Dataset) -> Result<String> {
+        let path = dataset.path();
+        let path_parts: Vec<&str> = path.split('/').collect();
+
+        match path_parts.as_slice() {
+            [org, app] => Ok(format!(
+                "{org}.{app}.{dataset_name}",
+                dataset_name = dataset.name
+            )),
+            [org, app, "datasets", dataset_name] => Ok(format!("{org}.{app}.{dataset_name}")),
+            _ => Err(Error::UnableToParseDatasetPath {
+                dataset_path: path.to_string(),
+            }),
+        }
+    }
+}

--- a/crates/runtime/src/datasource/spiceai.rs
+++ b/crates/runtime/src/datasource/spiceai.rs
@@ -36,8 +36,9 @@ impl DataSource for SpiceAI {
                 .and_then(|params| params.get("url").cloned())
                 .unwrap_or_else(|| "https://flight.spiceai.io".to_string());
             let flight = Flight::new(auth_provider, url);
-            let flight = flight.await?;
-            Ok(Self { flight })
+            Ok(Self {
+                flight: flight.await?,
+            })
         })
     }
 

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -10,8 +10,8 @@ pub struct Dataset {
 
     pub name: String,
 
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub params: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<HashMap<String, String>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acceleration: Option<acceleration::Acceleration>,


### PR DESCRIPTION
DataSources are responsible for parsing the `from` to extract out the dataset path on the source. Given this new responsibility, and the fact that Auth will be different as well, we can't have a generic Flight datasource. We can reuse most of the logic - all we need to pass in is the dataset path.

Also fixes a bug with runtime pegging the CPU at 100%. When a stream is finished in Rust, it returns a `None` value - indicating the stream has ended and no more data is coming. We were continuing in the loop, which just returned another `None` value. Break out if no more data will be coming.