### PR TITLE
Add `replication` configuration to Dataset to control data pushing

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
@@ -97,7 +98,7 @@ impl DataFusion {
     pub async fn attach_publisher(
         &mut self,
         table_name: &str,
-        dataset: Arc<Dataset>,
+        dataset: Dataset,
         publisher: Arc<Box<dyn DataPublisher>>,
     ) -> Result<()> {
         let entry = self
@@ -105,7 +106,7 @@ impl DataFusion {
             .entry(table_name.to_string())
             .or_insert_with(|| {
                 // If it does not exist, initialize it with the dataset and a new Vec for publishers
-                (dataset, Arc::new(RwLock::new(Vec::new())))
+                (Arc::new(dataset), Arc::new(RwLock::new(Vec::new())))
             });
 
         entry.1.write().await.push(publisher);
@@ -114,7 +115,11 @@ impl DataFusion {
     }
 
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new_accelerated_backend(&self, dataset: Arc<Dataset>) -> Result<Box<dyn DataPublisher>> {
+    pub fn new_accelerated_backend(
+        &self,
+        dataset: impl Borrow<Dataset>,
+    ) -> Result<Box<dyn DataPublisher>> {
+        let dataset = dataset.borrow();
         let table_name = dataset.name.as_str();
         let acceleration =
             dataset
@@ -161,7 +166,7 @@ impl DataFusion {
     #[allow(clippy::needless_pass_by_value)]
     pub fn attach_connector_to_publisher(
         &mut self,
-        dataset: Arc<Dataset>,
+        dataset: Dataset,
         data_connector: Box<dyn DataConnector>,
         publisher: Arc<Box<dyn DataPublisher>>,
     ) -> Result<()> {
@@ -171,9 +176,9 @@ impl DataFusion {
             return TableAlreadyExistsSnafu.fail();
         }
 
-        let dataset_clone = dataset.clone();
         let task_handle = task::spawn(async move {
-            let mut stream = data_connector.get_data(&dataset_clone);
+            let dataset = Arc::new(dataset);
+            let mut stream = data_connector.get_data(&dataset);
             loop {
                 let future_result = stream.next().await;
                 match future_result {
@@ -193,7 +198,8 @@ impl DataFusion {
         Ok(())
     }
 
-    pub fn attach_view(&self, dataset: &Arc<Dataset>) -> Result<()> {
+    pub fn attach_view(&self, dataset: impl Borrow<Dataset>) -> Result<()> {
+        let dataset = dataset.borrow();
         let table_exists = self.ctx.table_exist(dataset.name.as_str()).unwrap_or(false);
         if table_exists {
             return TableAlreadyExistsSnafu.fail();

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -145,12 +145,12 @@ impl DataFusion {
 
     #[must_use]
     #[allow(clippy::borrowed_box)]
-    pub fn get_publisher(&self, dataset: &str) -> Option<&DatasetAndPublishers> {
+    pub fn get_publishers(&self, dataset: &str) -> Option<&DatasetAndPublishers> {
         self.data_publishers.get(dataset)
     }
 
     #[must_use]
-    pub fn has_publisher(&self, dataset: &str) -> bool {
+    pub fn has_publishers(&self, dataset: &str) -> bool {
         self.data_publishers.contains_key(dataset)
     }
 

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -183,7 +183,7 @@ impl FlightService for Service {
 
         let df = self.datafusion.read().await;
 
-        let Some(publishers) = df.get_publisher(&path) else {
+        let Some(publishers) = df.get_publishers(&path) else {
             return Err(Status::invalid_argument(format!(
                 "No publishers registered for path: {path:?}",
             )));
@@ -323,7 +323,7 @@ impl FlightService for Service {
 
         let data_path = flight_descriptor.path.join(".");
 
-        if !self.datafusion.read().await.has_publisher(&data_path) {
+        if !self.datafusion.read().await.has_publishers(&data_path) {
             return Err(Status::invalid_argument(format!(
                 r#"Unknown dataset: "{data_path}""#,
             )));

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -46,6 +46,9 @@ pub struct Dataset {
     pub params: Option<HashMap<String, String>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replication: Option<replication::Replication>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acceleration: Option<acceleration::Acceleration>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -63,6 +66,7 @@ impl Dataset {
             sql: None,
             sql_ref: None,
             params: Option::default(),
+            replication: None,
             acceleration: None,
             depends_on: Vec::default(),
         }
@@ -164,6 +168,7 @@ impl WithDependsOn<Dataset> for Dataset {
             sql: self.sql.clone(),
             sql_ref: self.sql_ref.clone(),
             params: self.params.clone(),
+            replication: self.replication.clone(),
             acceleration: self.acceleration.clone(),
             depends_on: depends_on.to_vec(),
         }
@@ -228,5 +233,15 @@ pub mod acceleration {
         pub fn engine(&self) -> Engine {
             self.engine.clone().unwrap_or_default()
         }
+    }
+}
+
+pub mod replication {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Replication {
+        #[serde(default)]
+        pub enabled: bool,
     }
 }


### PR DESCRIPTION
Adds a `replicate` section to the Dataset config to control whether a `ReadWrite` Dataset is configured to push data back to the dataconnector.

There are a few cases to consider now:

- DatasetMode::ReadWrite && !Replication -> Ingestion is allowed via OTel & Flight endpoints, but only modifies the local accelerated backend
- DatasetMode::ReadWrite && Replication -> Ingestion is allowed, and will push data back to the data connector
- DatasetMode::Read && Replication -> Not a useful configuration, since the dataset is read-only and it can't actually replication - but we don't consider it an error.
- DatasetMode::Read && !Replication -> Same as `DatasetMode::Read && Replication`, but makes sense to configure like this.

Example:

This will configure the dataset to replicate local changes up. Local changes are allowed since `mode: read_write`
```yaml
datasets:
  - from: spice.ai/lukekim/demo/datasets/drive_stats
    name: smart_attribute_raw_value
    mode: read_write
    replication:
      enabled: true
    acceleration:
      enabled: true
```

This will configure the dataset allow local changes. However, local changes will not replicate to the cloud dataset. Omitting the `replication` section has the same effect as setting `replication.enabled = false`
```yaml
datasets:
  - from: spice.ai/lukekim/demo/datasets/drive_stats
    name: smart_attribute_raw_value
    mode: read_write
    acceleration:
      enabled: true
```