### PR TITLE
Lower default dataset refresh to 10 seconds

### DIFF
--- a/bin/spice/pkg/cli/cmd/dataset.go
+++ b/bin/spice/pkg/cli/cmd/dataset.go
@@ -66,7 +66,7 @@ spice dataset configure
 			Params: params,
 			Acceleration: &api.Acceleration{
 				Enabled:         accelerateDataset,
-				RefreshInterval: time.Hour,
+				RefreshInterval: time.Second * 10,
 				RefreshMode:     api.REFRESH_MODE_FULL,
 			},
 		}


### PR DESCRIPTION
10 seconds is a better demonstration refresh than 1 hour. We can revisit what the default should be for our first release.