### PR TITLE
Use quoted strings when performing federated SQL queries

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -36,7 +36,7 @@ pub enum Error {
     #[snafu(display("Unable to construct spice app: {source}"))]
     UnableToConstructSpiceApp { source: app::Error },
 
-    #[snafu(display("Unable to start Spice Runtime servers"))]
+    #[snafu(display("Unable to start Spice Runtime servers: {source}"))]
     UnableToStartServers { source: runtime::Error },
 
     #[snafu(display("Failed to load dataset: {source}"))]
@@ -50,7 +50,7 @@ pub enum Error {
         data_connector: String,
     },
 
-    #[snafu(display("Unable to create data backend"))]
+    #[snafu(display("Unable to create data backend: {source}"))]
     UnableToCreateBackend { source: runtime::datafusion::Error },
 
     #[snafu(display("Failed to start pods watcher: {source}"))]

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -265,7 +265,7 @@ impl FlightExec {
 
         Ok(format!(
             "SELECT {columns} FROM {table_reference} {where_expr} {limit_expr}",
-            table_reference = self.table_reference,
+            table_reference = self.table_reference.to_quoted_string(),
         ))
     }
 }

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -368,7 +368,7 @@ impl FlightSqlExec {
         };
         Ok(format!(
             "SELECT {columns} FROM {table_reference} {where_expr} {limit_expr}",
-            table_reference = self.table_reference,
+            table_reference = self.table_reference.to_quoted_string(),
         ))
     }
 }

--- a/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
@@ -68,7 +68,10 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSq
     fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef> {
         let mut stmt = self
             .conn
-            .prepare(&format!("SELECT * FROM {table_reference} LIMIT 0"))
+            .prepare(&format!(
+                "SELECT * FROM {} LIMIT 0",
+                table_reference.to_quoted_string()
+            ))
             .context(DuckDBSnafu)?;
 
         let result: duckdb::Arrow<'_> = stmt.query_arrow([]).context(DuckDBSnafu)?;

--- a/crates/db_connection_pool/src/dbconnection/mysqlconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/mysqlconn.rs
@@ -69,7 +69,10 @@ impl<'a> AsyncDbConnection<Conn, &'a (dyn ToValue + Sync)> for MySQLConnection {
         let conn = &mut *conn;
         let rows: Vec<Row> = conn
             .exec(
-                &format!("SELECT * FROM {table_reference} LIMIT 1"),
+                &format!(
+                    "SELECT * FROM {} LIMIT 1",
+                    table_reference.to_quoted_string()
+                ),
                 Params::Empty,
             )
             .await

--- a/crates/db_connection_pool/src/dbconnection/postgresconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/postgresconn.rs
@@ -89,7 +89,13 @@ impl<'a>
     async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef> {
         let rows = self
             .conn
-            .query(&format!("SELECT * FROM {table_reference} LIMIT 1"), &[])
+            .query(
+                &format!(
+                    "SELECT * FROM {} LIMIT 1",
+                    table_reference.to_quoted_string()
+                ),
+                &[],
+            )
             .await
             .context(QuerySnafu)?;
         let rec = rows_to_arrow(rows.as_slice()).context(ConversionSnafu)?;

--- a/crates/db_connection_pool/src/dbconnection/sqliteconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/sqliteconn.rs
@@ -69,7 +69,7 @@ impl AsyncDbConnection<Connection, &'static (dyn ToSql + Sync)> for SqliteConnec
     }
 
     async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef> {
-        let table_reference = table_reference.to_string();
+        let table_reference = table_reference.to_quoted_string();
         let schema = self
             .conn
             .call(move |conn| {

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -82,7 +82,6 @@ default = ["keyring-secret-store", "aws-secrets-manager"]
 dev = []
 duckdb = [
     "dep:duckdb",
-    "sql_provider_datafusion/duckdb",
     "r2d2",
     "db_connection_pool/duckdb",
     "spicepod/duckdb",

--- a/crates/sql_provider_datafusion/Cargo.toml
+++ b/crates/sql_provider_datafusion/Cargo.toml
@@ -11,7 +11,6 @@ exclude.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-duckdb = { workspace = true, features = ["bundled", "r2d2", "vtab", "vtab-arrow"], optional = true }
 datafusion.workspace = true
 async-trait.workspace = true
 r2d2.workspace = true
@@ -23,6 +22,8 @@ db_connection_pool = { path = "../db_connection_pool" }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+duckdb = { workspace = true, features = ["bundled", "r2d2", "vtab", "vtab-arrow"] }
+db_connection_pool = { path = "../db_connection_pool", features = ["duckdb"] }
 
 [features]
 postgres = ["db_connection_pool/postgres"]

--- a/crates/sql_provider_datafusion/src/lib.rs
+++ b/crates/sql_provider_datafusion/src/lib.rs
@@ -216,7 +216,7 @@ impl<T, P> SqlExec<T, P> {
 
         Ok(format!(
             "SELECT {columns} FROM {table_reference} {where_expr} {limit_expr}",
-            table_reference = self.table_reference,
+            table_reference = self.table_reference.to_quoted_string(),
         ))
     }
 }
@@ -298,6 +298,7 @@ mod tests {
     use std::{error::Error, sync::Arc};
 
     use datafusion::execution::context::SessionContext;
+    use datafusion::sql::TableReference;
     use db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
     use db_connection_pool::{duckdbpool::DuckDbConnectionPool, DbConnectionPool, Mode};
     use duckdb::{DuckdbConnectionManager, ToSql};
@@ -312,6 +313,12 @@ mod tests {
 
         let dispatch = Dispatch::new(subscriber);
         tracing::dispatcher::set_default(&dispatch)
+    }
+
+    #[test]
+    fn test_references() {
+        let table_ref = TableReference::bare("test");
+        assert_eq!(format!("{table_ref}"), "test");
     }
 
     #[tokio::test]


### PR DESCRIPTION
This partially fixes #1127.

It fixes it for the following data connectors: `duckdb`, `postgres`, `mysql`, `dremio`, `flightsql`, `spiceai`

It is still broken for `databricks` using Spark Connect.
`databricks` with direct S3 Delta Table is also fixed.