### PR TITLE
print out error message when failed to read parquet in get all data

### DIFF
--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -138,7 +138,7 @@ impl DataConnector for S3 {
                 Ok(df) => match df.collect().await {
                     Ok(batches) => batches,
                     Err(e) => {
-                        tracing::error!("Failed to collect record batches from S3: {e}");
+                        tracing::error!("Failed to retrieve data from S3: {e}");
                         vec![]
                     }
                 },


### PR DESCRIPTION
This improves the verbose logging when enchanting error when get all data from s3.