### PR TITLE
Remove dependency on `duckdb-rs` fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,7 +2284,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "duckdb"
 version = "0.10.1"
-source = "git+https://github.com/spicehq/duckdb-rs.git?rev=4e1cf06070891088a78085bef0aaa57944c19c8d#4e1cf06070891088a78085bef0aaa57944c19c8d"
+source = "git+https://github.com/duckdb/duckdb-rs.git?rev=b82db396d116fc2dd9311802544610c0f2d06c34#b82db396d116fc2dd9311802544610c0f2d06c34"
 dependencies = [
  "arrow",
  "cast",
@@ -3519,7 +3519,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "libduckdb-sys"
 version = "0.10.1"
-source = "git+https://github.com/spicehq/duckdb-rs.git?rev=4e1cf06070891088a78085bef0aaa57944c19c8d#4e1cf06070891088a78085bef0aaa57944c19c8d"
+source = "git+https://github.com/duckdb/duckdb-rs.git?rev=b82db396d116fc2dd9311802544610c0f2d06c34#b82db396d116fc2dd9311802544610c0f2d06c34"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ metrics = "0.22.0"
 datafusion = "35.0.0"
 arrow = "50.0.0"
 arrow-flight = "50.0.0"
-duckdb = { git = "https://github.com/spicehq/duckdb-rs.git", rev = "4e1cf06070891088a78085bef0aaa57944c19c8d" }
+duckdb = { git = "https://github.com/duckdb/duckdb-rs.git", rev = "b82db396d116fc2dd9311802544610c0f2d06c34" }
 tonic = "0.10.2"
 futures = "0.3.30"
 r2d2 = "0.8.10"


### PR DESCRIPTION
Now that https://github.com/duckdb/duckdb-rs/pull/259 is merged, we don't need to build using our fork.