### PR TITLE
Postgres login commands

### DIFF
--- a/bin/spice/cmd/login.go
+++ b/bin/spice/cmd/login.go
@@ -147,6 +147,36 @@ spice login s3 --access-key <key> --access-secret <secret>
 	}),
 }
 
+var postgresCmd = &cobra.Command{
+	Use:   "postgres",
+	Short: "Login to a Postgres instance",
+	Example: `
+spice login postgres --password <password>
+
+# See more at: https://docs.spiceai.org/
+`,
+	Run: CreateLoginRunFunc(api.AUTH_TYPE_POSTGRES, map[string]string{
+		passwordFlag: fmt.Sprintf("No password provided, use --%s or -p to provide a password", passwordFlag),
+	}, map[string]string{
+		passwordFlag: api.AUTH_PARAM_PG_PASSWORD,
+	}),
+}
+
+var postgresEngineCmd = &cobra.Command{
+	Use:   "engine",
+	Short: "Login to a Postgres instance as an engine",
+	Example: `
+spice login postgres engine --password <password>
+
+# See more at: https://docs.spiceai.org/
+`,
+	Run: CreateLoginRunFunc(api.AUTH_TYPE_POSTGRES, map[string]string{
+		passwordFlag: fmt.Sprintf("No password provided, use --%s or -p to provide a password", passwordFlag),
+	}, map[string]string{
+		passwordFlag: api.AUTH_PARAM_PG_PASSWORD,
+	}),
+}
+
 func CreateLoginRunFunc(authName string, requiredFlags map[string]string, flagToTomlKeys map[string]string) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 
@@ -309,6 +339,14 @@ func init() {
 	s3Cmd.Flags().StringP(accessKeyFlag, "k", "", "Access key")
 	s3Cmd.Flags().StringP(accessSecretFlag, "s", "", "Access Secret")
 	loginCmd.AddCommand(s3Cmd)
+
+	postgresCmd.Flags().BoolP("help", "h", false, "Print this help message")
+	postgresCmd.Flags().StringP(passwordFlag, "p", "", "Password")
+	loginCmd.AddCommand(postgresCmd)
+
+	postgresEngineCmd.Flags().BoolP("help", "h", false, "Print this help message")
+	postgresEngineCmd.Flags().StringP(passwordFlag, "p", "", "Password")
+	postgresCmd.AddCommand(postgresEngineCmd)
 
 	loginCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	loginCmd.Flags().StringP(apiKeyFlag, "k", "", "API key")

--- a/bin/spice/cmd/login.go
+++ b/bin/spice/cmd/login.go
@@ -170,7 +170,7 @@ spice login postgres engine --password <password>
 
 # See more at: https://docs.spiceai.org/
 `,
-	Run: CreateLoginRunFunc(api.AUTH_TYPE_POSTGRES, map[string]string{
+	Run: CreateLoginRunFunc(api.AUTH_TYPE_POSTGRES_ENGINE, map[string]string{
 		passwordFlag: fmt.Sprintf("No password provided, use --%s or -p to provide a password", passwordFlag),
 	}, map[string]string{
 		passwordFlag: api.AUTH_PARAM_PG_PASSWORD,

--- a/bin/spice/pkg/api/auth.go
+++ b/bin/spice/pkg/api/auth.go
@@ -1,10 +1,13 @@
 package api
 
 const (
-	AUTH_TYPE_SPICE_AI = "spiceai"
-	AUTH_TYPE_DREMIO   = "dremio"
-	AUTH_TYPE_S3       = "s3"
-	AUTH_TYPE_DATABRICKS = "databricks"
+	AUTH_TYPE_SPICE_AI        = "spiceai"
+	AUTH_TYPE_DREMIO          = "dremio"
+	AUTH_TYPE_S3              = "s3"
+	AUTH_TYPE_DATABRICKS      = "databricks"
+	AUTH_TYPE_POSTGRES        = "postgres"
+	AUTH_TYPE_POSTGRES_ENGINE = "postgres_engine"
+	AUTH_PARAM_PG_PASSWORD    = "pg_pass"
 
 	AUTH_PARAM_KEY      = "key"
 	AUTH_PARAM_PASSWORD = "password"
@@ -14,7 +17,7 @@ const (
 	AUTH_PARAM_AWS_DEFAULT_REGION    = "AWS_DEFAULT_REGION"
 	AUTH_PARAM_AWS_ACCESS_KEY_ID     = "AWS_ACCESS_KEY_ID"
 	AUTH_PARAM_AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
-	AUTH_PARAM_SECRET   = "secret"
+	AUTH_PARAM_SECRET                = "secret"
 )
 
 type Auth struct {

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -92,11 +92,14 @@ pub fn get_secret_or_param(
     secret_param_key: &str,
     param_key: &str,
 ) -> Option<String> {
-    if let Some(pg_secret_param_val) = params.get(secret_param_key) {
-        if let Some(secrets) = secret {
-            if let Some(pg_secret_val) = secrets.get(pg_secret_param_val) {
-                return Some(pg_secret_val.to_string());
-            };
+    let pg_secret_param_val = match params.get(secret_param_key) {
+        Some(val) => val,
+        None => param_key,
+    };
+
+    if let Some(secrets) = secret {
+        if let Some(pg_secret_val) = secrets.get(pg_secret_param_val) {
+            return Some(pg_secret_val.to_string());
         };
     };
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -153,7 +153,9 @@ impl DataFusion {
         let params: Arc<Option<HashMap<String, String>>> =
             Arc::new(dataset.acceleration_params().clone());
 
-        let secret_key = dataset.engine_secret().unwrap_or_default();
+        let secret_key = dataset
+            .engine_secret()
+            .unwrap_or(format!("{:?}_engine", acceleration.engine()).to_lowercase());
         let backend_secret = secrets_provider.read().await.get_secret(&secret_key).await;
 
         let data_backend: Box<dyn DataPublisher> =


### PR DESCRIPTION
This PR adds support for `spice login postgres` and `spice login postgres engine` to login to postgres as a Data Connector and Acceleration Engine respectively.

This PR also adds a default engine secret name as `{engine_name}_engine` and a default for postgres secret keys as `{param}` to make logging in a more seamless experience.

Closes #863 