### PR TITLE
PowerShell script to install Spice on Windows

### DIFF
--- a/install/Install.ps1
+++ b/install/Install.ps1
@@ -1,0 +1,66 @@
+# PowerShell Script to Install Spice CLI on Windows
+
+$spiceBin = ".spice\bin"
+$spiceCliInstallDir = Join-Path $HOME $spiceBin
+$spiceRepoName = "spiceai"
+$spiceOrgName = "spiceai"
+$spiceCliFileName = "spice.exe"
+$spiceCliFullPath= Join-Path $spiceCliInstallDir $spiceCliFileName
+
+# Ensure the installation directory and auth file exist
+New-Item -Path $spiceCliInstallDir -ItemType Directory -Force
+
+function Get-LatestRelease {
+    $url = "https://api.github.com/repos/$spiceOrgName/$spiceRepoName/releases/latest"
+    $releaseInfo = Invoke-RestMethod -Uri $url
+    return $releaseInfo.tag_name
+}
+
+# Function to download and install Spice CLIv
+function Download-And-Install-Spice {
+    Write-Host "Checking the the latest Spice version..."
+
+    $latestReleaseTag = Get-LatestRelease
+
+    Write-Host "Installing Spice $latestReleaseTag"
+
+    $artifactName = "${spiceCliFileName}"
+    $downloadUrl = "https://github.com/$spiceOrgName/$spiceRepoName/releases/download/$latestReleaseTag/$artifactName"
+    $tempPath = [System.IO.Path]::GetTempPath()
+    $tempFile = Join-Path $tempPath $artifactName
+
+    Write-Host "Downloading Spice CLI from $downloadUrl..."
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile
+
+    Move-Item -Path (Join-Path $tempPath $spiceCliFilename) -Destination $spiceCliFullPath -Force
+
+    # Temporary download Spice runtime as `spice upgrade` is not currently working on Windows.
+    $runtimeDownloadUrl = "https://github.com/$spiceOrgName/$spiceRepoName/releases/download/$latestReleaseTag/spiced.exe"
+    $runtimeInstallPath = Join-Path $spiceCliInstallDir "spiced.exe"
+    Write-Host "Downloading Spice Runtime from $runtimeDownloadUrl..."
+    Invoke-WebRequest -Uri $runtimeDownloadUrl -OutFile $runtimeInstallPath
+
+    Temporary workaround for spice CLI to work on Windows (expect runtime binary as spiced instead of spiced.exe).
+    $emptySpicedPath = Join-Path $spiceCliInstallDir "spiced"
+    $latestReleaseTag  | Out-File -FilePath $emptySpicedPath
+
+    if (Test-Path $spiceCliFullPath) {
+        Write-Host "Spice CLI installed into $spiceCliInstallDir successfully."
+    } else {
+        Write-Host "Failed to install Spice CLI."
+        exit
+    }
+}
+
+Download-And-Install-Spice
+
+# Add Spice CLI to system PATH
+$envPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User)
+if (-not $envPath.Contains($spiceCliInstallDir)) {
+    [Environment]::SetEnvironmentVariable("PATH", $envPath + ";$spiceCliInstallDir", [EnvironmentVariableTarget]::User)
+    Write-Host "Spice CLI directory added to PATH."
+} else {
+    Write-Host "Spice CLI directory is already in PATH."
+}
+
+Write-Host "`nTo get started with Spice.ai, visit https://docs.spiceai.org"

--- a/install/Install.ps1
+++ b/install/Install.ps1
@@ -40,7 +40,7 @@ function Download-And-Install-Spice {
     Write-Host "Downloading Spice Runtime from $runtimeDownloadUrl..."
     Invoke-WebRequest -Uri $runtimeDownloadUrl -OutFile $runtimeInstallPath
 
-    Temporary workaround for spice CLI to work on Windows (expect runtime binary as spiced instead of spiced.exe).
+    # Temporary workaround for spice CLI to work on Windows (expect runtime binary as spiced instead of spiced.exe).
     $emptySpicedPath = Join-Path $spiceCliInstallDir "spiced"
     $latestReleaseTag  | Out-File -FilePath $emptySpicedPath
 

--- a/install/Install.ps1
+++ b/install/Install.ps1
@@ -18,7 +18,7 @@ function Get-LatestRelease {
 
 # Function to download and install Spice CLIv
 function Download-And-Install-Spice {
-    Write-Host "Checking the the latest Spice version..."
+    Write-Host "Checking the latest Spice version..."
 
     $latestReleaseTag = Get-LatestRelease
 


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/853

Adds PowerShell script to install latest Spice version on Windows. Once merged Spice can be installed as 

```shell
curl -L "https://raw.githubusercontent.com/spiceai/spiceai/trunk/install/Install.ps1" -o Install.ps1 && PowerShell -ExecutionPolicy Bypass -File ./Install.ps1

System architecture is ARM64-based PC
Checking the latest Spice version...
Installing Spice v0.11.0-alpha
Downloading Spice CLI from https://github.com/spiceai/spiceai/releases/download/v0.11.0-alpha/spice.exe_windows_x86_64.tar.gz...
Downloading Spice Runtime from https://github.com/spiceai/spiceai/releases/download/v0.11.0-alpha/spiced.exe_windows_x86_64.tar.gz...
Spice CLI installed into C:\Users\sg\.spice\bin successfully.
Spice CLI directory is already in PATH.

To get started with Spice.ai, visit https://docs.spiceai.org
```

Notes:
1. While testing I found that Spice is unable to detect and download Spice runtime on Windows so runtime was added to installation as well.
2. Spice expects runtime to be `spiced` instead of `spiced.exe` on Windows and fails to start. Installation script temporary creates blank `spiced` file with installed version in order for Spice to work.
3. I'll address both items above as part of https://github.com/spiceai/spiceai/issues/853