### PR TITLE
Run E2E CI Tests on each pull requests with only linux target

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Allow only one workflow per any non-trunk branch. test
+  # Allow only one workflow per any non-trunk branch.
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha }}
   cancel-in-progress: true
 

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Allow only one workflow per any non-trunk branch.
+  # Allow only one workflow per any non-trunk branch. test
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha }}
   cancel-in-progress: true
 

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -34,7 +34,7 @@ jobs:
             const matrix = [
               {
                 name: "Linux x64",
-                runner: "rust",
+                runner: "ubuntu-latest",
                 target_os: "linux",
                 target_arch: "x86_64",
                 target_arch_go: "amd64"
@@ -108,34 +108,40 @@ jobs:
         with:
           go-version: ${{ env.GOVER }}
 
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
+      - run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
         with:
-          os: ${{ matrix.target.target_os }}
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
-      - name: Restore build cache (macOS)
-        if: matrix.target.target_os == 'darwin'
-        run: |
-          mkdir -p target
-          if [ -d /Users/spiceai/build/target ]; then
-            rsync -av /Users/spiceai/build/target/ target/
-          fi
+      # - name: Set up Rust
+      #   uses: ./.github/actions/setup-rust
+      #   with:
+      #     os: ${{ matrix.target.target_os }}
 
-      - name: Restore build cache (Linux)
-        if: matrix.target.target_os == 'linux'
-        run: |
-          mkdir -p target
-          if [ -d /home/spiceai/build/target ]; then
-            rsync -av /home/spiceai/build/target/ target/
-          fi
+      # - name: Restore build cache (macOS)
+      #   if: matrix.target.target_os == 'darwin'
+      #   run: |
+      #     mkdir -p target
+      #     if [ -d /Users/spiceai/build/target ]; then
+      #       rsync -av /Users/spiceai/build/target/ target/
+      #     fi
 
-      - name: Restore build cache (Windows)
-        if: matrix.target.target_os == 'windows'
-        run: |
-          mkdir -p target
-          if (Test-Path C:/spiceai/build/target) {
-            Copy-Item -Recurse -Force C:/spiceai/build/target/* target/
-          }
+      # - name: Restore build cache (Linux)
+      #   if: matrix.target.target_os == 'linux'
+      #   run: |
+      #     mkdir -p target
+      #     if [ -d /home/spiceai/build/target ]; then
+      #       rsync -av /home/spiceai/build/target/ target/
+      #     fi
+
+      # - name: Restore build cache (Windows)
+      #   if: matrix.target.target_os == 'windows'
+      #   run: |
+      #     mkdir -p target
+      #     if (Test-Path C:/spiceai/build/target) {
+      #       Copy-Item -Recurse -Force C:/spiceai/build/target/* target/
+      #     }
 
       - name: Build spiced
         run: make -C bin/spiced

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -48,7 +48,7 @@ jobs:
               }
             ];
 
-            return contet.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
+            return context.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
 
       - name: Set up test matrix
         uses: actions/github-script@v7
@@ -77,7 +77,7 @@ jobs:
               }
             ];
 
-            return contet.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
+            return context.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
 
   build:
     name: Build ${{ matrix.object.name }} binaries

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -111,6 +111,7 @@ jobs:
       - run: rustup toolchain install stable --profile minimal
 
       - uses: Swatinem/rust-cache@v2
+        # test run
         # with:
         #   save-if: ${{ github.ref == 'refs/heads/trunk' }}
 

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   # Allow only one workflow per any non-trunk branch.
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -26,6 +26,7 @@ jobs:
         id: setup-build-matrix
         with:
           script: |
+            console.log(context);
             return [
               {
                 name: "Linux x64",

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -104,10 +104,10 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:
-          os: ${{ matrix.target_os }}
+          os: ${{ matrix.object.target_os }}
 
       - name: Restore build cache (macOS)
-        if: matrix.target_os == 'darwin'
+        if: matrix.object.target_os == 'darwin'
         run: |
           mkdir -p target
           if [ -d /Users/spiceai/build/target ]; then
@@ -115,7 +115,7 @@ jobs:
           fi
 
       - name: Restore build cache (Linux)
-        if: matrix.target_os == 'linux'
+        if: matrix.object.target_os == 'linux'
         run: |
           mkdir -p target
           if [ -d /home/spiceai/build/target ]; then
@@ -123,7 +123,7 @@ jobs:
           fi
 
       - name: Restore build cache (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.object.target_os == 'windows'
         run: |
           mkdir -p target
           if (Test-Path C:/spiceai/build/target) {
@@ -134,21 +134,21 @@ jobs:
         run: make -C bin/spiced
 
       - name: Update build cache (macOS)
-        if: matrix.target_os == 'darwin'
+        if: matrix.object.target_os == 'darwin'
         run: |
           if [ -d /Users/spiceai/build/target ]; then
             rsync -av target/ /Users/spiceai/build/target/
           fi
 
       - name: Update build cache (Linux)
-        if: matrix.target_os == 'linux'
+        if: matrix.object.target_os == 'linux'
         run: |
           if [ -d /home/spiceai/build/target ]; then
             rsync -av target/ /home/spiceai/build/target/
           fi
 
       - name: Update build cache (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.object.target_os == 'windows'
         run: |
           if (Test-Path C:/spiceai/build/target) {
             Copy-Item -Recurse -Force target/* C:/spiceai/build/target
@@ -158,22 +158,22 @@ jobs:
         run: make -C bin/spice
 
       - name: make spiced executable
-        if: matrix.target_os != 'windows'
+        if: matrix.object.target_os != 'windows'
         run: |
           mv target/release/spiced spiced
           chmod +x spiced
 
       - name: make spice executable
-        if: matrix.target_os != 'windows'
+        if: matrix.object.target_os != 'windows'
         run: |
           mv target/release/spice spice
           chmod +x spice
 
       - name: Save spice artifact
         uses: actions/upload-artifact@v4
-        if: matrix.target_os != 'windows'
+        if: matrix.object.target_os != 'windows'
         with:
-          name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
           path: |
             spice
             spiced
@@ -365,285 +365,248 @@ jobs:
             exit 1
           fi
 
-  # test_quickstart_data_postgres:
-  #   name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target_os }}-${{ matrix.target_arch }}"
-  #   runs-on: ${{ matrix.runner }}
-  #   needs: build
+  test_quickstart_data_postgres:
+    name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.object.target_os }}-${{ matrix.object.target_arch }}"
+    runs-on: ${{ matrix.object.runner }}
+    needs:
+      - build
+      - setup-matrix
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - name: Linux x64
-  #           runner: ubuntu-latest
-  #           target_os: linux
-  #           target_arch: x86_64
-  #           target_arch_go: amd64
-  #         - name: macOS aarch64 (Apple Silicon)
-  #           runner: macos-14
-  #           target_os: darwin
-  #           target_arch: aarch64
-  #           target_arch_go: arm64
-  #         - name: macOS x64 (Intel)
-  #           runner: macos-12
-  #           target_os: darwin
-  #           target_arch: x86_64
-  #           target_arch_go: amd64
-  #         # - name: Windows x64
-  #         #   runner: rust-windows-x64
-  #         #   target_os: windows
-  #         #   target_arch: x86_64
-  #         #   target_arch_go: amd64
+    strategy:
+      matrix:
+        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
-  #   steps:
-  #     - name: Install PostgreSQL (Linux)
-  #       if: matrix.target_os == 'linux'
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y postgresql
-  #         sudo service postgresql start
-  #         sleep 5
-  #         sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || sudo -u postgres createuser -s postgres
-  #         sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
-  #         sudo -u postgres createdb testdb
+    steps:
+      - name: Install PostgreSQL (Linux)
+        if: matrix.object.target_os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql
+          sudo service postgresql start
+          sleep 5
+          sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || sudo -u postgres createuser -s postgres
+          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+          sudo -u postgres createdb testdb
 
-  #     - name: Install PostgreSQL (MacOS)
-  #       if: matrix.target_os == 'darwin'
-  #       run: |
-  #         brew install postgresql
-  #         brew services start postgresql
-  #         sleep 5
-  #         createuser -s postgres
-  #         psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
-  #         createdb testdb
+      - name: Install PostgreSQL (MacOS)
+        if: matrix.object.target_os == 'darwin'
+        run: |
+          brew install postgresql
+          brew services start postgresql
+          sleep 5
+          createuser -s postgres
+          psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
+          createdb testdb
 
-  #     - name: Wait for PostgreSQL to start
-  #       run: sleep 10
+      - name: Wait for PostgreSQL to start
+        run: sleep 10
 
-  #     - name: Check PostgreSQL
-  #       env:
-  #         PGPASSWORD: postgres
-  #       run: psql -h localhost -U postgres -c 'SELECT version();'
+      - name: Check PostgreSQL
+        env:
+          PGPASSWORD: postgres
+        run: psql -h localhost -U postgres -c 'SELECT version();'
 
-  #     - name: Prepare PostgreSQL dataset
-  #       env:
-  #         PGPASSWORD: postgres
-  #       run: |
-  #         psql -h localhost -U postgres -d testdb -c 'CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);'
-  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
-  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
-  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
-  #         psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
+      - name: Prepare PostgreSQL dataset
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d testdb -c 'CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);'
+          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
+          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
+          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
+          psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
 
-  #     - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-  #         path: ./build
+      - name: download artifacts - build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+          path: ./build
 
-  #     - name: Install spice
-  #       run: |
-  #         chmod +x ./build/spice
-  #         chmod +x ./build/spiced
-  #         mkdir -p "$HOME/.spice/bin"
-  #         mv ./build/spice "$HOME/.spice/bin"
-  #         mv ./build/spiced "$HOME/.spice/bin"
-  #         echo "$HOME/.spice/bin" >> $GITHUB_PATH
+      - name: Install spice
+        run: |
+          chmod +x ./build/spice
+          chmod +x ./build/spiced
+          mkdir -p "$HOME/.spice/bin"
+          mv ./build/spice "$HOME/.spice/bin"
+          mv ./build/spiced "$HOME/.spice/bin"
+          echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
-  #     - name: Check spice version
-  #       run: spice version
+      - name: Check spice version
+        run: spice version
 
-  #     - name: Init spice app
-  #       run: |
-  #         spice init test_app
+      - name: Init spice app
+        run: |
+          spice init test_app
 
-  #     - name: Spice dataset configure
-  #       working-directory: test_app
-  #       run: |
-  #         echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
-  #         # configure pg credentials
-  #         echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
-  #         # configure env secret store
-  #         echo -e "secrets:\n  store: env\n" >> spicepod.yaml
-  #         cat spicepod.yaml
+      - name: Spice dataset configure
+        working-directory: test_app
+        run: |
+          echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
+          # configure pg credentials
+          echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
+          # configure env secret store
+          echo -e "secrets:\n  store: env\n" >> spicepod.yaml
+          cat spicepod.yaml
 
-  #     - name: Start spice runtime
-  #       env:
-  #         SPICE_SECRET_POSTGRES_PASSWORD: postgres
-  #       working-directory: test_app
-  #       run: |
-  #         spice run &
-  #           # time to initialize added dataset
-  #         sleep 5
+      - name: Start spice runtime
+        env:
+          SPICE_SECRET_POSTGRES_PASSWORD: postgres
+        working-directory: test_app
+        run: |
+          spice run &
+            # time to initialize added dataset
+          sleep 5
 
-  #     - name: Wait for Spice runtime healthy
-  #       working-directory: test_app
-  #       timeout-minutes: 1
-  #       run: |
-  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+      - name: Wait for Spice runtime healthy
+        working-directory: test_app
+        timeout-minutes: 1
+        run: |
+          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
 
-  #     - name: Check datasets
-  #       working-directory: test_app
-  #       run: |
-  #         response=$(curl http://localhost:3000/v1/datasets)
-  #         echo $response | jq
-  #         length=$(echo $response | jq 'if type=="array" then length else empty end')
-  #         if [[ $length -ne 1 ]]; then
-  #           echo "Unexpected response: $response, expected 1 dataset but received $length"
-  #           exit 1
-  #         fi
+      - name: Check datasets
+        working-directory: test_app
+        run: |
+          response=$(curl http://localhost:3000/v1/datasets)
+          echo $response | jq
+          length=$(echo $response | jq 'if type=="array" then length else empty end')
+          if [[ $length -ne 1 ]]; then
+            echo "Unexpected response: $response, expected 1 dataset but received $length"
+            exit 1
+          fi
 
-  #     - name: Check eth_recent_blocks table exists
-  #       working-directory: test_app
-  #       run: |
-  #         response=$(curl -X POST \
-  #           -H "Content-Type: text/plain" \
-  #           -d "show tables;" \
-  #           http://localhost:3000/v1/sql
-  #         )
-  #         echo $response | jq
-  #         table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
-  #         if [[ $table_exists -eq 0 ]]; then
-  #           echo "Unexpected response: table 'eth_recent_blocks' does not exist."
-  #           exit 1
-  #         fi
+      - name: Check eth_recent_blocks table exists
+        working-directory: test_app
+        run: |
+          response=$(curl -X POST \
+            -H "Content-Type: text/plain" \
+            -d "show tables;" \
+            http://localhost:3000/v1/sql
+          )
+          echo $response | jq
+          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+          if [[ $table_exists -eq 0 ]]; then
+            echo "Unexpected response: table 'eth_recent_blocks' does not exist."
+            exit 1
+          fi
 
-  #     - name: Run Flight SQL query
-  #       working-directory: test_app
-  #       run: |
-  #         sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
-  #         echo "$sql_output"
-  #         if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
-  #           echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
-  #           exit 1
-  #         fi
+      - name: Run Flight SQL query
+        working-directory: test_app
+        run: |
+          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+          echo "$sql_output"
+          if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
+            echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
+            exit 1
+          fi
 
-  # test_local_acceleration:
-  #   name: "E2E Test: acceleration on ${{ matrix.name }} using ${{ matrix.acceleration.engine }}"
-  #   runs-on: ${{ matrix.runner }}
-  #   needs: build
+  test_local_acceleration:
+    name: "E2E Test: acceleration on ${{ matrix.object.name }} using ${{ matrix.acceleration.engine }}"
+    runs-on: ${{ matrix.object.runner }}
+    needs:
+      - build
+      - setup-matrix
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       acceleration: [
-  #           { engine: arrow, mode: memory },
-  #           { engine: duckdb, mode: memory },
-  #           { engine: duckdb, mode: file },
-  #           { engine: sqlite, mode: memory },
-  #           { engine: sqlite, mode: file },
-  #           # { engine: postgres},
-  #         ]
-  #       include:
-  #         - name: Linux x64
-  #           runner: ubuntu-latest
-  #           target_os: linux
-  #           target_arch: x86_64
-  #           target_arch_go: amd64
-  #         - name: macOS aarch64 (Apple Silicon)
-  #           runner: macos-14
-  #           target_os: darwin
-  #           target_arch: aarch64
-  #           target_arch_go: arm64
-  #         - name: macOS x64 (Intel)
-  #           runner: macos-12
-  #           target_os: darwin
-  #           target_arch: x86_64
-  #           target_arch_go: amd64
-  #         # - name: Windows x64
-  #         #   runner: rust-windows-x64
-  #         #   target_os: windows
-  #         #   target_arch: x86_64
-  #         #   target_arch_go: amd64
+    strategy:
+      fail-fast: false
+      matrix:
+        acceleration: [
+            { engine: arrow, mode: memory },
+            { engine: duckdb, mode: memory },
+            { engine: duckdb, mode: file },
+            { engine: sqlite, mode: memory },
+            { engine: sqlite, mode: file },
+            # { engine: postgres},
+          ]
+        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
-  #   steps:
-  #     - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-  #         path: ./build
+    steps:
+      - name: download artifacts - build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+          path: ./build
 
-  #     - name: Install spice
-  #       run: |
-  #         chmod +x ./build/spice
-  #         chmod +x ./build/spiced
-  #         mkdir -p "$HOME/.spice/bin"
-  #         mv ./build/spice "$HOME/.spice/bin"
-  #         mv ./build/spiced "$HOME/.spice/bin"
-  #         echo "$HOME/.spice/bin" >> $GITHUB_PATH
+      - name: Install spice
+        run: |
+          chmod +x ./build/spice
+          chmod +x ./build/spiced
+          mkdir -p "$HOME/.spice/bin"
+          mv ./build/spice "$HOME/.spice/bin"
+          mv ./build/spiced "$HOME/.spice/bin"
+          echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
-  #     - name: Check spice version
-  #       run: spice version
+      - name: Check spice version
+        run: spice version
 
-  #     - name: Init spice app
-  #       run: |
-  #         spice init test_app
+      - name: Init spice app
+        run: |
+          spice init test_app
 
-  #     - name: Spice dataset configure
-  #       working-directory: test_app
-  #       run: |
-  #         ENGINE=$(echo '${{ matrix.acceleration.engine }}')
-  #         MODE=$(echo '${{ matrix.acceleration.mode }}')
+      - name: Spice dataset configure
+        working-directory: test_app
+        run: |
+          ENGINE=$(echo '${{ matrix.acceleration.engine }}')
+          MODE=$(echo '${{ matrix.acceleration.mode }}')
 
-  #         echo "datasets:" >> spicepod.yaml
-  #         echo "  - name: eth_recent_blocks" >> spicepod.yaml
-  #         echo "    from: spice.ai/eth.recent_blocks" >> spicepod.yaml
-  #         echo "    acceleration:" >> spicepod.yaml
-  #         echo "      enabled: true" >> spicepod.yaml
-  #         echo "      engine: $ENGINE" >> spicepod.yaml
-  #         if [[ -n "$MODE" ]]; then
-  #           echo "      mode: $MODE" >> spicepod.yaml
-  #         fi
-  #         # configure env secret store
-  #         echo -e "secrets:\n  store: env\n" >> spicepod.yaml
-  #         cat spicepod.yaml
+          echo "datasets:" >> spicepod.yaml
+          echo "  - name: eth_recent_blocks" >> spicepod.yaml
+          echo "    from: spice.ai/eth.recent_blocks" >> spicepod.yaml
+          echo "    acceleration:" >> spicepod.yaml
+          echo "      enabled: true" >> spicepod.yaml
+          echo "      engine: $ENGINE" >> spicepod.yaml
+          if [[ -n "$MODE" ]]; then
+            echo "      mode: $MODE" >> spicepod.yaml
+          fi
+          # configure env secret store
+          echo -e "secrets:\n  store: env\n" >> spicepod.yaml
+          cat spicepod.yaml
 
-  #     - name: Start spice runtime
-  #       env:
-  #         SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
-  #       working-directory: test_app
-  #       run: |
-  #         spice run &
-  #         sleep 5
+      - name: Start spice runtime
+        env:
+          SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
+        working-directory: test_app
+        run: |
+          spice run &
+          sleep 5
 
-  #     - name: Wait for Spice runtime healthy
-  #       working-directory: test_app
-  #       timeout-minutes: 1
-  #       run: |
-  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+      - name: Wait for Spice runtime healthy
+        working-directory: test_app
+        timeout-minutes: 1
+        run: |
+          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
 
-  #     - name: Check datasets
-  #       working-directory: test_app
-  #       run: |
-  #         response=$(curl http://localhost:3000/v1/datasets)
-  #         echo $response | jq
-  #         length=$(echo $response | jq 'if type=="array" then length else empty end')
-  #         if [[ $length -ne 1 ]]; then
-  #           echo "Unexpected response: $response, expected 1 dataset but received $length"
-  #           exit 1
-  #         fi
+      - name: Check datasets
+        working-directory: test_app
+        run: |
+          response=$(curl http://localhost:3000/v1/datasets)
+          echo $response | jq
+          length=$(echo $response | jq 'if type=="array" then length else empty end')
+          if [[ $length -ne 1 ]]; then
+            echo "Unexpected response: $response, expected 1 dataset but received $length"
+            exit 1
+          fi
 
-  #     - name: Check eth_recent_blocks table exists
-  #       working-directory: test_app
-  #       run: |
-  #         response=$(curl -X POST \
-  #           -H "Content-Type: text/plain" \
-  #           -d "show tables;" \
-  #           http://localhost:3000/v1/sql
-  #         )
-  #         echo $response | jq
-  #         table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
-  #         if [[ $table_exists -eq 0 ]]; then
-  #           echo "Unexpected response: table 'taxi_trips' does not exist."
-  #           exit 1
-  #         fi
+      - name: Check eth_recent_blocks table exists
+        working-directory: test_app
+        run: |
+          response=$(curl -X POST \
+            -H "Content-Type: text/plain" \
+            -d "show tables;" \
+            http://localhost:3000/v1/sql
+          )
+          echo $response | jq
+          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+          if [[ $table_exists -eq 0 ]]; then
+            echo "Unexpected response: table 'taxi_trips' does not exist."
+            exit 1
+          fi
 
-  #     - name: Check Flight SQL query
-  #       working-directory: test_app
-  #       run: |
-  #         sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
-  #         echo "$sql_output"
-  #         if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
-  #           echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
-  #           exit 1
-  #         fi
+      - name: Check Flight SQL query
+        working-directory: test_app
+        run: |
+          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+          echo "$sql_output"
+          if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
+            echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
+            exit 1
+          fi

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -46,7 +46,7 @@ jobs:
                 target_arch: "x86_64",
                 target_arch_go: "amd64"
               }
-            ];
+            ].slice(0, 1);
       - name: Get result
         run: echo '${{ steps.setup-build-matrix.outputs.result }}'
 
@@ -75,17 +75,7 @@ jobs:
                 target_arch: "x86_64",
                 target_arch_go: "amd64"
               }
-            ];
-        # ÷÷run: |
-        # echo "matrix=" >> "$GITHUB_OUTPUT"
-        # run: |
-        #   echo "::set-output name=matrix::${{ toJson({
-        #     "name": ["Linux x64", "macOS aarch64 (Apple Silicon)", "macOS x64 (Intel)", "Windows x64"],
-        #     "runner": ["ubuntu-latest", "macos-14", "macos-12", "rust-windows-x64"],
-        #     "target_os": ["linux", "darwin", "darwin", "windows"],
-        #     "target_arch": ["x86_64", "aarch64", "x86_64", "x86_64"],
-        #     "target_arch_go": ["amd64", "arm64", "amd64", "amd64"]
-        #   }) }}"
+            ].slice(0, 1);
 
   build:
     name: Build ${{ matrix.object.name }} binaries
@@ -99,27 +89,6 @@ jobs:
     strategy:
       matrix:
         object: ${{ fromJson(needs.setup-matrix.outputs.matrix_build) }}
-        # include:
-        #   - name: Linux x64
-        #     runner: rust
-        #     target_os: linux
-        #     target_arch: x86_64
-        #     target_arch_go: amd64
-        #   - name: macOS aarch64 (Apple Silicon)
-        #     runner: macos-14
-        #     target_os: darwin
-        #     target_arch: aarch64
-        #     target_arch_go: arm64
-        #   - name: macOS x64 (Intel)
-        #     runner: macos-12
-        #     target_os: darwin
-        #     target_arch: x86_64
-        #     target_arch_go: amd64
-        # - name: Windows x64
-        #   runner: rust-windows-x64
-        #   target_os: windows
-        #   target_arch: x86_64
-        #   target_arch_go: amd64
 
     steps:
       - uses: actions/checkout@v3
@@ -217,31 +186,8 @@ jobs:
       - setup-matrix
 
     strategy:
-      fail-fast: false
       matrix:
         object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
-
-        # include:
-        #   - name: Linux x64
-        #     runner: ubuntu-latest
-        #     target_os: linux
-        #     target_arch: x86_64
-        #     target_arch_go: amd64
-        #   - name: macOS aarch64 (Apple Silicon)
-        #     runner: macos-14
-        #     target_os: darwin
-        #     target_arch: aarch64
-        #     target_arch_go: arm64
-        #   - name: macOS x64 (Intel)
-        #     runner: macos-12
-        #     target_os: darwin
-        #     target_arch: x86_64
-        #     target_arch_go: amd64
-        # - name: Windows x64
-        #   runner: rust-windows-x64
-        #   target_os: windows
-        #   target_arch: x86_64
-        #   target_arch_go: amd64
 
     steps:
       - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
@@ -326,117 +272,98 @@ jobs:
             exit 1
           fi
 
-  # test_quickstart_spiceai:
-  #   name: "E2E Test: SpiceAI quickstart, using ${{ matrix.target_os }}-${{ matrix.target_arch }}"
-  #   runs-on: ${{ matrix.runner }}
-  #   needs: build
+  test_quickstart_spiceai:
+    name: "E2E Test: SpiceAI quickstart, using ${{ matrix.object.target_os }}-${{ matrix.object.target_arch }}"
+    runs-on: ${{ matrix.object.runner }}
+    needs:
+      - build
+      - setup-matrix
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - name: Linux x64
-  #           runner: ubuntu-latest
-  #           target_os: linux
-  #           target_arch: x86_64
-  #           target_arch_go: amd64
-  #         - name: macOS aarch64 (Apple Silicon)
-  #           runner: macos-14
-  #           target_os: darwin
-  #           target_arch: aarch64
-  #           target_arch_go: arm64
-  #         - name: macOS x64 (Intel)
-  #           runner: macos-12
-  #           target_os: darwin
-  #           target_arch: x86_64
-  #           target_arch_go: amd64
-  #         # - name: Windows x64
-  #         #   runner: rust-windows-x64
-  #         #   target_os: windows
-  #         #   target_arch: x86_64
-  #         #   target_arch_go: amd64
+    strategy:
+      matrix:
+        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
-  #   steps:
-  #     - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-  #         path: ./build
+    steps:
+      - name: download artifacts - build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+          path: ./build
 
-  #     - name: Install spice
-  #       run: |
-  #         chmod +x ./build/spice
-  #         chmod +x ./build/spiced
-  #         mkdir -p "$HOME/.spice/bin"
-  #         mv ./build/spice "$HOME/.spice/bin"
-  #         mv ./build/spiced "$HOME/.spice/bin"
-  #         echo "$HOME/.spice/bin" >> $GITHUB_PATH
+      - name: Install spice
+        run: |
+          chmod +x ./build/spice
+          chmod +x ./build/spiced
+          mkdir -p "$HOME/.spice/bin"
+          mv ./build/spice "$HOME/.spice/bin"
+          mv ./build/spiced "$HOME/.spice/bin"
+          echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
-  #     - name: Check spice version
-  #       run: spice version
+      - name: Check spice version
+        run: spice version
 
-  #     - name: Init spice app
-  #       run: |
-  #         spice init test_app
+      - name: Init spice app
+        run: |
+          spice init test_app
 
-  #     - name: Spice dataset configure
-  #       working-directory: test_app
-  #       run: |
-  #         echo -e "eth_recent_blocks\neth recent logs\nspice.ai/eth.recent_blocks\ny" | spice dataset configure
-  #         # configure env secret store
-  #         echo -e "secrets:\n  store: env\n" >> spicepod.yaml
-  #         cat spicepod.yaml
+      - name: Spice dataset configure
+        working-directory: test_app
+        run: |
+          echo -e "eth_recent_blocks\neth recent logs\nspice.ai/eth.recent_blocks\ny" | spice dataset configure
+          # configure env secret store
+          echo -e "secrets:\n  store: env\n" >> spicepod.yaml
+          cat spicepod.yaml
 
-  #     - name: Start spice runtime
-  #       env:
-  #         SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
-  #       working-directory: test_app
-  #       run: |
-  #         spice run &
-  #          # time to initialize added dataset
-  #         sleep 5
+      - name: Start spice runtime
+        env:
+          SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
+        working-directory: test_app
+        run: |
+          spice run &
+           # time to initialize added dataset
+          sleep 5
 
-  #     - name: Wait for Spice runtime healthy
-  #       working-directory: test_app
-  #       timeout-minutes: 1
-  #       run: |
-  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+      - name: Wait for Spice runtime healthy
+        working-directory: test_app
+        timeout-minutes: 1
+        run: |
+          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
 
-  #     - name: Check datasets
-  #       working-directory: test_app
-  #       run: |
-  #         response=$(curl http://localhost:3000/v1/datasets)
-  #         echo $response | jq
-  #         length=$(echo $response | jq 'if type=="array" then length else empty end')
-  #         if [[ $length -ne 1 ]]; then
-  #           echo "Unexpected response: $response, expected 1 dataset but received $length"
-  #           exit 1
-  #         fi
+      - name: Check datasets
+        working-directory: test_app
+        run: |
+          response=$(curl http://localhost:3000/v1/datasets)
+          echo $response | jq
+          length=$(echo $response | jq 'if type=="array" then length else empty end')
+          if [[ $length -ne 1 ]]; then
+            echo "Unexpected response: $response, expected 1 dataset but received $length"
+            exit 1
+          fi
 
-  #     - name: Check eth_recent_blocks table exists
-  #       working-directory: test_app
-  #       run: |
-  #         response=$(curl -X POST \
-  #           -H "Content-Type: text/plain" \
-  #           -d "show tables;" \
-  #           http://localhost:3000/v1/sql
-  #         )
-  #         echo $response | jq
-  #         table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
-  #         if [[ $table_exists -eq 0 ]]; then
-  #           echo "Unexpected response: table 'eth_recent_blocks' does not exist."
-  #           exit 1
-  #         fi
+      - name: Check eth_recent_blocks table exists
+        working-directory: test_app
+        run: |
+          response=$(curl -X POST \
+            -H "Content-Type: text/plain" \
+            -d "show tables;" \
+            http://localhost:3000/v1/sql
+          )
+          echo $response | jq
+          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+          if [[ $table_exists -eq 0 ]]; then
+            echo "Unexpected response: table 'eth_recent_blocks' does not exist."
+            exit 1
+          fi
 
-  #     - name: Run Flight SQL query
-  #       working-directory: test_app
-  #       run: |
-  #         sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
-  #         echo "$sql_output"
-  #         if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
-  #           echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
-  #           exit 1
-  #         fi
+      - name: Run Flight SQL query
+        working-directory: test_app
+        run: |
+          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+          echo "$sql_output"
+          if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
+            echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
+            exit 1
+          fi
 
   # test_quickstart_data_postgres:
   #   name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target_os }}-${{ matrix.target_arch }}"

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -12,6 +12,11 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  # Allow only one workflow per any non-trunk branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha }}
+  cancel-in-progress: true
+
 jobs:
   setup-matrix:
     name: Setup strategy matrix
@@ -80,17 +85,17 @@ jobs:
             return context.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
 
   build:
-    name: Build ${{ matrix.object.name }} binaries
-    runs-on: ${{ matrix.object.runner }}
+    name: Build ${{ matrix.target.name }} binaries
+    runs-on: ${{ matrix.target.runner }}
     needs: setup-matrix
     env:
       GOVER: 1.22
-      GOOS: ${{ matrix.object.target_os }}
-      GOARCH: ${{ matrix.object.target_arch_go }}
+      GOOS: ${{ matrix.target.target_os }}
+      GOARCH: ${{ matrix.target.target_arch_go }}
 
     strategy:
       matrix:
-        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_build) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_build) }}
 
     steps:
       - uses: actions/checkout@v3
@@ -106,10 +111,10 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:
-          os: ${{ matrix.object.target_os }}
+          os: ${{ matrix.target.target_os }}
 
       - name: Restore build cache (macOS)
-        if: matrix.object.target_os == 'darwin'
+        if: matrix.target.target_os == 'darwin'
         run: |
           mkdir -p target
           if [ -d /Users/spiceai/build/target ]; then
@@ -117,7 +122,7 @@ jobs:
           fi
 
       - name: Restore build cache (Linux)
-        if: matrix.object.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         run: |
           mkdir -p target
           if [ -d /home/spiceai/build/target ]; then
@@ -125,7 +130,7 @@ jobs:
           fi
 
       - name: Restore build cache (Windows)
-        if: matrix.object.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: |
           mkdir -p target
           if (Test-Path C:/spiceai/build/target) {
@@ -136,21 +141,21 @@ jobs:
         run: make -C bin/spiced
 
       - name: Update build cache (macOS)
-        if: matrix.object.target_os == 'darwin'
+        if: matrix.target.target_os == 'darwin'
         run: |
           if [ -d /Users/spiceai/build/target ]; then
             rsync -av target/ /Users/spiceai/build/target/
           fi
 
       - name: Update build cache (Linux)
-        if: matrix.object.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         run: |
           if [ -d /home/spiceai/build/target ]; then
             rsync -av target/ /home/spiceai/build/target/
           fi
 
       - name: Update build cache (Windows)
-        if: matrix.object.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: |
           if (Test-Path C:/spiceai/build/target) {
             Copy-Item -Recurse -Force target/* C:/spiceai/build/target
@@ -160,42 +165,42 @@ jobs:
         run: make -C bin/spice
 
       - name: make spiced executable
-        if: matrix.object.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: |
           mv target/release/spiced spiced
           chmod +x spiced
 
       - name: make spice executable
-        if: matrix.object.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: |
           mv target/release/spice spice
           chmod +x spice
 
       - name: Save spice artifact
         uses: actions/upload-artifact@v4
-        if: matrix.object.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         with:
-          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: |
             spice
             spiced
 
   test_quickstart_dremio:
-    name: "E2E Test: Dremio quickstart, using ${{ matrix.object.target_os }}-${{ matrix.object.target_arch }}"
-    runs-on: ${{ matrix.object.runner }}
+    name: "E2E Test: Dremio quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
+    runs-on: ${{ matrix.target.runner }}
     needs:
       - build
       - setup-matrix
 
     strategy:
       matrix:
-        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
     steps:
-      - name: download artifacts - build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
         uses: actions/download-artifact@v4
         with:
-          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: ./build
 
       - name: Install spice
@@ -275,21 +280,21 @@ jobs:
           fi
 
   test_quickstart_spiceai:
-    name: "E2E Test: SpiceAI quickstart, using ${{ matrix.object.target_os }}-${{ matrix.object.target_arch }}"
-    runs-on: ${{ matrix.object.runner }}
+    name: "E2E Test: SpiceAI quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
+    runs-on: ${{ matrix.target.runner }}
     needs:
       - build
       - setup-matrix
 
     strategy:
       matrix:
-        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
     steps:
-      - name: download artifacts - build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
         uses: actions/download-artifact@v4
         with:
-          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: ./build
 
       - name: Install spice
@@ -368,19 +373,19 @@ jobs:
           fi
 
   test_quickstart_data_postgres:
-    name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.object.target_os }}-${{ matrix.object.target_arch }}"
-    runs-on: ${{ matrix.object.runner }}
+    name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
+    runs-on: ${{ matrix.target.runner }}
     needs:
       - build
       - setup-matrix
 
     strategy:
       matrix:
-        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
     steps:
       - name: Install PostgreSQL (Linux)
-        if: matrix.object.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y postgresql
@@ -391,7 +396,7 @@ jobs:
           sudo -u postgres createdb testdb
 
       - name: Install PostgreSQL (MacOS)
-        if: matrix.object.target_os == 'darwin'
+        if: matrix.target.target_os == 'darwin'
         run: |
           brew install postgresql
           brew services start postgresql
@@ -418,10 +423,10 @@ jobs:
           psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
           psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
 
-      - name: download artifacts - build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
         uses: actions/download-artifact@v4
         with:
-          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: ./build
 
       - name: Install spice
@@ -502,8 +507,8 @@ jobs:
           fi
 
   test_local_acceleration:
-    name: "E2E Test: acceleration on ${{ matrix.object.name }} using ${{ matrix.acceleration.engine }}"
-    runs-on: ${{ matrix.object.runner }}
+    name: "E2E Test: acceleration on ${{ matrix.target.name }} using ${{ matrix.acceleration.engine }}"
+    runs-on: ${{ matrix.target.runner }}
     needs:
       - build
       - setup-matrix
@@ -519,13 +524,13 @@ jobs:
             { engine: sqlite, mode: file },
             # { engine: postgres},
           ]
-        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
     steps:
-      - name: download artifacts - build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
         uses: actions/download-artifact@v4
         with:
-          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: ./build
 
       - name: Install spice

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -48,7 +48,7 @@ jobs:
               }
             ];
       - name: Get result
-        run: echo "${{ steps.setup-build-matrix.outputs.result }}"
+        run: echo '${{ steps.setup-build-matrix.outputs.result }}'
 
       - name: Set up test matrix
         uses: actions/github-script@v7

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -26,8 +26,7 @@ jobs:
         id: setup-build-matrix
         with:
           script: |
-            console.log(context);
-            return [
+            const matrix = [
               {
                 name: "Linux x64",
                 runner: "rust",
@@ -47,16 +46,16 @@ jobs:
                 target_arch: "x86_64",
                 target_arch_go: "amd64"
               }
-            ].slice(0, 1);
-      - name: Get result
-        run: echo '${{ steps.setup-build-matrix.outputs.result }}'
+            ];
+
+            return contet.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
 
       - name: Set up test matrix
         uses: actions/github-script@v7
         id: setup-test-matrix
         with:
           script: |
-            return [
+            const matrix = [
               {
                 name: "Linux x64",
                 runner: "ubuntu-latest",
@@ -76,7 +75,9 @@ jobs:
                 target_arch: "x86_64",
                 target_arch_go: "amd64"
               }
-            ].slice(0, 1);
+            ];
+
+            return contet.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
 
   build:
     name: Build ${{ matrix.object.name }} binaries

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -192,10 +192,10 @@ jobs:
         object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
     steps:
-      - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+      - name: download artifacts - build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
         uses: actions/download-artifact@v4
         with:
-          name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          name: build_${{ matrix.object.target_os }}_${{ matrix.object.target_arch }}
           path: ./build
 
       - name: Install spice

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -6,16 +6,62 @@ on:
       - trunk
       - release-*
 
-  # pull_request:
-  #   branches:
-  #     - trunk
+  pull_request:
+    branches:
+      - trunk
 
   workflow_dispatch:
 
 jobs:
+  setup-matrix:
+    name: Setup strategy matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_build: ${{ steps.setup-build-matrix.outputs.result }}
+      matrix_test: ${{ steps.setup-test-matrix.outputs.result }}
+
+    steps:
+      - name: Set up build matrix
+        uses: actions/github-script@v7
+        id: setup-build-matrix
+        with:
+          script: |
+            return {
+              name: [ "Linux x64", "macOS aarch64 (Apple Silicon)", "macOS x64 (Intel)", "Windows x64"],
+              runner: [ "rust", "macos-14", "macos-12", "rust-windows-x64"],
+              target_os: [ "linux", "darwin", "darwin", "windows"],
+              target_arch: [ "x86_64", "aarch64", "x86_64", "x86_64"],
+              target_arch_go: [ "amd64", "arm64", "amd64", "amd64"],
+            };
+
+      - name: Set up test matrix
+        uses: actions/github-script@v7
+        id: setup-test-matrix
+        with:
+          script: |
+            return {
+              name: [ "Linux x64", "macOS aarch64 (Apple Silicon)", "macOS x64 (Intel)", "Windows x64"],
+              runner: [ "ubuntu-latest", "macos-14", "macos-12", "rust-windows-x64"],
+              target_os: [ "linux", "darwin", "darwin", "windows"],
+              target_arch: [ "x86_64", "aarch64", "x86_64", "x86_64"],
+              target_arch_go: [ "amd64", "arm64", "amd64", "amd64"],
+            };
+
+        # ÷÷run: |
+        # echo "matrix=" >> "$GITHUB_OUTPUT"
+        # run: |
+        #   echo "::set-output name=matrix::${{ toJson({
+        #     "name": ["Linux x64", "macOS aarch64 (Apple Silicon)", "macOS x64 (Intel)", "Windows x64"],
+        #     "runner": ["ubuntu-latest", "macos-14", "macos-12", "rust-windows-x64"],
+        #     "target_os": ["linux", "darwin", "darwin", "windows"],
+        #     "target_arch": ["x86_64", "aarch64", "x86_64", "x86_64"],
+        #     "target_arch_go": ["amd64", "arm64", "amd64", "amd64"]
+        #   }) }}"
+
   build:
     name: Build ${{ matrix.name }} binaries
     runs-on: ${{ matrix.runner }}
+    needs: setup-matrix
     env:
       GOVER: 1.22
       GOOS: ${{ matrix.target_os }}
@@ -23,27 +69,28 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - name: Linux x64
-            runner: rust
-            target_os: linux
-            target_arch: x86_64
-            target_arch_go: amd64
-          - name: macOS aarch64 (Apple Silicon)
-            runner: macos-14
-            target_os: darwin
-            target_arch: aarch64
-            target_arch_go: arm64
-          - name: macOS x64 (Intel)
-            runner: macos-12
-            target_os: darwin
-            target_arch: x86_64
-            target_arch_go: amd64
-          # - name: Windows x64
-          #   runner: rust-windows-x64
-          #   target_os: windows
-          #   target_arch: x86_64
-          #   target_arch_go: amd64
+        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_build) }}
+        # include:
+        #   - name: Linux x64
+        #     runner: rust
+        #     target_os: linux
+        #     target_arch: x86_64
+        #     target_arch_go: amd64
+        #   - name: macOS aarch64 (Apple Silicon)
+        #     runner: macos-14
+        #     target_os: darwin
+        #     target_arch: aarch64
+        #     target_arch_go: arm64
+        #   - name: macOS x64 (Intel)
+        #     runner: macos-12
+        #     target_os: darwin
+        #     target_arch: x86_64
+        #     target_arch_go: amd64
+        # - name: Windows x64
+        #   runner: rust-windows-x64
+        #   target_os: windows
+        #   target_arch: x86_64
+        #   target_arch_go: amd64
 
     steps:
       - uses: actions/checkout@v3
@@ -141,27 +188,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: Linux x64
-            runner: ubuntu-latest
-            target_os: linux
-            target_arch: x86_64
-            target_arch_go: amd64
-          - name: macOS aarch64 (Apple Silicon)
-            runner: macos-14
-            target_os: darwin
-            target_arch: aarch64
-            target_arch_go: arm64
-          - name: macOS x64 (Intel)
-            runner: macos-12
-            target_os: darwin
-            target_arch: x86_64
-            target_arch_go: amd64
-          # - name: Windows x64
-          #   runner: rust-windows-x64
-          #   target_os: windows
-          #   target_arch: x86_64
-          #   target_arch_go: amd64
+        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_build) }}
+
+        # include:
+        #   - name: Linux x64
+        #     runner: ubuntu-latest
+        #     target_os: linux
+        #     target_arch: x86_64
+        #     target_arch_go: amd64
+        #   - name: macOS aarch64 (Apple Silicon)
+        #     runner: macos-14
+        #     target_os: darwin
+        #     target_arch: aarch64
+        #     target_arch_go: arm64
+        #   - name: macOS x64 (Intel)
+        #     runner: macos-12
+        #     target_os: darwin
+        #     target_arch: x86_64
+        #     target_arch_go: amd64
+        # - name: Windows x64
+        #   runner: rust-windows-x64
+        #   target_os: windows
+        #   target_arch: x86_64
+        #   target_arch_go: amd64
 
     steps:
       - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
@@ -246,399 +295,397 @@ jobs:
             exit 1
           fi
 
-  test_quickstart_spiceai:
-    name: "E2E Test: SpiceAI quickstart, using ${{ matrix.target_os }}-${{ matrix.target_arch }}"
-    runs-on: ${{ matrix.runner }}
-    needs: build
+  # test_quickstart_spiceai:
+  #   name: "E2E Test: SpiceAI quickstart, using ${{ matrix.target_os }}-${{ matrix.target_arch }}"
+  #   runs-on: ${{ matrix.runner }}
+  #   needs: build
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux x64
-            runner: ubuntu-latest
-            target_os: linux
-            target_arch: x86_64
-            target_arch_go: amd64
-          - name: macOS aarch64 (Apple Silicon)
-            runner: macos-14
-            target_os: darwin
-            target_arch: aarch64
-            target_arch_go: arm64
-          - name: macOS x64 (Intel)
-            runner: macos-12
-            target_os: darwin
-            target_arch: x86_64
-            target_arch_go: amd64
-          # - name: Windows x64
-          #   runner: rust-windows-x64
-          #   target_os: windows
-          #   target_arch: x86_64
-          #   target_arch_go: amd64
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - name: Linux x64
+  #           runner: ubuntu-latest
+  #           target_os: linux
+  #           target_arch: x86_64
+  #           target_arch_go: amd64
+  #         - name: macOS aarch64 (Apple Silicon)
+  #           runner: macos-14
+  #           target_os: darwin
+  #           target_arch: aarch64
+  #           target_arch_go: arm64
+  #         - name: macOS x64 (Intel)
+  #           runner: macos-12
+  #           target_os: darwin
+  #           target_arch: x86_64
+  #           target_arch_go: amd64
+  #         # - name: Windows x64
+  #         #   runner: rust-windows-x64
+  #         #   target_os: windows
+  #         #   target_arch: x86_64
+  #         #   target_arch_go: amd64
 
-    steps:
-      - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ./build
+  #   steps:
+  #     - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+  #         path: ./build
 
-      - name: Install spice
-        run: |
-          chmod +x ./build/spice
-          chmod +x ./build/spiced
-          mkdir -p "$HOME/.spice/bin"
-          mv ./build/spice "$HOME/.spice/bin"
-          mv ./build/spiced "$HOME/.spice/bin"
-          echo "$HOME/.spice/bin" >> $GITHUB_PATH
+  #     - name: Install spice
+  #       run: |
+  #         chmod +x ./build/spice
+  #         chmod +x ./build/spiced
+  #         mkdir -p "$HOME/.spice/bin"
+  #         mv ./build/spice "$HOME/.spice/bin"
+  #         mv ./build/spiced "$HOME/.spice/bin"
+  #         echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
-      - name: Check spice version
-        run: spice version
+  #     - name: Check spice version
+  #       run: spice version
 
-      - name: Init spice app
-        run: |
-          spice init test_app
+  #     - name: Init spice app
+  #       run: |
+  #         spice init test_app
 
-      - name: Spice dataset configure
-        working-directory: test_app
-        run: |
-          echo -e "eth_recent_blocks\neth recent logs\nspice.ai/eth.recent_blocks\ny" | spice dataset configure
-          # configure env secret store
-          echo -e "secrets:\n  store: env\n" >> spicepod.yaml
-          cat spicepod.yaml
+  #     - name: Spice dataset configure
+  #       working-directory: test_app
+  #       run: |
+  #         echo -e "eth_recent_blocks\neth recent logs\nspice.ai/eth.recent_blocks\ny" | spice dataset configure
+  #         # configure env secret store
+  #         echo -e "secrets:\n  store: env\n" >> spicepod.yaml
+  #         cat spicepod.yaml
 
-      - name: Start spice runtime
-        env:
-          SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
-        working-directory: test_app
-        run: |
-          spice run &
-           # time to initialize added dataset
-          sleep 5
+  #     - name: Start spice runtime
+  #       env:
+  #         SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
+  #       working-directory: test_app
+  #       run: |
+  #         spice run &
+  #          # time to initialize added dataset
+  #         sleep 5
 
-      - name: Wait for Spice runtime healthy
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+  #     - name: Wait for Spice runtime healthy
+  #       working-directory: test_app
+  #       timeout-minutes: 1
+  #       run: |
+  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
 
-      - name: Check datasets
-        working-directory: test_app
-        run: |
-          response=$(curl http://localhost:3000/v1/datasets)
-          echo $response | jq
-          length=$(echo $response | jq 'if type=="array" then length else empty end')
-          if [[ $length -ne 1 ]]; then
-            echo "Unexpected response: $response, expected 1 dataset but received $length"
-            exit 1
-          fi
+  #     - name: Check datasets
+  #       working-directory: test_app
+  #       run: |
+  #         response=$(curl http://localhost:3000/v1/datasets)
+  #         echo $response | jq
+  #         length=$(echo $response | jq 'if type=="array" then length else empty end')
+  #         if [[ $length -ne 1 ]]; then
+  #           echo "Unexpected response: $response, expected 1 dataset but received $length"
+  #           exit 1
+  #         fi
 
-      - name: Check eth_recent_blocks table exists
-        working-directory: test_app
-        run: |
-          response=$(curl -X POST \
-            -H "Content-Type: text/plain" \
-            -d "show tables;" \
-            http://localhost:3000/v1/sql
-          )
-          echo $response | jq
-          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
-          if [[ $table_exists -eq 0 ]]; then
-            echo "Unexpected response: table 'eth_recent_blocks' does not exist."
-            exit 1
-          fi
+  #     - name: Check eth_recent_blocks table exists
+  #       working-directory: test_app
+  #       run: |
+  #         response=$(curl -X POST \
+  #           -H "Content-Type: text/plain" \
+  #           -d "show tables;" \
+  #           http://localhost:3000/v1/sql
+  #         )
+  #         echo $response | jq
+  #         table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+  #         if [[ $table_exists -eq 0 ]]; then
+  #           echo "Unexpected response: table 'eth_recent_blocks' does not exist."
+  #           exit 1
+  #         fi
 
-      - name: Run Flight SQL query
-        working-directory: test_app
-        run: |
-          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
-          echo "$sql_output"
-          if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
-            echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
-            exit 1
-          fi
+  #     - name: Run Flight SQL query
+  #       working-directory: test_app
+  #       run: |
+  #         sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+  #         echo "$sql_output"
+  #         if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
+  #           echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
+  #           exit 1
+  #         fi
 
-  test_quickstart_data_postgres:
-    name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target_os }}-${{ matrix.target_arch }}"
-    runs-on: ${{ matrix.runner }}
-    needs: build
+  # test_quickstart_data_postgres:
+  #   name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target_os }}-${{ matrix.target_arch }}"
+  #   runs-on: ${{ matrix.runner }}
+  #   needs: build
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux x64
-            runner: ubuntu-latest
-            target_os: linux
-            target_arch: x86_64
-            target_arch_go: amd64
-          - name: macOS aarch64 (Apple Silicon)
-            runner: macos-14
-            target_os: darwin
-            target_arch: aarch64
-            target_arch_go: arm64
-          - name: macOS x64 (Intel)
-            runner: macos-12
-            target_os: darwin
-            target_arch: x86_64
-            target_arch_go: amd64
-          # - name: Windows x64
-          #   runner: rust-windows-x64
-          #   target_os: windows
-          #   target_arch: x86_64
-          #   target_arch_go: amd64
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - name: Linux x64
+  #           runner: ubuntu-latest
+  #           target_os: linux
+  #           target_arch: x86_64
+  #           target_arch_go: amd64
+  #         - name: macOS aarch64 (Apple Silicon)
+  #           runner: macos-14
+  #           target_os: darwin
+  #           target_arch: aarch64
+  #           target_arch_go: arm64
+  #         - name: macOS x64 (Intel)
+  #           runner: macos-12
+  #           target_os: darwin
+  #           target_arch: x86_64
+  #           target_arch_go: amd64
+  #         # - name: Windows x64
+  #         #   runner: rust-windows-x64
+  #         #   target_os: windows
+  #         #   target_arch: x86_64
+  #         #   target_arch_go: amd64
 
-    steps:
-      - name: Install PostgreSQL (Linux)
-        if: matrix.target_os == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql
-          sudo service postgresql start
-          sleep 5
-          sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || sudo -u postgres createuser -s postgres
-          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
-          sudo -u postgres createdb testdb
+  #   steps:
+  #     - name: Install PostgreSQL (Linux)
+  #       if: matrix.target_os == 'linux'
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y postgresql
+  #         sudo service postgresql start
+  #         sleep 5
+  #         sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || sudo -u postgres createuser -s postgres
+  #         sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+  #         sudo -u postgres createdb testdb
 
-      - name: Install PostgreSQL (MacOS)
-        if: matrix.target_os == 'darwin'
-        run: |
-          brew install postgresql
-          brew services start postgresql
-          sleep 5
-          createuser -s postgres
-          psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
-          createdb testdb
+  #     - name: Install PostgreSQL (MacOS)
+  #       if: matrix.target_os == 'darwin'
+  #       run: |
+  #         brew install postgresql
+  #         brew services start postgresql
+  #         sleep 5
+  #         createuser -s postgres
+  #         psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
+  #         createdb testdb
 
-      - name: Wait for PostgreSQL to start
-        run: sleep 10
+  #     - name: Wait for PostgreSQL to start
+  #       run: sleep 10
 
-      - name: Check PostgreSQL
-        env:
-          PGPASSWORD: postgres
-        run: psql -h localhost -U postgres -c 'SELECT version();'
+  #     - name: Check PostgreSQL
+  #       env:
+  #         PGPASSWORD: postgres
+  #       run: psql -h localhost -U postgres -c 'SELECT version();'
 
-      - name: Prepare PostgreSQL dataset
-        env:
-          PGPASSWORD: postgres
-        run: |
-          psql -h localhost -U postgres -d testdb -c 'CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);'
-          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
-          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
-          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
-          psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
+  #     - name: Prepare PostgreSQL dataset
+  #       env:
+  #         PGPASSWORD: postgres
+  #       run: |
+  #         psql -h localhost -U postgres -d testdb -c 'CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);'
+  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
+  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
+  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
+  #         psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
 
-      - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ./build
+  #     - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+  #         path: ./build
 
-      - name: Install spice
-        run: |
-          chmod +x ./build/spice
-          chmod +x ./build/spiced
-          mkdir -p "$HOME/.spice/bin"
-          mv ./build/spice "$HOME/.spice/bin"
-          mv ./build/spiced "$HOME/.spice/bin"
-          echo "$HOME/.spice/bin" >> $GITHUB_PATH
+  #     - name: Install spice
+  #       run: |
+  #         chmod +x ./build/spice
+  #         chmod +x ./build/spiced
+  #         mkdir -p "$HOME/.spice/bin"
+  #         mv ./build/spice "$HOME/.spice/bin"
+  #         mv ./build/spiced "$HOME/.spice/bin"
+  #         echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
-      - name: Check spice version
-        run: spice version
+  #     - name: Check spice version
+  #       run: spice version
 
-      - name: Init spice app
-        run: |
-          spice init test_app
+  #     - name: Init spice app
+  #       run: |
+  #         spice init test_app
 
-      - name: Spice dataset configure
-        working-directory: test_app
-        run: |
-          echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
-          # configure pg credentials
-          echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
-          # configure env secret store
-          echo -e "secrets:\n  store: env\n" >> spicepod.yaml
-          cat spicepod.yaml
+  #     - name: Spice dataset configure
+  #       working-directory: test_app
+  #       run: |
+  #         echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
+  #         # configure pg credentials
+  #         echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
+  #         # configure env secret store
+  #         echo -e "secrets:\n  store: env\n" >> spicepod.yaml
+  #         cat spicepod.yaml
 
-      - name: Start spice runtime
-        env:
-          SPICE_SECRET_POSTGRES_PASSWORD: postgres
-        working-directory: test_app
-        run: |
-          spice run &
-            # time to initialize added dataset
-          sleep 5
+  #     - name: Start spice runtime
+  #       env:
+  #         SPICE_SECRET_POSTGRES_PASSWORD: postgres
+  #       working-directory: test_app
+  #       run: |
+  #         spice run &
+  #           # time to initialize added dataset
+  #         sleep 5
 
-      - name: Wait for Spice runtime healthy
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+  #     - name: Wait for Spice runtime healthy
+  #       working-directory: test_app
+  #       timeout-minutes: 1
+  #       run: |
+  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
 
-      - name: Check datasets
-        working-directory: test_app
-        run: |
-          response=$(curl http://localhost:3000/v1/datasets)
-          echo $response | jq
-          length=$(echo $response | jq 'if type=="array" then length else empty end')
-          if [[ $length -ne 1 ]]; then
-            echo "Unexpected response: $response, expected 1 dataset but received $length"
-            exit 1
-          fi
+  #     - name: Check datasets
+  #       working-directory: test_app
+  #       run: |
+  #         response=$(curl http://localhost:3000/v1/datasets)
+  #         echo $response | jq
+  #         length=$(echo $response | jq 'if type=="array" then length else empty end')
+  #         if [[ $length -ne 1 ]]; then
+  #           echo "Unexpected response: $response, expected 1 dataset but received $length"
+  #           exit 1
+  #         fi
 
-      - name: Check eth_recent_blocks table exists
-        working-directory: test_app
-        run: |
-          response=$(curl -X POST \
-            -H "Content-Type: text/plain" \
-            -d "show tables;" \
-            http://localhost:3000/v1/sql
-          )
-          echo $response | jq
-          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
-          if [[ $table_exists -eq 0 ]]; then
-            echo "Unexpected response: table 'eth_recent_blocks' does not exist."
-            exit 1
-          fi
+  #     - name: Check eth_recent_blocks table exists
+  #       working-directory: test_app
+  #       run: |
+  #         response=$(curl -X POST \
+  #           -H "Content-Type: text/plain" \
+  #           -d "show tables;" \
+  #           http://localhost:3000/v1/sql
+  #         )
+  #         echo $response | jq
+  #         table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+  #         if [[ $table_exists -eq 0 ]]; then
+  #           echo "Unexpected response: table 'eth_recent_blocks' does not exist."
+  #           exit 1
+  #         fi
 
-      - name: Run Flight SQL query
-        working-directory: test_app
-        run: |
-          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
-          echo "$sql_output"
-          if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
-            echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
-            exit 1
-          fi
+  #     - name: Run Flight SQL query
+  #       working-directory: test_app
+  #       run: |
+  #         sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+  #         echo "$sql_output"
+  #         if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
+  #           echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
+  #           exit 1
+  #         fi
 
-  test_local_acceleration:
-    name: "E2E Test: acceleration on ${{ matrix.name }} using ${{ matrix.acceleration.engine }}"
-    runs-on: ${{ matrix.runner }}
-    needs: build
+  # test_local_acceleration:
+  #   name: "E2E Test: acceleration on ${{ matrix.name }} using ${{ matrix.acceleration.engine }}"
+  #   runs-on: ${{ matrix.runner }}
+  #   needs: build
 
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       acceleration: [
+  #           { engine: arrow, mode: memory },
+  #           { engine: duckdb, mode: memory },
+  #           { engine: duckdb, mode: file },
+  #           { engine: sqlite, mode: memory },
+  #           { engine: sqlite, mode: file },
+  #           # { engine: postgres},
+  #         ]
+  #       include:
+  #         - name: Linux x64
+  #           runner: ubuntu-latest
+  #           target_os: linux
+  #           target_arch: x86_64
+  #           target_arch_go: amd64
+  #         - name: macOS aarch64 (Apple Silicon)
+  #           runner: macos-14
+  #           target_os: darwin
+  #           target_arch: aarch64
+  #           target_arch_go: arm64
+  #         - name: macOS x64 (Intel)
+  #           runner: macos-12
+  #           target_os: darwin
+  #           target_arch: x86_64
+  #           target_arch_go: amd64
+  #         # - name: Windows x64
+  #         #   runner: rust-windows-x64
+  #         #   target_os: windows
+  #         #   target_arch: x86_64
+  #         #   target_arch_go: amd64
 
-    strategy:
-      fail-fast: false
-      matrix:
-        acceleration: [
-          { engine: arrow, mode: memory},
-          { engine: duckdb, mode: memory},
-          { engine: duckdb, mode: file},
-          { engine: sqlite, mode: memory},
-          { engine: sqlite, mode: file},
-          # { engine: postgres},
-        ]
-        include:
-          - name: Linux x64
-            runner: ubuntu-latest
-            target_os: linux
-            target_arch: x86_64
-            target_arch_go: amd64
-          - name: macOS aarch64 (Apple Silicon)
-            runner: macos-14
-            target_os: darwin
-            target_arch: aarch64
-            target_arch_go: arm64
-          - name: macOS x64 (Intel)
-            runner: macos-12
-            target_os: darwin
-            target_arch: x86_64
-            target_arch_go: amd64
-          # - name: Windows x64
-          #   runner: rust-windows-x64
-          #   target_os: windows
-          #   target_arch: x86_64
-          #   target_arch_go: amd64
+  #   steps:
+  #     - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
+  #         path: ./build
 
-    steps:
-      - name: download artifacts - build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ./build
+  #     - name: Install spice
+  #       run: |
+  #         chmod +x ./build/spice
+  #         chmod +x ./build/spiced
+  #         mkdir -p "$HOME/.spice/bin"
+  #         mv ./build/spice "$HOME/.spice/bin"
+  #         mv ./build/spiced "$HOME/.spice/bin"
+  #         echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
-      - name: Install spice
-        run: |
-          chmod +x ./build/spice
-          chmod +x ./build/spiced
-          mkdir -p "$HOME/.spice/bin"
-          mv ./build/spice "$HOME/.spice/bin"
-          mv ./build/spiced "$HOME/.spice/bin"
-          echo "$HOME/.spice/bin" >> $GITHUB_PATH
+  #     - name: Check spice version
+  #       run: spice version
 
-      - name: Check spice version
-        run: spice version
-    
-      - name: Init spice app
-        run: |
-          spice init test_app
+  #     - name: Init spice app
+  #       run: |
+  #         spice init test_app
 
-      - name: Spice dataset configure
-        working-directory: test_app
-        run: |
-          ENGINE=$(echo '${{ matrix.acceleration.engine }}')
-          MODE=$(echo '${{ matrix.acceleration.mode }}')
+  #     - name: Spice dataset configure
+  #       working-directory: test_app
+  #       run: |
+  #         ENGINE=$(echo '${{ matrix.acceleration.engine }}')
+  #         MODE=$(echo '${{ matrix.acceleration.mode }}')
 
-          
-          echo "datasets:" >> spicepod.yaml
-          echo "  - name: eth_recent_blocks" >> spicepod.yaml
-          echo "    from: spice.ai/eth.recent_blocks" >> spicepod.yaml
-          echo "    acceleration:" >> spicepod.yaml
-          echo "      enabled: true" >> spicepod.yaml
-          echo "      engine: $ENGINE" >> spicepod.yaml
-          if [[ -n "$MODE" ]]; then
-            echo "      mode: $MODE" >> spicepod.yaml
-          fi
-          # configure env secret store
-          echo -e "secrets:\n  store: env\n" >> spicepod.yaml
-          cat spicepod.yaml
+  #         echo "datasets:" >> spicepod.yaml
+  #         echo "  - name: eth_recent_blocks" >> spicepod.yaml
+  #         echo "    from: spice.ai/eth.recent_blocks" >> spicepod.yaml
+  #         echo "    acceleration:" >> spicepod.yaml
+  #         echo "      enabled: true" >> spicepod.yaml
+  #         echo "      engine: $ENGINE" >> spicepod.yaml
+  #         if [[ -n "$MODE" ]]; then
+  #           echo "      mode: $MODE" >> spicepod.yaml
+  #         fi
+  #         # configure env secret store
+  #         echo -e "secrets:\n  store: env\n" >> spicepod.yaml
+  #         cat spicepod.yaml
 
-      - name: Start spice runtime
-        env:
-          SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
-        working-directory: test_app
-        run: |
-          spice run &
-          sleep 5
+  #     - name: Start spice runtime
+  #       env:
+  #         SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
+  #       working-directory: test_app
+  #       run: |
+  #         spice run &
+  #         sleep 5
 
-      - name: Wait for Spice runtime healthy
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+  #     - name: Wait for Spice runtime healthy
+  #       working-directory: test_app
+  #       timeout-minutes: 1
+  #       run: |
+  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
 
-      - name: Check datasets
-        working-directory: test_app
-        run: |
-          response=$(curl http://localhost:3000/v1/datasets)
-          echo $response | jq
-          length=$(echo $response | jq 'if type=="array" then length else empty end')
-          if [[ $length -ne 1 ]]; then
-            echo "Unexpected response: $response, expected 1 dataset but received $length"
-            exit 1
-          fi
+  #     - name: Check datasets
+  #       working-directory: test_app
+  #       run: |
+  #         response=$(curl http://localhost:3000/v1/datasets)
+  #         echo $response | jq
+  #         length=$(echo $response | jq 'if type=="array" then length else empty end')
+  #         if [[ $length -ne 1 ]]; then
+  #           echo "Unexpected response: $response, expected 1 dataset but received $length"
+  #           exit 1
+  #         fi
 
-      - name: Check eth_recent_blocks table exists
-        working-directory: test_app
-        run: |
-          response=$(curl -X POST \
-            -H "Content-Type: text/plain" \
-            -d "show tables;" \
-            http://localhost:3000/v1/sql
-          )
-          echo $response | jq
-          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
-          if [[ $table_exists -eq 0 ]]; then
-            echo "Unexpected response: table 'taxi_trips' does not exist."
-            exit 1
-          fi
-    
-      - name: Check Flight SQL query
-        working-directory: test_app
-        run: |
-          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
-          echo "$sql_output"
-          if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
-            echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
-            exit 1
-          fi
+  #     - name: Check eth_recent_blocks table exists
+  #       working-directory: test_app
+  #       run: |
+  #         response=$(curl -X POST \
+  #           -H "Content-Type: text/plain" \
+  #           -d "show tables;" \
+  #           http://localhost:3000/v1/sql
+  #         )
+  #         echo $response | jq
+  #         table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+  #         if [[ $table_exists -eq 0 ]]; then
+  #           echo "Unexpected response: table 'taxi_trips' does not exist."
+  #           exit 1
+  #         fi
+
+  #     - name: Check Flight SQL query
+  #       working-directory: test_app
+  #       run: |
+  #         sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+  #         echo "$sql_output"
+  #         if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
+  #           echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
+  #           exit 1
+  #         fi

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -88,13 +88,13 @@ jobs:
         #   }) }}"
 
   build:
-    name: Build ${{ matrix.name }} binaries
-    runs-on: ${{ matrix.runner }}
+    name: Build ${{ matrix.object.name }} binaries
+    runs-on: ${{ matrix.object.runner }}
     needs: setup-matrix
     env:
       GOVER: 1.22
-      GOOS: ${{ matrix.target_os }}
-      GOARCH: ${{ matrix.target_arch_go }}
+      GOOS: ${{ matrix.object.target_os }}
+      GOARCH: ${{ matrix.object.target_arch_go }}
 
     strategy:
       matrix:
@@ -210,14 +210,16 @@ jobs:
             spiced
 
   test_quickstart_dremio:
-    name: "E2E Test: Dremio quickstart, using ${{ matrix.target_os }}-${{ matrix.target_arch }}"
-    runs-on: ${{ matrix.runner }}
-    needs: build
+    name: "E2E Test: Dremio quickstart, using ${{ matrix.object.target_os }}-${{ matrix.object.target_arch }}"
+    runs-on: ${{ matrix.object.runner }}
+    needs:
+      - build
+      - setup-matrix
 
     strategy:
       fail-fast: false
       matrix:
-        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_build) }}
+        object: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
 
         # include:
         #   - name: Linux x64

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -111,9 +111,8 @@ jobs:
       - run: rustup toolchain install stable --profile minimal
 
       - uses: Swatinem/rust-cache@v2
-        # test run
-        # with:
-        #   save-if: ${{ github.ref == 'refs/heads/trunk' }}
+        with:
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       # - name: Set up Rust
       #   uses: ./.github/actions/setup-rust

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -22,42 +22,12 @@ jobs:
     name: Setup strategy matrix
     runs-on: ubuntu-latest
     outputs:
-      matrix_build: ${{ steps.setup-build-matrix.outputs.result }}
-      matrix_test: ${{ steps.setup-test-matrix.outputs.result }}
+      matrix: ${{ steps.setup-matrix.outputs.result }}
 
     steps:
-      - name: Set up build matrix
+      - name: Set up matrix
         uses: actions/github-script@v7
-        id: setup-build-matrix
-        with:
-          script: |
-            const matrix = [
-              {
-                name: "Linux x64",
-                runner: "ubuntu-latest",
-                target_os: "linux",
-                target_arch: "x86_64",
-                target_arch_go: "amd64"
-              }, {
-                name: "macOS aarch64 (Apple Silicon)",
-                runner: "macos-14",
-                target_os: "darwin",
-                target_arch: "aarch64",
-                target_arch_go: "arm64"
-              }, {
-                name: "macOS x64 (Intel)",
-                runner: "macos-12",
-                target_os: "darwin",
-                target_arch: "x86_64",
-                target_arch_go: "amd64"
-              }
-            ];
-
-            return context.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
-
-      - name: Set up test matrix
-        uses: actions/github-script@v7
-        id: setup-test-matrix
+        id: setup-matrix
         with:
           script: |
             const matrix = [
@@ -95,7 +65,7 @@ jobs:
 
     strategy:
       matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_build) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v3
@@ -113,35 +83,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
-
-      # - name: Set up Rust
-      #   uses: ./.github/actions/setup-rust
-      #   with:
-      #     os: ${{ matrix.target.target_os }}
-
-      # - name: Restore build cache (macOS)
-      #   if: matrix.target.target_os == 'darwin'
-      #   run: |
-      #     mkdir -p target
-      #     if [ -d /Users/spiceai/build/target ]; then
-      #       rsync -av /Users/spiceai/build/target/ target/
-      #     fi
-
-      # - name: Restore build cache (Linux)
-      #   if: matrix.target.target_os == 'linux'
-      #   run: |
-      #     mkdir -p target
-      #     if [ -d /home/spiceai/build/target ]; then
-      #       rsync -av /home/spiceai/build/target/ target/
-      #     fi
-
-      # - name: Restore build cache (Windows)
-      #   if: matrix.target.target_os == 'windows'
-      #   run: |
-      #     mkdir -p target
-      #     if (Test-Path C:/spiceai/build/target) {
-      #       Copy-Item -Recurse -Force C:/spiceai/build/target/* target/
-      #     }
 
       - name: Build spiced
         run: make -C bin/spiced
@@ -200,7 +141,7 @@ jobs:
 
     strategy:
       matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     steps:
       - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
@@ -294,7 +235,7 @@ jobs:
 
     strategy:
       matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     steps:
       - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
@@ -387,7 +328,7 @@ jobs:
 
     strategy:
       matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     steps:
       - name: Install PostgreSQL (Linux)
@@ -530,7 +471,7 @@ jobs:
             { engine: sqlite, mode: file },
             # { engine: postgres},
           ]
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix_test) }}
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     steps:
       - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -111,8 +111,8 @@ jobs:
       - run: rustup toolchain install stable --profile minimal
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/trunk' }}
+        # with:
+        #   save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       # - name: Set up Rust
       #   uses: ./.github/actions/setup-rust

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -26,27 +26,56 @@ jobs:
         id: setup-build-matrix
         with:
           script: |
-            return {
-              name: [ "Linux x64", "macOS aarch64 (Apple Silicon)", "macOS x64 (Intel)", "Windows x64"],
-              runner: [ "rust", "macos-14", "macos-12", "rust-windows-x64"],
-              target_os: [ "linux", "darwin", "darwin", "windows"],
-              target_arch: [ "x86_64", "aarch64", "x86_64", "x86_64"],
-              target_arch_go: [ "amd64", "arm64", "amd64", "amd64"],
-            };
+            return [
+              {
+                name: "Linux x64",
+                runner: "rust",
+                target_os: "linux",
+                target_arch: "x86_64",
+                target_arch_go: "amd64"
+              }, {
+                name: "macOS aarch64 (Apple Silicon)",
+                runner: "macos-14",
+                target_os: "darwin",
+                target_arch: "aarch64",
+                target_arch_go: "arm64"
+              }, {
+                name: "macOS x64 (Intel)",
+                runner: "macos-12",
+                target_os: "darwin",
+                target_arch: "x86_64",
+                target_arch_go: "amd64"
+              }
+            ];
+      - name: Get result
+        run: echo "${{ steps.setup-build-matrix.outputs.result }}"
 
       - name: Set up test matrix
         uses: actions/github-script@v7
         id: setup-test-matrix
         with:
           script: |
-            return {
-              name: [ "Linux x64", "macOS aarch64 (Apple Silicon)", "macOS x64 (Intel)", "Windows x64"],
-              runner: [ "ubuntu-latest", "macos-14", "macos-12", "rust-windows-x64"],
-              target_os: [ "linux", "darwin", "darwin", "windows"],
-              target_arch: [ "x86_64", "aarch64", "x86_64", "x86_64"],
-              target_arch_go: [ "amd64", "arm64", "amd64", "amd64"],
-            };
-
+            return [
+              {
+                name: "Linux x64",
+                runner: "ubuntu-latest",
+                target_os: "linux",
+                target_arch: "x86_64",
+                target_arch_go: "amd64"
+              }, {
+                name: "macOS aarch64 (Apple Silicon)",
+                runner: "macos-14",
+                target_os: "darwin",
+                target_arch: "aarch64",
+                target_arch_go: "arm64"
+              }, {
+                name: "macOS x64 (Intel)",
+                runner: "macos-12",
+                target_os: "darwin",
+                target_arch: "x86_64",
+                target_arch_go: "amd64"
+              }
+            ];
         # ÷÷run: |
         # echo "matrix=" >> "$GITHUB_OUTPUT"
         # run: |


### PR DESCRIPTION
Split E2E CI Test into 2 cases:

- Run on each PR, with single linux target

![CleanShot 2024-03-26 at 17 00 44@2x](https://github.com/spiceai/spiceai/assets/827338/6f1651c2-68b7-4df8-89b3-66741f904b50)

- Run for all targets on merge to trunk/release, or manual trigger

![CleanShot 2024-03-26 at 17 39 55@2x](https://github.com/spiceai/spiceai/assets/827338/139181fd-e8ba-40ef-8e72-de56ca6dc263)

Also it will limit to have only one workflow running on a non trunk branch, automatically cancelling previous runs:

![CleanShot 2024-03-26 at 18 15 00@2x](https://github.com/spiceai/spiceai/assets/827338/a4e1fd7e-9792-49be-9a27-8d6b882a724a)

Switched to `ubuntu-latest` and https://github.com/Swatinem/rust-cache/tree/v2/ to speed up builds

