### PR TITLE
Workflow to test Spice installation via install.spiceai.org

### DIFF
--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -1,4 +1,4 @@
-name: Test Installation
+name: E2E Test Release Installation
 
 on:
   workflow_dispatch:
@@ -19,14 +19,14 @@ jobs:
 
     steps:
     - name: checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: install Spice (https://install.spiceai.org)
       run: |
         curl https://install.spiceai.org | /bin/bash
 
-    - name: Add Spice bin to PATH
-      run: echo "/home/runner/.spice/bin" >> $GITHUB_PATH
+    - name: add Spice bin to PATH
+      run: echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
     - name: check installation
       run: |
@@ -34,14 +34,15 @@ jobs:
   
     - name: start Spice runtime
       run: |
-        spice init app && spice run &
-
+        spice init app
+        [ -d app ] && cd app
+        spice run &
 
     - name: wait for Spice runtime healthy
       run: |
         timeout 60 bash -c 'while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done' || false
 
-    - name: check Spice CLI and runtime version
+    - name: check Spice cli and runtime version
       run: |
         version=$(spice version 2>&1)
         cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | xargs)
@@ -65,4 +66,3 @@ jobs:
           echo "Runtime version $runtime_version does not match the release version $release_version."
           exit 1
         fi
-

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -1,0 +1,68 @@
+name: Test Installation
+
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: choice
+        description: 'Operating System'
+        required: true
+        options:
+          - ubuntu-latest
+          - macos-latest
+        default: 'ubuntu-latest'
+
+jobs:
+  test-install:
+    name: test installation (${{ github.event.inputs.os }})
+    runs-on: ${{ github.event.inputs.os }}
+
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v2
+
+    - name: install Spice (https://install.spiceai.org)
+      run: |
+        curl https://install.spiceai.org | /bin/bash
+
+    - name: Add Spice bin to PATH
+      run: echo "/home/runner/.spice/bin" >> $GITHUB_PATH
+
+    - name: check installation
+      run: |
+        spice version
+  
+    - name: start Spice runtime
+      run: |
+        spice init app && spice run &
+
+
+    - name: wait for Spice runtime healthy
+      run: |
+        timeout 60 bash -c 'while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done' || false
+
+    - name: check Spice CLI and runtime version
+      run: |
+        version=$(spice version 2>&1)
+        cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | xargs)
+        runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | xargs)
+
+        # normalize runtime version from "0.9.0-alpha" to "v0.9-alpha". Later versions have uniform format and don't require modifications
+        runtime_version=$(echo "$runtime_version" | sed -e 's/^0\.9\.0-alpha$/v0.9-alpha/')
+
+        release_version=$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+        
+        echo "Release Version: $release_version"
+        echo "CLI Version: $cli_version"
+        echo "Runtime Version: $runtime_version"
+
+        if [ "$cli_version" != "$release_version" ]; then
+          echo "CLI version $cli_version does not match the release version $release_version."
+          exit 1
+        fi
+
+        if [ "$runtime_version" != "$release_version" ]; then
+          echo "Runtime version $runtime_version does not match the release version $release_version."
+          exit 1
+        fi
+


### PR DESCRIPTION
GH Action to test Spice installation:
1. Spice CLI **can be installed using repo Readme instructions** (via `https://install.spiceai.org`)
2. CLI can successfully download and start Spice runtime
3. Runtime is successfully started
4. CLI and runtime versions match the latest release version

Notes:
1. Currently the test Action should be run manually for specific platform (to be improved as a next iteration)
2. Linux (Ubuntu) and macOS as test platforms

Example runs:
1. Linux: https://github.com/sgrebnov/spiceai/actions/runs/8339390957
3. macOS: https://github.com/sgrebnov/spiceai/actions/runs/8339391825 (`No prebuilt binary for darwin-x86_64` will be investigated and reported as bug if valid)