### PR TITLE
DuckDB: friendly message instead of crash for unsupported type

### DIFF
--- a/crates/runtime/src/databackend/duckdb.rs
+++ b/crates/runtime/src/databackend/duckdb.rs
@@ -94,6 +94,18 @@ impl DataPublisher for DuckDBBackend {
                 );
             };
 
+            if let Some(batch) = data_update.data.first() {
+                for field in batch.schema().fields() {
+                    if field.data_type().is_nested() {
+                        let field_name = name + "." + field.name();
+                        tracing::error!("Unable to append {field_name}: nested types are not currently supported for local acceleration by DuckDB");
+                        return Err(Box::new(Error::DuckDB {
+                            source: duckdb::Error::AppendError,
+                        }) as Box<dyn std::error::Error>);
+                    }
+                }
+            }
+
             let mut duckdb_update = DuckDBUpdate {
                 name,
                 data: data_update.data,


### PR DESCRIPTION
Implements https://github.com/spiceai/spiceai/issues/878 for DuckDB

<img width="1090" alt="image" src="https://github.com/spiceai/spiceai/assets/981580/183023e9-63e5-45af-92d6-71fff3f9ed77">
