### PR TITLE
Pods watcher initialization and file system watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fundu"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +1954,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,6 +2034,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2245,6 +2303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.48.0",
 ]
@@ -2285,6 +2344,25 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3047,6 +3125,7 @@ dependencies = [
  "futures",
  "futures-core",
  "metrics",
+ "notify",
  "opentelemetry-proto",
  "r2d2",
  "serde",

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use app::App;
@@ -74,7 +75,7 @@ pub struct Args {
 
 pub async fn run(args: Args) -> Result<()> {
 
-    let current_dir = env::current_dir().unwrap();
+    let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
 
     let app = App::new(current_dir.clone()).context(UnableToConstructSpiceAppSnafu)?;
 
@@ -154,7 +155,7 @@ pub async fn run(args: Args) -> Result<()> {
 
     let pods_watcher = PodsWatcher::new(current_dir.clone());
 
-    let rt: Runtime = Runtime::new(args.runtime, app, df, pods_watcher);
+    let mut rt: Runtime = Runtime::new(args.runtime, app, df, pods_watcher);
 
     rt.start_pods_watcher()
         .context(UnableToInitializePodsWatcherSnafu)?;

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -74,7 +74,6 @@ pub struct Args {
 }
 
 pub async fn run(args: Args) -> Result<()> {
-
     let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
 
     let app = App::new(current_dir.clone()).context(UnableToConstructSpiceAppSnafu)?;

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 
-use std::env;
 use std::collections::HashMap;
+use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -36,6 +36,7 @@ duckdb = { git = "https://github.com/spicehq/duckdb-rs.git", rev = "8b57b1496eed
 duckdb_datafusion = { path = "../duckdb_datafusion", optional = true }
 r2d2 = { version = "0.8.10", optional = true }
 opentelemetry-proto = { version = "0.4.0", features = ["gen-tonic-messages", "gen-tonic", "metrics"] }
+notify = "6.1.1"
 
 [features]
 default = ["duckdb"]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -88,8 +88,8 @@ impl Runtime {
         let handle_event = move |event: podswatcher::PodsWatcherEvent| {
             match event {
                 podswatcher::PodsWatcherEvent::PodsUpdated(new_app) => {
-                    tracing::debug!("updated pods information: {:?}", new_app);
-                    tracing::debug!("previous pods information: {:?}", current_app);
+                    tracing::debug!("Updated pods information: {:?}", new_app);
+                    tracing::debug!("Previous pods information: {:?}", current_app);
 
                     // TODO: update runtime based on current_app vs new_app info
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -47,12 +47,17 @@ pub struct Runtime {
 
 impl Runtime {
     #[must_use]
-    pub fn new(config: Config, app: app::App, df: DataFusion, pods_watcher: podswatcher::PodsWatcher) -> Self {
+    pub fn new(
+        config: Config,
+        app: app::App,
+        df: DataFusion,
+        pods_watcher: podswatcher::PodsWatcher,
+    ) -> Self {
         Runtime {
             app: Arc::new(app),
             config,
             df: Arc::new(df),
-            pods_watcher: pods_watcher,
+            pods_watcher,
         }
     }
 

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -1,0 +1,77 @@
+use notify::{event::{CreateKind, ModifyKind, RemoveKind}, EventKind, RecursiveMode, Watcher};
+use std::path::PathBuf;
+
+use app::App;
+
+#[derive(Debug)]
+pub enum PodsWatcherEvent {
+    PodsUpdated(App),
+}
+
+pub struct PodsWatcher {
+    root_path: PathBuf,
+    watcher: Option<notify::RecommendedWatcher>,
+}
+
+impl PodsWatcher {
+   
+    #[must_use]
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            root_path: path.into(),
+            watcher: None
+        }
+    }
+
+    pub fn watch<F>(&mut self, mut event_handler: F) -> notify::Result<()> 
+    where
+        F: FnMut(PodsWatcherEvent) + 'static + Send,
+    {
+        let root_path = self.root_path.clone();
+
+        let mut watcher = notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+            match res {
+                Ok(event) => {
+                    tracing::debug!("detected content changes: {:?}", event);
+
+                    match event.kind {
+                        EventKind::Create(CreateKind::File) |
+                        EventKind::Remove(RemoveKind::File) |
+                        EventKind::Modify(ModifyKind::Data(_)) => {
+
+                            if let Ok(app) = App::new(root_path.clone()) {
+                                event_handler(PodsWatcherEvent::PodsUpdated(app));
+                            } else {
+                                tracing::debug!("invalid app state detected, ignoring changes.");
+                            }
+                        }
+                        _ => { /*  ignore meta events and other changes */ }
+                    }
+                },
+                Err(e) => tracing::error!("pod content watcher error: {:?}", e),
+            }
+        })?;
+
+        // root pod file
+        let root_yaml_files = vec![format!("spicepod.yaml"), format!("spicepod.yml")];
+        for yaml_file in root_yaml_files {
+            let yaml_path = self.root_path.clone().join(&yaml_file);
+            // check that file exists before watching
+            if yaml_path.exists() {
+                watcher.watch(&yaml_path, RecursiveMode::NonRecursive)?;
+            }
+        }
+        
+        // spicepods dir is required to start watcher; create it if it does not exist
+        let spicepods_dir = self.root_path.clone().join("spicepods");
+        if !spicepods_dir.exists() {
+            std::fs::create_dir(&spicepods_dir)?;
+        }
+        watcher.watch(&spicepods_dir, RecursiveMode::Recursive)?;
+
+        self.watcher = Some(watcher);
+
+        Ok(())
+    }
+}
+

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -77,20 +77,16 @@ fn get_watch_paths(app_path: impl Into<PathBuf>) -> Vec<PathBuf> {
     let root_dir: PathBuf = app_path.into();
 
     let mut dirs = vec![
-        // self.root_path.join("spicepods/"),
         root_dir.join("spicepod.yaml"),
         root_dir.join("spicepod.yml"),
     ];
 
-    // attempt to open root spicepod definition file
     if let Ok(spicepod) = spicepod::Spicepod::load_definition(&root_dir) {
-        // watch dependencies
         for dep in spicepod.dependencies {
             let dep_path = root_dir.join("spicepods").join(dep);
             dirs.push(dep_path);
         }
 
-        // watch ref datasets folders
         for dataset in spicepod.datasets {
             match dataset {
                 ComponentOrReference::Reference(reference) => {
@@ -101,7 +97,6 @@ fn get_watch_paths(app_path: impl Into<PathBuf>) -> Vec<PathBuf> {
             }
         }
 
-        // watch ref datasets folders
         for model in spicepod.models {
             match model {
                 ComponentOrReference::Reference(reference) => {
@@ -121,8 +116,6 @@ fn is_spicepods_modification_event(spicepod_paths: &[PathBuf], event: &notify::E
         EventKind::Create(CreateKind::File)
         | EventKind::Remove(RemoveKind::File)
         | EventKind::Modify(ModifyKind::Data(_)) => {
-            // iterate through all paths in the event and
-            // check if relative path is within the `spicepods` dir
             for event_path in &event.paths {
                 if spicepod_paths.iter().any(|dir| event_path.starts_with(dir)) {
                     return true;

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -1,4 +1,8 @@
-use notify::{event::{CreateKind, ModifyKind, RemoveKind}, EventKind, RecursiveMode, Watcher};
+use notify::{
+    event::{CreateKind, ModifyKind, RemoveKind},
+    EventKind, RecursiveMode, Watcher,
+};
+use spicepod::component::ComponentOrReference;
 use std::path::PathBuf;
 
 use app::App;
@@ -18,11 +22,11 @@ impl PodsWatcher {
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self {
             root_path: path.into(),
-            watcher: None
+            watcher: None,
         }
     }
 
-    pub fn watch<F>(&mut self, mut event_handler: F) -> notify::Result<()> 
+    pub fn watch<F>(&mut self, mut event_handler: F) -> notify::Result<()>
     where
         F: FnMut(PodsWatcherEvent) + 'static + Send,
     {
@@ -35,30 +39,31 @@ impl PodsWatcher {
 
         let mut watch_paths = get_watch_paths(&root_path);
 
-        let mut watcher = notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
-            match res {
-                Ok(event) => {
-                    if !is_spicepods_modification_event(&watch_paths, &event) {
-                        return;
-                    }
-                    tracing::debug!("Detected pods content changes: {:?}", event);
+        let mut watcher =
+            notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+                match res {
+                    Ok(event) => {
+                        if !is_spicepods_modification_event(&watch_paths, &event) {
+                            return;
+                        }
+                        tracing::debug!("Detected pods content changes: {:?}", event);
 
-                    // check if main spicepod file has been modified to update watching paths
-                    for event_path in event.paths.iter() {
-                        if root_spicepod_path.iter().any(|dir| event_path.eq(dir)) {
-                            watch_paths = get_watch_paths(&root_path);
+                        // check if main spicepod file has been modified to update watching paths
+                        for event_path in &event.paths {
+                            if root_spicepod_path.iter().any(|dir| event_path.eq(dir)) {
+                                watch_paths = get_watch_paths(&root_path);
+                            }
+                        }
+
+                        if let Ok(app) = App::new(root_path.clone()) {
+                            event_handler(PodsWatcherEvent::PodsUpdated(app));
+                        } else {
+                            tracing::debug!("Invalid app state detected, ignoring changes.");
                         }
                     }
-
-                    if let Ok(app) = App::new(root_path.clone()) {
-                        event_handler(PodsWatcherEvent::PodsUpdated(app));
-                    } else {
-                        tracing::debug!("Invalid app state detected, ignoring changes.");
-                    }
-                },
-                Err(e) => tracing::error!("Pods content watcher error: {:?}", e),
-            }
-        })?;
+                    Err(e) => tracing::error!("Pods content watcher error: {:?}", e),
+                }
+            })?;
 
         watcher.watch(&self.root_path, RecursiveMode::Recursive)?;
 
@@ -69,7 +74,6 @@ impl PodsWatcher {
 }
 
 fn get_watch_paths(app_path: impl Into<PathBuf>) -> Vec<PathBuf> {
-
     let root_dir: PathBuf = app_path.into();
 
     let mut dirs = vec![
@@ -89,47 +93,44 @@ fn get_watch_paths(app_path: impl Into<PathBuf>) -> Vec<PathBuf> {
         // watch ref datasets folders
         for dataset in spicepod.datasets {
             match dataset {
-                spicepod::component::ComponentOrReference::Reference(reference) => {
+                ComponentOrReference::Reference(reference) => {
                     let ref_path = root_dir.join(&reference.r#ref);
                     dirs.push(root_dir.join(ref_path));
                 }
-                _ => { /* ignore component */ }
+                ComponentOrReference::Component(_) => { /* ignore component */ }
             }
         }
 
         // watch ref datasets folders
         for model in spicepod.models {
             match model {
-                spicepod::component::ComponentOrReference::Reference(reference) => {
+                ComponentOrReference::Reference(reference) => {
                     let ref_path = root_dir.join(&reference.r#ref);
                     dirs.push(root_dir.join(ref_path));
                 }
-                _ => { /* ignore component */ }
+                ComponentOrReference::Component(_) => { /* ignore component */ }
             }
         }
     }
-    
+
     dirs
 }
 
-fn is_spicepods_modification_event(spicepod_paths: &Vec<PathBuf>, event: &notify::Event) -> bool {
-    
+fn is_spicepods_modification_event(spicepod_paths: &[PathBuf], event: &notify::Event) -> bool {
     match event.kind {
-        EventKind::Create(CreateKind::File) |
-        EventKind::Remove(RemoveKind::File) |
-        EventKind::Modify(ModifyKind::Data(_)) => {
-            // iterate through all paths in the event and 
+        EventKind::Create(CreateKind::File)
+        | EventKind::Remove(RemoveKind::File)
+        | EventKind::Modify(ModifyKind::Data(_)) => {
+            // iterate through all paths in the event and
             // check if relative path is within the `spicepods` dir
-            for event_path in event.paths.iter() {
+            for event_path in &event.paths {
                 if spicepod_paths.iter().any(|dir| event_path.starts_with(dir)) {
                     return true;
                 }
             }
-
         }
         _ => { /*  ignore meta events and other changes */ }
     }
 
     false
 }
-

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -1,5 +1,5 @@
 use notify::{event::{CreateKind, ModifyKind, RemoveKind}, EventKind, RecursiveMode, Watcher};
-use std::path::PathBuf;
+use std::path::{PathBuf};
 
 use app::App;
 
@@ -32,46 +32,54 @@ impl PodsWatcher {
         let mut watcher = notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
             match res {
                 Ok(event) => {
-                    tracing::debug!("detected content changes: {:?}", event);
+                    if !is_spicepods_modification_event(&root_path, &event) {
+                        return;
+                    }
+                    tracing::debug!("Detected pods content changes: {:?}", event);
 
-                    match event.kind {
-                        EventKind::Create(CreateKind::File) |
-                        EventKind::Remove(RemoveKind::File) |
-                        EventKind::Modify(ModifyKind::Data(_)) => {
-
-                            if let Ok(app) = App::new(root_path.clone()) {
-                                event_handler(PodsWatcherEvent::PodsUpdated(app));
-                            } else {
-                                tracing::debug!("invalid app state detected, ignoring changes.");
-                            }
-                        }
-                        _ => { /*  ignore meta events and other changes */ }
+                    if let Ok(app) = App::new(root_path.clone()) {
+                        event_handler(PodsWatcherEvent::PodsUpdated(app));
+                    } else {
+                        tracing::debug!("Invalid app state detected, ignoring changes.");
                     }
                 },
-                Err(e) => tracing::error!("pod content watcher error: {:?}", e),
+                Err(e) => tracing::error!("Pods content watcher error: {:?}", e),
             }
         })?;
 
-        // root pod file
-        let root_yaml_files = vec![format!("spicepod.yaml"), format!("spicepod.yml")];
-        for yaml_file in root_yaml_files {
-            let yaml_path = self.root_path.clone().join(&yaml_file);
-            // check that file exists before watching
-            if yaml_path.exists() {
-                watcher.watch(&yaml_path, RecursiveMode::NonRecursive)?;
-            }
-        }
-        
-        // spicepods dir is required to start watcher; create it if it does not exist
-        let spicepods_dir = self.root_path.clone().join("spicepods");
-        if !spicepods_dir.exists() {
-            std::fs::create_dir(&spicepods_dir)?;
-        }
-        watcher.watch(&spicepods_dir, RecursiveMode::Recursive)?;
+        watcher.watch(&self.root_path, RecursiveMode::Recursive)?;
 
         self.watcher = Some(watcher);
 
         Ok(())
     }
+}
+
+fn is_spicepods_modification_event(app_path: impl Into<PathBuf>, event: &notify::Event) -> bool {
+   let root_dir = app_path.into();
+    
+    let spicepod_paths = vec![
+        root_dir.join("spicepods/"),
+        root_dir.join("spicepod.yaml"),
+        root_dir.join("spicepod.yml"),
+    ];
+    
+    match event.kind {
+        EventKind::Create(CreateKind::File) |
+        EventKind::Remove(RemoveKind::File) |
+        EventKind::Modify(ModifyKind::Data(_)) => {
+            // iterate through all paths in the event and 
+            // check if relative path is within the `spicepods` dir
+            for event_path in event.paths.iter() {
+                if spicepod_paths.iter().any(|dir| event_path.starts_with(dir)) {
+                    return true;
+                }
+            }
+
+        }
+        _ => { /*  ignore meta events and other changes */ }
+    }
+
+    false
 }
 

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -79,6 +79,27 @@ impl Spicepod {
             resolved_models,
         ))
     }
+
+    pub fn load_definition(path: impl Into<PathBuf>) -> Result<SpicepodDefinition> {
+        Self::load_definition_from(&reader::StdFileSystem, path)
+    }
+
+    pub fn load_definition_from<T>(
+        fs: &impl reader::ReadableYaml<T>,
+        path: impl Into<PathBuf>,
+    ) -> Result<SpicepodDefinition> {
+        let path = path.into();
+        let path_str = path.to_string_lossy().to_string();
+
+        let spicepod_rdr = fs
+            .open_yaml(&path_str, "spicepod")
+            .ok_or_else(|| Error::SpicepodNotFound { path: path.clone() })?;
+
+        let spicepod_definition: SpicepodDefinition =
+            serde_yaml::from_reader(spicepod_rdr).context(UnableToParseSpicepodSnafu)?;
+
+        Ok(spicepod_definition)
+    }
 }
 
 #[must_use]


### PR DESCRIPTION
PRs implements initialization logic for PodsWatcher.

Once changes are detected event handler is called with prev and new pods information.

Next step is to provision vs stop vs update data sources based on prev vs new pods diff.