### PR TITLE
Update postgres parameter check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,6 +2420,7 @@ dependencies = [
  "snafu 0.8.2",
  "spicepod",
  "tokio",
+ "tokio-postgres",
  "tokio-rusqlite",
  "tracing",
  "tracing-subscriber",

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -51,6 +51,7 @@ postgres = [
     "dep:tokio",
     "arrow_sql_gen/postgres",
     "spicepod/postgres",
+    "dep:tokio-postgres",
 ]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "arrow_sql_gen/sqlite", "spicepod/sqlite"]
 mysql = ["dep:mysql_async", "arrow_sql_gen/mysql", "spicepod/mysql"]

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -34,6 +34,7 @@ odbc-api = { workspace = true, optional = true }
 arrow-odbc = { workspace = true, optional = true }
 lazy_static = "1.4.0"
 clickhouse-rs = { workspace = true, optional = true }
+tokio-postgres = "0.7.10"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -34,7 +34,7 @@ odbc-api = { workspace = true, optional = true }
 arrow-odbc = { workspace = true, optional = true }
 lazy_static = "1.4.0"
 clickhouse-rs = { workspace = true, optional = true }
-tokio-postgres = "0.7.10"
+tokio-postgres = { workspace = true , optional = true}
 async-stream = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
* Update the error handling for pg_port & pg_host check, previous handling method doesn't give any error messages.
* Use tokio-postgres to test connection using user provided parameters before connecting using bb8 pool. This will immediately propagate any error relevant to user parameter misconfiguration, and therefore avoid the waiting on bb8 connection result and the vague bb8 error message. 