### PR TITLE
Fix E2E flaky test - give spice more time for loading dremio dataset

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -188,7 +188,7 @@ jobs:
           spice add spiceai/quickstart
           cat spicepod.yaml
           # time to initialize added dataset
-          sleep 5
+          sleep 10
 
       - name: Check datasets
         working-directory: test_app


### PR DESCRIPTION
Fixing flaky dremio test, which fails sometimes