### PR TITLE
Fix version check upgrade logic

### DIFF
--- a/bin/spice/pkg/cli/cmd/version.go
+++ b/bin/spice/pkg/cli/cmd/version.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/github"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 	"github.com/spiceai/spiceai/bin/spice/pkg/version"
+	"golang.org/x/mod/semver"
 )
 
 var versionCmd = &cobra.Command{
@@ -86,7 +87,10 @@ func checkLatestCliReleaseVersion() error {
 	}
 
 	cliVersion := version.Version()
-	if !strings.HasPrefix(cliVersion, "local") && cliVersion != latestReleaseVersion {
+
+	cliIsPreRelease := strings.HasPrefix(cliVersion, "local") || strings.Contains(cliVersion, "rc")
+
+	if !cliIsPreRelease && semver.Compare(cliVersion, latestReleaseVersion) < 0 {
 		fmt.Printf("\nCLI version %s is now available!\nTo upgrade, run \"spice upgrade\".\n", aurora.BrightGreen(latestReleaseVersion))
 	}
 

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -120,8 +120,7 @@ func (c *RuntimeContext) IsRuntimeUpgradeAvailable() (string, error) {
 		return "", err
 	}
 
-	if currentVersion == "local" {
-		fmt.Println("Using latest 'local' runtime version.")
+	if strings.HasPrefix(currentVersion, "local") || strings.Contains(currentVersion, "rc") {
 		return "", nil
 	}
 


### PR DESCRIPTION
Closes #826 

Fixes the version check logic for `spice upgrade` to compare the SemVer versions of the current CLI vs the latest CLI and does not recommend an upgrade if the local CLI is a higher version.