### PR TITLE
Allow Spice CLI to control runtime installation on Windows

### DIFF
--- a/install/Install.ps1
+++ b/install/Install.ps1
@@ -51,19 +51,6 @@ function Download-And-Install-Spice {
 
     Move-Item -Path (Join-Path $tempPath $spiceCliFilename) -Destination $spiceCliFullPath -Force
 
-    # Download the Spice runtime
-    $runtimeInstallPath = Join-Path $spiceCliInstallDir "spiced.exe"
-    $runtimeDownloadUrl = "https://github.com/$spiceOrgName/$spiceRepoName/releases/download/$latestReleaseTag/spiced.exe_windows_$arch.tar.gz"
-    $tempFile = Join-Path $tempPath "spiced.exe_windows_$arch.tar.gz"
-    Write-Host "Downloading Spice Runtime from $runtimeDownloadUrl..."
-    Invoke-WebRequest -Uri $runtimeDownloadUrl -OutFile $tempFile
-    tar -xf $tempFile -C $tempPath
-
-    Move-Item -Path (Join-Path $tempPath "spiced.exe") -Destination $runtimeInstallPath -Force
-
-    # Temporary workaround for spice CLI to work on Windows (expect runtime binary as spiced instead of spiced.exe).
-    $latestReleaseTag  | Out-File -FilePath (Join-Path $spiceCliInstallDir "spiced")
-
     if (Test-Path $spiceCliFullPath) {
         Write-Host "Spice CLI installed into $spiceCliInstallDir successfully."
     } else {


### PR DESCRIPTION
[Spice 0.11.1-alpha release](https://github.com/spiceai/spiceai/releases/tag/v0.11.1-alpha) contains necessary improvements for Windows so we don't need the following logic anymore.
1. Adding empty `spiced` placeholder file so that Spice CLI can detect Spice runtime
2. Pre-installing Spice runtime as CLI can now download the latest runtime version automatically (similar to other platforms)