### PR TITLE
Ensure unit and doc tests compile and run.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,13 +32,9 @@ jobs:
           fi
 
       - name: Set up Rust
-        run: |
-          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
-          source $HOME/.cargo/env || true
-          if ! command -v rustup &> /dev/null ; then
-            curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y  
-          fi
-          rustup toolchain install stable
+        uses: ./.github/actions/setup-rust
+        with:
+          os: 'linux'
 
       - run: make lint
 
@@ -62,7 +58,7 @@ jobs:
         with:
           os: 'linux'
 
-      - run: make ci
+      - run: make test ci
 
   build-docker:
     name: Build Docker Image

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ ci:
 	make -C bin/spice
 	export SPICED_TARGET_DIR=/workspace/spiceai/target; make -C bin/spiced
 
+.PHONY: test
+test: 
+	@cargo test --all
+
 .PHONY: lint
 lint:
 	go vet ./...

--- a/crates/arrow_sql_gen/src/statement.rs
+++ b/crates/arrow_sql_gen/src/statement.rs
@@ -427,7 +427,7 @@ mod tests {
         let sql = InsertBuilder::new("arrays", vec![batch]).build_postgres();
         assert_eq!(
             sql,
-            "INSERT INTO \"arrays\" (\"list\") VALUES (ARRAY [1,2,3]), (ARRAY [4,5,6]), (ARRAY [7,8,9])"
+            "INSERT INTO \"arrays\" (\"list\") VALUES (CAST(ARRAY [1,2,3] AS int4[])), (CAST(ARRAY [4,5,6] AS int4[])), (CAST(ARRAY [7,8,9] AS int4[]))"
         );
     }
 }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -135,7 +135,7 @@ pub trait DataConnectorFactory {
 /// If `stream_data_updates` is not supported for a dataset, the runtime will fall back to polling `get_all_data` and returning a
 /// `DataUpdate` that is constructed like:
 ///
-/// ```rust
+/// ```rust,ignore
 /// DataUpdate {
 ///    data: get_all_data(dataset),
 ///    update_type: UpdateType::Overwrite,

--- a/crates/runtime/src/timing.rs
+++ b/crates/runtime/src/timing.rs
@@ -28,6 +28,10 @@ use pin_project::pin_project;
 /// ## Usage
 ///   - Example, measure a function's whole duration:
 ///   ```
+///   use std::thread::sleep;
+///   use std::time::Duration;
+///   use runtime::measure_scope_ms;
+///
 ///   fn my_function() {
 ///     measure_scope_ms!("process_data");
 ///     sleep(Duration::from_secs(1))
@@ -37,9 +41,13 @@ use pin_project::pin_project;
 ///
 ///   - Example, measure a specific scope
 ///   ```
+///   use std::thread::sleep;
+///   use std::time::Duration;
+///   use runtime::measure_scope_ms;
+///
 ///   fn my_function() {
 ///     // Some work
-///     sleep(Duration::from_secs(1))
+///     sleep(Duration::from_secs(1));
 ///     {
 ///         // Some work we don't want to measure
 ///         let x = 1+2;
@@ -47,13 +55,15 @@ use pin_project::pin_project;
 ///         // Some work we want to measure
 ///         measure_scope_ms!("process_data");
 ///         let y = 2*3;
-///         sleep(Duration::from_secs(1))
+///         sleep(Duration::from_secs(1));
 ///     } // 'process_data' duration ends here.
 ///   }
 ///   ```
 ///   - **Example**: Add properties to the measurement (key `&str`, value `ToString`)
 ///   ```
-///   fn my_function(x: int, y: String) {
+///   use runtime::measure_scope_ms;
+///
+///   fn my_function(x: usize, y: String) {
 ///     measure_scope_ms!("process_data", "x" => x, "y" => y);
 ///   }
 ///   ```


### PR DESCRIPTION
Previously, running `$ cargo test --all` would fail with doctest
compilation issues as well as unit test failures. This change ensures
that the doctests compile and the unit test is updated.

The unit test in question (`test_table_insertion_with_list`) was
failing due to the generated SQL having `CAST` statements in it - the
`assert_eq` has been updated.

This change also adds a `test` make target that will run the rust
tests and ensures that this is run as a part of the PR GHA.
