### PR TITLE
Implement the Localhost Data Connector & fix DoPut

### DIFF
--- a/crates/runtime/src/arrow.rs
+++ b/crates/runtime/src/arrow.rs
@@ -1,0 +1,53 @@
+// TODO: Move this to the arrow_tools crate when https://github.com/spiceai/spiceai/pull/1261 is merged
+
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Expected and actual number of fields in the query result don't match: expected {expected}, received {actual}"))]
+    SchemaMismatchNumFields { expected: usize, actual: usize },
+
+    #[snafu(display("Query returned an unexpected data type for column {name}: expected {expected}, received {actual}. Is the column data type supported by the data accelerator (https://docs.spiceai.org/reference/datatypes)?"))]
+    SchemaMismatchDataType {
+        name: String,
+        expected: String,
+        actual: String,
+    },
+
+    #[snafu(display("Failed to get field data type"))]
+    UnableToGetFieldDataType {},
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub fn verify_schema(
+    expected: &arrow::datatypes::Fields,
+    actual: &arrow::datatypes::Fields,
+) -> Result<()> {
+    if expected.len() != actual.len() {
+        return SchemaMismatchNumFieldsSnafu {
+            expected: expected.len(),
+            actual: actual.len(),
+        }
+        .fail();
+    }
+
+    for idx in 0..expected.len() {
+        let a = expected.get(idx).context(UnableToGetFieldDataTypeSnafu)?;
+        let b = actual.get(idx).context(UnableToGetFieldDataTypeSnafu)?;
+
+        let a_data_type = a.data_type();
+        let b_data_type = b.data_type();
+
+        if a_data_type != b_data_type {
+            return SchemaMismatchDataTypeSnafu {
+                name: a.name(),
+                expected: format!("{a_data_type}"),
+                actual: format!("{b_data_type}"),
+            }
+            .fail();
+        }
+    }
+
+    Ok(())
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -42,6 +42,7 @@ use tokio::{signal, sync::RwLock};
 
 use crate::{dataconnector::DataConnector, datafusion::DataFusion};
 mod accelerated_table;
+pub mod arrow;
 pub mod config;
 pub mod dataaccelerator;
 pub mod dataconnector;


### PR DESCRIPTION
This PR re-implements the Localhost Data Connector, which wasn't fully implemented after #1040 was merged.

There was also another bug that writing data via DoPut was also broken after #1040, so this PR fixes that as well.

This Spicepod is now possible:

```yaml
version: v1beta1
kind: Spicepod
name: localhost

datasets:
- from: localhost
  name: test
  mode: read_write
  replication:
    enabled: true
  params:
    schema: |
      CREATE TABLE test (
        log_index BIGINT,
        transaction_hash TEXT,
        transaction_index BIGINT,
        address TEXT,
        data TEXT,
        topics TEXT[],
        block_timestamp TIMESTAMP WITH TIME ZONE,
        block_number BIGINT,
        block_hash TEXT,
      )
  acceleration:
    enabled: true
    engine: duckdb
```

Note: There are some issues with handling nested types and timezones properly, but I will tackle them as follow-on PRs.