### PR TITLE
Better Data Connector Initialization Error Message Without Intermediate Layer

### DIFF
--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -31,7 +31,7 @@ use super::{DataConnector, DataConnectorFactory};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to create Postgres connection pool: {source}"))]
+    #[snafu(display("{source}"))]
     UnableToCreatePostgresConnectionPool { source: db_connection_pool::Error },
 
     #[snafu(display("{source}"))]


### PR DESCRIPTION
This is more about a design question: which intermediate layers we want to keep, which also apply to error messages other than Data Connector Initialization Error

- https://github.com/spiceai/spiceai/issues/856