### PR TITLE
Add metrics for FlightSQL server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,6 +4987,7 @@ dependencies = [
  "object_store",
  "once_cell",
  "opentelemetry-proto",
+ "pin-project",
  "prost 0.12.3",
  "quick-xml 0.23.1",
  "r2d2",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -78,6 +78,7 @@ keyring = { version = "2.3.2", optional = true }
 tonic-health = "0.11.0"
 db_connection_pool = { path = "../db_connection_pool" }
 secrecy = "0.8.0"
+pin-project = "1.0"
 
 [features]
 default = ["duckdb", "postgres", "keyring-secret-store"]

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -1,5 +1,6 @@
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
+use crate::measure_scope_ms;
 use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
 use arrow::ipc::writer::{DictionaryTracker, IpcDataGenerator};
@@ -51,6 +52,7 @@ impl FlightService for Service {
         &self,
         _request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
+        metrics::counter!("flight_handshake_requests").increment(1);
         handshake::handle()
     }
 
@@ -58,6 +60,7 @@ impl FlightService for Service {
         &self,
         _request: Request<Criteria>,
     ) -> Result<Response<Self::ListFlightsStream>, Status> {
+        metrics::counter!("flight_list_flights_requests").increment(1);
         tracing::trace!("list_flights - unimplemented");
         Err(Status::unimplemented("Not yet implemented"))
     }
@@ -66,6 +69,8 @@ impl FlightService for Service {
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        measure_scope_ms!("flight_get_flight_info_request_duration_ms");
+        metrics::counter!("flight_get_flight_info_requests").increment(1);
         get_flight_info::handle(self, request).await
     }
 
@@ -73,6 +78,7 @@ impl FlightService for Service {
         &self,
         _request: Request<FlightDescriptor>,
     ) -> Result<Response<SchemaResult>, Status> {
+        metrics::counter!("flight_get_schema_requests").increment(1);
         tracing::trace!("get_schema - unimplemented");
         Err(Status::unimplemented("Not yet implemented"))
     }
@@ -81,6 +87,7 @@ impl FlightService for Service {
         &self,
         request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
+        metrics::counter!("flight_do_get_requests").increment(1);
         do_get::handle(self, request).await
     }
 
@@ -88,6 +95,7 @@ impl FlightService for Service {
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
+        metrics::counter!("flight_do_put_requests").increment(1);
         do_put::handle(self, request).await
     }
 
@@ -95,6 +103,7 @@ impl FlightService for Service {
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
+        metrics::counter!("flight_do_exchange_requests").increment(1);
         do_exchange::handle(self, request).await
     }
 
@@ -102,6 +111,7 @@ impl FlightService for Service {
         &self,
         request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
+        metrics::counter!("flight_do_action_requests").increment(1);
         actions::do_action(self, request).await
     }
 
@@ -109,6 +119,7 @@ impl FlightService for Service {
         &self,
         _request: Request<arrow_flight::Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
+        metrics::counter!("flight_list_actions_requests").increment(1);
         Ok(actions::list())
     }
 }

--- a/crates/runtime/src/flight/do_exchange.rs
+++ b/crates/runtime/src/flight/do_exchange.rs
@@ -99,6 +99,8 @@ pub(crate) async fn handle(
                         flights.push(flight_batch.into());
                     }
 
+                    metrics::counter!("flight_do_exchange_data_updates_sent")
+                        .increment(flights.len() as u64);
                     let output = futures::stream::iter(flights.into_iter().map(Ok));
 
                     Some((output, rx))

--- a/crates/runtime/src/flight/do_get.rs
+++ b/crates/runtime/src/flight/do_get.rs
@@ -8,6 +8,8 @@ use arrow_flight::{
 use prost::Message;
 use tonic::{Request, Response, Status};
 
+use crate::timing::{TimeMeasurement, TimedStream};
+
 use super::{flightsql, to_tonic_err, Service};
 
 pub(crate) async fn handle(
@@ -49,9 +51,13 @@ async fn do_get_simple(
     tracing::trace!("do_get_simple: {ticket:?}");
     match std::str::from_utf8(&ticket.ticket) {
         Ok(sql) => {
+            let start = TimeMeasurement::new("flight_do_get_simple_duration_ms", vec![]);
             let output = Service::sql_to_flight_stream(datafusion, sql.to_owned()).await?;
+
+            let timed_output = TimedStream::new(output, move || start);
+
             Ok(Response::new(
-                Box::pin(output) as <Service as FlightService>::DoGetStream
+                Box::pin(timed_output) as <Service as FlightService>::DoGetStream
             ))
         }
         Err(e) => Err(Status::invalid_argument(format!("Invalid ticket: {e:?}"))),

--- a/crates/runtime/src/flight/flightsql/get_catalogs.rs
+++ b/crates/runtime/src/flight/flightsql/get_catalogs.rs
@@ -6,7 +6,10 @@ use arrow_flight::{
 use prost::Message;
 use tonic::{Request, Response, Status};
 
-use crate::flight::{record_batches_to_flight_stream, to_tonic_err, Service};
+use crate::{
+    flight::{record_batches_to_flight_stream, to_tonic_err, Service},
+    timing::{TimeMeasurement, TimedStream},
+};
 
 /// Get a `FlightInfo` for listing catalogs.
 pub(crate) fn get_flight_info(
@@ -31,6 +34,7 @@ pub(crate) async fn do_get(
     flight_svc: &Service,
     query: sql::CommandGetCatalogs,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
+    let start = TimeMeasurement::new("flight_do_get_get_catalogs_duration_ms", vec![]);
     tracing::trace!("do_get_catalogs: {query:?}");
     let mut builder = query.into_builder();
 
@@ -42,8 +46,9 @@ pub(crate) async fn do_get(
 
     let record_batch = builder.build().map_err(to_tonic_err)?;
 
-    Ok(Response::new(
-        Box::pin(record_batches_to_flight_stream(vec![record_batch]))
-            as <Service as FlightService>::DoGetStream,
+    Ok(Response::new(Box::pin(TimedStream::new(
+        record_batches_to_flight_stream(vec![record_batch]),
+        move || start,
     ))
+        as <Service as FlightService>::DoGetStream))
 }

--- a/crates/runtime/src/flight/flightsql/statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/statement_query.rs
@@ -8,7 +8,10 @@ use arrow_flight::{
 use prost::Message;
 use tonic::{Request, Response, Status};
 
-use crate::flight::{to_tonic_err, Service};
+use crate::{
+    flight::{to_tonic_err, Service},
+    timing::{TimeMeasurement, TimedStream},
+};
 
 /// Get a `FlightInfo` for executing a SQL query.
 pub(crate) async fn get_flight_info(
@@ -49,9 +52,11 @@ pub(crate) async fn do_get(
     tracing::trace!("do_get_statement: {ticket:?}");
     match std::str::from_utf8(&ticket.statement_handle) {
         Ok(sql) => {
+            let start = TimeMeasurement::new("flight_do_get_statement_query_duration_ms", vec![]);
             let output = Service::sql_to_flight_stream(datafusion, sql.to_owned()).await?;
+            let timed_output = TimedStream::new(output, move || start);
             Ok(Response::new(
-                Box::pin(output) as <Service as FlightService>::DoGetStream
+                Box::pin(timed_output) as <Service as FlightService>::DoGetStream
             ))
         }
         Err(e) => Err(Status::invalid_argument(format!("Invalid ticket: {e:?}"))),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -142,7 +142,6 @@ impl Runtime {
     }
 
     pub fn load_dataset(&self, ds: &Dataset) {
-        measure_scope_ms!("load_dataset", "dataset" => ds.name.clone());
         let df = Arc::clone(&self.df);
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
         let shared_secrets_provider: Arc<RwLock<secrets::SecretsProvider>> =
@@ -167,7 +166,7 @@ impl Runtime {
                     {
                         Ok(data_connector) => data_connector,
                         Err(err) => {
-                            metrics::counter!("datasets/load_error").increment(1);
+                            metrics::counter!("datasets_load_error").increment(1);
                             warn_spaced!(
                                 spaced_tracer,
                                 "Unable to get data connector from source for dataset {}, retrying: {err:?}",
@@ -197,7 +196,7 @@ impl Runtime {
                 {
                     Ok(()) => (),
                     Err(err) => {
-                        metrics::counter!("datasets/load_error").increment(1);
+                        metrics::counter!("datasets_load_error").increment(1);
                         warn_spaced!(
                             spaced_tracer,
                             "Unable to initialize data connector for dataset {}, retrying: {err:?}",
@@ -218,7 +217,7 @@ impl Runtime {
                         }
                     },
                 );
-                metrics::gauge!("datasets/count", "engine" => engine).increment(1.0);
+                metrics::gauge!("datasets_count", "engine" => engine).increment(1.0);
                 break;
             }
         });
@@ -245,7 +244,7 @@ impl Runtime {
                 }
             },
         );
-        metrics::gauge!("datasets/count", "engine" => engine).decrement(1.0);
+        metrics::gauge!("datasets_count", "engine" => engine).decrement(1.0);
     }
 
     pub async fn update_dataset(&self, ds: &Dataset) {
@@ -431,10 +430,10 @@ impl Runtime {
             Ok(in_m) => {
                 model_map.insert(m.name.clone(), in_m);
                 tracing::info!("Model [{}] deployed, ready for inferencing", m.name);
-                metrics::gauge!("models/count", "model" => m.name.clone(), "source" => model::source(&m.from)).increment(1.0);
+                metrics::gauge!("models_count", "model" => m.name.clone(), "source" => model::source(&m.from)).increment(1.0);
             }
             Err(e) => {
-                metrics::counter!("models/load_error").increment(1);
+                metrics::counter!("models_load_error").increment(1);
                 tracing::warn!(
                     "Unable to load runnable model from spicepod {}, error: {}",
                     m.name,
@@ -455,7 +454,7 @@ impl Runtime {
         }
         model_map.remove(&m.name);
         tracing::info!("Model [{}] has been unloaded", m.name);
-        metrics::gauge!("models/count", "model" => m.name.clone(), "source" => model::source(&m.from)).decrement(1.0);
+        metrics::gauge!("models_count", "model" => m.name.clone(), "source" => model::source(&m.from)).decrement(1.0);
     }
 
     pub async fn update_model(&self, m: &SpicepodModel) {

--- a/crates/runtime/src/timing.rs
+++ b/crates/runtime/src/timing.rs
@@ -1,4 +1,11 @@
-use std::time::Instant;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use futures::Stream;
+use pin_project::pin_project;
 
 /// `measure_scope_ms!` measures the time for which the designated scope lives.
 ///
@@ -67,11 +74,78 @@ impl TimeMeasurement {
             labels,
         }
     }
+
+    pub fn with_labels(&mut self, labels: Vec<(&'static str, String)>) {
+        self.labels.extend(labels);
+    }
 }
 
 impl Drop for TimeMeasurement {
     fn drop(&mut self) {
         metrics::histogram!(self.metric_name, &self.labels)
             .record(1000_f64 * self.start.elapsed().as_secs_f64());
+    }
+}
+
+#[pin_project]
+pub struct TimedStream<S, F>
+where
+    F: FnOnce() -> TimeMeasurement,
+{
+    #[pin]
+    stream: S,
+    start: Option<TimeMeasurement>,
+    start_timer: Option<F>,
+}
+
+impl<S: Stream, F> TimedStream<S, F>
+where
+    F: FnOnce() -> TimeMeasurement,
+{
+    pub fn new(stream: S, start_timer: F) -> Self {
+        TimedStream {
+            stream,
+            start: None,
+            start_timer: Some(start_timer),
+        }
+    }
+
+    fn emit_metric(mut metric: Option<TimeMeasurement>) {
+        if metric.is_some() {
+            let Some(start) = metric.take() else {
+                return;
+            };
+            drop(start);
+        }
+    }
+}
+
+impl<S: Stream, F> Stream for TimedStream<S, F>
+where
+    F: FnOnce() -> TimeMeasurement,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        if this.start.is_none() {
+            if let Some(start_timer) = this.start_timer.take() {
+                this.start.replace(start_timer());
+            }
+        }
+
+        let stream = &mut this.stream;
+
+        match stream.as_mut().poll_next(cx) {
+            Poll::Ready(None) => {
+                if this.start.is_some() {
+                    Self::emit_metric(this.start.take());
+                }
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }


### PR DESCRIPTION
Adds metrics to calculate number of requests and request durations for the Flight SQL server.

Also improves the `load_dataset` metric to be accurate.

Adds a `TimedStream` wrapper for a stream that will measure how long it takes to drain the stream and record the elapsed time as a metric.