### PR TITLE
Add additional release step to remove from ROADMAP

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -51,6 +51,7 @@ assignees: ''
 - [ ] Run [E2E Test Release Installation](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_release_install.yml)
 - [ ] Update `version.txt` and version in `Cargo.toml` to the next release version.
 - [ ] Update versions in [brew taps](https://github.com/spiceai/homebrew-spiceai)
+- [ ] Remove the released version from the [ROADMAP](docs/ROADMAP.md)
 
 ## Announcement Checklist
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,12 +12,6 @@ If you have a feature request or suggestion, please [get in touch](https://githu
 
 - See [Bugs](https://github.com/spiceai/spiceai/labels/bug). Feel free to file a new Issue if you see a bug and let us know on Discord.
 
-## v0.9.1-alpha (Mar 2024)
-
-- E2E tests
-- SQLite data backend (alpha)
-- Arrow Flight SQL data connector (alpha)
-
 ## v0.10-alpha (Mar 2024)
 
 - Helm chart


### PR DESCRIPTION
Updates the Endgame template to indicate we should remove the current release from the ROADMAP