### PR TITLE
Display SchemaError automatically in spice sql

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
       "preLaunchTask": "rust: cargo build",
     },
     {
+      "type": "lldb",
+      "request": "launch",
+      "name": "[Rust] Debug spice sql",
+      "program": "${workspaceFolder}/target/debug/spiced",
+      "args": ["--repl"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "rust: cargo build",
+    },
+    {
       "name": "spice version",
       "type": "go",
       "request": "launch",


### PR DESCRIPTION
1. Fixes https://github.com/spiceai/spiceai/issues/888
 - Note: for simplicity and to make this logic more generic (extensible)/reduce special string manipulations I keep "Schema error: " as part of the error message.
![image](https://github.com/spiceai/spiceai/assets/981580/2d6354ad-7468-4a17-9af8-22f2988c0bb1)
 2. Adds VSCode debug profile for SQL REPL