### PR TITLE
Only run CodeQL on push and schedule

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,13 +2,10 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [trunk, rust, release-*]
+    branches: [trunk, release-*]
     paths-ignore:
       - 'docs/**'
       - '.github/**'
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [trunk]
   schedule:
     - cron: '19 18 * * 4'
 


### PR DESCRIPTION
CodeQL doesn't support Rust - so its limited value to run it on PR just for the small portion of Go code we have. It also takes ~16 minutes to run, which unnecessarily adds time to our PR checks.