### PR TITLE
Allow flight endpoint to return empty results

### DIFF
--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -95,10 +95,6 @@ impl FlightService for Service {
                     .map_err(to_tonic_err)?;
                 let schema = df.schema().clone().into();
                 let results = df.collect().await.map_err(to_tonic_err)?;
-                if results.is_empty() {
-                    return Err(Status::internal("There were no results from ticket"));
-                }
-
                 let options = datafusion::arrow::ipc::writer::IpcWriteOptions::default();
                 let schema_flight_data = SchemaAsIpc::new(&schema, &options);
 


### PR DESCRIPTION
This PR allows the flight endpoint to return empty results instead of an error.