### PR TITLE
do not insert batch for sqlite and postgres if no records in the record batch

### DIFF
--- a/crates/data_components/src/postgres/write.rs
+++ b/crates/data_components/src/postgres/write.rs
@@ -185,7 +185,13 @@ impl DataSink for PostgresDataSink {
 
         while let Some(batch) = data.next().await {
             let batch = batch?;
-            num_rows += batch.num_rows() as u64;
+            let batch_num_rows = batch.num_rows();
+
+            if batch_num_rows == 0 {
+                continue;
+            };
+
+            num_rows += batch_num_rows as u64;
 
             self.postgres
                 .insert_batch(&tx, batch)

--- a/crates/data_components/src/sqlite/write.rs
+++ b/crates/data_components/src/sqlite/write.rs
@@ -144,7 +144,9 @@ impl DataSink for SqliteDataSink {
                 }
 
                 for batch in data_batches {
-                    sqlite.insert_batch(&transaction, batch)?;
+                    if batch.num_rows() > 0 {
+                        sqlite.insert_batch(&transaction, batch)?;
+                    }
                 }
 
                 transaction.commit()?;


### PR DESCRIPTION
Do not try to insert data into sqlite and postgres if record batch is empty.

Fixes #1281 

This is guarding just in case any empty record batch got sent in. Ideally there shouldn't be any empty record batch generated upstream.