### PR TITLE
Record batch casting to fix SQLite data type issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,6 @@ name = "arrow_tools"
 version = "0.12.1-alpha"
 dependencies = [
  "arrow",
- "chrono",
  "snafu 0.8.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow_tools"
+version = "0.12.1-alpha"
+dependencies = [
+ "arrow",
+ "chrono",
+ "snafu 0.8.2",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5750,6 +5750,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-json",
  "arrow_sql_gen",
+ "arrow_tools",
  "async-stream",
  "async-trait",
  "axum 0.7.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/spicepod",
     "crates/app",
     "crates/arrow_sql_gen",
+    "crates/arrow_tools",
     "crates/sql_provider_datafusion",
     "crates/flightrepl",
     "crates/ns_lookup",

--- a/crates/arrow_tools/Cargo.toml
+++ b/crates/arrow_tools/Cargo.toml
@@ -11,4 +11,3 @@ exclude.workspace = true
 [dependencies]
 arrow.workspace = true
 snafu.workspace = true
-chrono = { version = "0.4.38" }

--- a/crates/arrow_tools/Cargo.toml
+++ b/crates/arrow_tools/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "arrow_tools"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+arrow.workspace = true
+snafu.workspace = true
+chrono = { version = "0.4.38" }

--- a/crates/arrow_tools/README.md
+++ b/crates/arrow_tools/README.md
@@ -1,3 +1,3 @@
 # Arrow tools
 
-- Record batch conversion based on the provided schema
+- Cast RecordBatch from its schema to a given schema

--- a/crates/arrow_tools/README.md
+++ b/crates/arrow_tools/README.md
@@ -1,0 +1,3 @@
+# Arrow tools
+
+- Record batch conversion based on the provided schema

--- a/crates/arrow_tools/src/lib.rs
+++ b/crates/arrow_tools/src/lib.rs
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+pub mod record_batch;

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -15,55 +15,39 @@ limitations under the License.
 */
 
 use arrow::{
-    array::{
-        new_null_array, Array, Int32Array, Int64Array, LargeStringArray, RecordBatch, StringArray,
-        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampSecondArray,
-    },
-    datatypes::{DataType, Field, SchemaRef, TimeUnit},
+    array::{new_null_array, Array, RecordBatch},
+    compute::cast,
+    datatypes::SchemaRef,
 };
 use snafu::prelude::*;
-use std::{num::TryFromIntError, sync::Arc};
+use std::sync::Arc;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Error converting record batch: {}", source))]
-    ConvertRecordBatch { source: arrow::error::ArrowError },
+    #[snafu(display("Error converting record batch: {source}",))]
+    UnableToConvertRecordBatch { source: arrow::error::ArrowError },
 
-    #[snafu(display("Unable to convert array: {}", source))]
-    ParseTimestampFromString { source: chrono::ParseError },
-
-    #[snafu(display("Unable to convert {} array from {:?} to {:?}", name, from, to))]
-    ConvertArrowArray {
-        from: DataType,
-        to: DataType,
-        name: String,
-    },
-
-    #[snafu(display("Unable to try from int: {}", source))]
-    ConvertInt { source: TryFromIntError },
-
-    #[snafu(display("Unable to use null for field {field}"))]
-    UnableToUseNullForField { field: String },
-
-    #[snafu(display("Unable to downcast array {field} to {downcast_to}"))]
-    UnableToDowncast { field: String, downcast_to: String },
+    #[snafu(display("Field is not nullable: {field}"))]
+    FieldNotNullable { field: String },
 }
 
 /// Cast a given record batch into a new record batch with the given schema.
 ///
 /// # Errors
 ///
-/// This function will return an error if the record batch cannot be casted.
+/// This function will return an error if the record batch cannot be cast.
 #[allow(clippy::needless_pass_by_value)]
 pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
     let existing_schema = record_batch.schema();
 
+    // When schema is superset of the existing schema, including a new column, and nullable column,
+    // return a new RecordBatch to reflect the change
     if schema.contains(&existing_schema) {
         return record_batch
             .with_schema(schema)
-            .context(ConvertRecordBatchSnafu);
+            .context(UnableToConvertRecordBatchSnafu);
     }
 
     let cols = schema
@@ -77,12 +61,15 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
                 if field.contains(existing_field) {
                     Ok(Arc::clone(column))
                 } else {
-                    try_cast_array(Arc::clone(column), existing_field, field)
+                    {
+                        return cast(&*Arc::clone(column), field.data_type())
+                            .context(UnableToConvertRecordBatchSnafu);
+                    }
                 }
             } else if field.is_nullable() {
                 Ok(new_null_array(field.data_type(), record_batch.num_rows()))
             } else {
-                UnableToUseNullForFieldSnafu {
+                FieldNotNullableSnafu {
                     field: field.name(),
                 }
                 .fail()
@@ -90,140 +77,16 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
         })
         .collect::<Result<Vec<Arc<dyn Array>>>>()?;
 
-    RecordBatch::try_new(schema, cols).context(ConvertRecordBatchSnafu)
-}
-
-#[allow(clippy::needless_pass_by_value)]
-fn try_cast_array(
-    array: Arc<dyn Array>,
-    existing_field: &Field,
-    field: &Field,
-) -> Result<Arc<dyn Array>> {
-    let result: Arc<dyn Array> = match (existing_field.data_type(), field.data_type()) {
-        (DataType::Int32, DataType::Int64) => {
-            if let Some(array) = array.as_any().downcast_ref::<Int32Array>() {
-                Arc::new(Int64Array::from(
-                    array
-                        .into_iter()
-                        .map(|f| f.map(i64::from))
-                        .collect::<Vec<Option<i64>>>(),
-                ))
-            } else {
-                UnableToDowncastSnafu {
-                    field: field.name(),
-                    downcast_to: "Int32Array".to_string(),
-                }
-                .fail()?
-            }
-        }
-        (DataType::Int64, DataType::Int32) => {
-            if let Some(array) = array.as_any().downcast_ref::<Int64Array>() {
-                Arc::new(Int32Array::from(
-                    array
-                        .into_iter()
-                        .map(|f| {
-                            f.map_or_else(
-                                || Ok(None),
-                                |f| Ok(Some(i32::try_from(f).context(ConvertIntSnafu)?)),
-                            )
-                        })
-                        .collect::<Result<Vec<Option<i32>>, _>>()?,
-                ))
-            } else {
-                UnableToDowncastSnafu {
-                    field: field.name(),
-                    downcast_to: "Int64Array".to_string(),
-                }
-                .fail()?
-            }
-        }
-        (DataType::Utf8, DataType::LargeUtf8) => {
-            if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
-                Arc::new(LargeStringArray::from(
-                    array.into_iter().collect::<Vec<Option<&str>>>(),
-                ))
-            } else {
-                UnableToDowncastSnafu {
-                    field: field.name(),
-                    downcast_to: "StringArray".to_string(),
-                }
-                .fail()?
-            }
-        }
-        (DataType::Utf8, DataType::Timestamp(unit, _)) => {
-            try_cast_array_from_string_to_timestamp(array, unit, field)?
-        }
-        (_, _) => ConvertArrowArraySnafu {
-            from: existing_field.data_type().clone(),
-            to: field.data_type().clone(),
-            name: field.name(),
-        }
-        .fail()?,
-    };
-
-    Ok(result)
-}
-
-#[allow(clippy::needless_pass_by_value)]
-fn try_cast_array_from_string_to_timestamp(
-    array: Arc<dyn Array>,
-    unit: &TimeUnit,
-    field: &Field,
-) -> Result<Arc<dyn Array>> {
-    let data_type = field.data_type().clone();
-    Ok(
-        if let Some(array) = array.as_any().downcast_ref::<StringArray>() {
-            let converted: Vec<Option<i64>> = array
-                .into_iter()
-                .map(|f| -> Result<Option<i64>> {
-                    f.map_or_else(
-                        || Ok(None),
-                        |f| {
-                            let value =
-                                chrono::NaiveDateTime::parse_from_str(f, "%Y-%m-%d %H:%M:%S%.6f")
-                                    .context(ParseTimestampFromStringSnafu)?
-                                    .and_utc()
-                                    .timestamp_micros()
-                                    / (match unit {
-                                        TimeUnit::Second => 1_000_000,
-                                        TimeUnit::Millisecond => 1_000,
-                                        TimeUnit::Microsecond => 1,
-                                        TimeUnit::Nanosecond => ConvertArrowArraySnafu {
-                                            from: DataType::Timestamp(unit.clone(), None),
-                                            to: data_type.clone(),
-                                            name: field.name(),
-                                        }
-                                        .fail()?,
-                                    });
-                            Ok(Some(value))
-                        },
-                    )
-                })
-                .collect::<Result<_, _>>()?;
-            match unit.clone() {
-                TimeUnit::Second => Arc::new(TimestampSecondArray::from(converted)),
-                TimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(converted)),
-                TimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(converted)),
-                TimeUnit::Nanosecond => ConvertArrowArraySnafu {
-                    from: DataType::Timestamp(unit.clone(), None),
-                    to: data_type,
-                    name: field.name(),
-                }
-                .fail()?,
-            }
-        } else {
-            UnableToDowncastSnafu {
-                field: field.name(),
-                downcast_to: "StringArray".to_string(),
-            }
-            .fail()?
-        },
-    )
+    RecordBatch::try_new(schema, cols).context(UnableToConvertRecordBatchSnafu)
 }
 
 #[cfg(test)]
 mod test {
-    use arrow::datatypes::Schema;
+
+    use arrow::{
+        array::{Int32Array, StringArray},
+        datatypes::{DataType, Field, Schema, TimeUnit},
+    };
 
     use super::*;
 

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -49,7 +49,7 @@ pub enum Error {
 ///
 /// # Errors
 ///
-/// This function will return an error if the record batch cannot be cast.
+/// This function will return an error if the record batch cannot be casted.
 #[allow(clippy::needless_pass_by_value)]
 pub fn cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
     let existing_schema = record_batch.schema();
@@ -107,11 +107,11 @@ fn cast_array(
                 Arc::new(Int32Array::from(
                     array
                         .into_iter()
-                        .map(|f| -> Result<Option<i32>> {
-                            match f {
-                                Some(f) => Ok(Some(i32::try_from(f).context(ConvertIntSnafu)?)),
-                                None => Ok(None),
-                            }
+                        .map(|f| {
+                            f.map_or_else(
+                                || Ok(None),
+                                |f| Ok(Some(i32::try_from(f).context(ConvertIntSnafu)?)),
+                            )
                         })
                         .collect::<Result<Vec<Option<i32>>, _>>()?,
                 ))
@@ -147,7 +147,7 @@ fn cast_array_from_string_to_timestamp(
     array: Arc<dyn Array>,
     unit: &TimeUnit,
     field: &Field,
-) -> Result<Arc<dyn Array>, Error> {
+) -> Result<Arc<dyn Array>> {
     let data_type = field.data_type().clone();
     Ok(
         if let Some(array) = array.as_any().downcast_ref::<StringArray>() {

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -52,7 +52,7 @@ pub enum Error {
 ///
 /// This function will return an error if the record batch cannot be converted.
 #[allow(clippy::needless_pass_by_value)]
-pub fn convert_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
+pub fn cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
     let existing_schema = record_batch.schema();
 
     if schema.contains(&existing_schema) {
@@ -230,7 +230,7 @@ mod test {
 
     #[test]
     fn test_string_to_timestamp_conversion() {
-        let result = convert_to(batch_input(), to_schema()).expect("converted");
+        let result = cast_to(batch_input(), to_schema()).expect("converted");
         assert_eq!(3, result.num_rows());
     }
 }

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -1,0 +1,210 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use arrow::{
+    array::{
+        new_null_array, Array, ArrayRef, Int32Array, Int64Array, LargeStringArray, RecordBatch,
+        StringArray, TimestampMicrosecondArray, TimestampMillisecondArray, TimestampSecondArray,
+    },
+    datatypes::{DataType, Field, SchemaRef, TimeUnit},
+};
+use snafu::prelude::*;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Error converting record batch: {}", source))]
+    ConvertRecordBatch { source: arrow::error::ArrowError },
+
+    #[snafu(display("Unable to convert array: {}", source))]
+    ParseTimestampFromString { source: chrono::ParseError },
+
+    #[snafu(display("Unable to convert array from {:?} to {:?}", from, to))]
+    ConvertArrowArray { from: DataType, to: DataType },
+}
+
+/// Convert a given record batch into a new record batch with the given schema.
+///
+/// # Errors
+///
+/// This function will return an error if the record batch cannot be converted.
+#[allow(clippy::needless_pass_by_value)]
+pub fn convert_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
+    let existing_schema = record_batch.schema();
+
+    if schema.contains(&existing_schema) {
+        return record_batch
+            .with_schema(schema)
+            .context(ConvertRecordBatchSnafu);
+    }
+
+    let num_rows = record_batch.num_rows();
+    let mut cols = vec![];
+
+    for field in schema.fields() {
+        let mut array: ArrayRef = new_null_array(field.data_type(), num_rows);
+
+        if let (Ok(existing_field), Some(column)) = (
+            record_batch.schema().field_with_name(field.name()),
+            record_batch.column_by_name(field.name()),
+        ) {
+            if field.contains(existing_field) {
+                array = Arc::clone(column);
+            } else {
+                array = convert_column(Arc::clone(column), existing_field, field)?;
+            }
+        }
+
+        cols.push(array);
+    }
+
+    RecordBatch::try_new(schema, cols).context(ConvertRecordBatchSnafu)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn convert_column(
+    column: Arc<dyn Array>,
+    existing_field: &Field,
+    field: &Field,
+) -> Result<Arc<dyn Array>> {
+    let result: Arc<dyn Array> = match (existing_field.data_type(), field.data_type()) {
+        (DataType::Int32, DataType::Int64) => {
+            if let Some(array) = column.as_any().downcast_ref::<Int32Array>() {
+                let converted: Vec<Option<i64>> =
+                    array.into_iter().map(|f| f.map(i64::from)).collect();
+                Arc::new(Int64Array::from(converted))
+            } else {
+                Arc::new(new_null_array(field.data_type(), column.len()))
+            }
+        }
+        (DataType::Utf8, DataType::LargeUtf8) => {
+            if let Some(array) = column.as_any().downcast_ref::<StringArray>() {
+                let converted: Vec<Option<&str>> = array.into_iter().collect();
+                Arc::new(LargeStringArray::from(converted))
+            } else {
+                Arc::new(new_null_array(field.data_type(), column.len()))
+            }
+        }
+        (DataType::Utf8, DataType::Timestamp(unit, _)) => {
+            convert_timestamp_column(column, unit, field)?
+        }
+        (_, _) => ConvertArrowArraySnafu {
+            from: existing_field.data_type().clone(),
+            to: field.data_type().clone(),
+        }
+        .fail()?,
+    };
+
+    Ok(result)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn convert_timestamp_column(
+    column: Arc<dyn Array>,
+    unit: &TimeUnit,
+    field: &Field,
+) -> Result<Arc<dyn Array>, Error> {
+    let data_type = field.data_type().clone();
+    Ok(
+        if let Some(array) = column.as_any().downcast_ref::<StringArray>() {
+            let converted: Vec<Option<i64>> = array
+                .into_iter()
+                .map(|f| -> Result<Option<i64>> {
+                    if let Some(f) = f {
+                        let value =
+                            chrono::NaiveDateTime::parse_from_str(f, "%Y-%m-%d %H:%M:%S%.6f")
+                                .context(ParseTimestampFromStringSnafu)?
+                                .and_utc()
+                                .timestamp_micros()
+                                / (match unit {
+                                    TimeUnit::Second => 1_000_000,
+                                    TimeUnit::Millisecond => 1_000,
+                                    TimeUnit::Microsecond => 1,
+                                    TimeUnit::Nanosecond => ConvertArrowArraySnafu {
+                                        from: DataType::Timestamp(unit.clone(), None),
+                                        to: data_type.clone(),
+                                    }
+                                    .fail()?,
+                                });
+                        Ok(Some(value))
+                    } else {
+                        Ok(None)
+                    }
+                })
+                .collect::<Result<_, _>>()?;
+            match unit.clone() {
+                TimeUnit::Second => Arc::new(TimestampSecondArray::from(converted)),
+                TimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(converted)),
+                TimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(converted)),
+                TimeUnit::Nanosecond => ConvertArrowArraySnafu {
+                    from: DataType::Timestamp(unit.clone(), None),
+                    to: data_type,
+                }
+                .fail()?,
+            }
+        } else {
+            Arc::new(new_null_array(field.data_type(), column.len()))
+        },
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use arrow::datatypes::Schema;
+
+    use super::*;
+
+    fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Utf8, false),
+            Field::new("c", DataType::Utf8, false),
+        ]))
+    }
+
+    fn to_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::LargeUtf8, false),
+            Field::new("c", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+        ]))
+    }
+
+    fn batch_input() -> RecordBatch {
+        RecordBatch::try_new(
+            schema(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["foo", "bar", "baz"])),
+                Arc::new(StringArray::from(vec![
+                    "2024-01-13 03:18:09.000000",
+                    "2024-01-13 03:18:09",
+                    "2024-01-13 03:18:09.000",
+                ])),
+            ],
+        )
+        .expect("record batch should not panic")
+    }
+
+    #[test]
+    fn test_string_to_timestamp_conversion() {
+        let result = convert_to(batch_input(), to_schema()).expect("converted");
+        assert_eq!(3, result.num_rows());
+    }
+}

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -51,7 +51,7 @@ pub enum Error {
 ///
 /// This function will return an error if the record batch cannot be casted.
 #[allow(clippy::needless_pass_by_value)]
-pub fn cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
+pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
     let existing_schema = record_batch.schema();
 
     if schema.contains(&existing_schema) {
@@ -73,7 +73,7 @@ pub fn cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBat
             if field.contains(existing_field) {
                 array = Arc::clone(column);
             } else {
-                array = cast_array(Arc::clone(column), existing_field, field)?;
+                array = try_cast_array(Arc::clone(column), existing_field, field)?;
             }
         }
 
@@ -84,7 +84,7 @@ pub fn cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBat
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn cast_array(
+fn try_cast_array(
     array: Arc<dyn Array>,
     existing_field: &Field,
     field: &Field,
@@ -129,7 +129,7 @@ fn cast_array(
             }
         }
         (DataType::Utf8, DataType::Timestamp(unit, _)) => {
-            cast_array_from_string_to_timestamp(array, unit, field)?
+            try_cast_array_from_string_to_timestamp(array, unit, field)?
         }
         (_, _) => ConvertArrowArraySnafu {
             from: existing_field.data_type().clone(),
@@ -143,7 +143,7 @@ fn cast_array(
 }
 
 #[allow(clippy::needless_pass_by_value)]
-fn cast_array_from_string_to_timestamp(
+fn try_cast_array_from_string_to_timestamp(
     array: Arc<dyn Array>,
     unit: &TimeUnit,
     field: &Field,
@@ -234,7 +234,7 @@ mod test {
 
     #[test]
     fn test_string_to_timestamp_conversion() {
-        let result = cast_to(batch_input(), to_schema()).expect("converted");
+        let result = try_cast_to(batch_input(), to_schema()).expect("converted");
         assert_eq!(3, result.num_rows());
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -50,6 +50,7 @@ itertools = "0.12"
 object_store = { version = "0.9.1", features = ["aws"] }
 url = "2.5.0"
 arrow_sql_gen = { path = "../arrow_sql_gen", optional = true }
+arrow_tools = { path = "../arrow_tools" }
 bb8 = { workspace = true, optional = true }
 bb8-postgres = { workspace = true, optional = true }
 bytes = { version = "1", default-features = false }

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -550,7 +550,7 @@ impl TableProvider for AcceleratedTable {
             )),
         };
 
-        Ok(Arc::new(SchemaCastScanExec::new(plan)))
+        Ok(Arc::new(SchemaCastScanExec::new(plan, self.schema())))
     }
 
     async fn insert_into(

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -550,7 +550,7 @@ impl TableProvider for AcceleratedTable {
             )),
         };
 
-        Ok(Arc::new(SchemaCastScanExec::new(plan, self.schema())))
+        Ok(Arc::new(SchemaCastScanExec::new(plan)))
     }
 
     async fn insert_into(

--- a/crates/runtime/src/execution_plan/mod.rs
+++ b/crates/runtime/src/execution_plan/mod.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 pub mod fallback_on_zero_results;
 pub mod slice;
 pub mod tee;
+pub mod schema_cast;
 
 #[derive(Clone)]
 pub struct TableScanParams {

--- a/crates/runtime/src/execution_plan/mod.rs
+++ b/crates/runtime/src/execution_plan/mod.rs
@@ -24,9 +24,9 @@ use datafusion::physical_plan::ExecutionPlan;
 use std::sync::Arc;
 
 pub mod fallback_on_zero_results;
+pub mod schema_cast;
 pub mod slice;
 pub mod tee;
-pub mod schema_cast;
 
 #[derive(Clone)]
 pub struct TableScanParams {

--- a/crates/runtime/src/execution_plan/schema_cast.rs
+++ b/crates/runtime/src/execution_plan/schema_cast.rs
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
+    PlanProperties,
+};
+use futures::{stream, StreamExt};
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+use async_stream::stream;
+
+use super::TableScanParams;
+
+pub struct SchemaCastScanExec {
+    input: Arc<dyn ExecutionPlan>,
+    schema: SchemaRef,
+}
+
+impl SchemaCastScanExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, schema: SchemaRef) -> Self {
+        Self { input, schema }
+    }
+}
+
+impl DisplayAs for SchemaCastScanExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl fmt::Debug for SchemaCastScanExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SchemaCastScanExec").field("input", &self.input).field("schema", &self.schema).finish()
+    }
+}
+
+impl ExecutionPlan for SchemaCastScanExec {
+    fn as_any(&self) -> &dyn Any {
+        todo!()
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        todo!()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        todo!()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        todo!()
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let stream  = self.input.execute(partition, context)?;
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(self.schema, stream! {
+            while let batch = stream.next().await {
+                yield batch;
+            }
+        })))
+    }
+}

--- a/crates/runtime/src/execution_plan/schema_cast.rs
+++ b/crates/runtime/src/execution_plan/schema_cast.rs
@@ -128,7 +128,7 @@ impl ExecutionPlan for SchemaCastScanExec {
             {
                 stream! {
                     while let Some(batch) = stream.next().await {
-                        let batch = arrow_tools::record_batch::cast_to(batch?, Arc::clone(&schema));
+                        let batch = arrow_tools::record_batch::try_cast_to(batch?, Arc::clone(&schema));
                         yield batch.map_err(|e| { DataFusionError::External(Box::new(e)) });
                     }
                 }

--- a/crates/runtime/src/execution_plan/schema_cast.rs
+++ b/crates/runtime/src/execution_plan/schema_cast.rs
@@ -15,65 +15,91 @@ limitations under the License.
 */
 
 use arrow::datatypes::SchemaRef;
-use async_trait::async_trait;
-use datafusion::datasource::TableProvider;
+use arrow_tools::record_batch::convert_to;
+use async_stream::stream;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
     PlanProperties,
 };
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
-use async_stream::stream;
 
-use super::TableScanParams;
-
+#[allow(clippy::module_name_repetitions)]
 pub struct SchemaCastScanExec {
     input: Arc<dyn ExecutionPlan>,
     schema: SchemaRef,
+    properties: PlanProperties,
 }
 
 impl SchemaCastScanExec {
     pub fn new(input: Arc<dyn ExecutionPlan>, schema: SchemaRef) -> Self {
-        Self { input, schema }
+        let eq_properties = input.equivalence_properties().clone();
+        let execution_mode = input.execution_mode();
+        let properties = PlanProperties::new(
+            eq_properties,
+            Partitioning::UnknownPartitioning(1),
+            execution_mode,
+        );
+        Self {
+            input,
+            schema,
+            properties,
+        }
     }
 }
 
 impl DisplayAs for SchemaCastScanExec {
-    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        todo!()
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SchemaCastScanExec")
     }
 }
 
 impl fmt::Debug for SchemaCastScanExec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SchemaCastScanExec").field("input", &self.input).field("schema", &self.schema).finish()
+        f.debug_struct("SchemaCastScanExec")
+            .field("input", &self.input)
+            .field("schema", &self.schema)
+            .field("properties", &self.properties)
+            .finish()
     }
 }
 
 impl ExecutionPlan for SchemaCastScanExec {
     fn as_any(&self) -> &dyn Any {
-        todo!()
+        self
     }
 
     fn properties(&self) -> &PlanProperties {
-        todo!()
+        &self.properties
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
     }
 
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
-        todo!()
+        vec![Arc::clone(&self.input)]
     }
 
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        todo!()
+        if children.len() == 1 {
+            Ok(Arc::new(Self::new(
+                Arc::clone(&children[0]),
+                Arc::clone(&self.schema),
+            )))
+        } else {
+            Err(DataFusionError::Execution(
+                "SchemaCastScanExec expects exactly one input".to_string(),
+            ))
+        }
     }
 
     fn execute(
@@ -81,11 +107,25 @@ impl ExecutionPlan for SchemaCastScanExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let stream  = self.input.execute(partition, context)?;
+        let mut stream = self.input.execute(partition, context)?;
+        let schema = self.schema();
 
-        Ok(Box::pin(RecordBatchStreamAdapter::new(self.schema, stream! {
-            while let batch = stream.next().await {
-                yield batch;
+        Ok(Box::pin(RecordBatchStreamAdapter::new(self.schema(), {
+            stream! {
+                while let Some(batch) = stream.next().await {
+                    let batch = match batch {
+                        Ok(batch) => {
+                            let batch = convert_to(batch, Arc::clone(&schema));
+                            match batch {
+                                Ok(batch) => Ok(batch),
+                                Err(e) => Err(DataFusionError::External(Box::new(e))),
+                            }
+                        },
+                        Err(e) => Err(e),
+                    };
+
+                    yield batch;
+                }
             }
         })))
     }

--- a/crates/runtime/src/execution_plan/schema_cast.rs
+++ b/crates/runtime/src/execution_plan/schema_cast.rs
@@ -123,18 +123,8 @@ impl ExecutionPlan for SchemaCastScanExec {
             {
                 stream! {
                     while let Some(batch) = stream.next().await {
-                        let batch = match batch {
-                            Ok(batch) => {
-                                let batch = arrow_tools::record_batch::cast_to(batch, Arc::clone(&schema));
-                                match batch {
-                                    Ok(batch) => Ok(batch),
-                                    Err(e) => Err(DataFusionError::External(Box::new(e))),
-                                }
-                            },
-                            Err(e) => Err(e),
-                        };
-
-                        yield batch;
+                        let batch = arrow_tools::record_batch::cast_to(batch?, Arc::clone(&schema));
+                        yield batch.map_err(|e| { DataFusionError::External(Box::new(e)) });
                     }
                 }
             },

--- a/crates/runtime/src/execution_plan/schema_cast.rs
+++ b/crates/runtime/src/execution_plan/schema_cast.rs
@@ -20,8 +20,7 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
-    PlanProperties,
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
 use futures::StreamExt;
 use std::any::Any;
@@ -43,7 +42,7 @@ impl SchemaCastScanExec {
         let execution_mode = input.execution_mode();
         let properties = PlanProperties::new(
             eq_properties,
-            Partitioning::UnknownPartitioning(1),
+            input.output_partitioning().clone(),
             execution_mode,
         );
         Self {


### PR DESCRIPTION
fixes #1181 
fixes #1028 

fixes #1236

This introduces a RecordBatch helper that `try_cast_to` given schema for an existing record batch.

Also introduce a execution plan that casts the records in more engine primitive type schema to the schema defined in accelerated table.

Note, this is not trying to exhaust all possible casts, all casts need to be implemented on demand.