### PR TITLE
Store pulled secret values using secrecy::SecretString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3652,6 +3652,7 @@ dependencies = [
  "r2d2",
  "regex",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu 0.8.0",
@@ -3887,6 +3888,15 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -5379,6 +5389,12 @@ dependencies = [
  "quote",
  "syn 2.0.49",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zip"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -52,6 +52,7 @@ arrow_sql_gen = { path = "../arrow_sql_gen", optional = true }
 bb8 = {workspace = true, optional = true}
 bb8-postgres = {workspace = true, optional = true}
 base64 = "0.22.0"
+secrecy = "0.8.0"
 
 [features]
 default = ["duckdb", "postgres"]

--- a/crates/runtime/src/secrets/env.rs
+++ b/crates/runtime/src/secrets/env.rs
@@ -27,7 +27,7 @@ impl EnvSecretStore {
 
     fn add_secret_value(&mut self, secret_name: &str, key: &str, value: &str) {
         if let Some(secret) = self.secrets.get_mut(secret_name) {
-            secret.data.insert(key.to_string(), value.to_string());
+            secret.add(key.to_string(), value.to_string());
         } else {
             self.secrets.insert(
                 secret_name.to_string(),


### PR DESCRIPTION
Using `SecretString` wrapper from https://crates.io/crates/secrecy, for storing pulled secret values.