### PR TITLE
Fix `make install-dev`

### DIFF
--- a/bin/spice/pkg/api/client.go
+++ b/bin/spice/pkg/api/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/spiceai/spiceai/bin/spice/pkg/version"
 )
@@ -43,7 +44,7 @@ func NewSpiceApiClient() *SpiceApiClient {
 }
 
 func (s *SpiceApiClient) Init() error {
-	if version.Version() == "local-dev" {
+	if strings.HasSuffix(version.Version(), "-dev") {
 		s.baseUrl = "https://dev.spice.xyz"
 	} else {
 		s.baseUrl = "https://spice.ai"

--- a/bin/spice/pkg/registry/spicerack.go
+++ b/bin/spice/pkg/registry/spicerack.go
@@ -25,7 +25,7 @@ var (
 type SpiceRackRegistry struct{}
 
 func getSpiceRackBaseUrl() string {
-	if version.Version() == "local-dev" {
+	if strings.HasSuffix(version.Version(), "-dev") {
 		return "https://dev-data.spiceai.io/v0.1"
 	} else {
 		return "https://api.spicerack.org/v0.1"


### PR DESCRIPTION
I inadvertently broke `make install-dev` when implementing https://github.com/spiceai/spiceai/pull/825