### PR TITLE
add license checking for Rust

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check licenses of 
+      - name: Check Rust Licenses
         run: make dep-licenses |& ${{ env.FORBIDDEN_LICENSE_CHECK }}
 
   license-check-go:

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -27,15 +27,25 @@ on:
       - rust
       - release-*
 
+
+env:
+  FORBIDDEN_LICENSE_CHECK: |
+        grep -B 1 -E "GPL|CC-BY-SA|CC-BY-NC|CC-BY-NC-SA|CC-BY-NC-ND|APSL|CPAL|EUPL|NPOSL|OSL|SSPL|Parity|RPL|QPL|Sleepycat|copyleft|CDDL|CPL|EPL|ErlPL|IPL|MS-RL|SPL|Facebook|Commons-Clause" | grep . && exit 1 || echo "ok"
+
 jobs:
-  license-check:
-    name: license check
+  license-check-rust:
+    name: Check Rust Licenses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check licenses of 
+        run: make dep-licenses |& ${{ env.FORBIDDEN_LICENSE_CHECK }}
+
+  license-check-go:
+    name: Check Golang Licenses
     runs-on: ubuntu-latest
     env:
       GOVER: 1.22
-
-      FORBIDDEN_LICENSE_CHECK: |
-        grep -B 1 -E "GPL|CC-BY-SA|CC-BY-NC|CC-BY-NC-SA|CC-BY-NC-ND|APSL|CPAL|EUPL|NPOSL|OSL|SSPL|Parity|RPL|QPL|Sleepycat|copyleft|CDDL|CPL|EPL|ErlPL|IPL|MS-RL|SPL|Facebook|Commons-Clause" | grep . && exit 1 || echo "ok"
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,11 @@ docker-run:
 	docker stop spiceai && docker rm spiceai || true
 	docker run --name spiceai -p 3000:3000 -p 50051:50051 spiceai-rust:local-dev
 
+.PHONY: check-deps-licenses
+dep-licenses:
+	cargo install cargo-license
+	cargo license -d
+
 ################################################################################
 # Target: install                                                              #
 ################################################################################


### PR DESCRIPTION
## Changes
- In `license_check` Github workflow, add license checking for Rust.
- Dependencies can be retrieved locally via `make dep-licenses`