### PR TITLE
Fix linter warnings

### DIFF
--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -19,9 +19,7 @@ async fn get_sender_channel(
 ) -> Option<Arc<Sender<DataUpdate>>> {
     let channel_map_read = channel_map.read().await;
     if channel_map_read.contains_key(&path) {
-        let Some(channel) = channel_map_read.get(&path) else {
-            return None;
-        };
+        let channel = channel_map_read.get(&path)?;
         Some(Arc::clone(channel))
     } else {
         None

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -27,7 +27,7 @@ impl PodsWatcher {
 
         let (tx, rx) = channel(100);
 
-        let root_spicepod_path = vec![
+        let root_spicepod_path = [
             root_path.join("spicepod.yaml"),
             root_path.join("spicepod.yml"),
         ];

--- a/crates/secrets/src/keyring.rs
+++ b/crates/secrets/src/keyring.rs
@@ -42,9 +42,7 @@ impl SecretStore for KeyringSecretStore {
             return None;
         };
 
-        let Some(object) = parsed.as_object() else {
-            return None;
-        };
+        let object = parsed.as_object()?;
 
         let mut data = HashMap::new();
 

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -44,10 +44,7 @@ impl Secret {
 
     #[must_use]
     pub fn get(&self, key: &str) -> Option<&str> {
-        let Some(secret_value): Option<&SecretString> = self.data.get(key) else {
-            return None;
-        };
-
+        let secret_value = self.data.get(key)?;
         let exposed_secret = secret_value.expose_secret();
         Some(exposed_secret)
     }


### PR DESCRIPTION
It seems that there were updates in the toolchain, leading to the linter failing on our codebase.
Fixed linter warnings in CI:

```
error: this `let...else` may be rewritten with the `?` operator
  --> crates/secrets/src/keyring.rs:45:9
   |
45 | /         let Some(object) = parsed.as_object() else {
46 | |             return None;
47 | |         };
   | |__________^ help: replace it with: `let object = parsed.as_object()?;`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
   = note: `-D clippy::question-mark` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::question_mark)]`

error: this `let...else` may be rewritten with the `?` operator
  --> crates/secrets/src/lib.rs:47:9
   |
47 | /         let Some(secret_value): Option<&SecretString> = self.data.get(key) else {
48 | |             return None;
49 | |         };
   | |__________^ help: replace it with: `let secret_value = self.data.get(key)?;`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark

```

```
error: this `let...else` may be rewritten with the `?` operator
  --> crates/runtime/src/flight/do_put.rs:22:9
   |
22 | /         let Some(channel) = channel_map_read.get(&path) else {
23 | |             return None;
24 | |         };
   | |__________^ help: replace it with: `let channel = channel_map_read.get(&path)?;`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
   = note: `-D clippy::question-mark` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::question_mark)]`

error: useless use of `vec!`
  --> crates/runtime/src/podswatcher.rs:30:34
   |
30 |           let root_spicepod_path = vec![
   |  __________________________________^
31 | |             root_path.join("spicepod.yaml"),
32 | |             root_path.join("spicepod.yml"),
33 | |         ];
   | |_________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
   = note: `-D clippy::useless-vec` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::useless_vec)]`
help: you can use an array directly
   |
30 ~         let root_spicepod_path = [root_path.join("spicepod.yaml"),
31 ~             root_path.join("spicepod.yml")];
   |

```