### PR TITLE
Refactor duckdb to properly set access_mode for connection

### DIFF
--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -107,6 +107,7 @@ impl DuckDBTableProviderFactory {
         }
     }
 
+    #[must_use]
     pub fn access_mode(mut self, access_mode: AccessMode) -> Self {
         self.access_mode = access_mode;
         self

--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -97,6 +97,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct DuckDBTableProviderFactory {
     access_mode: AccessMode,
+    db_path_param: String,
 }
 
 impl DuckDBTableProviderFactory {
@@ -104,12 +105,19 @@ impl DuckDBTableProviderFactory {
     pub fn new() -> Self {
         Self {
             access_mode: AccessMode::ReadOnly,
+            db_path_param: "open".to_string(),
         }
     }
 
     #[must_use]
     pub fn access_mode(mut self, access_mode: AccessMode) -> Self {
         self.access_mode = access_mode;
+        self
+    }
+
+    #[must_use]
+    pub fn db_path_param(mut self, db_path_param: &str) -> Self {
+        self.db_path_param = db_path_param.to_string();
         self
     }
 }
@@ -141,7 +149,7 @@ impl TableProviderFactory for DuckDBTableProviderFactory {
                 // open duckdb at given path or create a new one
                 let db_path = cmd
                     .options
-                    .get("open")
+                    .get(self.db_path_param.as_str())
                     .cloned()
                     .unwrap_or(format!("{name}.db"));
 

--- a/crates/data_components/src/duckdb/write.rs
+++ b/crates/data_components/src/duckdb/write.rs
@@ -220,6 +220,7 @@ impl DeletionSink for DuckDBDeletionSink {
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
+    use crate::{delete::get_deletion_provider, duckdb::DuckDBTableProviderFactory};
     use arrow::{
         array::{Int64Array, RecordBatch, StringArray, TimestampSecondArray, UInt64Array},
         datatypes::{DataType, Schema},
@@ -232,8 +233,7 @@ mod tests {
         physical_plan::{collect, test::exec::MockExec},
         scalar::ScalarValue,
     };
-
-    use crate::{delete::get_deletion_provider, duckdb::DuckDBTableProviderFactory};
+    use duckdb::AccessMode;
 
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
@@ -268,6 +268,7 @@ mod tests {
         };
         let ctx = SessionContext::new();
         let table = DuckDBTableProviderFactory::default()
+            .access_mode(AccessMode::ReadWrite)
             .create(&ctx.state(), &external_table)
             .await
             .expect("table should be created");

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -45,7 +45,10 @@ impl DuckDBAccelerator {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            duckdb_factory: DuckDBTableProviderFactory::new().access_mode(AccessMode::ReadWrite),
+            // DuckDB accelerator uses params.duckdb_file for file connection
+            duckdb_factory: DuckDBTableProviderFactory::new()
+                .db_path_param("duckdb_file")
+                .access_mode(AccessMode::ReadWrite),
         }
     }
 }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -21,6 +21,7 @@ use datafusion::{
     execution::context::SessionContext,
     logical_expr::CreateExternalTable,
 };
+use duckdb::AccessMode;
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
@@ -44,7 +45,7 @@ impl DuckDBAccelerator {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            duckdb_factory: DuckDBTableProviderFactory::new(),
+            duckdb_factory: DuckDBTableProviderFactory::new().access_mode(AccessMode::ReadWrite),
         }
     }
 }

--- a/crates/runtime/src/dataconnector/duckdb.rs
+++ b/crates/runtime/src/dataconnector/duckdb.rs
@@ -69,7 +69,7 @@ impl DataConnectorFactory for DuckDB {
                 .ok_or(Error::MissingDuckDBFile {})?;
 
             let pool = Arc::new(
-                DuckDbConnectionPool::new_file(&db_path, &AccessMode::ReadOnly)
+                DuckDbConnectionPool::new_file(db_path, &AccessMode::ReadOnly)
                     .context(UnableToCreateDuckDBConnectionPoolSnafu)?,
             );
 

--- a/crates/runtime/src/dataconnector/duckdb.rs
+++ b/crates/runtime/src/dataconnector/duckdb.rs
@@ -71,21 +71,9 @@ impl DataConnectorFactory for DuckDB {
                 .and_then(|p| p.get("open").cloned())
                 .ok_or(Error::MissingDuckDBFile {})?;
 
-            let access_mode = params
-                .and_then(|p| p.get("access_mode").cloned())
-                .unwrap_or("automatic".to_string());
-
-            let access_mode = match access_mode.as_str() {
-                "read_only" => &AccessMode::ReadOnly,
-                "read_write" => &AccessMode::ReadWrite,
-                "automatic" => &AccessMode::Automatic,
-                _ => {
-                    return Err(Error::InvalidAccessMode { access_mode }.into());
-                }
-            };
-
+            // TODO: wire to dataset.mode once readwrite implemented for duckdb
             let pool = Arc::new(
-                DuckDbConnectionPool::new_file(&db_path, access_mode)
+                DuckDbConnectionPool::new_file(&db_path, &AccessMode::ReadOnly)
                     .context(UnableToCreateDuckDBConnectionPoolSnafu)?,
             );
 

--- a/crates/sql_provider_datafusion/src/lib.rs
+++ b/crates/sql_provider_datafusion/src/lib.rs
@@ -333,8 +333,8 @@ mod tests {
     use datafusion::execution::context::SessionContext;
     use datafusion::sql::TableReference;
     use db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
-    use db_connection_pool::{duckdbpool::DuckDbConnectionPool, DbConnectionPool, Mode};
-    use duckdb::{DuckdbConnectionManager, ToSql};
+    use db_connection_pool::{duckdbpool::DuckDbConnectionPool, DbConnectionPool};
+    use duckdb::{AccessMode, DuckdbConnectionManager, ToSql};
     use tracing::{level_filters::LevelFilter, subscriber::DefaultGuard, Dispatch};
 
     use crate::SqlTable;
@@ -362,11 +362,7 @@ mod tests {
             dyn DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSql>
                 + Send
                 + Sync,
-        > = Arc::new(DuckDbConnectionPool::new(
-            "test",
-            &Mode::Memory,
-            &Arc::new(Option::None),
-        )?);
+        > = Arc::new(DuckDbConnectionPool::new_memory(&AccessMode::ReadWrite)?);
         let conn = pool.connect().await?;
         let db_conn = conn
             .as_any()
@@ -392,11 +388,7 @@ mod tests {
             dyn DbConnectionPool<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSql>
                 + Send
                 + Sync,
-        > = Arc::new(DuckDbConnectionPool::new(
-            "test",
-            &Mode::Memory,
-            &Arc::new(Option::None),
-        )?);
+        > = Arc::new(DuckDbConnectionPool::new_memory(&AccessMode::ReadWrite)?);
         let conn = pool.connect().await?;
         let db_conn = conn
             .as_any()


### PR DESCRIPTION
closes #1264 

### Refactored DuckDB connection factory to utilize access_mode:

Note about concurrency - https://duckdb.org/docs/connect/concurrency
> One process can both read and write to the database.
Multiple processes can read from the database, but no processes can write ([access_mode = 'READ_ONLY'](https://duckdb.org/docs/configuration/overview#configuration-reference)).

- connector uses `read_only` connection
- accelerator uses `read_write` connection