### PR TITLE
Use hosted mac runner

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -39,7 +39,7 @@ jobs:
             target_arch: aarch64
             target_arch_go: arm64
           - name: macOS x64 (Intel)
-            runner: rust-osx-x64
+            runner: macos-13
             target_os: darwin
             target_arch: x86_64
             target_arch_go: amd64


### PR DESCRIPTION
Switches the build_and_release workflow to use the hosted mac intel runner