### PR TITLE
Fix spice init logic

### DIFF
--- a/bin/spice/cmd/init.go
+++ b/bin/spice/cmd/init.go
@@ -21,7 +21,7 @@ spice init my_app
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var spicepodName string
-		currentDir := "."
+		spicepodDir := "."
 
 		if len(args) < 1 {
 			wd, err := os.Getwd()
@@ -38,12 +38,12 @@ spice init my_app
 			}
 		} else {
 			spicepodName = args[0]
+			spicepodDir = path.Join(spicepodDir, spicepodName)
 		}
 
-		spicepodDir := path.Join(currentDir, spicepodName)
 		spicepodPath := path.Join(spicepodDir, "spicepod.yaml")
 		if _, err := os.Stat(spicepodPath); !os.IsNotExist(err) {
-			cmd.Println("spicepod.yaml already exists. Replace (y/n)?")
+			cmd.Print("spicepod.yaml already exists. Replace (y/n)? ")
 			var confirm string
 			fmt.Scanf("%s", &confirm)
 			if strings.ToLower(strings.TrimSpace(confirm)) != "y" {

--- a/bin/spice/cmd/init.go
+++ b/bin/spice/cmd/init.go
@@ -21,7 +21,7 @@ spice init my_app
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var spicepodName string
-		spicepodDir := "."
+		currentDir := "."
 
 		if len(args) < 1 {
 			wd, err := os.Getwd()
@@ -37,9 +37,10 @@ spice init my_app
 				spicepodName = dirName
 			}
 		} else {
-			spicepodDir = args[0]
+			spicepodName = args[0]
 		}
 
+		spicepodDir := path.Join(currentDir, spicepodName)
 		spicepodPath := path.Join(spicepodDir, "spicepod.yaml")
 		if _, err := os.Stat(spicepodPath); !os.IsNotExist(err) {
 			cmd.Println("spicepod.yaml already exists. Replace (y/n)?")


### PR DESCRIPTION
Closes #861 

There was a bug related to `spice init` that this PR fixes:

1. The argument in `spice init this_arg` was being set to the `spicepodDir` - which led to mkdir complaining that it couldn't find a file.