### PR TITLE
Improve model logging; fix an issue with view attempts to create before plan is ready

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -156,10 +156,11 @@ pub async fn run(args: Args) -> Result<()> {
 
     let mut model_map = HashMap::with_capacity(app.models.len());
     for m in &app.models {
+        tracing::info!("Deploying model [{}] from {}...", m.name, m.from);
         match Model::load(m, auth.get(m.source().as_str())) {
             Ok(in_m) => {
                 model_map.insert(m.name.clone(), in_m);
-                tracing::info!("Loaded model: {}", m.name);
+                tracing::info!("Model [{}] deployed, ready for inferencing", m.name);
             }
             Err(e) => {
                 tracing::warn!(

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -225,25 +225,6 @@ impl DataFusion {
                 }
             }
 
-            let mut attempts = 1;
-            loop {
-                if ctx
-                    .state()
-                    .statement_to_plan(statements[0].clone())
-                    .await
-                    .is_ok()
-                {
-                    break;
-                }
-
-                if attempts == 10 {
-                    tracing::error!("Unable to generate plan for view, retrying...");
-                    return;
-                }
-                attempts += 1;
-                sleep(Duration::from_secs(1)).await;
-            }
-
             let plan = match ctx.state().statement_to_plan(statements[0].clone()).await {
                 Ok(plan) => plan,
                 Err(e) => {
@@ -269,42 +250,65 @@ impl DataFusion {
 
     fn get_dependent_table_names(statement: &parser::Statement) -> Vec<String> {
         let mut table_names = Vec::new();
+        let mut with_to_tables = HashMap::new();
+
         match statement.clone() {
             parser::Statement::Statement(statement) => match *statement {
-                ast::Statement::Query(statement) => match *statement.body {
-                    SetExpr::Select(select_statement) => {
-                        for from in select_statement.from {
-                            if let TableFactor::Table {
-                                name,
-                                alias: _,
-                                args: _,
-                                with_hints: _,
-                                version: _,
-                                partitions: _,
-                            } = from.relation
-                            {
-                                table_names.push(name.to_string());
-                            }
+                ast::Statement::Query(statement) => {
+                    if let Some(with) = statement.with {
+                        for table in with.cte_tables {
+                            let with_table_names = DataFusion::get_dependent_table_names(
+                                &parser::Statement::Statement(Box::new(ast::Statement::Query(
+                                    table.query,
+                                ))),
+                            );
+                            with_to_tables.insert(table.alias.name.to_string(), with_table_names);
+                        }
+                    };
+                    match *statement.body {
+                        SetExpr::Select(select_statement) => {
+                            for from in select_statement.from {
+                                let mut relations = vec![];
+                                relations.push(from.relation.clone());
+                                for join in from.joins {
+                                    relations.push(join.relation.clone());
+                                }
 
-                            for join in from.joins {
-                                if let TableFactor::Table {
-                                    name,
-                                    alias: _,
-                                    args: _,
-                                    with_hints: _,
-                                    version: _,
-                                    partitions: _,
-                                } = join.relation
-                                {
-                                    table_names.push(name.to_string());
+                                for relation in relations {
+                                    match relation {
+                                        TableFactor::Table {
+                                            name,
+                                            alias: _,
+                                            args: _,
+                                            with_hints: _,
+                                            version: _,
+                                            partitions: _,
+                                        } => {
+                                            table_names.push(name.to_string());
+                                        }
+                                        TableFactor::Derived {
+                                            lateral: _,
+                                            subquery,
+                                            alias: _,
+                                        } => {
+                                            table_names.extend(
+                                                DataFusion::get_dependent_table_names(
+                                                    &parser::Statement::Statement(Box::new(
+                                                        ast::Statement::Query(subquery),
+                                                    )),
+                                                ),
+                                            );
+                                        }
+                                        _ => (),
+                                    }
                                 }
                             }
                         }
+                        _ => {
+                            return table_names;
+                        }
                     }
-                    _ => {
-                        return table_names;
-                    }
-                },
+                }
                 _ => {
                     return table_names;
                 }
@@ -313,7 +317,20 @@ impl DataFusion {
                 return table_names;
             }
         }
-        table_names
+
+        let mut result = vec![];
+
+        for table in table_names {
+            if let Some(with_table_names) = with_to_tables.get(&table) {
+                for with_table_name in with_table_names {
+                    result.push(with_table_name.to_string());
+                }
+            } else {
+                result.push(table);
+            }
+        }
+
+        result
     }
 }
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -236,8 +236,9 @@ impl DataFusion {
                     break;
                 }
 
-                if attempts % 10 == 0 {
+                if attempts == 10 {
                     tracing::error!("Unable to generate plan for view, retrying...");
+                    return;
                 }
                 attempts += 1;
                 sleep(Duration::from_secs(1)).await;

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -106,7 +106,10 @@ pub(crate) mod inference {
                 },
                 None => (StatusCode::INTERNAL_SERVER_ERROR,).into_response(),
             },
-            Err(_) => (StatusCode::INTERNAL_SERVER_ERROR,).into_response(),
+            Err(e) => {
+                tracing::error!("Unable to run inference: {}", e);
+                (StatusCode::INTERNAL_SERVER_ERROR,).into_response()
+            }
         }
     }
 }

--- a/crates/runtime/src/model.rs
+++ b/crates/runtime/src/model.rs
@@ -24,7 +24,7 @@ pub enum Error {
     #[snafu(display("Unable to init model: {source}"))]
     UnableToInitModel { source: crate::modelruntime::Error },
 
-    #[snafu(display("Unable to query"))]
+    #[snafu(display("Unable to query: {source}"))]
     UnableToQuery {
         source: datafusion::error::DataFusionError,
     },


### PR DESCRIPTION
This adds more verbose logging to model part.

Also fix dependent table detection for queries with subquery and with, like
```
      WITH bbb as (
            SELECT
                ROW_NUMBER() OVER (ORDER BY a.number) AS ts,
                2 * ROW_NUMBER() OVER (ORDER BY a.number) + 50 AS y,
                -3 * ROW_NUMBER() OVER (ORDER BY a.number) + 1 AS y2
            FROM
                eth_blocks a
      ), ccc as (
            SELECT
                ROW_NUMBER() OVER (ORDER BY a.number) AS ts,
                2 * ROW_NUMBER() OVER (ORDER BY a.number) + 50 AS y,
                -3 * ROW_NUMBER() OVER (ORDER BY a.number) + 1 AS y2
            FROM
                eth_blocks_2 a
      )
      SELECT nested_0.ts, CAST(nested_0.y as DOUBLE) AS y, CAST(nested_0.y2 as DOUBLE) AS y2
      FROM (
            SELECT * from bbb
            ORDER BY ts DESC
            LIMIT 50
      ) nested_0 inner join ccc on nested_0.ts = ccc.ts;
```