### PR TITLE
Fix MySQL `TINY` and `DATE` types support

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -133,7 +133,7 @@ jobs:
             spiced
 
   test_quickstart_dremio:
-    name: 'E2E Test: Dremio quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}'
+    name: "E2E Test: Dremio quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
     runs-on: ${{ matrix.target.runner }}
     # run quickstart with external service dependency only on manual trigger
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
@@ -238,7 +238,7 @@ jobs:
           cat spice.log
 
   test_quickstart_spiceai:
-    name: 'E2E Test: SpiceAI quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}'
+    name: "E2E Test: SpiceAI quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
     runs-on: ${{ matrix.target.runner }}
     # run quickstart with external service dependency only on manual trigger
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
@@ -340,7 +340,7 @@ jobs:
           cat spice.log
 
   test_quickstart_data_postgres:
-    name: 'E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}'
+    name: "E2E Test: SpiceAI Postgres quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
     runs-on: ${{ matrix.target.runner }}
     needs:
       - build
@@ -481,7 +481,7 @@ jobs:
           cat spice.log
 
   test_quickstart_data_mysql:
-    name: 'E2E Test: SpiceAI MySQL quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}'
+    name: "E2E Test: SpiceAI MySQL quickstart, using ${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}"
     runs-on: ${{ matrix.target.runner }}
     needs:
       - build
@@ -492,6 +492,8 @@ jobs:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install MySQL (Linux)
         if: matrix.target.target_os == 'linux'
         run: |
@@ -616,7 +618,7 @@ jobs:
           cat spice.log
 
   test_local_acceleration:
-    name: 'E2E Test: acceleration on ${{ matrix.target.name }} using ${{ matrix.acceleration.engine }}'
+    name: "E2E Test: acceleration on ${{ matrix.target.name }} using ${{ matrix.acceleration.engine }}"
     runs-on: ${{ matrix.target.runner }}
     needs:
       - build

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -521,11 +521,9 @@ jobs:
 
       - name: Prepare MysqlSQL dataset
         run: |
-          mysql -h localhost -utest_user -ppassword testdb -e "CREATE TABLE eth_recent_blocks (id SERIAL PRIMARY KEY, block_number INTEGER, block_hash TEXT, block_timestamp TIMESTAMP);"
-          mysql -h localhost -utest_user -ppassword testdb -e "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (1, '0x1234', '2022-01-01 00:00:00');"
-          mysql -h localhost -utest_user -ppassword testdb -e "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (2, '0x5678', '2022-01-01 00:00:00');"
-          mysql -h localhost -utest_user -ppassword testdb -e "INSERT INTO eth_recent_blocks (block_number, block_hash, block_timestamp) VALUES (3, '0x9abc', '2022-01-01 00:00:00');"
-          mysql -h localhost -utest_user -ppassword testdb -e "SELECT * FROM eth_recent_blocks;"
+
+          mysql -h localhost -utest_user -ppassword testdb < test/scripts/setup-data-mysql.sql
+          mysql -h localhost -utest_user -ppassword testdb -e "SELECT * FROM test_mysql_table;"
 
       - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
         uses: actions/download-artifact@v4
@@ -552,9 +550,9 @@ jobs:
       - name: Spice dataset configure
         working-directory: test_app
         run: |
-          echo -e "eth_recent_blocks\neth recent blocks\nmysql:eth_recent_blocks\ny" | spice dataset configure
+          echo -e "test_mysql_table\neth recent blocks\nmysql:test_mysql_table\ny" | spice dataset configure
           # configure mysql credentials
-          echo -e "params:\n  mysql_host: localhost\n  mysql_port: 3306\n  mysql_db: testdb\n  mysql_user: test_user\n  mysql_pass_key: password\n  mysql_sslmode: disabled" >> ./datasets/eth_recent_blocks/dataset.yaml
+          echo -e "params:\n  mysql_host: localhost\n  mysql_port: 3306\n  mysql_db: testdb\n  mysql_user: test_user\n  mysql_pass_key: password\n  mysql_sslmode: disabled" >> ./datasets/test_mysql_table/dataset.yaml
           # configure env secret store
           echo -e "secrets:\n  store: env\n" >> spicepod.yaml
           cat spicepod.yaml
@@ -585,7 +583,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check eth_recent_blocks table exists
+      - name: Check test_mysql_table table exists
         working-directory: test_app
         run: |
           response=$(curl -X POST \
@@ -594,16 +592,16 @@ jobs:
             http://localhost:3000/v1/sql
           )
           echo $response | jq
-          table_exists=$(echo $response | jq '[.[] | select(.table_name == "eth_recent_blocks")]' | jq 'length')
+          table_exists=$(echo $response | jq '[.[] | select(.table_name == "test_mysql_table")]' | jq 'length')
           if [[ $table_exists -eq 0 ]]; then
-            echo "Unexpected response: table 'eth_recent_blocks' does not exist."
+            echo "Unexpected response: table 'test_mysql_table' does not exist."
             exit 1
           fi
 
       - name: Run Flight SQL query
         working-directory: test_app
         run: |
-          sql_output=$(echo "select * from eth_recent_blocks limit 10;" | spice sql)
+          sql_output=$(echo "select * from test_mysql_table limit 10;" | spice sql)
           echo "$sql_output"
           if [[ $sql_output == *"error"* ]] || [[ $sql_output == *"not found"* ]]; then
             echo "Unexpected response from spice sql, failed to perform test query: $sql_output"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "app"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "snafu 0.8.2",
  "spicepod",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_sql_gen"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "arrow",
  "bigdecimal 0.3.1",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "db_connection_pool"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "arrow",
  "arrow_sql_gen",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "flight_client"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "flight_datafusion"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "flightpublisher"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "flightrepl"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "ansi_term",
  "arrow",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql_datafusion"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "flightsubscriber"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4185,6 +4185,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cc",
+ "chrono",
  "cmake",
  "crc32fast",
  "flate2",
@@ -4317,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "ns_lookup"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "snafu 0.8.2",
  "tracing",
@@ -5449,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "app",
  "arrow",
@@ -5944,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "secrets"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "async-trait",
  "aws-sdk-secretsmanager",
@@ -6245,7 +6246,7 @@ dependencies = [
 
 [[package]]
 name = "spiced"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "app",
  "clap",
@@ -6263,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "spicepod"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "fundu",
  "serde",
@@ -6286,7 +6287,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sql_provider_datafusion"
-version = "0.10.2-alpha"
+version = "0.11.0-alpha"
 dependencies = [
  "async-trait",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,4 @@ bb8 = "0.8"
 bb8-postgres = "0.8"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 tokio-rusqlite = "0.5.1"
-mysql_async = {version = "0.34.1", features = ["native-tls-tls"]}
+mysql_async = {version = "0.34.1", features = ["native-tls-tls", "chrono"]}

--- a/crates/arrow_sql_gen/src/arrow.rs
+++ b/crates/arrow_sql_gen/src/arrow.rs
@@ -17,8 +17,8 @@ limitations under the License.
 use arrow::{
     array::{
         ArrayBuilder, BinaryBuilder, BooleanBuilder, Date32Builder, Decimal128Builder,
-        Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder, ListBuilder,
-        StringBuilder, TimestampMicrosecondBuilder, TimestampMillisecondBuilder,
+        Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder, Int8Builder,
+        ListBuilder, StringBuilder, TimestampMicrosecondBuilder, TimestampMillisecondBuilder,
         TimestampNanosecondBuilder, TimestampSecondBuilder, UInt64Builder,
     },
     datatypes::{DataType, TimeUnit},
@@ -35,6 +35,7 @@ pub fn map_data_type_to_array_builder_optional(
 
 pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuilder> {
     match data_type {
+        DataType::Int8 => Box::new(Int8Builder::new()),
         DataType::Int16 => Box::new(Int16Builder::new()),
         DataType::Int32 => Box::new(Int32Builder::new()),
         DataType::Int64 => Box::new(Int64Builder::new()),
@@ -67,6 +68,7 @@ pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuil
         // We can't recursively call map_data_type_to_array_builder here because downcasting will not work if the
         // values_builder is boxed.
         DataType::List(values_field) => match values_field.data_type() {
+            DataType::Int8 => Box::new(ListBuilder::new(Int8Builder::new())),
             DataType::Int16 => Box::new(ListBuilder::new(Int16Builder::new())),
             DataType::Int32 => Box::new(ListBuilder::new(Int32Builder::new())),
             DataType::Int64 => Box::new(ListBuilder::new(Int64Builder::new())),

--- a/crates/arrow_sql_gen/src/mysql.rs
+++ b/crates/arrow_sql_gen/src/mysql.rs
@@ -297,7 +297,7 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
                                 }
                             };
 
-                            builder.append_value(Date32Type::from_naive_date(date))
+                            builder.append_value(Date32Type::from_naive_date(date));
                         }
                         None => builder.append_null(),
                     }

--- a/crates/arrow_sql_gen/src/mysql.rs
+++ b/crates/arrow_sql_gen/src/mysql.rs
@@ -281,25 +281,24 @@ pub fn rows_to_arrow(rows: &[Row]) -> Result<RecordBatch> {
                         },
                     )?;
 
-                    match v.clone() {
-                        Some(v) => {
-                            let date = match v {
-                                Value::Date(year, month, day, _, _, _, _) => {
-                                    chrono::NaiveDate::from_ymd_opt(
-                                        i32::from(year),
-                                        u32::from(month),
-                                        u32::from(day),
-                                    )
-                                    .unwrap_or_default()
-                                }
-                                _ => {
-                                    chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap_or_default()
-                                }
-                            };
+                    if let Some(v) = v.clone() {
+                        if let Value::Date(year, month, day, _, _, _, _) = v {
+                            let date = chrono::NaiveDate::from_ymd_opt(
+                                i32::from(year),
+                                u32::from(month),
+                                u32::from(day),
+                            );
 
-                            builder.append_value(Date32Type::from_naive_date(date));
+                            if let Some(date) = date {
+                                builder.append_value(Date32Type::from_naive_date(date));
+                            } else {
+                                builder.append_null();
+                            }
+                        } else {
+                            builder.append_null();
                         }
-                        None => builder.append_null(),
+                    } else {
+                        builder.append_null();
                     }
                 }
                 ColumnType::MYSQL_TYPE_TIMESTAMP => {

--- a/test/scripts/setup-data-mysql.sql
+++ b/test/scripts/setup-data-mysql.sql
@@ -1,0 +1,63 @@
+CREATE TABLE test_mysql_table (
+  id SERIAL PRIMARY KEY,
+  col_bit BIT(1),
+  col_tiny TINYINT,
+  col_short SMALLINT,
+  col_long INT,
+  col_longlong BIGINT,
+  col_float FLOAT,
+  col_double DOUBLE,
+  col_timestamp TIMESTAMP,
+  col_date DATE,
+  col_blob BLOB,
+  col_varchar VARCHAR(255),
+  col_string TEXT,
+  col_var_string VARCHAR(255)
+);
+
+INSERT INTO test_mysql_table (
+  col_bit,
+  col_tiny,
+  col_short,
+  col_long,
+  col_longlong,
+  col_float,
+  col_double,
+  col_timestamp,
+  col_date,
+  col_blob,
+  col_varchar,
+  col_string,
+  col_var_string
+) VALUES (
+  1,
+  1,
+  1,
+  1,
+  1,
+  1.1,
+  1.1,
+  '2019-01-01 00:00:00',
+  '2019-01-01',
+  'blob',
+  'varchar',
+  'string',
+  'var_string'
+);
+
+-- null not supported yet
+-- , (
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL,
+--   NULL
+-- );


### PR DESCRIPTION
- **Handle MYSQL_TYPE_DATE**
- **Add Int8 mapping for arrow types**

Fixed missing MySQL `DATE` type, and added int8 (MySQL `TINYINT`) to arrow types mapping

Before fix (mysql table with tinyint and date columns):

![CleanShot 2024-04-10 at 17 25 07@2x](https://github.com/spiceai/spiceai/assets/827338/d37355e2-e2d3-4f50-8dfd-29c63e5f0aeb)

![CleanShot 2024-04-10 at 17 26 28@2x](https://github.com/spiceai/spiceai/assets/827338/9807a243-689c-4f1f-9d76-dac9ef04fd1c)

After:

![CleanShot 2024-04-10 at 17 27 10@2x](https://github.com/spiceai/spiceai/assets/827338/19a1d5e1-7f8c-4fcf-bc9b-9fdb09ae789d)
