### PR TITLE
Huggingface models source

### DIFF
--- a/crates/runtime/src/model.rs
+++ b/crates/runtime/src/model.rs
@@ -111,6 +111,7 @@ impl Model {
 pub(crate) fn source(from: &str) -> String {
     match from {
         s if s.starts_with("spiceai:") => "spiceai".to_string(),
+        s if s.starts_with("huggingface:") => "huggingface".to_string(),
         s if s.starts_with("file:/") => "localhost".to_string(),
         _ => "spiceai".to_string(),
     }

--- a/crates/runtime/src/model.rs
+++ b/crates/runtime/src/model.rs
@@ -58,6 +58,7 @@ impl Model {
         params.insert("name".to_string(), model.name.to_string());
         params.insert("path".to_string(), path(&model.from));
         params.insert("from".to_string(), path(&model.from));
+        params.insert("files".to_string(), model.files.join(",").to_string());
 
         let tract = crate::modelruntime::tract::Tract {
             path: create_source_from(source)

--- a/crates/runtime/src/modelsource.rs
+++ b/crates/runtime/src/modelsource.rs
@@ -4,6 +4,7 @@ use snafu::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+pub mod huggingface;
 pub mod local;
 pub mod spiceai;
 
@@ -70,6 +71,7 @@ pub fn create_source_from(source: &str) -> Result<Box<dyn ModelSource>> {
     match source {
         "localhost" => Ok(Box::new(local::Local {})),
         "spiceai" => Ok(Box::new(spiceai::SpiceAI {})),
+        "huggingface" => Ok(Box::new(huggingface::Huggingface {})),
         _ => UnknownModelSourceSnafu {
             model_source: source,
         }

--- a/crates/runtime/src/modelsource.rs
+++ b/crates/runtime/src/modelsource.rs
@@ -17,6 +17,9 @@ pub enum Error {
     #[snafu(display("Unable to load the model: {source}"))]
     UnableToFetchModel { source: reqwest::Error },
 
+    #[snafu(display("Unable to download model file"))]
+    UnableToDownloadModelFile {},
+
     #[snafu(display("Unable to parse metadata"))]
     UnableToParseMetadata {},
 

--- a/crates/runtime/src/modelsource/huggingface.rs
+++ b/crates/runtime/src/modelsource/huggingface.rs
@@ -1,0 +1,129 @@
+use super::ModelSource;
+use crate::auth::AuthProvider;
+use async_trait::async_trait;
+use regex::Regex;
+use snafu::prelude::*;
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::sync::Arc;
+
+pub struct Huggingface {}
+
+#[async_trait]
+impl ModelSource for Huggingface {
+    async fn pull(
+        &self,
+        _: AuthProvider,
+        params: Arc<Option<HashMap<String, String>>>,
+    ) -> super::Result<String> {
+        let name = params
+            .as_ref()
+            .as_ref()
+            .and_then(|p| p.get("name"))
+            .map(ToString::to_string);
+
+        let Some(name) = name else {
+            return Err(super::UnableToLoadConfigSnafu {
+                reason: "Name is required",
+            }
+            .build());
+        };
+
+        let files_param = params
+            .as_ref()
+            .as_ref()
+            .and_then(|p| p.get("files"))
+            .map(ToString::to_string);
+
+        let files = match files_param {
+            Some(files) => files.split(',').map(ToString::to_string).collect(),
+            None => vec![],
+        };
+
+        // it is not copying local model into .spice folder
+        let local_path = super::ensure_model_path(name.as_str())?;
+
+        let remote_path = params
+            .as_ref()
+            .as_ref()
+            .and_then(|p| p.get("path"))
+            .map(ToString::to_string);
+
+        let Some(remote_path) = remote_path else {
+            return Err(super::UnableToLoadConfigSnafu {
+                reason: "From is required",
+            }
+            .build());
+        };
+
+        let Ok(re) = Regex::new(
+            r"\A(huggingface:)(huggingface\.co\/)?(?<org>[\w\-]+)\/(?<model>[\w\-]+)(:(?<revision>[\w\d\-\.]+))?\z",
+        ) else {
+            return Err(super::UnableToLoadConfigSnafu {
+                reason: "Invalid regex",
+            }
+            .build());
+        };
+        let Some(caps) = re.captures(remote_path.as_str()) else {
+            return Err(super::UnableToLoadConfigSnafu {
+                reason: format!("from is invalid for huggingface source: {remote_path}"),
+            }
+            .build());
+        };
+
+        let revision = match caps["revision"].to_owned() {
+            s if s.is_empty() => "main".to_string(),
+            s if s == "latest" => "main".to_string(),
+            _ => caps["revision"].to_string(),
+        };
+
+        let versioned_path = format!("{local_path}/{revision}");
+
+        let mut onnx_file_name = "".to_string();
+
+        std::fs::create_dir_all(versioned_path.clone())
+            .context(super::UnableToCreateModelPathSnafu {})?;
+
+        // replace lfs reference with file downloaded from huggingface api
+        let p = versioned_path.clone();
+        for file in files {
+            let file_name = format!("{p}/{file}");
+
+            if std::fs::metadata(file_name.clone()).is_ok() {
+                println!("File already exists: {file_name}, skipping download");
+                continue;
+            }
+
+            println!("Downloading {file_name}...");
+
+            let download_url = format!(
+                "https://huggingface.co/{}/{}/resolve/{}/{}",
+                caps["org"].to_owned(),
+                caps["model"].to_owned(),
+                revision,
+                file,
+            );
+
+            if file.ends_with(".onnx") {
+                onnx_file_name = file_name.clone();
+            }
+
+            let client = reqwest::Client::new();
+            let response = client
+                .get(download_url)
+                .send()
+                .await
+                .context(super::UnableToFetchModelSnafu {})?;
+
+            let mut file = std::fs::File::create(file_name.clone())
+                .context(super::UnableToCreateModelPathSnafu {})?;
+            let mut content = Cursor::new(response.bytes().await.unwrap_or_default());
+            std::io::copy(&mut content, &mut file)
+                .context(super::UnableToCreateModelPathSnafu {})?;
+
+            println!("Downloaded {file_name}");
+        }
+
+        Ok(onnx_file_name)
+    }
+}

--- a/crates/runtime/src/modelsource/huggingface.rs
+++ b/crates/runtime/src/modelsource/huggingface.rs
@@ -80,7 +80,7 @@ impl ModelSource for Huggingface {
 
         let versioned_path = format!("{local_path}/{revision}");
 
-        let mut onnx_file_name = "".to_string();
+        let mut onnx_file_name = String::new();
 
         std::fs::create_dir_all(versioned_path.clone())
             .context(super::UnableToCreateModelPathSnafu {})?;
@@ -106,7 +106,7 @@ impl ModelSource for Huggingface {
 
             tracing::info!("Downloading model: {}", download_url);
 
-            if file.ends_with(".onnx") {
+            if file.to_lowercase().ends_with(".onnx") {
                 onnx_file_name = file_name.clone();
             }
 

--- a/crates/runtime/src/modelsource/huggingface.rs
+++ b/crates/runtime/src/modelsource/huggingface.rs
@@ -1,7 +1,7 @@
 use super::ModelSource;
-use crate::auth::AuthProvider;
 use async_trait::async_trait;
 use regex::Regex;
+use secrets::Secret;
 use snafu::prelude::*;
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -13,7 +13,7 @@ pub struct Huggingface {}
 impl ModelSource for Huggingface {
     async fn pull(
         &self,
-        _: AuthProvider,
+        _: Secret,
         params: Arc<Option<HashMap<String, String>>>,
     ) -> super::Result<String> {
         let name = params
@@ -86,6 +86,7 @@ impl ModelSource for Huggingface {
 
         // replace lfs reference with file downloaded from huggingface api
         let p = versioned_path.clone();
+
         for file in files {
             let file_name = format!("{p}/{file}");
 
@@ -103,6 +104,8 @@ impl ModelSource for Huggingface {
                 revision,
                 file,
             );
+
+            println!("Downloading {download_url}...");
 
             if file.ends_with(".onnx") {
                 onnx_file_name = file_name.clone();

--- a/crates/runtime/src/modelsource/spiceai.rs
+++ b/crates/runtime/src/modelsource/spiceai.rs
@@ -119,6 +119,11 @@ impl ModelSource for SpiceAI {
         let versioned_path = format!("{local_path}/{version}");
         let file_name = format!("{versioned_path}/model.onnx");
 
+        if std::fs::metadata(file_name.clone()).is_ok() {
+            println!("File already exists: {file_name}, skipping download");
+            return Ok(file_name);
+        }
+
         let response = client
             .get(download_url)
             .send()

--- a/crates/runtime/src/modelsource/spiceai.rs
+++ b/crates/runtime/src/modelsource/spiceai.rs
@@ -120,7 +120,7 @@ impl ModelSource for SpiceAI {
         let file_name = format!("{versioned_path}/model.onnx");
 
         if std::fs::metadata(file_name.clone()).is_ok() {
-            println!("File already exists: {file_name}, skipping download");
+            tracing::debug!("File already exists: {file_name}, skipping download");
             return Ok(file_name);
         }
 

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -7,6 +7,10 @@ pub struct Model {
     pub name: String,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(rename = "files", default)]
+    pub files: Vec<String>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "datasets", default)]
     pub datasets: Vec<String>,
 }
@@ -16,6 +20,7 @@ impl WithDependsOn<Model> for Model {
         Model {
             from: self.from.clone(),
             name: self.name.clone(),
+            files: depends_on.to_vec(),
             datasets: depends_on.to_vec(),
         }
     }


### PR DESCRIPTION
Added support to pull models from huggingface.

Model can be configured using `huggingface` model source, and a link to the model `huggingface.co/spiceai/darts_private:latest`

Added optional `files` field to explicitly specify which files should be downloaded for HF model

```yaml


models:
  - from: huggingface:huggingface.co/spiceai/darts_private:latest
    name: darts_private
    datasets:
      - drive_stats_inferencing
    files:
      - model.onnx

```

It also requires `huggingface` secret with `token` field from HF user access tokens https://huggingface.co/settings/tokens

E.g. using env variables:

```bash
SPICE_SECRET_HUGGINGFACE_TOKEN='<...>' spice run
```