### PR TITLE
Rename `mysql_port` to `mysql_tcp_port`

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -553,7 +553,7 @@ jobs:
         run: |
           echo -e "test_mysql_table\neth recent blocks\nmysql:test_mysql_table\ny" | spice dataset configure
           # configure mysql credentials
-          echo -e "params:\n  mysql_host: localhost\n  mysql_port: 3306\n  mysql_db: testdb\n  mysql_user: test_user\n  mysql_pass_key: password\n  mysql_sslmode: disabled" >> ./datasets/test_mysql_table/dataset.yaml
+          echo -e "params:\n  mysql_host: localhost\n  mysql_tcp_port: 3306\n  mysql_db: testdb\n  mysql_user: test_user\n  mysql_pass_key: password\n  mysql_sslmode: disabled" >> ./datasets/test_mysql_table/dataset.yaml
           # configure env secret store
           echo -e "secrets:\n  store: env\n" >> spicepod.yaml
           cat spicepod.yaml

--- a/crates/db_connection_pool/src/mysqlpool.rs
+++ b/crates/db_connection_pool/src/mysqlpool.rs
@@ -84,9 +84,9 @@ impl MySQLConnectionPool {
                 {
                     connection_string = connection_string.pass(Some(mysql_pass));
                 }
-                if let Some(mysql_port) = params.get("mysql_port") {
+                if let Some(mysql_tcp_port) = params.get("mysql_tcp_port") {
                     connection_string =
-                        connection_string.tcp_port(mysql_port.parse::<u16>().unwrap_or(3306));
+                        connection_string.tcp_port(mysql_tcp_port.parse::<u16>().unwrap_or(3306));
                 }
                 if let Some(mysql_sslmode) = params.get("mysql_sslmode") {
                     match mysql_sslmode.to_lowercase().as_str() {


### PR DESCRIPTION
closes #1053 

Based on https://dev.mysql.com/doc/refman/8.3/en/environment-variables.html

Updating MySQL connector params to be consistent with `MYSQL_TCP_PORT` env variable
