### PR TITLE
Show schema and data plan errors more friendly (`spice sql`)

### DIFF
--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -210,16 +210,19 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
     Ok(())
 }
 
-const KNOWN_USER_FRIENDLY_MESSAGES: [&str; 1] = ["Schema error: "];
+const KNOWN_USER_FRIENDLY_MESSAGES_PREFIX: [&str; 2] =
+    ["Schema error: ", "Error during planning: "];
 
 fn get_user_friendly_message(err_msg: &str) -> String {
     // err_msg format: "status: Internal, message: "Schema error: ...", details: [], metadata: MetadataMap { headers: {} }"
     let parts: Vec<&str> = err_msg.split('"').collect();
     if parts.len() > 1 {
         let message = parts[1];
-        for &user_friendly_message in &KNOWN_USER_FRIENDLY_MESSAGES {
-            if message.starts_with(user_friendly_message) {
-                return message.to_string();
+        for &user_friendly_message_prefix in &KNOWN_USER_FRIENDLY_MESSAGES_PREFIX {
+            if message.starts_with(user_friendly_message_prefix) {
+                return message
+                    .replace(user_friendly_message_prefix, "")
+                    .to_string();
             }
         }
     }


### PR DESCRIPTION
Show schema and data plan errors more friendly. 

<img width="1073" alt="image" src="https://github.com/spiceai/spiceai/assets/981580/c7f6de10-fbb3-4da4-b402-0498fa3bc260">

Adding temporary improvement until we have proper way to pass error messages