### PR TITLE
Make Windows installation less verbose

### DIFF
--- a/install/Install.ps1
+++ b/install/Install.ps1
@@ -7,7 +7,7 @@ $spiceOrgName = "spiceai"
 $spiceCliFileName = "spice.exe"
 $spiceCliFullPath= Join-Path $spiceCliInstallDir $spiceCliFileName
 
-# Ensure the installation directory and auth file exist
+# Ensure the installation directory exists
 New-Item -Path $spiceCliInstallDir -ItemType Directory -Force > $null
 
 function Get-LatestRelease {

--- a/install/Install.ps1
+++ b/install/Install.ps1
@@ -8,7 +8,7 @@ $spiceCliFileName = "spice.exe"
 $spiceCliFullPath= Join-Path $spiceCliInstallDir $spiceCliFileName
 
 # Ensure the installation directory and auth file exist
-New-Item -Path $spiceCliInstallDir -ItemType Directory -Force
+New-Item -Path $spiceCliInstallDir -ItemType Directory -Force > $null
 
 function Get-LatestRelease {
     $url = "https://api.github.com/repos/$spiceOrgName/$spiceRepoName/releases/latest"


### PR DESCRIPTION
Update Windows installation script to not print details of created .spice home directory. 