### PR TITLE
Bundle sqlite into the build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,7 +62,6 @@ jobs:
         with:
           os: 'linux'
 
-      - run: sudo apt update && sudo apt install --yes libsqlite3-dev
       - run: make ci
 
   build-docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,6 +3500,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,5 @@ async-stream = "0.3.5"
 async-trait = "0.1.77"
 bb8 = "0.8"
 bb8-postgres = "0.8"
-rusqlite = "0.31.0"
+rusqlite = { version = "0.31.0", features = ["bundled"] }
 tokio-rusqlite = "0.5.1"


### PR DESCRIPTION
This changes the build so that we don't rely on the system installed version of sqlite - we bundle it into the build.