### PR TITLE
WIP MotherDuck data connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,28 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc25126d18a012146a888a0298f2c22e1150327bd2765fc76d710a556b2d614"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-arith 49.0.0",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-csv 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-ipc 49.0.0",
+ "arrow-json 49.0.0",
+ "arrow-ord 49.0.0",
+ "arrow-row 49.0.0",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
+ "arrow-string 49.0.0",
+]
+
+[[package]]
+name = "arrow"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa285343fba4d829d49985bdc541e3789cf6000ed0e84be7c039438df4a4e78c"
@@ -233,6 +255,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ccd45e217ffa6e53bbb0080990e77113bdd4e91ddb84e97b77649810bcf1a7"
+dependencies = [
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "chrono",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "753abd0a5290c1bcade7c6623a556f7d1659c5f4148b140b5b63ce7bd1a45705"
@@ -258,6 +295,22 @@ dependencies = [
  "arrow-schema 51.0.0",
  "chrono",
  "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bda9acea48b25123c08340f3a8ac361aa0f74469bb36f5ee9acf923fce23e9d"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "chrono",
+ "half",
+ "hashbrown 0.14.3",
  "num",
 ]
 
@@ -297,6 +350,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a0fc21915b00fc6c2667b069c1b64bdd920982f426079bc4a7cab86822886c"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69615b061701bcdffbc62756bc7e85c827d5290b472b580c972ebbbf690f5aa4"
@@ -314,6 +378,25 @@ checksum = "0d0a2432f0cba5692bf4cb757469c66791394bac9ec7ce63c1afe74744c37b27"
 dependencies = [
  "bytes",
  "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc0368ed618d509636c1e3cc20db1281148190a78f43519487b2daf07b63b4a"
+dependencies = [
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
+ "base64 0.21.7",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
  "num",
 ]
 
@@ -359,6 +442,25 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09aa6246a1d6459b3f14baeaa49606cfdbca34435c46320e14054d244987ca"
+dependencies = [
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-csv"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46af72211f0712612f5b18325530b9ad1bfbdc87290d5fbfd32a7da128983781"
@@ -393,6 +495,18 @@ dependencies = [
  "lazy_static",
  "lexical-core",
  "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907fafe280a3874474678c1858b9ca4cb7fd83fb8034ff5b6d6376205a08c634"
+dependencies = [
+ "arrow-buffer 49.0.0",
+ "arrow-schema 49.0.0",
+ "half",
+ "num",
 ]
 
 [[package]]
@@ -449,6 +563,20 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79a43d6808411886b8c7d4f6f7dd477029c1e77ffffffb7923555cc6579639cd"
+dependencies = [
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ipc"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03dea5e79b48de6c2e04f03f62b0afea7105be7b77d134f6c5414868feefb80d"
@@ -475,6 +603,26 @@ dependencies = [
  "arrow-schema 51.0.0",
  "flatbuffers",
  "lz4_flex",
+]
+
+[[package]]
+name = "arrow-json"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82565c91fd627922ebfe2810ee4e8346841b6f9361b87505a9acea38b614fee"
+dependencies = [
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-cast 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "chrono",
+ "half",
+ "indexmap 2.2.6",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -519,6 +667,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b23b0e53c0db57c6749997fd343d4c0354c994be7eca67152dd2bdb9a3e1bb4"
+dependencies = [
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ord"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ed9630979034077982d8e74a942b7ac228f33dd93a93b615b4d02ad60c260be"
@@ -545,6 +708,21 @@ dependencies = [
  "arrow-select 51.0.0",
  "half",
  "num",
+]
+
+[[package]]
+name = "arrow-row"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361249898d2d6d4a6eeb7484be6ac74977e48da12a4dd81a708d620cc558117a"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "half",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -579,6 +757,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e28a5e781bf1b0f981333684ad13f5901f4cd2f20589eab7cf1797da8fc167"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
+name = "arrow-schema"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ff3e9c01f7cd169379d269f926892d0e622a704960350d09d331be3ec9e0029"
@@ -594,6 +781,20 @@ checksum = "02d9483aaabe910c4781153ae1b6ae0393f72d9ef757d38d09d450070cf2e528"
 dependencies = [
  "bitflags 2.5.0",
  "serde",
+]
+
+[[package]]
+name = "arrow-select"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6208466590960efc1d2a7172bc4ff18a67d6e25c529381d7f96ddaf0dc4036"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "num",
 ]
 
 [[package]]
@@ -622,6 +823,22 @@ dependencies = [
  "arrow-data 51.0.0",
  "arrow-schema 51.0.0",
  "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a48149c63c11c9ff571e50ab8f017d2a7cb71037a882b42f6354ed2da9acc7"
+dependencies = [
+ "arrow-array 49.0.0",
+ "arrow-buffer 49.0.0",
+ "arrow-data 49.0.0",
+ "arrow-schema 49.0.0",
+ "arrow-select 49.0.0",
+ "num",
+ "regex",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2151,7 +2368,7 @@ dependencies = [
  "datafusion 37.0.0",
  "db_connection_pool",
  "deltalake 0.17.1",
- "duckdb",
+ "duckdb 0.10.1",
  "flight_client",
  "futures",
  "mysql_async",
@@ -2670,13 +2887,15 @@ dependencies = [
 name = "db_connection_pool"
 version = "0.11.0-alpha"
 dependencies = [
+ "arrow 49.0.0",
  "arrow 51.0.0",
  "arrow_sql_gen",
  "async-trait",
  "bb8",
  "bb8-postgres",
  "datafusion 37.0.0",
- "duckdb",
+ "duckdb 0.10.1",
+ "duckdb 0.9.2",
  "futures",
  "mysql_async",
  "native-tls",
@@ -3034,6 +3253,26 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "duckdb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "326e8f84acb4d57c4025637f77e89dc3eee0e25b3a79c21cfd8b72db5ecd3c97"
+dependencies = [
+ "arrow 49.0.0",
+ "cast",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.8.4",
+ "libduckdb-sys 0.9.2",
+ "memchr",
+ "num",
+ "r2d2",
+ "rust_decimal",
+ "smallvec",
+ "strum 0.25.0",
+]
+
+[[package]]
+name = "duckdb"
 version = "0.10.1"
 source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a0ae8ed71bef6dff779f5ce0a37038b0b916e0ca#a0ae8ed71bef6dff779f5ce0a37038b0b916e0ca"
 dependencies = [
@@ -3042,7 +3281,7 @@ dependencies = [
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.8.4",
- "libduckdb-sys",
+ "libduckdb-sys 0.10.1",
  "memchr",
  "num",
  "r2d2",
@@ -4281,6 +4520,22 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libduckdb-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666dbbb7ac31fc49fc2535df5d6efe9ce09815783a0ad98eea3564d2f0223974"
+dependencies = [
+ "autocfg",
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+]
 
 [[package]]
 name = "libduckdb-sys"
@@ -6022,7 +6277,8 @@ dependencies = [
  "db_connection_pool",
  "deltalake 0.17.0",
  "dirs",
- "duckdb",
+ "duckdb 0.10.1",
+ "duckdb 0.9.2",
  "flight_client",
  "futures",
  "futures-core",
@@ -6894,7 +7150,7 @@ dependencies = [
  "async-trait",
  "datafusion 37.0.0",
  "db_connection_pool",
- "duckdb",
+ "duckdb 0.10.1",
  "futures",
  "r2d2",
  "snafu 0.8.2",

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -84,7 +84,7 @@ fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
     let filter = if let Ok(env_log) = std::env::var("SPICED_LOG") {
         EnvFilter::new(env_log)
     } else {
-        EnvFilter::new("spiced=INFO,runtime=INFO,secrets=INFO,sql_provider_datafusion=INFO")
+        EnvFilter::new("spiced=INFO,runtime=INFO,secrets=INFO,sql_provider_datafusion=INFO,data_components=INFO,db_connection_pool=INFO")
     };
 
     let subscriber = tracing_subscriber::FmtSubscriber::builder()

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -10,6 +10,8 @@ exclude.workspace = true
 
 [dependencies]
 duckdb = { workspace = true, features = ["bundled", "r2d2", "vtab", "vtab-arrow"], optional = true }
+duckdb_0_9_2 = { version = "0.9.2", package = "duckdb", features = ["bundled", "r2d2", "vtab", "vtab-arrow"], optional = true  }
+arrow_49_0_0 = { version = "49.0.0", package = "arrow", features = [], optional = true }
 datafusion.workspace = true
 async-trait.workspace = true
 r2d2 = { workspace = true, optional = true }
@@ -35,7 +37,7 @@ postgres-native-tls = { version = "0.5.0", optional = true }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [features]
-duckdb = ["dep:duckdb", "dep:r2d2", "spicepod/duckdb"]
+duckdb = ["dep:duckdb", "dep:duckdb_0_9_2", "dep:arrow_49_0_0", "dep:r2d2", "spicepod/duckdb"]
 postgres = [
     "dep:bb8",
     "dep:bb8-postgres",

--- a/crates/db_connection_pool/src/dbconnection.rs
+++ b/crates/db_connection_pool/src/dbconnection.rs
@@ -22,6 +22,8 @@ use datafusion::{
 use snafu::prelude::*;
 
 #[cfg(feature = "duckdb")]
+pub mod duckdb_legacy_conn;
+#[cfg(feature = "duckdb")]
 pub mod duckdbconn;
 #[cfg(feature = "mysql")]
 pub mod mysqlconn;

--- a/crates/db_connection_pool/src/dbconnection/duckdb_legacy_conn.rs
+++ b/crates/db_connection_pool/src/dbconnection/duckdb_legacy_conn.rs
@@ -1,0 +1,230 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::any::Any;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::memory::MemoryStream;
+use datafusion::sql::TableReference;
+use duckdb_0_9_2::DuckdbConnectionManager;
+use duckdb_0_9_2::ToSql;
+use snafu::{prelude::*, ResultExt};
+
+use super::DbConnection;
+use super::Result;
+use super::SyncDbConnection;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("DuckDBError: {source}"))]
+    DuckDBError { source: duckdb_0_9_2::Error },
+}
+
+pub struct LegacyDuckDbConnection {
+    pub conn: r2d2::PooledConnection<DuckdbConnectionManager>,
+}
+
+impl<'a> DbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &'a dyn ToSql>
+    for LegacyDuckDbConnection
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn as_sync(
+        &self,
+    ) -> Option<&dyn SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &'a dyn ToSql>>
+    {
+        Some(self)
+    }
+}
+
+impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSql>
+    for LegacyDuckDbConnection
+{
+    fn new(conn: r2d2::PooledConnection<DuckdbConnectionManager>) -> Self {
+        LegacyDuckDbConnection { conn }
+    }
+
+    fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef> {
+        let mut stmt = self
+            .conn
+            .prepare(&format!("SELECT * FROM {table_reference} LIMIT 0"))
+            .context(DuckDBSnafu)?;
+
+        let result: duckdb_0_9_2::Arrow<'_> = stmt.query_arrow([]).context(DuckDBSnafu)?;
+
+        Ok(Arc::new(upgrade_schema(&result.get_schema())))
+    }
+
+    fn query_arrow(&self, sql: &str, params: &[&dyn ToSql]) -> Result<SendableRecordBatchStream> {
+        let mut stmt = self.conn.prepare(sql).context(DuckDBSnafu)?;
+
+        let result: duckdb_0_9_2::Arrow<'_> = stmt.query_arrow(params).context(DuckDBSnafu)?;
+        let schema = result.get_schema();
+        let recs: Vec<duckdb_0_9_2::arrow::array::RecordBatch> = result.collect();
+
+        let new_recs = recs.iter().map(upgrade_record_batch).collect::<Vec<_>>();
+
+        Ok(Box::pin(MemoryStream::try_new(
+            new_recs,
+            Arc::new(upgrade_schema(&schema)),
+            None,
+        )?))
+    }
+
+    fn execute(&self, sql: &str, params: &[&dyn ToSql]) -> Result<u64> {
+        let rows_modified = self.conn.execute(sql, params).context(DuckDBSnafu)?;
+        Ok(rows_modified as u64)
+    }
+}
+fn upgrade_schema(schema: &duckdb_0_9_2::arrow::datatypes::Schema) -> arrow::datatypes::Schema {
+    let fields = schema
+        .fields()
+        .iter()
+        .map(|f| {
+            arrow::datatypes::Field::new(f.name(), map_data_type(f.data_type()), f.is_nullable())
+        })
+        .collect::<Vec<_>>();
+
+    arrow::datatypes::Schema::new(fields)
+}
+
+fn upgrade_record_batch(
+    record_batch: &duckdb_0_9_2::arrow::array::RecordBatch,
+) -> arrow::array::RecordBatch {
+    let mut buffer = std::io::Cursor::new(Vec::new());
+    {
+        let mut writer = arrow_49_0_0::ipc::writer::StreamWriter::try_new(
+            &mut buffer,
+            record_batch.schema().as_ref(),
+        )
+        .unwrap();
+        writer.write(&record_batch).unwrap();
+        writer.finish().unwrap();
+    }
+    let data = buffer.into_inner();
+
+    let buffer = Cursor::new(data);
+    let mut reader = arrow::ipc::reader::StreamReader::try_new(buffer, None).unwrap();
+    let new_record_batch = reader.next().unwrap().unwrap();
+
+    return new_record_batch;
+}
+
+fn map_data_type(
+    field_type: &duckdb_0_9_2::arrow::datatypes::DataType,
+) -> arrow::datatypes::DataType {
+    match field_type {
+        duckdb_0_9_2::arrow::datatypes::DataType::Null => arrow::datatypes::DataType::Null,
+        duckdb_0_9_2::arrow::datatypes::DataType::Boolean => arrow::datatypes::DataType::Boolean,
+
+        duckdb_0_9_2::arrow::datatypes::DataType::Int8 => arrow::datatypes::DataType::Int8,
+        duckdb_0_9_2::arrow::datatypes::DataType::Int16 => arrow::datatypes::DataType::Int16,
+        duckdb_0_9_2::arrow::datatypes::DataType::Int32 => arrow::datatypes::DataType::Int32,
+        duckdb_0_9_2::arrow::datatypes::DataType::Int64 => arrow::datatypes::DataType::Int64,
+
+        duckdb_0_9_2::arrow::datatypes::DataType::UInt8 => arrow::datatypes::DataType::UInt8,
+        duckdb_0_9_2::arrow::datatypes::DataType::UInt16 => arrow::datatypes::DataType::UInt16,
+        duckdb_0_9_2::arrow::datatypes::DataType::UInt32 => arrow::datatypes::DataType::UInt32,
+        duckdb_0_9_2::arrow::datatypes::DataType::UInt64 => arrow::datatypes::DataType::UInt64,
+
+        duckdb_0_9_2::arrow::datatypes::DataType::Float16 => arrow::datatypes::DataType::Float16,
+        duckdb_0_9_2::arrow::datatypes::DataType::Float32 => arrow::datatypes::DataType::Float32,
+        duckdb_0_9_2::arrow::datatypes::DataType::Float64 => arrow::datatypes::DataType::Float64,
+
+        duckdb_0_9_2::arrow::datatypes::DataType::Utf8 => arrow::datatypes::DataType::Utf8,
+        duckdb_0_9_2::arrow::datatypes::DataType::LargeUtf8 => {
+            arrow::datatypes::DataType::LargeUtf8
+        }
+
+        duckdb_0_9_2::arrow::datatypes::DataType::Date32 => arrow::datatypes::DataType::Date32,
+        duckdb_0_9_2::arrow::datatypes::DataType::Date64 => arrow::datatypes::DataType::Date64,
+
+        duckdb_0_9_2::arrow::datatypes::DataType::Timestamp(p1, p2) => {
+            arrow::datatypes::DataType::Timestamp(map_time_unit(p1), p2.clone())
+        }
+        duckdb_0_9_2::arrow::datatypes::DataType::Time32(p1) => {
+            arrow::datatypes::DataType::Time32(map_time_unit(p1))
+        }
+        duckdb_0_9_2::arrow::datatypes::DataType::Time64(p1) => {
+            arrow::datatypes::DataType::Time64(map_time_unit(p1))
+        }
+        duckdb_0_9_2::arrow::datatypes::DataType::Interval(p1) => {
+            arrow::datatypes::DataType::Interval(map_interval_unit(p1))
+        }
+        duckdb_0_9_2::arrow::datatypes::DataType::Duration(p1) => {
+            arrow::datatypes::DataType::Duration(map_time_unit(p1))
+        }
+
+        duckdb_0_9_2::arrow::datatypes::DataType::Binary => arrow::datatypes::DataType::Binary,
+        duckdb_0_9_2::arrow::datatypes::DataType::LargeBinary => {
+            arrow::datatypes::DataType::LargeBinary
+        }
+
+        duckdb_0_9_2::arrow::datatypes::DataType::Decimal128(p1, p2) => {
+            arrow::datatypes::DataType::Decimal128(*p1, *p2)
+        }
+        duckdb_0_9_2::arrow::datatypes::DataType::Decimal256(p1, p2) => {
+            arrow::datatypes::DataType::Decimal256(*p1, *p2)
+        }
+
+        _ => {
+            tracing::warn!("Unsupported data type: {field_type}");
+            arrow::datatypes::DataType::Null
+        }
+    }
+}
+
+fn map_time_unit(
+    time_unit: &duckdb_0_9_2::arrow::datatypes::TimeUnit,
+) -> arrow::datatypes::TimeUnit {
+    match time_unit {
+        duckdb_0_9_2::arrow::datatypes::TimeUnit::Second => arrow::datatypes::TimeUnit::Second,
+        duckdb_0_9_2::arrow::datatypes::TimeUnit::Millisecond => {
+            arrow::datatypes::TimeUnit::Millisecond
+        }
+        duckdb_0_9_2::arrow::datatypes::TimeUnit::Microsecond => {
+            arrow::datatypes::TimeUnit::Microsecond
+        }
+        duckdb_0_9_2::arrow::datatypes::TimeUnit::Nanosecond => {
+            arrow::datatypes::TimeUnit::Nanosecond
+        }
+    }
+}
+
+fn map_interval_unit(
+    interval_unit: &duckdb_0_9_2::arrow::datatypes::IntervalUnit,
+) -> arrow::datatypes::IntervalUnit {
+    match interval_unit {
+        duckdb_0_9_2::arrow::datatypes::IntervalUnit::YearMonth => {
+            arrow::datatypes::IntervalUnit::YearMonth
+        }
+        duckdb_0_9_2::arrow::datatypes::IntervalUnit::DayTime => {
+            arrow::datatypes::IntervalUnit::DayTime
+        }
+        duckdb_0_9_2::arrow::datatypes::IntervalUnit::MonthDayNano => {
+            arrow::datatypes::IntervalUnit::MonthDayNano
+        }
+    }
+}

--- a/crates/db_connection_pool/src/duckdb_legacy_pool.rs
+++ b/crates/db_connection_pool/src/duckdb_legacy_pool.rs
@@ -1,0 +1,87 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use duckdb_0_9_2::{DuckdbConnectionManager, ToSql};
+use snafu::{prelude::*, ResultExt};
+
+use super::{DbConnectionPool, Result};
+use crate::dbconnection::{
+    duckdb_legacy_conn::LegacyDuckDbConnection, DbConnection, SyncDbConnection,
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("DuckDBError: {source}"))]
+    DuckDBError { source: duckdb_0_9_2::Error },
+
+    #[snafu(display("ConnectionPoolError: {source}"))]
+    ConnectionPoolError { source: r2d2::Error },
+
+    #[snafu(display("Missing required parameter: open"))]
+    MissingDuckDBFile {},
+}
+
+pub struct LegacyDuckDbConnectionPool {
+    pool: Arc<r2d2::Pool<DuckdbConnectionManager>>,
+}
+
+impl LegacyDuckDbConnectionPool {
+    /// Create a new `DuckDbConnectionPool` from data connector params.
+    ///
+    /// # Arguments
+    ///
+    /// * `params` - Data connector parameters for the connection pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is a problem creating the connection pool.
+    pub fn new_with_file_mode(params: &Arc<Option<HashMap<String, String>>>) -> Result<Self> {
+        let path = params
+            .as_ref()
+            .as_ref()
+            .and_then(|params| params.get("open").cloned())
+            .ok_or(Error::MissingDuckDBFile {})?;
+
+        let manager = DuckdbConnectionManager::file(path).context(DuckDBSnafu)?;
+        let pool = Arc::new(r2d2::Pool::new(manager).context(ConnectionPoolSnafu)?);
+
+        // TODO SG: review if this is required
+        // let conn = pool.get().context(ConnectionPoolSnafu)?;
+        // conn.register_table_function::<ArrowVTab>("arrow")
+        //     .context(DuckDBSnafu)?;
+
+        Ok(LegacyDuckDbConnectionPool { pool })
+    }
+}
+
+#[async_trait]
+impl DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &'static dyn ToSql>
+    for LegacyDuckDbConnectionPool
+{
+    async fn connect(
+        &self,
+    ) -> Result<
+        Box<dyn DbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &'static dyn ToSql>>,
+    > {
+        let pool = Arc::clone(&self.pool);
+        let conn: r2d2::PooledConnection<DuckdbConnectionManager> =
+            pool.get().context(ConnectionPoolSnafu)?;
+        Ok(Box::new(LegacyDuckDbConnection::new(conn)))
+    }
+}

--- a/crates/db_connection_pool/src/lib.rs
+++ b/crates/db_connection_pool/src/lib.rs
@@ -20,6 +20,8 @@ use spicepod::component::dataset::acceleration;
 
 pub mod dbconnection;
 #[cfg(feature = "duckdb")]
+pub mod duckdb_legacy_pool;
+#[cfg(feature = "duckdb")]
 pub mod duckdbpool;
 #[cfg(feature = "mysql")]
 pub mod mysqlpool;

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -41,6 +41,7 @@ tract-onnx = "0.21.0"
 ndarray = "0.15.3"
 ndarray-npy = { version = "0.8.0", features = ["compressed_npz"] }
 duckdb = { workspace = true, features = ["bundled", "r2d2", "vtab", "vtab-arrow"], optional = true }
+duckdb_0_9_2 = { version = "0.9.2", package = "duckdb", features = ["bundled", "r2d2", "vtab", "vtab-arrow"], optional = true  }
 sql_provider_datafusion = { path = "../sql_provider_datafusion", optional = true }
 r2d2 = { workspace = true, optional = true }
 opentelemetry-proto = { version = "0.4.0", features = ["gen-tonic-messages", "gen-tonic", "metrics"] }
@@ -80,7 +81,7 @@ ns_lookup = { path = "../ns_lookup" }
 [features]
 default = ["keyring-secret-store", "aws-secrets-manager"]
 dev = []
-duckdb = ["dep:duckdb", "sql_provider_datafusion/duckdb", "r2d2", "db_connection_pool/duckdb", "spicepod/duckdb", "data_components/duckdb"]
+duckdb = ["dep:duckdb", "dep:duckdb_0_9_2", "sql_provider_datafusion/duckdb", "r2d2", "db_connection_pool/duckdb", "spicepod/duckdb", "data_components/duckdb"]
 postgres = [
     "dep:bb8",
     "dep:bb8-postgres",

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -38,10 +38,13 @@ use std::future::Future;
 #[cfg(feature = "databricks")]
 pub mod databricks;
 pub mod dremio;
+#[cfg(feature = "duckdb")]
 pub mod duckdb;
 #[cfg(feature = "flightsql")]
 pub mod flightsql;
 pub mod localhost;
+#[cfg(feature = "duckdb")]
+pub mod motherduck;
 #[cfg(feature = "mysql")]
 pub mod mysql;
 #[cfg(feature = "postgres")]
@@ -141,6 +144,7 @@ pub async fn register_all() {
     #[cfg(feature = "postgres")]
     register_connector_factory("postgres", postgres::Postgres::create).await;
     register_connector_factory("duckdb", duckdb::DuckDB::create).await;
+    register_connector_factory("md", motherduck::Motherduck::create).await;
 }
 
 pub trait DataConnectorFactory {

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -144,7 +144,7 @@ pub async fn register_all() {
     #[cfg(feature = "postgres")]
     register_connector_factory("postgres", postgres::Postgres::create).await;
     register_connector_factory("duckdb", duckdb::DuckDB::create).await;
-    register_connector_factory("md", motherduck::Motherduck::create).await;
+    register_connector_factory("md", motherduck::MotherDuck::create).await;
 }
 
 pub trait DataConnectorFactory {

--- a/crates/runtime/src/dataconnector/motherduck.rs
+++ b/crates/runtime/src/dataconnector/motherduck.rs
@@ -1,0 +1,118 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use async_trait::async_trait;
+use data_components::Read;
+use datafusion::common::OwnedTableReference;
+use datafusion::datasource::TableProvider;
+use db_connection_pool::duckdb_legacy_pool::LegacyDuckDbConnectionPool;
+use duckdb_0_9_2::ToSql;
+use secrets::Secret;
+use snafu::prelude::*;
+use spicepod::component::dataset::Dataset;
+use sql_provider_datafusion::SqlTable;
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{collections::HashMap, future::Future};
+
+use super::{DataConnector, DataConnectorFactory};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to create DuckDB connection pool: {source}"))]
+    UnableToCreateDuckDBConnectionPool { source: db_connection_pool::Error },
+
+    #[snafu(display("{source}"))]
+    UnableToGetReadProvider {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct LegacyDuckDBTableFactory {
+    pool: Arc<LegacyDuckDbConnectionPool>,
+}
+
+impl LegacyDuckDBTableFactory {
+    #[must_use]
+    pub fn new(pool: Arc<LegacyDuckDbConnectionPool>) -> Self {
+        Self { pool }
+    }
+}
+
+type DynDuckDbConnectionPool = dyn db_connection_pool::DbConnectionPool<
+        r2d2::PooledConnection<duckdb_0_9_2::DuckdbConnectionManager>,
+        &'static dyn ToSql,
+    > + Send
+    + Sync;
+
+#[async_trait]
+impl Read for LegacyDuckDBTableFactory {
+    async fn table_provider(
+        &self,
+        table_reference: OwnedTableReference,
+    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
+        let pool = Arc::clone(&self.pool);
+        let dyn_pool: Arc<DynDuckDbConnectionPool> = pool;
+        let table_provider = SqlTable::new(&dyn_pool, table_reference)
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+
+        Ok(Arc::new(table_provider))
+    }
+}
+
+pub struct Motherduck {
+    duckdb_factory: LegacyDuckDBTableFactory,
+}
+
+impl DataConnectorFactory for Motherduck {
+    fn create(
+        _secret: Option<Secret>,
+        params: Arc<Option<HashMap<String, String>>>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move {
+            let pool = Arc::new(
+                LegacyDuckDbConnectionPool::new_with_file_mode(&params)
+                    .context(UnableToCreateDuckDBConnectionPoolSnafu)?,
+            );
+
+            let duckdb_factory = LegacyDuckDBTableFactory::new(pool);
+
+            Ok(Arc::new(Self { duckdb_factory }) as Arc<dyn DataConnector>)
+        })
+    }
+}
+
+#[async_trait]
+impl DataConnector for Motherduck {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> super::AnyErrorResult<Arc<dyn TableProvider>> {
+        Ok(
+            Read::table_provider(&self.duckdb_factory, dataset.path().into())
+                .await
+                .context(UnableToGetReadProviderSnafu)?,
+        )
+    }
+}

--- a/crates/runtime/src/dataconnector/motherduck.rs
+++ b/crates/runtime/src/dataconnector/motherduck.rs
@@ -77,11 +77,11 @@ impl Read for LegacyDuckDBTableFactory {
     }
 }
 
-pub struct Motherduck {
+pub struct MotherDuck {
     duckdb_factory: LegacyDuckDBTableFactory,
 }
 
-impl DataConnectorFactory for Motherduck {
+impl DataConnectorFactory for MotherDuck {
     fn create(
         _secret: Option<Secret>,
         params: Arc<Option<HashMap<String, String>>>,
@@ -100,7 +100,7 @@ impl DataConnectorFactory for Motherduck {
 }
 
 #[async_trait]
-impl DataConnector for Motherduck {
+impl DataConnector for MotherDuck {
     fn as_any(&self) -> &dyn Any {
         self
     }


### PR DESCRIPTION
WIP implementation of MotherDuck connector:
1.  Separate DuckDB connection pool based on `duckdb-rs 0.9.2` (based on `arrow 49.0.0`)
2. Basic logic for Arrow 49.0.0 -> 51.0.0 upgrade for legacy duckdb query result (platform requires 51.0.0).
3. MotherDuck connector: `md:`. Currently expects connection is configured via `open` param.

```yaml
- from: md:sample_data.nyc.taxi
  name: taxi
  params:
    open: "md:?motherduck_token=XXXXX.."
```

Tests:
1. Can open and query local duckdb files
1. MotherDuck extension fails to open: there is [similar issue reported](https://github.com/duckdb/duckdb-rs/issues/252)
>DuckDBError: Invalid Input Error: Initialization function "motherduck_init" from file "/Users/sg/.duckdb/extensions/v0.9.2/osx_arm64/motherduck.duckdb_extension" threw an exception: "IO Error: Extension "/Users/sg/.duckdb/extensions/v0.9.2/osx_arm64/motherduck.v1.15.25.duckdb_extension" could not be loaded: dlopen(/Users/sg/.duckdb/extensions/v0.9.2/osx_arm64/motherduck.v1.15.25.duckdb_extension, 0x0006): symbol not found in flat namespace '__ZN6duckdb24LogicalExtensionOperator21ResolveColumnBindingsERNS_21ColumnBindingResolverERNS_6vectorINS_13ColumnBindingELb1EEE'"

TODO:
1. Fix extension binding issue (above)
1. Cleanup (remove unwrap, etc)
1. Read motherduck_token from secret store, remove param: open
1. Own feature flag for motherduck