### PR TITLE
Allow dataset to be initialized if there is a table provider for the data source even no acceleration defined

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -1,3 +1,4 @@
+use datafusion::datasource::TableProvider;
 use futures::stream;
 use snafu::prelude::*;
 use spicepod::component::dataset::acceleration::RefreshMode;
@@ -69,6 +70,10 @@ pub trait DataConnector: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = Vec<RecordBatch>> + Send>>;
 
     fn get_data_publisher(&self) -> Option<Box<dyn DataPublisher>> {
+        None
+    }
+
+    fn get_table_provider(&self) -> Option<Box<dyn TableProvider>> {
         None
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -162,7 +162,7 @@ impl Runtime {
                 };
 
                 if ds.acceleration.is_none() && !ds.is_view() && !has_table_provider {
-                    tracing::warn!("No acceleration specified for dataset and no table provider found for dataset's connector: {}", ds.name);
+                    tracing::warn!("No acceleration specified for dataset '{}' and no table provider found for dataset's connector '{}'", ds.name, source);
                     break;
                 };
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -151,18 +151,11 @@ impl Runtime {
                         }
                     };
 
-                let mut has_table_provider = false;
-
-                if data_connector.is_some()
-                    && data_connector
-                        .as_ref()
-                        .is_some_and(|dc| dc.get_table_provider().is_some())
+                if ds.acceleration.is_none()
+                    && !ds.is_view()
+                    && !has_table_provider(&data_connector)
                 {
-                    has_table_provider = true;
-                };
-
-                if ds.acceleration.is_none() && !ds.is_view() && !has_table_provider {
-                    tracing::warn!("No acceleration specified for dataset '{}' and no table provider found for dataset's connector '{}'", ds.name, source);
+                    tracing::warn!("Dataset cannot be loaded: {}", ds.name);
                     break;
                 };
 
@@ -371,6 +364,13 @@ impl Runtime {
 
         Ok(())
     }
+}
+
+fn has_table_provider(data_connector: &Option<Box<dyn DataConnector + Send>>) -> bool {
+    data_connector.is_some()
+        && data_connector
+            .as_ref()
+            .is_some_and(|dc| dc.get_table_provider().is_some())
 }
 
 pub fn load_auth_providers() -> auth::AuthProviders {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -155,7 +155,7 @@ impl Runtime {
                     && !ds.is_view()
                     && !has_table_provider(&data_connector)
                 {
-                    tracing::warn!("Dataset cannot be loaded: {}", ds.name);
+                    tracing::warn!("No acceleration specified for dataset: {}", ds.name);
                     break;
                 };
 


### PR DESCRIPTION
This is the first step to allow user to do a `mesh` query: even the table is not accelerated in local, the query will be sent down to the data source.

With this change, instead of erroring out when no acceleration detected for dataset, it will check if there is a `TableProvider` defined for the data connector.

`TableProvider` is datafusion concept for extending queries on data not in local. https://arrow.apache.org/datafusion/library-user-guide/custom-table-providers.html