### PR TITLE
Add support for Spice AI blessed datasets

### DIFF
--- a/bin/spice/pkg/api/dataset.go
+++ b/bin/spice/pkg/api/dataset.go
@@ -5,6 +5,9 @@ import "time"
 const (
 	REFRESH_MODE_FULL   = "full"
 	REFRESH_MODE_APPEND = "append"
+
+	DATA_SOURCE_SPICEAI = "spice.ai"
+	DATA_SOURCE_DREMIO  = "dremio"
 )
 
 type Dataset struct {

--- a/bin/spice/pkg/api/pod.go
+++ b/bin/spice/pkg/api/pod.go
@@ -12,6 +12,6 @@ type Pod struct {
 }
 
 type Reference struct {
-	Import    string `json:"import,omitempty" csv:"import" yaml:"import,omitempty"`
+	Ref       string `json:"ref,omitempty" csv:"ref" yaml:"ref,omitempty"`
 	DependsOn string `json:"depends_on,omitempty" csv:"depends_on" yaml:"dependsOn,omitempty"`
 }

--- a/bin/spice/pkg/api/pod.go
+++ b/bin/spice/pkg/api/pod.go
@@ -12,6 +12,6 @@ type Pod struct {
 }
 
 type Reference struct {
-	From      string `json:"from,omitempty" csv:"from" yaml:"from,omitempty"`
+	Import    string `json:"import,omitempty" csv:"import" yaml:"import,omitempty"`
 	DependsOn string `json:"depends_on,omitempty" csv:"depends_on" yaml:"dependsOn,omitempty"`
 }

--- a/bin/spice/pkg/cli/cmd/dataset.go
+++ b/bin/spice/pkg/cli/cmd/dataset.go
@@ -106,7 +106,7 @@ spice dataset configure
 
 		var datasetReferenced bool
 		for _, dataset := range spicePod.Datasets {
-			if dataset.Import == dirPath {
+			if dataset.Ref == dirPath {
 				datasetReferenced = true
 				break
 			}
@@ -114,7 +114,7 @@ spice dataset configure
 
 		if !datasetReferenced {
 			spicePod.Datasets = append(spicePod.Datasets, &api.Reference{
-				Import: dirPath,
+				Ref: dirPath,
 			})
 			spicepodBytes, err = yaml.Marshal(spicePod)
 			if err != nil {

--- a/bin/spice/pkg/cli/cmd/dataset.go
+++ b/bin/spice/pkg/cli/cmd/dataset.go
@@ -54,9 +54,16 @@ spice dataset configure
 		accelerateDatasetString = strings.TrimSuffix(accelerateDatasetString, "\n")
 		accelerateDataset := strings.ToLower(accelerateDatasetString) == "y"
 
+		params := map[string]string{}
+		if strings.Split(datasetLocation, "/")[0] == api.DATA_SOURCE_DREMIO {
+			// TODO: Allow user to specify own dremio instance. Needs UX design for how the command should handle.
+			params["url"] = "http://dremio-4mimamg7rdeve.eastus.cloudapp.azure.com:32010"
+		}
+
 		dataset := api.Dataset{
-			From: datasetLocation,
-			Name: datasetName,
+			From:   datasetLocation,
+			Name:   datasetName,
+			Params: params,
 			Acceleration: &api.Acceleration{
 				Enabled:         accelerateDataset,
 				RefreshInterval: time.Hour,
@@ -99,7 +106,7 @@ spice dataset configure
 
 		var datasetReferenced bool
 		for _, dataset := range spicePod.Datasets {
-			if dataset.From == dirPath {
+			if dataset.Import == dirPath {
 				datasetReferenced = true
 				break
 			}
@@ -107,7 +114,7 @@ spice dataset configure
 
 		if !datasetReferenced {
 			spicePod.Datasets = append(spicePod.Datasets, &api.Reference{
-				From: dirPath,
+				Import: dirPath,
 			})
 			spicepodBytes, err = yaml.Marshal(spicePod)
 			if err != nil {

--- a/bin/spice/pkg/cli/cmd/dataset.go
+++ b/bin/spice/pkg/cli/cmd/dataset.go
@@ -57,7 +57,7 @@ spice dataset configure
 		params := map[string]string{}
 		if strings.Split(datasetLocation, "/")[0] == api.DATA_SOURCE_DREMIO {
 			// TODO: Allow user to specify own dremio instance. Needs UX design for how the command should handle.
-			params["url"] = "http://dremio-4mimamg7rdeve.eastus.cloudapp.azure.com:32010"
+			params["endpoint"] = "http://dremio-4mimamg7rdeve.eastus.cloudapp.azure.com:32010"
 		}
 
 		dataset := api.Dataset{

--- a/crates/runtime/src/datasource/dremio.rs
+++ b/crates/runtime/src/datasource/dremio.rs
@@ -21,14 +21,14 @@ impl DataSource for Dremio {
         Self: Sized,
     {
         Box::pin(async move {
-            let url: String = params
+            let endpoint: String = params
                 .as_ref() // &Option<HashMap<String, String>>
                 .as_ref() // Option<&HashMap<String, String>>
-                .and_then(|params| params.get("url").cloned())
+                .and_then(|params| params.get("endpoint").cloned())
                 .ok_or_else(|| super::Error::UnableToCreateDataSource {
-                    source: "Missing required parameter: url".into(),
+                    source: "Missing required parameter: endpoint".into(),
                 })?;
-            let flight = Flight::new(auth_provider, url);
+            let flight = Flight::new(auth_provider, endpoint);
             Ok(Self {
                 flight: flight.await?,
             })

--- a/crates/runtime/src/datasource/flight.rs
+++ b/crates/runtime/src/datasource/flight.rs
@@ -14,14 +14,14 @@ impl Flight {
     #[must_use]
     pub(crate) fn new(
         auth_provider: Box<dyn AuthProvider>,
-        url: String,
+        endpoint: String,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>>>>
     where
         Self: Sized,
     {
         Box::pin(async move {
             let flight_client = FlightClient::new(
-                url.as_str(),
+                endpoint.as_str(),
                 auth_provider.get_username(),
                 auth_provider.get_password(),
             )

--- a/crates/runtime/src/datasource/spiceai.rs
+++ b/crates/runtime/src/datasource/spiceai.rs
@@ -46,14 +46,7 @@ impl DataSource for SpiceAI {
         &self,
         dataset: &Dataset,
     ) -> Pin<Box<dyn Future<Output = Vec<arrow::record_batch::RecordBatch>> + Send>> {
-        let spice_dataset_path = match Self::spice_dataset_path(dataset) {
-            Ok(path) => path,
-            Err(error) => {
-                tracing::error!("Unable to parse SpiceAI dataset path: {:?}", error);
-                return Box::pin(async move { vec![] });
-            }
-        };
-
+        let spice_dataset_path = Self::spice_dataset_path(dataset);
         self.flight.get_all_data(&spice_dataset_path)
     }
 }
@@ -61,28 +54,28 @@ impl DataSource for SpiceAI {
 impl SpiceAI {
     /// Parses a dataset path from a Spice AI dataset definition.
     ///
-    /// Spice AI datasets have two possible formats for `dataset.path()`:
+    /// Spice AI datasets have three possible formats for `dataset.path()`:
     /// 1. `<org>/<app>/datasets/<dataset_name>`.
     /// 2. `<org>/<app>`.
+    /// 3. `some.blessed.dataset`.
     ///
     /// The second format is a shorthand for the first format, where the dataset name
     /// is the same as the local table name specified in `name`.
     ///
+    /// The third format is a path to a "blessed" Spice AI dataset (i.e. a dataset that is
+    /// defined and provided by Spice). If the dataset path does not match the first two formats,
+    /// then it is assumed to be a path to a blessed dataset.
+    ///
     /// This function returns the full dataset path for the given dataset as you would query for it in Spice.
     /// i.e. `<org>.<app>.<dataset_name>`
-    fn spice_dataset_path(dataset: &Dataset) -> Result<String> {
+    fn spice_dataset_path(dataset: &Dataset) -> String {
         let path = dataset.path();
         let path_parts: Vec<&str> = path.split('/').collect();
 
         match path_parts.as_slice() {
-            [org, app] => Ok(format!(
-                "{org}.{app}.{dataset_name}",
-                dataset_name = dataset.name
-            )),
-            [org, app, "datasets", dataset_name] => Ok(format!("{org}.{app}.{dataset_name}")),
-            _ => Err(Error::UnableToParseDatasetPath {
-                dataset_path: path.to_string(),
-            }),
+            [org, app] => format!("{org}.{app}.{dataset_name}", dataset_name = dataset.name),
+            [org, app, "datasets", dataset_name] => format!("{org}.{app}.{dataset_name}"),
+            _ => path,
         }
     }
 }

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -13,7 +13,7 @@ pub trait WithDependsOn<T> {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComponentReference {
-    pub import: String,
+    pub r#ref: String,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "dependsOn", default)]
@@ -57,7 +57,7 @@ where
         .map(|item| match item {
             ComponentOrReference::Component(component) => Ok(component.clone()),
             ComponentOrReference::Reference(reference) => {
-                let component_base_path = base_path.join(&reference.import);
+                let component_base_path = base_path.join(&reference.r#ref);
                 let component_base_path_str = component_base_path
                     .to_str()
                     .ok_or(Error::UnableToConvertPath)?;


### PR DESCRIPTION
Adds support for "blessed" Spice AI dataset (i.e. a dataset that is defined and provided by Spice).

These are specified by using the format `spice.ai/some.blessed.dataset` in the `from` field of a dataset definition.