### PR TITLE
Explicitly pass the schema to data accelerator SqlTable

### DIFF
--- a/crates/sql_provider_datafusion/src/lib.rs
+++ b/crates/sql_provider_datafusion/src/lib.rs
@@ -170,6 +170,7 @@ impl<T, P> SqlExec<T, P> {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Self> {
+        tracing::trace!("original schema {:?}", schema);
         let projected_schema = project_schema(schema, projections)?;
         Ok(Self {
             projected_schema,
@@ -188,6 +189,9 @@ impl<T, P> SqlExec<T, P> {
             .map(|f| format!("\"{}\"", f.name()))
             .collect::<Vec<_>>()
             .join(", ");
+
+        tracing::trace!("projected_schema {:?}", self.projected_schema);
+        tracing::trace!("sql columns {columns}");
 
         let limit_expr = match self.limit {
             Some(limit) => format!("LIMIT {limit}"),


### PR DESCRIPTION
Fixes an issue with the `sqlite` data accelerator where the schema couldn't be inferred - we know the schema up front, so just use that when constructing the `SqlTable` object.