### PR TITLE
Automation and instructions for local TPC-H benchmark setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ venv_acknowledgements
 __pycache__
 venv
 .venv
+
+/test/tpch/tmp/
+/test/tpch/tpch-kit
+/test/tpch/tpch_queries.sql

--- a/test/tpch/Makefile
+++ b/test/tpch/Makefile
@@ -1,9 +1,8 @@
 # Makefile
 
 .PHONY: all
-all: tpch-get
 
-.PHONY: tpch-get tpch-gen
+all: tpch-gen pg-load
 
 tpch-init:
 	@if [ ! -d "tpch-kit" ]; then \
@@ -31,7 +30,10 @@ tpch-gen: tpch-init
 
 	@# skip query 20.sql temporarily as it is unable to run
 	@for i in tpch-kit/dbgen/queries/*.sql; do \
-		if [ `basename $$i` = "20.sql" ]; then continue; fi; \
+		if [ `basename $$i` = "20.sql" ]; then \
+			touch ./tmp/queries/`basename $$i`; \
+			continue; \
+		fi; \
 		tail -r $$i | sed '2s/;//' | tail -r > ./tmp/queries/`basename $$i`; \
 	done
 
@@ -46,7 +48,7 @@ pg-init:
 	(createdb tpch && echo "Database 'tpch' created successfully.")
 	
 	@psql tpch -c "DROP TABLE IF EXISTS nation, region, part, supplier, partsupp, customer, orders, lineitem;"
-	@psql tpch -f ./tpch-kit/dbgen/
+	@psql tpch -f ./tpch-kit/dbgen/dss.ddl
 
 	@echo "Database 'tpch' has been successfuly created or updated."
 

--- a/test/tpch/Makefile
+++ b/test/tpch/Makefile
@@ -1,0 +1,66 @@
+# Makefile
+
+.PHONY: all
+all: tpch-get
+
+.PHONY: tpch-get tpch-gen
+
+tpch-init:
+	@if [ ! -d "tpch-kit" ]; then \
+		git clone https://github.com/gregrahn/tpch-kit.git; \
+	fi
+	@OS=`uname`; \
+	if [ -z "$(MACHINE)" ]; then \
+		if [ "$$OS" = "Linux" ]; then \
+			MACHINE=LINUX; \
+		elif [ "$$OS" = "Darwin" ]; then \
+			MACHINE=MACOS; \
+		else \
+			echo "Unsupported operating system: $$OS."; \
+			exit 1; \
+		fi; \
+	fi; \
+	$(MAKE) -C tpch-kit/dbgen MACHINE=$$MACHINE DATABASE=POSTGRESQL
+
+	@echo "Initialized successfully."
+
+tpch-gen: tpch-init
+	@(cd tpch-kit/dbgen && ./dbgen -vf -s 0.1)
+
+	@mkdir -p ./tmp/queries
+
+	@# skip query 20.sql temporarily as it is unable to run
+	@for i in tpch-kit/dbgen/queries/*.sql; do \
+		if [ `basename $$i` = "20.sql" ]; then continue; fi; \
+		tail -r $$i | sed '2s/;//' | tail -r > ./tmp/queries/`basename $$i`; \
+	done
+
+	@(cd tpch-kit/dbgen && DSS_QUERY=../../tmp/queries ./qgen | sed 's/limit -1//' | sed 's/day (3)/day/' > ../../tpch_queries.sql)
+
+	@echo "Test data and queries generated successfully."
+
+# Example: PGPORT=5432 PGUSER=postgres make pg-init
+pg-init:
+	@psql -tAc "SELECT 1 FROM pg_database WHERE datname='tpch'" | grep -q 1 && \
+	(echo "Database 'tpch' already exists, skipping creation." ) || \
+	(createdb tpch && echo "Database 'tpch' created successfully.")
+	
+	@psql tpch -c "DROP TABLE IF EXISTS nation, region, part, supplier, partsupp, customer, orders, lineitem;"
+	@psql tpch -f ./tpch-kit/dbgen/
+
+	@echo "Database 'tpch' has been successfuly created or updated."
+
+# Example: PGPORT=5432 PGUSER=postgres make pg-load
+pg-load:
+	@for i in tpch-kit/dbgen/*.tbl; do \
+		table=$$(basename $$i .tbl); \
+		echo "Loading $$table..."; \
+		sed 's/|$$//' $$i > ./tmp/$$table.tbl; \
+		psql tpch -q -c "TRUNCATE $$table"; \
+		psql tpch -c "\\copy $$table FROM './tmp/$$table.tbl' CSV DELIMITER '|';"; \
+	done
+	@echo "Benchmark dataset has been successfully loaded to 'tpch' database"
+
+# Example: PGPORT=5432 PGUSER=postgres make tpch-run-pq
+tpch-run-pq:
+	psql tpch < ./tpch_queries.sql

--- a/test/tpch/Readme.md
+++ b/test/tpch/Readme.md
@@ -1,0 +1,40 @@
+# TPC-H Setup
+
+Instructions to create test queries and dataset for [TPC-H benchmark](https://www.tpc.org/tpch/). 
+
+## Prerequisites
+- Linux or MacOS
+- Git
+- `make` utility
+- PostgreSQL installed and running to load test dataset
+
+## Generate TPC-H test dataset and test queries
+
+Run commands below to generate test queries (`tpch_queries.sql`) and test data (`tmp/*.tbl`):
+
+```bash
+make tpch-init
+make tpch-gen
+```
+
+## Load test dataset to PostgreSQL
+
+Run commands below to create `tpch` dataset and load test data:
+
+```bash
+make pg-init
+make pg-load
+```
+Pass PostgresSQL connection parameters as needed:
+
+```bash
+PGPORT=5432 PGUSER=postgres make pg-init
+PGPORT=5432 PGUSER=postgres make pg-load
+```
+
+## Run TPC-H queries
+Verify generated queries and test data by running queries against configured PostgreSQL instance using `make tpch-run-pq`, for example
+
+```bash
+PGPORT=5432 PGUSER=postgres make tpch-run-pq
+```


### PR DESCRIPTION
Instructions to build and load TPC-H benchmark data to PostgreSQL locally.

There will be a separate PR with spicepod configuration for Spice to use TPC-H benchmark as a source to run benchmark queries against Spice instance