### PR TITLE
Add secret provider and secret store implementation. Replace auth with secret for datasets loading.

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -82,6 +82,8 @@ pub async fn run(args: Args) -> Result<()> {
 
     let mut rt: Runtime = Runtime::new(args.runtime, app, df, pods_watcher, auth);
 
+    rt.load_secrets().await;
+
     rt.load_datasets().await;
 
     rt.load_models().await;

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -13,9 +13,9 @@ use async_stream::stream;
 use futures_core::stream::BoxStream;
 use std::future::Future;
 
-use crate::auth::AuthProvider;
 use crate::datapublisher::DataPublisher;
 use crate::dataupdate::{DataUpdate, UpdateType};
+use crate::secrets::Secret;
 
 pub mod debug;
 pub mod dremio;
@@ -54,7 +54,7 @@ pub type AnyErrorResult = std::result::Result<(), Box<dyn std::error::Error>>;
 pub trait DataConnector: Send + Sync {
     /// Create a new `DataConnector` with the given `AuthProvider`.
     fn new(
-        auth_provider: AuthProvider,
+        secret: Secret,
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = Result<Self>> + Send>>
     where

--- a/crates/runtime/src/dataconnector/debug.rs
+++ b/crates/runtime/src/dataconnector/debug.rs
@@ -1,5 +1,3 @@
-use crate::auth::AuthProvider;
-
 use std::collections::HashMap;
 use std::{future::Future, pin::Pin};
 use std::{sync::Arc, time::Duration};
@@ -19,7 +17,7 @@ pub struct DebugSource {}
 
 impl DataConnector for DebugSource {
     fn new(
-        _auth_provider: AuthProvider,
+        _secret: super::Secret,
         _params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>> {
         Box::pin(async move { Ok(Self {}) })

--- a/crates/runtime/src/dataconnector/debug.rs
+++ b/crates/runtime/src/dataconnector/debug.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::{future::Future, pin::Pin};
 use std::{sync::Arc, time::Duration};
 
+use crate::secrets::Secret;
+
 use super::{DataConnector, DataUpdate, UpdateType};
 use arrow::{
     array::{Int32Array, StringArray},

--- a/crates/runtime/src/dataconnector/debug.rs
+++ b/crates/runtime/src/dataconnector/debug.rs
@@ -17,7 +17,7 @@ pub struct DebugSource {}
 
 impl DataConnector for DebugSource {
     fn new(
-        _secret: super::Secret,
+        _secret: Secret,
         _params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>> {
         Box::pin(async move { Ok(Self {}) })

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -7,7 +7,7 @@ use flight_client::FlightClient;
 use flight_datafusion::FlightTable;
 use spicepod::component::dataset::Dataset;
 
-use crate::auth::AuthProvider;
+use crate::secrets::Secret;
 
 use super::{flight::Flight, DataConnector};
 
@@ -18,7 +18,7 @@ pub struct Dremio {
 #[async_trait]
 impl DataConnector for Dremio {
     fn new(
-        auth_provider: AuthProvider,
+        secret: Secret,
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>>
     where
@@ -34,8 +34,8 @@ impl DataConnector for Dremio {
                 })?;
             let flight_client = FlightClient::new(
                 endpoint.as_str(),
-                auth_provider.get_param("username").unwrap_or_default(),
-                auth_provider.get_param("password").unwrap_or_default(),
+                secret.get("username").unwrap_or_default(),
+                secret.get("password").unwrap_or_default(),
             )
             .await
             .map_err(|e| super::Error::UnableToCreateDataConnector { source: e.into() })?;

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -15,10 +15,10 @@ use spicepod::component::dataset::Dataset;
 
 use flight_datafusion::FlightTable;
 
-use crate::auth::AuthProvider;
 use crate::datapublisher::{AddDataResult, DataPublisher};
 use crate::dataupdate::{DataUpdate, UpdateType};
 use crate::info_spaced;
+use crate::secrets::Secret;
 use crate::tracers::SpacedTracer;
 
 use super::{flight::Flight, DataConnector};
@@ -43,7 +43,7 @@ pub struct SpiceAI {
 #[async_trait]
 impl DataConnector for SpiceAI {
     fn new(
-        auth_provider: AuthProvider,
+        secret: Secret,
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>>
     where
@@ -61,13 +61,10 @@ impl DataConnector for SpiceAI {
                 .and_then(|params| params.get("endpoint").cloned())
                 .unwrap_or(default_flight_url);
             tracing::trace!("Connecting to SpiceAI with flight url: {url}");
-            let flight_client = FlightClient::new(
-                url.as_str(),
-                "",
-                auth_provider.get_param("key").unwrap_or_default(),
-            )
-            .await
-            .map_err(|e| super::Error::UnableToCreateDataConnector { source: e.into() })?;
+            let flight_client =
+                FlightClient::new(url.as_str(), "", secret.get("key").unwrap_or_default())
+                    .await
+                    .map_err(|e| super::Error::UnableToCreateDataConnector { source: e.into() })?;
             let flight = Flight::new(flight_client);
             Ok(Self {
                 flight,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -74,7 +74,7 @@ pub enum Error {
     UnknownDataConnector { data_connector: String },
 
     #[snafu(display("Unable to load secrets for data connector: {data_connector}"))]
-    UnableToLoadDataConnectorSecret { data_connector: String },
+    UnableToLoadDataConnectorSecrets { data_connector: String },
 
     #[snafu(display("Unable to create view: {source}"))]
     InvalidSQLView {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub enum Error {
     #[snafu(display("Unknown data connector: {data_connector}"))]
     UnknownDataConnector { data_connector: String },
 
-    #[snafu(display("Unable to load data connector secret: {data_connector}"))]
+    #[snafu(display("Unable to load secrets for data connector: {data_connector}"))]
     UnableToLoadDataConnectorSecret { data_connector: String },
 
     #[snafu(display("Unable to create view: {source}"))]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -240,7 +240,7 @@ impl Runtime {
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Result<Option<Box<dyn DataConnector + Send>>> {
         let Some(secret) = secrets_provider.get_secret(source) else {
-            return UnableToLoadDataConnectorSecretSnafu {
+            return UnableToLoadDataConnectorSecretsSnafu {
                 data_connector: source,
             }
             .fail()?;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -87,7 +87,7 @@ pub enum Error {
         data_connector: String,
     },
 
-    #[snafu(display("Unable to load secrets {store}"))]
+    #[snafu(display("Unable to load secrets for {store}"))]
     UnableToLoadSecrets { store: String },
 }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -32,6 +32,7 @@ pub mod modelruntime;
 pub mod modelsource;
 mod opentelemetry;
 pub mod podswatcher;
+pub mod secrets;
 pub(crate) mod tracers;
 
 #[derive(Debug, Snafu)]
@@ -72,6 +73,9 @@ pub enum Error {
     #[snafu(display("Unknown data connector: {data_connector}"))]
     UnknownDataConnector { data_connector: String },
 
+    #[snafu(display("Unable to load data connector secret: {data_connector}"))]
+    UnableToLoadDataConnectorSecret { data_connector: String },
+
     #[snafu(display("Unable to create view: {source}"))]
     InvalidSQLView {
         source: spicepod::component::dataset::Error,
@@ -82,6 +86,9 @@ pub enum Error {
         source: datafusion::Error,
         data_connector: String,
     },
+
+    #[snafu(display("Unable to load secrets {store}"))]
+    UnableToLoadSecrets { store: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -93,6 +100,7 @@ pub struct Runtime {
     pub models: Arc<RwLock<HashMap<String, Model>>>,
     pub pods_watcher: podswatcher::PodsWatcher,
     pub auth: Arc<RwLock<auth::AuthProviders>>,
+    pub secrets_provider: Arc<RwLock<secrets::SecretsProvider>>,
 
     spaced_tracer: Arc<tracers::SpacedTracer>,
 }
@@ -113,7 +121,21 @@ impl Runtime {
             models: Arc::new(RwLock::new(HashMap::new())),
             pods_watcher,
             auth,
+            secrets_provider: Arc::new(RwLock::new(secrets::SecretsProvider::new())),
             spaced_tracer: Arc::new(tracers::SpacedTracer::new(Duration::from_secs(15))),
+        }
+    }
+
+    pub async fn load_secrets(&self) {
+        let mut secret_store = self.secrets_provider.write().await;
+
+        let app_lock = self.app.read().await;
+        if let Some(app) = app_lock.as_ref() {
+            secret_store.store = app.secrets.store.clone();
+        }
+
+        if let Err(e) = secret_store.load_secrets() {
+            tracing::warn!("Unable to load secrets: {}", e);
         }
     }
 
@@ -129,20 +151,21 @@ impl Runtime {
     pub fn load_dataset(&self, ds: &Dataset) {
         let df = Arc::clone(&self.df);
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
-        let shared_auth = Arc::clone(&self.auth);
+        let shared_secrets_provider = Arc::clone(&self.secrets_provider);
 
         let ds = ds.clone();
 
         tokio::spawn(async move {
             loop {
-                let auth = shared_auth.read().await;
+                let secrets_provider = shared_secrets_provider.read().await;
 
                 let source = ds.source();
+
                 let params = Arc::new(ds.params.clone());
                 let data_connector: Option<Box<dyn DataConnector + Send>> =
                     match Runtime::get_dataconnector_from_source(
                         &source,
-                        &auth,
+                        &secrets_provider,
                         Arc::clone(&params),
                     )
                     .await
@@ -213,19 +236,26 @@ impl Runtime {
 
     async fn get_dataconnector_from_source(
         source: &str,
-        auth: &auth::AuthProviders,
+        secrets_provider: &secrets::SecretsProvider,
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Result<Option<Box<dyn DataConnector + Send>>> {
+        let Some(secret) = secrets_provider.get_secret(source) else {
+            return UnableToLoadDataConnectorSecretSnafu {
+                data_connector: source,
+            }
+            .fail()?;
+        };
+
         match source {
             "spiceai" => Ok(Some(Box::new(
-                dataconnector::spiceai::SpiceAI::new(auth.get(source), params)
+                dataconnector::spiceai::SpiceAI::new(secret, params)
                     .await
                     .context(UnableToInitializeDataConnectorSnafu {
                         data_connector: source,
                     })?,
             ))),
             "dremio" => Ok(Some(Box::new(
-                dataconnector::dremio::Dremio::new(auth.get(source), params)
+                dataconnector::dremio::Dremio::new(secret, params)
                     .await
                     .context(UnableToInitializeDataConnectorSnafu {
                         data_connector: source,

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -66,7 +66,6 @@ impl SecretsProvider {
                 self.secret_store = Some(Box::new(file_secret_store));
             }
             SpiceSecretStore::Keyring => {
-                println!("Loading secrets from keyring");
             }
         }
 

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -1,0 +1,85 @@
+pub mod file;
+use std::collections::HashMap;
+
+use super::Result;
+use crate::{secrets::file::FileSecretStore, Error};
+use spicepod::component::secrets::SpiceSecretStore;
+
+pub trait SecretStore {
+    fn get_secret(&self, secret_name: &str) -> Option<Secret>;
+}
+
+#[derive(Debug, Clone)]
+pub struct Secret {
+    data: HashMap<String, String>,
+}
+
+impl Secret {
+    #[must_use]
+    pub fn new(data: HashMap<String, String>) -> Self {
+        Self { data }
+    }
+
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&str> {
+        if let Some(value) = self.data.get(key) {
+            Some(value.as_str())
+        } else {
+            None
+        }
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct SecretsProvider {
+    pub store: SpiceSecretStore,
+
+    secret_store: Option<Box<dyn SecretStore + Send + Sync>>,
+}
+
+impl Default for SecretsProvider {
+    fn default() -> Self {
+        Self {
+            store: SpiceSecretStore::File,
+            secret_store: None,
+        }
+    }
+}
+
+impl SecretsProvider {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn load_secrets(&mut self) -> Result<()> {
+        match self.store {
+            SpiceSecretStore::File => {
+                println!("Loading secrets from file");
+                let mut file_secret_store = FileSecretStore::new();
+
+                if file_secret_store.load_secrets().is_err() {
+                    return Err(Error::UnableToLoadSecrets {
+                        store: "file".to_string(),
+                    });
+                }
+
+                self.secret_store = Some(Box::new(file_secret_store));
+            }
+            SpiceSecretStore::Keyring => {
+                println!("Loading secrets from keyring");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn get_secret(&self, secret_name: &str) -> Option<Secret> {
+        if let Some(ref secret_store) = self.secret_store {
+            secret_store.get_secret(secret_name)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -55,7 +55,6 @@ impl SecretsProvider {
     pub fn load_secrets(&mut self) -> Result<()> {
         match self.store {
             SpiceSecretStore::File => {
-                println!("Loading secrets from file");
                 let mut file_secret_store = FileSecretStore::new();
 
                 if file_secret_store.load_secrets().is_err() {

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -65,8 +65,6 @@ impl SecretsProvider {
 
                 self.secret_store = Some(Box::new(file_secret_store));
             }
-            SpiceSecretStore::Keyring => {
-            }
         }
 
         Ok(())

--- a/crates/runtime/src/secrets/file.rs
+++ b/crates/runtime/src/secrets/file.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+
+use dirs;
+use serde::Deserialize;
+use snafu::prelude::*;
+
+use super::{Secret, SecretStore};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to find home directory"))]
+    UnableToFindHomeDir {},
+
+    #[snafu(display("Unable to open auth file: {source}"))]
+    UnableToOpenAuthFile { source: std::io::Error },
+
+    #[snafu(display("Unable to read auth file: {source}"))]
+    UnableToReadAuthFile { source: std::io::Error },
+
+    #[snafu(display("Unable to parse auth file: {source}"))]
+    UnableToParseAuthFile { source: toml::de::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[allow(clippy::module_name_repetitions)]
+pub type AuthConfigs = HashMap<String, AuthConfig>;
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Default, Deserialize, Clone)]
+pub struct AuthConfig {
+    pub params: HashMap<String, String>,
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct FileSecretStore {
+    secrets: HashMap<String, Secret>,
+}
+
+impl FileSecretStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            secrets: HashMap::new(),
+        }
+    }
+}
+
+impl Default for FileSecretStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileSecretStore {
+    pub fn load_secrets(&mut self) -> Result<()> {
+        let mut auth_path = dirs::home_dir().context(UnableToFindHomeDirSnafu)?;
+        auth_path.push(".spice/auth");
+
+        let mut auth_file = File::open(auth_path).context(UnableToOpenAuthFileSnafu)?;
+        let mut auth_contents = String::new();
+        auth_file
+            .read_to_string(&mut auth_contents)
+            .context(UnableToReadAuthFileSnafu)?;
+
+        let auth_configs =
+            toml::from_str::<AuthConfigs>(&auth_contents).context(UnableToParseAuthFileSnafu)?;
+
+        self.secrets = auth_configs
+            .iter()
+            .map(|(k, v)| (k.clone(), Secret::new(v.params.clone())))
+            .collect();
+
+        Ok(())
+    }
+}
+
+impl SecretStore for FileSecretStore {
+    #[must_use]
+    fn get_secret(&self, secret_name: &str) -> Option<Secret> {
+        if let Some(secret) = self.secrets.get(secret_name) {
+            return Some(secret.clone());
+        }
+
+        None
+    }
+}

--- a/crates/spicepod/src/component/secrets.rs
+++ b/crates/spicepod/src/component/secrets.rs
@@ -24,5 +24,4 @@ impl Default for Secrets {
 #[serde(rename_all = "lowercase")]
 pub enum SpiceSecretStore {
     File,
-    Keyring,
 }


### PR DESCRIPTION
Based #762 

Adds `SecretsProvider` to spice runtime with File secret store implementation (reading auth secrets from ~/.spice/auth).
Replaced auth with secrets provider in dataset loader.

A "secret" is always stored as a hashmap. The file store naturally supports this, but in other storage types like keyring that only allow string values, each secret needs to be serialized as a JSON string. The secret store implementation is responsible for the parsing.