### PR TITLE
Add Snowflake data connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6772,7 +6772,8 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 [[package]]
 name = "snowflake-api"
 version = "0.8.0"
-source = "git+https://github.com/xmakro/snowflake-rs.git#5616c31294d6e9deebd4b45200f1d57e9691aca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1434bfb85dc18773aa4ff2f9824117f55304c4e2d1406aaea06cbcf29beb2047"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,7 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "hyper 0.14.28",
- "ring",
+ "ring 0.17.8",
  "time",
  "tokio",
  "tracing",
@@ -1027,7 +1027,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.0",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -1247,6 +1247,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1268,6 +1274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bb8"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,7 +1288,7 @@ dependencies = [
  "async-trait",
  "futures-channel",
  "futures-util",
- "parking_lot",
+ "parking_lot 0.12.1",
  "tokio",
 ]
 
@@ -1839,6 +1851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,7 +2084,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -2098,11 +2116,12 @@ dependencies = [
  "odbc-api",
  "postgres-native-tls",
  "r2d2",
- "reqwest",
+ "reqwest 0.11.27",
  "rusqlite",
  "secrets",
  "serde",
  "snafu 0.8.2",
+ "snowflake-api",
  "spark-connect-rs",
  "sql_provider_datafusion",
  "tokio",
@@ -2150,7 +2169,7 @@ dependencies = [
  "log",
  "num_cpus",
  "object_store",
- "parking_lot",
+ "parking_lot 0.12.1",
  "parquet",
  "pin-project-lite",
  "rand",
@@ -2209,7 +2228,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "log",
  "object_store",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rand",
  "tempfile",
  "url",
@@ -2355,7 +2374,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "rand",
  "tokio",
@@ -2412,12 +2431,13 @@ dependencies = [
  "native-tls",
  "ns_lookup",
  "odbc-api",
- "pem",
+ "pem 3.0.4",
  "postgres-native-tls",
  "r2d2",
  "rusqlite",
  "secrets",
  "snafu 0.8.2",
+ "snowflake-api",
  "spicepod",
  "tokio",
  "tokio-rusqlite",
@@ -2523,7 +2543,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "parquet",
  "percent-encoding",
  "pin-project-lite",
@@ -2539,6 +2559,17 @@ dependencies = [
  "url",
  "uuid",
  "z85",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -2579,6 +2610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -3243,8 +3275,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3503,6 +3537,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -3519,6 +3554,23 @@ dependencies = [
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -3553,6 +3605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -3560,6 +3613,9 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3711,7 +3767,7 @@ dependencies = [
  "socket2 0.5.6",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -3785,6 +3841,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.7",
+ "pem 1.1.1",
+ "ring 0.16.20",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keyed_priority_queue"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,6 +3912,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -4362,7 +4435,7 @@ dependencies = [
  "mysql_common",
  "native-tls",
  "once_cell",
- "pem",
+ "pem 3.0.4",
  "percent-encoding",
  "pin-project",
  "rand",
@@ -4585,6 +4658,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4718,12 +4808,12 @@ dependencies = [
  "hyper 0.14.28",
  "itertools 0.12.1",
  "md-5",
- "parking_lot",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "quick-xml",
  "rand",
- "reqwest",
- "ring",
+ "reqwest 0.11.27",
+ "ring 0.17.8",
  "serde",
  "serde_json",
  "snafu 0.7.5",
@@ -4917,12 +5007,37 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -4990,12 +5105,30 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
+name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64 0.22.0",
  "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -5138,6 +5271,27 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.0.2",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -5452,7 +5606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.12.1",
  "scheduled-thread-pool",
 ]
 
@@ -5532,6 +5686,15 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -5636,7 +5799,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -5664,7 +5827,87 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "async-compression",
+ "base64 0.22.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.22.4",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg 0.52.0",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209efb52486ad88136190094ee214759ef7507068b27992256ed6610eb71a01"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.1.0",
+ "reqwest 0.12.4",
+ "serde",
+ "thiserror",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f342894422862af74c50e1e9601cf0931accc9c6981e5eb413c46603b616b5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "getrandom",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "parking_lot 0.11.2",
+ "reqwest 0.12.4",
+ "reqwest-middleware",
+ "retry-policies",
+ "tokio",
+ "tracing",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -5678,6 +5921,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "retry-policies"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "493b4243e32d6eedd29f9a398896e35c6943a123b55eec97dcaee98310d25810"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5687,8 +5956,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
- "untrusted",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5729,6 +5998,26 @@ checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5776,12 +6065,13 @@ dependencies = [
  "prost 0.12.4",
  "r2d2",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "rusqlite",
  "secrets",
  "serde",
  "serde_json",
  "snafu 0.8.2",
+ "snowflake-api",
  "spicepod",
  "sql_provider_datafusion",
  "tokio",
@@ -5897,7 +6187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.8",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -5909,7 +6199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki 0.102.3",
  "subtle",
@@ -5987,8 +6277,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5998,9 +6288,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "aws-lc-rs",
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6076,7 +6366,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -6091,8 +6381,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6166,7 +6456,7 @@ dependencies = [
  "base64 0.22.0",
  "dirs",
  "keyring",
- "reqwest",
+ "reqwest 0.11.27",
  "secrecy",
  "serde",
  "serde_json",
@@ -6344,10 +6634,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -6435,6 +6747,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "snowflake-api"
+version = "0.8.0"
+source = "git+https://github.com/xmakro/snowflake-rs.git#5616c31294d6e9deebd4b45200f1d57e9691aca1"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "base64 0.22.0",
+ "bytes",
+ "futures",
+ "glob",
+ "log",
+ "object_store",
+ "regex",
+ "reqwest 0.12.4",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "serde",
+ "serde_json",
+ "snowflake-jwt",
+ "thiserror",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "snowflake-jwt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a6dfdd7c433e0f4bb96d777c88d900c5abe3dc4d2f26d2340fd6c7caadcc6c"
+dependencies = [
+ "base64 0.21.7",
+ "jsonwebtoken",
+ "rsa",
+ "serde",
+ "sha2",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6462,7 +6815,7 @@ dependencies = [
  "arrow",
  "arrow-ipc",
  "chrono",
- "parking_lot",
+ "parking_lot 0.12.1",
  "prost 0.12.4",
  "prost-types",
  "rand",
@@ -6504,9 +6857,25 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "sql_provider_datafusion"
@@ -6864,7 +7233,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.6",
@@ -6916,7 +7285,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "phf",
  "pin-project-lite",
@@ -7407,7 +7776,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rand",
  "resolv-conf",
  "smallvec",
@@ -7495,6 +7864,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -7676,6 +8051,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7693,6 +8083,15 @@ checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8028,6 +8427,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,5 @@ uuid = "1.6.1"
 pem = "3.0.4"
 odbc-api = { version = "7.0.0" }
 arrow-odbc = { version = "9.0.0" }
+# Temporarily use git repo that has Arrow 51.0.0. This will be available in next release (0.8.0).
+snowflake-api = { git = "https://github.com/xmakro/snowflake-rs.git", commit="5616c31294d6e9deebd4b45200f1d57e9691aca1", folder = "snowflake-api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,5 +60,4 @@ uuid = "1.6.1"
 pem = "3.0.4"
 odbc-api = { version = "7.0.0" }
 arrow-odbc = { version = "9.0.0" }
-# Temporarily use git repo that has Arrow 51.0.0. This will be available in next release (0.8.0).
-snowflake-api = { git = "https://github.com/xmakro/snowflake-rs.git", commit="5616c31294d6e9deebd4b45200f1d57e9691aca1", folder = "snowflake-api" }
+snowflake-api = { version = "0.8.0"}

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -21,7 +21,7 @@ tracing-subscriber.workspace = true
 metrics-exporter-prometheus = "0.13.0"
 
 [features]
-default = ["duckdb", "postgres", "sqlite", "mysql", "flightsql", "databricks", "dremio", "clickhouse", "spark"]
+default = ["duckdb", "postgres", "sqlite", "mysql", "flightsql", "databricks", "dremio", "clickhouse", "spark", "snowflake"]
 duckdb = ["runtime/duckdb", "spicepod/duckdb", "app/duckdb"]
 postgres = ["runtime/postgres", "spicepod/postgres", "app/postgres"]
 sqlite = ["runtime/sqlite", "spicepod/sqlite", "app/sqlite"]
@@ -36,3 +36,4 @@ databricks = ["runtime/databricks"]
 dremio = ["runtime/dremio"]
 odbc = ["runtime/odbc"]
 spark = ["runtime/spark"]
+snowflake = ["runtime/snowflake"]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -46,6 +46,7 @@ spark-connect-rs =  { git = "https://github.com/edmondop/spark-connect-rs.git", 
 odbc-api = { workspace = true, optional = true }
 arrow-odbc = { workspace = true, optional = true }
 clickhouse-rs = { workspace = true, optional = true }
+snowflake-api ={ workspace = true, optional = true }
 uuid.workspace = true
 
 [features]
@@ -58,4 +59,5 @@ clickhouse = ["dep:clickhouse-rs", "arrow_sql_gen/clickhouse"]
 spark_connect = ["dep:spark-connect-rs"]
 databricks = ["dep:deltalake", "spark_connect"]
 odbc = ["dep:odbc-api", "dep:arrow-odbc"]
+snowflake = ["dep:snowflake-api"]
 

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -46,6 +46,9 @@ pub mod spark_connect;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+#[cfg(feature = "snowflake")]
+pub mod snowflake;
+
 pub mod delete;
 pub mod util;
 

--- a/crates/data_components/src/snowflake.rs
+++ b/crates/data_components/src/snowflake.rs
@@ -1,0 +1,49 @@
+#![allow(clippy::module_name_repetitions)]
+use async_trait::async_trait;
+use datafusion::{common::OwnedTableReference, datasource::TableProvider};
+use db_connection_pool::DbConnectionPool;
+use snafu::prelude::*;
+use snowflake_api::SnowflakeApi;
+use sql_provider_datafusion::SqlTable;
+use std::sync::Arc;
+
+use crate::Read;
+
+pub type SnowflakeConnectionPool =
+    dyn DbConnectionPool<Arc<SnowflakeApi>, &'static (dyn Sync)> + Send + Sync;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to construct SQL table: {source}"))]
+    UnableToConstructSQLTable {
+        source: sql_provider_datafusion::Error,
+    },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct SnowflakeTableFactory {
+    pool: Arc<SnowflakeConnectionPool>,
+}
+
+impl SnowflakeTableFactory {
+    #[must_use]
+    pub fn new(pool: Arc<SnowflakeConnectionPool>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl Read for SnowflakeTableFactory {
+    async fn table_provider(
+        &self,
+        table_reference: OwnedTableReference,
+    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
+        let pool = Arc::clone(&self.pool);
+        let table_provider = SqlTable::new(&pool, table_reference, None)
+            .await
+            .context(UnableToConstructSQLTableSnafu)?;
+
+        Ok(Arc::new(table_provider))
+    }
+}

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -35,6 +35,7 @@ arrow-odbc = { workspace = true, optional = true }
 lazy_static = "1.4.0"
 clickhouse-rs = { workspace = true, optional = true }
 async-stream = { workspace = true, optional = true }
+snowflake-api = { workspace = true, optional = true }
 
 
 [dev-dependencies]
@@ -56,4 +57,5 @@ sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "arrow_sql_gen/sqlite", "spicepo
 mysql = ["dep:mysql_async", "arrow_sql_gen/mysql", "spicepod/mysql"]
 clickhouse = ["dep:clickhouse-rs", "arrow_sql_gen/clickhouse", "dep:async-stream"]
 odbc = ["dep:odbc-api", "dep:arrow-odbc", "dep:tokio"]
+snowflake = ["dep:snowflake-api"]
 

--- a/crates/db_connection_pool/src/dbconnection.rs
+++ b/crates/db_connection_pool/src/dbconnection.rs
@@ -31,6 +31,8 @@ pub mod mysqlconn;
 pub mod odbcconn;
 #[cfg(feature = "postgres")]
 pub mod postgresconn;
+#[cfg(feature = "snowflake")]
+pub mod snowflakeconn;
 #[cfg(feature = "sqlite")]
 pub mod sqliteconn;
 

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::datatypes::{Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::memory::MemoryStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::sql::TableReference;
+use futures::stream;
+use snafu::prelude::*;
+use snowflake_api::SnowflakeApi;
+
+use super::AsyncDbConnection;
+use super::DbConnection;
+use super::Result;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Not implemented"))]
+    NotImplemented,
+
+    #[snafu(display("Unable to retrieve schema"))]
+    UnableToRetrieveSchema,
+
+    #[snafu(display("Unexpected query response, expected Arrow, got JSON"))]
+    UnexpectedResponse,
+
+    #[snafu(display("Error executing query: {source}"))]
+    SnowflakeQueryError {
+        source: snowflake_api::SnowflakeApiError,
+    },
+}
+
+pub struct SnowflakeConnection {
+    pub api: Arc<SnowflakeApi>,
+}
+
+impl<'a> DbConnection<Arc<SnowflakeApi>, &'a (dyn Sync)> for SnowflakeConnection {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn as_async(&self) -> Option<&dyn super::AsyncDbConnection<Arc<SnowflakeApi>, &'a (dyn Sync)>> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a (dyn Sync)> for SnowflakeConnection {
+    fn new(api: Arc<SnowflakeApi>) -> Self {
+        SnowflakeConnection { api }
+    }
+
+    async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef> {
+        let table = table_reference.to_quoted_string();
+
+        let res = self
+            .api
+            .exec(format!("SELECT * FROM {table} limit 1").as_str())
+            .await
+            .context(SnowflakeQuerySnafu)?;
+
+        match res {
+            snowflake_api::QueryResult::Arrow(record_batches) => {
+                let schema = record_batches[0].schema();
+                return Ok(Arc::clone(&schema));
+            }
+            _ => UnableToRetrieveSchemaSnafu.fail()?,
+        }
+    }
+
+    async fn query_arrow(
+        &self,
+        sql: &str,
+        _: &[&'a (dyn Sync)],
+    ) -> Result<SendableRecordBatchStream> {
+        let sql = sql.to_string();
+
+        let res = self.api.exec(&sql).await.context(SnowflakeQuerySnafu)?;
+
+        match res {
+            snowflake_api::QueryResult::Arrow(record_batches) => {
+                let schema = record_batches[0].schema();
+                return Ok(Box::pin(MemoryStream::try_new(
+                    record_batches,
+                    schema,
+                    None,
+                )?));
+            }
+            snowflake_api::QueryResult::Empty => {
+                return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                    Arc::new(Schema::empty()),
+                    stream::empty(),
+                )));
+            }
+            snowflake_api::QueryResult::Json(json) => {
+                tracing::debug!("Unexpected response from Snowflake query: {json}");
+                UnexpectedResponseSnafu.fail()?
+            }
+        }
+    }
+
+    async fn execute(&self, _query: &str, _: &[&'a (dyn Sync)]) -> Result<u64> {
+        return NotImplementedSnafu.fail()?;
+    }
+}

--- a/crates/db_connection_pool/src/lib.rs
+++ b/crates/db_connection_pool/src/lib.rs
@@ -35,6 +35,9 @@ pub mod postgrespool;
 #[cfg(feature = "sqlite")]
 pub mod sqlitepool;
 
+#[cfg(feature = "snowflake")]
+pub mod snowflakepool;
+
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/crates/db_connection_pool/src/snowflakepool.rs
+++ b/crates/db_connection_pool/src/snowflakepool.rs
@@ -1,0 +1,110 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use async_trait::async_trait;
+use secrets::Secret;
+use snafu::prelude::*;
+use snowflake_api::SnowflakeApi;
+use std::{collections::HashMap, sync::Arc};
+
+use super::{DbConnectionPool, Result};
+
+use crate::{
+    dbconnection::{snowflakeconn::SnowflakeConnection, DbConnection},
+    get_secret_or_param,
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Missing required parameter: {name}"))]
+    MissingRequiredParameter { name: String },
+
+    #[snafu(display("Missing required secret: {name}"))]
+    MissingRequiredSecret { name: String },
+
+    #[snafu(display("Unable to connect to Snowflake: {source}"))]
+    UnableToConnect {
+        source: snowflake_api::SnowflakeApiError,
+    },
+}
+
+pub struct SnowflakeConnectionPool {
+    pub api: Arc<SnowflakeApi>,
+}
+
+fn get_param(
+    params: &Arc<Option<HashMap<String, String>>>,
+    secret: &Option<Secret>,
+    param_name: &str,
+) -> Option<String> {
+    return get_secret_or_param(
+        params.as_ref().as_ref(),
+        secret,
+        &format!("{param_name}_key"),
+        param_name,
+    );
+}
+
+impl SnowflakeConnectionPool {
+    // Creates a new instance of `SnowflakeConnectionPool`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is a problem creating the connection pool.
+    pub async fn new(
+        params: &Arc<Option<HashMap<String, String>>>,
+        secret: &Option<Secret>,
+    ) -> Result<Self> {
+        let username = get_param(params, secret, "username")
+            .context(MissingRequiredSecretSnafu { name: "username" })?;
+        let password = get_param(params, secret, "password")
+            .context(MissingRequiredSecretSnafu { name: "password" })?;
+
+        let account = get_param(params, secret, "account")
+            .context(MissingRequiredParameterSnafu { name: "account" })?;
+        let warehouse = get_param(params, secret, "warehouse")
+            .context(MissingRequiredParameterSnafu { name: "warehouse" })?;
+
+        let api = SnowflakeApi::with_password_auth(
+            &account,
+            Some(&warehouse),
+            None,
+            None,
+            &username,
+            None,
+            &password,
+        )
+        .context(UnableToConnectSnafu)?;
+
+        // auth happens on the first request; test auth and connection
+        api.exec("SELECT 1").await.context(UnableToConnectSnafu)?;
+
+        Ok(Self { api: Arc::new(api) })
+    }
+}
+
+#[async_trait]
+impl DbConnectionPool<Arc<SnowflakeApi>, &'static (dyn Sync)> for SnowflakeConnectionPool {
+    async fn connect(
+        &self,
+    ) -> Result<Box<dyn DbConnection<Arc<SnowflakeApi>, &'static (dyn Sync)>>> {
+        let api = Arc::clone(&self.api);
+
+        let conn = SnowflakeConnection { api };
+
+        Ok(Box::new(conn))
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -69,6 +69,7 @@ odbc-api = { version = "7.0.0", optional = true }
 chrono = { version = "0.4.38" }
 clickhouse-rs = { workspace = true, optional = true }
 dashmap = "5.5.3"
+snowflake-api = { workspace = true, optional = true }
 
 [features]
 default = ["keyring-secret-store", "aws-secrets-manager"]
@@ -106,3 +107,4 @@ databricks = ["data_components/databricks"]
 spark = ["data_components/spark_connect"]
 dremio = []
 odbc = ["db_connection_pool/odbc", "data_components/odbc", "dep:odbc-api"]
+snowflake = ["dep:snowflake-api", "db_connection_pool/snowflake", "data_components/snowflake"]

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -57,6 +57,9 @@ pub mod s3;
 pub mod spark;
 pub mod spiceai;
 
+#[cfg(feature = "snowflake")]
+pub mod snowflake;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Unable to scan table provider: {source}"))]
@@ -163,6 +166,8 @@ pub async fn register_all() {
     register_connector_factory("odbc", odbc::ODBC::create).await;
     #[cfg(feature = "spark")]
     register_connector_factory("spark", spark::Spark::create).await;
+    #[cfg(feature = "snowflake")]
+    register_connector_factory("snowflake", snowflake::Snowflake::create).await;
 }
 
 pub trait DataConnectorFactory {

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::DataConnector;
+use super::DataConnectorFactory;
+use async_trait::async_trait;
+use data_components::snowflake::SnowflakeTableFactory;
+use data_components::Read;
+
+use datafusion::datasource::TableProvider;
+use db_connection_pool::snowflakepool::SnowflakeConnectionPool;
+use db_connection_pool::DbConnectionPool;
+use secrets::Secret;
+use snafu::prelude::*;
+use snowflake_api::SnowflakeApi;
+use spicepod::component::dataset::Dataset;
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{collections::HashMap, future::Future};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to create flight client: {source}"))]
+    UnableToCreateFlightClient { source: flight_client::Error },
+
+    #[snafu(display("{source}"))]
+    UnableToGetReadProvider {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Unable to create Snowflake connection pool: {source}"))]
+    UnableToCreateSnowflakeConnectionPool { source: db_connection_pool::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct Snowflake {
+    table_factory: SnowflakeTableFactory,
+}
+
+impl DataConnectorFactory for Snowflake {
+    fn create(
+        secret: Option<Secret>,
+        params: Arc<Option<HashMap<String, String>>>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move {
+            let pool: Arc<
+                dyn DbConnectionPool<Arc<SnowflakeApi>, &'static (dyn Sync)> + Send + Sync,
+            > = Arc::new(
+                SnowflakeConnectionPool::new(&params, &secret)
+                    .await
+                    .context(UnableToCreateSnowflakeConnectionPoolSnafu)?,
+            );
+
+            let table_factory = SnowflakeTableFactory::new(pool);
+
+            Ok(Arc::new(Self { table_factory }) as Arc<dyn DataConnector>)
+        })
+    }
+}
+
+#[async_trait]
+impl DataConnector for Snowflake {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> super::AnyErrorResult<Arc<dyn TableProvider>> {
+        Ok(
+            Read::table_provider(&self.table_factory, dataset.path().into())
+                .await
+                .context(UnableToGetReadProviderSnafu)?,
+        )
+    }
+}

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -34,15 +34,12 @@ use std::{collections::HashMap, future::Future};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to create flight client: {source}"))]
-    UnableToCreateFlightClient { source: flight_client::Error },
-
     #[snafu(display("{source}"))]
     UnableToGetReadProvider {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Unable to create Snowflake connection pool: {source}"))]
+    #[snafu(display("{source}"))]
     UnableToCreateSnowflakeConnectionPool { source: db_connection_pool::Error },
 }
 


### PR DESCRIPTION
Implements Snowflake data connector basic functionality.

Example configuration:

```
datasets:
- from: snowflake:snowflake_sample_data.tpch_sf1.customer
  name: customer
  params: 
    account: ztyvqyb-vgb35424
    warehouse: COMPUTE_WH
```

Associated PR for login functionality: https://github.com/spiceai/spiceai/pull/1272
