### PR TITLE
Add `spice datasets` and `spice models`

### DIFF
--- a/bin/spice/cmd/dataset.go
+++ b/bin/spice/cmd/dataset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/api"
+	"github.com/spiceai/spiceai/bin/spice/pkg/spec"
 	"gopkg.in/yaml.v2"
 )
 
@@ -71,7 +72,7 @@ spice dataset configure
 
 		params := map[string]string{}
 		datasetPrefix := strings.Split(from, ":")[0]
-		if datasetPrefix == api.DATA_SOURCE_DREMIO || datasetPrefix == api.DATA_SOURCE_DATABRICKS {
+		if datasetPrefix == spec.DATA_SOURCE_DREMIO || datasetPrefix == spec.DATA_SOURCE_DATABRICKS {
 			cmd.Print("endpoint: ")
 			endpoint, err := reader.ReadString('\n')
 			if err != nil {
@@ -92,7 +93,7 @@ spice dataset configure
 		locallyAccelerateStr = strings.TrimSuffix(locallyAccelerateStr, "\n")
 		accelerateDataset := locallyAccelerateStr == "" || strings.ToLower(locallyAccelerateStr) == "y"
 
-		dataset := api.Dataset{
+		dataset := spec.DatasetSpec{
 			From:        from,
 			Name:        datasetName,
 			Description: description,
@@ -100,10 +101,10 @@ spice dataset configure
 		}
 
 		if accelerateDataset {
-			dataset.Acceleration = &api.Acceleration{
+			dataset.Acceleration = &spec.AccelerationSpec{
 				Enabled:         accelerateDataset,
 				RefreshInterval: time.Second * 10,
-				RefreshMode:     api.REFRESH_MODE_FULL,
+				RefreshMode:     spec.REFRESH_MODE_FULL,
 			}
 		}
 

--- a/bin/spice/cmd/datasets.go
+++ b/bin/spice/cmd/datasets.go
@@ -6,15 +6,15 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 )
 
-var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Spice runtime status",
+var datasetsCmd = &cobra.Command{
+	Use:   "datasets",
+	Short: "Lists datasets loaded by the Spice runtime",
 	Example: `
-spice status
+spice datasets
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		err := api.WriteDataTable(rtcontext, "/v1/status", api.Service{})
+		err := api.WriteDataTable(rtcontext, "/v1/datasets", api.Dataset{})
 		if err != nil {
 			cmd.PrintErrln(err.Error())
 		}
@@ -22,5 +22,5 @@ spice status
 }
 
 func init() {
-	RootCmd.AddCommand(statusCmd)
+	RootCmd.AddCommand(datasetsCmd)
 }

--- a/bin/spice/cmd/models.go
+++ b/bin/spice/cmd/models.go
@@ -6,15 +6,15 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 )
 
-var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Spice runtime status",
+var modelsCmd = &cobra.Command{
+	Use:   "models",
+	Short: "Lists models loaded by the Spice runtime",
 	Example: `
-spice status
+spice models
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		err := api.WriteDataTable(rtcontext, "/v1/status", api.Service{})
+		err := api.WriteDataTable(rtcontext, "/v1/models", api.Model{})
 		if err != nil {
 			cmd.PrintErrln(err.Error())
 		}
@@ -22,5 +22,5 @@ spice status
 }
 
 func init() {
-	RootCmd.AddCommand(statusCmd)
+	RootCmd.AddCommand(modelsCmd)
 }

--- a/bin/spice/pkg/api/dataset.go
+++ b/bin/spice/pkg/api/dataset.go
@@ -1,31 +1,9 @@
 package api
 
-import "time"
-
-const (
-	REFRESH_MODE_FULL   = "full"
-	REFRESH_MODE_APPEND = "append"
-
-	DATA_SOURCE_SPICEAI    = "spice.ai"
-	DATA_SOURCE_DREMIO     = "dremio"
-	DATA_SOURCE_DATABRICKS = "databricks"
-)
-
 type Dataset struct {
-	From         string            `json:"from,omitempty" csv:"from" yaml:"from,omitempty"`
-	Name         string            `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
-	Description  string            `json:"description,omitempty" csv:"description" yaml:"description,omitempty"`
-	Params       map[string]string `json:"params,omitempty" csv:"params" yaml:"params,omitempty"`
-	Acceleration *Acceleration     `json:"acceleration,omitempty" csv:"acceleration" yaml:"acceleration,omitempty"`
-}
-
-type Acceleration struct {
-	Enabled         bool              `json:"enabled,omitempty" csv:"enabled" yaml:"enabled,omitempty"`
-	Mode            string            `json:"mode,omitempty" csv:"mode" yaml:"mode,omitempty"`
-	Engine          string            `json:"engine,omitempty" csv:"engine" yaml:"engine,omitempty"`
-	RefreshInterval time.Duration     `json:"refresh_interval,omitempty" csv:"refresh_interval" yaml:"refresh_interval,omitempty"`
-	RefreshMode     string            `json:"refresh_mode,omitempty" csv:"refresh_mode" yaml:"refresh_mode,omitempty"`
-	Retention       time.Duration     `json:"retention,omitempty" csv:"retention" yaml:"retention,omitempty"`
-	Params          map[string]string `json:"params,omitempty" csv:"params" yaml:"params,omitempty"`
-	EngineSecret    string            `json:"engine_secret,omitempty" csv:"engine_secret" yaml:"engine_secret,omitempty"`
+	From                string `json:"from,omitempty" csv:"from" yaml:"from,omitempty"`
+	Name                string `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
+	ReplicationEnabled  bool   `json:"replication_enabled,omitempty" csv:"replication_enabled" yaml:"replication_enabled,omitempty"`
+	AccelerationEnabled bool   `json:"acceleration_enabled,omitempty" csv:"acceleration_enabled" yaml:"acceleration_enabled,omitempty"`
+	DependsOn           string `json:"depends_on,omitempty" csv:"depends_on" yaml:"depends_on,omitempty"`
 }

--- a/bin/spice/pkg/api/model.go
+++ b/bin/spice/pkg/api/model.go
@@ -1,0 +1,7 @@
+package api
+
+type Model struct {
+	Name     string   `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
+	From     string   `json:"from,omitempty" csv:"from" yaml:"from,omitempty"`
+	Datasets []string `json:"datasets,omitempty" csv:"datasets" yaml:"datasets,omitempty"`
+}

--- a/bin/spice/pkg/api/util.go
+++ b/bin/spice/pkg/api/util.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spiceai/spiceai/bin/spice/pkg/context"
+	"github.com/spiceai/spiceai/bin/spice/pkg/util"
+)
+
+func WriteDataTable[T interface{}](rtcontext *context.RuntimeContext, path string, t T) error {
+	url := fmt.Sprintf("%s%s", rtcontext.HttpEndpoint(), path)
+	resp, err := http.Get(url)
+	if err != nil {
+		if strings.HasSuffix(err.Error(), "connection refused") {
+			return rtcontext.RuntimeUnavailableError()
+		}
+		return fmt.Errorf("Error fetching %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	var datasets []T
+	err = json.NewDecoder(resp.Body).Decode(&datasets)
+	if err != nil {
+		return fmt.Errorf("Error decoding items: %w", err)
+	}
+
+	var table []interface{}
+	for _, s := range datasets {
+		table = append(table, s)
+	}
+
+	util.WriteTable(table)
+
+	return nil
+}

--- a/bin/spice/pkg/spec/dataset.go
+++ b/bin/spice/pkg/spec/dataset.go
@@ -1,0 +1,31 @@
+package spec
+
+import "time"
+
+const (
+	REFRESH_MODE_FULL   = "full"
+	REFRESH_MODE_APPEND = "append"
+
+	DATA_SOURCE_SPICEAI    = "spice.ai"
+	DATA_SOURCE_DREMIO     = "dremio"
+	DATA_SOURCE_DATABRICKS = "databricks"
+)
+
+type DatasetSpec struct {
+	From         string            `json:"from,omitempty" csv:"from" yaml:"from,omitempty"`
+	Name         string            `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
+	Description  string            `json:"description,omitempty" csv:"description" yaml:"description,omitempty"`
+	Params       map[string]string `json:"params,omitempty" csv:"params" yaml:"params,omitempty"`
+	Acceleration *AccelerationSpec `json:"acceleration,omitempty" csv:"acceleration" yaml:"acceleration,omitempty"`
+}
+
+type AccelerationSpec struct {
+	Enabled         bool              `json:"enabled,omitempty" csv:"enabled" yaml:"enabled,omitempty"`
+	Mode            string            `json:"mode,omitempty" csv:"mode" yaml:"mode,omitempty"`
+	Engine          string            `json:"engine,omitempty" csv:"engine" yaml:"engine,omitempty"`
+	RefreshInterval time.Duration     `json:"refresh_interval,omitempty" csv:"refresh_interval" yaml:"refresh_interval,omitempty"`
+	RefreshMode     string            `json:"refresh_mode,omitempty" csv:"refresh_mode" yaml:"refresh_mode,omitempty"`
+	Retention       time.Duration     `json:"retention,omitempty" csv:"retention" yaml:"retention,omitempty"`
+	Params          map[string]string `json:"params,omitempty" csv:"params" yaml:"params,omitempty"`
+	EngineSecret    string            `json:"engine_secret,omitempty" csv:"engine_secret" yaml:"engine_secret,omitempty"`
+}

--- a/bin/spice/pkg/spec/spicepod.go
+++ b/bin/spice/pkg/spec/spicepod.go
@@ -1,6 +1,6 @@
 package spec
 
-type PodSpec struct {
+type SpicepodSpec struct {
 	Name   string            `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 	Params map[string]string `json:"params,omitempty" yaml:"params,omitempty" mapstructure:"params,omitempty"`
 }

--- a/bin/spice/pkg/util/out.go
+++ b/bin/spice/pkg/util/out.go
@@ -1,8 +1,10 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 )
@@ -16,7 +18,7 @@ func WriteTable(items []interface{}) {
 
 	headers := make([]string, t.NumField())
 	for i := 0; i < t.NumField(); i++ {
-		headers[i] = t.Field(i).Name
+		headers[i] = strings.TrimSuffix(t.Field(i).Name, "Enabled")
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
@@ -36,7 +38,7 @@ func WriteTable(items []interface{}) {
 		v := reflect.ValueOf(item)
 		row := make([]string, v.NumField())
 		for i := 0; i < v.NumField(); i++ {
-			row[i] = v.Field(i).String()
+			row[i] = fmt.Sprintf("%v", v.Field(i))
 		}
 		table.Append(row)
 	}


### PR DESCRIPTION
- Add `spice datasets` CLI command which displays `/v1/datasets`
- Add `spice models` CLI command which displays `/v1/models`
- Refactor so datasets, models, and status can share same code