### PR TITLE
Keep the orgname when installing a spicepod dependency

### DIFF
--- a/bin/spice/pkg/cli/cmd/add.go
+++ b/bin/spice/pkg/cli/cmd/add.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/api"
@@ -25,7 +24,6 @@ spice add samples/LogPruner
 
 		cmd.Printf("Getting Pod %s ...\n", podPath)
 
-		podName := filepath.Base(podPath)
 		r := registry.GetRegistry(podPath)
 		downloadPath, err := r.GetPod(podPath)
 		if err != nil {
@@ -55,14 +53,14 @@ spice add samples/LogPruner
 
 		var podReferenced bool
 		for _, dependency := range spicePod.Dependencies {
-			if dependency == podName {
+			if dependency == podPath {
 				podReferenced = true
 				break
 			}
 		}
 
 		if !podReferenced {
-			spicePod.Dependencies = append(spicePod.Dependencies, podName)
+			spicePod.Dependencies = append(spicePod.Dependencies, podPath)
 			spicepodBytes, err = yaml.Marshal(spicePod)
 			if err != nil {
 				cmd.Println(err)

--- a/bin/spice/pkg/registry/spicerack.go
+++ b/bin/spice/pkg/registry/spicerack.go
@@ -40,7 +40,6 @@ func (r *SpiceRackRegistry) GetPod(podFullPath string) (string, error) {
 		podPath = parts[0]
 		podVersion = parts[1]
 	}
-	podName := filepath.Base(podPath)
 
 	url := fmt.Sprintf("%s/spicepods/%s", getSpiceRackBaseUrl(), podPath)
 	if podVersion != "" {
@@ -75,7 +74,7 @@ func (r *SpiceRackRegistry) GetPod(podFullPath string) (string, error) {
 	}
 
 	podsPath := context.NewContext().PodsDir()
-	podsPathWithName := filepath.Join(podsPath, podName)
+	podsPathWithName := filepath.Join(podsPath, podPath)
 
 	podsPerm, err := util.MkDirAllInheritPerm(podsPathWithName)
 	if err != nil {


### PR DESCRIPTION
Previously running `spice add lukekim/demo` would create a directory structure like:

```bash
├── spicepod.yaml
└── spicepods
    └── demo
        └── spicepod.yaml
```

Now it will create a directory structure that keeps the orgname:

```bash
├── spicepod.yaml
└── spicepods
    └── lukekim
        └── demo
            └── spicepod.yaml
```

This is a CLI-only change - the runtime already supports this structure.