### PR TITLE
add model parser

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -7,7 +7,8 @@ use app::App;
 use clap::Parser;
 use runtime::config::Config as RuntimeConfig;
 use runtime::datasource::DataSource;
-use runtime::{databackend, datasource, Runtime};
+use runtime::modelformat::ModelFormat;
+use runtime::{databackend, datasource, modelformat, Runtime};
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -7,8 +7,8 @@ use app::App;
 use clap::Parser;
 use runtime::config::Config as RuntimeConfig;
 use runtime::datasource::DataSource;
-use runtime::modelformat::ModelFormat;
-use runtime::{databackend, datasource, modelformat, Runtime};
+
+use runtime::{databackend, datasource, Runtime};
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -3,13 +3,15 @@
 use std::path::PathBuf;
 
 use snafu::prelude::*;
-use spicepod::{component::dataset::Dataset, Spicepod};
+use spicepod::{component::dataset::Dataset, component::model::Model, Spicepod};
 
 #[derive(Debug)]
 pub struct App {
     pub name: String,
 
     pub datasets: Vec<Dataset>,
+
+    pub models: Vec<Model>,
 
     pub spicepods: Vec<Spicepod>,
 }
@@ -32,8 +34,13 @@ impl App {
         let spicepod_root =
             Spicepod::load(&path).context(UnableToLoadSpicepodSnafu { path: path.clone() })?;
         let mut datasets: Vec<Dataset> = vec![];
+        let mut models: Vec<Model> = vec![];
         for dataset in &spicepod_root.datasets {
             datasets.push(dataset.clone());
+        }
+
+        for model in &spicepod_root.models {
+            models.push(model.clone());
         }
 
         let root_spicepod_name = spicepod_root.name.clone();
@@ -56,6 +63,7 @@ impl App {
         Ok(App {
             name: root_spicepod_name,
             datasets,
+            models,
             spicepods,
         })
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -12,11 +12,11 @@ pub mod auth;
 pub mod config;
 pub mod databackend;
 pub mod datafusion;
-pub mod modelformat;
 pub mod datasource;
 pub mod dataupdate;
 mod flight;
 mod http;
+pub mod modelformat;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -12,6 +12,7 @@ pub mod auth;
 pub mod config;
 pub mod databackend;
 pub mod datafusion;
+pub mod modelformat;
 pub mod datasource;
 pub mod dataupdate;
 mod flight;

--- a/crates/runtime/src/modelformat.rs
+++ b/crates/runtime/src/modelformat.rs
@@ -1,0 +1,5 @@
+pub mod onnx;
+
+pub trait ModelFormat {
+    fn from_bytes(bytes: &[u8]) -> Self;
+}

--- a/crates/runtime/src/modelformat/onnx.rs
+++ b/crates/runtime/src/modelformat/onnx.rs
@@ -1,0 +1,2 @@
+pub struct Onnx {
+}

--- a/crates/runtime/src/modelformat/onnx.rs
+++ b/crates/runtime/src/modelformat/onnx.rs
@@ -1,2 +1,1 @@
-pub struct Onnx {
-}
+pub struct Onnx {}

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -6,6 +6,7 @@ use snafu::prelude::*;
 
 use crate::reader;
 pub mod dataset;
+pub mod model;
 
 pub trait WithDependsOn<T> {
     fn depends_on(&self, depends_on: &[String]) -> T;

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -17,7 +17,7 @@ pub struct ComponentReference {
     pub r#ref: String,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(rename = "dependsOn", default)]
+    #[serde(rename = "dependsOn", alias = "datasets", default)]
     pub depends_on: Vec<String>,
 }
 

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use super::WithDependsOn;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {
@@ -10,7 +10,6 @@ pub struct Model {
     #[serde(rename = "datasets", default)]
     pub datasets: Vec<String>,
 }
-
 
 impl WithDependsOn<Model> for Model {
     fn depends_on(&self, depends_on: &[String]) -> Model {

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+use super::WithDependsOn;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Model {
+    pub from: String,
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(rename = "datasets", default)]
+    pub datasets: Vec<String>,
+}
+
+
+impl WithDependsOn<Model> for Model {
+    fn depends_on(&self, depends_on: &[String]) -> Model {
+        Model {
+            from: self.from.clone(),
+            name: self.name.clone(),
+            datasets: depends_on.to_vec(),
+        }
+    }
+}

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -73,12 +73,20 @@ impl Spicepod {
         )
         .context(UnableToResolveSpicepodComponentsSnafu { path: path.clone() })?;
 
-        Ok(from_definition(spicepod_definition, resolved_datasets, resolved_models))
+        Ok(from_definition(
+            spicepod_definition,
+            resolved_datasets,
+            resolved_models,
+        ))
     }
 }
 
 #[must_use]
-fn from_definition(spicepod_definition: SpicepodDefinition, datasets: Vec<Dataset>, models: Vec<Model>) -> Spicepod {
+fn from_definition(
+    spicepod_definition: SpicepodDefinition,
+    datasets: Vec<Dataset>,
+    models: Vec<Model>,
+) -> Spicepod {
     Spicepod {
         name: spicepod_definition.name,
         datasets,

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -5,6 +5,7 @@ use snafu::prelude::*;
 use std::{fmt::Debug, path::PathBuf};
 
 use component::dataset::Dataset;
+use component::model::Model;
 use spec::SpicepodDefinition;
 
 pub mod component;
@@ -31,6 +32,8 @@ pub struct Spicepod {
     pub name: String,
 
     pub datasets: Vec<Dataset>,
+
+    pub models: Vec<Model>,
 
     pub dependencies: Vec<String>,
 }
@@ -62,15 +65,24 @@ impl Spicepod {
         )
         .context(UnableToResolveSpicepodComponentsSnafu { path: path.clone() })?;
 
-        Ok(from_definition(spicepod_definition, resolved_datasets))
+        let resolved_models = component::resolve_component_references(
+            fs,
+            &path,
+            &spicepod_definition.models,
+            "model",
+        )
+        .context(UnableToResolveSpicepodComponentsSnafu { path: path.clone() })?;
+
+        Ok(from_definition(spicepod_definition, resolved_datasets, resolved_models))
     }
 }
 
 #[must_use]
-fn from_definition(spicepod_definition: SpicepodDefinition, datasets: Vec<Dataset>) -> Spicepod {
+fn from_definition(spicepod_definition: SpicepodDefinition, datasets: Vec<Dataset>, models: Vec<Model>) -> Spicepod {
     Spicepod {
         name: spicepod_definition.name,
         datasets,
+        models,
         dependencies: spicepod_definition.dependencies,
     }
 }

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::{self, Value};
 use std::{collections::HashMap, fmt::Debug};
 
-use crate::component::{dataset::Dataset, ComponentOrReference};
+use crate::component::{dataset::Dataset, model::Model, ComponentOrReference};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -25,6 +25,10 @@ pub struct SpicepodDefinition {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
     pub datasets: Vec<ComponentOrReference<Dataset>>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub models: Vec<ComponentOrReference<Model>>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]


### PR DESCRIPTION
This adds a serde parse function to parse `models`.

Which can be:
```yaml
models:
- from: spice.ai/xyz/model-a
  name: model-a
  datasets:
    - eth_blocks
```
