### PR TITLE
PostgreSQL: support for Date type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "arrow",
  "bigdecimal 0.3.1",
  "bigdecimal 0.4.3",
+ "chrono",
  "rusqlite",
  "sea-query",
  "snafu 0.8.2",
@@ -1544,8 +1545,10 @@ checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
 
@@ -4491,6 +4494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
  "bytes",
+ "chrono",
  "fallible-iterator 0.2.0",
  "postgres-protocol",
 ]

--- a/crates/arrow_sql_gen/Cargo.toml
+++ b/crates/arrow_sql_gen/Cargo.toml
@@ -15,9 +15,10 @@ tracing.workspace = true
 arrow.workspace = true
 sea-query = {version = "0.30.7" , features = ["backend-sqlite", "backend-postgres", "postgres-array", "with-rust_decimal", "with-bigdecimal", "with-time"]}
 snafu.workspace = true
-tokio-postgres = "0.7.10"
+tokio-postgres = {version = "0.7.10", features = ["with-chrono-0_4"]}
 bigdecimal_0_3_0 = { package = "bigdecimal", version = "0.3.0"}
 time = "0.3.34"
 bigdecimal = "0.4.3"
 tokio.workspace = true
 rusqlite.workspace = true
+chrono = "0.4.35"

--- a/crates/arrow_sql_gen/src/arrow.rs
+++ b/crates/arrow_sql_gen/src/arrow.rs
@@ -1,7 +1,7 @@
 use arrow::{
     array::{
-        ArrayBuilder, BooleanBuilder, Decimal128Builder, Float32Builder, Float64Builder,
-        Int16Builder, Int32Builder, Int64Builder, ListBuilder, StringBuilder,
+        ArrayBuilder, BooleanBuilder, Date32Builder, Decimal128Builder, Float32Builder,
+        Float64Builder, Int16Builder, Int32Builder, Int64Builder, ListBuilder, StringBuilder,
         TimestampMicrosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder,
         TimestampSecondBuilder,
     },
@@ -45,6 +45,7 @@ pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuil
                 Box::new(TimestampNanosecondBuilder::new().with_timezone_opt(time_zone.clone()))
             }
         },
+        DataType::Date32 => Box::new(Date32Builder::new()),
         // We can't recursively call map_data_type_to_array_builder here because downcasting will not work if the
         // values_builder is boxed.
         DataType::List(values_field) => match values_field.data_type() {


### PR DESCRIPTION
Add `Date` support for PostgreSQL. Spice (PostgreSQL) currently supports `timestamp` only

Fixes https://github.com/spiceai/spiceai/issues/908