### PR TITLE
Enable manual table refresh for AcceleratedTable

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -120,7 +120,6 @@ impl AcceleratedTable {
             refresh_trigger_receiver,
         );
 
-        // If a refresh_interval is specified, start a background task to send refresh signals periodically.
         if let Some(refresh_interval) = refresh_interval {
             let mut interval_timer = interval(refresh_interval);
             let sender_clone = refresh_trigger.clone();

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -79,13 +79,14 @@ impl AcceleratedTable {
         refresh_interval: Option<Duration>,
         object_store: Option<(Url, Arc<dyn ObjectStore + 'static>)>,
     ) -> Self {
-        let refresh_trigger = None;
+        let mut refresh_trigger = None;
         let mut refresh_trigger_receiver = None;
         let mut scheduled_refreshes_handle: Option<JoinHandle<()>> = None;
 
         if refresh_mode == RefreshMode::Full {
             let (trigger, receiver) = mpsc::channel::<()>(1);
             refresh_trigger_receiver = Some(receiver);
+            refresh_trigger = Some(trigger.clone());
             scheduled_refreshes_handle =
                 Self::schedule_regular_refreshes(refresh_interval, trigger).await;
         };

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -274,7 +274,8 @@ impl DataFusion {
             acceleration_settings.refresh_mode.clone(),
             dataset.refresh_interval(),
             obj_store,
-        );
+        )
+        .await;
 
         self.ctx
             .register_table(&dataset.name, Arc::new(accelerated_table))


### PR DESCRIPTION
Updates `AcceleratedTable` refresh logic implementation to use mpsc::channel. This enables manual table refresh.
 - channel capacity is set to 1 so that sender is waiting until there is capacity
 - added `trigger_refresh` method as an example of manual refresh 