### PR TITLE
Change Spicepod DataConnector/ModelSource selector

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - rust
       - release-*
     tags:
       - v*

--- a/bin/spice/pkg/api/auth.go
+++ b/bin/spice/pkg/api/auth.go
@@ -1,7 +1,7 @@
 package api
 
 const (
-	AUTH_TYPE_SPICE_AI = "spice.ai"
+	AUTH_TYPE_SPICE_AI = "spiceai"
 	AUTH_TYPE_DREMIO   = "dremio"
 
 	AUTH_PARAM_KEY      = "key"

--- a/bin/spice/pkg/cli/cmd/dataset.go
+++ b/bin/spice/pkg/cli/cmd/dataset.go
@@ -55,7 +55,7 @@ spice dataset configure
 		accelerateDataset := strings.ToLower(accelerateDatasetString) == "y"
 
 		params := map[string]string{}
-		if strings.Split(datasetLocation, "/")[0] == api.DATA_SOURCE_DREMIO {
+		if strings.Split(datasetLocation, ":")[0] == api.DATA_SOURCE_DREMIO {
 			// TODO: Allow user to specify own dremio instance. Needs UX design for how the command should handle.
 			params["endpoint"] = "http://dremio-4mimamg7rdeve.eastus.cloudapp.azure.com:32010"
 		}

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -222,6 +222,7 @@ mod tests {
                 "lukekim.demo.my_data",
             ),
             ("lukekim/demo/my_data".to_string(), "lukekim.demo.my_data"),
+            ("eth.recent_blocks".to_string(), "eth.recent_blocks"),
         ];
 
         for (input, expected) in tests {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -135,11 +135,14 @@ impl Runtime {
                 let auth = shared_auth.read().await;
 
                 let source = ds.source();
-                let source = source.as_str();
                 let params = Arc::new(ds.params.clone());
                 let data_connector: Option<Box<dyn DataConnector + Send>> =
-                    match Runtime::get_dataconnector_from_source(source, &auth, Arc::clone(&params))
-                        .await
+                    match Runtime::get_dataconnector_from_source(
+                        &source,
+                        &auth,
+                        Arc::clone(&params),
+                    )
+                    .await
                     {
                         Ok(data_connector) => data_connector,
                         Err(err) => {
@@ -164,7 +167,7 @@ impl Runtime {
                 match Runtime::initialize_dataconnector(
                     data_connector,
                     Arc::clone(&df),
-                    source,
+                    &source,
                     &ds,
                 )
                 .await
@@ -211,7 +214,7 @@ impl Runtime {
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Result<Option<Box<dyn DataConnector + Send>>> {
         match source {
-            "spice.ai" => Ok(Some(Box::new(
+            "spiceai" => Ok(Some(Box::new(
                 dataconnector::spiceai::SpiceAI::new(auth.get(source), params)
                     .await
                     .context(UnableToInitializeDataConnectorSnafu {
@@ -225,7 +228,7 @@ impl Runtime {
                         data_connector: source,
                     })?,
             ))),
-            "localhost" | "" => Ok(None),
+            "localhost" => Ok(None),
             "debug" => Ok(Some(Box::new(dataconnector::debug::DebugSource {}))),
             _ => UnknownDataConnectorSnafu {
                 data_connector: source,

--- a/crates/runtime/src/modelsource.rs
+++ b/crates/runtime/src/modelsource.rs
@@ -69,7 +69,7 @@ pub fn ensure_model_path(name: &str) -> Result<String> {
 pub fn create_source_from(source: &str) -> Result<Box<dyn ModelSource>> {
     match source {
         "localhost" => Ok(Box::new(local::Local {})),
-        "spice.ai" => Ok(Box::new(spiceai::SpiceAI {})),
+        "spiceai" => Ok(Box::new(spiceai::SpiceAI {})),
         _ => UnknownModelSourceSnafu {
             model_source: source,
         }

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -72,20 +72,14 @@ impl Dataset {
         }
     }
 
-    /// Returns the dataset source - the first part of the `from` field before the first `/`.
+    /// Returns the dataset source - the first part of the `from` field before the first `:`.
     ///
     /// # Examples
     ///
     /// ```
     /// use spicepod::component::dataset::Dataset;
     ///
-    /// let dataset = Dataset {
-    ///    from: "foo/bar".to_string(),
-    ///    name: "bar".to_string(),
-    ///    acceleration: None,
-    ///    params: Default::default(),
-    ///    depends_on: Default::default(),
-    /// };
+    /// let dataset = Dataset::new("foo:bar".to_string(), "bar".to_string());
     ///
     /// assert_eq!(dataset.source(), "foo".to_string());
     /// ```
@@ -93,19 +87,18 @@ impl Dataset {
     /// ```
     /// use spicepod::component::dataset::Dataset;
     ///
-    /// let dataset = Dataset {
-    ///   from: "foo".to_string(),
-    ///   name: "bar".to_string(),
-    ///   acceleration: None,
-    ///   params: Default::default(),
-    ///   depends_on: Default::default(),
-    /// };
+    /// let dataset = Dataset::new("foo".to_string(), "bar".to_string());
     ///
-    /// assert_eq!(dataset.source(), "foo".to_string());
+    /// assert_eq!(dataset.source(), "spiceai");
     /// ```
     #[must_use]
     pub fn source(&self) -> String {
-        self.from.split('/').next().unwrap_or_default().to_string()
+        let parts: Vec<&str> = self.from.splitn(2, ':').collect();
+        if parts.len() > 1 {
+            parts[0].to_string()
+        } else {
+            "spiceai".to_string()
+        }
     }
 
     #[must_use]

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -101,11 +101,30 @@ impl Dataset {
         }
     }
 
+    /// Returns the dataset path - the remainder of the `from` field after the first `:` or the whole string if no `:`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spicepod::component::dataset::Dataset;
+    ///
+    /// let dataset = Dataset::new("foo:bar".to_string(), "bar".to_string());
+    ///
+    /// assert_eq!(dataset.path(), "bar".to_string());
+    /// ```
+    ///
+    /// ```
+    /// use spicepod::component::dataset::Dataset;
+    ///
+    /// let dataset = Dataset::new("foo".to_string(), "bar".to_string());
+    ///
+    /// assert_eq!(dataset.path(), "foo".to_string());
+    /// ```
     #[must_use]
     pub fn path(&self) -> String {
-        match self.from.find('/') {
+        match self.from.find(':') {
             Some(index) => self.from[index + 1..].to_string(),
-            None => String::new(),
+            None => self.from.clone(),
         }
     }
 

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -27,9 +27,9 @@ impl Model {
         let from = self.from.clone();
 
         match from {
-            s if s.starts_with("spice.ai") => "spice.ai".to_string(),
+            s if s.starts_with("spiceai:") => "spiceai".to_string(),
             s if s.starts_with("file:/") => "localhost".to_string(),
-            _ => "debug".to_string(),
+            _ => "spiceai".to_string(),
         }
     }
 


### PR DESCRIPTION
## What

The Spicepod `from` will now select the DataConnector/ModelSource to load based on the first string before a colon (`:`) rather than a slash (`/`). If there is no colon, then we default to the Spice.ai Data Connector/Model Source.

The Spice.ai Data Connector will also change to accept new formats:

```
spiceai:spice.ai/lukekim/demo/datasets/my_data
spiceai:spice.ai/lukekim/demo/my_data
spiceai:lukekim/demo/datasets/my_data
spiceai:lukekim/demo/my_data
spice.ai/lukekim/demo/datasets/my_data
spice.ai/lukekim/demo/my_data
lukekim/demo/datasets/my_data
lukekim/demo/my_data
```

Would all be equivalent - they select the `my_data` dataset from the Spice.ai App `lukekim/demo`

## Why

The current solution to select the dataconnector is confusing when it isn't a URL, as is the case with `dremio`.