### PR TITLE
Add Api to trigger manual refresh for dataset

### DIFF
--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -44,6 +44,10 @@ pub(crate) fn routes(
         .route("/v1/sql", post(v1::query::post))
         .route("/v1/status", get(v1::status::get))
         .route("/v1/datasets", get(v1::datasets::get))
+        .route(
+            "/v1/datasets/:name/refresh",
+            post(v1::dataset_refresh::post),
+        )
         .route("/v1/spicepods", get(v1::spicepods::get))
         .route("/v1/models", get(v1::models::get))
         .route("/v1/models/:name/predict", get(v1::inference::get))

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -44,10 +44,7 @@ pub(crate) fn routes(
         .route("/v1/sql", post(v1::query::post))
         .route("/v1/status", get(v1::status::get))
         .route("/v1/datasets", get(v1::datasets::get))
-        .route(
-            "/v1/datasets/:name/refresh",
-            post(v1::dataset_refresh::post),
-        )
+        .route("/v1/datasets/:name/refresh", post(v1::datasets::refresh))
         .route("/v1/spicepods", get(v1::spicepods::get))
         .route("/v1/models", get(v1::models::get))
         .route("/v1/models/:name/predict", get(v1::inference::get))

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -408,7 +408,7 @@ pub(crate) mod datasets {
         let Some(dataset) = readable_app
             .datasets
             .iter()
-            .find(|d| d.name == dataset_name)
+            .find(|d| d.name.to_lowercase() == dataset_name.to_lowercase())
         else {
             return (
                 status::StatusCode::NOT_FOUND,

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -426,7 +426,7 @@ pub(crate) mod datasets {
                 status::StatusCode::BAD_REQUEST,
                 Json(DatasetRefreshResponse {
                     message: format!(
-                        "Dataset {dataset_name} does not have local acceleration enabled"
+                        "Dataset {dataset_name} does not have acceleration enabled"
                     ),
                 }),
             )

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -276,75 +276,12 @@ pub(crate) mod status {
     }
 }
 
-pub(crate) mod dataset_refresh {
-    use std::sync::Arc;
-
-    use app::App;
-    use axum::{
-        extract::Path,
-        http::status,
-        response::{IntoResponse, Response},
-        Extension, Json,
-    };
-
-    use crate::datafusion::DataFusion;
-
-    use serde::{Deserialize, Serialize};
-    use tokio::sync::RwLock;
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "lowercase")]
-    pub(crate) struct DatasetRefreshResponse {
-        pub message: String,
-    }
-
-    pub(crate) async fn post(
-        Extension(app): Extension<Arc<RwLock<Option<App>>>>,
-        Extension(_df): Extension<Arc<RwLock<DataFusion>>>,
-        Path(dataset_name): Path<String>,
-    ) -> Response {
-        let app_lock = app.read().await;
-        let Some(readable_app) = &*app_lock else {
-            return (status::StatusCode::INTERNAL_SERVER_ERROR).into_response();
-        };
-
-        let Some(dataset) = readable_app
-            .datasets
-            .iter()
-            .find(|d| d.name == dataset_name)
-        else {
-            return (
-                status::StatusCode::BAD_REQUEST,
-                Json(DatasetRefreshResponse {
-                    message: format!("Dataset {dataset_name} not found"),
-                }),
-            )
-                .into_response();
-        };
-
-        let acceleration_enabled = dataset.acceleration.as_ref().is_some_and(|f| f.enabled);
-
-        if !acceleration_enabled {
-            return (
-                status::StatusCode::BAD_REQUEST,
-                Json(DatasetRefreshResponse {
-                    message: format!(
-                        "Dataset {dataset_name} does not have local acceleration enabled"
-                    ),
-                }),
-            )
-                .into_response();
-        };
-
-        (status::StatusCode::NOT_IMPLEMENTED).into_response()
-    }
-}
-
 pub(crate) mod datasets {
     use std::sync::Arc;
 
     use app::App;
     use axum::{
+        extract::Path,
         extract::Query,
         http::status,
         response::{IntoResponse, Response},
@@ -450,6 +387,53 @@ pub(crate) mod datasets {
                 }
             },
         }
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    pub(crate) struct DatasetRefreshResponse {
+        pub message: String,
+    }
+
+    pub(crate) async fn refresh(
+        Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+        Extension(_df): Extension<Arc<RwLock<DataFusion>>>,
+        Path(dataset_name): Path<String>,
+    ) -> Response {
+        let app_lock = app.read().await;
+        let Some(readable_app) = &*app_lock else {
+            return (status::StatusCode::INTERNAL_SERVER_ERROR).into_response();
+        };
+
+        let Some(dataset) = readable_app
+            .datasets
+            .iter()
+            .find(|d| d.name == dataset_name)
+        else {
+            return (
+                status::StatusCode::BAD_REQUEST,
+                Json(DatasetRefreshResponse {
+                    message: format!("Dataset {dataset_name} not found"),
+                }),
+            )
+                .into_response();
+        };
+
+        let acceleration_enabled = dataset.acceleration.as_ref().is_some_and(|f| f.enabled);
+
+        if !acceleration_enabled {
+            return (
+                status::StatusCode::BAD_REQUEST,
+                Json(DatasetRefreshResponse {
+                    message: format!(
+                        "Dataset {dataset_name} does not have local acceleration enabled"
+                    ),
+                }),
+            )
+                .into_response();
+        };
+
+        (status::StatusCode::NOT_IMPLEMENTED).into_response()
     }
 }
 

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -276,6 +276,70 @@ pub(crate) mod status {
     }
 }
 
+pub(crate) mod dataset_refresh {
+    use std::sync::Arc;
+
+    use app::App;
+    use axum::{
+        extract::Path,
+        http::status,
+        response::{IntoResponse, Response},
+        Extension, Json,
+    };
+
+    use crate::datafusion::DataFusion;
+
+    use serde::{Deserialize, Serialize};
+    use tokio::sync::RwLock;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    pub(crate) struct DatasetRefreshResponse {
+        pub message: String,
+    }
+
+    pub(crate) async fn post(
+        Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+        Extension(_df): Extension<Arc<RwLock<DataFusion>>>,
+        Path(dataset_name): Path<String>,
+    ) -> Response {
+        let app_lock = app.read().await;
+        let Some(readable_app) = &*app_lock else {
+            return (status::StatusCode::INTERNAL_SERVER_ERROR).into_response();
+        };
+
+        let Some(dataset) = readable_app
+            .datasets
+            .iter()
+            .find(|d| d.name == dataset_name)
+        else {
+            return (
+                status::StatusCode::BAD_REQUEST,
+                Json(DatasetRefreshResponse {
+                    message: format!("Dataset {dataset_name} not found"),
+                }),
+            )
+                .into_response();
+        };
+
+        let acceleration_enabled = dataset.acceleration.as_ref().is_some_and(|f| f.enabled);
+
+        if !acceleration_enabled {
+            return (
+                status::StatusCode::BAD_REQUEST,
+                Json(DatasetRefreshResponse {
+                    message: format!(
+                        "Dataset {dataset_name} does not have local acceleration enabled"
+                    ),
+                }),
+            )
+                .into_response();
+        };
+
+        (status::StatusCode::NOT_IMPLEMENTED).into_response()
+    }
+}
+
 pub(crate) mod datasets {
     use std::sync::Arc;
 

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -411,7 +411,7 @@ pub(crate) mod datasets {
             .find(|d| d.name == dataset_name)
         else {
             return (
-                status::StatusCode::BAD_REQUEST,
+                status::StatusCode::NOT_FOUND,
                 Json(DatasetRefreshResponse {
                     message: format!("Dataset {dataset_name} not found"),
                 }),

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -425,9 +425,7 @@ pub(crate) mod datasets {
             return (
                 status::StatusCode::BAD_REQUEST,
                 Json(DatasetRefreshResponse {
-                    message: format!(
-                        "Dataset {dataset_name} does not have acceleration enabled"
-                    ),
+                    message: format!("Dataset {dataset_name} does not have acceleration enabled"),
                 }),
             )
                 .into_response();


### PR DESCRIPTION
Adds `v1/datasets/:name/refresh` Api endpoint to trigger manual dataset refresh.

Refresh logic is not implemented yet; `501 Not Implemented` is currently returned.

```
curl -i -X POST 127.0.0.1:3000/v1/datasets/taxi_trips/refresh
```

