### PR TITLE
Run metrics server by default on `spice run`

### DIFF
--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -147,7 +147,7 @@ func (c *RuntimeContext) GetSpiceAppRelativePath(absolutePath string) string {
 func (c *RuntimeContext) GetRunCmd() (*exec.Cmd, error) {
 	spiceCMD := c.binaryFilePath("spiced")
 
-	cmd := exec.Command(spiceCMD)
+	cmd := exec.Command(spiceCMD, "--metrics", "127.0.0.1:9091")
 
 	return cmd, nil
 }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -87,7 +87,7 @@ fn init_metrics(socket_addr: SocketAddr) -> Result<(), Box<dyn std::error::Error
 
     // This needs to run inside a Tokio runtime.
     builder.install()?;
-    tracing::trace!("Prometheus metrics server started on {socket_addr:?}");
+    tracing::info!("Metrics listening on {socket_addr:?}");
 
     Ok(())
 }


### PR DESCRIPTION
Closes #817

Adds the commands to run the metrics server by default when running `spice run`.