### PR TITLE
Write metrics received from the OpenTelemetry endpoint to databackends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,6 +3046,7 @@ dependencies = [
  "flight_client",
  "futures",
  "futures-core",
+ "indexmap 2.2.2",
  "metrics",
  "opentelemetry-proto",
  "r2d2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "lexical-core",
  "num",
  "serde",
@@ -1027,7 +1027,7 @@ dependencies = [
  "glob",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itertools 0.12.0",
  "log",
  "num_cpus",
@@ -1142,7 +1142,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.3",
  "hex",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itertools 0.12.0",
  "log",
  "md-5",
@@ -1175,7 +1175,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itertools 0.12.0",
  "log",
  "once_cell",
@@ -1621,7 +1621,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1640,7 +1640,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.0.0",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1927,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2472,7 +2472,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -2624,7 +2624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
 ]
 
 [[package]]
@@ -3334,7 +3334,7 @@ version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itoa",
  "ryu",
  "serde",
@@ -3803,7 +3803,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -36,6 +36,7 @@ duckdb = { git = "https://github.com/spicehq/duckdb-rs.git", rev = "8b57b1496eed
 duckdb_datafusion = { path = "../duckdb_datafusion", optional = true }
 r2d2 = { version = "0.8.10", optional = true }
 opentelemetry-proto = { version = "0.4.0", features = ["gen-tonic-messages", "gen-tonic", "metrics"] }
+indexmap = "2.2.2"
 
 [features]
 default = ["duckdb"]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -53,7 +53,7 @@ impl Runtime {
         let http_server_future = http::start(self.config.http_bind_address, self.app.clone());
         let flight_server_future = flight::start(self.config.flight_bind_address, self.df.clone());
         let open_telemetry_server_future =
-            opentelemetry::start(self.config.open_telemetry_bind_address);
+            opentelemetry::start(self.config.open_telemetry_bind_address, self.df.clone());
 
         tokio::select! {
             http_res = http_server_future => http_res.context(UnableToStartHttpServerSnafu),

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -331,7 +331,7 @@ fn attributes_to_fields_and_columns(
                                 metric
                             );
                         }
-                        // TODO: Support other attribute types
+                        // TODO: Support List and Map attribute types
                         _ => {
                             tracing::error!(
                                 "Unsupported metric attribute type for {metric}.{:?}",

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -222,8 +222,12 @@ fn number_data_points_to_record_batch(
 
     let (attribute_fields_map, attribute_columns_map) =
         attributes_to_fields_and_columns(metric, attributes);
-    let attribute_fields: Vec<Field> = attribute_fields_map.into_iter().map(|(_, v)| v).collect();
-    fields.extend(attribute_fields);
+    fields.extend(
+        attribute_fields_map
+            .into_iter()
+            .map(|(_, v)| v)
+            .collect::<Vec<Field>>(),
+    );
     columns.extend(
         attribute_columns_map
             .into_iter()

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -233,7 +233,7 @@ fn number_data_points_to_record_batch(
     }
 }
 
-macro_rules! handle_attribute {
+macro_rules! insert_attribute {
     ($columns:expr, $fields:expr, $key:expr, $value:expr, $builder_type:ty, $data_type:expr, $metric:expr) => {{
         let key_str = $key.as_str();
         match $columns.get_mut(key_str) {
@@ -275,7 +275,7 @@ fn attributes_to_fields_and_columns(
                 Some(any_value) => match &any_value.value {
                     Some(value) => match value {
                         any_value::Value::StringValue(string_value) => {
-                            handle_attribute!(
+                            insert_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,
@@ -286,7 +286,7 @@ fn attributes_to_fields_and_columns(
                             );
                         }
                         any_value::Value::BoolValue(bool_value) => {
-                            handle_attribute!(
+                            insert_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,
@@ -297,7 +297,7 @@ fn attributes_to_fields_and_columns(
                             );
                         }
                         any_value::Value::IntValue(int_value) => {
-                            handle_attribute!(
+                            insert_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,
@@ -308,7 +308,7 @@ fn attributes_to_fields_and_columns(
                             );
                         }
                         any_value::Value::DoubleValue(double_value) => {
-                            handle_attribute!(
+                            insert_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,
@@ -319,7 +319,7 @@ fn attributes_to_fields_and_columns(
                             );
                         }
                         any_value::Value::BytesValue(bytes_value) => {
-                            handle_attribute!(
+                            insert_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -352,55 +352,28 @@ fn attributes_to_fields_and_columns(
     (fields, columns)
 }
 
+macro_rules! append_null {
+    ($columns:expr, $key:expr, $builder_type:ty) => {
+        if let Some(column) = $columns.get_mut($key) {
+            if let Some(builder) = column.as_any_mut().downcast_mut::<$builder_type>() {
+                builder.append_null();
+            }
+        }
+    };
+}
+
 fn append_null(
     fields: &mut IndexMap<String, Field>,
     columns: &mut IndexMap<String, Box<dyn ArrayBuilder>>,
     key: &str,
 ) {
-    if let Some(field) = fields.get_mut(key) {
+    if let Some(field) = fields.get(key) {
         match field.data_type() {
-            DataType::Utf8 => {
-                if let Some(column) = columns.get_mut(key) {
-                    if let Some(string_builder) =
-                        column.as_any_mut().downcast_mut::<StringBuilder>()
-                    {
-                        string_builder.append_null();
-                    }
-                }
-            }
-            DataType::Boolean => {
-                if let Some(column) = columns.get_mut(key) {
-                    if let Some(bool_builder) = column.as_any_mut().downcast_mut::<BooleanBuilder>()
-                    {
-                        bool_builder.append_null();
-                    }
-                }
-            }
-            DataType::Int64 => {
-                if let Some(column) = columns.get_mut(key) {
-                    if let Some(int_builder) = column.as_any_mut().downcast_mut::<Int64Builder>() {
-                        int_builder.append_null();
-                    }
-                }
-            }
-            DataType::Float64 => {
-                if let Some(column) = columns.get_mut(key) {
-                    if let Some(double_builder) =
-                        column.as_any_mut().downcast_mut::<Float64Builder>()
-                    {
-                        double_builder.append_null();
-                    }
-                }
-            }
-            DataType::Binary => {
-                if let Some(column) = columns.get_mut(key) {
-                    if let Some(binary_builder) =
-                        column.as_any_mut().downcast_mut::<BinaryBuilder>()
-                    {
-                        binary_builder.append_null();
-                    }
-                }
-            }
+            DataType::Utf8 => append_null!(columns, key, StringBuilder),
+            DataType::Boolean => append_null!(columns, key, BooleanBuilder),
+            DataType::Int64 => append_null!(columns, key, Int64Builder),
+            DataType::Float64 => append_null!(columns, key, Float64Builder),
+            DataType::Binary => append_null!(columns, key, BinaryBuilder),
             _ => {}
         }
     }

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -233,7 +233,7 @@ fn number_data_points_to_record_batch(
     }
 }
 
-macro_rules! insert_attribute {
+macro_rules! append_attribute {
     ($columns:expr, $fields:expr, $key:expr, $value:expr, $builder_type:ty, $data_type:expr, $metric:expr) => {{
         let key_str = $key.as_str();
         match $columns.get_mut(key_str) {
@@ -275,7 +275,7 @@ fn attributes_to_fields_and_columns(
                 Some(any_value) => match &any_value.value {
                     Some(value) => match value {
                         any_value::Value::StringValue(string_value) => {
-                            insert_attribute!(
+                            append_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,
@@ -286,7 +286,7 @@ fn attributes_to_fields_and_columns(
                             );
                         }
                         any_value::Value::BoolValue(bool_value) => {
-                            insert_attribute!(
+                            append_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,
@@ -297,7 +297,7 @@ fn attributes_to_fields_and_columns(
                             );
                         }
                         any_value::Value::IntValue(int_value) => {
-                            insert_attribute!(
+                            append_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,
@@ -308,7 +308,7 @@ fn attributes_to_fields_and_columns(
                             );
                         }
                         any_value::Value::DoubleValue(double_value) => {
-                            insert_attribute!(
+                            append_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,
@@ -319,7 +319,7 @@ fn attributes_to_fields_and_columns(
                             );
                         }
                         any_value::Value::BytesValue(bytes_value) => {
-                            insert_attribute!(
+                            append_attribute!(
                                 columns,
                                 fields,
                                 attribute.key,

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -1,17 +1,30 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
+use arrow::array::Float64Array;
+use arrow::datatypes::DataType;
+use arrow::datatypes::Field;
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
 use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::MetricsService;
 use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::MetricsServiceServer;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsPartialSuccess;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceResponse;
+use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value;
+use opentelemetry_proto::tonic::metrics::v1::NumberDataPoint;
 use snafu::prelude::*;
-use tonic::async_trait;
+use tonic_0_9_0::async_trait;
 use tonic_0_9_0::codec::CompressionEncoding;
 use tonic_0_9_0::transport::Server;
 use tonic_0_9_0::Request;
 use tonic_0_9_0::Response;
 use tonic_0_9_0::Status;
+
+use crate::datafusion::DataFusion;
+use crate::dataupdate::DataUpdate;
+use crate::dataupdate::UpdateType;
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -21,9 +34,17 @@ pub enum Error {
     UnableToServe {
         source: tonic_0_9_0::transport::Error,
     },
+
+    #[snafu(display("Failed to build record batch"))]
+    FailedToBuildRecordBatch { source: arrow::error::ArrowError },
+
+    #[snafu(display("Unsupported metric data type"))]
+    UnsupportedMetricDataType {},
 }
 
-pub struct Service;
+pub struct Service {
+    data_fusion: Arc<DataFusion>,
+}
 
 #[async_trait]
 impl MetricsService for Service {
@@ -33,25 +54,52 @@ impl MetricsService for Service {
     ) -> std::result::Result<Response<ExportMetricsServiceResponse>, Status> {
         let mut rejected_data_points = 0;
         let mut total_data_points = 0;
+        let mut results = Vec::new();
         for resource_metric in request.into_inner().resource_metrics {
             for scope_metric in resource_metric.scope_metrics {
                 for metric in scope_metric.metrics {
-                    total_data_points += 1;
-                    tracing::debug!("Metric: {:?}", metric.name);
-                    match metric.data {
-                        Some(data) => {
-                            // TODO: Check if localhost table exists and write to Databackend
-                            tracing::debug!("Data: {:?}", data);
-                        }
-                        None => {
-                            rejected_data_points += 1;
+                    if let Some(data) = metric.data {
+                        let (record_batch_result, accepted_points, rejected_points) =
+                            metric_data_to_record_batch(&data);
+                        total_data_points += accepted_points + rejected_points;
+                        rejected_data_points += rejected_points;
+
+                        let Some(backend) = self.data_fusion.get_backend(metric.name.as_str())
+                        else {
+                            tracing::warn!("No backend found for metric {}", metric.name);
+                            rejected_data_points += accepted_points;
+                            continue;
+                        };
+
+                        if let Ok(record_batch) = record_batch_result {
+                            tracing::info!("Original {} {:?}", metric.name, data);
+                            tracing::info!(
+                                "Adding data to backend {} {:?}",
+                                metric.name,
+                                record_batch
+                            );
+                            results.push((
+                                backend.add_data(DataUpdate {
+                                    log_sequence_number: None,
+                                    data: vec![record_batch],
+                                    update_type: UpdateType::Append,
+                                }),
+                                accepted_points,
+                            ));
                         }
                     }
                 }
             }
         }
 
-        if rejected_data_points == total_data_points {
+        for (result, accepted_points) in results {
+            if let Err(e) = result.await {
+                rejected_data_points += accepted_points;
+                tracing::error!("Failed to add OpenTelemetry data to backend: {}", e);
+            }
+        }
+
+        if rejected_data_points >= total_data_points {
             return Err(Status::invalid_argument("All data points were rejected"));
         }
 
@@ -69,8 +117,60 @@ impl MetricsService for Service {
     }
 }
 
-pub async fn start(bind_address: SocketAddr) -> Result<()> {
-    let service = Service;
+pub fn metric_data_to_record_batch(data: &Data) -> (Result<RecordBatch>, i64, i64) {
+    match data {
+        Data::Gauge(gauge) => number_data_points_to_record_batch(&gauge.data_points),
+        Data::Sum(sum) => number_data_points_to_record_batch(&sum.data_points),
+        // Data::Histogram(histogram) => histogram.data_points,
+        // Data::ExponentialHistogram(exponential_histogram) => exponential_histogram.data_points,
+        // Data::Summary(summary) => summary.data_points,
+        _ => (UnsupportedMetricDataTypeSnafu.fail(), 0, 0),
+    }
+}
+
+fn number_data_points_to_record_batch(
+    data_points: &Vec<NumberDataPoint>,
+) -> (Result<RecordBatch>, i64, i64) {
+    let mut accepted_data_points = 0;
+    let mut rejected_data_points = 0;
+
+    let mut values = Vec::new();
+    for data_point in data_points {
+        if let Some(value) = &data_point.value {
+            accepted_data_points += 1;
+            match value {
+                Value::AsDouble(double_value) => {
+                    values.push(*double_value);
+                }
+                Value::AsInt(int_value) => {
+                    values.push(*int_value as f64);
+                }
+            }
+        } else {
+            rejected_data_points += 1;
+            continue;
+        }
+    }
+
+    match RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Float64,
+            false,
+        )])),
+        vec![Arc::new(Float64Array::from(values))],
+    ) {
+        Ok(record_batch) => (Ok(record_batch), accepted_data_points, rejected_data_points),
+        Err(e) => (
+            Err(e).context(FailedToBuildRecordBatchSnafu),
+            0,
+            accepted_data_points + rejected_data_points,
+        ),
+    }
+}
+
+pub async fn start(bind_address: SocketAddr, data_fusion: Arc<DataFusion>) -> Result<()> {
+    let service = Service { data_fusion };
     let svc = MetricsServiceServer::new(service).accept_compressed(CompressionEncoding::Gzip);
 
     tracing::info!("Spice Runtime OpenTelemetry listening on {bind_address}");

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -261,7 +261,6 @@ macro_rules! append_attribute {
     }};
 }
 
-#[allow(clippy::too_many_lines)]
 fn attributes_to_fields_and_columns(
     metric: &str,
     attributes: Vec<&Vec<KeyValue>>,


### PR DESCRIPTION
This PR finishes implementing the OpenTelemetry API to convert received metrics to arrow and write them to datafusion tables.

There is a limitation currently that columns are always written in the order that attributes are received from OpenTelemetry. This order is no consistent so column values are written out of order to datafusion. This PR is already extremely dense so I will fix this in a follow up PR as it is non-trivial.