### PR TITLE
Refactor dataset params, to support non-string values

### DIFF
--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -215,8 +215,12 @@ pub async fn create_accelerator_table(
     acceleration_settings: &acceleration::Acceleration,
     acceleration_secret: Option<Secret>,
 ) -> Result<Arc<dyn TableProvider>> {
-    let params: Arc<Option<HashMap<String, String>>> =
-        Arc::new(acceleration_settings.params.clone());
+    let params = Arc::new(
+        acceleration_settings
+            .params
+            .clone()
+            .map(|params| params.as_string_map()),
+    );
 
     let table_name = table_name.to_string();
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -217,8 +217,7 @@ impl Runtime {
                 }
 
                 let source = ds.source();
-
-                let params = Arc::new(ds.params.clone());
+                let params = Arc::new(ds.params.clone().map(|params| params.as_string_map()));
                 let data_connector: Arc<dyn DataConnector> =
                     match Runtime::get_dataconnector_from_source(
                         &source,

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -23,6 +23,7 @@ use snafu::prelude::*;
 use crate::reader;
 pub mod dataset;
 pub mod model;
+pub mod params;
 pub mod secrets;
 
 pub trait WithDependsOn<T> {

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, fs, time::Duration};
+use std::{fs, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
-use super::WithDependsOn;
+use super::{params::Params, WithDependsOn};
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
@@ -59,7 +59,7 @@ pub struct Dataset {
     sql_ref: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub params: Option<HashMap<String, String>>,
+    pub params: Option<Params>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replication: Option<replication::Replication>,
@@ -148,7 +148,7 @@ impl Dataset {
     }
 
     #[must_use]
-    pub fn acceleration_params(&self) -> Option<HashMap<String, String>> {
+    pub fn acceleration_params(&self) -> Option<Params> {
         if let Some(acceleration) = &self.acceleration {
             return acceleration.params.clone();
         }
@@ -240,7 +240,9 @@ impl WithDependsOn<Dataset> for Dataset {
 
 pub mod acceleration {
     use serde::{Deserialize, Serialize};
-    use std::{collections::HashMap, fmt::Display, sync::Arc};
+    use std::{fmt::Display, sync::Arc};
+
+    use crate::component::params::Params;
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
     #[serde(rename_all = "lowercase")]
@@ -297,7 +299,7 @@ pub mod acceleration {
         pub retention: Option<String>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub params: Option<HashMap<String, String>>,
+        pub params: Option<Params>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub engine_secret: Option<String>,

--- a/crates/spicepod/src/component/params.rs
+++ b/crates/spicepod/src/component/params.rs
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ParamValue {
+    String(String),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+}
+
+impl ParamValue {
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        match self {
+            ParamValue::String(value) => value.clone(),
+            ParamValue::Int(value) => value.to_string(),
+            ParamValue::Float(value) => value.to_string(),
+            ParamValue::Bool(value) => value.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Params {
+    pub data: HashMap<String, ParamValue>,
+}
+
+impl Params {
+    #[must_use]
+    pub fn as_string_map(&self) -> HashMap<String, String> {
+        self.data
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_string()))
+            .collect()
+    }
+}
+
+impl Serialize for Params {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.data.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Params {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let params = HashMap::<String, ParamValue>::deserialize(deserializer)?;
+        Ok(Params { data: params })
+    }
+}


### PR DESCRIPTION
closes #912 

The custom ﻿Params type replaces ﻿HashMap<String, String> and enables the serialization and deserialization of non-string values, such as integers, floats, strings, and booleans.
For internal usage inside runtime, params represented as strings.