### PR TITLE
Support pushing data to Spice.ai

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ dependencies = [
 name = "flight_client"
 version = "0.10.0-alpha.0"
 dependencies = [
+ "arrow",
  "arrow-flight",
  "base64",
  "bytes",

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -11,11 +11,13 @@ use clap::Parser;
 use flightrepl::ReplConfig;
 use runtime::config::Config as RuntimeConfig;
 use runtime::dataconnector::DataConnector;
+use runtime::datafusion::DataFusion;
 use runtime::model::Model;
 
 use runtime::podswatcher::PodsWatcher;
 use runtime::{dataconnector, Runtime};
 use snafu::prelude::*;
+use spicepod::component::dataset::{Dataset, Mode};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -88,92 +90,45 @@ pub struct Args {
     pub repl_config: ReplConfig,
 }
 
-#[allow(clippy::too_many_lines)]
 pub async fn run(args: Args) -> Result<()> {
     let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
 
     let app = App::new(current_dir.clone()).context(UnableToConstructSpiceAppSnafu)?;
 
-    let mut auth = runtime::auth::AuthProviders::default();
-    match auth.parse_from_config() {
-        Ok(()) => {}
-        Err(e) => {
-            tracing::warn!(
-                "Unable to parse auth from config, proceeding without auth: {}",
-                e
-            );
-        }
-    }
+    let auth = load_auth_providers();
 
     let mut df = runtime::datafusion::DataFusion::new();
 
-    for ds in &app.datasets {
-        let ds_name = ds.name.clone();
-        let ds = Arc::new(ds.clone());
-        if ds.acceleration.is_none() && !ds.is_view() {
-            tracing::warn!("No acceleration specified for dataset: {}", ds.name);
-            continue;
-        };
+    load_datasets(&app, &mut df, &auth).await?;
 
-        let source = ds.source();
-        let source = source.as_str();
-        let params = Arc::new(ds.params.clone());
-        let data_connector: Option<Box<dyn DataConnector>> = match source {
-            "spice.ai" => Some(Box::new(
-                dataconnector::spiceai::SpiceAI::new(auth.get(source), params)
-                    .await
-                    .context(UnableToInitializeDataConnectorSnafu {
-                        data_connector: source,
-                    })?,
-            )),
-            "dremio" => Some(Box::new(
-                dataconnector::dremio::Dremio::new(auth.get(source), params)
-                    .await
-                    .context(UnableToInitializeDataConnectorSnafu {
-                        data_connector: source,
-                    })?,
-            )),
-            "localhost" | "" => None,
-            "debug" => Some(Box::new(dataconnector::debug::DebugSource {})),
-            _ => UnknownDataConnectorSnafu {
-                data_connector: source,
-            }
-            .fail()?,
-        };
+    let model_map = load_models(&app, &auth);
 
-        let view_sql = ds.view_sql().context(InvalidSQLViewSnafu)?;
+    let pods_watcher = PodsWatcher::new(current_dir.clone());
 
-        match data_connector {
-            Some(data_connector) => {
-                let data_connector = Box::leak(data_connector);
-                let data_backend = df
-                    .new_accelerated_backend(Arc::clone(&ds))
-                    .context(UnableToCreateBackendSnafu)?;
+    let mut rt: Runtime = Runtime::new(args.runtime, app, df, model_map, pods_watcher);
 
-                df.attach_connector_to_publisher(ds, data_connector, data_backend)
-                    .context(UnableToAttachDataConnectorSnafu {
-                        data_connector: source,
-                    })?;
-            }
-            None => {
-                if view_sql.is_some() {
-                    df.attach_view(&ds).context(UnableToAttachViewSnafu)?;
-                } else {
-                    let data_backend = df
-                        .new_accelerated_backend(Arc::clone(&ds))
-                        .context(UnableToCreateBackendSnafu)?;
-                    df.attach_publisher(&ds.name.clone(), Arc::clone(&ds), data_backend)
-                        .await
-                        .context(UnableToAttachDataConnectorSnafu {
-                            data_connector: source,
-                        })?;
-                }
-            }
-        }
+    rt.start_pods_watcher()
+        .context(UnableToInitializePodsWatcherSnafu)?;
 
-        tracing::info!("Loaded dataset: {}", ds_name);
+    rt.start_servers()
+        .await
+        .context(UnableToStartServersSnafu)?;
+
+    Ok(())
+}
+
+fn load_auth_providers() -> runtime::auth::AuthProviders {
+    let mut auth = runtime::auth::AuthProviders::default();
+    if let Err(e) = auth.parse_from_config() {
+        tracing::warn!(
+            "Unable to parse auth from config, proceeding without auth: {}",
+            e
+        );
     }
+    auth
+}
 
+fn load_models(app: &App, auth: &runtime::auth::AuthProviders) -> HashMap<String, Model> {
     let mut model_map = HashMap::with_capacity(app.models.len());
     for m in &app.models {
         tracing::info!("Deploying model [{}] from {}...", m.name, m.from);
@@ -192,16 +147,113 @@ pub async fn run(args: Args) -> Result<()> {
         }
     }
 
-    let pods_watcher = PodsWatcher::new(current_dir.clone());
+    model_map
+}
 
-    let mut rt: Runtime = Runtime::new(args.runtime, app, df, model_map, pods_watcher);
+async fn load_datasets(
+    app: &App,
+    df: &mut DataFusion,
+    auth: &runtime::auth::AuthProviders,
+) -> Result<()> {
+    for ds in &app.datasets {
+        let ds = Arc::new(ds.clone());
+        if ds.acceleration.is_none() && !ds.is_view() {
+            tracing::warn!("No acceleration specified for dataset: {}", ds.name);
+            continue;
+        };
 
-    rt.start_pods_watcher()
-        .context(UnableToInitializePodsWatcherSnafu)?;
+        let source = ds.source();
+        let source = source.as_str();
+        let params = Arc::new(ds.params.clone());
+        let data_connector: Option<Box<dyn DataConnector>> =
+            get_dataconnector_from_source(source, auth, Arc::clone(&params)).await?;
 
-    rt.start_servers()
-        .await
-        .context(UnableToStartServersSnafu)?;
+        initialize_dataconnector(data_connector, df, source, &ds).await?;
+
+        tracing::info!("Loaded dataset: {}", &ds.name);
+    }
+
+    Ok(())
+}
+
+async fn get_dataconnector_from_source(
+    source: &str,
+    auth: &runtime::auth::AuthProviders,
+    params: Arc<Option<HashMap<String, String>>>,
+) -> Result<Option<Box<dyn DataConnector>>> {
+    match source {
+        "spice.ai" => Ok(Some(Box::new(
+            dataconnector::spiceai::SpiceAI::new(auth.get(source), params)
+                .await
+                .context(UnableToInitializeDataConnectorSnafu {
+                    data_connector: source,
+                })?,
+        ))),
+        "dremio" => Ok(Some(Box::new(
+            dataconnector::dremio::Dremio::new(auth.get(source), params)
+                .await
+                .context(UnableToInitializeDataConnectorSnafu {
+                    data_connector: source,
+                })?,
+        ))),
+        "localhost" | "" => Ok(None),
+        "debug" => Ok(Some(Box::new(dataconnector::debug::DebugSource {}))),
+        _ => UnknownDataConnectorSnafu {
+            data_connector: source,
+        }
+        .fail()?,
+    }
+}
+
+async fn initialize_dataconnector(
+    data_connector: Option<Box<dyn DataConnector>>,
+    df: &mut DataFusion,
+    source: &str,
+    ds: &Arc<Dataset>,
+) -> Result<()> {
+    let view_sql = ds.view_sql().context(InvalidSQLViewSnafu)?;
+
+    match data_connector {
+        Some(data_connector) => {
+            let data_backend = df
+                .new_accelerated_backend(Arc::clone(ds))
+                .context(UnableToCreateBackendSnafu)?;
+
+            if ds.mode() == Mode::ReadWrite {
+                if let Some(data_publisher) = data_connector.get_data_publisher() {
+                    df.attach_publisher(&ds.name.clone(), Arc::clone(ds), data_publisher)
+                        .await
+                        .context(UnableToAttachDataConnectorSnafu {
+                            data_connector: source,
+                        })?;
+                } else {
+                    tracing::warn!(
+                    "Data connector {source} does not support writes, but dataset {ds_name} is in read-write mode",
+                    ds_name = ds.name
+                );
+                }
+            }
+
+            df.attach_connector_to_publisher(Arc::clone(ds), data_connector, data_backend)
+                .context(UnableToAttachDataConnectorSnafu {
+                    data_connector: source,
+                })?;
+        }
+        None => {
+            if view_sql.is_some() {
+                df.attach_view(ds).context(UnableToAttachViewSnafu)?;
+            } else {
+                let data_backend = df
+                    .new_accelerated_backend(Arc::clone(ds))
+                    .context(UnableToCreateBackendSnafu)?;
+                df.attach_publisher(&ds.name.clone(), Arc::clone(ds), data_backend)
+                    .await
+                    .context(UnableToAttachDataConnectorSnafu {
+                        data_connector: source,
+                    })?;
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/flight_client/Cargo.toml
+++ b/crates/flight_client/Cargo.toml
@@ -11,6 +11,7 @@ exclude.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arrow = "49.0.0"
 arrow-flight = { version = "49.0.0", features = ["flight-sql-experimental"] }
 base64 = "0.21.7"
 bytes = "1.5.0"

--- a/crates/runtime/src/databackend/duckdb.rs
+++ b/crates/runtime/src/databackend/duckdb.rs
@@ -75,6 +75,10 @@ impl DataPublisher for DuckDBBackend {
             Ok(())
         })
     }
+
+    fn name(&self) -> &str {
+        "DuckDB"
+    }
 }
 
 impl DuckDBBackend {

--- a/crates/runtime/src/databackend/memtable.rs
+++ b/crates/runtime/src/databackend/memtable.rs
@@ -69,6 +69,10 @@ impl DataPublisher for MemTableBackend {
             Ok(())
         })
     }
+
+    fn name(&self) -> &str {
+        "MemTable"
+    }
 }
 
 struct MemTableUpdate {

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -12,6 +12,7 @@ use futures_core::stream::BoxStream;
 use std::future::Future;
 
 use crate::auth::AuthProvider;
+use crate::datapublisher::DataPublisher;
 use crate::dataupdate::{DataUpdate, UpdateType};
 
 pub mod debug;
@@ -67,18 +68,8 @@ pub trait DataConnector: Send + Sync {
         dataset: &Dataset,
     ) -> Pin<Box<dyn Future<Output = Vec<RecordBatch>> + Send>>;
 
-    /// Returns true if the given dataset supports writing data back to this `DataConnector`.
-    fn supports_data_writes(&self, _dataset: &Dataset) -> bool {
-        false
-    }
-
-    /// Adds data ingested locally back to the source.
-    fn add_data(
-        &self,
-        dataset: &Dataset,
-        _data: DataUpdate,
-    ) -> Pin<Box<dyn Future<Output = AnyErrorResult>>> {
-        panic!("add_data not implemented for {}", dataset.name)
+    fn get_data_publisher(&self) -> Option<Box<dyn DataPublisher>> {
+        None
     }
 }
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -104,7 +104,6 @@ impl dyn DataConnector + '_ {
                 loop {
                     tracing::info!("Refreshing data for {}", dataset.name);
                     yield DataUpdate {
-                        log_sequence_number: None,
                         data: self.get_all_data(dataset).await,
                         update_type: UpdateType::Overwrite,
                     };
@@ -117,7 +116,6 @@ impl dyn DataConnector + '_ {
         // Otherwise, just return the data once.
         Box::pin(stream::once(async move {
             DataUpdate {
-                log_sequence_number: None,
                 data: self.get_all_data(dataset).await,
                 update_type: UpdateType::Overwrite,
             }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -28,6 +28,7 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type AnyErrorResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
 /// A `DataConnector` knows how to retrieve and modify data for a given dataset.
 ///
@@ -76,7 +77,7 @@ pub trait DataConnector: Send + Sync {
         &self,
         dataset: &Dataset,
         _data: DataUpdate,
-    ) -> Pin<Box<dyn Future<Output = Result<()>>>> {
+    ) -> Pin<Box<dyn Future<Output = AnyErrorResult>>> {
         panic!("add_data not implemented for {}", dataset.name)
     }
 }

--- a/crates/runtime/src/dataconnector/debug.rs
+++ b/crates/runtime/src/dataconnector/debug.rs
@@ -75,7 +75,6 @@ impl DataConnector for DebugSource {
                   ],
               ) {
                 yield DataUpdate {
-                  log_sequence_number: None,
                   update_type: UpdateType::Append,
                   data: vec![batch],
                 };

--- a/crates/runtime/src/dataconnector/flight.rs
+++ b/crates/runtime/src/dataconnector/flight.rs
@@ -5,6 +5,7 @@ use arrow::record_batch::RecordBatch;
 use flight_client::FlightClient;
 use futures::StreamExt;
 
+#[derive(Debug, Clone)]
 pub struct Flight {
     pub client: FlightClient,
 }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -147,6 +147,10 @@ impl DataPublisher for SpiceAI {
             Ok(())
         })
     }
+
+    fn name(&self) -> &str {
+        "SpiceAI"
+    }
 }
 
 impl SpiceAI {

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -31,6 +31,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[derive(Clone)]
 pub struct SpiceAI {
     flight: Flight,
     spaced_trace: Arc<SpacedTracer>,
@@ -122,9 +123,8 @@ impl DataConnector for SpiceAI {
         self.flight.get_all_data(&spice_dataset_path)
     }
 
-    /// Returns true if the given dataset supports writing data back to this `DataConnector`.
-    fn supports_data_writes(&self, _dataset: &Dataset) -> bool {
-        true
+    fn get_data_publisher(&self) -> Option<Box<dyn DataPublisher>> {
+        Some(Box::new(self.clone()))
     }
 }
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -162,7 +162,7 @@ impl DataFusion {
     pub fn attach_connector_to_publisher(
         &mut self,
         dataset: Arc<Dataset>,
-        data_connector: &'static mut dyn DataConnector,
+        data_connector: Box<dyn DataConnector>,
         publisher: Box<dyn DataPublisher>,
     ) -> Result<()> {
         let table_name = dataset.name.as_str();

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::databackend::{self, DataBackend};
 use crate::dataconnector::DataConnector;
+use crate::datapublisher::DataPublisher;
 use datafusion::datasource::ViewTable;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionConfig;
@@ -16,6 +17,7 @@ use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use futures::StreamExt;
 use snafu::prelude::*;
 use spicepod::component::dataset::Dataset;
+use tokio::sync::RwLock;
 use tokio::time::sleep;
 use tokio::{spawn, task};
 
@@ -61,10 +63,14 @@ pub enum Error {
     ExpectedSqlView,
 }
 
+type PublisherList = Arc<RwLock<Vec<Box<dyn DataPublisher>>>>;
+
+type DatasetAndPublishers = (Arc<Dataset>, PublisherList);
+
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     tasks: Vec<task::JoinHandle<()>>,
-    backends: HashMap<String, Arc<Box<dyn DataBackend>>>,
+    data_publishers: HashMap<String, DatasetAndPublishers>,
 }
 
 impl DataFusion {
@@ -77,7 +83,7 @@ impl DataFusion {
                 SessionConfig::new().with_information_schema(true),
             )),
             tasks: Vec::new(),
-            backends: HashMap::new(),
+            data_publishers: HashMap::new(),
         }
     }
 
@@ -88,23 +94,27 @@ impl DataFusion {
             .context(RegisterParquetSnafu { file: path })
     }
 
-    pub fn attach_backend(
+    pub async fn attach_publisher(
         &mut self,
         table_name: &str,
-        backend: Box<dyn DataBackend>,
+        dataset: Arc<Dataset>,
+        publisher: Box<dyn DataPublisher>,
     ) -> Result<()> {
-        let table_exists = self.ctx.table_exist(table_name).unwrap_or(false);
-        if table_exists {
-            return TableAlreadyExistsSnafu.fail();
-        }
+        let entry = self
+            .data_publishers
+            .entry(table_name.to_string())
+            .or_insert_with(|| {
+                // If it does not exist, initialize it with the dataset and a new Vec for publishers
+                (dataset, Arc::new(RwLock::new(Vec::new())))
+            });
 
-        self.backends
-            .insert(table_name.to_string(), Arc::new(backend));
+        entry.1.write().await.push(publisher);
 
         Ok(())
     }
 
-    pub fn new_backend(&self, dataset: &Dataset) -> Result<Box<dyn DataBackend>> {
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new_accelerated_backend(&self, dataset: Arc<Dataset>) -> Result<Box<dyn DataPublisher>> {
         let table_name = dataset.name.as_str();
         let acceleration =
             dataset
@@ -116,7 +126,7 @@ impl DataFusion {
 
         let params: Arc<Option<HashMap<String, String>>> = Arc::new(dataset.params.clone());
 
-        let data_backend: Box<dyn DataBackend> = <dyn DataBackend>::new(
+        let data_backend: Box<dyn DataPublisher> = DataBackend::new(
             &self.ctx,
             table_name,
             acceleration.engine(),
@@ -130,13 +140,13 @@ impl DataFusion {
 
     #[must_use]
     #[allow(clippy::borrowed_box)]
-    pub fn get_backend(&self, dataset: &str) -> Option<&Arc<Box<dyn DataBackend>>> {
-        self.backends.get(dataset)
+    pub fn get_publisher(&self, dataset: &str) -> Option<&DatasetAndPublishers> {
+        self.data_publishers.get(dataset)
     }
 
     #[must_use]
-    pub fn has_backend(&self, dataset: &str) -> bool {
-        self.backends.contains_key(dataset)
+    pub fn has_publisher(&self, dataset: &str) -> bool {
+        self.data_publishers.contains_key(dataset)
     }
 
     pub async fn get_arrow_schema(&self, dataset: &str) -> Result<arrow::datatypes::Schema> {
@@ -149,11 +159,11 @@ impl DataFusion {
     }
 
     #[allow(clippy::needless_pass_by_value)]
-    pub fn attach(
+    pub fn attach_connector_to_publisher(
         &mut self,
-        dataset: &Dataset,
+        dataset: Arc<Dataset>,
         data_connector: &'static mut dyn DataConnector,
-        backend: Box<dyn DataBackend>,
+        publisher: Box<dyn DataPublisher>,
     ) -> Result<()> {
         let table_name = dataset.name.as_str();
         let table_exists = self.ctx.table_exist(table_name).unwrap_or(false);
@@ -167,10 +177,12 @@ impl DataFusion {
             loop {
                 let future_result = stream.next().await;
                 match future_result {
-                    Some(data_update) => match backend.add_data(data_update).await {
-                        Ok(()) => (),
-                        Err(e) => tracing::error!("Error adding data: {e:?}"),
-                    },
+                    Some(data_update) => {
+                        match publisher.add_data(Arc::clone(&dataset), data_update).await {
+                            Ok(()) => (),
+                            Err(e) => tracing::error!("Error adding data: {e:?}"),
+                        }
+                    }
                     None => break,
                 };
             }
@@ -181,7 +193,7 @@ impl DataFusion {
         Ok(())
     }
 
-    pub fn attach_view(&self, dataset: &Dataset) -> Result<()> {
+    pub fn attach_view(&self, dataset: &Arc<Dataset>) -> Result<()> {
         let table_exists = self.ctx.table_exist(dataset.name.as_str()).unwrap_or(false);
         if table_exists {
             return TableAlreadyExistsSnafu.fail();

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -63,7 +63,7 @@ pub enum Error {
     ExpectedSqlView,
 }
 
-type PublisherList = Arc<RwLock<Vec<Box<dyn DataPublisher>>>>;
+type PublisherList = Arc<RwLock<Vec<Arc<Box<dyn DataPublisher>>>>>;
 
 type DatasetAndPublishers = (Arc<Dataset>, PublisherList);
 
@@ -98,7 +98,7 @@ impl DataFusion {
         &mut self,
         table_name: &str,
         dataset: Arc<Dataset>,
-        publisher: Box<dyn DataPublisher>,
+        publisher: Arc<Box<dyn DataPublisher>>,
     ) -> Result<()> {
         let entry = self
             .data_publishers
@@ -163,7 +163,7 @@ impl DataFusion {
         &mut self,
         dataset: Arc<Dataset>,
         data_connector: Box<dyn DataConnector>,
-        publisher: Box<dyn DataPublisher>,
+        publisher: Arc<Box<dyn DataPublisher>>,
     ) -> Result<()> {
         let table_name = dataset.name.as_str();
         let table_exists = self.ctx.table_exist(table_name).unwrap_or(false);

--- a/crates/runtime/src/datapublisher.rs
+++ b/crates/runtime/src/datapublisher.rs
@@ -11,4 +11,6 @@ pub type AddDataResult<'a> =
 
 pub trait DataPublisher: Send + Sync {
     fn add_data(&self, dataset: Arc<Dataset>, data_update: DataUpdate) -> AddDataResult;
+
+    fn name(&self) -> &str;
 }

--- a/crates/runtime/src/datapublisher.rs
+++ b/crates/runtime/src/datapublisher.rs
@@ -1,0 +1,14 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use spicepod::component::dataset::Dataset;
+
+use crate::dataupdate::DataUpdate;
+
+pub type AddDataResult<'a> =
+    Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'a>>;
+
+pub trait DataPublisher: Send + Sync {
+    fn add_data(&self, dataset: Arc<Dataset>, data_update: DataUpdate) -> AddDataResult;
+}

--- a/crates/runtime/src/dataupdate.rs
+++ b/crates/runtime/src/dataupdate.rs
@@ -8,12 +8,6 @@ pub enum UpdateType {
 
 #[derive(Debug, Clone)]
 pub struct DataUpdate {
-    /// The unique identifier associated with this DataUpdate.
-    /// If the runtime sees two DataUpdates with the same log_sequence_number,
-    /// it will remove the data associated with the first DataUpdate, and replace it with the second.
-    ///
-    /// A None value will disable the de-duplication logic.
-    pub log_sequence_number: Option<u64>,
     pub data: Vec<RecordBatch>,
     /// The type of update to perform.
     /// If UpdateType::Append, the runtime will append the data to the existing dataset.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod config;
 pub mod databackend;
 pub mod dataconnector;
 pub mod datafusion;
+pub mod datapublisher;
 pub mod dataupdate;
 mod flight;
 mod http;

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -113,8 +113,8 @@ impl MetricsService for Service {
 
                         match record_batch_result {
                             Ok(record_batch) => {
-                                let Some(backend) =
-                                    self.data_fusion.get_backend(metric.name.as_str())
+                                let Some(publishers) =
+                                    self.data_fusion.get_publisher(metric.name.as_str())
                                 else {
                                     warn_once!(
                                         self.once_tracer,
@@ -125,19 +125,28 @@ impl MetricsService for Service {
                                     continue;
                                 };
 
-                                let add_data_future = backend.add_data(DataUpdate {
-                                    log_sequence_number: None,
+                                let dataset = Arc::clone(&publishers.0);
+                                let data_publishers = Arc::clone(&publishers.1);
+
+                                let data_update = DataUpdate {
                                     data: vec![record_batch],
                                     update_type: UpdateType::Append,
-                                });
-                                // We need to await the Future here in case it adds new columns to the schema and later metrics will need
-                                // to respect that schema.
-                                if let Err(e) = add_data_future.await {
-                                    rejected_data_points += data_points_count;
-                                    tracing::error!(
-                                        "Failed to add OpenTelemetry data to backend: {}",
-                                        e
-                                    );
+                                };
+
+                                let data_publishers = data_publishers.read().await;
+                                for publisher in data_publishers.iter() {
+                                    // We need to await the Future here in case it adds new columns to the schema and later metrics will need
+                                    // to respect that schema.
+                                    if let Err(e) = publisher
+                                        .add_data(Arc::clone(&dataset), data_update.clone())
+                                        .await
+                                    {
+                                        rejected_data_points += data_points_count;
+                                        tracing::error!(
+                                            "Failed to add OpenTelemetry data to backend: {}",
+                                            e
+                                        );
+                                    }
                                 }
                             }
                             Err(e) => {

--- a/crates/runtime/src/tracers.rs
+++ b/crates/runtime/src/tracers.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, sync::Mutex};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Mutex,
+    time::{Duration, Instant},
+};
 
 /// Traces a log with a given parameter once, to prevent log spam.
 ///
@@ -20,12 +24,53 @@ macro_rules! warn_once {
     ($tracer:expr, $msg:expr, $value:expr) => {{
         let mut logged_values = $tracer.logged_values.lock().unwrap_or_else(|poisoned| {
             tracing::error!("Lock poisoned while logging: {poisoned}");
-            tracing::warn!($msg, $value);
-            return poisoned.into_inner();
+            poisoned.into_inner()
         });
         if !logged_values.contains(&$value) {
             logged_values.insert($value.clone());
             tracing::warn!($msg, $value);
+        }
+    }};
+}
+
+/// Traces a log with a given parameter at most once every N seconds, to prevent log spam.
+///
+/// Suitable for controlling log frequency.
+pub struct SpacedTracer {
+    pub logged_times: Mutex<HashMap<String, Instant>>,
+    pub interval: Duration,
+}
+
+impl SpacedTracer {
+    pub fn new(interval: Duration) -> Self {
+        SpacedTracer {
+            logged_times: Mutex::new(HashMap::new()),
+            interval,
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! info_spaced {
+    ($tracer:expr, $msg:expr, $key:expr) => {{
+        let mut logged_times = $tracer.logged_times.lock().unwrap_or_else(|poisoned| {
+            tracing::error!("Lock poisoned while logging: {poisoned}");
+            poisoned.into_inner()
+        });
+
+        let now = std::time::Instant::now();
+        let mut should_log = true;
+        if let Some(last_time) = logged_times.get($key) {
+            if now.duration_since(*last_time) < $tracer.interval {
+                // If the interval hasn't elapsed, do not log.
+                should_log = false;
+            }
+        }
+
+        if should_log {
+            // Update the last logged time and log the message.
+            logged_times.insert($key.to_string(), now);
+            tracing::info!($msg, $key);
         }
     }};
 }

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -43,6 +43,19 @@ pub struct Dataset {
 }
 
 impl Dataset {
+    #[must_use]
+    pub fn new(from: String, name: String) -> Self {
+        Dataset {
+            from,
+            name,
+            sql: None,
+            sql_ref: None,
+            params: Option::default(),
+            acceleration: None,
+            depends_on: Vec::default(),
+        }
+    }
+
     /// Returns the dataset source - the first part of the `from` field before the first `/`.
     ///
     /// # Examples

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -17,7 +17,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum Mode {
     Read,
     ReadWrite,

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -16,12 +16,23 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Mode {
+    Read,
+    ReadWrite,
+    Append,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Dataset {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub from: String,
 
     pub name: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    mode: Option<Mode>,
 
     /// Inline SQL that describes a view.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -48,6 +59,7 @@ impl Dataset {
         Dataset {
             from,
             name,
+            mode: None,
             sql: None,
             sql_ref: None,
             params: Option::default(),
@@ -136,6 +148,11 @@ impl Dataset {
 
         Ok(None)
     }
+
+    #[must_use]
+    pub fn mode(&self) -> Mode {
+        self.mode.clone().unwrap_or(Mode::Read)
+    }
 }
 
 impl WithDependsOn<Dataset> for Dataset {
@@ -143,6 +160,7 @@ impl WithDependsOn<Dataset> for Dataset {
         Dataset {
             from: self.from.clone(),
             name: self.name.clone(),
+            mode: self.mode.clone(),
             sql: self.sql.clone(),
             sql_ref: self.sql_ref.clone(),
             params: self.params.clone(),

--- a/docs/EXTENSIBILITY.md
+++ b/docs/EXTENSIBILITY.md
@@ -6,3 +6,4 @@ This document is an overview of all the interfaces and extension points in Spice
 |---------------|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
 | DataConnector | Represents the source of data to the Spice.ai runtime. Specifies how to retrieve data, stream data updates, and write data back. | [dataconnector.rs](../crates/runtime/src/dataconnector.rs) |
 | DataBackend   | Used by the runtime to store accelerated data locally. Specifies which data backend to use via `engine` & `mode` fields.          | [databackend.rs](../crates/runtime/src/databackend.rs)     |
+| DataPublisher   | An interface that specifies how to publish data updates. All DataBackends implement it, and DataConnectors that support writing data back.          | [datapublisher.rs](../crates/runtime/src/datapublisher.rs)     |


### PR DESCRIPTION
Allow datasets to specify that they are `mode: read_write`, which enables the ability to push data back to the dataconnector, if the dataconnector supports it.

This allows for dataset definitions like:
```yaml
from: spice.ai/phillipleblanc/demo/datasets/drive_stats
name: drive_stats
mode: read_write
acceleration:
  enabled: true
```

This tells the runtime "Please load `drive_stats` from spice.ai, and accept writes for `drive_stats` via the runtime's ingestion endpoints (i.e. DoPut Flight API or OpenTelemetry API) and publish that data back to spice.ai`

This ended up being quite a large refactor, since I needed to support having multiple publishers configured for a dataset (i.e. the accelerated backend and the dataconnector), rather than a single one.