### PR TITLE
Add support for `spiced --version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ all: build
 .PHONY: build
 build:
 	make -C bin/spice
-	cargo build --release
 
 .PHONY: ci
 ci:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ build:
 
 .PHONY: ci
 ci:
-	make -C bin/spice
-	cargo build --release --target-dir /workspace/spiceai/target
+	export SPICED_TARGET_DIR=/workspace/spiceai/target; make -C bin/spice
 
 .PHONY: lint
 lint:

--- a/bin/spice/Makefile
+++ b/bin/spice/Makefile
@@ -2,6 +2,7 @@ BASE_PACKAGE_NAME := github.com/spiceai/spiceai
 
 ifdef REL_VERSION
 	SPICE_VERSION := $(REL_VERSION)
+	SPICED_FEATURES := --features release
 else
 	SPICE_VERSION := local
 endif
@@ -12,3 +13,4 @@ LDFLAGS:="-X $(BASE_PACKAGE_NAME)/pkg/version.version=$(SPICE_VERSION)"
 all:
 	mkdir -p ../../target/release 2> /dev/null|| true
 	go build -v -ldflags=$(LDFLAGS) -o ../../target/release/spice
+	cargo build --release $(SPICED_FEATURES) --target-dir ../../target

--- a/bin/spice/Makefile
+++ b/bin/spice/Makefile
@@ -7,10 +7,16 @@ else
 	SPICE_VERSION := local
 endif
 
+ifdef SPICED_TARGET_DIR
+	TARGET_DIR := $(SPICED_TARGET_DIR)
+else
+	TARGET_DIR := ../../target
+endif
+
 LDFLAGS:="-X $(BASE_PACKAGE_NAME)/pkg/version.version=$(SPICE_VERSION)"
 
 .PHONY: all
 all:
 	mkdir -p ../../target/release 2> /dev/null|| true
 	go build -v -ldflags=$(LDFLAGS) -o ../../target/release/spice
-	cargo build --release $(SPICED_FEATURES) --target-dir ../../target
+	cargo build --release $(SPICED_FEATURES) --target-dir $(TARGET_DIR)

--- a/bin/spice/pkg/context/metal/metal.go
+++ b/bin/spice/pkg/context/metal/metal.go
@@ -63,7 +63,7 @@ func (c *MetalContext) Init() error {
 
 func (c *MetalContext) Version() (string, error) {
 	spiceCMD := c.binaryFilePath(constants.SpiceRuntimeFilename)
-	version, err := exec.Command(spiceCMD, "version").Output()
+	version, err := exec.Command(spiceCMD, "--version").Output()
 	if err != nil {
 		return "", err
 	}

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -19,3 +19,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus = "0.13.0"
+
+[features]
+release = []

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -51,6 +51,10 @@ pub struct Args {
     #[arg(long, value_name = "BIND_ADDRESS", help_heading = "Metrics")]
     pub metrics: Option<SocketAddr>,
 
+    /// Print the version and exit.
+    #[arg(long)]
+    pub version: bool,
+
     /// All runtime related arguments
     #[clap(flatten)]
     pub runtime: RuntimeConfig,

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -13,6 +13,17 @@ fn main() {
         std::process::exit(1);
     }
 
+    if args.version {
+        let version = if cfg!(feature = "release") {
+            env!("CARGO_PKG_VERSION")
+        } else {
+            "local"
+        };
+
+        println!("{version}");
+        return;
+    }
+
     let tokio_runtime = match Runtime::new() {
         Ok(runtime) => runtime,
         Err(err) => {


### PR DESCRIPTION
`spiced --version` prints the cargo package version if the build is marked for release and prints "local" otherwise to signal to the CLI that upgrade is not necessary.