### PR TITLE
Remove extraneous login parameters for databricks

### DIFF
--- a/bin/spice/cmd/login.go
+++ b/bin/spice/cmd/login.go
@@ -231,12 +231,11 @@ var databricksCmd = &cobra.Command{
 	Use:   "databricks",
 	Short: "Login to a Databricks instance",
 	Example: `
-spice login databricks --token <access-token> --aws-region <aws-region> --aws-access-key-id <aws-access-key-id> --aws-secret-access-key <aws-secret-access-key>
+spice login databricks --token <access-token>
 
 # See more at: https://docs.spiceai.org/
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		token, err := cmd.Flags().GetString(token)
 		if err != nil {
 			cmd.Println(err.Error())
@@ -248,45 +247,9 @@ spice login databricks --token <access-token> --aws-region <aws-region> --aws-ac
 			os.Exit(1)
 		}
 
-		awsRegion, err := cmd.Flags().GetString(awsRegion)
-		if err != nil {
-			cmd.Println(err.Error())
-			os.Exit(1)
-		}
-
-		if awsRegion == "" {
-			cmd.Println("No AWS Region provided, use --aws-region")
-			os.Exit(1)
-		}
-
-		awsAccessKeyId, err := cmd.Flags().GetString(awsAccessKeyId)
-		if err != nil {
-			cmd.Println(err.Error())
-			os.Exit(1)
-		}
-
-		if awsAccessKeyId == "" {
-			cmd.Println("No AWS Access Key ID provided, use --aws-access-key-id")
-			os.Exit(1)
-		}
-
-		awsSecret, err := cmd.Flags().GetString(awsSecret)
-		if err != nil {
-			cmd.Println(err.Error())
-			os.Exit(1)
-		}
-
-		if awsSecret == "" {
-			cmd.Println("No AWS Secret Access Key provided, use --aws-secret-access-key")
-			os.Exit(1)
-		}
-
 		mergeAuthConfig(cmd, api.AUTH_TYPE_DATABRICKS, &api.Auth{
 			Params: map[string]string{
-				api.AUTH_PARAM_TOKEN:                 token,
-				api.AUTH_PARAM_AWS_DEFAULT_REGION:    awsRegion,
-				api.AUTH_PARAM_AWS_ACCESS_KEY_ID:     awsAccessKeyId,
-				api.AUTH_PARAM_AWS_SECRET_ACCESS_KEY: awsSecret,
+				api.AUTH_PARAM_TOKEN: token,
 			},
 		},
 		)


### PR DESCRIPTION
Now that we're merging in https://github.com/spiceai/spiceai/pull/1110 - we don't need the S3 parameters to be specified on `spice login databricks`