### PR TITLE
load models from spicepod dependencies too

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -55,6 +55,9 @@ impl App {
             for dataset in &dependent_spicepod.datasets {
                 datasets.push(dataset.clone());
             }
+            for model in &dependent_spicepod.models {
+                models.push(model.clone());
+            }
             spicepods.push(dependent_spicepod);
         }
 


### PR DESCRIPTION
This allows the model to be loaded even they are in dependencies spicepod.