### PR TITLE
Make `spice init` work like other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ curl https://install.spiceai.org | /bin/bash
 **Step 2.** Initialize a new Spice app with the `spice init` command:
 
 ```bash
-spice init spice_app
+spice init spice_qs
 ```
 
-A `Spicepod.yaml` file is created in the working directory.
+A `Spicepod.yaml` file is created in the `spice_qs` directory. Change to that directory:
+
+```bash
+cd spice_qs
+```
 
 **Step 3.** Connect to the sample Dremio instance to access the sample data:
 
@@ -178,19 +182,22 @@ After creating an account, you will need to create an app in order to create to 
 
 You will now be able to access datasets from Spice.ai. For this demonstration, we will be using the Spice.ai/eth.recent_blocks dataset.
 
-**Step 1.** In a new directory, log in and authenticate from the command line using the `spice login` command. A pop up browser window will prompt you to authenticate:
+**Step 1.** Log in and authenticate from the command line using the `spice login` command. A pop up browser window will prompt you to authenticate:
 
 ```bash
 spice login
 ```
 
-**Step 2.** Initialize a new project if you haven't already done so. Then, start the runtime:
+**Step 2.** Initialize a new project and start the runtime:
 
 ```bash
-spice init my_spiceai_project
-```
+# Initialize a new Spice app
+spice init spice_app
 
-```bash
+# Change to app directory
+cd spice_app
+
+# Start the runtime
 spice run
 ```
 

--- a/bin/spice/pkg/cli/cmd/init.go
+++ b/bin/spice/pkg/cli/cmd/init.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/logrusorgru/aurora"
@@ -15,14 +16,52 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize Spice app - initializes a new Spice app",
 	Example: `
+spice init
 spice init <spice app name>
 spice init my_app
 `,
-	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		podName := args[0]
-		podPath := "./spicepod.yaml"
-		if _, err := os.Stat(podPath); !os.IsNotExist(err) {
+		var spicepodName string
+		spicepodDir := "."
+
+		if len(args) < 1 {
+			wd, err := os.Getwd()
+			if err != nil {
+				cmd.PrintErrf("Error getting current working directory: %s\n", err.Error())
+				return
+			}
+			dirName := path.Base(wd)
+
+			cmd.Printf("name: (%s)? ", dirName)
+			fmt.Scanf("%s", &spicepodName)
+			if strings.TrimSpace(spicepodName) == "" {
+				spicepodName = dirName
+			}
+		} else {
+			spicepodName = args[0]
+			fs, err := os.Stat(spicepodName)
+			if err != nil {
+				if os.IsNotExist(err) {
+					err = os.Mkdir(spicepodName, 0766)
+					if err != nil {
+						cmd.PrintErrf("Error creating directory: %s\n", err.Error())
+						return
+					}
+				} else {
+					cmd.PrintErrf("Error checking if directory exists: %s\n", err.Error())
+					return
+				}
+			} else {
+				if !fs.IsDir() {
+					cmd.PrintErrf("Error: %s exists and is not a directory\n", spicepodName)
+					return
+				}
+			}
+			spicepodDir = spicepodName
+		}
+
+		spicepodPath := path.Join(spicepodDir, "spicepod.yaml")
+		if _, err := os.Stat(spicepodPath); !os.IsNotExist(err) {
 			cmd.Println("spicepod.yaml already exists. Replace (y/n)?")
 			var confirm string
 			fmt.Scanf("%s", &confirm)
@@ -32,7 +71,7 @@ spice init my_app
 		}
 
 		skeletonPod := &api.Spicepod{
-			Name:    podName,
+			Name:    spicepodName,
 			Version: "v1beta1",
 			Kind:    "Spicepod",
 		}
@@ -43,7 +82,7 @@ spice init my_app
 			return
 		}
 
-		err = os.WriteFile(podPath, skeletonPodContentBytes, 0766)
+		err = os.WriteFile(spicepodPath, skeletonPodContentBytes, 0766)
 		if err != nil {
 			cmd.Println(err)
 			return

--- a/bin/spice/pkg/cli/cmd/init.go
+++ b/bin/spice/pkg/cli/cmd/init.go
@@ -47,16 +47,16 @@ spice init my_app
 						cmd.PrintErrf("Error creating directory: %s\n", err.Error())
 						return
 					}
-				} else {
-					cmd.PrintErrf("Error checking if directory exists: %s\n", err.Error())
-					return
 				}
-			} else {
-				if !fs.IsDir() {
-					cmd.PrintErrf("Error: %s exists and is not a directory\n", spicepodName)
-					return
-				}
+				cmd.PrintErrf("Error checking if directory exists: %s\n", err.Error())
+				return
 			}
+
+			if !fs.IsDir() {
+				cmd.PrintErrf("Error: %s exists and is not a directory\n", spicepodName)
+				return
+			}
+
 			spicepodDir = spicepodName
 		}
 


### PR DESCRIPTION
- Create a subdirectory of the app name
- If no argument supplied, detect working directory and default to that name