### PR TITLE
timeout for databricks

### DIFF
--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -157,6 +157,8 @@ async fn get_table_provider(
     Ok(Arc::new(delta_table))
 }
 
+const DEFAULT_TIMEOUT: &str = "300s";
+
 async fn get_delta_table(
     secret: &Arc<Option<Secret>>,
     params: &Arc<Option<HashMap<String, String>>>,
@@ -184,6 +186,8 @@ async fn get_delta_table(
 
     if let Some(timeout) = timeout {
         storage_options.insert("timeout".to_string(), timeout);
+    } else {
+        storage_options.insert("timeout".to_string(), DEFAULT_TIMEOUT.to_string());
     }
 
     let delta_table = open_table_with_storage_options(table_uri, storage_options)

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -18,7 +18,6 @@ use async_trait::async_trait;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::options::ParquetReadOptions;
 use object_store::aws::AmazonS3Builder;
-use object_store::ClientOptions;
 use secrets::Secret;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -108,13 +107,6 @@ impl DataConnector for S3 {
         }
         if let Some(endpoint) = self.params.get("endpoint") {
             s3_builder = s3_builder.with_endpoint(endpoint);
-        }
-        if let Some(timeout) = self.params.get("timeout") {
-            if let Ok(parse) = timeout.parse() {
-                s3_builder = s3_builder.with_client_options(
-                    ClientOptions::default().with_timeout(std::time::Duration::from_secs(parse)),
-                );
-            }
         }
         if let Some(secret) = &self.secret {
             if let Some(key) = secret.get("key") {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::options::ParquetReadOptions;
 use object_store::aws::AmazonS3Builder;
+use object_store::ClientOptions;
 use secrets::Secret;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -107,6 +108,13 @@ impl DataConnector for S3 {
         }
         if let Some(endpoint) = self.params.get("endpoint") {
             s3_builder = s3_builder.with_endpoint(endpoint);
+        }
+        if let Some(timeout) = self.params.get("timeout") {
+            if let Ok(parse) = timeout.parse() {
+                s3_builder = s3_builder.with_client_options(
+                    ClientOptions::default().with_timeout(std::time::Duration::from_secs(parse)),
+                );
+            }
         }
         if let Some(secret) = &self.secret {
             if let Some(key) = secret.get("key") {


### PR DESCRIPTION
this will address one of the problem in #1033 .

Default timeout is 30s, which failed on my test - a query with where clause on 30G+ dataset.
```
sql> select * from transactions where hash = '0xeabc0e3694a6e202c360a48b380b4205ee15541b816d66f56da687b3a3a0fd79';
Error An internal error occurred while processing the query. Show technical details with '.error'
No data returned for query
```

Increase it to 120s fixed the issue, result is returned successfully.

By
```
params:
  timeout: 120s
```

```
sql> select * from transactions where hash = '0xeabc0e3694a6e202c360a48b380b4205ee15541b816d66f56da687b3a3a0fd79';



+--------------------------------------------------------------------+-------+-------------------+--------------------------------------------+--------------------------------------------+-------+-------------+-------+-----------------------------+------------------+--------------------------+--------------+----------------+-----------------------+--------------+--------------------------------------------------------------------+-----------------+--------------------------+------------------+-----------------------------+-----------+
| hash                                                               | nonce | transaction_index | from_address                               | to_address                                 | gas   | gas_price   | input | receipt_cumulative_gas_used | receipt_gas_used | receipt_contract_address | receipt_root | receipt_status | block_timestamp       | block_number | block_hash                                                         | max_fee_per_gas | max_priority_fee_per_gas | transaction_type | receipt_effective_gas_price | end_block |
+--------------------------------------------------------------------+-------+-------------------+--------------------------------------------+--------------------------------------------+-------+-------------+-------+-----------------------------+------------------+--------------------------+--------------+----------------+-----------------------+--------------+--------------------------------------------------------------------+-----------------+--------------------------+------------------+-----------------------------+-----------+
| 0xeabc0e3694a6e202c360a48b380b4205ee15541b816d66f56da687b3a3a0fd79 | 18    | 74                | 0xdc4392cfde1d0e467a3d7602bbbc500bfe20304d | 0xdc4392cfde1d0e467a3d7602bbbc500bfe20304d | 46814 | 90340839758 | input | 3950477                     | 21000            |                          |              | 1              | +54048-12-19T15:20:00 | 14100236     | 0x000d2ed73601ebe1cadd19bec68cf2e59a44239bf8ee29e43da801d0d49fa2ed | 110709536502    | 1650000000               | 2                | 90340839758                 | 14441014  |
+--------------------------------------------------------------------+-------+-------------------+--------------------------------------------+--------------------------------------------+-------+-------------+-------+-----------------------------+------------------+--------------------------+--------------+----------------+-----------------------+--------------+--------------------------------------------------------------------+-----------------+--------------------------+------------------+-----------------------------+-----------+

Query took: 1008.800289729 seconds. 1/1 rows displayed.
```