### PR TITLE
Don't fail spice login in environment with no browser

### DIFF
--- a/bin/spice/cmd/login.go
+++ b/bin/spice/cmd/login.go
@@ -70,7 +70,7 @@ spice login
 		cmd.Println("\nIf the browser does not open, please visit the following URL manually:")
 		cmd.Printf("\n%s\n\n", spiceAuthUrl)
 
-		browser.OpenURL(spiceApiClient.GetAuthUrl(authCode))
+		_ = browser.OpenURL(spiceApiClient.GetAuthUrl(authCode))
 
 		var accessToken string
 

--- a/bin/spice/cmd/login.go
+++ b/bin/spice/cmd/login.go
@@ -56,9 +56,6 @@ spice login
 	Run: func(cmd *cobra.Command, args []string) {
 		authCode := generateAuthCode()
 
-		cmd.Println("Opening browser to authenticate with Spice.ai")
-		cmd.Printf("Auth Code: %s-%s\n", authCode[:4], authCode[4:])
-
 		spiceApiClient := api.NewSpiceApiClient()
 		err := spiceApiClient.Init()
 		if err != nil {
@@ -66,11 +63,14 @@ spice login
 			os.Exit(1)
 		}
 
-		err = browser.OpenURL(spiceApiClient.GetAuthUrl(authCode))
-		if err != nil {
-			cmd.Println(err.Error())
-			os.Exit(1)
-		}
+		spiceAuthUrl := spiceApiClient.GetAuthUrl(authCode)
+
+		cmd.Println("Attempting to open Spice.ai authorization page in your default browser")
+		cmd.Printf("\nYour auth code:\n\n%s-%s\n", authCode[:4], authCode[4:])
+		cmd.Println("\nIf the browser does not open, please visit the following URL manually:")
+		cmd.Printf("\n%s\n\n", spiceAuthUrl)
+
+		browser.OpenURL(spiceApiClient.GetAuthUrl(authCode))
 
 		var accessToken string
 


### PR DESCRIPTION
closes #951 

- `spice login` does not end if no browser is available.
- added authorization link in the output

```
root@eb72a28c5e77:/usr/src/app# spice login
Attempting to open Spice.ai authorization page in your default browser

Your auth code:

CO48-9IUM

If the browser does not open, please visit the following URL manually:

https://spice.ai/auth/token?code=CO489IUM

Waiting for authentication...

```

https://github.com/spiceai/spiceai/assets/827338/0fedd846-3e5c-4b0f-9f14-77e8af95307d

