### PR TITLE
Fix `spice upgrade` on Windows

### DIFF
--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -89,6 +89,17 @@ spice upgrade
 
 		releaseFilePath := filepath.Join(spiceBinDir, constants.SpiceCliFilename)
 
+		// On Windows, it is not possible to overwrite a binary while it's running.
+		// However, it can be moved/renamed making it possible to save new release with the original name.
+		if util.IsWindows() {
+			runningCliTempLocation := filepath.Join(spiceBinDir, constants.SpiceCliFilename+".bak")
+			err = os.Rename(releaseFilePath, runningCliTempLocation)
+			if err != nil {
+				cmd.PrintErrln("Error upgrading the spice binary:", err)
+				return
+			}
+		}
+
 		err = os.Rename(tempFilePath, releaseFilePath)
 		if err != nil {
 			cmd.PrintErrln("Error upgrading the spice binary:", err)

--- a/bin/spice/pkg/util/platform.go
+++ b/bin/spice/pkg/util/platform.go
@@ -14,28 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package constants
+package util
 
-import (
-	"github.com/spiceai/spiceai/bin/spice/pkg/util"
-)
+import "runtime"
 
-const (
-	DotSpice               = ".spice"
-	SpicePodsDirectoryName = "spicepods"
-)
-
-var (
-	SpiceRuntimeFilename string
-	SpiceCliFilename     string
-)
-
-func init() {
-	if util.IsWindows() {
-		SpiceRuntimeFilename = "spiced.exe"
-		SpiceCliFilename = "spice.exe"
-	} else {
-		SpiceRuntimeFilename = "spiced"
-		SpiceCliFilename = "spice"
-	}
+func IsWindows() bool {
+	return runtime.GOOS == "windows"
 }


### PR DESCRIPTION
Fixes https://github.com/spiceai/spiceai/issues/1144

Adds an additional step on Windows to rename the running CLI binary before replacing it by a new release.

Note: this introduces a risk that if the next operation, which renames downloaded release binary, fails, then the setup could end up in a corrupted state because we've renamed spice.exe but have not fully completed the release. Since two rename operations occur consecutively, such a risk is extremely unlikely, so I decided to keep the current implementation very simple
