### PR TITLE
Don't require secrets for all dataconnectors

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -54,7 +54,7 @@ pub type AnyErrorResult = std::result::Result<(), Box<dyn std::error::Error>>;
 pub trait DataConnector: Send + Sync {
     /// Create a new `DataConnector` with the given `Secret`.
     fn new(
-        secret: Secret,
+        secret: Option<Secret>,
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = Result<Self>> + Send>>
     where

--- a/crates/runtime/src/dataconnector/debug.rs
+++ b/crates/runtime/src/dataconnector/debug.rs
@@ -19,7 +19,7 @@ pub struct DebugSource {}
 
 impl DataConnector for DebugSource {
     fn new(
-        _secret: Secret,
+        _secret: Option<Secret>,
         _params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>> {
         Box::pin(async move { Ok(Self {}) })

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -18,13 +18,17 @@ pub struct Dremio {
 #[async_trait]
 impl DataConnector for Dremio {
     fn new(
-        secret: Secret,
+        secret: Option<Secret>,
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>>
     where
         Self: Sized,
     {
         Box::pin(async move {
+            let secret = secret.ok_or_else(|| super::Error::UnableToCreateDataConnector {
+                source: "Missing required secrets".into(),
+            })?;
+
             let endpoint: String = params
                 .as_ref() // &Option<HashMap<String, String>>
                 .as_ref() // Option<&HashMap<String, String>>

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -43,7 +43,7 @@ pub struct SpiceAI {
 #[async_trait]
 impl DataConnector for SpiceAI {
     fn new(
-        secret: Secret,
+        secret: Option<Secret>,
         params: Arc<Option<HashMap<String, String>>>,
     ) -> Pin<Box<dyn Future<Output = super::Result<Self>> + Send>>
     where
@@ -55,6 +55,10 @@ impl DataConnector for SpiceAI {
             "https://flight.spiceai.io".to_string()
         };
         Box::pin(async move {
+            let secret = secret.ok_or_else(|| super::Error::UnableToCreateDataConnector {
+                source: "Missing required secrets".into(),
+            })?;
+
             let url: String = params
                 .as_ref() // &Option<HashMap<String, String>>
                 .as_ref() // Option<&HashMap<String, String>>


### PR DESCRIPTION
Currently we require that all data connectors have some secrets - but there are a couple of cases where this isn't necessary, but we still want to create a data connector for other reasons.