### PR TITLE
Respect executables file extension on Windows

### DIFF
--- a/bin/spice/pkg/constants/constants.go
+++ b/bin/spice/pkg/constants/constants.go
@@ -16,9 +16,24 @@ limitations under the License.
 
 package constants
 
+import "runtime"
+
 const (
 	DotSpice               = ".spice"
 	SpicePodsDirectoryName = "spicepods"
-	SpiceRuntimeFilename   = "spiced"
-	SpiceCliFilename       = "spice"
 )
+
+var (
+	SpiceRuntimeFilename string
+	SpiceCliFilename     string
+)
+
+func init() {
+	if runtime.GOOS == "windows" {
+		SpiceRuntimeFilename = "spiced.exe"
+		SpiceCliFilename = "spice.exe"
+	} else {
+		SpiceRuntimeFilename = "spiced"
+		SpiceCliFilename = "spice"
+	}
+}


### PR DESCRIPTION
Add required file extension on Windows so that Spice CLI can detect Spice runtime

Before
```bash
spice version

CLI version:     local
Runtime version: not installed
```
After
```bash
spice version

CLI version:     local
Runtime version: v0.11.0-alpha
```