### PR TITLE
Fix optional features: duckdb, databricks

### DIFF
--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -22,7 +22,7 @@ metrics.workspace = true
 metrics-exporter-prometheus = "0.13.0"
 
 [features]
-default = ["duckdb", "postgres", "sqlite", "mysql", "flightsql", "databricks"]
+default = ["duckdb", "postgres", "sqlite", "mysql", "flightsql", "databricks", "dremio"]
 duckdb = ["runtime/duckdb", "spicepod/duckdb", "app/duckdb"]
 postgres = ["runtime/postgres", "spicepod/postgres", "app/postgres"]
 sqlite = ["runtime/sqlite", "spicepod/sqlite", "app/sqlite"]
@@ -33,3 +33,4 @@ keyring-secret-store = ["runtime/keyring-secret-store"]
 flightsql = ["runtime/flightsql"]
 aws-secrets-manager = ["runtime/aws-secrets-manager"]
 databricks = ["runtime/databricks"]
+dremio = ["runtime/dremio"]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -24,7 +24,11 @@ tracing.workspace = true
 flight_client = { path = "../flight_client" }
 sql_provider_datafusion = { path = "../sql_provider_datafusion" }
 secrets = { path = "../secrets" }
-deltalake = { git = "https://github.com/spiceai/delta-rs.git", rev = "30c52fe9408de8d96b4618c336c2202e896a967b", features = ["datafusion-ext", "s3", "azure"], optional = true }
+deltalake = { git = "https://github.com/spiceai/delta-rs.git", rev = "30c52fe9408de8d96b4618c336c2202e896a967b", features = [
+    "datafusion-ext",
+    "s3",
+    "azure",
+], optional = true }
 serde.workspace = true
 reqwest = { version = "0.11.24", features = ["json"] }
 db_connection_pool = { path = "../db_connection_pool" }
@@ -44,5 +48,5 @@ duckdb = ["dep:duckdb", "dep:r2d2"]
 flightsql = ["dep:tonic", "dep:r2d2"]
 postgres = ["dep:bb8", "dep:bb8-postgres", "dep:postgres-native-tls", "arrow_sql_gen/postgres", "dep:tokio-postgres"]
 mysql = ["dep:mysql_async", "arrow_sql_gen/mysql"]
-sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
+sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "arrow_sql_gen/sqlite"]
 databricks = ["dep:deltalake"]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -80,7 +80,14 @@ ns_lookup = { path = "../ns_lookup" }
 [features]
 default = ["keyring-secret-store", "aws-secrets-manager"]
 dev = []
-duckdb = ["dep:duckdb", "sql_provider_datafusion/duckdb", "r2d2", "db_connection_pool/duckdb", "spicepod/duckdb", "data_components/duckdb"]
+duckdb = [
+    "dep:duckdb",
+    "sql_provider_datafusion/duckdb",
+    "r2d2",
+    "db_connection_pool/duckdb",
+    "spicepod/duckdb",
+    "data_components/duckdb",
+]
 postgres = [
     "dep:bb8",
     "dep:bb8-postgres",
@@ -101,5 +108,6 @@ sqlite = [
 mysql = ["dep:mysql_async", "db_connection_pool/mysql", "arrow_sql_gen/mysql", "data_components/mysql"]
 keyring-secret-store = ["secrets/keyring-secret-store"]
 flightsql = ["data_components/flightsql"]
-aws-secrets-manager= ["secrets/aws-secrets-manager"]
+aws-secrets-manager = ["secrets/aws-secrets-manager"]
 databricks = ["data_components/databricks"]
+dremio = []

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -29,12 +29,14 @@ use spicepod::component::dataset::acceleration::{self, Mode};
 use std::{any::Any, collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
-use self::{arrow::ArrowAccelerator, sqlite::SqliteAccelerator};
+use self::arrow::ArrowAccelerator;
 
 #[cfg(feature = "duckdb")]
 use self::duckdb::DuckDBAccelerator;
 #[cfg(feature = "postgres")]
 use self::postgres::PostgresAccelerator;
+#[cfg(feature = "sqlite")]
+use self::sqlite::SqliteAccelerator;
 
 pub mod arrow;
 #[cfg(feature = "duckdb")]

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -38,6 +38,7 @@ use std::future::Future;
 #[cfg(feature = "databricks")]
 pub mod databricks;
 pub mod dremio;
+#[cfg(feature = "duckdb")]
 pub mod duckdb;
 #[cfg(feature = "flightsql")]
 pub mod flightsql;
@@ -130,6 +131,7 @@ pub async fn create_new_connector(
 
 pub async fn register_all() {
     register_connector_factory("localhost", localhost::LocalhostConnector::create).await;
+    #[cfg(feature = "databricks")]
     register_connector_factory("databricks", databricks::Databricks::create).await;
     register_connector_factory("dremio", dremio::Dremio::create).await;
     #[cfg(feature = "flightsql")]
@@ -140,6 +142,7 @@ pub async fn register_all() {
     register_connector_factory("mysql", mysql::MySQL::create).await;
     #[cfg(feature = "postgres")]
     register_connector_factory("postgres", postgres::Postgres::create).await;
+    #[cfg(feature = "duckdb")]
     register_connector_factory("duckdb", duckdb::DuckDB::create).await;
 }
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -37,6 +37,7 @@ use std::future::Future;
 
 #[cfg(feature = "databricks")]
 pub mod databricks;
+#[cfg(feature = "dremio")]
 pub mod dremio;
 #[cfg(feature = "duckdb")]
 pub mod duckdb;
@@ -133,6 +134,7 @@ pub async fn register_all() {
     register_connector_factory("localhost", localhost::LocalhostConnector::create).await;
     #[cfg(feature = "databricks")]
     register_connector_factory("databricks", databricks::Databricks::create).await;
+    #[cfg(feature = "dremio")]
     register_connector_factory("dremio", dremio::Dremio::create).await;
     #[cfg(feature = "flightsql")]
     register_connector_factory("flightsql", flightsql::FlightSQL::create).await;


### PR DESCRIPTION
This excludes dataconnector features for duckdb, databricks where needed.

How to reproduce:

```
cargo build --no-default-features --features "sqlite postgres"
```

```
error[E0432]: unresolved import `data_components::duckdb`
  --> crates/runtime/src/dataconnector/duckdb.rs:18:22
   |
18 | use data_components::duckdb::DuckDBTableFactory;
   |                      ^^^^^^ could not find `duckdb` in `data_components`

error[E0432]: unresolved import `db_connection_pool::duckdbpool`
  --> crates/runtime/src/dataconnector/duckdb.rs:21:25
   |
21 | use db_connection_pool::duckdbpool::DuckDbConnectionPool;
   |                         ^^^^^^^^^^ could not find `duckdbpool` in `db_connection_pool`

error[E0433]: failed to resolve: use of undeclared crate or module `databricks`
   --> crates/runtime/src/dataconnector.rs:133:46
    |
133 |     register_connector_factory("databricks", databricks::Databricks::create).await;
    |                                              ^^^^^^^^^^ use of undeclared crate or module `databricks`
```

Errors were introduced in #1085 and #1097 and the databricks not made optional in #1029.