### PR TITLE
Rename `/v1/models/[model_name]/predictions` to  `/v1/models/[model_name]/predict` and add `/v1/models/predict` for batching support

### DIFF
--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -4,7 +4,7 @@ use crate::{datafusion::DataFusion, model::Model};
 use app::App;
 
 use axum::{
-    routing::{get, Router},
+    routing::{get, post, Router},
     Extension,
 };
 
@@ -18,7 +18,7 @@ pub(crate) fn routes(
     Router::new()
         .route("/health", get(|| async { "ok\n" }))
         .route("/v1/datasets", get(v1::datasets::get))
-        .route("/v1/models/:name/predictions", get(v1::inference::get))
+        .route("/v1/models/predict", post(v1::inference::post))
         .layer(Extension(app))
         .layer(Extension(df))
         .layer(Extension(models))

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -19,6 +19,7 @@ pub(crate) fn routes(
     Router::new()
         .route("/health", get(|| async { "ok\n" }))
         .route("/v1/datasets", get(v1::datasets::get))
+        .route("/v1/models/:name/predict", get(v1::inference::get))
         .route("/v1/models/predict", post(v1::inference::post))
         .layer(Extension(app))
         .layer(Extension(df))

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -93,6 +93,9 @@ pub(crate) mod inference {
 
         pub model_name: String,
 
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub model_version: Option<String>,
+
         pub lookback: usize,
 
         #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -185,6 +188,7 @@ pub(crate) mod inference {
                 status: PredictStatus::BadRequest,
                 error_message: Some(format!("Model {model_name} not found")),
                 model_name,
+                model_version: None,
                 lookback,
                 prediction: vec![],
                 duration_ms: start_time.elapsed().as_millis(),
@@ -197,6 +201,7 @@ pub(crate) mod inference {
                 status: PredictStatus::BadRequest,
                 error_message: Some(format!("Model {model_name} not found")),
                 model_name,
+                model_version: Some(model.version()),
                 lookback,
                 prediction: vec![],
                 duration_ms: start_time.elapsed().as_millis(),
@@ -212,6 +217,7 @@ pub(crate) mod inference {
                             status: PredictStatus::Success,
                             error_message: None,
                             model_name,
+                            model_version: Some(model.version()),
                             lookback,
                             prediction: result,
                             duration_ms: start_time.elapsed().as_millis(),
@@ -226,6 +232,7 @@ pub(crate) mod inference {
                             "Unable to cast inference result to Float32Array".to_string(),
                         ),
                         model_name,
+                        model_version: Some(model.version()),
                         lookback,
                         prediction: vec![],
                         duration_ms: start_time.elapsed().as_millis(),
@@ -240,6 +247,7 @@ pub(crate) mod inference {
                         "Unable to find column 'y' in inference result".to_string(),
                     ),
                     model_name,
+                    model_version: Some(model.version()),
                     lookback,
                     prediction: vec![],
                     duration_ms: start_time.elapsed().as_millis(),
@@ -251,6 +259,7 @@ pub(crate) mod inference {
                     status: PredictStatus::InternalError,
                     error_message: Some(e.to_string()),
                     model_name,
+                    model_version: Some(model.version()),
                     lookback,
                     prediction: vec![],
                     duration_ms: start_time.elapsed().as_millis(),

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -96,7 +96,7 @@ pub(crate) mod inference {
         pub lookback: usize,
 
         #[serde(skip_serializing_if = "Vec::is_empty")]
-        pub forecast: Vec<f32>,
+        pub prediction: Vec<f32>,
 
         pub duration_ms: u128,
     }
@@ -186,7 +186,7 @@ pub(crate) mod inference {
                 error_message: Some(format!("Model {model_name} not found")),
                 model_name,
                 lookback,
-                forecast: vec![],
+                prediction: vec![],
                 duration_ms: start_time.elapsed().as_millis(),
             };
         };
@@ -198,7 +198,7 @@ pub(crate) mod inference {
                 error_message: Some(format!("Model {model_name} not found")),
                 model_name,
                 lookback,
-                forecast: vec![],
+                prediction: vec![],
                 duration_ms: start_time.elapsed().as_millis(),
             };
         };
@@ -213,7 +213,7 @@ pub(crate) mod inference {
                             error_message: None,
                             model_name,
                             lookback,
-                            forecast: result,
+                            prediction: result,
                             duration_ms: start_time.elapsed().as_millis(),
                         };
                     }
@@ -227,7 +227,7 @@ pub(crate) mod inference {
                         ),
                         model_name,
                         lookback,
-                        forecast: vec![],
+                        prediction: vec![],
                         duration_ms: start_time.elapsed().as_millis(),
                     };
                 }
@@ -241,7 +241,7 @@ pub(crate) mod inference {
                     ),
                     model_name,
                     lookback,
-                    forecast: vec![],
+                    prediction: vec![],
                     duration_ms: start_time.elapsed().as_millis(),
                 }
             }
@@ -252,7 +252,7 @@ pub(crate) mod inference {
                     error_message: Some(e.to_string()),
                     model_name,
                     lookback,
-                    forecast: vec![],
+                    prediction: vec![],
                     duration_ms: start_time.elapsed().as_millis(),
                 }
             }

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -137,7 +137,7 @@ pub(crate) mod inference {
 
     async fn run_inference(
         app: Arc<App>,
-        df: Arc<DataFusion>,
+        df: Arc<RwLock<DataFusion>>,
         models: Arc<HashMap<String, Model>>,
         model_predict_request: ModelPredictRequest,
     ) -> ModelPredictResponse {

--- a/crates/runtime/src/model.rs
+++ b/crates/runtime/src/model.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 
 pub struct Model {
     runnable: Box<dyn Runnable>,
-    datasets: Vec<String>,
+    model: spicepod::component::model::Model,
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -56,7 +56,7 @@ impl Model {
 
         Ok(Self {
             runnable: tract,
-            datasets: model.datasets.clone(),
+            model: model.clone(),
         })
     }
 
@@ -72,7 +72,7 @@ impl Model {
             .sql(
                 &(format!(
                     "select * from datafusion.public.{} order by ts asc",
-                    self.datasets[0]
+                    self.model.datasets[0]
                 )),
             )
             .await

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -32,4 +32,9 @@ impl Model {
             _ => "debug".to_string(),
         }
     }
+
+    #[must_use]
+    pub fn version(&self) -> String {
+        self.from.split(':').last().unwrap_or("").to_string()
+    }
 }


### PR DESCRIPTION
This PR modifies the `/v1/models/[model_name]/predictions` method to be named `/v1/models/[model_name]/predict` and adds batching support with a new method `/v1/models/predict`.