### PR TITLE
Add support for "ssl_rootcert_path" parameter for mysql data connector

### DIFF
--- a/crates/db_connection_pool/src/mysqlpool.rs
+++ b/crates/db_connection_pool/src/mysqlpool.rs
@@ -135,8 +135,8 @@ fn get_ssl_opts(ssl_mode: &str, rootcert_path: Option<PathBuf>) -> Option<SslOpt
 
     let mut opts = SslOpts::default();
 
-    if rootcert_path.is_some() {
-        let path = rootcert_path.unwrap();
+    if let Some(rootcert_path) = rootcert_path {
+        let path = rootcert_path;
         opts = opts.with_root_certs(vec![path.into()]);
     }
 
@@ -148,7 +148,7 @@ fn get_ssl_opts(ssl_mode: &str, rootcert_path: Option<PathBuf>) -> Option<SslOpt
             .with_danger_skip_domain_validation(true);
     }
 
-    return Some(opts);
+    Some(opts)
 }
 
 #[must_use]


### PR DESCRIPTION
Allows establishing a secure MySQL connection with the required SSL and custom root certificate.

Example:

SSL Connection to AWS Aurora MySQL, with regional root certificate

```yaml
datasets:
  - from: mysql:test_mysql_table
    name: test_mysql_table
    description: eth recent blocks
    acceleration:
      enabled: true
      refresh_interval: 10s
      refresh_mode: full
    params:
      mysql_host: <...>.us-east-2.rds.amazonaws.com
      mysql_port: '3306'
      mysql_db: spice_test_db
      mysql_user: admin
      mysql_pass_key: password
      mysql_sslmode: required
      mysql_sslrootcert: us-east-2-bundle.pem
```

#### ⚠️ Note
In some cases, the `mysql_sslmode: required` setting with custom root certificate may not work on MacOS hosts due to stricter security policies: https://github.com/sfackler/rust-native-tls/issues/143
`mysql_sslmode: preferred` should be used in that case
