### PR TITLE
Handle and trace errors in secret stores

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -93,7 +93,7 @@ pub enum Error {
     #[snafu(display("Unable to load secrets for data connector: {data_connector}"))]
     UnableToLoadDataConnectorSecrets { data_connector: String },
 
-    #[snafu(display("Unable to get secret for data connector: {source}"))]
+    #[snafu(display("Unable to get secret for data connector {data_connector}: {source}"))]
     UnableToGetSecretForDataConnector {
         source: Box<dyn std::error::Error + Send + Sync>,
         data_connector: String,

--- a/crates/secrets/src/aws_secrets_manager.rs
+++ b/crates/secrets/src/aws_secrets_manager.rs
@@ -37,7 +37,7 @@ pub enum Error {
         source: SdkError<GetCallerIdentityError>,
     },
 
-    #[snafu(display("Unable to parse AWS secret as JSON: {}", source))]
+    #[snafu(display("Unable to parse AWS secret as JSON: {source}"))]
     UnableToParseJson { source: serde_json::Error },
 
     #[snafu(display("Invalid AWS secret value: JSON object is expected"))]

--- a/crates/secrets/src/aws_secrets_manager.rs
+++ b/crates/secrets/src/aws_secrets_manager.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[snafu(display("Invalid AWS secret value: JSON object is expected"))]
     InvalidJsonFormat {},
 
-    #[snafu(display("Unable to get AWS secret: {}", source))]
+    #[snafu(display("Unable to get AWS secret: {source}"))]
     UnableToGetSecret {
         source: SdkError<GetSecretValueError>,
     },

--- a/crates/secrets/src/aws_secrets_manager.rs
+++ b/crates/secrets/src/aws_secrets_manager.rs
@@ -37,13 +37,13 @@ pub enum Error {
         source: SdkError<GetCallerIdentityError>,
     },
 
-    #[snafu(display("Unable to parse as JSON: {}", source))]
+    #[snafu(display("Unable to parse AWS secret as JSON: {}", source))]
     UnableToParseJson { source: serde_json::Error },
 
-    #[snafu(display("Invalid JSON format: JSON object is expected"))]
+    #[snafu(display("Invalid AWS secret value: JSON object is expected"))]
     InvalidJsonFormat {},
 
-    #[snafu(display("Unable to get secret: {}", source))]
+    #[snafu(display("Unable to get AWS secret: {}", source))]
     UnableToGetSecret {
         source: SdkError<GetSecretValueError>,
     },

--- a/crates/secrets/src/aws_secrets_manager.rs
+++ b/crates/secrets/src/aws_secrets_manager.rs
@@ -87,7 +87,7 @@ impl AwsSecretsManager {
 #[async_trait]
 impl SecretStore for AwsSecretsManager {
     #[must_use]
-    async fn get_secret(&self, secret_name: &str) -> Option<Secret> {
+    async fn get_secret(&self, secret_name: &str) -> super::Result<Option<Secret>> {
         let secret_name = format!("{SPICE_SECRET_PREFIX}{secret_name}");
 
         tracing::trace!("Getting secret {} from AWS Secrets Manager", secret_name);
@@ -110,7 +110,7 @@ impl SecretStore for AwsSecretsManager {
                         e.err()
                     );
                 }
-                return None;
+                return Ok(None);
             }
             Err(err) => {
                 tracing::warn!(
@@ -118,21 +118,21 @@ impl SecretStore for AwsSecretsManager {
                     secret_name,
                     err
                 );
-                return None;
+                return Ok(None);
             }
         };
 
         if let Some(secret_str) = secret_value.secret_string() {
             match parse_json_to_hashmap(secret_str) {
-                Ok(data) => return Some(Secret::new(data)),
+                Ok(data) => return Ok(Some(Secret::new(data))),
                 Err(err) => {
                     tracing::warn!("Failed to parse secret {} content: {}", secret_name, err);
-                    return None;
+                    return Ok(None);
                 }
             }
         }
 
-        None
+        Ok(None)
     }
 }
 /// Parses a JSON string into a `HashMap<String, String>`.

--- a/crates/secrets/src/aws_secrets_manager.rs
+++ b/crates/secrets/src/aws_secrets_manager.rs
@@ -111,11 +111,6 @@ impl SecretStore for AwsSecretsManager {
                 // It is expected that not all parameters are present in secrets.
                 // Pass through only if it is a different error
                 if !e.err().is_resource_not_found_exception() {
-                    tracing::warn!(
-                        "Failed to get secret {} from AWS Secrets Manager: {}",
-                        secret_name,
-                        e.err()
-                    );
                     return Err(Box::new(Error::UnableToGetSecret {
                         source: SdkError::ServiceError(e),
                     }));
@@ -123,11 +118,6 @@ impl SecretStore for AwsSecretsManager {
                 return Ok(None);
             }
             Err(err) => {
-                tracing::warn!(
-                    "Failed to get secret {} from AWS Secrets Manager: {}",
-                    secret_name,
-                    err
-                );
                 return Err(Box::new(Error::UnableToGetSecret { source: err }));
             }
         };

--- a/crates/secrets/src/aws_secrets_manager.rs
+++ b/crates/secrets/src/aws_secrets_manager.rs
@@ -109,13 +109,16 @@ impl SecretStore for AwsSecretsManager {
             Ok(secret) => secret,
             Err(SdkError::ServiceError(e)) => {
                 // It is expected that not all parameters are present in secrets.
-                // Warn only if it is a different error
+                // Pass through only if it is a different error
                 if !e.err().is_resource_not_found_exception() {
                     tracing::warn!(
                         "Failed to get secret {} from AWS Secrets Manager: {}",
                         secret_name,
                         e.err()
                     );
+                    return Err(Box::new(Error::UnableToGetSecret {
+                        source: SdkError::ServiceError(e),
+                    }));
                 }
                 return Ok(None);
             }

--- a/crates/secrets/src/env.rs
+++ b/crates/secrets/src/env.rs
@@ -101,11 +101,11 @@ impl EnvSecretStore {
 #[async_trait]
 impl SecretStore for EnvSecretStore {
     #[must_use]
-    async fn get_secret(&self, secret_name: &str) -> Option<Secret> {
+    async fn get_secret(&self, secret_name: &str) -> super::Result<Option<Secret>> {
         if let Some(secret) = self.secrets.get(secret_name) {
-            return Some(secret.clone());
+            return Ok(Some(secret.clone()));
         }
 
-        None
+        Ok(None)
     }
 }

--- a/crates/secrets/src/env.rs
+++ b/crates/secrets/src/env.rs
@@ -101,7 +101,7 @@ impl EnvSecretStore {
 #[async_trait]
 impl SecretStore for EnvSecretStore {
     #[must_use]
-    async fn get_secret(&self, secret_name: &str) -> super::Result<Option<Secret>> {
+    async fn get_secret(&self, secret_name: &str) -> super::AnyErrorResult<Option<Secret>> {
         if let Some(secret) = self.secrets.get(secret_name) {
             return Ok(Some(secret.clone()));
         }

--- a/crates/secrets/src/file.rs
+++ b/crates/secrets/src/file.rs
@@ -102,11 +102,11 @@ impl FileSecretStore {
 #[async_trait]
 impl SecretStore for FileSecretStore {
     #[must_use]
-    async fn get_secret(&self, secret_name: &str) -> Option<Secret> {
+    async fn get_secret(&self, secret_name: &str) -> super::Result<Option<Secret>> {
         if let Some(secret) = self.secrets.get(secret_name) {
-            return Some(secret.clone());
+            return Ok(Some(secret.clone()));
         }
 
-        None
+        Ok(None)
     }
 }

--- a/crates/secrets/src/file.rs
+++ b/crates/secrets/src/file.rs
@@ -77,7 +77,7 @@ impl FileSecretStore {
     /// # Errors
     ///
     /// Returns an error if there is a problem loading the secrets.
-    pub fn load_secrets(&mut self) -> Result<()> {
+    pub fn load_secrets(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let mut auth_path = dirs::home_dir().context(UnableToFindHomeDirSnafu)?;
         auth_path.push(".spice/auth");
 
@@ -102,7 +102,7 @@ impl FileSecretStore {
 #[async_trait]
 impl SecretStore for FileSecretStore {
     #[must_use]
-    async fn get_secret(&self, secret_name: &str) -> super::Result<Option<Secret>> {
+    async fn get_secret(&self, secret_name: &str) -> super::AnyErrorResult<Option<Secret>> {
         if let Some(secret) = self.secrets.get(secret_name) {
             return Ok(Some(secret.clone()));
         }

--- a/crates/secrets/src/keyring.rs
+++ b/crates/secrets/src/keyring.rs
@@ -26,16 +26,16 @@ const KEYRING_SECRET_PREFIX: &str = "spice_secret_";
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to get secret: {source}"))]
+    #[snafu(display("Unable to get secret from keyring: {source}"))]
     UnableToGetSecret { source: keyring::Error },
 
-    #[snafu(display("Unable to get secret value: {source}"))]
+    #[snafu(display("Unable to get keyring secret value: {source}"))]
     UnableToGetSecretValue { source: keyring::Error },
 
-    #[snafu(display("Unable to parse secret value: {source}"))]
+    #[snafu(display("Unable to parse keyring secret value: {source}"))]
     UnableToParseSecretValue { source: serde_json::Error },
 
-    #[snafu(display("Invalid JSON format: JSON object is expected"))]
+    #[snafu(display("Invalid keyring secret value: JSON object is expected"))]
     InvalidJsonFormat {},
 }
 

--- a/crates/secrets/src/keyring.rs
+++ b/crates/secrets/src/keyring.rs
@@ -64,10 +64,6 @@ impl SecretStore for KeyringSecretStore {
         let entry = match Entry::new(entry_key.as_str(), "spiced") {
             Ok(entry) => entry,
             Err(keyring::Error::NoEntry) => {
-                tracing::warn!(
-                    "Failed to get secret entry {} from keyring store, no entry found",
-                    entry_key,
-                );
                 return Ok(None);
             }
             Err(err) => {

--- a/crates/secrets/src/keyring.rs
+++ b/crates/secrets/src/keyring.rs
@@ -67,11 +67,6 @@ impl SecretStore for KeyringSecretStore {
                 return Ok(None);
             }
             Err(err) => {
-                tracing::warn!(
-                    "Failed to get secret entry {} from keyring store, {}",
-                    entry_key,
-                    err
-                );
                 return Err(Box::new(Error::UnableToGetSecret { source: err }));
             }
         };
@@ -82,11 +77,6 @@ impl SecretStore for KeyringSecretStore {
                 return Ok(None);
             }
             Err(err) => {
-                tracing::warn!(
-                    "Failed to get secret value for secret entry {} from keyring store, {}",
-                    entry_key,
-                    err
-                );
                 return Err(Box::new(Error::UnableToGetSecretValue { source: err }));
             }
         };
@@ -95,21 +85,11 @@ impl SecretStore for KeyringSecretStore {
         let parsed = match parsed {
             Ok(parsed) => parsed,
             Err(err) => {
-                tracing::warn!(
-                    "Failed to parse secret value for secret entry {} from keyring store, {}",
-                    entry_key,
-                    err
-                );
                 return Err(Box::new(Error::UnableToParseSecretValue { source: err }));
             }
         };
 
         let Some(object) = parsed.as_object() else {
-            tracing::warn!(
-                "Failed to parse secret value for secret entry {} from keyring store, {}",
-                entry_key,
-                "value is not an object"
-            );
             return Err(Box::new(Error::InvalidJsonFormat {}));
         };
 

--- a/crates/secrets/src/keyring.rs
+++ b/crates/secrets/src/keyring.rs
@@ -78,6 +78,9 @@ impl SecretStore for KeyringSecretStore {
 
         let secret = match entry.get_password() {
             Ok(secret) => secret,
+            Err(keyring::Error::NoEntry) => {
+                return Ok(None);
+            }
             Err(err) => {
                 tracing::warn!(
                     "Failed to get secret value for secret entry {} from keyring store, {}",

--- a/crates/secrets/src/kubernetes.rs
+++ b/crates/secrets/src/kubernetes.rs
@@ -171,10 +171,16 @@ impl KubernetesSecretStore {
 impl SecretStore for KubernetesSecretStore {
     #[must_use]
     async fn get_secret(&self, secret_name: &str) -> Option<Secret> {
-        if let Ok(secret) = self.kubernetes_client.get_secret(secret_name).await {
-            return Some(Secret::new(secret.clone()));
+        match self.kubernetes_client.get_secret(secret_name).await {
+            Ok(secret) => Some(Secret::new(secret.clone())),
+            Err(err) => {
+                tracing::warn!(
+                    "Failed to get secret {} from kubernetes store, {}",
+                    secret_name,
+                    err
+                );
+                None
+            }
         }
-
-        None
     }
 }

--- a/crates/secrets/src/kubernetes.rs
+++ b/crates/secrets/src/kubernetes.rs
@@ -198,14 +198,7 @@ impl SecretStore for KubernetesSecretStore {
     async fn get_secret(&self, secret_name: &str) -> super::AnyErrorResult<Option<Secret>> {
         match self.kubernetes_client.get_secret(secret_name).await {
             Ok(secret) => Ok(Some(Secret::new(secret.clone()))),
-            Err(err) => {
-                tracing::warn!(
-                    "Failed to get secret {} from kubernetes store, {}",
-                    secret_name,
-                    err
-                );
-                return Err(Box::new(StoreError::UnableToGetSecret { source: err }));
-            }
+            Err(err) => Err(Box::new(StoreError::UnableToGetSecret { source: err })),
         }
     }
 }

--- a/crates/secrets/src/kubernetes.rs
+++ b/crates/secrets/src/kubernetes.rs
@@ -19,14 +19,38 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine};
 use reqwest;
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
 
 use super::{Secret, SecretStore};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
+    #[snafu(display("Unable to read K8S token: {source}"))]
+    UnableToReadK8SToken { source: std::io::Error },
+
+    #[snafu(display("Unable to read K8S namespace: {source}"))]
+    UnableToReadK8SNamespace { source: std::io::Error },
+
+    #[snafu(display("Unable to read CA certificate: {source}"))]
+    UnableToReadCACertificate { source: std::io::Error },
+
     #[snafu(display("Unable to read kubernetes credentials"))]
     UnableToReadKubernetesCredentials {},
+
+    #[snafu(display("Unable to create K8S http client: {source}"))]
+    UnableToCreateK8SClient { source: reqwest::Error },
+
+    #[snafu(display("Unable to get secret from K8S: {source}"))]
+    UnableToGetK8SSecret { source: reqwest::Error },
+}
+
+#[derive(Debug, Snafu)]
+pub enum StoreError {
+    #[snafu(display("Unable to init kubernetes store: {source}"))]
+    UnableToInitKubernetesClient { source: Error },
+
+    #[snafu(display("Unable to get secret from: {source}"))]
+    UnableToGetSecret { source: Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -49,60 +73,59 @@ impl KubernetesClient {
         }
     }
 
-    fn init(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        self.token = Some(std::fs::read_to_string(format!(
-            "{KUBERNETES_ACCOUNT_PATH}/token"
-        ))?);
+    fn init(&mut self) -> Result<(), Error> {
+        self.token = Some(
+            std::fs::read_to_string(format!("{KUBERNETES_ACCOUNT_PATH}/token"))
+                .context(UnableToReadK8STokenSnafu)?,
+        );
 
-        self.namespace = Some(std::fs::read_to_string(format!(
-            "{KUBERNETES_ACCOUNT_PATH}/namespace"
-        ))?);
+        self.namespace = Some(
+            std::fs::read_to_string(format!("{KUBERNETES_ACCOUNT_PATH}/namespace"))
+                .context(UnableToReadK8SNamespaceSnafu)?,
+        );
 
-        let ca_cert = std::fs::read_to_string(format!("{KUBERNETES_ACCOUNT_PATH}/ca.crt"))?;
+        let ca_cert = std::fs::read_to_string(format!("{KUBERNETES_ACCOUNT_PATH}/ca.crt"))
+            .context(UnableToReadCACertificateSnafu)?;
 
         let Ok(certificate) = reqwest::Certificate::from_pem(ca_cert.as_bytes()) else {
-            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+            return Err(Error::UnableToReadKubernetesCredentials {});
         };
 
         self.client = Some(
             reqwest::Client::builder()
                 .add_root_certificate(certificate)
-                .build()?,
+                .build()
+                .context(UnableToCreateK8SClientSnafu)?,
         );
 
         Ok(())
     }
 
-    async fn get_secret(
-        &self,
-        secret_name: &str,
-    ) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+    async fn get_secret(&self, secret_name: &str) -> Result<HashMap<String, String>, Error> {
         let Some(client) = &self.client else {
-            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+            return Err(Error::UnableToReadKubernetesCredentials {});
         };
 
         let Some(token) = &self.token else {
-            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+            return Err(Error::UnableToReadKubernetesCredentials {});
         };
 
         let Some(namespace) = &self.namespace else {
-            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+            return Err(Error::UnableToReadKubernetesCredentials {});
         };
 
         let url =
             format!("{KUBERNETES_API_SERVER}/api/v1/namespaces/{namespace}/secrets/{secret_name}");
 
-        let kubernetes_secret = match client
+        let kubernetes_secret = client
             .get(url.clone())
             .bearer_auth(token.clone())
             .send()
-            .await?
+            .await
+            .context(UnableToGetK8SSecretSnafu)?
             .json::<HashMap<String, serde_json::value::Value>>()
             .await
-        {
-            Ok(response) => response,
-            Err(e) => return Err(Box::new(e)),
-        };
+            .context(UnableToGetK8SSecretSnafu)?;
 
         let mut secret: HashMap<String, String> = HashMap::new();
 
@@ -159,8 +182,10 @@ impl KubernetesSecretStore {
     ///
     /// Returns an error if unable to read Kubernetes credentials.
     pub fn init(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        if let Err(_e) = self.kubernetes_client.init() {
-            return Err(Box::new(Error::UnableToReadKubernetesCredentials {}));
+        if let Err(err) = self.kubernetes_client.init() {
+            return Err(Box::new(StoreError::UnableToInitKubernetesClient {
+                source: err,
+            }));
         }
 
         Ok(())
@@ -170,7 +195,7 @@ impl KubernetesSecretStore {
 #[async_trait]
 impl SecretStore for KubernetesSecretStore {
     #[must_use]
-    async fn get_secret(&self, secret_name: &str) -> super::Result<Option<Secret>> {
+    async fn get_secret(&self, secret_name: &str) -> super::AnyErrorResult<Option<Secret>> {
         match self.kubernetes_client.get_secret(secret_name).await {
             Ok(secret) => Ok(Some(Secret::new(secret.clone()))),
             Err(err) => {
@@ -179,7 +204,7 @@ impl SecretStore for KubernetesSecretStore {
                     secret_name,
                     err
                 );
-                Ok(None)
+                return Err(Box::new(StoreError::UnableToGetSecret { source: err }));
             }
         }
     }

--- a/crates/secrets/src/kubernetes.rs
+++ b/crates/secrets/src/kubernetes.rs
@@ -170,16 +170,16 @@ impl KubernetesSecretStore {
 #[async_trait]
 impl SecretStore for KubernetesSecretStore {
     #[must_use]
-    async fn get_secret(&self, secret_name: &str) -> Option<Secret> {
+    async fn get_secret(&self, secret_name: &str) -> super::Result<Option<Secret>> {
         match self.kubernetes_client.get_secret(secret_name).await {
-            Ok(secret) => Some(Secret::new(secret.clone())),
+            Ok(secret) => Ok(Some(Secret::new(secret.clone()))),
             Err(err) => {
                 tracing::warn!(
                     "Failed to get secret {} from kubernetes store, {}",
                     secret_name,
                     err
                 );
-                None
+                Ok(None)
             }
         }
     }

--- a/crates/secrets/src/kubernetes.rs
+++ b/crates/secrets/src/kubernetes.rs
@@ -31,10 +31,10 @@ pub enum Error {
     #[snafu(display("Unable to read K8S namespace: {source}"))]
     UnableToReadK8SNamespace { source: std::io::Error },
 
-    #[snafu(display("Unable to read CA certificate: {source}"))]
+    #[snafu(display("Unable to read K8S CA certificate: {source}"))]
     UnableToReadCACertificate { source: std::io::Error },
 
-    #[snafu(display("Unable to read kubernetes credentials"))]
+    #[snafu(display("Unable to read K8S credentials"))]
     UnableToReadKubernetesCredentials {},
 
     #[snafu(display("Unable to create K8S http client: {source}"))]


### PR DESCRIPTION
closes #1070 

Adds error handling and tracing for secret stores. Handles all suitable errors, swallowing them only when the secret is explicitly known to be none. Properly passes errors down.

Examples:

![CleanShot 2024-04-22 at 23 59 14@2x](https://github.com/spiceai/spiceai/assets/827338/795a01f9-9cce-4751-b5f9-8ea088ed2729)

![CleanShot 2024-04-22 at 23 59 34@2x](https://github.com/spiceai/spiceai/assets/827338/6007d824-06b4-4c41-84a9-90b1dc35ecc3)

![CleanShot 2024-04-23 at 00 00 00@2x](https://github.com/spiceai/spiceai/assets/827338/4e766100-5187-4d7f-97c6-add7c3bf51dc)

![CleanShot 2024-04-23 at 00 02 02@2x](https://github.com/spiceai/spiceai/assets/827338/f63a4767-b7bb-4603-9a37-19e90b3022b7)

![CleanShot 2024-04-23 at 00 01 02@2x](https://github.com/spiceai/spiceai/assets/827338/c29cb0e9-1014-43df-b5b5-5cc6c3c6bda6)
