### PR TITLE
Only warn once if a metric isn't supported

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -215,7 +215,7 @@ impl DataFusion {
                 loop {
                     if !ctx.table_exist(&dependent_table_name).unwrap_or(false) {
                         if attempts % 10 == 0 {
-                            tracing::error!("Dependent table {dependent_table_name} for {table_name} does not exist, retrying...");
+                            tracing::warn!("Dependent table {dependent_table_name} for view {table_name} does not exist, retrying...");
                         }
                         attempts += 1;
                         sleep(Duration::from_secs(1)).await;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -8,6 +8,7 @@ use snafu::prelude::*;
 use tokio::signal;
 
 use crate::datafusion::DataFusion;
+pub use notify::Error as NotifyError;
 
 pub mod auth;
 pub mod config;
@@ -23,7 +24,7 @@ pub mod modelruntime;
 pub mod modelsource;
 mod opentelemetry;
 pub mod podswatcher;
-pub use notify::Error as NotifyError;
+pub(crate) mod tracers;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime/src/tracers.rs
+++ b/crates/runtime/src/tracers.rs
@@ -1,0 +1,31 @@
+use std::{collections::HashSet, sync::Mutex};
+
+/// Traces a log with a given parameter once, to prevent log spam.
+///
+/// Not suitable for high-frequency logs.
+pub struct OnceTracer {
+    pub logged_values: Mutex<HashSet<String>>,
+}
+
+impl OnceTracer {
+    pub fn new() -> Self {
+        OnceTracer {
+            logged_values: Mutex::new(HashSet::new()),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! warn_once {
+    ($tracer:expr, $msg:expr, $value:expr) => {{
+        let mut logged_values = $tracer.logged_values.lock().unwrap_or_else(|poisoned| {
+            tracing::error!("Lock poisoned while logging: {poisoned}");
+            tracing::warn!($msg, $value);
+            return poisoned.into_inner();
+        });
+        if !logged_values.contains(&$value) {
+            logged_values.insert($value.clone());
+            tracing::warn!($msg, $value);
+        }
+    }};
+}


### PR DESCRIPTION
Adds a new `OnceTracer` that keeps track of values it has traced. Adds a `warn_once!` macro that will only log a value the first time it is seen.