### PR TITLE
Use Builder pattern for DataBackend

### DIFF
--- a/crates/runtime/src/databackend.rs
+++ b/crates/runtime/src/databackend.rs
@@ -24,8 +24,8 @@ pub enum Error {
 pub struct DataBackendBuilder {
     ctx: Arc<SessionContext>,
     name: String,
-    engine: Engine,
-    mode: Mode,
+    engine: Option<Engine>,
+    mode: Option<Mode>,
     params: Arc<Option<HashMap<String, String>>>,
     primary_keys: Option<Vec<String>>,
 }
@@ -36,56 +36,92 @@ impl DataBackendBuilder {
         Self {
             ctx,
             name,
-            engine: Engine::Arrow,
-            mode: Mode::Memory,
+            engine: None,
+            mode: None,
             params: Arc::new(None),
             primary_keys: None,
         }
     }
 
     #[must_use]
-    pub fn with_engine(mut self, engine: Engine) -> Self {
-        self.engine = engine;
+    pub fn engine(mut self, engine: Engine) -> Self {
+        self.engine = Some(engine);
         self
     }
 
     #[must_use]
-    pub fn with_mode(mut self, mode: Mode) -> Self {
-        self.mode = mode;
+    pub fn mode(mut self, mode: Mode) -> Self {
+        self.mode = Some(mode);
         self
     }
 
     #[must_use]
-    pub fn with_params(mut self, params: Arc<Option<HashMap<String, String>>>) -> Self {
+    pub fn params(mut self, params: Arc<Option<HashMap<String, String>>>) -> Self {
         self.params = params;
         self
     }
 
     #[must_use]
-    pub fn with_primary_keys(mut self, primary_keys: Option<Vec<String>>) -> Self {
+    pub fn primary_keys(mut self, primary_keys: Option<Vec<String>>) -> Self {
         self.primary_keys = primary_keys;
         self
     }
 
-    pub fn build(self) -> std::result::Result<Box<dyn DataPublisher>, Error> {
+    /// Build the data backend, panicking if it fails
+    ///
+    /// # Panics
+    ///
+    /// Panics if the backend fails to build
+    #[must_use]
+    pub fn must_build(self) -> Box<dyn DataPublisher> {
+        match self.build() {
+            Ok(backend) => backend,
+            Err(e) => panic!("Failed to build backend: {e}"),
+        }
+    }
+
+    fn validate_arrow(&self) -> std::result::Result<(), Error> {
+        if let Some(Mode::File) = self.mode {
+            InvalidConfigurationSnafu {
+                msg: "File mode not supported for Arrow engine".to_string(),
+            }
+            .fail()?;
+        } else if self.primary_keys.is_some() {
+            InvalidConfigurationSnafu {
+                msg: "Primary keys not supported for Arrow engine".to_string(),
+            }
+            .fail()?;
+        }
+        Ok(())
+    }
+
+    fn validate(&self) -> std::result::Result<(), Error> {
         match self.engine {
-            Engine::Arrow => match self.mode {
-                Mode::Memory => Ok(Box::new(MemTableBackend::new(
-                    Arc::clone(&self.ctx),
-                    self.name.as_str(),
-                ))),
-                Mode::File => InvalidConfigurationSnafu {
-                    msg: "File mode not supported for Arrow engine".to_string(),
-                }
-                .fail()?,
-            },
+            Some(Engine::Arrow) => self.validate_arrow(),
+            #[cfg(feature = "duckdb")]
+            Some(Engine::DuckDB) => Ok(()),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn build(self) -> std::result::Result<Box<dyn DataPublisher>, Error> {
+        self.validate()?;
+        let engine = self.engine.unwrap_or_default();
+        let mode = self.mode.unwrap_or_default();
+
+        match engine {
+            Engine::Arrow => Ok(Box::new(MemTableBackend::new(
+                Arc::clone(&self.ctx),
+                self.name.as_str(),
+            ))),
             #[cfg(feature = "duckdb")]
             Engine::DuckDB => Ok(Box::new(
                 DuckDBBackend::new(
                     Arc::clone(&self.ctx),
                     self.name.as_str(),
-                    self.mode.into(),
+                    mode.into(),
                     self.params,
+                    self.primary_keys,
                 )
                 .boxed()
                 .context(BackendCreationFailedSnafu)?,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -133,9 +133,9 @@ impl DataFusion {
 
         let data_backend: Box<dyn DataPublisher> =
             DataBackendBuilder::new(Arc::clone(&self.ctx), table_name)
-                .with_engine(acceleration.engine())
-                .with_mode(acceleration.mode())
-                .with_params(params)
+                .engine(acceleration.engine())
+                .mode(acceleration.mode())
+                .params(params)
                 .build()
                 .context(DatasetConfigurationSnafu)?;
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::databackend::{self, DataBackend};
+use crate::databackend::{self, DataBackendBuilder};
 use crate::dataconnector::DataConnector;
 use crate::datapublisher::DataPublisher;
 use datafusion::datasource::ViewTable;
@@ -120,7 +120,7 @@ impl DataFusion {
         dataset: impl Borrow<Dataset>,
     ) -> Result<Box<dyn DataPublisher>> {
         let dataset = dataset.borrow();
-        let table_name = dataset.name.as_str();
+        let table_name = dataset.name.to_string();
         let acceleration =
             dataset
                 .acceleration
@@ -131,14 +131,13 @@ impl DataFusion {
 
         let params: Arc<Option<HashMap<String, String>>> = Arc::new(dataset.params.clone());
 
-        let data_backend: Box<dyn DataPublisher> = DataBackend::new(
-            &self.ctx,
-            table_name,
-            acceleration.engine(),
-            acceleration.mode(),
-            params,
-        )
-        .context(DatasetConfigurationSnafu)?;
+        let data_backend: Box<dyn DataPublisher> =
+            DataBackendBuilder::new(Arc::clone(&self.ctx), table_name)
+                .with_engine(acceleration.engine())
+                .with_mode(acceleration.mode())
+                .with_params(params)
+                .build()
+                .context(DatasetConfigurationSnafu)?;
 
         Ok(data_backend)
     }


### PR DESCRIPTION
Changes to use the [Builder pattern](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html) for the DataBackend constructor. This is a common pattern when a struct has a lot of optional parameters and you don't want to require every caller to pass something in `new()` for each possible parameter.

I felt this would be useful for passing through primary keys - since not all DataBackends will use them.

I will implement the actual primary keys in a follow-up PR.