### PR TITLE
Dremio endpoint bugfix

### DIFF
--- a/bin/spice/pkg/cli/cmd/dataset.go
+++ b/bin/spice/pkg/cli/cmd/dataset.go
@@ -46,7 +46,7 @@ spice dataset configure
 		datasetLocation = strings.TrimSuffix(datasetLocation, "\n")
 
 		params := map[string]string{}
-		if strings.Split(datasetLocation, "/")[0] == api.DATA_SOURCE_DREMIO {
+		if strings.Split(datasetLocation, ":")[0] == api.DATA_SOURCE_DREMIO {
 
 			cmd.Print("\nWhat is your dremio endpoint? ")
 			endpoint, err := reader.ReadString('\n')


### PR DESCRIPTION
We changed the namespace but didn't update the string split for dremio.  This change modifies it so the dremio demo works.