### PR TITLE
Remove unix-specific code

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -382,18 +382,7 @@ async fn shutdown_signal() {
         }
     };
 
-    let terminate = async {
-        match signal::unix::signal(signal::unix::SignalKind::terminate()) {
-            Ok(mut signal) => signal.recv().await,
-            Err(err) => {
-                tracing::error!("Unable to listen to shutdown signal: {err:?}");
-                None
-            }
-        }
-    };
-
     tokio::select! {
         () = ctrl_c => {},
-        _ = terminate => {},
     }
 }


### PR DESCRIPTION
Listening to the `ctrl_c` signal works cross-platform and is sufficient for us.

With this removed - we can build a Windows binary.