### PR TITLE
SQLite/Accelerators handle null values

### DIFF
--- a/crates/arrow_sql_gen/src/sqlite.rs
+++ b/crates/arrow_sql_gen/src/sqlite.rs
@@ -113,8 +113,11 @@ macro_rules! append_value {
             }
             .fail()?
         };
-        let value: $type = $row.get($index).context(FailedToExtractRowValueSnafu)?;
-        builder.append_value(value);
+        let value: Option<$type> = $row.get($index).context(FailedToExtractRowValueSnafu)?;
+        match value {
+            Some(value) => builder.append_value(value),
+            None => builder.append_null(),
+        }
     }};
 }
 


### PR DESCRIPTION
- Properly handle null values in sqlite
- Properly handle null values in accelerators 
- Issue still persists with duckdb (seems there is a problem on duckdb side)

Before fix:
![CleanShot 2024-05-04 at 5  58 37@2x](https://github.com/spiceai/spiceai/assets/20399045/e51b4440-aef4-4e6d-8444-82029cdd622f)

After fix: 
![CleanShot 2024-05-04 at 5  57 41@2x](https://github.com/spiceai/spiceai/assets/20399045/98b69774-c5d7-4003-a68a-d7616730d751)
