### PR TITLE
Add "secrets" configuration to spicepod definition

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -3,11 +3,16 @@
 use std::path::PathBuf;
 
 use snafu::prelude::*;
-use spicepod::{component::dataset::Dataset, component::model::Model, Spicepod};
+use spicepod::{
+    component::{dataset::Dataset, model::Model, secrets::Secrets},
+    Spicepod,
+};
 
 #[derive(Debug, PartialEq)]
 pub struct App {
     pub name: String,
+
+    pub secrets: Secrets,
 
     pub datasets: Vec<Dataset>,
 
@@ -33,6 +38,7 @@ impl App {
         let path = path.into();
         let spicepod_root =
             Spicepod::load(&path).context(UnableToLoadSpicepodSnafu { path: path.clone() })?;
+        let secrets = spicepod_root.secrets.clone();
         let mut datasets: Vec<Dataset> = vec![];
         let mut models: Vec<Model> = vec![];
         for dataset in &spicepod_root.datasets {
@@ -65,6 +71,7 @@ impl App {
 
         Ok(App {
             name: root_spicepod_name,
+            secrets,
             datasets,
             models,
             spicepods,

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -7,6 +7,7 @@ use snafu::prelude::*;
 use crate::reader;
 pub mod dataset;
 pub mod model;
+pub mod secrets;
 
 pub trait WithDependsOn<T> {
     fn depends_on(&self, depends_on: &[String]) -> T;

--- a/crates/spicepod/src/component/secrets.rs
+++ b/crates/spicepod/src/component/secrets.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+/// The secrets configuration for a Spicepod.
+///
+/// Example:
+/// ```yaml
+/// secrets:
+///   store: file
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Secrets {
+    pub store: SpiceSecretStore,
+}
+
+impl Default for Secrets {
+    fn default() -> Self {
+        Self {
+            store: SpiceSecretStore::File,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SpiceSecretStore {
+    File,
+    Keyring,
+}

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -6,6 +6,7 @@ use std::{fmt::Debug, path::PathBuf};
 
 use component::dataset::Dataset;
 use component::model::Model;
+use component::secrets::Secrets;
 use spec::SpicepodDefinition;
 
 pub mod component;
@@ -30,6 +31,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, PartialEq)]
 pub struct Spicepod {
     pub name: String,
+
+    pub secrets: Secrets,
 
     pub datasets: Vec<Dataset>,
 
@@ -110,6 +113,7 @@ fn from_definition(
 ) -> Spicepod {
     Spicepod {
         name: spicepod_definition.name,
+        secrets: spicepod_definition.secrets,
         datasets,
         models,
         dependencies: spicepod_definition.dependencies,

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::{self, Value};
 use std::{collections::HashMap, fmt::Debug};
 
+use crate::component::secrets::Secrets;
 use crate::component::{dataset::Dataset, model::Model, ComponentOrReference};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -17,6 +18,11 @@ pub struct SpicepodDefinition {
     pub version: SpicepodVersion,
 
     pub kind: SpicepodKind,
+
+    /// Optional spicepod secrets configuration
+    /// Default value is `store: file`
+    #[serde(default)]
+    pub secrets: Secrets,
 
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]


### PR DESCRIPTION
Added an optional `secrets` field to specify the secrets store for spicepod configuration.

If not specified, spicepod will always have a default value (using `~/.spice/auth` file):

```yaml

secrets:
  store: file

```
