### PR TITLE
Tokio postgres more types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,6 +5233,7 @@ dependencies = [
  "chrono",
  "fallible-iterator 0.2.0",
  "postgres-protocol",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5069,6 +5069,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgtemp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc39977b03503cfcf74ce2f8938d7b8340d1f8ef31a3f2a289b1c1abff8ace2c"
+dependencies = [
+ "libc",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6529,6 +6541,7 @@ dependencies = [
  "db_connection_pool",
  "duckdb",
  "futures",
+ "pgtemp",
  "r2d2",
  "snafu 0.8.2",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ bb8-postgres = "0.8"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 tokio-rusqlite = "0.5.1"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
-tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-uuid-1"] }
 clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", branch = "async-await", features = [
     "tokio_io",
     "tls",

--- a/crates/arrow_sql_gen/Cargo.toml
+++ b/crates/arrow_sql_gen/Cargo.toml
@@ -22,7 +22,7 @@ sea-query = { version = "0.30.7", features = [
     "with-time",
 ] }
 snafu.workspace = true
-tokio-postgres = { workspace = true, features = ["with-chrono-0_4"], optional = true }
+tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-uuid-1"], optional = true }
 bigdecimal_0_3_0 = { package = "bigdecimal", version = "0.3.0" }
 time = "0.3.34"
 bigdecimal = "0.4.3"
@@ -37,6 +37,6 @@ uuid = { workspace = true, optional = true }
 
 [features]
 sqlite = ["dep:rusqlite"]
-postgres = ["dep:tokio-postgres"]
+postgres = ["dep:tokio-postgres", "dep:uuid"]
 mysql = ["dep:mysql_async"]
 clickhouse = ["dep:clickhouse-rs", "dep:uuid"]

--- a/crates/arrow_sql_gen/src/arrow.rs
+++ b/crates/arrow_sql_gen/src/arrow.rs
@@ -68,6 +68,7 @@ pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuil
             }
         },
         DataType::Date32 => Box::new(Date32Builder::new()),
+        DataType::FixedSizeBinary(s) => Box::new(FixedSizeBinaryBuilder::new(*s)),
         // We can't recursively call map_data_type_to_array_builder here because downcasting will not work if the
         // values_builder is boxed.
         DataType::List(values_field) => match values_field.data_type() {

--- a/crates/arrow_sql_gen/src/arrow.rs
+++ b/crates/arrow_sql_gen/src/arrow.rs
@@ -82,7 +82,6 @@ pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuil
             DataType::Boolean => Box::new(ListBuilder::new(BooleanBuilder::new())),
             _ => unimplemented!("Unsupported list value data type {:?}", data_type),
         },
-        DataType::FixedSizeBinary(size) => Box::new(FixedSizeBinaryBuilder::new(*size)),
         _ => unimplemented!("Unsupported data type {:?}", data_type),
     }
 }

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -182,6 +182,7 @@ impl PostgresConnectionPool {
 
         let pool = bb8::Pool::builder()
             .error_sink(Box::new(error_sink))
+            .test_on_check_out(false)
             .build(manager)
             .await
             .context(ConnectionPoolSnafu)?;

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -149,7 +149,7 @@ impl PostgresConnectionPool {
             _ => "require",
         };
 
-        // connection_string.push_str(format!("sslmode={mode} ").as_str());
+        connection_string.push_str(format!("sslmode={mode} ").as_str());
         let config = Config::from_str(connection_string.as_str()).context(ConnectionPoolSnafu)?;
 
         for host in config.get_hosts() {

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -182,7 +182,6 @@ impl PostgresConnectionPool {
 
         let pool = bb8::Pool::builder()
             .error_sink(Box::new(error_sink))
-            .test_on_check_out(false)
             .build(manager)
             .await
             .context(ConnectionPoolSnafu)?;

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -149,7 +149,7 @@ impl PostgresConnectionPool {
             _ => "require",
         };
 
-        connection_string.push_str(format!("sslmode={mode} ").as_str());
+        // connection_string.push_str(format!("sslmode={mode} ").as_str());
         let config = Config::from_str(connection_string.as_str()).context(ConnectionPoolSnafu)?;
 
         for host in config.get_hosts() {

--- a/crates/sql_provider_datafusion/Cargo.toml
+++ b/crates/sql_provider_datafusion/Cargo.toml
@@ -25,6 +25,7 @@ db_connection_pool = { path = "../db_connection_pool" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 duckdb = { workspace = true, features = ["bundled", "r2d2", "vtab", "vtab-arrow"] }
 db_connection_pool = { path = "../db_connection_pool", features = ["duckdb"] }
+pgtemp = "0.3.0"
 
 [features]
 postgres = ["db_connection_pool/postgres"]

--- a/crates/sql_provider_datafusion/tests/postgres_integration_test.rs
+++ b/crates/sql_provider_datafusion/tests/postgres_integration_test.rs
@@ -1,0 +1,91 @@
+use std::{collections::HashMap, sync::Arc};
+
+use arrow::{
+    array::TimestampMillisecondArray,
+    datatypes::{DataType, TimeUnit},
+};
+use datafusion::execution::context::SessionContext;
+use db_connection_pool::{
+    dbconnection::postgresconn::PostgresConnection, postgrespool::PostgresConnectionPool,
+    DbConnectionPool,
+};
+use pgtemp::PgTempDB;
+use sql_provider_datafusion::SqlTable;
+
+// Run this test requires local installation of postgres
+// See Requirements in https://github.com/boustrophedon/pgtemp
+#[tokio::test]
+#[ignore]
+async fn test_postgres_types() {
+    let db = PgTempDB::async_new().await;
+    let ctx = SessionContext::new();
+    println!("{}", db.connection_string());
+    let params = Arc::new(Some(HashMap::from([(
+        "pg_connection_string".to_string(),
+        db.connection_string(),
+    )])));
+    let pool: Arc<dyn DbConnectionPool<_, _> + Send + Sync> = Arc::new(
+        PostgresConnectionPool::new(params, None)
+            .await
+            .expect("Postgres connection pool should be created"),
+    );
+    let conn = pool.connect().await.expect("Connection should be created");
+    let db_conn = conn
+        .as_any()
+        .downcast_ref::<PostgresConnection>()
+        .expect("Unable to downcast to DuckDbConnection");
+    db_conn
+        .conn
+        .execute(
+            "
+CREATE TABLE test (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);",
+            &[],
+        )
+        .await
+        .expect("table created");
+    db_conn
+        .conn
+        .execute(
+            "INSERT INTO test (id, created_at) VALUES (gen_random_uuid(), '2023-05-02 10:30:00-04:00');",
+            &[],
+        )
+        .await
+        .expect("row inserted");
+    let table = SqlTable::new(&pool, "test", None)
+        .await
+        .expect("SqlTable should be created");
+    ctx.register_table("test_datafusion", Arc::new(table))
+        .expect("Table should be registered");
+    let sql = "SELECT id, created_at FROM test_datafusion";
+    let df = ctx
+        .sql(sql)
+        .await
+        .expect("DataFrame can be created from query");
+    let record_batch = df.collect().await.expect("RecordBatch can be collected");
+    assert_eq!(record_batch.len(), 1);
+    let record_batch = record_batch
+        .first()
+        .expect("At least 1 record batch is returned");
+    assert_eq!(record_batch.num_rows(), 1);
+
+    assert_eq!(
+        DataType::FixedSizeBinary(16),
+        *record_batch.schema().fields()[0].data_type()
+    );
+    assert_eq!(
+        DataType::Timestamp(TimeUnit::Millisecond, None),
+        *record_batch.schema().fields()[1].data_type()
+    );
+
+    assert_eq!(
+        1_683_037_800_000,
+        record_batch.columns()[1]
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .expect("array can be cast")
+            .value(0)
+    );
+}

--- a/crates/sql_provider_datafusion/tests/postgres_integration_test.rs
+++ b/crates/sql_provider_datafusion/tests/postgres_integration_test.rs
@@ -14,16 +14,19 @@ use sql_provider_datafusion::SqlTable;
 
 // Run this test requires local installation of postgres
 // See Requirements in https://github.com/boustrophedon/pgtemp
-#[tokio::test]
 #[ignore]
+#[tokio::test]
 async fn test_postgres_types() {
     let db = PgTempDB::async_new().await;
     let ctx = SessionContext::new();
-    println!("{}", db.connection_string());
-    let params = Arc::new(Some(HashMap::from([(
-        "pg_connection_string".to_string(),
-        db.connection_string(),
-    )])));
+    let params = Arc::new(Some(HashMap::from([
+        ("pg_host".to_string(), "localhost".into()),
+        ("pg_port".to_string(), format!("{}", db.db_port())),
+        ("pg_user".to_string(), db.db_user().into()),
+        ("pg_pass".to_string(), db.db_pass().into()),
+        ("pg_db".to_string(), db.db_name().into()),
+        ("pg_sslmode".to_string(), "disable".into()),
+    ])));
     let pool: Arc<dyn DbConnectionPool<_, _> + Send + Sync> = Arc::new(
         PostgresConnectionPool::new(params, None)
             .await


### PR DESCRIPTION
fixes #1148 

Add support for postgres UUID and timestamptz.

Also adds an integration test (ignored by default) to cover this case.

<img width="511" alt="Screenshot 2024-05-02 at 18 06 25" src="https://github.com/spiceai/spiceai/assets/561715/174fe29d-509e-431c-9a91-63b64ec5c3b0">
<img width="517" alt="Screenshot 2024-05-02 at 18 06 15" src="https://github.com/spiceai/spiceai/assets/561715/88852377-1b36-4776-aec8-e53a297dab76">

Known limitation:

- the pretty print of arrow FixedBinaryArray omit the dash in uuid.
- UUID is not supported in accelerator engine in postgres, sqlite and duckdb yet.