### PR TITLE
apply df filter when get_all_data

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -214,7 +214,7 @@ pub async fn get_all_data(
     };
 
     for filter in filters {
-        df = df.filter(filter).context(UnableToCreateDataFrameSnafu)?;
+        df = df.filter(filter).context(UnableToFilterDataFrameSnafu {})?;
     }
 
     let batches = df.collect().await.context(UnableToScanTableProviderSnafu)?;


### PR DESCRIPTION

Fixes #1176 

- Apply temporal filter when refreshing acceleration. This happens on the df level in get_all_data.
This will enable below work.

```
  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
    name: taxi_trips
    time_column: tpep_pickup_datetime
    acceleration:
      enabled: true
      refresh_interval: 10m
      refresh_period: 1000w
      refresh_sql: |
        SELECT * FROM taxi_trips WHERE passenger_count = 1;
```
