### PR TITLE
Top level err handler

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -895,8 +895,5 @@ pub fn get_source_error(error: &impl std::error::Error) -> &dyn snafu::Error {
     for e in iter::successors(error.source(), |&e| e.source()) {
         last_error = Some(e);
     }
-    if let Some(e) = last_error {
-        return e;
-    }
-    error
+    last_error.unwrap_or(error)
 }


### PR DESCRIPTION
A minimal version of error traversal and retrieval of the last error in error source chain. However we still need a way to distinguish Spice defined error versus external crate errors.

The current solution I’ve tried is bring Spice defined errors into scope and try to downcast error source to Spice errors, but there are 2 problems
* Bringing Spice defined errors into runtime scope will cause cyclical dependency, for example, adding db_connection_pool into Cargo.toml in runtime
* We will have to bring in all Spice defined errors into runtime and downcast for every source in the error chain, which is extremely inefficient.
We probably need a better way to infer whether the error is Spice error or not.