### PR TITLE
Don't downgrade the runtime if the CLI version is lower

### DIFF
--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -129,7 +129,7 @@ func (c *RuntimeContext) IsRuntimeUpgradeAvailable() (string, error) {
 		return "", err
 	}
 
-	if semver.Compare(currentVersion, release.TagName) == 0 {
+	if semver.Compare(currentVersion, release.TagName) >= 0 {
 		return "", nil
 	}
 


### PR DESCRIPTION
I tested all of the upgrade scenarios we want, and the only one that didn't work was:

> If spiced is installed and the version is higher than the CLI version, the CLI will just run the runtime.

This change fixes it so that the CLI will not attempt to downgrade the runtime if it is a newer version, and will just run it as is.