### PR TITLE
Make target `make generate-acknowledgements`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,17 @@ docker-run:
 	docker stop spiceai && docker rm spiceai || true
 	docker run --name spiceai -p 3000:3000 -p 50051:50051 spiceai-rust:local-dev
 
+
+.PHONY: deps-licenses
+dep-licenses:
+	@cargo install cargo-license --quiet
+	@cargo license -d 
+
+.PHONY: display-deps
+display-deps:
+	@cargo install cargo-license --quiet
+	@cargo license -d  --tsv --direct-deps-only
+
 ################################################################################
 # Target: install                                                              #
 ################################################################################
@@ -63,3 +74,47 @@ install-dev: build-dev
 .PHONY: modtidy
 modtidy:
 	go mod tidy
+
+
+################################################################################
+# Target: generate-acknowledgements                                            #
+################################################################################
+ACKNOWLEDGEMENTS_PATH := acknowledgements.md
+
+.PHONY: generate-acknowledgements
+generate-acknowledgements:
+	echo "# Open Source Acknowledgements\n\nSpice.ai acknowledges the following open source projects for making this project possible:\n\n" > $(ACKNOWLEDGEMENTS_PATH)
+	make generate-acknowledgements-go
+	make generate-acknowledgements-rust
+	make generate-acknowledgements-formatting
+
+.PHONY: generate-acknowledgements-go
+generate-acknowledgements-go:
+	echo "\n## Go Modules\n" >> $(ACKNOWLEDGEMENTS_PATH)
+	go install github.com/google/go-licenses
+	pushd bin/spice && go-licenses csv . 2>/dev/null >> ../../$(ACKNOWLEDGEMENTS_PATH) && popd
+
+.PHONY: generate-acknowledgements-rust
+generate-acknowledgements-rust:
+	@echo "\n## Rust Crates\n" >> "$(ACKNOWLEDGEMENTS_PATH)"
+	@make display-deps 2>/dev/null | awk 'BEGIN { \
+		FS="\t"; \
+		print "| name | version | authors | repository | license | license_file | description |"; \
+		print "|------|---------|---------|------------|---------|--------------|-------------|"; \
+	} \
+	{ \
+		printf("| %s | %s | %s | %s | %s | %s | %s |\n", $$1, $$2, $$3, $$4, $$5, $$6, $$7); \
+	}' >> "$(ACKNOWLEDGEMENTS_PATH)"
+
+
+.PHONY: generate-acknowledgements-formatting
+generate-acknowledgements-formatting:
+	@if [[ "$(UNAME)" -eq "Darwin" ]]; then\
+		sed -i '' 's/\"//g' $(ACKNOWLEDGEMENTS_PATH); \
+		sed -i '' 's/,/, /g' $(ACKNOWLEDGEMENTS_PATH); \
+		sed -i '' 's/,  /, /g' $(ACKNOWLEDGEMENTS_PATH); \
+	else\
+		sed -i 's/\"//g' $(ACKNOWLEDGEMENTS_PATH); \
+		sed -i 's/,/, /g' $(ACKNOWLEDGEMENTS_PATH); \
+		sed -i 's/,  /, /g' $(ACKNOWLEDGEMENTS_PATH); \
+	fi


### PR DESCRIPTION
## Changes
- New target to make a `acknowledgement.md`

## Example `acknowledgement.md`
---


# Open Source Acknowledgements

Spice.ai acknowledges the following open source projects for making this project possible:



## Go Modules

github.com/fsnotify/fsnotify, https://github.com/fsnotify/fsnotify/blob/v1.5.4/LICENSE, BSD-3-Clause
github.com/gocarina/gocsv, https://github.com/gocarina/gocsv/blob/b87c2d0e983a/LICENSE, MIT
github.com/hashicorp/go-cleanhttp, https://github.com/hashicorp/go-cleanhttp/blob/v0.5.2/LICENSE, MPL-2.0
github.com/hashicorp/go-retryablehttp, https://github.com/hashicorp/go-retryablehttp/blob/v0.7.1/LICENSE, MPL-2.0
github.com/hashicorp/hcl, https://github.com/hashicorp/hcl/blob/v1.0.0/LICENSE, MPL-2.0
github.com/logrusorgru/aurora, https://github.com/logrusorgru/aurora/blob/v2.0.3/LICENSE, Unlicense
github.com/magiconair/properties, https://github.com/magiconair/properties/blob/v1.8.6/LICENSE.md, BSD-2-Clause
github.com/mattn/go-runewidth, https://github.com/mattn/go-runewidth/blob/v0.0.15/LICENSE, MIT
github.com/mitchellh/mapstructure, https://github.com/mitchellh/mapstructure/blob/v1.5.0/LICENSE, MIT
github.com/olekukonko/tablewriter, https://github.com/olekukonko/tablewriter/blob/v0.0.5/LICENSE.md, MIT
github.com/pelletier/go-toml, https://github.com/pelletier/go-toml/blob/v1.9.5/LICENSE, Apache-2.0
github.com/pelletier/go-toml/v2, https://github.com/pelletier/go-toml/blob/v2.0.2/LICENSE, MIT
github.com/pkg/browser, https://github.com/pkg/browser/blob/5ac0b6a4141c/LICENSE, BSD-2-Clause
github.com/rivo/uniseg, https://github.com/rivo/uniseg/blob/v0.4.6/LICENSE.txt, MIT
github.com/spf13/afero, https://github.com/spf13/afero/blob/v1.8.2/LICENSE.txt, Apache-2.0
github.com/spf13/cast, https://github.com/spf13/cast/blob/v1.5.0/LICENSE, MIT
github.com/spf13/cobra, https://github.com/spf13/cobra/blob/v1.6.0/LICENSE.txt, Apache-2.0
github.com/spf13/jwalterweatherman, https://github.com/spf13/jwalterweatherman/blob/v1.1.0/LICENSE, MIT
github.com/spf13/pflag, https://github.com/spf13/pflag/blob/v1.0.5/LICENSE, BSD-3-Clause
github.com/spf13/viper, https://github.com/spf13/viper/blob/v1.12.0/LICENSE, MIT
github.com/spiceai/spiceai/bin/spice, https://github.com/spiceai/spiceai/blob/HEAD/LICENSE, Apache-2.0
github.com/subosito/gotenv, https://github.com/subosito/gotenv/blob/v1.4.0/LICENSE, MIT
go.uber.org/atomic, https://github.com/uber-go/atomic/blob/v1.9.0/LICENSE.txt, MIT
go.uber.org/multierr, https://github.com/uber-go/multierr/blob/v1.8.0/LICENSE.txt, MIT
go.uber.org/zap, https://github.com/uber-go/zap/blob/v1.21.0/LICENSE.txt, MIT
golang.org/x/mod/semver, https://cs.opensource.google/go/x/mod/+/v0.14.0:LICENSE, BSD-3-Clause
golang.org/x/sys/unix, https://cs.opensource.google/go/x/sys/+/v0.16.0:LICENSE, BSD-3-Clause
golang.org/x/text, https://cs.opensource.google/go/x/text/+/v0.14.0:LICENSE, BSD-3-Clause
gopkg.in/ini.v1, https://github.com/go-ini/ini/blob/v1.66.6/LICENSE, Apache-2.0
gopkg.in/natefinch/lumberjack.v2, https://github.com/natefinch/lumberjack/blob/v2.0.0/LICENSE, MIT
gopkg.in/yaml.v2, https://github.com/go-yaml/yaml/blob/v2.4.0/LICENSE, Apache-2.0
gopkg.in/yaml.v3, https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE, MIT

## Rust Crates

| name | version | authors | repository | license | license_file | description |
|------|---------|---------|------------|---------|--------------|-------------|
| name | version | authors | repository | license | license_file | description |
| app | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  | All loaded components from the root Spicepod and its dependencies |
| arrow | 49.0.0 | Apache Arrow <dev@arrow.apache.org> | https://github.com/apache/arrow-rs | Apache-2.0 |  | Rust implementation of Apache Arrow |
| arrow-flight | 49.0.0 | Apache Arrow <dev@arrow.apache.org> | https://github.com/apache/arrow-rs | Apache-2.0 |  | Apache Arrow Flight |
| arrow-ipc | 49.0.0 | Apache Arrow <dev@arrow.apache.org> | https://github.com/apache/arrow-rs | Apache-2.0 |  | Support for the Arrow IPC format |
| arrow-json | 49.0.0 | Apache Arrow <dev@arrow.apache.org> | https://github.com/apache/arrow-rs | Apache-2.0 |  | Support for parsing JSON format into the Arrow format |
| async-stream | 0.3.5 | Carl Lerche <me@carllerche.com> | https://github.com/tokio-rs/async-stream | MIT |  | Asynchronous streams using async & await notation |
| async-trait | 0.1.77 | David Tolnay <dtolnay@gmail.com> | https://github.com/dtolnay/async-trait | Apache-2.0 OR MIT |  | Type erasure for async trait methods |
| axum | 0.6.20 |  | https://github.com/tokio-rs/axum | MIT |  | Web framework that focuses on ergonomics and modularity |
| axum | 0.7.4 |  | https://github.com/tokio-rs/axum | MIT |  | Web framework that focuses on ergonomics and modularity |
| base64 | 0.21.7 | Alice Maz <alice@alicemaz.com>|Marshall Pierce <marshall@mpierce.org> | https://github.com/marshallpierce/rust-base64 | Apache-2.0 OR MIT |  | encodes and decodes base64 as bytes or utf8 |
| bytes | 1.5.0 | Carl Lerche <me@carllerche.com>|Sean McArthur <sean@seanmonstar.com> | https://github.com/tokio-rs/bytes | MIT |  | Types and traits for working with bytes |
| clap | 4.5.1 |  | https://github.com/clap-rs/clap | Apache-2.0 OR MIT |  | A simple to use, efficient, and full-featured Command Line Argument Parser |
| datafusion | 34.0.0 | Apache Arrow <dev@arrow.apache.org> | https://github.com/apache/arrow-datafusion | Apache-2.0 |  | DataFusion is an in-memory query engine that uses Apache Arrow as the memory model |
| dirs | 5.0.1 | Simon Ochsenreither <simon@ochsenreither.de> | https://github.com/soc/dirs-rs | Apache-2.0 OR MIT |  | A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows, macOS and Redox by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS. |
| duckdb | 0.9.2 | wangfenjin <wangfenj@gmail.com> | https://github.com/wangfenjin/duckdb-rs | MIT |  | Ergonomic wrapper for DuckDB |
| flight_client | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  |  |
| flightpublisher | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  | Spice OSS Flight Publisher |
| flightrepl | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  | Spice OSS Flight Query Repl |
| flightsubscriber | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  | Spice OSS Flight Subscriber |
| fundu | 2.0.0 | Joining7943 <joining@posteo.de> | https://github.com/fundu-rs/fundu | MIT |  | Configurable, precise and fast rust string parser to a Duration |
| futures | 0.3.30 |  | https://github.com/rust-lang/futures-rs | Apache-2.0 OR MIT |  | An implementation of futures and streams featuring zero allocations, composability, and iterator-like interfaces. |
| futures-core | 0.3.30 |  | https://github.com/rust-lang/futures-rs | Apache-2.0 OR MIT |  | The core traits and types in for the `futures` library. |
| indexmap | 1.9.3 |  | https://github.com/bluss/indexmap | Apache-2.0 OR MIT |  | A hash table with consistent order and fast iteration. |
| indexmap | 2.2.3 |  | https://github.com/indexmap-rs/indexmap | Apache-2.0 OR MIT |  | A hash table with consistent order and fast iteration. |
| metrics | 0.22.1 | Toby Lawrence <toby@nuclearfurnace.com> | https://github.com/metrics-rs/metrics | MIT |  | A lightweight metrics facade. |
| metrics-exporter-prometheus | 0.13.1 | Toby Lawrence <toby@nuclearfurnace.com> | https://github.com/metrics-rs/metrics | MIT |  | A metrics-compatible exporter for sending metrics to Prometheus. |
| ndarray | 0.15.6 | Ulrik Sverdrup bluss|Jim Turner | https://github.com/rust-ndarray/ndarray | Apache-2.0 OR MIT |  | An n-dimensional array for general elements and for numerics. Lightweight array views and slicing; views support chunking and splitting. |
| ndarray-npy | 0.8.1 | Jim Turner <ndarray-npy@turner.link> | https://github.com/jturner314/ndarray-npy | Apache-2.0 OR MIT |  | .npy and .npz file format support for ndarray |
| notify | 6.1.1 | Félix Saparelli <me@passcod.name>|Daniel Faust <hessijames@gmail.com>|Aron Heinecke <Ox0p54r36@t-online.de> | https://github.com/notify-rs/notify.git | CC0-1.0 |  | Cross-platform filesystem notification library |
| opentelemetry-proto | 0.4.0 |  | https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto | Apache-2.0 |  | Protobuf generated files and transformations. |
| parquet | 49.0.0 | Apache Arrow <dev@arrow.apache.org> | https://github.com/apache/arrow-rs | Apache-2.0 |  | Apache Parquet implementation in Rust |
| r2d2 | 0.8.10 | Steven Fackler <sfackler@gmail.com> | https://github.com/sfackler/r2d2 | Apache-2.0 OR MIT |  | A generic connection pool |
| regex | 1.10.3 | The Rust Project Developers|Andrew Gallant <jamslam@gmail.com> | https://github.com/rust-lang/regex | Apache-2.0 OR MIT |  | An implementation of regular expressions for Rust. This implementation uses finite automata and guarantees linear time matching on all inputs. |
| reqwest | 0.11.24 | Sean McArthur <sean@seanmonstar.com> | https://github.com/seanmonstar/reqwest | Apache-2.0 OR MIT |  | higher level HTTP client library |
| runtime | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  | The spiced runtime |
| rustls | 0.21.10 |  | https://github.com/rustls/rustls | Apache-2.0 OR ISC OR MIT |  | Rustls is a modern TLS library written in Rust. |
| rustls-native-certs | 0.6.3 |  | https://github.com/ctz/rustls-native-certs | Apache-2.0 OR ISC OR MIT |  | rustls-native-certs allows rustls to use the platform native certificate store |
| rustls-pemfile | 1.0.4 |  | https://github.com/rustls/pemfile | Apache-2.0 OR ISC OR MIT |  | Basic .pem file parser for keys and certificates |
| rustyline | 13.0.0 | Katsu Kawakami <kkawa1570@gmail.com> | https://github.com/kkawakam/rustyline | MIT |  | Rustyline, a readline implementation based on Antirez's Linenoise |
| serde | 1.0.196 | Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com> | https://github.com/serde-rs/serde | Apache-2.0 OR MIT |  | A generic serialization/deserialization framework |
| serde_json | 1.0.113 | Erick Tryzelaar <erick.tryzelaar@gmail.com>|David Tolnay <dtolnay@gmail.com> | https://github.com/serde-rs/json | Apache-2.0 OR MIT |  | A JSON serialization file format |
| serde_yaml | 0.9.31 | David Tolnay <dtolnay@gmail.com> | https://github.com/dtolnay/serde-yaml | Apache-2.0 OR MIT |  | YAML data format for Serde |
| snafu | 0.7.5 | Jake Goulding <jake.goulding@gmail.com> | https://github.com/shepmaster/snafu | Apache-2.0 OR MIT |  | An ergonomic error handling library |
| snafu | 0.8.0 | Jake Goulding <jake.goulding@gmail.com> | https://github.com/shepmaster/snafu | Apache-2.0 OR MIT |  | An ergonomic error handling library |
| spiced | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  | Spice OSS |
| spicepod | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  |  |
| sql_provider_datafusion | 0.7.0-alpha |  | https://github.com/spiceai/spiceai | Apache-2.0 |  |  |
| tokio | 1.36.0 | Tokio Contributors <team@tokio.rs> | https://github.com/tokio-rs/tokio | MIT |  | An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. |
| tokio-stream | 0.1.14 | Tokio Contributors <team@tokio.rs> | https://github.com/tokio-rs/tokio | MIT |  | Utilities to work with `Stream` and `tokio`. |
| toml | 0.8.10 | Alex Crichton <alex@alexcrichton.com> | https://github.com/toml-rs/toml | Apache-2.0 OR MIT |  | A native Rust encoder and decoder of TOML-formatted files and streams. Provides implementations of the standard Serialize/Deserialize traits for TOML data to facilitate deserializing and serializing Rust structures. |
| tonic | 0.9.2 | Lucio Franco <luciofranco14@gmail.com> | https://github.com/hyperium/tonic | MIT |  | A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. |
| tonic | 0.10.2 | Lucio Franco <luciofranco14@gmail.com> | https://github.com/hyperium/tonic | MIT |  | A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility. |
| tracing | 0.1.40 | Eliza Weisman <eliza@buoyant.io>|Tokio Contributors <team@tokio.rs> | https://github.com/tokio-rs/tracing | MIT |  | Application-level tracing for Rust. |
| tracing-subscriber | 0.3.18 | Eliza Weisman <eliza@buoyant.io>|David Barsky <me@davidbarsky.com>|Tokio Contributors <team@tokio.rs> | https://github.com/tokio-rs/tracing | MIT |  | Utilities for implementing and composing `tracing` subscribers. |
| tract-core | 0.21.1 | Mathieu Poumeyrol <kali@zoy.org> | https://github.com/snipsco/tract | Apache-2.0 OR MIT |  | Tiny, no-nonsense, self contained, TensorFlow and ONNX inference |
| tract-onnx | 0.21.1 | Mathieu Poumeyrol <kali@zoy.org> | https://github.com/snipsco/tract | Apache-2.0 OR MIT |  | Tiny, no-nonsense, self contained, TensorFlow and ONNX inference |
| uuid | 1.7.0 | Ashley Mannix<ashleymannix@live.com.au>|Christopher Armstrong|Dylan DPC<dylan.dpc@gmail.com>|Hunar Roop Kahlon<hunar.roop@gmail.com> | https://github.com/uuid-rs/uuid | Apache-2.0 OR MIT |  | A library to generate and parse UUIDs. |
