### PR TITLE
Consistent spice and spiced versions - with better pre-release versioning

### DIFF
--- a/bin/spice/Makefile
+++ b/bin/spice/Makefile
@@ -1,14 +1,17 @@
 BASE_PACKAGE_NAME := github.com/spiceai/spiceai
 
+GIT_SHA := $(shell git rev-parse --short HEAD)
+FILE_VERSION := $(shell cat ../../version.txt)
+
 ifdef REL_VERSION
 	SPICE_VERSION := $(REL_VERSION)
 	SPICED_FEATURES := --features release
 else
-	SPICE_VERSION := local
+	SPICE_VERSION := $(if $(FILE_VERSION),$(FILE_VERSION)-rc.$(GIT_SHA),local)
 endif
 
 ifdef DEV
-	SPICE_VERSION := local-dev
+	SPICE_VERSION := $(if $(FILE_VERSION),$(FILE_VERSION)-rc.$(GIT_SHA)-dev,local-dev)
 endif
 
 LDFLAGS:="-X $(BASE_PACKAGE_NAME)/bin/spice/pkg/version.version=$(SPICE_VERSION)"

--- a/bin/spiced/build.rs
+++ b/bin/spiced/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    let git_hash: String = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .map_or_else(
+            |_| "unknown".to_string(),
+            |output| String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        );
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={git_hash}");
+}

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -14,13 +14,16 @@ fn main() {
     }
 
     if args.version {
-        let version = if cfg!(feature = "release") {
-            env!("CARGO_PKG_VERSION")
+        if cfg!(feature = "release") {
+            println!("v{}", env!("CARGO_PKG_VERSION"));
         } else {
-            "local"
+            println!(
+                "v{}-rc.{}",
+                env!("CARGO_PKG_VERSION"),
+                env!("GIT_COMMIT_HASH")
+            );
         };
 
-        println!("{version}");
         return;
     }
 

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -17,11 +17,17 @@ fn main() {
         if cfg!(feature = "release") {
             println!("v{}", env!("CARGO_PKG_VERSION"));
         } else {
-            println!(
+            print!(
                 "v{}-rc.{}",
                 env!("CARGO_PKG_VERSION"),
                 env!("GIT_COMMIT_HASH")
             );
+
+            if cfg!(feature = "dev") {
+                print!("-dev");
+            }
+
+            println!();
         };
 
         return;


### PR DESCRIPTION
Closes #823

For pre-release versions:
```bash
$ spice version
CLI version:     v0.9.1-alpha-rc.a7e7c0c
Runtime version: v0.9.1-alpha-rc.a7e7c0c
```

For pre-release dev versions:
```bash
$ spice version
CLI version:     v0.9.1-alpha-rc.a7e7c0c-dev
Runtime version: v0.9.1-alpha-rc.a7e7c0c-dev
```

For release versions:

```bash
$ spice version
CLI version:     v0.9.1-alpha
Runtime version: v0.9.1-alpha
```