### PR TITLE
Generalize connection pooler to accept anything as pool

### DIFF
--- a/crates/runtime/src/databackend/duckdb.rs
+++ b/crates/runtime/src/databackend/duckdb.rs
@@ -57,7 +57,11 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct DuckDBBackend {
     ctx: Arc<SessionContext>,
     name: String,
-    pool: Arc<dyn DbConnectionPool<DuckdbConnectionManager, &'static dyn ToSql> + Send + Sync>,
+    pool: Arc<
+        dyn DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &'static dyn ToSql>
+            + Send
+            + Sync,
+    >,
     create_mutex: std::sync::Mutex<()>,
     _primary_keys: Option<Vec<String>>,
 }

--- a/crates/sql_provider_datafusion/src/dbconnection.rs
+++ b/crates/sql_provider_datafusion/src/dbconnection.rs
@@ -8,8 +8,8 @@ pub mod duckdbconn;
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub trait DbConnection<T: r2d2::ManageConnection, P> {
-    fn new(conn: r2d2::PooledConnection<T>) -> Self
+pub trait DbConnection<T, P> {
+    fn new(conn: T) -> Self
     where
         Self: Sized;
     fn get_schema(&mut self, table_reference: &TableReference) -> Result<SchemaRef>;

--- a/crates/sql_provider_datafusion/src/dbconnection/duckdbconn.rs
+++ b/crates/sql_provider_datafusion/src/dbconnection/duckdbconn.rs
@@ -20,7 +20,9 @@ pub struct DuckDbConnection {
     pub conn: r2d2::PooledConnection<DuckdbConnectionManager>,
 }
 
-impl DbConnection<DuckdbConnectionManager, &dyn ToSql> for DuckDbConnection {
+impl DbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSql>
+    for DuckDbConnection
+{
     fn new(conn: r2d2::PooledConnection<DuckdbConnectionManager>) -> Self {
         DuckDbConnection { conn }
     }

--- a/crates/sql_provider_datafusion/src/dbconnectionpool.rs
+++ b/crates/sql_provider_datafusion/src/dbconnectionpool.rs
@@ -12,7 +12,7 @@ pub enum Mode {
     File,
 }
 
-pub trait DbConnectionPool<T: r2d2::ManageConnection, P: 'static> {
+pub trait DbConnectionPool<T, P: 'static> {
     fn new(name: &str, mode: Mode, params: Arc<Option<HashMap<String, String>>>) -> Result<Self>
     where
         Self: Sized;

--- a/crates/sql_provider_datafusion/src/dbconnectionpool/duckdbpool.rs
+++ b/crates/sql_provider_datafusion/src/dbconnectionpool/duckdbpool.rs
@@ -19,7 +19,9 @@ pub struct DuckDbConnectionPool {
     pool: Arc<r2d2::Pool<DuckdbConnectionManager>>,
 }
 
-impl DbConnectionPool<DuckdbConnectionManager, &'static dyn ToSql> for DuckDbConnectionPool {
+impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &'static dyn ToSql>
+    for DuckDbConnectionPool
+{
     fn new(name: &str, mode: Mode, params: Arc<Option<HashMap<String, String>>>) -> Result<Self> {
         let manager = match mode {
             Mode::Memory => DuckdbConnectionManager::memory().context(DuckDBSnafu)?,
@@ -38,7 +40,9 @@ impl DbConnectionPool<DuckdbConnectionManager, &'static dyn ToSql> for DuckDbCon
 
     fn connect(
         &self,
-    ) -> Result<Box<dyn DbConnection<DuckdbConnectionManager, &'static dyn ToSql>>> {
+    ) -> Result<
+        Box<dyn DbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &'static dyn ToSql>>,
+    > {
         let pool = Arc::clone(&self.pool);
         let conn: r2d2::PooledConnection<DuckdbConnectionManager> =
             pool.get().context(ConnectionPoolSnafu)?;

--- a/crates/sql_provider_datafusion/src/lib.rs
+++ b/crates/sql_provider_datafusion/src/lib.rs
@@ -36,13 +36,13 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub struct SqlTable<T: r2d2::ManageConnection, P: 'static> {
+pub struct SqlTable<T: 'static, P: 'static> {
     pool: Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
     schema: SchemaRef,
     table_reference: OwnedTableReference,
 }
 
-impl<T: r2d2::ManageConnection, P> SqlTable<T, P> {
+impl<T, P> SqlTable<T, P> {
     pub fn new(
         pool: &Arc<dyn DbConnectionPool<T, P> + Send + Sync>,
         table_reference: impl Into<OwnedTableReference>,
@@ -90,7 +90,7 @@ impl<T: r2d2::ManageConnection, P> SqlTable<T, P> {
 }
 
 #[async_trait]
-impl<T: r2d2::ManageConnection, P> TableProvider for SqlTable<T, P> {
+impl<T, P> TableProvider for SqlTable<T, P> {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -138,7 +138,7 @@ struct SqlExec<T, P> {
     limit: Option<usize>,
 }
 
-impl<T: r2d2::ManageConnection, P> SqlExec<T, P> {
+impl<T, P> SqlExec<T, P> {
     fn new(
         projections: Option<&Vec<usize>>,
         schema: &SchemaRef,
@@ -190,21 +190,21 @@ impl<T: r2d2::ManageConnection, P> SqlExec<T, P> {
     }
 }
 
-impl<T: r2d2::ManageConnection, P> std::fmt::Debug for SqlExec<T, P> {
+impl<T, P> std::fmt::Debug for SqlExec<T, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let sql = self.sql().unwrap_or_default();
         write!(f, "SqlExec sql={sql}")
     }
 }
 
-impl<T: r2d2::ManageConnection, P> DisplayAs for SqlExec<T, P> {
+impl<T, P> DisplayAs for SqlExec<T, P> {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
         let sql = self.sql().unwrap_or_default();
         write!(f, "SqlExec sql={sql}")
     }
 }
 
-impl<T: r2d2::ManageConnection, P: 'static> ExecutionPlan for SqlExec<T, P> {
+impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -280,12 +280,15 @@ mod tests {
     async fn test_duckdb_table() -> Result<(), Box<dyn Error + Send + Sync>> {
         let t = setup_tracing();
         let ctx = SessionContext::new();
-        let pool: Arc<dyn DbConnectionPool<DuckdbConnectionManager, &dyn ToSql> + Send + Sync> =
-            Arc::new(DuckDbConnectionPool::new(
-                "test",
-                Mode::Memory,
-                Arc::new(Option::None),
-            )?);
+        let pool: Arc<
+            dyn DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSql>
+                + Send
+                + Sync,
+        > = Arc::new(DuckDbConnectionPool::new(
+            "test",
+            Mode::Memory,
+            Arc::new(Option::None),
+        )?);
         let conn = pool.connect()?;
         let db_conn = conn
             .as_any()
@@ -307,12 +310,15 @@ mod tests {
     async fn test_duckdb_table_filter() -> Result<(), Box<dyn Error + Send + Sync>> {
         let t = setup_tracing();
         let ctx = SessionContext::new();
-        let pool: Arc<dyn DbConnectionPool<DuckdbConnectionManager, &dyn ToSql> + Send + Sync> =
-            Arc::new(DuckDbConnectionPool::new(
-                "test",
-                Mode::Memory,
-                Arc::new(Option::None),
-            )?);
+        let pool: Arc<
+            dyn DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSql>
+                + Send
+                + Sync,
+        > = Arc::new(DuckDbConnectionPool::new(
+            "test",
+            Mode::Memory,
+            Arc::new(Option::None),
+        )?);
         let conn = pool.connect()?;
         let db_conn = conn
             .as_any()


### PR DESCRIPTION
This PR makes a change to allow anything to be provided as the connection pool and db connection in the DbConnection and DbConnectionPool interfaces.