### PR TITLE
Correct all existing errors to display underlying error

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -18,7 +18,7 @@ pub struct App {
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to load spicepod {}", path.display()))]
+    #[snafu(display("Unable to load spicepod {}: {source}", path.display()))]
     UnableToLoadSpicepod {
         source: spicepod::Error,
         path: PathBuf,

--- a/crates/duckdb_datafusion/src/lib.rs
+++ b/crates/duckdb_datafusion/src/lib.rs
@@ -23,13 +23,13 @@ mod expr;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to get a DuckDB connection from the pool: {}", source))]
+    #[snafu(display("Unable to get a DuckDB connection from the pool: {source}"))]
     UnableToGetConnectionFromPool { source: r2d2::Error },
 
-    #[snafu(display("Unable to query DuckDB: {}", source))]
+    #[snafu(display("Unable to query DuckDB: {source}"))]
     UnableToQueryDuckDB { source: duckdb::Error },
 
-    #[snafu(display("Unable to generate SQL: {}", source))]
+    #[snafu(display("Unable to generate SQL: {source}"))]
     UnableToGenerateSQL { source: expr::Error },
 }
 

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -19,23 +19,23 @@ mod tls;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to connect to server"))]
+    #[snafu(display("Unable to connect to server:m {source}"))]
     UnableToConnectToServer { source: tls::Error },
 
-    #[snafu(display("Invalid metadata value"))]
+    #[snafu(display("Invalid metadata value: {source}"))]
     InvalidMetadata {
         source: tonic::metadata::errors::InvalidMetadataValue,
     },
 
-    #[snafu(display("Unable to perform handshake"))]
+    #[snafu(display("Unable to perform handshake: {source}"))]
     UnableToPerformHandshake { source: tonic::Status },
 
-    #[snafu(display("Unable to convert metadata to string"))]
+    #[snafu(display("Unable to convert metadata to string: {source}"))]
     UnableToConvertMetadataToString {
         source: tonic::metadata::errors::ToStrError,
     },
 
-    #[snafu(display("Unable to query"))]
+    #[snafu(display("Unable to query: {source}"))]
     UnableToQuery { source: tonic::Status },
 
     #[snafu(display("Unauthorized"))]

--- a/crates/flight_client/src/tls.rs
+++ b/crates/flight_client/src/tls.rs
@@ -4,13 +4,13 @@ use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to load system TLS certificate"))]
+    #[snafu(display("Unable to load system TLS certificate: {source}"))]
     FailedToLoadCerts { source: std::io::Error },
 
-    #[snafu(display("Unable to convert PEMs to string"))]
+    #[snafu(display("Unable to convert PEMs to string: {source}"))]
     FailedToConvertPems { source: std::string::FromUtf8Error },
 
-    #[snafu(display("Unable to connect to endpoint"))]
+    #[snafu(display("Unable to connect to endpoint: {source}"))]
     UnableToConnectToEndpoint { source: tonic::transport::Error },
 }
 

--- a/crates/runtime/src/auth.rs
+++ b/crates/runtime/src/auth.rs
@@ -11,13 +11,13 @@ pub enum Error {
     #[snafu(display("Unable to find home directory"))]
     UnableToFindHomeDir {},
 
-    #[snafu(display("Unable to open auth file"))]
+    #[snafu(display("Unable to open auth file: {source}"))]
     UnableToOpenAuthFile { source: std::io::Error },
 
-    #[snafu(display("Unable to read auth file"))]
+    #[snafu(display("Unable to read auth file: {source}"))]
     UnableToReadAuthFile { source: std::io::Error },
 
-    #[snafu(display("Unable to parse auth file"))]
+    #[snafu(display("Unable to parse auth file: {source}"))]
     UnableToParseAuthFile { source: toml::de::Error },
 }
 

--- a/crates/runtime/src/databackend.rs
+++ b/crates/runtime/src/databackend.rs
@@ -15,7 +15,7 @@ pub enum Error {
     #[snafu(display("Invalid configuration: {msg}"))]
     InvalidConfiguration { msg: String },
 
-    #[snafu(display("Backend creation failed"))]
+    #[snafu(display("Backend creation failed: {source}"))]
     BackendCreationFailed {
         source: Box<dyn std::error::Error + Send + Sync>,
     },

--- a/crates/runtime/src/databackend/duckdb.rs
+++ b/crates/runtime/src/databackend/duckdb.rs
@@ -21,26 +21,21 @@ use super::{AddDataResult, DataBackend};
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("DuckDBError: {source}"))]
-    DuckDBError {
-        source: duckdb::Error,
-    },
+    DuckDBError { source: duckdb::Error },
 
-    ConnectionPoolError {
-        source: r2d2::Error,
-    },
+    #[snafu(display("ConnectionPoolError: {source}"))]
+    ConnectionPoolError { source: r2d2::Error },
 
-    DuckDBDataFusion {
-        source: duckdb_datafusion::Error,
-    },
+    #[snafu(display("DuckDBDataFusionError: {source}"))]
+    DuckDBDataFusion { source: duckdb_datafusion::Error },
 
+    #[snafu(display("DataFusionError: {source}"))]
     DataFusion {
         source: datafusion::error::DataFusionError,
     },
 
     #[snafu(display("Lock is poisoned: {message}"))]
-    LockPoisoned {
-        message: String,
-    },
+    LockPoisoned { message: String },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/databackend/memtable.rs
+++ b/crates/runtime/src/databackend/memtable.rs
@@ -22,6 +22,7 @@ pub enum Error {
     #[snafu(display("Unable to add data: {source}"))]
     UnableToAddData { source: DataFusionError },
 
+    #[snafu(display("Unable to parse SQL: {source}"))]
     UnableToParseSql {
         source: sqlparser::parser::ParserError,
     },

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -21,6 +21,7 @@ pub mod spiceai;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
+    #[snafu(display("Unable to create data connector: {source}"))]
     UnableToCreateDataConnector {
         source: Box<dyn std::error::Error + Send + Sync>,
     },

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -23,7 +23,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to register parquet file {}", file))]
+    #[snafu(display("Unable to register parquet file {file}: {source}"))]
     RegisterParquet {
         source: DataFusionError,
         file: String,

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -416,17 +416,15 @@ where
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("A test error"))]
-    Arrow { source: ArrowError },
-
-    #[snafu(display("Unable to register parquet file"))]
+    #[snafu(display("Unable to register parquet file: {source}"))]
     RegisterParquet { source: crate::datafusion::Error },
 
+    #[snafu(display("{source}"))]
     DataFusion {
         source: datafusion::error::DataFusionError,
     },
 
-    #[snafu(display("Unable to start Flight server"))]
+    #[snafu(display("Unable to start Flight server: {source}"))]
     UnableToStartFlightServer { source: tonic::transport::Error },
 }
 

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -11,10 +11,10 @@ mod v1;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to bind to address"))]
+    #[snafu(display("Unable to bind to address: {source}"))]
     UnableToBindServerToPort { source: std::io::Error },
 
-    #[snafu(display("Unable to start HTTP server"))]
+    #[snafu(display("Unable to start HTTP server: {source}"))]
     UnableToStartHttpServer { source: std::io::Error },
 }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -28,13 +28,13 @@ pub(crate) mod tracers;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to start HTTP server"))]
+    #[snafu(display("Unable to start HTTP server: {source}"))]
     UnableToStartHttpServer { source: http::Error },
 
-    #[snafu(display("Unable to start Flight server"))]
+    #[snafu(display("Unable to start Flight server: {source}"))]
     UnableToStartFlightServer { source: flight::Error },
 
-    #[snafu(display("Unable to start OpenTelemetry server"))]
+    #[snafu(display("Unable to start OpenTelemetry server: {source}"))]
     UnableToStartOpenTelemetryServer { source: opentelemetry::Error },
 }
 

--- a/crates/runtime/src/modelruntime/tract.rs
+++ b/crates/runtime/src/modelruntime/tract.rs
@@ -19,10 +19,13 @@ pub struct Tract {
 
 #[derive(Debug, Snafu)]
 pub enum Error {
+    #[snafu(display("{source}"))]
     TractError { source: tract_core::anyhow::Error },
 
+    #[snafu(display("{source}"))]
     ArrowError { source: arrow::error::ArrowError },
 
+    #[snafu(display("{source}"))]
     ShapeError { source: ndarray::ShapeError },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -32,7 +32,7 @@ pub enum ComponentOrReference<T> {
 pub enum Error {
     #[snafu(display("Unable to convert the path into a string"))]
     UnableToConvertPath,
-    #[snafu(display("Unable to parse spicepod component {}", path.display()))]
+    #[snafu(display("Unable to parse spicepod component {}: {source}", path.display()))]
     UnableToParseSpicepodComponent {
         source: serde_yaml::Error,
         path: PathBuf,

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -14,9 +14,9 @@ mod spec;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to parse spicepod.yaml"))]
+    #[snafu(display("Unable to parse spicepod.yaml: {source}"))]
     UnableToParseSpicepod { source: serde_yaml::Error },
-    #[snafu(display("Unable to resolve spicepod components {}", path.display()))]
+    #[snafu(display("Unable to resolve spicepod components {}: {source}", path.display()))]
     UnableToResolveSpicepodComponents {
         source: component::Error,
         path: PathBuf,

--- a/crates/spicepod/src/reader.rs
+++ b/crates/spicepod/src/reader.rs
@@ -6,7 +6,7 @@ use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to open path {}", path.display()))]
+    #[snafu(display("Unable to open path {}: {source}", path.display()))]
     UnableToOpenPath {
         source: std::io::Error,
         path: PathBuf,


### PR DESCRIPTION
The new standard in the OSS project is to always print the underlying error in the display message for an error because this is not done by default. This PR goes back and corrects this for all existing errors.