### PR TITLE
Implement `sql_ref` and improve view CTE detection

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -85,7 +85,11 @@ impl dyn DataConnector + '_ {
         let refresh_mode = dataset
             .acceleration
             .as_ref()
-            .map_or(RefreshMode::Full, |acc| acc.refresh_mode.clone());
+            .map_or(RefreshMode::Full, |acc| {
+                acc.refresh_mode
+                    .as_ref()
+                    .map_or(RefreshMode::Full, Clone::clone)
+            });
 
         if refresh_mode == RefreshMode::Append && self.supports_data_streaming(dataset) {
             return self.stream_data_updates(dataset);

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -264,7 +264,7 @@ impl DataFusion {
                             DataFusion::get_dependent_table_names(&parser::Statement::Statement(
                                 Box::new(ast::Statement::Query(table.query)),
                             ));
-                        // This might include actual table names used within the CTE
+                        // Extend table_names with names found in CTEs if they reference actual tables
                         table_names.extend(cte_table_names);
                     }
                 }
@@ -308,7 +308,7 @@ impl DataFusion {
             }
         }
 
-        // Filter out CTEs that are not referenced outside their definition
+        // Filter out CTEs and temporary views (aliases of subqueries)
         table_names
             .into_iter()
             .filter(|name| !cte_names.contains(name))

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -29,7 +29,7 @@ pub(crate) mod datasets {
         };
 
         if filter.remove_views {
-            datasets.retain(|d| d.sql.is_none());
+            datasets.retain(|d| !d.is_view());
         }
 
         Json(datasets)

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -7,8 +7,11 @@ use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to load SQL file: {source}"))]
-    UnableToLoadSqlFile { source: std::io::Error },
+    #[snafu(display("Unable to load SQL file {file}: {source}"))]
+    UnableToLoadSqlFile {
+        file: String,
+        source: std::io::Error,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -113,7 +116,8 @@ impl Dataset {
         }
 
         if let Some(sql_ref) = &self.sql_ref {
-            let sql = fs::read_to_string(sql_ref).context(UnableToLoadSqlFileSnafu)?;
+            let sql =
+                fs::read_to_string(sql_ref).context(UnableToLoadSqlFileSnafu { file: sql_ref })?;
             return Ok(Some(sql));
         }
 

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -1,8 +1,17 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, fs, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
 use super::WithDependsOn;
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to load SQL file: {source}"))]
+    UnableToLoadSqlFile { source: std::io::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Dataset {
@@ -11,8 +20,13 @@ pub struct Dataset {
 
     pub name: String,
 
+    /// Inline SQL that describes a view.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sql: Option<String>,
+    sql: Option<String>,
+
+    /// Reference to a SQL file that describes a view.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sql_ref: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<HashMap<String, String>>,
@@ -87,6 +101,24 @@ impl Dataset {
 
         None
     }
+
+    #[must_use]
+    pub fn is_view(&self) -> bool {
+        self.sql.is_some() || self.sql_ref.is_some()
+    }
+
+    pub fn view_sql(&self) -> Result<Option<String>> {
+        if let Some(sql) = &self.sql {
+            return Ok(Some(sql.clone()));
+        }
+
+        if let Some(sql_ref) = &self.sql_ref {
+            let sql = fs::read_to_string(sql_ref).context(UnableToLoadSqlFileSnafu)?;
+            return Ok(Some(sql));
+        }
+
+        Ok(None)
+    }
 }
 
 impl WithDependsOn<Dataset> for Dataset {
@@ -95,6 +127,7 @@ impl WithDependsOn<Dataset> for Dataset {
             from: self.from.clone(),
             name: self.name.clone(),
             sql: self.sql.clone(),
+            sql_ref: self.sql_ref.clone(),
             params: self.params.clone(),
             acceleration: self.acceleration.clone(),
             depends_on: depends_on.to_vec(),

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -143,7 +143,8 @@ pub mod acceleration {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub refresh_interval: Option<String>,
 
-        pub refresh_mode: RefreshMode,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub refresh_mode: Option<RefreshMode>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub retention: Option<String>,


### PR DESCRIPTION
Adds support for loading SQL views that have CTEs that are temporary, i.e.:

```sql
WITH temporary_view AS (
   SELECT 1 as foo
)

SELECT * FROM temporary_view
```

The previous detection logic would block waiting for a table with `temporary_view` to exist - but now we exclude those.

This PR also adds support for including a SQL view file via `sql_ref`

```yaml
datasets:
  # The inferencing view that combines data from the below raw metrics
  - from: localhost
    name: drive_stats_inferencing
    sql_ref: inference.sql
```

Will pull the SQL to use for the view from `inference.sql` - one restriction is that the reference is based on the root of the app, not based on the spicepod.yaml