### PR TITLE
More flexible model source selection

### DIFF
--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -110,6 +110,7 @@ pub(crate) mod datasets {
 
 pub(crate) mod inference {
     use crate::datafusion::DataFusion;
+    use crate::model::version as model_version;
     use crate::model::Model;
     use app::App;
     use arrow::array::Float32Array;
@@ -274,7 +275,7 @@ pub(crate) mod inference {
                 status: PredictStatus::BadRequest,
                 error_message: Some(format!("Model {model_name} not found")),
                 model_name,
-                model_version: Some(model.version()),
+                model_version: Some(model_version(&model.from)),
                 lookback,
                 prediction: vec![],
                 duration_ms: start_time.elapsed().as_millis(),
@@ -290,7 +291,7 @@ pub(crate) mod inference {
                             status: PredictStatus::Success,
                             error_message: None,
                             model_name,
-                            model_version: Some(model.version()),
+                            model_version: Some(model_version(&model.from)),
                             lookback,
                             prediction: result,
                             duration_ms: start_time.elapsed().as_millis(),
@@ -305,7 +306,7 @@ pub(crate) mod inference {
                             "Unable to cast inference result to Float32Array".to_string(),
                         ),
                         model_name,
-                        model_version: Some(model.version()),
+                        model_version: Some(model_version(&model.from)),
                         lookback,
                         prediction: vec![],
                         duration_ms: start_time.elapsed().as_millis(),
@@ -320,7 +321,7 @@ pub(crate) mod inference {
                         "Unable to find column 'y' in inference result".to_string(),
                     ),
                     model_name,
-                    model_version: Some(model.version()),
+                    model_version: Some(model_version(&model.from)),
                     lookback,
                     prediction: vec![],
                     duration_ms: start_time.elapsed().as_millis(),
@@ -332,7 +333,7 @@ pub(crate) mod inference {
                     status: PredictStatus::InternalError,
                     error_message: Some(e.to_string()),
                     model_name,
-                    model_version: Some(model.version()),
+                    model_version: Some(model_version(&model.from)),
                     lookback,
                     prediction: vec![],
                     duration_ms: start_time.elapsed().as_millis(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -337,7 +337,7 @@ impl Runtime {
         let mut model_map = self.models.write().await;
         let auth = self.auth.read().await;
 
-        match Model::load(m, auth.get(m.source().as_str())).await {
+        match Model::load(m, auth.get(model::source(&m.from).as_str())).await {
             Ok(in_m) => {
                 model_map.insert(m.name.clone(), in_m);
                 tracing::info!("Model [{}] deployed, ready for inferencing", m.name);

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -97,6 +97,9 @@ impl Dataset {
         if parts.len() > 1 {
             parts[0].to_string()
         } else {
+            if self.from == "localhost" || self.from.is_empty() {
+                return "localhost".to_string();
+            }
             "spiceai".to_string()
         }
     }

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -20,21 +20,3 @@ impl WithDependsOn<Model> for Model {
         }
     }
 }
-
-impl Model {
-    #[must_use]
-    pub fn source(&self) -> String {
-        let from = self.from.clone();
-
-        match from {
-            s if s.starts_with("spiceai:") => "spiceai".to_string(),
-            s if s.starts_with("file:/") => "localhost".to_string(),
-            _ => "spiceai".to_string(),
-        }
-    }
-
-    #[must_use]
-    pub fn version(&self) -> String {
-        self.from.split(':').last().unwrap_or("").to_string()
-    }
-}


### PR DESCRIPTION
Moves the custom logic to parse the model source from the spicepod crate to the runtime crate.

Changes the model source parser to account for a prefix with `spiceai:`.

Fixes a bug with localhost datasets