### PR TITLE
Add user facing errors guidelines + don't use debug to display errors

### DIFF
--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     let args = spiced::Args::parse();
 
     if let Err(err) = init_tracing() {
-        eprintln!("Unable to initialize tracing: {err:?}");
+        eprintln!("Unable to initialize tracing: {err}");
         std::process::exit(1);
     }
 
@@ -36,7 +36,7 @@ fn main() {
     let tokio_runtime = match Runtime::new() {
         Ok(runtime) => runtime,
         Err(err) => {
-            tracing::error!("Unable to start Tokio runtime: {err:?}");
+            tracing::error!("Unable to start Tokio runtime: {err}");
             std::process::exit(1);
         }
     };
@@ -51,7 +51,7 @@ fn main() {
     tracing::trace!("Starting Spice Runtime!");
 
     if let Err(err) = tokio_runtime.block_on(start_runtime(args)) {
-        tracing::error!("Spice Runtime error: {err:?}");
+        tracing::error!("Spice Runtime error: {err}");
     }
 }
 
@@ -87,7 +87,7 @@ fn init_metrics(socket_addr: SocketAddr) -> Result<(), Box<dyn std::error::Error
 
     // This needs to run inside a Tokio runtime.
     builder.install()?;
-    tracing::info!("Metrics listening on {socket_addr:?}");
+    tracing::info!("Metrics listening on {socket_addr}");
 
     Ok(())
 }

--- a/crates/runtime/src/databackend/duckdb.rs
+++ b/crates/runtime/src/databackend/duckdb.rs
@@ -274,7 +274,7 @@ impl<'a> DuckDBUpdate<'a> {
 #[allow(clippy::needless_pass_by_value)]
 fn handle_poison<T: fmt::Debug>(e: PoisonError<T>) -> Error {
     Error::LockPoisoned {
-        message: format!("{e:?}"),
+        message: format!("{e}"),
     }
 }
 

--- a/crates/runtime/src/databackend/memtable.rs
+++ b/crates/runtime/src/databackend/memtable.rs
@@ -179,7 +179,7 @@ impl Drop for MemTableUpdate {
             TableReference::bare(MemTableUpdate::temp_table_name(self.name.as_str()));
         let deregister_result = self.ctx.deregister_table(temp_table_name);
         if let Err(e) = deregister_result {
-            tracing::error!("Error dropping temp table: {e:?}");
+            tracing::error!("Error dropping temp table: {e}");
         }
     }
 }

--- a/crates/runtime/src/dataconnector/flight.rs
+++ b/crates/runtime/src/dataconnector/flight.rs
@@ -35,7 +35,7 @@ impl Flight {
             let mut flight_record_batch_stream = match flight_record_batch_stream_result {
                 Ok(stream) => stream,
                 Err(error) => {
-                    tracing::error!("Failed to query with flight client: {:?}", error);
+                    tracing::error!("Failed to query with flight client: {error}",);
                     return vec![];
                 }
             };
@@ -47,7 +47,7 @@ impl Flight {
                         result_data.push(batch);
                     }
                     Err(error) => {
-                        tracing::error!("Failed to read batch from flight client: {:?}", error);
+                        tracing::error!("Failed to read batch from flight client: {error}",);
                         return result_data;
                     }
                 };

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -66,7 +66,7 @@ impl DataConnector for Postgres {
             let conn = match pool.connect().await {
                 Ok(conn) => conn,
                 Err(e) => {
-                    tracing::error!("Failed to connect to Postgres: {:?}", e);
+                    tracing::error!("Failed to connect to Postgres: {e}");
                     return vec![];
                 }
             };
@@ -82,7 +82,7 @@ impl DataConnector for Postgres {
             {
                 Ok(stream) => stream,
                 Err(e) => {
-                    tracing::error!("Failed to query Postgres: {:?}", e);
+                    tracing::error!("Failed to query Postgres: {e}");
                     return vec![];
                 }
             };
@@ -91,7 +91,7 @@ impl DataConnector for Postgres {
                 match record_batch_stream.try_collect::<Vec<RecordBatch>>().await {
                     Ok(recs) => recs,
                     Err(e) => {
-                        tracing::error!("Failed to collect record batches from Postgres: {:?}", e);
+                        tracing::error!("Failed to collect record batches from Postgres: {e}");
                         return vec![];
                     }
                 };

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -138,7 +138,7 @@ impl DataConnector for S3 {
                         return batches;
                     }
                     Err(e) => {
-                        tracing::error!("Failed to collect record batches from S3: {:?}", e);
+                        tracing::error!("Failed to collect record batches from S3: {e}");
                         return vec![];
                     }
                 }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -90,7 +90,7 @@ impl DataConnector for SpiceAI {
           let mut stream = match flight.subscribe(&spice_dataset_path).await {
             Ok(stream) => stream,
             Err(error) => {
-              tracing::error!("Unable to subscribe to {spice_dataset_path}: {:?}", error);
+              tracing::error!("Unable to subscribe to {spice_dataset_path}: {error}");
               return;
             }
           };
@@ -108,7 +108,7 @@ impl DataConnector for SpiceAI {
                   }
                 }
               Some(Err(error)) => {
-                tracing::error!("Error in subscription to {spice_dataset_path}: {:?}", error);
+                tracing::error!("Error in subscription to {spice_dataset_path}: {error}");
                 continue;
               },
               None => {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -339,7 +339,7 @@ impl DataFusion {
             let plan = match ctx.state().statement_to_plan(statements[0].clone()).await {
                 Ok(plan) => plan,
                 Err(e) => {
-                    tracing::error!("Unable to create view: {e}");
+                    tracing::error!("Failed to create view: {e}");
                     return;
                 }
             };
@@ -347,12 +347,12 @@ impl DataFusion {
             let view = match ViewTable::try_new(plan, Some(sql.to_string())) {
                 Ok(view) => view,
                 Err(e) => {
-                    tracing::error!("Unable to create view: {e}");
+                    tracing::error!("Failed to create view: {e}");
                     return;
                 }
             };
             if let Err(e) = ctx.register_table(table_name.as_str(), Arc::new(view)) {
-                tracing::error!("Unable to create view: {e}");
+                tracing::error!("Failed to create view: {e}");
             };
 
             tracing::info!("Created view {table_name}");

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -211,7 +211,7 @@ impl DataFusion {
                     Some(data_update) => {
                         match publisher.add_data(Arc::clone(&dataset), data_update).await {
                             Ok(()) => (),
-                            Err(e) => tracing::error!("Error adding data: {e:?}"),
+                            Err(e) => tracing::error!("Error adding data: {e}"),
                         }
                     }
                     None => break,
@@ -339,7 +339,7 @@ impl DataFusion {
             let plan = match ctx.state().statement_to_plan(statements[0].clone()).await {
                 Ok(plan) => plan,
                 Err(e) => {
-                    tracing::error!("Unable to create view: {e:?}");
+                    tracing::error!("Unable to create view: {e}");
                     return;
                 }
             };
@@ -347,12 +347,12 @@ impl DataFusion {
             let view = match ViewTable::try_new(plan, Some(sql.to_string())) {
                 Ok(view) => view,
                 Err(e) => {
-                    tracing::error!("Unable to create view: {e:?}");
+                    tracing::error!("Unable to create view: {e}");
                     return;
                 }
             };
             if let Err(e) = ctx.register_table(table_name.as_str(), Arc::new(view)) {
-                tracing::error!("Unable to create view: {e:?}");
+                tracing::error!("Unable to create view: {e}");
             };
 
             tracing::info!("Created view {table_name}");

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -221,9 +221,9 @@ fn record_batches_to_flight_stream(
 #[allow(clippy::needless_pass_by_value)]
 fn to_tonic_err<E>(e: E) -> Status
 where
-    E: std::fmt::Debug,
+    E: std::fmt::Display,
 {
-    Status::internal(format!("{e:?}"))
+    Status::internal(format!("{e}"))
 }
 
 #[derive(Debug, Snafu)]

--- a/crates/runtime/src/flight/do_exchange.rs
+++ b/crates/runtime/src/flight/do_exchange.rs
@@ -27,7 +27,7 @@ pub(crate) async fn handle(
         Ok(subscription_request) => subscription_request,
         Err(e) => {
             return Err(Status::invalid_argument(format!(
-                "Unable to read subscription request: {e:?}",
+                "Unable to read subscription request: {e}",
             )));
         }
     };

--- a/crates/runtime/src/flight/do_get.rs
+++ b/crates/runtime/src/flight/do_get.rs
@@ -60,6 +60,6 @@ async fn do_get_simple(
                 Box::pin(timed_output) as <Service as FlightService>::DoGetStream
             ))
         }
-        Err(e) => Err(Status::invalid_argument(format!("Invalid ticket: {e:?}"))),
+        Err(e) => Err(Status::invalid_argument(format!("Invalid ticket: {e}"))),
     }
 }

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -53,14 +53,14 @@ pub(crate) async fn handle(
 
     let Some(publishers) = df.get_publishers(&path) else {
         return Err(Status::invalid_argument(format!(
-            "No publishers registered for path: {path:?}",
+            "No publishers registered for path: {path}",
         )));
     };
     let dataset = Arc::clone(&publishers.0);
     let data_publishers = Arc::clone(&publishers.1);
 
     let schema = try_schema_from_flatbuffer_bytes(&message.data_header)
-        .map_err(|e| Status::internal(format!("Unable to get schema from data header: {e:?}")))?;
+        .map_err(|e| Status::internal(format!("Unable to get schema from data header: {e}")))?;
     let schema = Arc::new(schema);
     let dictionaries_by_id = Arc::new(HashMap::new());
 
@@ -96,7 +96,7 @@ pub(crate) async fn handle(
                     ) {
                         Ok(batches) => batches,
                         Err(e) => {
-                            tracing::error!("Unable to convert flight data to batches: {e:?}");
+                            tracing::error!("Unable to convert flight data to batches: {e}");
                             return None;
                         }
                     };
@@ -116,7 +116,7 @@ pub(crate) async fn handle(
                         if let Err(err) = publisher
                             .add_data(Arc::clone(&dataset), data_update.clone())
                             .await
-                            .map_err(|e| Status::internal(format!("Unable to add data: {e:?}")))
+                            .map_err(|e| Status::internal(format!("Unable to add data: {e}")))
                         {
                             return Some((Err(err), flight));
                         };
@@ -129,7 +129,7 @@ pub(crate) async fn handle(
                     None
                 }
                 Err(e) => Some((
-                    Err(Status::internal(format!("Error reading message: {e:?}"))),
+                    Err(Status::internal(format!("Error reading message: {e}"))),
                     flight,
                 )),
             }

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -60,7 +60,7 @@ pub(crate) async fn handle(
     let data_publishers = Arc::clone(&publishers.1);
 
     let schema = try_schema_from_flatbuffer_bytes(&message.data_header)
-        .map_err(|e| Status::internal(format!("Unable to get schema from data header: {e}")))?;
+        .map_err(|e| Status::internal(format!("Failed to get schema from data header: {e}")))?;
     let schema = Arc::new(schema);
     let dictionaries_by_id = Arc::new(HashMap::new());
 
@@ -96,7 +96,7 @@ pub(crate) async fn handle(
                     ) {
                         Ok(batches) => batches,
                         Err(e) => {
-                            tracing::error!("Unable to convert flight data to batches: {e}");
+                            tracing::error!("Failed to convert flight data to batches: {e}");
                             return None;
                         }
                     };
@@ -116,7 +116,7 @@ pub(crate) async fn handle(
                         if let Err(err) = publisher
                             .add_data(Arc::clone(&dataset), data_update.clone())
                             .await
-                            .map_err(|e| Status::internal(format!("Unable to add data: {e}")))
+                            .map_err(|e| Status::internal(format!("Failed to add data: {e}")))
                         {
                             return Some((Err(err), flight));
                         };

--- a/crates/runtime/src/flight/flightsql/get_sql_info.rs
+++ b/crates/runtime/src/flight/flightsql/get_sql_info.rs
@@ -583,7 +583,7 @@ static INSTANCE: Lazy<SqlInfoData> = Lazy::new(|| {
 
     match builder.build() {
         Ok(data) => data,
-        Err(e) => panic!("Error building SqlInfoData: {e:?}"),
+        Err(e) => panic!("Error building SqlInfoData: {e}"),
     }
 });
 

--- a/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
@@ -46,7 +46,7 @@ pub(crate) async fn get_flight_info(
         Ok(sql) => sql.to_string(),
         Err(e) => {
             return Err(Status::invalid_argument(format!(
-                "Invalid prepared statement handle: {e:?}"
+                "Invalid prepared statement handle: {e}"
             )))
         }
     };
@@ -93,7 +93,7 @@ pub(crate) async fn do_get(
             ))
         }
         Err(e) => Err(Status::invalid_argument(format!(
-            "Invalid prepared statement handle: {e:?}"
+            "Invalid prepared statement handle: {e}"
         ))),
     }
 }

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -659,8 +659,9 @@ pub(crate) mod inference {
                         };
                     }
                     tracing::error!(
-                        "Unable to cast inference result for model {model_name} to Float32Array: {column_data:?}"
+                        "Unable to cast inference result for model {model_name} to Float32Array"
                     );
+                    tracing::debug!("Unable to cast inference result for model {model_name} to Float32Array: {column_data:?}");
                     return PredictResponse {
                         status: PredictStatus::InternalError,
                         error_message: Some(

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -659,9 +659,9 @@ pub(crate) mod inference {
                         };
                     }
                     tracing::error!(
-                        "Unable to cast inference result for model {model_name} to Float32Array"
+                        "Failed to cast inference result for model {model_name} to Float32Array"
                     );
-                    tracing::debug!("Unable to cast inference result for model {model_name} to Float32Array: {column_data:?}");
+                    tracing::debug!("Failed to cast inference result for model {model_name} to Float32Array: {column_data:?}");
                     return PredictResponse {
                         status: PredictStatus::InternalError,
                         error_message: Some(

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -169,7 +169,7 @@ impl Runtime {
                             metrics::counter!("datasets_load_error").increment(1);
                             warn_spaced!(
                                 spaced_tracer,
-                                "Unable to get data connector from source for dataset {}, retrying: {err}",
+                                "Failed to get data connector from source for dataset {}, retrying: {err}",
                                 &ds.name
                             );
                             sleep(Duration::from_secs(1)).await;
@@ -199,7 +199,7 @@ impl Runtime {
                         metrics::counter!("datasets_load_error").increment(1);
                         warn_spaced!(
                             spaced_tracer,
-                            "Unable to initialize data connector for dataset {}, retrying: {err}",
+                            "Failed to initialize data connector for dataset {}, retrying: {err}",
                             &ds.name
                         );
                         sleep(Duration::from_secs(1)).await;
@@ -563,7 +563,7 @@ async fn shutdown_signal() {
     let ctrl_c = async {
         let signal_result = signal::ctrl_c().await;
         if let Err(err) = signal_result {
-            tracing::error!("Unable to listen to shutdown signal: {err}");
+            tracing::error!("Failed to listen to shutdown signal: {err}");
         }
     };
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -169,7 +169,7 @@ impl Runtime {
                             metrics::counter!("datasets_load_error").increment(1);
                             warn_spaced!(
                                 spaced_tracer,
-                                "Unable to get data connector from source for dataset {}, retrying: {err:?}",
+                                "Unable to get data connector from source for dataset {}, retrying: {err}",
                                 &ds.name
                             );
                             sleep(Duration::from_secs(1)).await;
@@ -199,7 +199,7 @@ impl Runtime {
                         metrics::counter!("datasets_load_error").increment(1);
                         warn_spaced!(
                             spaced_tracer,
-                            "Unable to initialize data connector for dataset {}, retrying: {err:?}",
+                            "Unable to initialize data connector for dataset {}, retrying: {err}",
                             &ds.name
                         );
                         sleep(Duration::from_secs(1)).await;
@@ -563,7 +563,7 @@ async fn shutdown_signal() {
     let ctrl_c = async {
         let signal_result = signal::ctrl_c().await;
         if let Err(err) = signal_result {
-            tracing::error!("Unable to listen to shutdown signal: {err:?}");
+            tracing::error!("Unable to listen to shutdown signal: {err}");
         }
     };
 

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -62,7 +62,7 @@ impl PodsWatcher {
                             ),
                         }
                     }
-                    Err(e) => tracing::error!("Pods content watcher error: {:?}", e),
+                    Err(e) => tracing::error!("Pods content watcher error: {e}"),
                 }
             },
         )?;

--- a/crates/sql_provider_datafusion/src/expr.rs
+++ b/crates/sql_provider_datafusion/src/expr.rs
@@ -32,11 +32,11 @@ pub fn to_sql(expr: &Expr) -> Result<String> {
             ScalarValue::UInt32(Some(value)) => Ok(value.to_string()),
             ScalarValue::UInt64(Some(value)) => Ok(value.to_string()),
             _ => Err(Error::UnsupportedFilterExpr {
-                expr: format!("{expr:?}"),
+                expr: format!("{expr}"),
             }),
         },
         _ => Err(Error::UnsupportedFilterExpr {
-            expr: format!("{expr:?}"),
+            expr: format!("{expr}"),
         }),
     }
 }

--- a/docs/dev/user_facing_errors.md
+++ b/docs/dev/user_facing_errors.md
@@ -6,18 +6,21 @@
 1. **Internal/Unknown Errors**: If the error is internal to the application or unknown, the error message should be generic and not expose any internal details. The error message should indicate how to report the error to the developers.
   - We should strive to have as few of these as possible.
 
+## Rust Error Traits
 In Rust, the Error trait implements both the Debug and Display traits. All user-facing errors should use the Display trait, not the Debug trait.
 
 i.e.
 
-Good
+Good (uses Display trait)
 ```rust
-let err = io::Error::new(io::ErrorKind::NotFound, "File not found");
-println!("{}", err);
+if let Err(user_facing_err) = upload_data(datasource) {
+    tracing::error!("Unable to upload data to {datasource}: {user_facing_err}");
+}
 ```
 
-Bad
+Bad (uses Debug trait `:?`)
 ```rust
-let err = io::Error::new(io::ErrorKind::NotFound, "File not found");
-println!("{:?}", err);
+if let Err(user_facing_err) = upload_data(datasource) {
+    tracing::error!("Unable to upload data to {datasource}: {user_facing_err:?}");
+}
 ```

--- a/docs/dev/user_facing_errors.md
+++ b/docs/dev/user_facing_errors.md
@@ -1,0 +1,23 @@
+# Guidelines for displaying errors to the user
+
+1. **Specific**: The error message should be specific enough to help the user understand what went wrong and how to fix it.
+1. **Avoid Debugging Information**: The error message should not contain any debugging information. This includes stack traces, Rust debug representations, or any other technical information that the user cannot act on.
+  - It can be helpful for developers to access this, but it should be gated behind a debug mode/log level/log file, etc and not shown by default.
+1. **Internal/Unknown Errors**: If the error is internal to the application or unknown, the error message should be generic and not expose any internal details. The error message should indicate how to report the error to the developers.
+  - We should strive to have as few of these as possible.
+
+In Rust, the Error trait implements both the Debug and Display traits. All user-facing errors should use the Display trait, not the Debug trait.
+
+i.e.
+
+Good
+```rust
+let err = io::Error::new(io::ErrorKind::NotFound, "File not found");
+println!("{}", err);
+```
+
+Bad
+```rust
+let err = io::Error::new(io::ErrorKind::NotFound, "File not found");
+println!("{:?}", err);
+```

--- a/docs/dev/user_facing_errors.md
+++ b/docs/dev/user_facing_errors.md
@@ -4,7 +4,7 @@
 1. **Avoid Debugging Information**: The error message should not contain any debugging information. This includes stack traces, Rust debug representations, or any other technical information that the user cannot act on.
   - It can be helpful for developers to access this, but it should be gated behind a debug mode/log level/log file, etc and not shown by default.
 1. **Internal/Unknown Errors**: If the error is internal to the application or unknown, the error message should be generic and not expose any internal details. The error message should indicate how to report the error to the developers.
-  - We should strive to have as few of these as possible.
+  - Strive to have as few of these as possible.
 
 ## Rust Error Traits
 In Rust, the Error trait implements both the Debug and Display traits. All user-facing errors should use the Display trait, not the Debug trait.

--- a/tools/flightsubscriber/src/main.rs
+++ b/tools/flightsubscriber/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             },
             Some(Err(e)) => {
-                tracing::error!("Error receiving message: {e:?}");
+                tracing::error!("Error receiving message: {e}");
             }
             None => {
                 tracing::info!("No more messages.");


### PR DESCRIPTION
Adds guidelines on how to provide usable error messages to the user.

Refactors all places that use the Debug trait to log an error, to use the Display trait - as per the new guidelines.