### PR TITLE
Add if not exists clause to create statement on when creating a table using duckdb acceleration.

### DIFF
--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -290,7 +290,7 @@ impl DuckDB {
             .collect::<Vec<_>>();
         let arrow_params_ref: &[&dyn ToSql] = &arrow_params_vec;
         let sql = format!(
-            r#"CREATE TABLE "{name}" AS SELECT * FROM arrow(?, ?)"#,
+            r#"CREATE TABLE IF NOT EXISTS "{name}" AS SELECT * FROM arrow(?, ?)"#,
             name = self.table_name
         );
         tracing::trace!("{sql}");


### PR DESCRIPTION
In the case that we're using file based duckdb acceleration, we get an error if we start spice, stop it, and restart, because the table already exists.

For other persistent stores, postgres and sqlite, we check for existence.  If there is a change in schema in the data connector, it'll still error out.  But thats OK since a schema change would probably be a situation where you'd want the user to think and take action before erasing existing data.

