### PR TITLE
Enable clippy::clone_on_ref_ptr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ To configure VSCode to automatically apply the rustfmt style on save and to use 
   },
   "rust-analyzer.check.command": "clippy",
   "rust-analyzer.check.features": "all",
-  "rust-analyzer.check.extraArgs": ["--", "-Dclippy::pedantic", "-Dclippy::unwrap_used", "-Dclippy::expect_used"]
+  "rust-analyzer.check.extraArgs": ["--", "-Dclippy::pedantic", "-Dclippy::unwrap_used", "-Dclippy::clone_on_ref_ptr"]
 ```
 
 By default, `rust-analyzer` will attempt to rebuild all dependencies when a change is made to a `cargo.toml` file. To prevent this and only rebuild what has changed, add the following in your User Settings JSON file, setting the value to your architecture:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ lint:
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \
-		-Dclippy::expect_used
+		-Dclippy::expect_used \
+		-Dclippy::clone_on_ref_ptr
 
 .PHONY: docker
 docker:

--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -113,7 +113,7 @@ impl TableProvider for MemTable {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        Arc::clone(&self.schema)
     }
 
     fn constraints(&self) -> Option<&Constraints> {
@@ -176,7 +176,7 @@ impl TableProvider for MemTable {
         Ok(Arc::new(FileSinkExec::new(
             input,
             sink,
-            self.schema.clone(),
+            Arc::clone(&self.schema),
             None,
         )))
     }

--- a/crates/data_components/src/databricks_delta.rs
+++ b/crates/data_components/src/databricks_delta.rs
@@ -48,7 +48,7 @@ impl Read for DatabricksDelta {
         get_delta_table(
             Arc::clone(&self.secret),
             table_reference,
-            self.params.clone(),
+            Arc::clone(&self.params),
         )
         .await
     }
@@ -63,7 +63,7 @@ impl ReadWrite for DatabricksDelta {
         let delta_table = get_delta_table(
             Arc::clone(&self.secret),
             table_reference,
-            self.params.clone(),
+            Arc::clone(&self.params),
         )
         .await?;
 

--- a/crates/data_components/src/databricks_spark.rs
+++ b/crates/data_components/src/databricks_spark.rs
@@ -78,7 +78,7 @@ impl ReadWrite for DatabricksSparkConnect {
         table_reference: OwnedTableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>> {
         let provider =
-            spark_connect::get_table_provider(self.session.clone(), table_reference).await?;
+            spark_connect::get_table_provider(Arc::clone(&self.session), table_reference).await?;
         Ok(provider)
     }
 }
@@ -90,7 +90,7 @@ impl Read for DatabricksSparkConnect {
         table_reference: OwnedTableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>> {
         let provider =
-            spark_connect::get_table_provider(self.session.clone(), table_reference).await?;
+            spark_connect::get_table_provider(Arc::clone(&self.session), table_reference).await?;
         Ok(provider)
     }
 }

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -294,7 +294,7 @@ impl ExecutionPlan for FlightExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.projected_schema.clone()
+        Arc::clone(&self.projected_schema)
     }
 
     fn properties(&self) -> &PlanProperties {

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -397,7 +397,7 @@ impl ExecutionPlan for FlightSqlExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.projected_schema.clone()
+        Arc::clone(&self.projected_schema)
     }
 
     fn properties(&self) -> &PlanProperties {

--- a/crates/data_components/src/spark_connect.rs
+++ b/crates/data_components/src/spark_connect.rs
@@ -150,7 +150,7 @@ impl TableProvider for SparkConnectTablePovider {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        Arc::clone(&self.schema)
     }
 
     fn table_type(&self) -> TableType {
@@ -166,7 +166,7 @@ impl TableProvider for SparkConnectTablePovider {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(SparkConnectExecutionPlan::new(
             self.dataframe.clone(),
-            self.schema.clone(),
+            Arc::clone(&self.schema),
             projection,
             filters,
             limit,
@@ -245,7 +245,7 @@ impl ExecutionPlan for SparkConnectExecutionPlan {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.projected_schema.clone()
+        Arc::clone(&self.projected_schema)
     }
 
     fn execute(

--- a/crates/runtime/src/execution_plan/slice.rs
+++ b/crates/runtime/src/execution_plan/slice.rs
@@ -68,7 +68,7 @@ impl ExecutionPlan for SliceExec {
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
-        vec![self.input.clone()]
+        vec![Arc::clone(&self.input)]
     }
 
     fn with_new_children(
@@ -77,7 +77,7 @@ impl ExecutionPlan for SliceExec {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() == 1 {
             Ok(Arc::new(SliceExec::new(
-                children[0].clone(),
+                Arc::clone(&children[0]),
                 self.partition,
             )))
         } else {

--- a/crates/runtime/src/execution_plan/tee.rs
+++ b/crates/runtime/src/execution_plan/tee.rs
@@ -69,7 +69,7 @@ impl ExecutionPlan for TeeExec {
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
-        vec![self.input.clone()]
+        vec![Arc::clone(&self.input)]
     }
 
     fn with_new_children(
@@ -77,7 +77,7 @@ impl ExecutionPlan for TeeExec {
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if children.len() == 1 {
-            Ok(Arc::new(TeeExec::new(children[0].clone(), self.n)))
+            Ok(Arc::new(TeeExec::new(Arc::clone(&children[0]), self.n)))
         } else {
             Err(DataFusionError::Execution(
                 "TeeExec expects exactly one input".to_string(),
@@ -98,7 +98,7 @@ impl ExecutionPlan for TeeExec {
         }
 
         // Coalesce the input into a single partition
-        let coalesce_plan = CoalescePartitionsExec::new(self.input.clone());
+        let coalesce_plan = CoalescePartitionsExec::new(Arc::clone(&self.input));
         let single_partition = coalesce_plan.execute(0, context)?;
 
         Ok(single_partition)

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -288,7 +288,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub async fn start(bind_address: std::net::SocketAddr, df: Arc<RwLock<DataFusion>>) -> Result<()> {
     let service = Service {
-        datafusion: df.clone(),
+        datafusion: Arc::clone(&df),
         channel_map: Arc::new(RwLock::new(HashMap::new())),
     };
     let svc = FlightServiceServer::new(service);

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -80,7 +80,7 @@ pub(crate) async fn handle(
     // Sometimes the first message only contains the schema and no data
     let first_batch = arrow_flight::utils::flight_data_to_arrow_batch(
         &message,
-        schema.clone(),
+        Arc::clone(&schema),
         &dictionaries_by_id,
     )
     .ok();

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -708,9 +708,9 @@ pub(crate) mod inference {
 
         for model_predict_request in payload.predictions {
             let prediction_future = run_inference(
-                app.clone(),
-                df.clone(),
-                models.clone(),
+                Arc::clone(&app),
+                Arc::clone(&df),
+                Arc::clone(&models),
                 model_predict_request.model_name,
             );
             model_prediction_futures.push(prediction_future);
@@ -776,7 +776,7 @@ pub(crate) mod inference {
             };
         };
 
-        match runnable.run(df.clone()).await {
+        match runnable.run(Arc::clone(&df)).await {
             Ok(inference_result) => {
                 if let Some(column_data) = inference_result.column_by_name("y") {
                     if let Some(array) = column_data.as_any().downcast_ref::<Float32Array>() {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -551,16 +551,19 @@ impl Runtime {
     pub async fn start_servers(&mut self, with_metrics: Option<SocketAddr>) -> Result<()> {
         let http_server_future = http::start(
             self.config.http_bind_address,
-            self.app.clone(),
-            self.df.clone(),
-            self.models.clone(),
+            Arc::clone(&self.app),
+            Arc::clone(&self.df),
+            Arc::clone(&self.models),
             self.config.clone().into(),
             with_metrics,
         );
 
-        let flight_server_future = flight::start(self.config.flight_bind_address, self.df.clone());
-        let open_telemetry_server_future =
-            opentelemetry::start(self.config.open_telemetry_bind_address, self.df.clone());
+        let flight_server_future =
+            flight::start(self.config.flight_bind_address, Arc::clone(&self.df));
+        let open_telemetry_server_future = opentelemetry::start(
+            self.config.open_telemetry_bind_address,
+            Arc::clone(&self.df),
+        );
         let pods_watcher_future = self.start_pods_watcher();
 
         tokio::select! {

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -530,7 +530,7 @@ fn initialize_attribute_schema(
                 continue;
             }
 
-            fields.insert(field.name().clone(), field.clone());
+            fields.insert(field.name().clone(), Arc::clone(field));
             match field.data_type() {
                 DataType::Utf8 => {
                     columns.insert(field.name().clone(), Box::new(StringBuilder::new()));

--- a/crates/sql_provider_datafusion/src/lib.rs
+++ b/crates/sql_provider_datafusion/src/lib.rs
@@ -245,7 +245,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.projected_schema.clone()
+        Arc::clone(&self.projected_schema)
     }
 
     fn properties(&self) -> &PlanProperties {
@@ -274,7 +274,7 @@ impl<T: 'static, P: 'static> ExecutionPlan for SqlExec<T, P> {
         let fut = get_stream(Arc::clone(&self.pool), sql);
 
         let stream = futures::stream::once(fut).try_flatten();
-        let schema = self.schema().clone();
+        let schema = Arc::clone(&self.schema());
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }
 }


### PR DESCRIPTION
Enables the following lint rule: https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_ref_ptr