### PR TITLE
Add spiced Docker build & release

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -24,7 +24,6 @@ on:
   pull_request:
     branches:
       - trunk
-      - rust
       - release-*
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
       - trunk
-      - rust
       - release-*
 
   workflow_dispatch:

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - v*
 
+  # REVERT
+  pull_request:
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -1,0 +1,71 @@
+name: spiced_docker
+
+on:
+  push:
+    branches:
+      - trunk
+    tags:
+      - v*
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Spice ${{ matrix.target_os }}_${{ matrix.target_arch }} Docker image
+    runs-on: rust
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        target_arch: [amd64]
+        include:
+          - os: ubuntu-latest
+            target_os: linux
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set REL_VERSION from version.txt
+        run: python ./.github/scripts/get_release_version.py
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Sets latest tags for release
+        run: |
+          echo "LATEST_GHCR_TAG=ghcr.io/spiceai/spiceai:latest" >> $GITHUB_ENV
+          echo "LATEST_DOCKERHUB_TAG=spiceai/spiceai:latest" >> $GITHUB_ENV
+
+      - name: Build and push Docker images
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.target_os }}/${{ matrix.target_arch }}
+          push: ${{ startswith(github.ref, 'refs/tags/v') }}
+          build-args: |
+            REL_VERSION=${{ env.REL_VERSION }}
+          tags: |
+            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}
+            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}-${{ matrix.target_os }}-${{ matrix.target_arch }}
+            spiceai/spiceai:${{ env.REL_VERSION }}
+            spiceai/spiceai:${{ env.REL_VERSION }}-${{ matrix.target_os }}-${{ matrix.target_arch }}
+            ${{ env.LATEST_GHCR_TAG }}
+            ${{ env.LATEST_DOCKERHUB_TAG }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -7,9 +7,6 @@ on:
     tags:
       - v*
 
-  # REVERT
-  pull_request:
-
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -11,16 +11,8 @@ on:
 
 jobs:
   build:
-    name: Build Spice ${{ matrix.target_os }}_${{ matrix.target_arch }} Docker image
+    name: Build Spice linux_amd64 Docker image
     runs-on: rust
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        target_arch: [amd64]
-        include:
-          - os: ubuntu-latest
-            target_os: linux
 
     steps:
       - uses: actions/checkout@v4
@@ -55,15 +47,15 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: ${{ matrix.target_os }}/${{ matrix.target_arch }}
+          platforms: linux/amd64
           push: ${{ startswith(github.ref, 'refs/tags/v') }}
           build-args: |
             REL_VERSION=${{ env.REL_VERSION }}
           tags: |
             ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}
-            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}-${{ matrix.target_os }}-${{ matrix.target_arch }}
+            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}-linux-amd64
             spiceai/spiceai:${{ env.REL_VERSION }}
-            spiceai/spiceai:${{ env.REL_VERSION }}-${{ matrix.target_os }}-${{ matrix.target_arch }}
+            spiceai/spiceai:${{ env.REL_VERSION }}-linux-amd64
             ${{ env.LATEST_GHCR_TAG }}
             ${{ env.LATEST_DOCKERHUB_TAG }}
 

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set REL_VERSION from version.txt
-        run: python ./.github/scripts/get_release_version.py
+        run: python3 ./.github/scripts/get_release_version.py
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Closes #822

Brings back the Docker build & push for `spiced` on release