### PR TITLE
Gracefully handle connection resets

### DIFF
--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -105,40 +105,53 @@ impl DataConnector for SpiceAI {
         let spice_dataset_path = Self::spice_dataset_path(dataset);
         let spice_dataset_name = dataset.name.clone();
         Box::pin(stream! {
-          let mut stream = match flight.subscribe(&spice_dataset_path).await {
-            Ok(stream) => stream,
-            Err(error) => {
-              status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Error);
-              tracing::error!("Unable to subscribe to {spice_dataset_path}: {error}");
-              return;
-            }
-          };
-          loop {
-            let result = stream.next().await;
-            status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Refreshing);
-            match result {
-              Some(Ok(decoded_data)) => if let DecodedPayload::RecordBatch(batch) = decoded_data.payload {
-                    status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Ready);
+            let mut initial_connect = true;
+            loop {
+                // On connection reset, clear the data by sending an empty overwrite update and re-subscribe.
+                if !initial_connect {
                     yield DataUpdate {
-                        data: vec![batch],
-                        update_type: UpdateType::Append,
+                        data: vec![],
+                        update_type: UpdateType::Overwrite,
                     };
-                } else {
-                    status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Ready);
-                    continue;
-                },
-              Some(Err(error)) => {
-                status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Error);
-                tracing::error!("Error in subscription to {spice_dataset_path}: {error}");
-                continue;
-              },
-              None => {
-                status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Ready);
-                tracing::error!("Flight stream ended for {spice_dataset_path}");
-                break;
-              }
-            };
-          }
+                }
+
+                let mut stream = match flight.subscribe(&spice_dataset_path).await {
+                    Ok(stream) => stream,
+                    Err(error) => {
+                    status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Error);
+                    tracing::error!("Unable to subscribe to {spice_dataset_path}: {error}");
+                    return;
+                    }
+                };
+                loop {
+                    let result = stream.next().await;
+                    status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Refreshing);
+                    match result {
+                    Some(Ok(decoded_data)) => if let DecodedPayload::RecordBatch(batch) = decoded_data.payload {
+                            status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Ready);
+                            yield DataUpdate {
+                                data: vec![batch],
+                                update_type: UpdateType::Append,
+                            };
+                        } else {
+                            status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Ready);
+                            continue;
+                        },
+                    Some(Err(error)) => {
+                        status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Error);
+                        tracing::error!("Error in subscription to {spice_dataset_path}: {error}");
+                        continue;
+                    },
+                    None => {
+                        status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Ready);
+                        tracing::error!("Flight stream ended for {spice_dataset_path}");
+                        break;
+                    }
+                    };
+                }
+
+                initial_connect = false;
+            }
         })
     }
 

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -109,6 +109,7 @@ impl DataConnector for SpiceAI {
             loop {
                 // On connection reset, clear the data by sending an empty overwrite update and re-subscribe.
                 if !initial_connect {
+                    tracing::info!("Reconnecting to {spice_dataset_path}");
                     yield DataUpdate {
                         data: vec![],
                         update_type: UpdateType::Overwrite,
@@ -139,7 +140,8 @@ impl DataConnector for SpiceAI {
                         },
                     Some(Err(error)) => {
                         status::update_dataset(spice_dataset_name.clone(), status::ComponentStatus::Error);
-                        tracing::error!("Error in subscription to {spice_dataset_path}: {error}");
+                        tracing::debug!("Error in subscription to {spice_dataset_path}: {error}");
+                        tracing::error!("Error in subscription to {spice_dataset_path}");
                         continue;
                     },
                     None => {


### PR DESCRIPTION
Handle connection resets in DoExchange by adding another loop in the main work loop and resetting the data on every iteration.