### PR TITLE
HTTP SQL API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3469,6 +3469,7 @@ dependencies = [
  "arrow",
  "arrow-flight",
  "arrow-ipc",
+ "arrow-json",
  "async-stream",
  "axum 0.7.4",
  "clap",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -45,6 +45,7 @@ indexmap = "2.2.2"
 regex = "1.10.3"
 reqwest = { version = "0.11.24", features = ["blocking", "json"] }
 notify = "6.1.1"
+arrow-json = "49.0.0"
 
 [features]
 default = ["duckdb"]

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -18,6 +18,7 @@ pub(crate) fn routes(
 ) -> Router {
     Router::new()
         .route("/health", get(|| async { "ok\n" }))
+        .route("/v1/sql", post(v1::query::post))
         .route("/v1/datasets", get(v1::datasets::get))
         .route("/v1/models/:name/predict", get(v1::inference::get))
         .route("/v1/models/predict", post(v1::inference::post))

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -1,3 +1,65 @@
+pub(crate) mod query {
+    use std::sync::Arc;
+
+    use arrow::record_batch::RecordBatch;
+    use axum::{
+        body::Bytes,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        Extension,
+    };
+    use tokio::sync::RwLock;
+
+    use crate::datafusion::DataFusion;
+
+    pub(crate) async fn post(
+        Extension(df): Extension<Arc<RwLock<DataFusion>>>,
+        body: Bytes,
+    ) -> Response {
+        let query = &String::from_utf8_lossy(&body);
+        let data_frame = match df.read().await.ctx.sql(query).await {
+            Ok(data_frame) => data_frame,
+            Err(e) => {
+                tracing::debug!("Error running query: {e}");
+                return (StatusCode::BAD_REQUEST, query.to_string()).into_response();
+            }
+        };
+
+        let results = match data_frame.collect().await {
+            Ok(results) => results,
+            Err(e) => {
+                tracing::debug!("Error collecting results: {e}");
+                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+            }
+        };
+
+        let buf = Vec::new();
+        let mut writer = arrow_json::ArrayWriter::new(buf);
+
+        if let Err(e) =
+            writer.write_batches(results.iter().collect::<Vec<&RecordBatch>>().as_slice())
+        {
+            tracing::debug!("Error converting results to JSON: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+        if let Err(e) = writer.finish() {
+            tracing::debug!("Error finishing JSON conversion: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+
+        let buf = writer.into_inner();
+        let res = match String::from_utf8(buf) {
+            Ok(res) => res,
+            Err(e) => {
+                tracing::debug!("Error converting JSON buffer to string: {e}");
+                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+            }
+        };
+
+        (StatusCode::OK, res).into_response()
+    }
+}
+
 pub(crate) mod datasets {
     use std::sync::Arc;
 


### PR DESCRIPTION
Adds an API for making SQL queries via HTTP. The `arrow-json` crate does not currently support decimal128:

`Json error: data type Decimal128(38, 9) not supported in nested map for json writer`

There is a new version of arrow (50.0.0) but the issue persists with that version.