### PR TITLE
Improve Spice REPL show tables & row limit

### DIFF
--- a/bin/spice/cmd/init.go
+++ b/bin/spice/cmd/init.go
@@ -39,7 +39,7 @@ spice init my_app
 		var spicepodName string
 		spicepodDir := "."
 
-		if len(args) < 1 {
+		if len(args) < 1 || args[0] == "." {
 			wd, err := os.Getwd()
 			if err != nil {
 				cmd.PrintErrf("Error getting current working directory: %s\n", err.Error())

--- a/bin/spice/pkg/spicepod/spicepod.go
+++ b/bin/spice/pkg/spicepod/spicepod.go
@@ -28,7 +28,7 @@ import (
 func CreateManifest(name string, spicepodDir string) (string, error) {
 	fs, err := os.Stat(name)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) && spicepodDir != "." {
 			err = os.Mkdir(name, 0766)
 			if err != nil {
 				return "", fmt.Errorf("Error creating directory: %w", err)
@@ -37,8 +37,13 @@ func CreateManifest(name string, spicepodDir string) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("Error checking if directory exists: %w", err)
 			}
-		} else {
+		} else if spicepodDir != "." {
 			return "", fmt.Errorf("Error checking if directory exists: %w", err)
+		} else {
+			fs, err = os.Stat(spicepodDir)
+			if err != nil {
+				return "", fmt.Errorf("Error checking if directory exists: %w", err)
+			}
 		}
 	}
 

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -88,7 +88,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         if line.is_empty() {
             continue;
         }
-        match line {
+        let line = match line {
             ".exit" | "exit" | "quit" | "q" => break,
             ".error" => {
                 match last_error {
@@ -111,8 +111,11 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                 println!("\nAny other line will be interpreted as a SQL query");
                 continue;
             }
-            _ => {}
-        }
+            "show tables" => {
+                "select table_name from information_schema.tables where table_schema = 'public'"
+            }
+            _ => line,
+        };
 
         let _ = rl.add_history_entry(line);
 
@@ -187,6 +190,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         let df = DataFrame::new(
             ctx.state(),
             LogicalPlanBuilder::scan(UNNAMED_TABLE, provider_as_source(Arc::new(provider)), None)?
+                .limit(0, Some(500))?
                 .build()?,
         );
 


### PR DESCRIPTION
Improves the Spice REPL to rewrite the query for `show tables` to just list the tables in the `public` schema.

Also limits the output to the terminal to 500 lines.

Also fixes a bug with `spice init` creating an empty dir.

Closes #952
Closes #874 
Closes #839