### PR TITLE
Add Kubernetes secret store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.21.7",
  "chrono",
  "comfy-table",
  "half",
@@ -300,7 +300,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "arrow-string",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "futures",
  "once_cell",
@@ -617,6 +617,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "bb8"
@@ -1226,7 +1232,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-ord",
  "arrow-schema",
- "base64",
+ "base64 0.21.7",
  "blake2",
  "blake3",
  "chrono",
@@ -1510,7 +1516,7 @@ version = "0.7.0-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "futures",
  "rustls",
@@ -2505,7 +2511,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "hyper 0.14.28",
  "hyper-tls",
  "indexmap 2.2.3",
@@ -2979,7 +2985,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.21.7",
  "brotli",
  "bytes",
  "chrono",
@@ -3177,7 +3183,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
@@ -3536,7 +3542,7 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3627,6 +3633,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.7.4",
+ "base64 0.22.0",
  "bb8",
  "bb8-postgres",
  "clap",
@@ -3751,7 +3758,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4607,7 +4614,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
  "axum 0.6.20",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "flate2",
  "futures-core",
@@ -4637,7 +4644,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.6.20",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "h2 0.3.24",
  "http 0.2.11",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -51,6 +51,7 @@ flight_datafusion = { path = "../flight_datafusion" }
 arrow_sql_gen = { path = "../arrow_sql_gen", optional = true }
 bb8 = {workspace = true, optional = true}
 bb8-postgres = {workspace = true, optional = true}
+base64 = "0.22.0"
 
 [features]
 default = ["duckdb", "postgres"]

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -1,5 +1,6 @@
 pub mod env;
 pub mod file;
+pub mod kubernetes;
 
 use std::collections::HashMap;
 
@@ -76,6 +77,17 @@ impl SecretsProvider {
                 env_secret_store.load_secrets();
 
                 self.secret_store = Some(Box::new(env_secret_store));
+            }
+            SpiceSecretStore::Kubernetes => {
+                let mut kubernetes_secret_store = kubernetes::KubernetesSecretStore::new();
+
+                if kubernetes_secret_store.init().is_err() {
+                    return Err(Error::UnableToLoadSecrets {
+                        store: "kubernetes".to_string(),
+                    });
+                };
+
+                self.secret_store = Some(Box::new(kubernetes_secret_store));
             }
         }
 

--- a/crates/runtime/src/secrets/kubernetes.rs
+++ b/crates/runtime/src/secrets/kubernetes.rs
@@ -1,0 +1,159 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose, Engine};
+use reqwest;
+use snafu::Snafu;
+
+use super::{Secret, SecretStore};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to read kubernetes credentials"))]
+    UnableToReadKubernetesCredentials {},
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+const KUBERNETES_ACCOUNT_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount";
+const KUBERNETES_API_SERVER: &str = "https://kubernetes.default.svc";
+
+struct KubernetesClient {
+    client: Option<reqwest::Client>,
+    token: Option<String>,
+    namespace: Option<String>,
+}
+
+impl KubernetesClient {
+    fn new() -> Self {
+        Self {
+            client: None,
+            token: None,
+            namespace: None,
+        }
+    }
+
+    fn init(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.token = Some(std::fs::read_to_string(format!(
+            "{KUBERNETES_ACCOUNT_PATH}/token"
+        ))?);
+
+        self.namespace = Some(std::fs::read_to_string(format!(
+            "{KUBERNETES_ACCOUNT_PATH}/namespace"
+        ))?);
+
+        let ca_cert = std::fs::read_to_string(format!("{KUBERNETES_ACCOUNT_PATH}/ca.crt"))?;
+
+        let Ok(certificate) = reqwest::Certificate::from_pem(ca_cert.as_bytes()) else {
+            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+        };
+
+        self.client = Some(
+            reqwest::Client::builder()
+                .add_root_certificate(certificate)
+                .build()?,
+        );
+
+        Ok(())
+    }
+
+    async fn get_secret(
+        &self,
+        secret_name: &str,
+    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+        let Some(client) = &self.client else {
+            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+        };
+
+        let Some(token) = &self.token else {
+            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+        };
+
+        let Some(namespace) = &self.namespace else {
+            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+        };
+
+        let url =
+            format!("{KUBERNETES_API_SERVER}/api/v1/namespaces/{namespace}/secrets/{secret_name}");
+
+        let kubernetes_secret = match client
+            .get(url.clone())
+            .bearer_auth(token.clone())
+            .send()
+            .await?
+            .json::<HashMap<String, serde_json::value::Value>>()
+            .await
+        {
+            Ok(response) => response,
+            Err(e) => return Err(Box::new(e)),
+        };
+
+        let mut secret: HashMap<String, String> = HashMap::new();
+
+        let Some(data) = kubernetes_secret.get("data") else {
+            return Ok(secret);
+        };
+
+        let Some(obj) = data.as_object() else {
+            return Ok(secret);
+        };
+
+        obj.iter().for_each(|(key, value)| {
+            let Some(value) = value.as_str() else {
+                return;
+            };
+
+            let Ok(decoded_string) = general_purpose::STANDARD.decode(value) else {
+                return;
+            };
+
+            let Ok(secret_value) = String::from_utf8(decoded_string) else {
+                return;
+            };
+
+            secret.insert(key.clone(), secret_value.trim_end_matches('\n').to_string());
+        });
+
+        Ok(secret)
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct KubernetesSecretStore {
+    kubernetes_client: KubernetesClient,
+}
+
+impl Default for KubernetesSecretStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KubernetesSecretStore {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            kubernetes_client: KubernetesClient::new(),
+        }
+    }
+
+    pub fn init(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if let Err(_e) = self.kubernetes_client.init() {
+            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SecretStore for KubernetesSecretStore {
+    #[must_use]
+    async fn get_secret(&self, secret_name: &str) -> Option<Secret> {
+        if let Ok(secret) = self.kubernetes_client.get_secret(secret_name).await {
+            return Some(Secret::new(secret.clone()));
+        }
+
+        None
+    }
+}

--- a/crates/spicepod/src/component/secrets.rs
+++ b/crates/spicepod/src/component/secrets.rs
@@ -25,4 +25,5 @@ impl Default for Secrets {
 pub enum SpiceSecretStore {
     File,
     Env,
+    Kubernetes,
 }


### PR DESCRIPTION
Adds support to pull kubernetes secrets, when spiced is running inside kube pod.

That requires additional configuration for the Kubernetes service account to grant access for reading secrets:

```yaml

kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: spiced-account-role
rules:
  - apiGroups: [""]
    resources: ["secrets"]
    verbs: ["get"]

---

apiVersion: v1
kind: Pod
metadata:
  name: spiced

spec:
  serviceAccountName: spiced-account
  containers:
    - name: spiced
 ...
```

![CleanShot 2024-03-07 at 23 25 20@2x](https://github.com/spiceai/spiceai/assets/827338/116c2e2f-4325-4ea9-842a-cc0041159a82)
