### PR TITLE
Error out if the dataset to subscribe to doesn't exist

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -72,6 +72,11 @@ impl DataFusion {
         self.backends.get(dataset)
     }
 
+    #[must_use]
+    pub fn has_backend(&self, dataset: &str) -> bool {
+        self.backends.contains_key(dataset)
+    }
+
     #[allow(clippy::needless_pass_by_value)]
     pub fn attach(
         &mut self,

--- a/crates/runtime/src/datasource/spiceai.rs
+++ b/crates/runtime/src/datasource/spiceai.rs
@@ -34,12 +34,17 @@ impl DataSource for SpiceAI {
     where
         Self: Sized,
     {
+        let default_flight_url = if cfg!(release) {
+            "https://flight.spiceai.io".to_string()
+        } else {
+            "https://dev-flight.spiceai.io".to_string()
+        };
         Box::pin(async move {
             let url: String = params
                 .as_ref() // &Option<HashMap<String, String>>
                 .as_ref() // Option<&HashMap<String, String>>
                 .and_then(|params| params.get("endpoint").cloned())
-                .unwrap_or_else(|| "https://flight.spiceai.io".to_string());
+                .unwrap_or(default_flight_url);
             let flight = Flight::new(auth_provider, url);
             Ok(Self {
                 flight: flight.await?,

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -314,6 +314,12 @@ impl FlightService for Service {
 
         let data_path = flight_descriptor.path.join(".");
 
+        if !self.datafusion.has_backend(&data_path) {
+            return Err(Status::invalid_argument(format!(
+                r#"Unknown dataset: "{data_path}""#,
+            )));
+        };
+
         let channel_map = Arc::clone(&self.channel_map);
         let channel_map_read = channel_map.read().await;
         let (tx, rx) = if let Some(channel) = channel_map_read.get(&data_path) {


### PR DESCRIPTION
In `DoExchange` we don't check if the dataset the client wants to subscribe to exists - leading to the stream being created, but will never be able to send any data.

Return an error if we don't have any registered datasets matching their subscription request.

Also defaults to the DEV Spice endpoint for non-release builds for the Spice AI datasource.