### PR TITLE
Fix `spice add` to work with new spicepod format

### DIFF
--- a/bin/spice/pkg/cli/cmd/add.go
+++ b/bin/spice/pkg/cli/cmd/add.go
@@ -2,11 +2,15 @@ package cmd
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/spiceai/spiceai/bin/spice/pkg/api"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/registry"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
+	"gopkg.in/yaml.v2"
 )
 
 var addCmd = &cobra.Command{
@@ -21,6 +25,7 @@ spice add samples/LogPruner
 
 		cmd.Printf("Getting Pod %s ...\n", podPath)
 
+		podName := filepath.Base(podPath)
 		r := registry.GetRegistry(podPath)
 		downloadPath, err := r.GetPod(podPath)
 		if err != nil {
@@ -34,6 +39,42 @@ spice add samples/LogPruner
 		}
 
 		relativePath := context.NewContext().GetSpiceAppRelativePath(downloadPath)
+
+		spicepodBytes, err := os.ReadFile("spicepod.yaml")
+		if err != nil {
+			cmd.Println(err)
+			os.Exit(1)
+		}
+
+		var spicePod api.Pod
+		err = yaml.Unmarshal(spicepodBytes, &spicePod)
+		if err != nil {
+			cmd.Println(err)
+			os.Exit(1)
+		}
+
+		var podReferenced bool
+		for _, dependency := range spicePod.Dependencies {
+			if dependency == podName {
+				podReferenced = true
+				break
+			}
+		}
+
+		if !podReferenced {
+			spicePod.Dependencies = append(spicePod.Dependencies, podName)
+			spicepodBytes, err = yaml.Marshal(spicePod)
+			if err != nil {
+				cmd.Println(err)
+				os.Exit(1)
+			}
+
+			err = os.WriteFile("spicepod.yaml", spicepodBytes, 0766)
+			if err != nil {
+				cmd.Println(err)
+				os.Exit(1)
+			}
+		}
 
 		cmd.Printf("Added %s\n", relativePath)
 

--- a/bin/spice/pkg/cli/cmd/version.go
+++ b/bin/spice/pkg/cli/cmd/version.go
@@ -86,7 +86,7 @@ func checkLatestCliReleaseVersion() error {
 	}
 
 	cliVersion := version.Version()
-	if cliVersion != latestReleaseVersion {
+	if cliVersion != "local" && cliVersion != latestReleaseVersion {
 		fmt.Printf("\nCLI version %s is now available!\nTo upgrade, run \"spice upgrade\".\n", aurora.BrightGreen(latestReleaseVersion))
 	}
 

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -21,5 +21,9 @@ type RuntimeContext interface {
 }
 
 func NewContext() RuntimeContext {
-	return metal.NewMetalContext()
+	rtcontext := metal.NewMetalContext()
+	if err := rtcontext.Init(); err != nil {
+		panic(err)
+	}
+	return rtcontext
 }


### PR DESCRIPTION
Fixes `spice add` to work with adding a spicepod in the new spicepod format.

Also fixes the update check to not print a message if the CLI was built locally.

And finally changes the registry to pull from DEV if the CLI was built locally.