### PR TITLE
Improve Postgres VARCHAR and BPCHAR conversion

### DIFF
--- a/crates/arrow_sql_gen/src/postgres.rs
+++ b/crates/arrow_sql_gen/src/postgres.rs
@@ -196,8 +196,14 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
                 Type::FLOAT8 => {
                     handle_primitive_type!(builder, Type::FLOAT8, Float64Builder, f64, row, i);
                 }
-                Type::TEXT | Type::VARCHAR | Type::BPCHAR => {
+                Type::TEXT => {
                     handle_primitive_type!(builder, Type::TEXT, StringBuilder, &str, row, i);
+                }
+                Type::VARCHAR => {
+                    handle_primitive_type!(builder, Type::VARCHAR, StringBuilder, &str, row, i);
+                }
+                Type::BPCHAR => {
+                    handle_primitive_type!(builder, Type::BPCHAR, StringBuilder, &str, row, i);
                 }
                 Type::BOOL => {
                     handle_primitive_type!(builder, Type::BOOL, BooleanBuilder, bool, row, i);

--- a/test/tpch/tpch-spicepod/spicepod.yaml
+++ b/test/tpch/tpch-spicepod/spicepod.yaml
@@ -14,6 +14,7 @@ datasets:
       pg_db: tpch
       pg_user: postgres
       pg_pass: postgres
+      pg_insecure: "true"
 
   - from: postgres:lineitem
     name: lineitem
@@ -26,6 +27,7 @@ datasets:
       pg_db: tpch
       pg_user: postgres
       pg_pass: postgres
+      pg_insecure: "true"
 
   - from: postgres:nation
     name: nation
@@ -38,6 +40,7 @@ datasets:
       pg_db: tpch
       pg_user: postgres
       pg_pass: postgres
+      pg_insecure: "true"
 
   - from: postgres:orders
     name: orders
@@ -50,6 +53,7 @@ datasets:
       pg_db: tpch
       pg_user: postgres
       pg_pass: postgres
+      pg_insecure: "true"
 
   - from: postgres:part
     name: part
@@ -62,6 +66,7 @@ datasets:
       pg_db: tpch
       pg_user: postgres
       pg_pass: postgres
+      pg_insecure: "true"
 
   - from: postgres:partsupp
     name: partsupp
@@ -74,6 +79,7 @@ datasets:
       pg_db: tpch
       pg_user: postgres
       pg_pass: postgres
+      pg_insecure: "true"
 
   - from: postgres:region
     name: region
@@ -86,6 +92,7 @@ datasets:
       pg_db: tpch
       pg_user: postgres
       pg_pass: postgres
+      pg_insecure: "true"
   
   - from: postgres:supplier
     name: supplier
@@ -98,6 +105,7 @@ datasets:
       pg_db: tpch
       pg_user: postgres
       pg_pass: postgres
+      pg_insecure: "true"
 
 secrets:
   store: env


### PR DESCRIPTION
Fixes incorrect conversion of strings with trailing blanks when translating [BPCHAR(n) (fixed length, blank-padded)](https://www.postgresql.org/docs/current/datatype-character.html) from PG to Arrow.

Trailing blanks in PBCHAR values are always semantically insignificant. They should be disregarded when compare CHAR values, not included in LENGTH calculations, and removed when you convert a CHAR value to another string type.

This fixes TPC-H benchmark queries (`No data returned for query` Spice response): https://github.com/spiceai/spiceai/actions/runs/8475924421/job/23224846047