### PR TITLE
Use shared spice.ai api_key to unblock e2e tests for external contributions

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -17,6 +17,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
   cancel-in-progress: true
 
+env:
+  # shared spice.ai api_key for test app
+  SPICE_SECRET_SPICEAI_KEY: "31303937|ade78ae18f26498e9a79fca73c41670d"
+
 jobs:
   setup-matrix:
     name: Setup strategy matrix
@@ -278,8 +282,6 @@ jobs:
           cat spicepod.yaml
 
       - name: Start spice runtime
-        env:
-          SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
         working-directory: test_app
         run: |
           spice run &> spice.log &
@@ -539,8 +541,6 @@ jobs:
           cat spicepod.yaml
 
       - name: Start spice runtime
-        env:
-          SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
         working-directory: test_app
         run: |
           spice run &> spice.log &


### PR DESCRIPTION
GitHub secrets are not passed to the runner when a workflow is triggered from a forked repository https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-encrypted-secrets-in-a-workflow

Added shared spice.ai api_key to allow running e2e tests for external contributions