### PR TITLE
split record batch into chunks up to 2048 per chunk due to duckdb downstream limitation

### DIFF
--- a/crates/runtime/src/databackend/duckdb.rs
+++ b/crates/runtime/src/databackend/duckdb.rs
@@ -242,12 +242,16 @@ impl<'a> DuckDBUpdate<'a> {
         Ok(())
     }
 
+    const MAX_BATCH_SIZE: usize = 2048;
+
     fn split_batch(batch: &RecordBatch) -> Vec<RecordBatch> {
         let mut result = vec![];
-        for offset in (0..=batch.num_rows()).step_by(2048) {
-            let length = cmp::min(2048, batch.num_rows() - offset);
-            result.push(batch.slice(offset, length));
-        }
+        (0..=batch.num_rows())
+            .step_by(Self::MAX_BATCH_SIZE)
+            .for_each(|offset| {
+                let length = cmp::min(Self::MAX_BATCH_SIZE, batch.num_rows() - offset);
+                result.push(batch.slice(offset, length));
+            });
         result
     }
 


### PR DESCRIPTION
when writing to duckdb backend, only 2048 maximum is allowed to be in the vector. That could be some downstream limitation we can investigate further to unblock this.