### PR TITLE
Convert temporal column and refresh period to datafusion expr

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -203,9 +203,8 @@ impl AcceleratedTable {
 
         let mut interval_timer = tokio::time::interval(retention.check_interval);
 
-        let var_name = Some(time_column.clone());
         let Some(timestamp_filter_converter) =
-            TimestampFilterConvert::create(field, retention.time_format, var_name)
+            TimestampFilterConvert::create(field, retention.time_format, Some(time_column.clone()))
         else {
             tracing::error!("[retention] Failed to get the expression time format for {time_column}, check schema and time format");
             return;

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -2,19 +2,16 @@ use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 use std::{any::Any, sync::Arc, time::Duration};
 
 use arrow::array::UInt64Array;
-use arrow::datatypes::{DataType, SchemaRef};
+use arrow::datatypes::SchemaRef;
 use async_stream::stream;
 use async_trait::async_trait;
 use data_components::delete::get_deletion_provider;
 use datafusion::common::OwnedTableReference;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::context::SessionState;
-use datafusion::logical_expr::{
-    binary_expr, cast, col, lit, Operator, TableProviderFilterPushDown,
-};
+use datafusion::logical_expr::{Operator, TableProviderFilterPushDown};
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{collect, ExecutionPlan, ExecutionPlanProperties};
-use datafusion::scalar::ScalarValue;
 use datafusion::{
     datasource::{TableProvider, TableType},
     execution::context::SessionContext,
@@ -24,7 +21,6 @@ use futures::{stream::BoxStream, StreamExt};
 use object_store::ObjectStore;
 use snafu::prelude::*;
 use spicepod::component::dataset::acceleration::RefreshMode;
-use spicepod::component::dataset::TimeFormat;
 use tokio::task::JoinHandle;
 use tokio::time::interval;
 use url::Url;
@@ -33,11 +29,12 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::datafusion::filter_converter::TimestampFilterConvert;
 use crate::datafusion::{Refresh, Retention};
 use crate::execution_plan::slice::SliceExec;
 use crate::execution_plan::tee::TeeExec;
 use crate::{
-    dataconnector::{self, get_all_data},
+    dataconnector::{self, get_data},
     dataupdate::{DataUpdate, DataUpdateExecutionPlan, UpdateType},
     status,
     timing::TimeMeasurement,
@@ -80,18 +77,6 @@ pub(crate) struct AcceleratedTable {
 enum AccelerationRefreshMode {
     Full(Receiver<()>),
     Append,
-}
-
-#[derive(Debug, Clone)]
-enum ExprTimeFormat {
-    ISO8601,
-    UnixTimestamp(ExprUnixTimestamp),
-    Timestamp,
-}
-
-#[derive(Debug, Clone)]
-struct ExprUnixTimestamp {
-    scale: u64,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -405,7 +390,7 @@ impl AcceleratedTable {
                             _ => vec![],
                         };
 
-                        let all_data = match get_all_data(&mut ctx, OwnedTableReference::bare(dataset_name.clone()), Arc::clone(&federated), refresh.sql.clone(), filters).await {
+                        let data = match get_data(&mut ctx, OwnedTableReference::bare(dataset_name.clone()), Arc::clone(&federated), refresh.sql.clone(), filters).await {
                             Ok(data) => data,
                             Err(e) => {
                                 tracing::error!("[refresh] Error refreshing data for {dataset_name}: {e}");
@@ -414,8 +399,8 @@ impl AcceleratedTable {
                             }
                         };
                         yield Ok(DataUpdate {
-                            schema: all_data.0,
-                            data: all_data.1,
+                            schema: data.0,
+                            data: data.1,
                             update_type: UpdateType::Overwrite,
                         });
 
@@ -424,94 +409,6 @@ impl AcceleratedTable {
                 }
             }
         })
-    }
-}
-
-#[derive(Clone, Debug)]
-struct TimestampFilterConvert {
-    time_column: String,
-    time_format: ExprTimeFormat,
-}
-
-#[allow(clippy::needless_pass_by_value)]
-impl TimestampFilterConvert {
-    fn create(
-        field: Option<(usize, &arrow::datatypes::Field)>,
-        time_column: Option<String>,
-        time_format: Option<TimeFormat>,
-    ) -> Option<Self> {
-        let time_column = time_column?;
-
-        let time_format = match field {
-            Some(field) => match field.1.data_type() {
-                DataType::Int8
-                | DataType::Int16
-                | DataType::Int32
-                | DataType::Int64
-                | DataType::UInt8
-                | DataType::UInt16
-                | DataType::UInt32
-                | DataType::UInt64
-                | DataType::Float16
-                | DataType::Float32
-                | DataType::Float64 => {
-                    let mut scale = 1;
-                    if let Some(time_format) = time_format.clone() {
-                        if time_format == TimeFormat::UnixMillis {
-                            scale = 1000;
-                        }
-                    }
-                    ExprTimeFormat::UnixTimestamp(ExprUnixTimestamp { scale })
-                }
-                DataType::Timestamp(_, _)
-                | DataType::Date32
-                | DataType::Date64
-                | DataType::Time32(_)
-                | DataType::Time64(_) => ExprTimeFormat::Timestamp,
-                DataType::Utf8 | DataType::LargeUtf8 => ExprTimeFormat::ISO8601,
-                _ => {
-                    tracing::warn!("Date type is not handled yet: {}", field.1.data_type());
-                    return None;
-                }
-            },
-            None => return None,
-        };
-
-        Some(Self {
-            time_column,
-            time_format,
-        })
-    }
-
-    #[allow(clippy::cast_possible_wrap)]
-    fn convert(&self, timestamp: u64, op: Operator) -> Expr {
-        let format = self.time_format.clone();
-        let time_column: &str = &self.time_column.clone();
-        let expr_time_format = format.clone();
-        match expr_time_format {
-            ExprTimeFormat::ISO8601 => binary_expr(
-                cast(
-                    col(time_column),
-                    DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
-                ),
-                op,
-                Expr::Literal(ScalarValue::TimestampMillisecond(
-                    Some((timestamp * 1000) as i64),
-                    None,
-                )),
-            ),
-            ExprTimeFormat::UnixTimestamp(format) => {
-                binary_expr(col(time_column), op, lit(timestamp * format.scale))
-            }
-            ExprTimeFormat::Timestamp => binary_expr(
-                col(time_column),
-                op,
-                Expr::Literal(ScalarValue::TimestampMillisecond(
-                    Some((timestamp * 1000) as i64),
-                    None,
-                )),
-            ),
-        }
     }
 }
 

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -204,7 +204,7 @@ impl AcceleratedTable {
         let mut interval_timer = tokio::time::interval(retention.check_interval);
 
         let Some(timestamp_filter_converter) =
-            TimestampFilterConvert::create(field, retention.time_format, Some(time_column.clone()))
+            TimestampFilterConvert::create(field, Some(time_column.clone()), retention.time_format)
         else {
             tracing::error!("[retention] Failed to get the expression time format for {time_column}, check schema and time format");
             return;
@@ -380,7 +380,7 @@ impl AcceleratedTable {
                         (Some(_), Some(column)) => {
                             let schema = federated.schema();
                             let field = schema.column_with_name(column.as_str());
-                            TimestampFilterConvert::create(field, refresh.time_format, Some(column))
+                            TimestampFilterConvert::create(field, Some(column), refresh.time_format)
                         }
                     };
 
@@ -427,16 +427,16 @@ impl AcceleratedTable {
 
 #[derive(Clone, Debug)]
 struct TimestampFilterConvert {
-    time_format: ExprTimeFormat,
     time_column: String,
+    time_format: ExprTimeFormat,
 }
 
 #[allow(clippy::needless_pass_by_value)]
 impl TimestampFilterConvert {
     fn create(
         field: Option<(usize, &arrow::datatypes::Field)>,
-        time_format: Option<TimeFormat>,
         time_column: Option<String>,
+        time_format: Option<TimeFormat>,
     ) -> Option<Self> {
         let time_column = time_column?;
 
@@ -476,8 +476,8 @@ impl TimestampFilterConvert {
         };
 
         Some(Self {
-            time_format,
             time_column,
+            time_format,
         })
     }
 

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -193,7 +193,9 @@ impl AcceleratedTable {
         let time_column = retention.time_column;
         let retention_period = retention.period;
         let schema = accelerator.schema();
-        let field = schema.column_with_name(time_column.as_str());
+        let field = schema
+            .column_with_name(time_column.as_str())
+            .map(|(_, f)| f);
 
         let mut interval_timer = tokio::time::interval(retention.check_interval);
 
@@ -365,7 +367,7 @@ impl AcceleratedTable {
                 AccelerationRefreshMode::Full(receiver) => {
                     let schema = federated.schema();
                     let column = refresh.time_column.clone().unwrap_or_default();
-                    let field = schema.column_with_name(column.as_str());
+                    let field = schema.column_with_name(column.as_str()).map(|(_, f)| f);
                     let filter_converter = TimestampFilterConvert::create(field, refresh.time_column, refresh.time_format);
 
                     let mut refresh_stream = ReceiverStream::new(receiver);

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -377,7 +377,7 @@ impl AcceleratedTable {
                         tracing::info!("[refresh] Refreshing data for {dataset_name}");
                         status::update_dataset(&dataset_name, status::ComponentStatus::Refreshing);
                         let timer = TimeMeasurement::new("load_dataset_duration_ms", vec![("dataset", dataset_name.clone())]);
-                        let  filters = match (refresh.period, filter_converter.clone()){
+                        let filters = match (refresh.period, filter_converter.clone()){
                             (Some(period), Some(converter)) => {
                                 let start = SystemTime::now() - period;
 

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -366,8 +366,8 @@ impl AcceleratedTable {
                 }
                 AccelerationRefreshMode::Full(receiver) => {
                     let schema = federated.schema();
-                    let column = refresh.time_column.clone().unwrap_or_default();
-                    let field = schema.column_with_name(column.as_str()).map(|(_, f)| f);
+                    let column = refresh.time_column.as_deref().unwrap_or_default();
+                    let field = schema.column_with_name(column).map(|(_, f)| f);
                     let filter_converter = TimestampFilterConvert::create(field, refresh.time_column, refresh.time_format);
 
                     let mut refresh_stream = ReceiverStream::new(receiver);
@@ -376,7 +376,7 @@ impl AcceleratedTable {
                         tracing::info!("[refresh] Refreshing data for {dataset_name}");
                         status::update_dataset(&dataset_name, status::ComponentStatus::Refreshing);
                         let timer = TimeMeasurement::new("load_dataset_duration_ms", vec![("dataset", dataset_name.clone())]);
-                        let filters = match (refresh.period, filter_converter.clone()){
+                        let filters = match (refresh.period, filter_converter.as_ref()){
                             (Some(period), Some(converter)) => {
                                 let start = SystemTime::now() - period;
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -189,8 +189,8 @@ pub trait DataConnector: Send + Sync {
     }
 }
 
-// Gets all data from a table provider and returns it as a vector of RecordBatches.
-pub async fn get_all_data(
+// Gets data from a table provider and returns it as a vector of RecordBatches.
+pub async fn get_data(
     ctx: &mut SessionContext,
     table_name: OwnedTableReference,
     table_provider: Arc<dyn TableProvider>,

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -192,6 +192,7 @@ pub async fn get_all_data(
     sql: Option<String>,
     filters: Vec<Expr>,
 ) -> Result<(SchemaRef, Vec<arrow::record_batch::RecordBatch>)> {
+    // TODO: handle filters in following PR
     _ = filters;
 
     let df = match sql {

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -77,6 +77,11 @@ pub enum Error {
     UnableToCreateDataFrame {
         source: datafusion::error::DataFusionError,
     },
+
+    #[snafu(display("Unable to filter data frame: {source}"))]
+    UnableToFilterDataFrame {
+        source: datafusion::error::DataFusionError,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -192,10 +197,7 @@ pub async fn get_all_data(
     sql: Option<String>,
     filters: Vec<Expr>,
 ) -> Result<(SchemaRef, Vec<arrow::record_batch::RecordBatch>)> {
-    // TODO: handle filters in following PR
-    _ = filters;
-
-    let df = match sql {
+    let mut df = match sql {
         None => {
             let table_source = Arc::new(DefaultTableSource::new(Arc::clone(&table_provider)));
             let logical_plan = LogicalPlanBuilder::scan(table_name.clone(), table_source, None)
@@ -210,6 +212,10 @@ pub async fn get_all_data(
             .await
             .context(UnableToCreateDataFrameSnafu {})?,
     };
+
+    for filter in filters {
+        df = df.filter(filter).context(UnableToFilterDataFrameSnafu {})?;
+    }
 
     let batches = df.collect().await.context(UnableToScanTableProviderSnafu)?;
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -20,7 +20,7 @@ use datafusion::common::OwnedTableReference;
 use datafusion::dataframe::DataFrame;
 use datafusion::datasource::{DefaultTableSource, TableProvider};
 use datafusion::execution::context::SessionContext;
-use datafusion::logical_expr::LogicalPlanBuilder;
+use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use lazy_static::lazy_static;
 use object_store::ObjectStore;
 use snafu::prelude::*;
@@ -190,7 +190,10 @@ pub async fn get_all_data(
     table_name: OwnedTableReference,
     table_provider: Arc<dyn TableProvider>,
     sql: Option<String>,
+    filters: Vec<Expr>,
 ) -> Result<(SchemaRef, Vec<arrow::record_batch::RecordBatch>)> {
+    _ = filters;
+
     let df = match sql {
         None => {
             let table_source = Arc::new(DefaultTableSource::new(Arc::clone(&table_provider)));

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -164,6 +164,7 @@ impl Retention {
     }
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct Refresh {
     pub(crate) time_column: Option<String>,
     pub(crate) time_format: Option<TimeFormat>,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -164,6 +164,8 @@ impl Retention {
 }
 
 pub(crate) struct Refresh {
+    pub(crate) time_column: Option<String>,
+    pub(crate) time_format: Option<TimeFormat>,
     pub(crate) check_interval: Option<Duration>,
     pub(crate) sql: Option<String>,
     pub(crate) mode: RefreshMode,
@@ -174,12 +176,16 @@ impl Refresh {
     #[allow(clippy::needless_pass_by_value)]
     #[must_use]
     pub(crate) fn new(
+        time_column: Option<String>,
+        time_format: Option<TimeFormat>,
         check_interval: Option<Duration>,
         sql: Option<String>,
         mode: RefreshMode,
         period: Option<Duration>,
     ) -> Self {
         Self {
+            time_column,
+            time_format,
             check_interval,
             sql,
             mode,
@@ -351,6 +357,8 @@ impl DataFusion {
             source_table_provider,
             accelerated_table_provider,
             Refresh::new(
+                dataset.time_column.clone(),
+                dataset.time_format.clone(),
                 dataset.refresh_interval(),
                 refresh_sql.clone(),
                 acceleration_settings.refresh_mode.clone(),

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -40,6 +40,7 @@ use spicepod::component::dataset::{Dataset, Mode, TimeFormat};
 use tokio::spawn;
 use tokio::time::{sleep, Instant};
 
+pub mod filter_converter;
 pub mod refresh_sql;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/datafusion/filter_converter.rs
+++ b/crates/runtime/src/datafusion/filter_converter.rs
@@ -28,7 +28,7 @@ impl TimestampFilterConvert {
     pub(crate) fn create(
         field: Option<&arrow::datatypes::Field>,
         time_column: Option<String>,
-        time_format: Option<TimeFormat>,
+        mut time_format: Option<TimeFormat>,
     ) -> Option<Self> {
         let field = field?;
         let time_column = time_column?;
@@ -46,7 +46,7 @@ impl TimestampFilterConvert {
             | DataType::Float32
             | DataType::Float64 => {
                 let mut scale = 1;
-                if let Some(time_format) = time_format.clone() {
+                if let Some(time_format) = time_format.take() {
                     if time_format == TimeFormat::UnixMillis {
                         scale = 1000;
                     }

--- a/crates/runtime/src/datafusion/filter_converter.rs
+++ b/crates/runtime/src/datafusion/filter_converter.rs
@@ -75,10 +75,8 @@ impl TimestampFilterConvert {
 
     #[allow(clippy::cast_possible_wrap)]
     pub(crate) fn convert(&self, timestamp: u64, op: Operator) -> Expr {
-        let format = self.time_format.clone();
         let time_column: &str = &self.time_column.clone();
-        let expr_time_format = format.clone();
-        match expr_time_format {
+        match self.time_format.clone() {
             ExprTimeFormat::ISO8601 => binary_expr(
                 cast(
                     col(time_column),

--- a/crates/runtime/src/datafusion/filter_converter.rs
+++ b/crates/runtime/src/datafusion/filter_converter.rs
@@ -1,0 +1,106 @@
+use arrow::datatypes::DataType;
+use datafusion::{
+    logical_expr::{binary_expr, cast, col, lit, Expr, Operator},
+    scalar::ScalarValue,
+};
+use spicepod::component::dataset::TimeFormat;
+
+#[derive(Debug, Clone)]
+enum ExprTimeFormat {
+    ISO8601,
+    UnixTimestamp(ExprUnixTimestamp),
+    Timestamp,
+}
+
+#[derive(Debug, Clone)]
+struct ExprUnixTimestamp {
+    scale: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TimestampFilterConvert {
+    time_column: String,
+    time_format: ExprTimeFormat,
+}
+
+#[allow(clippy::needless_pass_by_value)]
+impl TimestampFilterConvert {
+    pub(crate) fn create(
+        field: Option<(usize, &arrow::datatypes::Field)>,
+        time_column: Option<String>,
+        time_format: Option<TimeFormat>,
+    ) -> Option<Self> {
+        let time_column = time_column?;
+
+        let time_format = match field {
+            Some(field) => match field.1.data_type() {
+                DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Float16
+                | DataType::Float32
+                | DataType::Float64 => {
+                    let mut scale = 1;
+                    if let Some(time_format) = time_format.clone() {
+                        if time_format == TimeFormat::UnixMillis {
+                            scale = 1000;
+                        }
+                    }
+                    ExprTimeFormat::UnixTimestamp(ExprUnixTimestamp { scale })
+                }
+                DataType::Timestamp(_, _)
+                | DataType::Date32
+                | DataType::Date64
+                | DataType::Time32(_)
+                | DataType::Time64(_) => ExprTimeFormat::Timestamp,
+                DataType::Utf8 | DataType::LargeUtf8 => ExprTimeFormat::ISO8601,
+                _ => {
+                    tracing::warn!("Date type is not handled yet: {}", field.1.data_type());
+                    return None;
+                }
+            },
+            None => return None,
+        };
+
+        Some(Self {
+            time_column,
+            time_format,
+        })
+    }
+
+    #[allow(clippy::cast_possible_wrap)]
+    pub(crate) fn convert(&self, timestamp: u64, op: Operator) -> Expr {
+        let format = self.time_format.clone();
+        let time_column: &str = &self.time_column.clone();
+        let expr_time_format = format.clone();
+        match expr_time_format {
+            ExprTimeFormat::ISO8601 => binary_expr(
+                cast(
+                    col(time_column),
+                    DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),
+                ),
+                op,
+                Expr::Literal(ScalarValue::TimestampMillisecond(
+                    Some((timestamp * 1000) as i64),
+                    None,
+                )),
+            ),
+            ExprTimeFormat::UnixTimestamp(format) => {
+                binary_expr(col(time_column), op, lit(timestamp * format.scale))
+            }
+            ExprTimeFormat::Timestamp => binary_expr(
+                col(time_column),
+                op,
+                Expr::Literal(ScalarValue::TimestampMillisecond(
+                    Some((timestamp * 1000) as i64),
+                    None,
+                )),
+            ),
+        }
+    }
+}


### PR DESCRIPTION
Add a timestamp converter to simplify the logic.
Convert the refresh period logic to expr.

There will be following PR to enable the filter when fetching the data.

Fixes #1175 


Edit:
With the merge of #1188 . This allows the period to work properly

```
  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
    name: taxi_trips
    time_column: tpep_pickup_datetime
    acceleration:
      enabled: true
      refresh_interval: 10m
      refresh_period: 1000w
      refresh_sql: |
        SELECT * FROM taxi_trips WHERE passenger_count = 1;
 ```