### PR TITLE
Add CommandGetTableTypes for Tableau min support

### DIFF
--- a/crates/runtime/src/flight/do_get.rs
+++ b/crates/runtime/src/flight/do_get.rs
@@ -37,6 +37,7 @@ pub(crate) async fn handle(
         Command::CommandGetTables(command) => {
             flightsql::get_tables::do_get(flight_svc, command).await
         }
+        Command::CommandGetTableTypes(command) => flightsql::get_table_types::do_get(&command),
         Command::CommandGetSqlInfo(command) => flightsql::get_sql_info::do_get(command),
         _ => Err(Status::unimplemented("Not yet implemented")),
     }

--- a/crates/runtime/src/flight/flightsql.rs
+++ b/crates/runtime/src/flight/flightsql.rs
@@ -1,6 +1,7 @@
 pub(crate) mod get_catalogs;
 pub(crate) mod get_schemas;
 pub(crate) mod get_sql_info;
+pub(crate) mod get_table_types;
 pub(crate) mod get_tables;
 pub(crate) mod prepared_statement_query;
 pub(crate) mod statement_query;

--- a/crates/runtime/src/flight/flightsql/get_table_types.rs
+++ b/crates/runtime/src/flight/flightsql/get_table_types.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use arrow::{
+    array::{RecordBatch, StringArray},
+    datatypes::{DataType, Field, Schema},
+};
+use arrow_flight::{
+    flight_service_server::FlightService, sql, FlightDescriptor, FlightEndpoint, FlightInfo, Ticket,
+};
+use datafusion::datasource::TableType;
+use tonic::{Request, Response, Status};
+
+use crate::{
+    flight::{flightsql::get_tables, record_batches_to_flight_stream, to_tonic_err, Service},
+    timing::{TimeMeasurement, TimedStream},
+};
+
+pub(crate) fn get_flight_info(
+    query: &sql::CommandGetTableTypes,
+    request: Request<FlightDescriptor>,
+) -> Response<FlightInfo> {
+    let fd = request.into_inner();
+    tracing::trace!("get_flight_info: {query:?}");
+    Response::new(FlightInfo {
+        flight_descriptor: Some(fd.clone()),
+        endpoint: vec![FlightEndpoint {
+            ticket: Some(Ticket { ticket: fd.cmd }),
+            ..Default::default()
+        }],
+        ..Default::default()
+    })
+}
+
+pub(crate) fn do_get(
+    query: &sql::CommandGetTableTypes,
+) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
+    let start = TimeMeasurement::new("flight_do_get_table_types_duration_ms", vec![]);
+    tracing::trace!("do_get_table_types: {query:?}");
+
+    let schema = Schema::new(vec![Field::new("table_type", DataType::Utf8, false)]);
+    let table_type = vec![
+        get_tables::table_type_name(TableType::Base),
+        get_tables::table_type_name(TableType::View),
+    ];
+    let record_batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(StringArray::from(table_type))],
+    )
+    .map_err(to_tonic_err)?;
+
+    Ok(Response::new(Box::pin(TimedStream::new(
+        record_batches_to_flight_stream(vec![record_batch]),
+        move || start,
+    ))
+        as <Service as FlightService>::DoGetStream))
+}

--- a/crates/runtime/src/flight/flightsql/get_tables.rs
+++ b/crates/runtime/src/flight/flightsql/get_tables.rs
@@ -81,7 +81,7 @@ pub(crate) async fn do_get(
         as <Service as FlightService>::DoGetStream))
 }
 
-fn table_type_name(table_type: TableType) -> &'static str {
+pub(crate) fn table_type_name(table_type: TableType) -> &'static str {
     match table_type {
         // from https://github.com/apache/arrow-datafusion/blob/26b8377b0690916deacf401097d688699026b8fb/datafusion/core/src/catalog/information_schema.rs#L284-L288
         TableType::Base => "BASE TABLE",

--- a/crates/runtime/src/flight/get_flight_info.rs
+++ b/crates/runtime/src/flight/get_flight_info.rs
@@ -34,6 +34,9 @@ pub(crate) async fn handle(
         Command::CommandGetSqlInfo(token) => {
             flightsql::get_sql_info::get_flight_info(&token, request)
         }
+        Command::CommandGetTableTypes(token) => {
+            Ok(flightsql::get_table_types::get_flight_info(&token, request))
+        }
         _ => Err(Status::unimplemented("Not yet implemented")),
     }
 }


### PR DESCRIPTION
Adds support for Flight SQL CommandGetTableTypes command. This allows Tableau to connect to Spice using JDBC driver.
 - PR does not add full support as Tableau requires at least CommandGetPrimaryKeys to work  properly but it enables to connect to Spice and work with Spice data by adding additional query (New Custom SQL) on top of Spice dataset

![image](https://github.com/spiceai/spiceai/assets/981580/7f4798e4-e93d-4982-b424-11f020f23e35)

![image](https://github.com/spiceai/spiceai/assets/981580/8c24a1ce-3841-424f-bd8f-4f388d995e16)
