### PR TITLE
Add basic Helm chart for spiceai

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: Spice.ai OSS
+description: Spice.ai OSS
+version: 0.1.0

--- a/deploy/chart/templates/spiceai-config.yaml
+++ b/deploy/chart/templates/spiceai-config.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+data:
+  spicepod.yaml: |
+    {{- toYaml .Values.spicepod | nindent 4 }}

--- a/deploy/chart/templates/spiceai.yaml
+++ b/deploy/chart/templates/spiceai.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: spiceai
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: Always
+          workingDir: /app
+          command:
+            [
+              "/usr/local/bin/spiced",
+              "--http",
+              "0.0.0.0:3000",
+              "--metrics",
+              "0.0.0.0:9000",
+              "--flight",
+              "0.0.0.0:50051",
+              "--open_telemetry",
+              "0.0.0.0:50052"
+            ]
+          env:
+            {{- if .Values.additionalEnv }}
+            {{- .Values.additionalEnv | toYaml | nindent 12 }}
+            {{- end }}
+          ports:
+            - containerPort: 3000
+              name: http
+            - containerPort: 9000
+              name: metrics
+            - containerPort: 50051
+              name: flight
+            - containerPort: 50052
+              name: otel
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 3000
+          volumeMounts:
+            {{- if .Values.volumeMounts }}
+            {{- .Values.volumeMounts | toYaml | nindent 12 }}
+            {{- end }}
+            - name: spiceai-config-volume
+              mountPath: /app/spicepod.yaml
+              subPath: spicepod.yaml
+          {{- if .Values.resources }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+      volumes:
+        {{- if .Values.volumes }}
+        {{- .Values.volumes | toYaml | nindent 8 }}
+        {{- end }}
+        - name: spiceai-config-volume
+          configMap:
+            name: {{ .Release.Name }}-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  ports:
+    - port: 3000
+      name: http
+    - port: 9000
+      name: metrics
+    - port: 50051
+      name: flight
+    - port: 50052
+      name: otel
+  selector:
+    app: {{ .Release.Name }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -14,5 +14,6 @@ spicepod:
       description: Demo taxi trips in s3
       acceleration:
         enabled: true
-        refresh_interval: 1h
-        refresh_mode: full
+        # Uncomment to refresh the acceleration on a schedule
+        # refresh_interval: 1h
+        # refresh_mode: full

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: spiceai/spiceai
+  # Replace this with a specific version, i.e. 0.10.0-alpha
+  tag: latest
+replicaCount: 1
+spicepod:
+  name: app
+  version: v1beta1
+  kind: Spicepod
+
+  datasets:
+    - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+      name: taxi_trips
+      description: Demo taxi trips in s3
+      acceleration:
+        enabled: true
+        refresh_interval: 1h
+        refresh_mode: full


### PR DESCRIPTION
Adds a basic Helm chart that deploys Spice.ai into Kubernetes with a Spicepod loaded from a configmap.

Install by running the following Helm commands:

```bash
helm repo add spiceai https://helm.spiceai.org
helm upgrade --install spiceai spiceai/spiceai
```