### PR TITLE
Integrate device auth with SpiceAI datasource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "rustls-pemfile",
  "snafu 0.8.0",
  "tonic",
+ "tracing",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,17 @@ all: build
 .PHONY: build
 build:
 	make -C bin/spice
+	make -C bin/spiced
+
+.PHONY: build-dev
+build-dev:
+	make -C bin/spice
+	export DEV=true; make -C bin/spiced
 
 .PHONY: ci
 ci:
-	export SPICED_TARGET_DIR=/workspace/spiceai/target; make -C bin/spice
+	make -C bin/spice
+	export SPICED_TARGET_DIR=/workspace/spiceai/target; make -C bin/spiced
 
 .PHONY: lint
 lint:
@@ -37,6 +44,15 @@ docker-run:
 ################################################################################
 .PHONY: install
 install: build
+	mkdir -p ~/.spice/bin
+	install -m 755 target/release/spice ~/.spice/bin/spice
+	install -m 755 target/release/spiced ~/.spice/bin/spiced
+
+################################################################################
+# Target: install-dev                                                          #
+################################################################################
+.PHONY: install-dev
+install-dev: build-dev
 	mkdir -p ~/.spice/bin
 	install -m 755 target/release/spice ~/.spice/bin/spice
 	install -m 755 target/release/spiced ~/.spice/bin/spiced

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 
 .PHONY: build-dev
 build-dev:
-	make -C bin/spice
+	export DEV=true; make -C bin/spice
 	export DEV=true; make -C bin/spiced
 
 .PHONY: ci

--- a/bin/spice/Makefile
+++ b/bin/spice/Makefile
@@ -7,16 +7,9 @@ else
 	SPICE_VERSION := local
 endif
 
-ifdef SPICED_TARGET_DIR
-	TARGET_DIR := $(SPICED_TARGET_DIR)
-else
-	TARGET_DIR := ../../target
-endif
-
 LDFLAGS:="-X $(BASE_PACKAGE_NAME)/pkg/version.version=$(SPICE_VERSION)"
 
 .PHONY: all
 all:
 	mkdir -p ../../target/release 2> /dev/null|| true
 	go build -v -ldflags=$(LDFLAGS) -o ../../target/release/spice
-	cargo build --release $(SPICED_FEATURES) --target-dir $(TARGET_DIR)

--- a/bin/spice/Makefile
+++ b/bin/spice/Makefile
@@ -7,7 +7,11 @@ else
 	SPICE_VERSION := local
 endif
 
-LDFLAGS:="-X $(BASE_PACKAGE_NAME)/pkg/version.version=$(SPICE_VERSION)"
+ifdef DEV
+	SPICE_VERSION := local-dev
+endif
+
+LDFLAGS:="-X $(BASE_PACKAGE_NAME)/bin/spice/pkg/version.version=$(SPICE_VERSION)"
 
 .PHONY: all
 all:

--- a/bin/spice/pkg/api/spice_api_client.go
+++ b/bin/spice/pkg/api/spice_api_client.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/spiceai/spiceai/bin/spice/pkg/version"
 )
 
 type SpiceUser struct {
@@ -41,7 +43,11 @@ func NewSpiceApiClient() *SpiceApiClient {
 }
 
 func (s *SpiceApiClient) Init() error {
-	s.baseUrl = "https://spice.ai"
+	if version.Version() == "local-dev" {
+		s.baseUrl = "https://dev.spice.xyz"
+	} else {
+		s.baseUrl = "https://spice.ai"
+	}
 
 	if os.Getenv("SPICE_BASE_URL") != "" {
 		s.baseUrl = os.Getenv("SPICE_BASE_URL")

--- a/bin/spice/pkg/cli/cmd/version.go
+++ b/bin/spice/pkg/cli/cmd/version.go
@@ -86,7 +86,7 @@ func checkLatestCliReleaseVersion() error {
 	}
 
 	cliVersion := version.Version()
-	if cliVersion != "local" && cliVersion != latestReleaseVersion {
+	if !strings.HasPrefix(cliVersion, "local") && cliVersion != latestReleaseVersion {
 		fmt.Printf("\nCLI version %s is now available!\nTo upgrade, run \"spice upgrade\".\n", aurora.BrightGreen(latestReleaseVersion))
 	}
 

--- a/bin/spice/pkg/registry/spicerack.go
+++ b/bin/spice/pkg/registry/spicerack.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	spice_http "github.com/spiceai/spiceai/bin/spice/pkg/http"
+	"github.com/spiceai/spiceai/bin/spice/pkg/version"
 
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/loggers"
@@ -24,9 +25,7 @@ var (
 type SpiceRackRegistry struct{}
 
 func getSpiceRackBaseUrl() string {
-	rtcontext := context.NewContext()
-	version, _ := rtcontext.Version()
-	if version == "local" {
+	if version.Version() == "local-dev" {
 		return "https://dev-data.spiceai.io/v0.1"
 	} else {
 		return "https://api.spicerack.org/v0.1"

--- a/bin/spice/pkg/version/version.go
+++ b/bin/spice/pkg/version/version.go
@@ -1,6 +1,9 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 var (
 	// Values for these are injected by the build.
@@ -8,9 +11,9 @@ var (
 )
 
 // Version returns the Spice version. This is either a semantic version
-// number or else, in the case of unreleased code, the string "local".
+// number or else, in the case of unreleased code, the string prefix "local".
 func Version() string {
-	if version == "local" {
+	if strings.HasPrefix(version, "local") {
 		return version
 	}
 

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -22,4 +22,4 @@ metrics-exporter-prometheus = "0.13.0"
 
 [features]
 release = []
-dev = []
+dev = ["runtime/dev"]

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -22,3 +22,4 @@ metrics-exporter-prometheus = "0.13.0"
 
 [features]
 release = []
+dev = []

--- a/bin/spiced/Makefile
+++ b/bin/spiced/Makefile
@@ -1,0 +1,17 @@
+ifdef REL_VERSION
+	SPICED_FEATURES := --features release
+endif
+
+ifdef DEV
+	SPICED_FEATURES := --features dev
+endif
+
+ifdef SPICED_TARGET_DIR
+	TARGET_DIR := $(SPICED_TARGET_DIR)
+else
+	TARGET_DIR := ../../target
+endif
+
+.PHONY: all
+all:
+	cargo build --release $(SPICED_FEATURES) --target-dir $(TARGET_DIR)

--- a/crates/flight_client/Cargo.toml
+++ b/crates/flight_client/Cargo.toml
@@ -24,3 +24,4 @@ tonic = { version = "0.10.2", default-features = false, features = [
   "tls",
   "tls-roots",
 ] }
+tracing.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -31,3 +31,6 @@ dirs = "5.0.1"
 toml = "0.8.8"
 serde.workspace = true
 flight_client = { version = "0.10.0-alpha.0", path = "../flight_client" }
+
+[features]
+dev = []

--- a/crates/runtime/src/datasource/flight.rs
+++ b/crates/runtime/src/datasource/flight.rs
@@ -1,7 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::auth::AuthProvider;
 use arrow::record_batch::RecordBatch;
 use flight_client::FlightClient;
 use futures::StreamExt;
@@ -12,25 +11,13 @@ pub struct Flight {
 
 impl Flight {
     #[must_use]
-    pub(crate) fn new(
-        auth_provider: AuthProvider,
-        endpoint: String,
-    ) -> Pin<Box<dyn Future<Output = super::Result<Self>>>>
+    pub(crate) fn new(flight_client: FlightClient) -> Self
     where
         Self: Sized,
     {
-        Box::pin(async move {
-            let flight_client = FlightClient::new(
-                endpoint.as_str(),
-                auth_provider.get_param("username").unwrap_or_default(),
-                auth_provider.get_param("password").unwrap_or_default(),
-            )
-            .await
-            .map_err(|e| super::Error::UnableToCreateDataSource { source: e.into() })?;
-            Ok(Flight {
-                client: flight_client,
-            })
-        })
+        Flight {
+            client: flight_client,
+        }
     }
 
     pub(crate) fn get_all_data(

--- a/crates/runtime/src/datasource/spiceai.rs
+++ b/crates/runtime/src/datasource/spiceai.rs
@@ -35,7 +35,7 @@ impl DataSource for SpiceAI {
     where
         Self: Sized,
     {
-        let default_flight_url = if cfg!(dev) {
+        let default_flight_url = if cfg!(feature = "dev") {
             "https://dev-flight.spiceai.io".to_string()
         } else {
             "https://flight.spiceai.io".to_string()


### PR DESCRIPTION
Fixes the SpiceAI DataSource to integrate with the Spice AI device auth flow.

Refactors the Makefiles to separate the CLI and runtime targets.

Adds a new `make install-dev` that will install a local version of the runtime configured to talk to DEV.