### PR TITLE
Fix missing app extension in routes, due to type mismatch

### DIFF
--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -89,12 +89,9 @@ pub(crate) mod datasets {
         Query(filter): Query<DatasetFilter>,
     ) -> Json<Vec<Dataset>> {
         let app_lock = app.read().await;
-        let readable_app = match &*app_lock {
-            Some(app) => app,
-            None => {
-                tracing::debug!("App not found");
-                return Json(vec![]);
-            }
+        let Some(readable_app) = &*app_lock else {
+            tracing::debug!("App not found");
+            return Json(vec![]);
         };
 
         let mut datasets: Vec<Dataset> = match filter.source {
@@ -261,20 +258,17 @@ pub(crate) mod inference {
         let start_time = Instant::now();
 
         let app_lock = app.read().await;
-        let readable_app = match &*app_lock {
-            Some(app) => app,
-            None => {
-                tracing::debug!("App not found");
-                return PredictResponse {
-                    status: PredictStatus::BadRequest,
-                    error_message: Some("App not found".to_string()),
-                    model_name,
-                    model_version: None,
-                    lookback,
-                    prediction: vec![],
-                    duration_ms: start_time.elapsed().as_millis(),
-                };
-            }
+        let Some(readable_app) = &*app_lock else {
+            tracing::debug!("App not found");
+            return PredictResponse {
+                status: PredictStatus::BadRequest,
+                error_message: Some("App not found".to_string()),
+                model_name,
+                model_version: None,
+                lookback,
+                prediction: vec![],
+                duration_ms: start_time.elapsed().as_millis(),
+            };
         };
 
         let model = readable_app.models.iter().find(|m| m.name == model_name);

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -258,7 +258,6 @@ pub(crate) mod inference {
 
         let app_lock = app.read().await;
         let Some(readable_app) = &*app_lock else {
-            tracing::debug!("App not found");
             return PredictResponse {
                 status: PredictStatus::BadRequest,
                 error_message: Some("App not found".to_string()),

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -90,7 +90,6 @@ pub(crate) mod datasets {
     ) -> Json<Vec<Dataset>> {
         let app_lock = app.read().await;
         let Some(readable_app) = &*app_lock else {
-            tracing::debug!("App not found");
             return Json(vec![]);
         };
 


### PR DESCRIPTION
From changes in #720, app object is passed with type `Arc<RwLock<Option<App>>>`
https://github.com/spiceai/spiceai/blob/63ff3bbd6e0cf5b02efc871a83baabf6ff8a90b1/crates/runtime/src/http/routes.rs#L15

It was still expected as `Arc<RwLock<App>>` in some handlers, which was causing following error:

![CleanShot 2024-03-02 at 23 56 54@2x](https://github.com/spiceai/spiceai/assets/827338/4be5d7a8-ad6d-497a-8e87-8ce96b8a7614)

After the fix:

![CleanShot 2024-03-02 at 23 57 17@2x](https://github.com/spiceai/spiceai/assets/827338/98042145-82fd-451f-b148-334fe3dda042)

