### PR TITLE
Flight REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "flightrepl"
+version = "0.10.0-alpha.0"
+dependencies = [
+ "arrow",
+ "arrow-flight",
+ "async-stream",
+ "clap",
+ "datafusion",
+ "futures",
+ "parquet",
+ "tokio",
+ "tonic 0.10.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "flightsubscriber"
 version = "0.10.0-alpha.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "clipboard-win"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec832972fefb8cf9313b45a0d1945e29c9c251f1d4c6eafc5fe2124c02d2e81"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1278,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1298,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
 
 [[package]]
 name = "fallible-iterator"
@@ -1301,6 +1322,17 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "filetime"
@@ -1381,6 +1413,7 @@ dependencies = [
  "datafusion",
  "futures",
  "parquet",
+ "rustyline",
  "tokio",
  "tonic 0.10.2",
  "tracing",
@@ -1679,6 +1712,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -2223,6 +2265,26 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2802,6 +2864,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,6 +3153,28 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rustyline"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "bin/spiced/",
     "bin/flightpublisher/",
     "bin/flightsubscriber/",
+    "bin/flightrepl/",
     "crates/flight_client",
     "crates/spicepod",
     "crates/app",

--- a/bin/flightrepl/Cargo.toml
+++ b/bin/flightrepl/Cargo.toml
@@ -24,3 +24,4 @@ futures = "0.3.30"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 datafusion = "34.0.0"
+rustyline = "13.0.0"

--- a/bin/flightrepl/Cargo.toml
+++ b/bin/flightrepl/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "flightrepl"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Spice OSS Flight Query Repl"
+
+[dependencies]
+arrow = "49.0.0"
+arrow-flight = "49.0.0"
+parquet = "49.0.0"
+clap.workspace = true
+tokio.workspace = true
+tonic = { version = "0.10.0", default-features = false, features = [
+  "transport",
+  "tls",
+  "tls-roots",
+] }
+async-stream = "0.3.5"
+futures = "0.3.30"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+datafusion = "34.0.0"

--- a/bin/flightrepl/src/main.rs
+++ b/bin/flightrepl/src/main.rs
@@ -43,8 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         print!("query> ");
         let _ = io::stdout().flush();
         let mut line = String::new();
-        let stdin = std::io::stdin();
-        let _ = stdin.read_line(&mut line);
+        let _ = io::stdin().read_line(&mut line);
 
         let line = line.trim();
         if line.is_empty() {

--- a/bin/flightrepl/src/main.rs
+++ b/bin/flightrepl/src/main.rs
@@ -1,0 +1,127 @@
+use std::io;
+use std::io::Write;
+use std::sync::Arc;
+
+use arrow_flight::{
+    decode::FlightRecordBatchStream, error::FlightError,
+    flight_service_client::FlightServiceClient, FlightDescriptor,
+};
+use clap::Parser;
+use datafusion::dataframe::DataFrame;
+use datafusion::datasource::{provider_as_source, MemTable};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
+use futures::{StreamExt, TryStreamExt};
+use tonic::transport::Channel;
+use tonic::IntoRequest;
+use tracing_subscriber::filter::Directive;
+
+#[derive(Parser)]
+#[clap(about = "Spice.ai Flight Query Utility")]
+pub struct Args {
+    #[arg(
+        long,
+        value_name = "FLIGHT_ENDPOINT",
+        default_value = "http://localhost:50051"
+    )]
+    pub flight_endpoint: String,
+}
+
+/// Reads a Parquet file and sends it via DoPut to an Apache Arrow Flight endpoint.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = init_tracing();
+    let args = Args::parse();
+
+    // Set up the Flight client
+    let channel = Channel::from_shared(args.flight_endpoint)?
+        .connect()
+        .await?;
+    let mut client = FlightServiceClient::new(channel);
+
+    loop {
+        print!("query> ");
+        let _ = io::stdout().flush();
+        let mut line = String::new();
+        let stdin = std::io::stdin();
+        let _ = stdin.read_line(&mut line);
+
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match line {
+            ".exit" | "exit" | "quit" | "q" => break,
+            "help" => {
+                println!("Available commands:\n");
+                println!(".exit, exit, quit, q: Exit the REPL");
+                println!("help: Show this help message");
+                println!("\nAny other line will be interpreted as a SQL query");
+                continue;
+            }
+            _ => {}
+        }
+
+        let request = FlightDescriptor::new_cmd(line.to_string());
+
+        let mut flight_info = client.get_flight_info(request).await?.into_inner();
+        let Some(endpoint) = flight_info.endpoint.pop() else {
+            println!("No endpoint");
+            continue;
+        };
+        let Some(ticket) = endpoint.ticket else {
+            println!("No ticket");
+            continue;
+        };
+        let request = ticket.into_request();
+
+        let stream = match client.do_get(request).await {
+            Ok(stream) => stream.into_inner(),
+            Err(e) => {
+                println!("{e}");
+                continue;
+            }
+        };
+        let mut stream =
+            FlightRecordBatchStream::new_from_flight_data(stream.map_err(FlightError::Tonic));
+        let mut records = vec![];
+        while let Some(data) = stream.next().await {
+            let data = data?;
+            records.push(data);
+        }
+        if records.is_empty() {
+            println!("No data returned for query");
+            continue;
+        }
+        let schema = records[0].schema();
+
+        let ctx = SessionContext::new();
+        let provider = MemTable::try_new(schema, vec![records])?;
+        let df = DataFrame::new(
+            ctx.state(),
+            LogicalPlanBuilder::scan(UNNAMED_TABLE, provider_as_source(Arc::new(provider)), None)?
+                .build()?,
+        );
+
+        if let Err(e) = df.show().await {
+            println!("Error displaying results: {e}");
+        };
+    }
+
+    Ok(())
+}
+
+fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
+    let filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive("flightrepl".parse::<Directive>()?)
+        .with_env_var("REPL_LOG")
+        .from_env_lossy();
+
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(filter)
+        .with_ansi(true)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    Ok(())
+}

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -6,6 +6,7 @@ use crate::databackend::{self, DataBackend};
 use crate::datasource::DataSource;
 use datafusion::datasource::ViewTable;
 use datafusion::error::DataFusionError;
+use datafusion::execution::context::SessionConfig;
 use datafusion::execution::{context::SessionContext, options::ParquetReadOptions};
 use datafusion::sql::parser;
 use datafusion::sql::parser::DFParser;
@@ -67,7 +68,9 @@ impl DataFusion {
     #[must_use]
     pub fn new() -> Self {
         DataFusion {
-            ctx: Arc::new(SessionContext::new()),
+            ctx: Arc::new(SessionContext::new_with_config(
+                SessionConfig::new().with_information_schema(true),
+            )),
             tasks: Vec::new(),
             backends: HashMap::new(),
         }


### PR DESCRIPTION
A small CLI REPL that makes it easy to test SQL queries against the runtime's Flight endpoint.

```bash
query> show tables
+---------------+--------------------+-------------------+------------+
| table_catalog | table_schema       | table_name        | table_type |
+---------------+--------------------+-------------------+------------+
| datafusion    | public             | eth_recent_blocks | BASE TABLE |
| datafusion    | information_schema | tables            | VIEW       |
| datafusion    | information_schema | views             | VIEW       |
| datafusion    | information_schema | columns           | VIEW       |
| datafusion    | information_schema | df_settings       | VIEW       |
+---------------+--------------------+-------------------+------------+
query> help
Available commands:

.exit, exit, quit, q: Exit the REPL
help: Show this help message

Any other line will be interpreted as a SQL query
```