### PR TITLE
Friendlier DataFusion errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2575,7 @@ dependencies = [
 name = "flightrepl"
 version = "0.9.1-alpha"
 dependencies = [
+ "ansi_term",
  "arrow",
  "arrow-flight",
  "async-stream",
@@ -2573,6 +2583,7 @@ dependencies = [
  "datafusion",
  "futures",
  "parquet 49.0.0",
+ "prost 0.12.3",
  "rustyline",
  "tokio",
  "tonic 0.10.2",

--- a/crates/flightrepl/Cargo.toml
+++ b/crates/flightrepl/Cargo.toml
@@ -25,3 +25,5 @@ tracing.workspace = true
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 datafusion.workspace = true
 rustyline = "13.0.0"
+prost = { version = "0.12.1", default-features = false, features = ["prost-derive"] }
+ansi_term = "0.12.1"

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -168,7 +168,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
 fn display_grpc_error(err: &Status) {
     let user_err_msg = match err.code() {
         Code::Ok => return,
-        Code::Unknown | Code::Internal | Code::Unauthenticated | Code::DataLoss | Code::OutOfRange | Code::FailedPrecondition => 
+        Code::Unknown | Code::Internal | Code::Unauthenticated | Code::DataLoss | Code::OutOfRange | Code::FailedPrecondition =>
             "An internal error occurred while processing the query. Show technical details with '.error'"
         ,
         Code::InvalidArgument | Code::AlreadyExists | Code::NotFound => err.message(),

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -181,5 +181,5 @@ fn display_grpc_error(err: &Status) {
         Code::Unavailable => "The query could not be completed because the server is unavailable.",
     };
 
-    println!("{} {user_err_msg}", Colour::Red.paint("ERROR"));
+    println!("{} {user_err_msg}", Colour::Red.paint("Query Error"));
 }

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use ansi_term::Colour;
+use arrow_flight::sql::{CommandStatementQuery, ProstMessageExt};
 use arrow_flight::{
     decode::FlightRecordBatchStream, error::FlightError,
     flight_service_client::FlightServiceClient, FlightDescriptor,
@@ -11,10 +13,11 @@ use datafusion::datasource::{provider_as_source, MemTable};
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
 use futures::{StreamExt, TryStreamExt};
+use prost::Message;
 use rustyline::error::ReadlineError;
 use rustyline::DefaultEditor;
 use tonic::transport::Channel;
-use tonic::IntoRequest;
+use tonic::{Code, IntoRequest, Status};
 
 #[derive(Parser)]
 #[clap(about = "Spice.ai Flight Query Utility")]
@@ -28,6 +31,7 @@ pub struct ReplConfig {
     pub repl_flight_endpoint: String,
 }
 
+#[allow(clippy::too_many_lines)]
 #[allow(clippy::missing_errors_doc)]
 pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Error>> {
     // Set up the Flight client
@@ -41,8 +45,12 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
     println!("Welcome to the interactive Spice.ai SQL Query Utility! Type 'help' for help.\n");
     println!("show tables; -- list available tables");
 
+    let mut last_error: Option<Status> = None;
+    let prompt_color = Colour::Fixed(8);
+    let prompt = prompt_color.paint("sql> ").to_string();
+
     loop {
-        let line_result = rl.readline("sql> ");
+        let line_result = rl.readline(&prompt);
         let line = match line_result {
             Ok(line) => line,
             Err(ReadlineError::Interrupted | ReadlineError::Eof) => {
@@ -60,10 +68,24 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         }
         match line {
             ".exit" | "exit" | "quit" | "q" => break,
+            ".error" => {
+                match last_error {
+                    Some(ref err) => println!("{err:?}"),
+                    None => println!("No error to display"),
+                }
+                continue;
+            }
             "help" => {
                 println!("Available commands:\n");
-                println!(".exit, exit, quit, q: Exit the REPL");
-                println!("help: Show this help message");
+                println!(
+                    "{} Exit the REPL",
+                    prompt_color.paint(".exit, exit, quit, q:")
+                );
+                println!(
+                    "{} Show technical details from the last error",
+                    prompt_color.paint(".error:")
+                );
+                println!("{} Show this help message", prompt_color.paint("help:"));
                 println!("\nAny other line will be interpreted as a SQL query");
                 continue;
             }
@@ -72,16 +94,33 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
 
         let _ = rl.add_history_entry(line);
 
-        let request = FlightDescriptor::new_cmd(line.to_string());
+        let sql_command = CommandStatementQuery {
+            query: line.to_string(),
+            transaction_id: None,
+        };
+        let sql_command_bytes = sql_command.as_any().encode_to_vec();
+
+        let request = FlightDescriptor::new_cmd(sql_command_bytes);
 
         let start_time = Instant::now();
-        let mut flight_info = client.get_flight_info(request).await?.into_inner();
+        let mut flight_info = match client.get_flight_info(request).await {
+            Ok(flight_info) => flight_info.into_inner(),
+            Err(e) => {
+                display_grpc_error(&e);
+                last_error = Some(e);
+                continue;
+            }
+        };
         let Some(endpoint) = flight_info.endpoint.pop() else {
-            println!("No endpoint");
+            let internal_err = Status::internal("No endpoint");
+            display_grpc_error(&internal_err);
+            last_error = Some(internal_err);
             continue;
         };
         let Some(ticket) = endpoint.ticket else {
-            println!("No ticket");
+            let internal_err = Status::internal("No ticket");
+            display_grpc_error(&internal_err);
+            last_error = Some(internal_err);
             continue;
         };
         let request = ticket.into_request();
@@ -89,7 +128,8 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         let stream = match client.do_get(request).await {
             Ok(stream) => stream.into_inner(),
             Err(e) => {
-                println!("{e}");
+                display_grpc_error(&e);
+                last_error = Some(e);
                 continue;
             }
         };
@@ -119,7 +159,27 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         };
         let elapsed = start_time.elapsed();
         println!("\nQuery took: {} seconds", elapsed.as_secs_f64());
+        last_error = None;
     }
 
     Ok(())
+}
+
+fn display_grpc_error(err: &Status) {
+    let user_err_msg = match err.code() {
+        Code::Ok => return,
+        Code::Unknown | Code::Internal | Code::Unauthenticated | Code::DataLoss | Code::OutOfRange | Code::FailedPrecondition => 
+            "An internal error occurred while processing the query. Show technical details with '.error'"
+        ,
+        Code::InvalidArgument | Code::AlreadyExists | Code::NotFound => err.message(),
+        Code::Cancelled => "The query was cancelled before it could complete.",
+        Code::Aborted => "The query was aborted before it could complete.",
+        Code::DeadlineExceeded => "The query could not be completed because the deadline for the query was exceeded.",
+        Code::PermissionDenied => "The query could not be completed because the user does not have permission to access the requested data.",
+        Code::ResourceExhausted => "The query could not be completed because the server has run out of resources.",
+        Code::Unimplemented => "The query could not be completed because the server does not support the requested operation.",
+        Code::Unavailable => "The query could not be completed because the server is unavailable.",
+    };
+
+    println!("{} {user_err_msg}", Colour::Red.paint("ERROR"));
 }

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -8,7 +8,9 @@ use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::{Action, ActionType, Criteria, IpcMessage, SchemaResult};
 use arrow_ipc::writer::IpcWriteOptions;
 use bytes::Bytes;
+use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
+use datafusion::sql::sqlparser::parser::ParserError;
 use futures::stream::{self, BoxStream, StreamExt};
 use futures::{Stream, TryStreamExt};
 use snafu::prelude::*;
@@ -135,12 +137,12 @@ impl Service {
             .ctx
             .sql(&sql)
             .await
-            .map_err(to_tonic_err)?;
+            .map_err(handle_datafusion_error)?;
 
         let schema = df.schema();
         let arrow_schema: Schema = schema.into();
 
-        let size = df.count().await.map_err(to_tonic_err)?;
+        let size = df.count().await.map_err(handle_datafusion_error)?;
 
         Ok((arrow_schema, size))
     }
@@ -164,7 +166,7 @@ impl Service {
             .ctx
             .sql(&sql)
             .await
-            .map_err(to_tonic_err)?;
+            .map_err(handle_datafusion_error)?;
         let schema = df.schema().clone().into();
         let options = datafusion::arrow::ipc::writer::IpcWriteOptions::default();
         let schema_as_ipc = SchemaAsIpc::new(&schema, &options);
@@ -224,6 +226,27 @@ where
     E: std::fmt::Debug,
 {
     Status::internal(format!("{e:?}"))
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_datafusion_error(e: DataFusionError) -> Status {
+    match e {
+        DataFusionError::Plan(err_msg) | DataFusionError::Execution(err_msg) => {
+            Status::invalid_argument(err_msg)
+        }
+        DataFusionError::SQL(sql_err, _) => match sql_err {
+            ParserError::RecursionLimitExceeded => {
+                Status::invalid_argument("Recursion limit exceeded")
+            }
+            ParserError::ParserError(err_msg) | ParserError::TokenizerError(err_msg) => {
+                Status::invalid_argument(err_msg)
+            }
+        },
+        DataFusionError::SchemaError(schema_err, _) => {
+            Status::invalid_argument(format!("{schema_err}"))
+        }
+        _ => to_tonic_err(e),
+    }
 }
 
 #[derive(Debug, Snafu)]

--- a/crates/runtime/src/flight/flightsql/statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/statement_query.rs
@@ -25,8 +25,7 @@ pub(crate) async fn get_flight_info(
 
     let (arrow_schema, num_rows) =
         Service::get_arrow_schema_and_size_sql(Arc::clone(&flight_svc.datafusion), sql.to_string())
-            .await
-            .map_err(to_tonic_err)?;
+            .await?;
 
     let fd = request.into_inner();
 


### PR DESCRIPTION
Closes #837

Passes the actionable DataFusion errors directly as an invalid argument GRPC error. In the REPL, we interpret that to provide a better user experience.

Also adds colors to make the output easier to read in the REPL. Adds a `.error` command to retrieve the full technical details of an error.

Uses FlightSQL to make the request.

<img width="1047" alt="Screenshot 2024-03-18 at 6 09 40 PM" src="https://github.com/spiceai/spiceai/assets/879445/05683c70-1516-482c-a978-6da00247702e">
