### PR TITLE
Add TLS support in Postgres connector

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -367,7 +367,7 @@ jobs:
           createdb testdb
 
       - name: Wait for PostgreSQL to start
-        run: sleep 35
+        run: sleep 10
 
       - name: Check PostgreSQL
         env:
@@ -423,7 +423,7 @@ jobs:
         run: |
           spice run &> spice.log &
           # time to initialize added dataset
-          sleep 10
+          sleep 35
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Start spice runtime
         working-directory: test_app
         run: |
-          spice run &> spice.log &
+          spice run &
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -226,13 +226,6 @@ jobs:
             exit 1
           fi
 
-      - name: Stop spice and check logs
-        working-directory: test_app
-        if: always()
-        run: |
-          killall spice
-          cat spice.log
-
   test_quickstart_spiceai:
     name: "E2E Test: SpiceAI quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
     runs-on: ${{ matrix.target.runner }}
@@ -280,9 +273,9 @@ jobs:
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
         working-directory: test_app
         run: |
-          spice run &> spice.log &
-          # time to initialize added dataset
-          sleep 10
+          spice run &
+           # time to initialize added dataset
+          sleep 5
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -326,154 +319,139 @@ jobs:
             exit 1
           fi
 
-      - name: Stop spice and check logs
-        working-directory: test_app
-        if: always()
+  test_quickstart_data_postgres:
+    name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
+    runs-on: ${{ matrix.target.runner }}
+    needs:
+      - build
+      - setup-matrix
+
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Install PostgreSQL (Linux)
+        if: matrix.target.target_os == 'linux'
         run: |
-          killall spice
-          cat spice.log
+          sudo apt-get update
+          sudo apt-get install -y postgresql
+          sudo service postgresql start
+          sleep 5
+          sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || sudo -u postgres createuser -s postgres
+          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+          sudo -u postgres createdb testdb
 
-  # TODO: test is broken, need to check postgres connection
-  # test_quickstart_data_postgres:
-  #   name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
-  #   runs-on: ${{ matrix.target.runner }}
-  #   needs:
-  #     - build
-  #     - setup-matrix
+      - name: Install PostgreSQL (MacOS)
+        if: matrix.target.target_os == 'darwin'
+        run: |
+          brew install postgresql
+          brew services start postgresql
+          sleep 5
+          createuser -s postgres
+          psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
+          createdb testdb
 
-  #   strategy:
-  #     matrix:
-  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+      - name: Wait for PostgreSQL to start
+        run: sleep 10
 
-  #   steps:
-  #     - name: Install PostgreSQL (Linux)
-  #       if: matrix.target.target_os == 'linux'
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y postgresql
-  #         sudo service postgresql start
-  #         sleep 5
-  #         sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || sudo -u postgres createuser -s postgres
-  #         sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
-  #         sudo -u postgres createdb testdb
+      - name: Check PostgreSQL
+        env:
+          PGPASSWORD: postgres
+        run: psql -h localhost -U postgres -c 'SELECT version();'
 
-  #     - name: Install PostgreSQL (MacOS)
-  #       if: matrix.target.target_os == 'darwin'
-  #       run: |
-  #         brew install postgresql
-  #         brew services start postgresql
-  #         sleep 5
-  #         createuser -s postgres
-  #         psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
-  #         createdb testdb
+      - name: Prepare PostgreSQL dataset
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d testdb -c 'CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);'
+          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
+          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
+          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
+          psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
 
-  #     - name: Wait for PostgreSQL to start
-  #       run: sleep 10
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: ./build
 
-  #     - name: Check PostgreSQL
-  #       env:
-  #         PGPASSWORD: postgres
-  #       run: psql -h localhost -U postgres -c 'SELECT version();'
+      - name: Install spice
+        run: |
+          chmod +x ./build/spice
+          chmod +x ./build/spiced
+          mkdir -p "$HOME/.spice/bin"
+          mv ./build/spice "$HOME/.spice/bin"
+          mv ./build/spiced "$HOME/.spice/bin"
+          echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
-  #     - name: Prepare PostgreSQL dataset
-  #       env:
-  #         PGPASSWORD: postgres
-  #       run: |
-  #         psql -h localhost -U postgres -d testdb -c 'CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);'
-  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
-  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
-  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
-  #         psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
+      - name: Check spice version
+        run: spice version
 
-  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #         path: ./build
+      - name: Init spice app
+        run: |
+          spice init test_app
 
-  #     - name: Install spice
-  #       run: |
-  #         chmod +x ./build/spice
-  #         chmod +x ./build/spiced
-  #         mkdir -p "$HOME/.spice/bin"
-  #         mv ./build/spice "$HOME/.spice/bin"
-  #         mv ./build/spiced "$HOME/.spice/bin"
-  #         echo "$HOME/.spice/bin" >> $GITHUB_PATH
+      - name: Spice dataset configure
+        working-directory: test_app
+        run: |
+          echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
+          # configure pg credentials
+          echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
+          # configure env secret store
+          echo -e "secrets:\n  store: env\n" >> spicepod.yaml
+          cat spicepod.yaml
 
-  #     - name: Check spice version
-  #       run: spice version
+      - name: Start spice runtime
+        env:
+          SPICE_SECRET_POSTGRES_PASSWORD: postgres
+        working-directory: test_app
+        run: |
+          spice run &
+            # time to initialize added dataset
+          sleep 5
 
-  #     - name: Init spice app
-  #       run: |
-  #         spice init test_app
+      - name: Wait for Spice runtime healthy
+        working-directory: test_app
+        timeout-minutes: 1
+        run: |
+          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
 
-  #     - name: Spice dataset configure
-  #       working-directory: test_app
-  #       run: |
-  #         echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
-  #         # configure pg credentials
-  #         echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
-  #         # configure env secret store
-  #         echo -e "secrets:\n  store: env\n" >> spicepod.yaml
-  #         cat spicepod.yaml
+      - name: Check datasets
+        working-directory: test_app
+        run: |
+          response=$(curl http://localhost:3000/v1/datasets)
+          echo $response | jq
+          length=$(echo $response | jq 'if type=="array" then length else empty end')
+          if [[ $length -ne 1 ]]; then
+            echo "Unexpected response: $response, expected 1 dataset but received $length"
+            exit 1
+          fi
 
-  #     - name: Start spice runtime
-  #       env:
-  #         SPICE_SECRET_POSTGRES_PASSWORD: postgres
-  #       working-directory: test_app
-  #       run: |
-  #         spice run &> spice.log &
-  #         # time to initialize added dataset
-  #         sleep 35
+      - name: Check eth_recent_blocks table exists
+        working-directory: test_app
+        run: |
+          response=$(curl -X POST \
+            -H "Content-Type: text/plain" \
+            -d "show tables;" \
+            http://localhost:3000/v1/sql
+          )
+          echo $response | jq
+          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+          if [[ $table_exists -eq 0 ]]; then
+            echo "Unexpected response: table 'eth_recent_blocks' does not exist."
+            exit 1
+          fi
 
-  #     - name: Wait for Spice runtime healthy
-  #       working-directory: test_app
-  #       timeout-minutes: 1
-  #       run: |
-  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
-
-  #     - name: Check datasets
-  #       working-directory: test_app
-  #       run: |
-  #         response=$(curl http://localhost:3000/v1/datasets)
-  #         echo $response | jq
-  #         length=$(echo $response | jq 'if type=="array" then length else empty end')
-  #         if [[ $length -ne 1 ]]; then
-  #           echo "Unexpected response: $response, expected 1 dataset but received $length"
-  #           exit 1
-  #         fi
-
-  #     - name: Check eth_recent_blocks table exists
-  #       working-directory: test_app
-  #       run: |
-  #         response=$(curl -X POST \
-  #           -H "Content-Type: text/plain" \
-  #           -d "show tables;" \
-  #           http://localhost:3000/v1/sql
-  #         )
-  #         echo $response | jq
-  #         table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
-  #         if [[ $table_exists -eq 0 ]]; then
-  #           echo "Unexpected response: table 'eth_recent_blocks' does not exist."
-  #           exit 1
-  #         fi
-
-  #     - name: Run Flight SQL query
-  #       working-directory: test_app
-  #       run: |
-  #         sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
-  #         echo "$sql_output"
-  #         if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
-  #           echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
-  #           exit 1
-  #         fi
-
-  #     - name: Stop spice and check logs
-  #       working-directory: test_app
-  #       if: always()
-  #       run: |
-  #         killall spice
-  #         cat spice.log
+      - name: Run Flight SQL query
+        working-directory: test_app
+        run: |
+          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+          echo "$sql_output"
+          if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
+            echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
+            exit 1
+          fi
 
   test_local_acceleration:
     name: "E2E Test: acceleration on ${{ matrix.target.name }} using ${{ matrix.acceleration.engine }}"
@@ -542,7 +520,7 @@ jobs:
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
         working-directory: test_app
         run: |
-          spice run &> spice.log &
+          spice run &
           sleep 5
 
       - name: Wait for Spice runtime healthy
@@ -586,10 +564,3 @@ jobs:
             echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
             exit 1
           fi
-
-      - name: Stop spice and check logs
-        working-directory: test_app
-        if: always()
-        run: |
-          killall spice
-          cat spice.log

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -411,7 +411,7 @@ jobs:
         run: |
           echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
           # configure pg credentials
-          echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
+          echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password\n  pg_sslmode: disable" >> ./datasets/eth_recent_blocks/dataset.yaml
           # configure env secret store
           echo -e "secrets:\n  store: env\n" >> spicepod.yaml
           cat spicepod.yaml

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -85,7 +85,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Build spiced
-        run: make -C bin/spiced DEV=1
+        run: make -C bin/spiced
 
       - name: Update build cache (macOS)
         if: matrix.target.target_os == 'darwin'

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -175,6 +175,8 @@ jobs:
         working-directory: test_app
         run: |
           spice run &> spice.log &
+          # time to initialize added dataset
+          sleep 10
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -423,7 +425,7 @@ jobs:
         run: |
           spice run &> spice.log &
           # time to initialize added dataset
-          sleep 35
+          sleep 10
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -542,7 +544,8 @@ jobs:
         working-directory: test_app
         run: |
           spice run &> spice.log &
-          sleep 5
+          # time to initialize added dataset
+          sleep 10
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Start spice runtime
         working-directory: test_app
         run: |
-          spice run &
+          spice run &> spice.log &
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -226,6 +226,13 @@ jobs:
             exit 1
           fi
 
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          killall spice
+          cat spice.log
+
   test_quickstart_spiceai:
     name: "E2E Test: SpiceAI quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
     runs-on: ${{ matrix.target.runner }}
@@ -273,7 +280,7 @@ jobs:
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
         working-directory: test_app
         run: |
-          spice run &
+          spice run &> spice.log &
           # time to initialize added dataset
           sleep 10
 
@@ -318,6 +325,13 @@ jobs:
             echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
             exit 1
           fi
+
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          killall spice
+          cat spice.log
 
   test_quickstart_data_postgres:
     name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
@@ -407,7 +421,7 @@ jobs:
           SPICE_SECRET_POSTGRES_PASSWORD: postgres
         working-directory: test_app
         run: |
-          spice run &
+          spice run &> spice.log &
           # time to initialize added dataset
           sleep 10
 
@@ -452,6 +466,13 @@ jobs:
             echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
             exit 1
           fi
+
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          killall spice
+          cat spice.log
 
   test_local_acceleration:
     name: "E2E Test: acceleration on ${{ matrix.target.name }} using ${{ matrix.acceleration.engine }}"
@@ -520,7 +541,7 @@ jobs:
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
         working-directory: test_app
         run: |
-          spice run &
+          spice run &> spice.log &
           sleep 5
 
       - name: Wait for Spice runtime healthy
@@ -564,3 +585,10 @@ jobs:
             echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
             exit 1
           fi
+
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          killall spice
+          cat spice.log

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Start spice runtime
         working-directory: test_app
         run: |
-          spice run &
+          spice run &> spice.log &
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -226,6 +226,13 @@ jobs:
             exit 1
           fi
 
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          killall spice
+          cat spice.log
+
   test_quickstart_spiceai:
     name: "E2E Test: SpiceAI quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
     runs-on: ${{ matrix.target.runner }}
@@ -273,9 +280,9 @@ jobs:
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
         working-directory: test_app
         run: |
-          spice run &
-           # time to initialize added dataset
-          sleep 5
+          spice run &> spice.log &
+          # time to initialize added dataset
+          sleep 10
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -318,6 +325,13 @@ jobs:
             echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
             exit 1
           fi
+
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          killall spice
+          cat spice.log
 
   test_quickstart_data_postgres:
     name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
@@ -407,9 +421,9 @@ jobs:
           SPICE_SECRET_POSTGRES_PASSWORD: postgres
         working-directory: test_app
         run: |
-          spice run &
-            # time to initialize added dataset
-          sleep 5
+          spice run &> spice.log &
+          # time to initialize added dataset
+          sleep 35
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -452,6 +466,13 @@ jobs:
             echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
             exit 1
           fi
+
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          killall spice
+          cat spice.log
 
   test_local_acceleration:
     name: "E2E Test: acceleration on ${{ matrix.target.name }} using ${{ matrix.acceleration.engine }}"
@@ -520,7 +541,7 @@ jobs:
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
         working-directory: test_app
         run: |
-          spice run &
+          spice run &> spice.log &
           sleep 5
 
       - name: Wait for Spice runtime healthy
@@ -564,3 +585,10 @@ jobs:
             echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
             exit 1
           fi
+
+      - name: Stop spice and check logs
+        working-directory: test_app
+        if: always()
+        run: |
+          killall spice
+          cat spice.log

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -274,8 +274,8 @@ jobs:
         working-directory: test_app
         run: |
           spice run &
-           # time to initialize added dataset
-          sleep 5
+          # time to initialize added dataset
+          sleep 10
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app
@@ -408,8 +408,8 @@ jobs:
         working-directory: test_app
         run: |
           spice run &
-            # time to initialize added dataset
-          sleep 5
+          # time to initialize added dataset
+          sleep 10
 
       - name: Wait for Spice runtime healthy
         working-directory: test_app

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -367,7 +367,7 @@ jobs:
           createdb testdb
 
       - name: Wait for PostgreSQL to start
-        run: sleep 10
+        run: sleep 35
 
       - name: Check PostgreSQL
         env:

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -85,7 +85,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/trunk' }}
 
       - name: Build spiced
-        run: make -C bin/spiced
+        run: make -C bin/spiced DEV=1
 
       - name: Update build cache (macOS)
         if: matrix.target.target_os == 'darwin'

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -333,146 +333,147 @@ jobs:
           killall spice
           cat spice.log
 
-  test_quickstart_data_postgres:
-    name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
-    runs-on: ${{ matrix.target.runner }}
-    needs:
-      - build
-      - setup-matrix
+  # TODO: test is broken, need to check postgres connection
+  # test_quickstart_data_postgres:
+  #   name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
+  #   runs-on: ${{ matrix.target.runner }}
+  #   needs:
+  #     - build
+  #     - setup-matrix
 
-    strategy:
-      matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+  #   strategy:
+  #     matrix:
+  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-    steps:
-      - name: Install PostgreSQL (Linux)
-        if: matrix.target.target_os == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql
-          sudo service postgresql start
-          sleep 5
-          sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || sudo -u postgres createuser -s postgres
-          sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
-          sudo -u postgres createdb testdb
+  #   steps:
+  #     - name: Install PostgreSQL (Linux)
+  #       if: matrix.target.target_os == 'linux'
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y postgresql
+  #         sudo service postgresql start
+  #         sleep 5
+  #         sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='postgres'" | grep -q 1 || sudo -u postgres createuser -s postgres
+  #         sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+  #         sudo -u postgres createdb testdb
 
-      - name: Install PostgreSQL (MacOS)
-        if: matrix.target.target_os == 'darwin'
-        run: |
-          brew install postgresql
-          brew services start postgresql
-          sleep 5
-          createuser -s postgres
-          psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
-          createdb testdb
+  #     - name: Install PostgreSQL (MacOS)
+  #       if: matrix.target.target_os == 'darwin'
+  #       run: |
+  #         brew install postgresql
+  #         brew services start postgresql
+  #         sleep 5
+  #         createuser -s postgres
+  #         psql -d postgres -c "ALTER USER postgres PASSWORD 'postgres';"
+  #         createdb testdb
 
-      - name: Wait for PostgreSQL to start
-        run: sleep 10
+  #     - name: Wait for PostgreSQL to start
+  #       run: sleep 10
 
-      - name: Check PostgreSQL
-        env:
-          PGPASSWORD: postgres
-        run: psql -h localhost -U postgres -c 'SELECT version();'
+  #     - name: Check PostgreSQL
+  #       env:
+  #         PGPASSWORD: postgres
+  #       run: psql -h localhost -U postgres -c 'SELECT version();'
 
-      - name: Prepare PostgreSQL dataset
-        env:
-          PGPASSWORD: postgres
-        run: |
-          psql -h localhost -U postgres -d testdb -c 'CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);'
-          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
-          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
-          psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
-          psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
+  #     - name: Prepare PostgreSQL dataset
+  #       env:
+  #         PGPASSWORD: postgres
+  #       run: |
+  #         psql -h localhost -U postgres -d testdb -c 'CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);'
+  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
+  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
+  #         psql -h localhost -U postgres -d testdb -c "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
+  #         psql -h localhost -U postgres -d testdb -c 'SELECT * FROM eth_recent_blocks;'
 
-      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          path: ./build
+  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #         path: ./build
 
-      - name: Install spice
-        run: |
-          chmod +x ./build/spice
-          chmod +x ./build/spiced
-          mkdir -p "$HOME/.spice/bin"
-          mv ./build/spice "$HOME/.spice/bin"
-          mv ./build/spiced "$HOME/.spice/bin"
-          echo "$HOME/.spice/bin" >> $GITHUB_PATH
+  #     - name: Install spice
+  #       run: |
+  #         chmod +x ./build/spice
+  #         chmod +x ./build/spiced
+  #         mkdir -p "$HOME/.spice/bin"
+  #         mv ./build/spice "$HOME/.spice/bin"
+  #         mv ./build/spiced "$HOME/.spice/bin"
+  #         echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
-      - name: Check spice version
-        run: spice version
+  #     - name: Check spice version
+  #       run: spice version
 
-      - name: Init spice app
-        run: |
-          spice init test_app
+  #     - name: Init spice app
+  #       run: |
+  #         spice init test_app
 
-      - name: Spice dataset configure
-        working-directory: test_app
-        run: |
-          echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
-          # configure pg credentials
-          echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
-          # configure env secret store
-          echo -e "secrets:\n  store: env\n" >> spicepod.yaml
-          cat spicepod.yaml
+  #     - name: Spice dataset configure
+  #       working-directory: test_app
+  #       run: |
+  #         echo -e "eth_recent_blocks\neth recent blocks\npostgres:eth_recent_blocks\ny" | spice dataset configure
+  #         # configure pg credentials
+  #         echo -e "params:\n  pg_host: localhost\n  pg_port: 5432\n  pg_db: testdb\n  pg_user: postgres\n  pg_pass_key: password" >> ./datasets/eth_recent_blocks/dataset.yaml
+  #         # configure env secret store
+  #         echo -e "secrets:\n  store: env\n" >> spicepod.yaml
+  #         cat spicepod.yaml
 
-      - name: Start spice runtime
-        env:
-          SPICE_SECRET_POSTGRES_PASSWORD: postgres
-        working-directory: test_app
-        run: |
-          spice run &> spice.log &
-          # time to initialize added dataset
-          sleep 35
+  #     - name: Start spice runtime
+  #       env:
+  #         SPICE_SECRET_POSTGRES_PASSWORD: postgres
+  #       working-directory: test_app
+  #       run: |
+  #         spice run &> spice.log &
+  #         # time to initialize added dataset
+  #         sleep 35
 
-      - name: Wait for Spice runtime healthy
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+  #     - name: Wait for Spice runtime healthy
+  #       working-directory: test_app
+  #       timeout-minutes: 1
+  #       run: |
+  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
 
-      - name: Check datasets
-        working-directory: test_app
-        run: |
-          response=$(curl http://localhost:3000/v1/datasets)
-          echo $response | jq
-          length=$(echo $response | jq 'if type=="array" then length else empty end')
-          if [[ $length -ne 1 ]]; then
-            echo "Unexpected response: $response, expected 1 dataset but received $length"
-            exit 1
-          fi
+  #     - name: Check datasets
+  #       working-directory: test_app
+  #       run: |
+  #         response=$(curl http://localhost:3000/v1/datasets)
+  #         echo $response | jq
+  #         length=$(echo $response | jq 'if type=="array" then length else empty end')
+  #         if [[ $length -ne 1 ]]; then
+  #           echo "Unexpected response: $response, expected 1 dataset but received $length"
+  #           exit 1
+  #         fi
 
-      - name: Check eth_recent_blocks table exists
-        working-directory: test_app
-        run: |
-          response=$(curl -X POST \
-            -H "Content-Type: text/plain" \
-            -d "show tables;" \
-            http://localhost:3000/v1/sql
-          )
-          echo $response | jq
-          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
-          if [[ $table_exists -eq 0 ]]; then
-            echo "Unexpected response: table 'eth_recent_blocks' does not exist."
-            exit 1
-          fi
+  #     - name: Check eth_recent_blocks table exists
+  #       working-directory: test_app
+  #       run: |
+  #         response=$(curl -X POST \
+  #           -H "Content-Type: text/plain" \
+  #           -d "show tables;" \
+  #           http://localhost:3000/v1/sql
+  #         )
+  #         echo $response | jq
+  #         table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+  #         if [[ $table_exists -eq 0 ]]; then
+  #           echo "Unexpected response: table 'eth_recent_blocks' does not exist."
+  #           exit 1
+  #         fi
 
-      - name: Run Flight SQL query
-        working-directory: test_app
-        run: |
-          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
-          echo "$sql_output"
-          if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
-            echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
-            exit 1
-          fi
+  #     - name: Run Flight SQL query
+  #       working-directory: test_app
+  #       run: |
+  #         sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+  #         echo "$sql_output"
+  #         if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
+  #           echo "Unexpected response from spice sql, failed to perform test query: $sql_output"
+  #           exit 1
+  #         fi
 
-      - name: Stop spice and check logs
-        working-directory: test_app
-        if: always()
-        run: |
-          killall spice
-          cat spice.log
+  #     - name: Stop spice and check logs
+  #       working-directory: test_app
+  #       if: always()
+  #       run: |
+  #         killall spice
+  #         cat spice.log
 
   test_local_acceleration:
     name: "E2E Test: acceleration on ${{ matrix.target.name }} using ${{ matrix.acceleration.engine }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
  "generic-array",
  "subtle",
@@ -2046,7 +2046,9 @@ dependencies = [
  "datafusion",
  "duckdb",
  "futures",
+ "native-tls",
  "ns_lookup",
+ "postgres-native-tls",
  "r2d2",
  "rusqlite",
  "secrets",
@@ -4553,6 +4555,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
+name = "postgres-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d442770e2b1e244bb5eb03b31c79b65bb2568f413b899eaba850fa945a65954"
+dependencies = [
+ "futures",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5111,6 +5126,7 @@ dependencies = [
  "once_cell",
  "opentelemetry-proto",
  "pin-project",
+ "postgres-native-tls",
  "prost 0.12.3",
  "quick-xml 0.23.1",
  "r2d2",
@@ -5990,9 +6006,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -25,6 +25,8 @@ spicepod = { path = "../spicepod" }
 rusqlite.workspace = true
 tokio-rusqlite.workspace = true
 ns_lookup = { path = "../ns_lookup" }
+native-tls = "0.2.11"
+postgres-native-tls = "0.5.0"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/crates/db_connection_pool/src/dbconnection/postgresconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/postgresconn.rs
@@ -19,11 +19,11 @@ use std::any::Any;
 use arrow::datatypes::SchemaRef;
 use arrow_sql_gen::postgres::rows_to_arrow;
 use bb8_postgres::tokio_postgres::types::ToSql;
-use bb8_postgres::tokio_postgres::NoTls;
 use bb8_postgres::PostgresConnectionManager;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::memory::MemoryStream;
 use datafusion::sql::TableReference;
+use postgres_native_tls::MakeTlsConnector;
 use snafu::prelude::*;
 
 use super::AsyncDbConnection;
@@ -44,12 +44,12 @@ pub enum Error {
 }
 
 pub struct PostgresConnection {
-    pub conn: bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+    pub conn: bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
 }
 
 impl<'a>
     DbConnection<
-        bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+        bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
         &'a (dyn ToSql + Sync),
     > for PostgresConnection
 {
@@ -65,7 +65,7 @@ impl<'a>
         &self,
     ) -> Option<
         &dyn AsyncDbConnection<
-            bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+            bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
             &'a (dyn ToSql + Sync),
         >,
     > {
@@ -76,11 +76,13 @@ impl<'a>
 #[async_trait::async_trait]
 impl<'a>
     AsyncDbConnection<
-        bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+        bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
         &'a (dyn ToSql + Sync),
     > for PostgresConnection
 {
-    fn new(conn: bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>) -> Self {
+    fn new(
+        conn: bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
+    ) -> Self {
         PostgresConnection { conn }
     }
 

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -141,8 +141,8 @@ where
     E: std::fmt::Display,
 {
     fn sink(&self, error: E) {
-        tracing::error!("Postgres Connection Error: {error}");
-        println!("Postgres Connection Error: {error}");
+        println!("Postgres Connection Error: {:?}", error);
+        tracing::error!("Postgres Connection Error: {:?}", error);
     }
 
     fn boxed_clone(&self) -> Box<dyn ErrorSink<E>> {

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -141,8 +141,8 @@ where
     E: std::fmt::Display,
 {
     fn sink(&self, error: E) {
-        tracing::error!("Postgres Connection Error: {}", error);
-        println!("Postgres Connection Error: {}", error);
+        tracing::error!("Postgres Connection Error: {error}");
+        println!("Postgres Connection Error: {error}");
     }
 
     fn boxed_clone(&self) -> Box<dyn ErrorSink<E>> {

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -83,6 +83,7 @@ rusqlite = { workspace = true, optional = true }
 tokio-rusqlite = { workspace = true, optional = true }
 pin-project = "1.0"
 lazy_static = "1.4.0"
+postgres-native-tls = "0.5.0"
 
 [features]
 default = ["duckdb", "postgres", "keyring-secret-store", "sqlite"]

--- a/crates/runtime/src/databackend/postgres.rs
+++ b/crates/runtime/src/databackend/postgres.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, mem, sync::Arc};
 use arrow::record_batch::RecordBatch;
 use arrow_sql_gen::statement::{CreateTableBuilder, InsertBuilder};
 use bb8_postgres::{
-    tokio_postgres::{types::ToSql, NoTls, Transaction},
+    tokio_postgres::{types::ToSql, Transaction},
     PostgresConnectionManager,
 };
 use datafusion::{execution::context::SessionContext, sql::TableReference};
@@ -27,6 +27,7 @@ use db_connection_pool::{
     dbconnection::postgresconn::PostgresConnection, postgrespool::PostgresConnectionPool,
     DbConnectionPool,
 };
+use postgres_native_tls::MakeTlsConnector;
 use secrets::Secret;
 use snafu::{prelude::*, ResultExt};
 use spicepod::component::dataset::Dataset;
@@ -78,7 +79,7 @@ pub struct PostgresBackend {
     name: String,
     pool: Arc<
         dyn DbConnectionPool<
-                bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+                bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
                 &'static (dyn ToSql + Sync),
             > + Send
             + Sync,
@@ -163,7 +164,7 @@ struct PostgresUpdate<'a> {
     update_type: UpdateType,
     pool: Arc<
         dyn DbConnectionPool<
-                bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+                bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
                 &'static (dyn ToSql + Sync),
             > + Send
             + Sync,

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -17,13 +17,13 @@ limitations under the License.
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
 use bb8_postgres::tokio_postgres::types::ToSql;
-use bb8_postgres::tokio_postgres::NoTls;
 use bb8_postgres::PostgresConnectionManager;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use db_connection_pool::postgrespool::PostgresConnectionPool;
 use db_connection_pool::DbConnectionPool;
 use futures::TryStreamExt;
+use postgres_native_tls::MakeTlsConnector;
 use secrets::Secret;
 use snafu::prelude::*;
 use spicepod::component::dataset::Dataset;
@@ -39,7 +39,7 @@ use super::{DataConnector, DataConnectorFactory};
 pub struct Postgres {
     pool: Arc<
         dyn DbConnectionPool<
-                bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+                bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
                 &'static (dyn ToSql + Sync),
             > + Send
             + Sync,
@@ -54,7 +54,7 @@ impl DataConnectorFactory for Postgres {
         Box::pin(async move {
             let pool: Arc<
                 dyn DbConnectionPool<
-                        bb8::PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+                        bb8::PooledConnection<'static, PostgresConnectionManager<MakeTlsConnector>>,
                         &'static (dyn ToSql + Sync),
                     > + Send
                     + Sync,


### PR DESCRIPTION
closes #868 

Added TLS support for PostgreSQL connector.
Added two optional params:

- `--pg_pg_sslmode`
- `--pg_insecure` - Allows TLS connectivity to servers with invalid/expired certificates

```yaml

  - from: postgres:my_table
    name: my_table
    description: neon db with TLS enabled
    acceleration:
      enabled: true
      refresh_interval: 10s
      refresh_mode: full
    params:
      pg_host: ep-little-surf-320325.us-west-2.aws.neon.tech
      pg_port: '5432'
      pg_db: main
      pg_user: ewgenius
      pg_pass_key: pgpass 
      pg_sslmode: require
      pg_insecure: true

```
