### PR TITLE
Dynamic pods: support for loading new datasets

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -4,16 +4,14 @@ use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use app::App;
 use clap::Parser;
 use runtime::config::Config as RuntimeConfig;
-use runtime::dataconnector::DataConnector;
 use runtime::model::Model;
 
 use runtime::podswatcher::PodsWatcher;
-use runtime::{dataconnector, Runtime};
+use runtime::Runtime;
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
@@ -24,20 +22,8 @@ pub enum Error {
     #[snafu(display("Unable to start Spice Runtime servers"))]
     UnableToStartServers { source: runtime::Error },
 
-    #[snafu(display("Unable to attach data connector: {data_connector}"))]
-    UnableToAttachDataConnector {
-        source: runtime::datafusion::Error,
-        data_connector: String,
-    },
-
-    #[snafu(display("Unable to attach view"))]
-    UnableToAttachView { source: runtime::datafusion::Error },
-
-    #[snafu(display("Unable to initialize data connector: {data_connector}"))]
-    UnableToInitializeDataConnector {
-        source: runtime::dataconnector::Error,
-        data_connector: String,
-    },
+    #[snafu(display("Failed to load dataset: {source}"))]
+    UnableToLoadDataset { source: runtime::Error },
 
     #[snafu(display(
         "A required parameter ({parameter}) is missing for data connector: {data_connector}",
@@ -47,19 +33,11 @@ pub enum Error {
         data_connector: String,
     },
 
-    #[snafu(display("Unknown data connector: {data_connector}"))]
-    UnknownDataConnector { data_connector: String },
-
     #[snafu(display("Unable to create data backend"))]
     UnableToCreateBackend { source: runtime::datafusion::Error },
 
     #[snafu(display("Failed to start pods watcher: {source}"))]
     UnableToInitializePodsWatcher { source: runtime::NotifyError },
-
-    #[snafu(display("Unable to create view: {source}"))]
-    InvalidSQLView {
-        source: spicepod::component::dataset::Error,
-    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -99,65 +77,9 @@ pub async fn run(args: Args) -> Result<()> {
     let mut df = runtime::datafusion::DataFusion::new();
 
     for ds in &app.datasets {
-        if ds.acceleration.is_none() && !ds.is_view() {
-            tracing::warn!("No acceleration specified for dataset: {}", ds.name);
-            continue;
-        };
-
-        let source = ds.source();
-        let source = source.as_str();
-        let params = Arc::new(ds.params.clone());
-        let data_connector: Option<Box<dyn DataConnector>> = match source {
-            "spice.ai" => Some(Box::new(
-                dataconnector::spiceai::SpiceAI::new(auth.get(source), params)
-                    .await
-                    .context(UnableToInitializeDataConnectorSnafu {
-                        data_connector: source,
-                    })?,
-            )),
-            "dremio" => Some(Box::new(
-                dataconnector::dremio::Dremio::new(auth.get(source), params)
-                    .await
-                    .context(UnableToInitializeDataConnectorSnafu {
-                        data_connector: source,
-                    })?,
-            )),
-            "localhost" | "" => None,
-            "debug" => Some(Box::new(dataconnector::debug::DebugSource {})),
-            _ => UnknownDataConnectorSnafu {
-                data_connector: source,
-            }
-            .fail()?,
-        };
-
-        let view_sql = ds.view_sql().context(InvalidSQLViewSnafu)?;
-
-        match data_connector {
-            Some(data_connector) => {
-                let data_connector = Box::leak(data_connector);
-                let data_backend = df.new_backend(ds).context(UnableToCreateBackendSnafu)?;
-
-                df.attach(ds, data_connector, data_backend).context(
-                    UnableToAttachDataConnectorSnafu {
-                        data_connector: source,
-                    },
-                )?;
-            }
-            None => {
-                if view_sql.is_some() {
-                    df.attach_view(ds).context(UnableToAttachViewSnafu)?;
-                } else {
-                    let data_backend = df.new_backend(ds).context(UnableToCreateBackendSnafu)?;
-                    df.attach_backend(&ds.name, data_backend).context(
-                        UnableToAttachDataConnectorSnafu {
-                            data_connector: source,
-                        },
-                    )?;
-                }
-            }
-        }
-
-        tracing::info!("Loaded dataset: {}", ds.name);
+        Runtime::load_dataset(ds, &auth, &mut df)
+            .await
+            .context(UnableToLoadDatasetSnafu)?;
     }
 
     let mut model_map = HashMap::with_capacity(app.models.len());
@@ -181,9 +103,6 @@ pub async fn run(args: Args) -> Result<()> {
     let pods_watcher = PodsWatcher::new(current_dir.clone());
 
     let mut rt: Runtime = Runtime::new(args.runtime, app, df, model_map, pods_watcher);
-
-    rt.start_pods_watcher()
-        .context(UnableToInitializePodsWatcherSnafu)?;
 
     rt.start_servers()
         .await

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -64,14 +64,11 @@ pub async fn run(args: Args) -> Result<()> {
     let app = App::new(current_dir.clone()).context(UnableToConstructSpiceAppSnafu)?;
 
     let mut auth = runtime::auth::AuthProviders::default();
-    match auth.parse_from_config() {
-        Ok(()) => {}
-        Err(e) => {
-            tracing::warn!(
-                "Unable to parse auth from config, proceeding without auth: {}",
-                e
-            );
-        }
+    if let Err(e) = auth.parse_from_config() {
+        tracing::warn!(
+            "Unable to parse auth from config, proceeding without auth: {}",
+            e
+        );
     }
 
     let mut df = runtime::datafusion::DataFusion::new();
@@ -102,7 +99,7 @@ pub async fn run(args: Args) -> Result<()> {
 
     let pods_watcher = PodsWatcher::new(current_dir.clone());
 
-    let mut rt: Runtime = Runtime::new(args.runtime, app, df, model_map, pods_watcher);
+    let mut rt: Runtime = Runtime::new(args.runtime, app, auth, df, model_map, pods_watcher);
 
     rt.start_servers()
         .await

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -85,7 +85,14 @@ impl FlightService for Service {
         let ticket = request.into_inner();
         match std::str::from_utf8(&ticket.ticket) {
             Ok(sql) => {
-                let df = self.datafusion.read().await.ctx.sql(sql).await.map_err(to_tonic_err)?;
+                let df = self
+                    .datafusion
+                    .read()
+                    .await
+                    .ctx
+                    .sql(sql)
+                    .await
+                    .map_err(to_tonic_err)?;
                 let schema = df.schema().clone().into();
                 let results = df.collect().await.map_err(to_tonic_err)?;
                 if results.is_empty() {

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -27,7 +27,7 @@ use arrow_flight::{
 };
 
 pub struct Service {
-    datafusion: Arc<DataFusion>,
+    datafusion: Arc<RwLock<DataFusion>>,
     channel_map: Arc<RwLock<HashMap<String, Arc<Sender<DataUpdate>>>>>,
 }
 
@@ -66,7 +66,7 @@ impl FlightService for Service {
         let table_path = ListingTableUrl::parse(&request.path[0]).map_err(to_tonic_err)?;
 
         let schema = listing_options
-            .infer_schema(&self.datafusion.ctx.state(), &table_path)
+            .infer_schema(&self.datafusion.read().await.ctx.state(), &table_path)
             .await
             .map_err(to_tonic_err)?;
 
@@ -85,7 +85,7 @@ impl FlightService for Service {
         let ticket = request.into_inner();
         match std::str::from_utf8(&ticket.ticket) {
             Ok(sql) => {
-                let df = self.datafusion.ctx.sql(sql).await.map_err(to_tonic_err)?;
+                let df = self.datafusion.read().await.ctx.sql(sql).await.map_err(to_tonic_err)?;
                 let schema = df.schema().clone().into();
                 let results = df.collect().await.map_err(to_tonic_err)?;
                 if results.is_empty() {
@@ -178,7 +178,9 @@ impl FlightService for Service {
 
         let path = fd.path.join(".");
 
-        let Some(backend) = self.datafusion.get_backend(&path) else {
+        let df = self.datafusion.read().await;
+
+        let Some(backend) = df.get_backend(&path) else {
             return Err(Status::invalid_argument(format!(
                 "No backend registered for path: {path:?}",
             )));
@@ -314,7 +316,7 @@ impl FlightService for Service {
 
         let data_path = flight_descriptor.path.join(".");
 
-        if !self.datafusion.has_backend(&data_path) {
+        if !self.datafusion.read().await.has_backend(&data_path) {
             return Err(Status::invalid_argument(format!(
                 r#"Unknown dataset: "{data_path}""#,
             )));
@@ -379,6 +381,8 @@ impl FlightService for Service {
         let datafusion = Arc::clone(&self.datafusion);
         tokio::spawn(async move {
             let Ok(df) = datafusion
+                .read()
+                .await
                 .ctx
                 .sql(&format!(r#"SELECT * FROM "{data_path}""#))
                 .await
@@ -432,7 +436,7 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub async fn start(bind_address: std::net::SocketAddr, df: Arc<DataFusion>) -> Result<()> {
+pub async fn start(bind_address: std::net::SocketAddr, df: Arc<RwLock<DataFusion>>) -> Result<()> {
     let service = Service {
         datafusion: df.clone(),
         channel_map: Arc::new(RwLock::new(HashMap::new())),

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -2,7 +2,10 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use app::App;
 use snafu::prelude::*;
-use tokio::{net::{TcpListener, ToSocketAddrs}, sync::RwLock};
+use tokio::{
+    net::{TcpListener, ToSocketAddrs},
+    sync::RwLock,
+};
 
 use crate::{datafusion::DataFusion, model::Model};
 

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use app::App;
 use snafu::prelude::*;
-use tokio::net::{TcpListener, ToSocketAddrs};
+use tokio::{net::{TcpListener, ToSocketAddrs}, sync::RwLock};
 
 use crate::{datafusion::DataFusion, model::Model};
 
@@ -23,7 +23,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 pub(crate) async fn start<A>(
     bind_address: A,
     app: Arc<App>,
-    df: Arc<DataFusion>,
+    df: Arc<RwLock<DataFusion>>,
     models: Arc<HashMap<String, Model>>,
 ) -> Result<()>
 where

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -7,12 +7,13 @@ use axum::{
     routing::{get, Router},
     Extension,
 };
+use tokio::sync::RwLock;
 
 use super::v1;
 
 pub(crate) fn routes(
     app: Arc<App>,
-    df: Arc<DataFusion>,
+    df: Arc<RwLock<DataFusion>>,
     models: Arc<HashMap<String, Model>>,
 ) -> Router {
     Router::new()

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -206,15 +206,16 @@ impl Runtime {
             tracing::debug!("Updated pods information: {:?}", new_app);
             tracing::debug!("Previous pods information: {:?}", current_app);
 
-            // TODO: This is a placeholder to demo/test that datasets could be loaded here
-            // To be replaced with actual implementation using shared ds/datafusion instance
 
-            // let mut df = datafusion::DataFusion::new();
-            // let auth = auth::AuthProviders::default();
+            let existing_dataset_names = current_app.datasets.iter().map(|ds| ds.name.clone()).collect::<Vec<String>>();
 
-            // if let Err(err) = Runtime::load_dataset(&new_app.datasets[0], &auth, &mut df).await {
-            //     tracing::error!("Unable to load dataset: {err:?}");
-            // }
+            for ds in &new_app.datasets {
+                if !existing_dataset_names.contains(&ds.name) {
+                    if let Err(err) = Runtime::load_dataset(ds, &auth::AuthProviders::default(), &mut *self.df.write().await).await {
+                        tracing::error!("Unable to load dataset: {err:?}");
+                    }
+                }
+            }
 
             current_app = Arc::new(new_app);
         }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -6,7 +6,7 @@ use config::Config;
 use model::Model;
 use snafu::prelude::*;
 use spicepod::component::dataset;
-use tokio::signal;
+use tokio::{signal, sync::RwLock};
 
 use crate::{dataconnector::DataConnector, datafusion::DataFusion};
 pub use notify::Error as NotifyError;
@@ -82,7 +82,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct Runtime {
     pub app: Arc<app::App>,
     pub config: config::Config,
-    pub df: Arc<DataFusion>,
+    pub df: Arc<RwLock<DataFusion>>,
     pub models: Arc<HashMap<String, Model>>,
     pub pods_watcher: podswatcher::PodsWatcher,
 }
@@ -99,7 +99,7 @@ impl Runtime {
         Runtime {
             app: Arc::new(app),
             config,
-            df: Arc::new(df),
+            df: Arc::new(RwLock::new(df)),
             models: Arc::new(models),
             pods_watcher,
         }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -5,9 +5,10 @@ use std::{collections::HashMap, sync::Arc};
 use config::Config;
 use model::Model;
 use snafu::prelude::*;
+use spicepod::component::dataset;
 use tokio::signal;
 
-use crate::datafusion::DataFusion;
+use crate::{dataconnector::DataConnector, datafusion::DataFusion};
 
 pub mod auth;
 pub mod config;
@@ -35,6 +36,44 @@ pub enum Error {
 
     #[snafu(display("Unable to start OpenTelemetry server"))]
     UnableToStartOpenTelemetryServer { source: opentelemetry::Error },
+
+    #[snafu(display("Unknown data source: {data_source}"))]
+    UnknownDataSource { data_source: String },
+
+    #[snafu(display("Unable to create data backend"))]
+    UnableToCreateBackend { source: datafusion::Error },
+
+    #[snafu(display("Unable to attach data source: {data_source}"))]
+    UnableToAttachDataSource {
+        source: datafusion::Error,
+        data_source: String,
+    },
+
+    #[snafu(display("Unable to attach view"))]
+    UnableToAttachView { source: datafusion::Error },
+
+    #[snafu(display("Failed to start pods watcher: {source}"))]
+    UnableToInitializePodsWatcher { source: NotifyError },
+
+    #[snafu(display("Unable to initialize data connector: {data_connector}"))]
+    UnableToInitializeDataConnector {
+        source: dataconnector::Error,
+        data_connector: String,
+    },
+
+    #[snafu(display("Unknown data connector: {data_connector}"))]
+    UnknownDataConnector { data_connector: String },
+
+    #[snafu(display("Unable to create view: {source}"))]
+    InvalidSQLView {
+        source: spicepod::component::dataset::Error,
+    },
+
+    #[snafu(display("Unable to attach data connector: {data_connector}"))]
+    UnableToAttachDataConnector {
+        source: datafusion::Error,
+        data_connector: String,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -65,7 +104,75 @@ impl Runtime {
         }
     }
 
-    pub async fn start_servers(&self) -> Result<()> {
+    pub async fn load_dataset(
+        ds: &dataset::Dataset,
+        auth: &auth::AuthProviders,
+        df: &mut datafusion::DataFusion,
+    ) -> Result<()> {
+        if ds.acceleration.is_none() && !ds.is_view() {
+            tracing::warn!("No acceleration specified for dataset: {}", ds.name);
+            return Ok(());
+        };
+
+        let source = ds.source();
+        let source = source.as_str();
+        let params = Arc::new(ds.params.clone());
+        let data_connector: Option<Box<dyn DataConnector>> = match source {
+            "spice.ai" => Some(Box::new(
+                dataconnector::spiceai::SpiceAI::new(auth.get(source), params)
+                    .await
+                    .context(UnableToInitializeDataConnectorSnafu {
+                        data_connector: source,
+                    })?,
+            )),
+            "dremio" => Some(Box::new(
+                dataconnector::dremio::Dremio::new(auth.get(source), params)
+                    .await
+                    .context(UnableToInitializeDataConnectorSnafu {
+                        data_connector: source,
+                    })?,
+            )),
+            "localhost" | "" => None,
+            "debug" => Some(Box::new(dataconnector::debug::DebugSource {})),
+            _ => UnknownDataConnectorSnafu {
+                data_connector: source,
+            }
+            .fail()?,
+        };
+
+        let view_sql = ds.view_sql().context(InvalidSQLViewSnafu)?;
+
+        match data_connector {
+            Some(data_connector) => {
+                let data_connector = Box::leak(data_connector);
+                let data_backend = df.new_backend(ds).context(UnableToCreateBackendSnafu)?;
+
+                df.attach(ds, data_connector, data_backend).context(
+                    UnableToAttachDataConnectorSnafu {
+                        data_connector: source,
+                    },
+                )?;
+            }
+            None => {
+                if view_sql.is_some() {
+                    df.attach_view(ds).context(UnableToAttachViewSnafu)?;
+                } else {
+                    let data_backend = df.new_backend(ds).context(UnableToCreateBackendSnafu)?;
+                    df.attach_backend(&ds.name, data_backend).context(
+                        UnableToAttachDataConnectorSnafu {
+                            data_connector: source,
+                        },
+                    )?;
+                }
+            }
+        }
+
+        tracing::info!("Loaded dataset: {}", ds.name);
+
+        Ok(())
+    }
+
+    pub async fn start_servers(&mut self) -> Result<()> {
         let http_server_future = http::start(
             self.config.http_bind_address,
             self.app.clone(),
@@ -75,11 +182,13 @@ impl Runtime {
         let flight_server_future = flight::start(self.config.flight_bind_address, self.df.clone());
         let open_telemetry_server_future =
             opentelemetry::start(self.config.open_telemetry_bind_address, self.df.clone());
+        let pods_watcher_future = self.start_pods_watcher();
 
         tokio::select! {
             http_res = http_server_future => http_res.context(UnableToStartHttpServerSnafu),
             flight_res = flight_server_future => flight_res.context(UnableToStartFlightServerSnafu),
             open_telemetry_res = open_telemetry_server_future => open_telemetry_res.context(UnableToStartOpenTelemetryServerSnafu),
+            pods_watcher_res = pods_watcher_future => pods_watcher_res.context(UnableToInitializePodsWatcherSnafu),
             () = shutdown_signal() => {
                 tracing::info!("Goodbye!");
                 Ok(())
@@ -87,23 +196,27 @@ impl Runtime {
         }
     }
 
-    pub fn start_pods_watcher(&mut self) -> notify::Result<()> {
+    pub async fn start_pods_watcher(&mut self) -> notify::Result<()> {
         let mut current_app = Arc::clone(&self.app);
 
-        let handle_event = move |event: podswatcher::PodsWatcherEvent| {
-            match event {
-                podswatcher::PodsWatcherEvent::PodsUpdated(new_app) => {
-                    tracing::debug!("Updated pods information: {:?}", new_app);
-                    tracing::debug!("Previous pods information: {:?}", current_app);
+        let mut rx = self.pods_watcher.watch()?;
 
-                    // TODO: update runtime based on current_app vs new_app info
+        while let Some(new_app) = rx.recv().await {
+            tracing::debug!("Updated pods information: {:?}", new_app);
+            tracing::debug!("Previous pods information: {:?}", current_app);
 
-                    current_app = Arc::new(new_app);
-                }
-            }
-        };
+            // TODO: This is a placeholder to demo/test that datasets could be loaded here
+            // To be replaced with actual implementation using shared ds/datafusion instance
 
-        self.pods_watcher.watch(handle_event)?;
+            // let mut df = datafusion::DataFusion::new();
+            // let auth = auth::AuthProviders::default();
+
+            // if let Err(err) = Runtime::load_dataset(&new_app.datasets[0], &auth, &mut df).await {
+            //     tracing::error!("Unable to load dataset: {err:?}");
+            // }
+
+            current_app = Arc::new(new_app);
+        }
 
         Ok(())
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -204,19 +204,27 @@ impl Runtime {
 
         let mut auth = auth::AuthProviders::default();
         if let Err(err) = auth.parse_from_config() {
-            tracing::error!("Unable to parse auth from config, proceeding without auth: {}", err);
+            tracing::error!(
+                "Unable to parse auth from config, proceeding without auth: {}",
+                err
+            );
         }
 
         while let Some(new_app) = rx.recv().await {
             tracing::debug!("Updated pods information: {:?}", new_app);
             tracing::debug!("Previous pods information: {:?}", current_app);
 
-
-            let existing_dataset_names = current_app.datasets.iter().map(|ds| ds.name.clone()).collect::<Vec<String>>();
+            let existing_dataset_names = current_app
+                .datasets
+                .iter()
+                .map(|ds| ds.name.clone())
+                .collect::<Vec<String>>();
 
             for ds in &new_app.datasets {
                 if !existing_dataset_names.contains(&ds.name) {
-                    if let Err(err) = Runtime::load_dataset(ds, &auth, &mut *self.df.write().await).await {
+                    if let Err(err) =
+                        Runtime::load_dataset(ds, &auth, &mut *self.df.write().await).await
+                    {
                         tracing::error!("Unable to load dataset: {err:?}");
                     }
                 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -41,22 +41,22 @@ pub enum Error {
     #[snafu(display("Unknown data source: {data_source}"))]
     UnknownDataSource { data_source: String },
 
-    #[snafu(display("Unable to create data backend"))]
+    #[snafu(display("Unable to create data backend: {source}"))]
     UnableToCreateBackend { source: datafusion::Error },
 
-    #[snafu(display("Unable to attach data source: {data_source}"))]
+    #[snafu(display("Unable to attach data source {data_source}: {source}"))]
     UnableToAttachDataSource {
         source: datafusion::Error,
         data_source: String,
     },
 
-    #[snafu(display("Unable to attach view"))]
+    #[snafu(display("Unable to attach view: {source}"))]
     UnableToAttachView { source: datafusion::Error },
 
     #[snafu(display("Failed to start pods watcher: {source}"))]
     UnableToInitializePodsWatcher { source: NotifyError },
 
-    #[snafu(display("Unable to initialize data connector: {data_connector}"))]
+    #[snafu(display("Unable to initialize data connector {data_connector}: {source}"))]
     UnableToInitializeDataConnector {
         source: dataconnector::Error,
         data_connector: String,
@@ -70,7 +70,7 @@ pub enum Error {
         source: spicepod::component::dataset::Error,
     },
 
-    #[snafu(display("Unable to attach data connector: {data_connector}"))]
+    #[snafu(display("Unable to attach data connector {data_connector}: {source}"))]
     UnableToAttachDataConnector {
         source: datafusion::Error,
         data_connector: String,

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -27,6 +27,7 @@ use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value;
 use opentelemetry_proto::tonic::metrics::v1::DataPointFlags;
 use opentelemetry_proto::tonic::metrics::v1::NumberDataPoint;
 use snafu::prelude::*;
+use tokio::sync::RwLock;
 use tonic_0_9_0::async_trait;
 use tonic_0_9_0::codec::CompressionEncoding;
 use tonic_0_9_0::transport::Server;
@@ -80,7 +81,7 @@ const TIME_UNIX_NANO_COLUMN_NAME: &str = "time_unix_nano";
 const START_TIME_UNIX_NANO_COLUMN_NAME: &str = "start_time_unix_nano";
 
 pub struct Service {
-    data_fusion: Arc<DataFusion>,
+    data_fusion: Arc<RwLock<DataFusion>>,
     once_tracer: OnceTracer,
 }
 
@@ -98,6 +99,8 @@ impl MetricsService for Service {
                     if let Some(data) = metric.data {
                         let existing_schema = match self
                             .data_fusion
+                            .read()
+                            .await
                             .get_arrow_schema(metric.name.as_str())
                             .await
                         {
@@ -113,8 +116,9 @@ impl MetricsService for Service {
 
                         match record_batch_result {
                             Ok(record_batch) => {
-                                let Some(backend) =
-                                    self.data_fusion.get_backend(metric.name.as_str())
+                                let df = self.data_fusion.read().await;
+                                
+                                let Some(backend) = df.get_backend(metric.name.as_str())
                                 else {
                                     warn_once!(
                                         self.once_tracer,
@@ -547,7 +551,7 @@ fn append_null(
     }
 }
 
-pub async fn start(bind_address: SocketAddr, data_fusion: Arc<DataFusion>) -> Result<()> {
+pub async fn start(bind_address: SocketAddr, data_fusion: Arc<RwLock<DataFusion>>) -> Result<()> {
     let service = Service {
         data_fusion,
         once_tracer: OnceTracer::new(),

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -117,9 +117,8 @@ impl MetricsService for Service {
                         match record_batch_result {
                             Ok(record_batch) => {
                                 let df = self.data_fusion.read().await;
-                                
-                                let Some(backend) = df.get_backend(metric.name.as_str())
-                                else {
+
+                                let Some(backend) = df.get_backend(metric.name.as_str()) else {
                                     warn_once!(
                                         self.once_tracer,
                                         "No dataset defined for metric {}, skipping",

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -4,13 +4,9 @@ use notify::{
 };
 use spicepod::component::ComponentOrReference;
 use std::path::PathBuf;
+use tokio::sync::mpsc::{channel, Receiver};
 
 use app::App;
-
-#[derive(Debug)]
-pub enum PodsWatcherEvent {
-    PodsUpdated(App),
-}
 
 pub struct PodsWatcher {
     root_path: PathBuf,
@@ -26,11 +22,10 @@ impl PodsWatcher {
         }
     }
 
-    pub fn watch<F>(&mut self, mut event_handler: F) -> notify::Result<()>
-    where
-        F: FnMut(PodsWatcherEvent) + 'static + Send,
-    {
+    pub fn watch(&mut self) -> notify::Result<Receiver<App>> {
         let root_path = self.root_path.clone();
+
+        let (tx, rx) = channel(100);
 
         let root_spicepod_path = vec![
             root_path.join("spicepod.yaml"),
@@ -39,8 +34,8 @@ impl PodsWatcher {
 
         let mut watch_paths = get_watch_paths(&root_path);
 
-        let mut watcher =
-            notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+        let mut watcher = notify::recommended_watcher(
+            move |res: Result<notify::Event, notify::Error>| {
                 match res {
                     Ok(event) => {
                         if !is_spicepods_modification_event(&watch_paths, &event) {
@@ -56,20 +51,25 @@ impl PodsWatcher {
                         }
 
                         if let Ok(app) = App::new(root_path.clone()) {
-                            event_handler(PodsWatcherEvent::PodsUpdated(app));
+                            futures::executor::block_on(async {
+                                if let Err(err) = tx.send(app).await {
+                                    tracing::error!("Pods content watcher is unable to notify detected state change: {:?}", err);
+                                }
+                            });
                         } else {
                             tracing::debug!("Invalid app state detected, ignoring changes.");
                         }
                     }
                     Err(e) => tracing::error!("Pods content watcher error: {:?}", e),
                 }
-            })?;
+            },
+        )?;
 
         watcher.watch(&self.root_path, RecursiveMode::Recursive)?;
 
         self.watcher = Some(watcher);
 
-        Ok(())
+        Ok(rx)
     }
 }
 


### PR DESCRIPTION
1. Extracted dataset loading logic to re-usable function so it cab used by pods watcher
2. Pods watcher is now async  so it can work with datasets loading and other async functionality
3. Datafusion is shared via RWLock


