### PR TITLE
Update Helm to reference helm chart repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -40,18 +40,19 @@ assignees: ''
 - [ ] Merge [Quickstarts PRs](https://github.com/spiceai/samples/pulls)
 - [ ] Update release notes
 - [ ] Update acknowledgements by triggering [Generate Acknowledgements](https://github.com/spiceai/spiceai/actions/workflows/generate_acknowledgements.yml) workflow
-- [ ] Verify `version.txt` and version in `Cargo.toml` is correct using [docs/RELEASE.md](https://github.com/spiceai/spiceai/blob/trunk/docs/RELEASE.md#version-update)
+- [ ] Verify `version.txt` and version in `Cargo.toml` are correct using [docs/RELEASE.md](https://github.com/spiceai/spiceai/blob/trunk/docs/RELEASE.md#version-update)
 - [ ] Ensure [E2E Test CI](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_ci.yml) is green on trunk branch
 - [ ] QA DRI sign-off
 - [ ] Docs DRI sign-off
 - [ ] Create a new branch `release-v[semver]` and merge all relevant changes into it. E.g. `release-v0.9.1-alpha`
 - [ ] Release the new version by creating a `pre-release` [GitHub Release](https://github.com/spiceai/spiceai/releases/new) with the tag from the release branch. E.g. `v0.9.1-alpha`
 - [ ] Release any docs updates by creating a `v[semver]` tag.
+- [ ] If there were any changes to the [Helm chart](https://github.com/spiceai/spiceai/blob/trunk/deploy/chart), update the Helm chart version and trigger the [Release Chart](https://github.com/spiceai/helm-charts/actions/workflows/release.yml) workflow.
 - [ ] Final test pass on released binaries
 - [ ] Run [E2E Test Release Installation](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_release_install.yml)
 - [ ] Update `version.txt` and version in `Cargo.toml` to the next release version.
 - [ ] Update versions in [brew taps](https://github.com/spiceai/homebrew-spiceai)
-- [ ] Remove the released version from the [ROADMAP](docs/ROADMAP.md)
+- [ ] Remove the released version from the [ROADMAP](https://github.com/spiceai/spiceai/blob/trunk/docs/ROADMAP.md)
 
 ## Announcement Checklist
 

--- a/README.md
+++ b/README.md
@@ -224,8 +224,7 @@ Using Helm:
 
 ```bash
 helm repo add spiceai https://helm.spiceai.org
-helm repo update
-helm upgrade --install spiceai spiceai/spiceai
+helm install spiceai spiceai/spiceai
 ```
 
 ## 🏎️ Next Steps

--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ from spiceai/spiceai:latest
 Using Helm:
 
 ```bash
-git clone https://github.com/spiceai/spiceai.git
-cd spiceai
-helm upgrade --install spiceai ./deploy/chart
+helm repo add spiceai https://helm.spiceai.org
+helm repo update
+helm upgrade --install spiceai spiceai/spiceai
 ```
 
 ## 🏎️ Next Steps

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: spiceai
 description: Spice.ai OSS
-version: 0.1.0
+version: 0.1.1

--- a/deploy/chart/templates/spiceai.yaml
+++ b/deploy/chart/templates/spiceai.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ toYaml .Values.spicepod | sha256sum }}
+        checksum/spicepod: {{ toYaml .Values.spicepod | sha256sum }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/deploy/chart/templates/spiceai.yaml
+++ b/deploy/chart/templates/spiceai.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ toYaml .Values.spicepod | sha256sum }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}


### PR DESCRIPTION
Updates the Helm install steps to reference the chart repository at https://helm.spiceai.org