### PR TITLE
Clean up postgres error when table doesn't exist

### DIFF
--- a/crates/db_connection_pool/src/dbconnection/postgresconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/postgresconn.rs
@@ -16,7 +16,7 @@ use super::Result;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to query: {source}"))]
+    #[snafu(display("{source}"))]
     QueryError {
         source: bb8_postgres::tokio_postgres::Error,
     },

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -81,7 +81,7 @@ impl DataConnector for Postgres {
             {
                 Ok(stream) => stream,
                 Err(e) => {
-                    tracing::error!("Failed to query Postgres: {e}");
+                    tracing::error!("{e}");
                     return vec![];
                 }
             };


### PR DESCRIPTION
This PR cleans up postgres errors to just be the underlying database error that is returned when a table doesn't exist.

Closes: #866 