### PR TITLE
Allow only alphanumeric dataset names when using `spice dataset configure`

### DIFF
--- a/bin/spice/cmd/dataset.go
+++ b/bin/spice/cmd/dataset.go
@@ -81,6 +81,11 @@ spice dataset configure
 			os.Exit(1)
 		}
 
+		if strings.Contains(datasetName, "-") {
+			// warn that dataset name with hyphen should be quoted in queries
+			cmd.Println(aurora.BrightYellow(fmt.Sprintf("Dataset names with hyphens should be quoted in queries:\nSELECT * FROM \"%s\"", datasetName)))
+		}
+
 		cmd.Print("description: ")
 		description, err := reader.ReadString('\n')
 		if err != nil {

--- a/bin/spice/cmd/dataset.go
+++ b/bin/spice/cmd/dataset.go
@@ -83,7 +83,7 @@ spice dataset configure
 
 		if strings.Contains(datasetName, "-") {
 			// warn that dataset name with hyphen should be quoted in queries
-			cmd.Println(aurora.BrightYellow(fmt.Sprintf("Dataset names with hyphens should be quoted in queries:\nSELECT * FROM \"%s\"", datasetName)))
+			cmd.Println(aurora.BrightYellow(fmt.Sprintf("Dataset names with hyphens should be quoted in queries:\ni.e. SELECT * FROM \"%s\"", datasetName)))
 		}
 
 		cmd.Print("description: ")

--- a/bin/spice/cmd/dataset.go
+++ b/bin/spice/cmd/dataset.go
@@ -69,6 +69,11 @@ spice dataset configure
 			datasetName = defaultDatasetName
 		}
 
+		if strings.Contains(datasetName, ".") {
+			cmd.Println(aurora.BrightRed("Dataset name cannot contain '.'"))
+			os.Exit(1)
+		}
+
 		cmd.Print("description: ")
 		description, err := reader.ReadString('\n')
 		if err != nil {

--- a/bin/spice/cmd/dataset.go
+++ b/bin/spice/cmd/dataset.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -69,8 +70,14 @@ spice dataset configure
 			datasetName = defaultDatasetName
 		}
 
-		if strings.Contains(datasetName, ".") {
-			cmd.Println(aurora.BrightRed("Dataset name cannot contain '.'"))
+		match, err := regexp.MatchString("^[a-zA-Z0-9_-]+$", datasetName)
+		if err != nil {
+			cmd.Println(err.Error())
+			os.Exit(1)
+		}
+
+		if !match {
+			cmd.Println(aurora.BrightRed("Dataset name can only contain letters, numbers, underscores, and hyphens"))
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
closes #957 

![CleanShot 2024-04-19 at 12 48 25@2x](https://github.com/spiceai/spiceai/assets/827338/b1c14ae4-392c-44fb-9a1a-32e09d883254)

![CleanShot 2024-04-19 at 12 49 41@2x](https://github.com/spiceai/spiceai/assets/827338/26744a87-06c5-4ab6-a348-e07f6cabd4a8)

