### PR TITLE
allow installation script to work with x86-64 darwin

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -43,7 +43,7 @@ getSystemInfo() {
 }
 
 verifySupported() {
-    local supported=(linux-x86_64 darwin-aarch64)
+    local supported=(linux-x86_64 darwin-aarch64 darwin-x86_64)
     local current_osarch="${OS}-${ARCH}"
 
     for osarch in "${supported[@]}"; do


### PR DESCRIPTION
put darwin-x86_64 in allowed list

fixes https://github.com/spiceai/spiceai/issues/871