### PR TITLE
Hot reload accelerated table on dataset update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,6 +5430,7 @@ dependencies = [
  "clap",
  "clickhouse-rs",
  "csv",
+ "dashmap",
  "data_components",
  "datafusion",
  "db_connection_pool",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -67,6 +67,7 @@ postgres-native-tls = { version = "0.5.0", optional = true }
 ns_lookup = { path = "../ns_lookup" }
 chrono = { version = "0.4.38" }
 clickhouse-rs = { workspace = true, optional = true }
+dashmap = "5.5.3"
 
 [features]
 default = ["keyring-secret-store", "aws-secrets-manager"]

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -67,6 +67,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 // An accelerated table consists of a federated table and a local accelerator.
 //
 // The accelerator must support inserts.
+// AcceleratedTable::new returns an instance of the table and a oneshot receiver that will be triggered when the table is ready, right after the initial data refresh finishes.
 pub struct AcceleratedTable {
     accelerator: Arc<dyn TableProvider>,
     federated: Arc<dyn TableProvider>,

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -503,7 +503,7 @@ impl TableProvider for AcceleratedTable {
     }
 }
 
-pub(crate) struct Retention {
+pub struct Retention {
     pub(crate) time_column: String,
     pub(crate) time_format: Option<TimeFormat>,
     pub(crate) period: Duration,
@@ -537,7 +537,7 @@ impl Retention {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Refresh {
+pub struct Refresh {
     pub(crate) time_column: Option<String>,
     pub(crate) time_format: Option<TimeFormat>,
     pub(crate) check_interval: Option<Duration>,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -137,6 +137,11 @@ pub struct DataFusion {
 }
 
 impl DataFusion {
+    /// Create a new `DataFusion` instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default schema cannot be registered.
     #[must_use]
     pub fn new() -> Self {
         let catalog_options = CatalogOptions::default();

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -209,6 +209,7 @@ impl DataFusion {
         let dataset = dataset.borrow();
 
         if let Some(accelerated_table) = accelerated_table {
+            tracing::debug!("Registering dataset {dataset:?} with preloaded accelerated table");
             self.ctx
                 .register_table(&dataset.name, Arc::new(accelerated_table))
                 .context(UnableToRegisterTableToDataFusionSnafu)?;

--- a/crates/runtime/src/datafusion/schema.rs
+++ b/crates/runtime/src/datafusion/schema.rs
@@ -24,7 +24,7 @@ use datafusion::{
     error::{DataFusionError, Result},
 };
 
-// Copy of default MemorySchemaProvider, with allowed table register overwrites
+// Copy of default MemorySchemaProvider that allows `register_table` to atomically overwrite any existing tables
 // https://github.com/apache/datafusion/blob/deebda78a34251b2bddf0c5f66edfaa112c4559b/datafusion/core/src/catalog/schema.rs#L84
 pub struct SpiceSchemaProvider {
     tables: DashMap<String, Arc<dyn TableProvider>>,

--- a/crates/runtime/src/datafusion/schema.rs
+++ b/crates/runtime/src/datafusion/schema.rs
@@ -31,6 +31,7 @@ pub struct SpiceSchemaProvider {
 }
 
 impl SpiceSchemaProvider {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             tables: DashMap::new(),
@@ -58,7 +59,7 @@ impl SchemaProvider for SpiceSchemaProvider {
     }
 
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
-        Ok(self.tables.get(name).map(|table| table.value().clone()))
+        Ok(self.tables.get(name).map(|table| Arc::clone(table.value())))
     }
 
     fn register_table(

--- a/crates/runtime/src/datafusion/schema.rs
+++ b/crates/runtime/src/datafusion/schema.rs
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{any::Any, sync::Arc};
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+use datafusion::{
+    catalog::schema::SchemaProvider,
+    datasource::TableProvider,
+    error::{DataFusionError, Result},
+};
+
+// Copy of default MemorySchemaProvider, with allowed table register overwrites
+// https://github.com/apache/datafusion/blob/deebda78a34251b2bddf0c5f66edfaa112c4559b/datafusion/core/src/catalog/schema.rs#L84
+pub struct SpiceSchemaProvider {
+    tables: DashMap<String, Arc<dyn TableProvider>>,
+}
+
+impl SpiceSchemaProvider {
+    pub fn new() -> Self {
+        Self {
+            tables: DashMap::new(),
+        }
+    }
+}
+
+impl Default for SpiceSchemaProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for SpiceSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        self.tables
+            .iter()
+            .map(|table| table.key().clone())
+            .collect()
+    }
+
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
+        Ok(self.tables.get(name).map(|table| table.value().clone()))
+    }
+
+    fn register_table(
+        &self,
+        name: String,
+        table: Arc<dyn TableProvider>,
+    ) -> Result<Option<Arc<dyn TableProvider>>> {
+        Ok(self.tables.insert(name, table))
+    }
+
+    fn deregister_table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+        Ok(self.tables.remove(name).map(|(_, table)| table))
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables.contains_key(name)
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -388,7 +388,7 @@ impl Runtime {
         status::update_dataset(&ds.name, status::ComponentStatus::Refreshing);
         if let Ok(connector) = self.load_dataset_connector(ds, all_datasets).await {
             if ds.is_file_accelerated() {
-                tracing::warn!("File accelerated datasets doesn't support hot reload, falling back to full dataset reload");
+                tracing::warn!("File accelerated datasets currently don't support hot reload, falling back to full dataset reload");
             } else if ds.is_accelerated() {
                 tracing::info!("Hot reloading accelerated dataset: {}...", &ds.name);
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -525,7 +525,7 @@ impl Runtime {
             let view_sql = view_sql.context(InvalidSQLViewSnafu)?;
             df.write()
                 .await
-                .register_table(ds, datafusion::Table::View(view_sql), accelerated_table)
+                .register_table(ds, datafusion::Table::View(view_sql))
                 .await
                 .context(UnableToAttachViewSnafu)?;
             return Ok(());
@@ -542,7 +542,7 @@ impl Runtime {
 
             df.write()
                 .await
-                .register_table(ds, datafusion::Table::Federated(data_connector), None)
+                .register_table(ds, datafusion::Table::Federated(data_connector))
                 .await
                 .context(UnableToAttachDataConnectorSnafu {
                     data_connector: source,
@@ -573,8 +573,8 @@ impl Runtime {
                 datafusion::Table::Accelerated {
                     source: data_connector,
                     acceleration_secret,
+                    accelerated_table,
                 },
-                accelerated_table,
             )
             .await
             .context(UnableToAttachDataConnectorSnafu {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -323,7 +323,7 @@ impl Runtime {
         .await
         {
             Ok(()) => {
-                tracing::info!("Loaded dataset: {} {}", &ds.name, ds.is_accelerated());
+                tracing::info!("Loaded dataset: {}", &ds.name);
                 let engine = ds.acceleration.map_or_else(
                     || "None".to_string(),
                     |acc| {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -445,8 +445,6 @@ impl Runtime {
 
         tracing::info!("Accelerated table for dataset {} is ready", ds.name);
 
-        // swap old dataset with new one, using preloaded accelerated table
-        self.remove_dataset(ds).await;
         self.register_loaded_dataset(ds, Arc::clone(&connector), Some(accelerated_table))
             .await?;
 
@@ -709,6 +707,9 @@ impl Runtime {
                     if let Some(current_ds) =
                         current_app.datasets.iter().find(|d| d.name == ds.name)
                     {
+                        tracing::info!("Checking dataset: {}", ds.name);
+                        tracing::info!("Current dataset: {:?}", current_ds);
+                        tracing::info!("New dataset: {:?}", ds);
                         if current_ds != ds {
                             self.update_dataset(ds, &new_app.datasets).await;
                         }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -707,9 +707,6 @@ impl Runtime {
                     if let Some(current_ds) =
                         current_app.datasets.iter().find(|d| d.name == ds.name)
                     {
-                        tracing::info!("Checking dataset: {}", ds.name);
-                        tracing::info!("Current dataset: {:?}", current_ds);
-                        tracing::info!("New dataset: {:?}", ds);
                         if current_ds != ds {
                             self.update_dataset(ds, &new_app.datasets).await;
                         }

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -305,6 +305,15 @@ impl Dataset {
 
         false
     }
+
+    #[must_use]
+    pub fn is_file_accelerated(&self) -> bool {
+        if let Some(acceleration) = &self.acceleration {
+            return acceleration.enabled && acceleration.mode == acceleration::Mode::File;
+        }
+
+        false
+    }
 }
 
 impl WithDependsOn<Dataset> for Dataset {


### PR DESCRIPTION
closes #1084

Refactored dataset update logic:
For accelerated datasets (only memory mode), spice runtime performs hot reload:

- create new accelerated table and wait until it loaded with data, while keeping old dataset registered in datafusion
- once new table successfully loaded, unregister old dataset and register new one
- in case of failure it falls back to regular reload

https://github.com/spiceai/spiceai/assets/827338/5e3838cb-4be4-44e7-82b7-90ae930fc551

