### PR TITLE
Don't require internet access for the runtime to start

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -77,10 +77,7 @@ pub async fn run(args: Args) -> Result<()> {
     let pods_watcher = PodsWatcher::new(current_dir.clone());
 
     let mut rt: Runtime = Runtime::new(args.runtime, app.clone(), df, model_map, pods_watcher);
-
-    for ds in app.datasets.clone() {
-        rt.load_dataset(&ds, &auth);
-    }
+    rt.load_datasets(&auth);
 
     rt.start_servers()
         .await

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -84,7 +84,7 @@ pub async fn run(args: Args) -> Result<()> {
         pods_watcher,
         auth.clone(),
     );
-    rt.load_datasets();
+    rt.load_datasets(&auth);
 
     rt.start_servers()
         .await

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -76,8 +76,15 @@ pub async fn run(args: Args) -> Result<()> {
     let model_map = load_models(&app, &auth);
     let pods_watcher = PodsWatcher::new(current_dir.clone());
 
-    let mut rt: Runtime = Runtime::new(args.runtime, app.clone(), df, model_map, pods_watcher);
-    rt.load_datasets(&auth);
+    let mut rt: Runtime = Runtime::new(
+        args.runtime,
+        app.clone(),
+        df,
+        model_map,
+        pods_watcher,
+        auth.clone(),
+    );
+    rt.load_datasets();
 
     rt.start_servers()
         .await

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use app::App;
 use clap::Parser;
@@ -14,6 +15,7 @@ use runtime::model::Model;
 use runtime::podswatcher::PodsWatcher;
 use runtime::Runtime;
 use snafu::prelude::*;
+use tokio::sync::RwLock;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -68,24 +70,17 @@ pub struct Args {
 
 pub async fn run(args: Args) -> Result<()> {
     let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
-
-    let app = App::new(current_dir.clone()).context(UnableToConstructSpiceAppSnafu)?;
-
-    let auth = load_auth_providers();
-
-    let mut df = runtime::datafusion::DataFusion::new();
-
-    for ds in &app.datasets {
-        Runtime::load_dataset(ds, &mut df, &auth)
-            .await
-            .context(UnableToLoadDatasetSnafu)?;
-    }
-
+    let app = Arc::new(App::new(current_dir.clone()).context(UnableToConstructSpiceAppSnafu)?);
+    let auth = Arc::new(load_auth_providers());
+    let df = Arc::new(RwLock::new(runtime::datafusion::DataFusion::new()));
     let model_map = load_models(&app, &auth);
-
     let pods_watcher = PodsWatcher::new(current_dir.clone());
 
-    let mut rt: Runtime = Runtime::new(args.runtime, app, df, model_map, pods_watcher);
+    let mut rt: Runtime = Runtime::new(args.runtime, app.clone(), df, model_map, pods_watcher);
+
+    for ds in app.datasets.clone() {
+        rt.load_dataset(&ds, &auth);
+    }
 
     rt.start_servers()
         .await

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -78,11 +78,11 @@ pub async fn run(args: Args) -> Result<()> {
 
     let mut rt: Runtime = Runtime::new(
         args.runtime,
-        app.clone(),
+        Arc::clone(&app),
         df,
         model_map,
         pods_watcher,
-        auth.clone(),
+        Arc::clone(&auth),
     );
     rt.load_datasets(&auth);
 

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -28,13 +28,4 @@ pub struct Config {
         action
     )]
     pub open_telemetry_bind_address: SocketAddr,
-
-    /// Configure remote dataset retry attempts.
-    #[arg(
-        long = "dataset_load_retries",
-        value_name = "DATASET_LOAD_RETRIES",
-        default_value = "5",
-        action
-    )]
-    pub dataset_load_retries: u32,
 }

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -28,4 +28,13 @@ pub struct Config {
         action
     )]
     pub open_telemetry_bind_address: SocketAddr,
+
+    /// Configure remote dataset retry attempts.
+    #[arg(
+        long = "remote_dataset_retries",
+        value_name = "REMOTE_DATASET_RETRIES",
+        default_value = "5",
+        action
+    )]
+    pub remote_dataset_retries: u32,
 }

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -31,10 +31,10 @@ pub struct Config {
 
     /// Configure remote dataset retry attempts.
     #[arg(
-        long = "remote_dataset_retries",
-        value_name = "REMOTE_DATASET_RETRIES",
+        long = "dataset_load_retries",
+        value_name = "DATASET_LOAD_RETRIES",
         default_value = "5",
         action
     )]
-    pub remote_dataset_retries: u32,
+    pub dataset_load_retries: u32,
 }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -48,7 +48,7 @@ pub trait DataConnector: Send + Sync {
     fn new(
         auth_provider: AuthProvider,
         params: Arc<Option<HashMap<String, String>>>,
-    ) -> Pin<Box<dyn Future<Output = Result<Self>>>>
+    ) -> Pin<Box<dyn Future<Output = Result<Self>> + Send>>
     where
         Self: Sized;
 

--- a/crates/runtime/src/dataconnector/debug.rs
+++ b/crates/runtime/src/dataconnector/debug.rs
@@ -21,7 +21,7 @@ impl DataConnector for DebugSource {
     fn new(
         _auth_provider: AuthProvider,
         _params: Arc<Option<HashMap<String, String>>>,
-    ) -> Pin<Box<dyn Future<Output = super::Result<Self>>>> {
+    ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>> {
         Box::pin(async move { Ok(Self {}) })
     }
 

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -17,7 +17,7 @@ impl DataConnector for Dremio {
     fn new(
         auth_provider: AuthProvider,
         params: Arc<Option<HashMap<String, String>>>,
-    ) -> Pin<Box<dyn Future<Output = super::Result<Self>>>>
+    ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>>
     where
         Self: Sized,
     {

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -41,7 +41,7 @@ impl DataConnector for SpiceAI {
     fn new(
         auth_provider: AuthProvider,
         params: Arc<Option<HashMap<String, String>>>,
-    ) -> Pin<Box<dyn Future<Output = super::Result<Self>>>>
+    ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>>
     where
         Self: Sized,
     {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -120,8 +120,8 @@ impl Runtime {
 
     pub fn load_dataset(&self, ds: &Dataset, auth: &Arc<auth::AuthProviders>) {
         let ds = ds.clone();
-        let df = self.df.clone();
-        let auth = auth.clone();
+        let df = Arc::clone(&self.df);
+        let auth = Arc::clone(auth);
         let retries = self.config.dataset_load_retries;
         tokio::spawn(async move {
             for _i in 0..retries {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -109,6 +109,12 @@ impl Runtime {
         }
     }
 
+    pub fn load_datasets(&self, auth: &Arc<auth::AuthProviders>) {
+        for ds in self.app.datasets.clone() {
+            self.load_dataset(&ds, auth);
+        }
+    }
+
     pub fn load_dataset(&self, ds: &Dataset, auth: &Arc<auth::AuthProviders>) {
         let ds = ds.clone();
         let df = self.df.clone();

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -122,9 +122,8 @@ impl Runtime {
         let ds = ds.clone();
         let df = Arc::clone(&self.df);
         let auth = Arc::clone(auth);
-        let retries = self.config.dataset_load_retries;
         tokio::spawn(async move {
-            for _i in 0..retries {
+            loop {
                 let ds = Arc::new(ds.clone());
                 if ds.acceleration.is_none() && !ds.is_view() {
                     tracing::warn!("No acceleration specified for dataset: {}", ds.name);

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -113,7 +113,7 @@ impl Runtime {
         let ds = ds.clone();
         let df = self.df.clone();
         let auth = auth.clone();
-        let retries = self.config.remote_dataset_retries;
+        let retries = self.config.dataset_load_retries;
         tokio::spawn(async move {
             for _i in 0..retries {
                 let ds = Arc::new(ds.clone());

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -148,8 +148,13 @@ impl Runtime {
                         }
                     };
 
-                match Runtime::initialize_dataconnector(data_connector, df.clone(), source, &ds)
-                    .await
+                match Runtime::initialize_dataconnector(
+                    data_connector,
+                    Arc::clone(&df),
+                    source,
+                    &ds,
+                )
+                .await
                 {
                     Ok(()) => (),
                     Err(err) => {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -112,16 +112,16 @@ impl Runtime {
         }
     }
 
-    pub fn load_datasets(&self) {
+    pub fn load_datasets(&self, auth: &Arc<auth::AuthProviders>) {
         for ds in self.app.datasets.clone() {
-            self.load_dataset(&ds);
+            self.load_dataset(&ds, auth);
         }
     }
 
-    pub fn load_dataset(&self, ds: &Dataset) {
+    pub fn load_dataset(&self, ds: &Dataset, auth: &Arc<auth::AuthProviders>) {
         let ds = ds.clone();
         let df = self.df.clone();
-        let auth = self.auth.clone();
+        let auth = auth.clone();
         let retries = self.config.dataset_load_retries;
         tokio::spawn(async move {
             for _i in 0..retries {
@@ -324,6 +324,7 @@ impl Runtime {
                     e
                 );
             }
+            let auth_arc = Arc::new(auth);
 
             let existing_dataset_names = current_app
                 .datasets
@@ -333,7 +334,7 @@ impl Runtime {
 
             for ds in &new_app.datasets {
                 if !existing_dataset_names.contains(&ds.name) {
-                    self.load_dataset(ds);
+                    self.load_dataset(ds, &auth_arc);
                 }
             }
 


### PR DESCRIPTION
This PR makes the necessary changes to allow the runtime to start without internet access. It also makes the necessary change to allow the runtime to start even if a bad dataset is loaded. To do this, on dataset load failure the load is reattempted a configurable number of times. If it is unsuccessful after the configured retries then it gives up.