### PR TITLE
Build a multi-platform Docker image for amd64/arm64

### DIFF
--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: Build Spice linux_amd64 Docker image
+    name: Build Spice linux_amd64/linux_arm64 Docker image
     runs-on: rust
 
     steps:
@@ -47,15 +47,13 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ startswith(github.ref, 'refs/tags/v') }}
           build-args: |
             REL_VERSION=${{ env.REL_VERSION }}
           tags: |
             ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}
-            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}-linux-amd64
             spiceai/spiceai:${{ env.REL_VERSION }}
-            spiceai/spiceai:${{ env.REL_VERSION }}-linux-amd64
             ${{ env.LATEST_GHCR_TAG }}
             ${{ env.LATEST_DOCKERHUB_TAG }}
 


### PR DESCRIPTION
Modifies the Docker build to also build a multi-platform image that includes arm64.

Test build: https://github.com/spiceai/spiceai/actions/runs/8446103613/job/23134370647