### PR TITLE
fix spice pods command

### DIFF
--- a/bin/spice/cmd/datasets.go
+++ b/bin/spice/cmd/datasets.go
@@ -31,7 +31,7 @@ spice datasets
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		_, dataset_statues, err := api.GetComponentStatuses(PROM_ENDPOINT)
+		_, dataset_statuses, err := api.GetComponentStatuses(PROM_ENDPOINT)
 		if err != nil {
 			cmd.PrintErrln(err.Error())
 		}
@@ -42,7 +42,7 @@ spice datasets
 		}
 		table := make([]interface{}, len(datasets))
 		for i, dataset := range datasets {
-			statusEnum, exists := dataset_statues[dataset.Name]
+			statusEnum, exists := dataset_statuses[dataset.Name]
 			if exists {
 				dataset.Status = statusEnum.String()
 			}

--- a/bin/spice/cmd/pods.go
+++ b/bin/spice/cmd/pods.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/api"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
+	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
 
 var podsCmd = &cobra.Command{
@@ -30,10 +31,23 @@ spice pods
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		err := api.WriteDataTable(rtcontext, "/v1/spicepods", api.Spicepod{})
+
+		spicepods, err := api.GetData[api.Spicepod](rtcontext, "/v1/spicepods")
 		if err != nil {
 			cmd.PrintErrln(err.Error())
 		}
+		table := make([]interface{}, len(spicepods))
+		for i, spicepod := range spicepods {
+			spicepodStatus := api.SpicepodStatus{
+				Version:           spicepod.Version,
+				Name:              spicepod.Name,
+				DatasetsCount:     len(spicepod.Datasets),
+				ModelsCount:       len(spicepod.Models),
+				DependenciesCount: len(spicepod.Dependencies),
+			}
+			table[i] = spicepodStatus
+		}
+		util.WriteTable(table)
 	},
 }
 

--- a/bin/spice/pkg/api/spicepod.go
+++ b/bin/spice/pkg/api/spicepod.go
@@ -17,6 +17,14 @@ limitations under the License.
 package api
 
 type Spicepod struct {
+	Version      string    `json:"version,omitempty" csv:"version" yaml:"version,omitempty"`
+	Name         string    `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
+	Datasets     []Dataset `json:"datasets,omitempty" csv:"datasets" yaml:"datasets,omitempty"`
+	Models       []Model   `json:"models,omitempty" csv:"models" yaml:"models,omitempty"`
+	Dependencies []string  `json:"dependencies,omitempty" csv:"depdencies" yaml:"dependencies,omitempty"`
+}
+
+type SpicepodStatus struct {
 	Version           string `json:"version,omitempty" csv:"version" yaml:"version,omitempty"`
 	Name              string `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
 	DatasetsCount     int    `json:"datasets_count,omitempty" csv:"datasets_count" yaml:"datasets_count,omitempty"`


### PR DESCRIPTION
the spice pods command didn't work because we were parsing the json response from the runtime into a format that just counts the datasets, models, and dependencies.

This change fixes the response to actually get counts of each element.  For details on models, datasets, and dependencies the user should be directed to spice datasets, spice models, respectively.  



There was also a typo in the datasets.go command that was fixed in this PR.  