### PR TITLE
Add spicepod "secret" component

### DIFF
--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -7,6 +7,7 @@ use snafu::prelude::*;
 use crate::reader;
 pub mod dataset;
 pub mod model;
+pub mod secret;
 
 pub trait WithDependsOn<T> {
     fn depends_on(&self, depends_on: &[String]) -> T;

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fs, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
+use super::secret::{resolve_secrets, Secret, SecretWithValueFrom, WithGetSecrets};
 use super::WithDependsOn;
 use snafu::prelude::*;
 
@@ -54,6 +55,9 @@ pub struct Dataset {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "dependsOn", default)]
     pub depends_on: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secrets: Vec<Secret>,
 }
 
 impl Dataset {
@@ -69,6 +73,7 @@ impl Dataset {
             replication: None,
             acceleration: None,
             depends_on: Vec::default(),
+            secrets: Vec::default(),
         }
     }
 
@@ -186,6 +191,7 @@ impl WithDependsOn<Dataset> for Dataset {
             replication: self.replication.clone(),
             acceleration: self.acceleration.clone(),
             depends_on: depends_on.to_vec(),
+            secrets: self.secrets.clone(),
         }
     }
 }
@@ -267,5 +273,11 @@ pub mod replication {
     pub struct Replication {
         #[serde(default)]
         pub enabled: bool,
+    }
+}
+
+impl WithGetSecrets for Dataset {
+    fn get_secrets(&self, default_from: Option<String>) -> Vec<SecretWithValueFrom> {
+        resolve_secrets(&self.secrets, default_from)
     }
 }

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -1,6 +1,8 @@
 use super::WithDependsOn;
 use serde::{Deserialize, Serialize};
 
+use super::secret::{resolve_secrets, Secret, SecretWithValueFrom, WithGetSecrets};
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Model {
     pub from: String,
@@ -9,6 +11,9 @@ pub struct Model {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "datasets", default)]
     pub datasets: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secrets: Vec<Secret>,
 }
 
 impl WithDependsOn<Model> for Model {
@@ -17,6 +22,13 @@ impl WithDependsOn<Model> for Model {
             from: self.from.clone(),
             name: self.name.clone(),
             datasets: depends_on.to_vec(),
+            secrets: Vec::default(),
         }
+    }
+}
+
+impl WithGetSecrets for Model {
+    fn get_secrets(&self, default_from: Option<String>) -> Vec<SecretWithValueFrom> {
+        resolve_secrets(&self.secrets, default_from)
     }
 }

--- a/crates/spicepod/src/component/secret.rs
+++ b/crates/spicepod/src/component/secret.rs
@@ -1,0 +1,109 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum Secret {
+    SecretBase(SecretBase),
+    SecretWithValueFrom(SecretWithValueFrom),
+}
+
+/// SecretBase is a shorthand for a secret that is stored in a file
+///
+/// ```yaml
+/// secrets:
+///   - name: my_secret
+///     key: my_secret_key
+/// ```
+///
+/// is equivalent to
+///
+/// ```yaml
+/// secrets:
+///   - name: my_secret
+///     valueFrom:
+///       file:
+///         name: my_secret
+///         key: my_secret_key
+/// ```
+///
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SecretBase {
+    pub name: String,
+    pub key: String,
+}
+
+/// SecretWithValueFrom is a secret that is resolved from a secret store
+///
+/// ```yaml
+/// secrets:
+///   - name: my_secret
+///     valueFrom:
+///       file:
+///         name: my_secret
+///         key: my_secret_key
+/// ```
+///
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SecretWithValueFrom {
+    pub name: String,
+    pub value_from: HashMap<String, SecretReference>,
+}
+
+/// SecretReference is a reference to a secret value in a secret store
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SecretReference {
+    pub name: String,
+
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub key: String,
+}
+
+/// WithGetSecrets is a trait for components that have secrets
+pub trait WithGetSecrets {
+    fn get_secrets(&self, default_from: Option<String>) -> Vec<SecretWithValueFrom>;
+}
+
+/// resolve_secrets resolves secrets into SecretWithValueFrom
+///
+/// Example:
+///
+/// ```rust
+/// use spicepod::component::secret::{resolve_secrets, Secret};
+/// use std::collections::HashMap;
+///
+/// let secrets = resolve_secrets(secrets, None); // resolve secrets with a default file secret store
+///
+/// let secrets = resolve_secrets(secrets, Some("keyring".to_string())); // resolve secrets from keyring store
+/// ````
+pub fn resolve_secrets(
+    secrets: &[Secret],
+    default_from: Option<String>,
+) -> Vec<SecretWithValueFrom> {
+    secrets
+        .iter()
+        .map(|s| match s {
+            Secret::SecretWithValueFrom(s) => s.clone(),
+
+            // default spice secret store is file
+            Secret::SecretBase(s) => {
+                let mut value_from: HashMap<String, SecretReference> = HashMap::new();
+
+                let from = default_from.clone().unwrap_or_else(|| "file".to_string());
+
+                value_from.insert(
+                    from,
+                    SecretReference {
+                        name: s.name.clone(),
+                        key: s.key.clone(),
+                    },
+                );
+
+                SecretWithValueFrom {
+                    name: s.name.clone(),
+                    value_from,
+                }
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
Based on draft work in #758

Added a new component "secret" to the spicepod library, and `secrets` list to datasets and models.

Examples:

```yaml

# loading spiceai token and key from spice file secret storage (`~/.spice/auth`)

datasets:
  - from: spice.ai/eth.recent_transactions
    name: eth_recent_transactions

    secrets:

      - name: spiceai_api_key
        value_from:
          file:
            name: spiceai
            key: key

      - name: spiceai_cloud_token
        value_from:
          file:
            name: spiceai
            key: token

```