### PR TITLE
Fix unsupported SSL mode options for PostgreSQL connection string

### DIFF
--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -160,7 +160,7 @@ impl PostgresConnectionPool {
 
         connection_string.push_str(format!("sslmode={mode} ").as_str());
         let config = Config::from_str(connection_string.as_str()).context(ConnectionPoolSnafu)?;
-        verify_posstgres_config(&config).await?;
+        verify_postgres_config(&config).await?;
 
         let mut certs: Option<Vec<Certificate>> = None;
 

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -232,7 +232,7 @@ async fn test_postgres_connection(
     Ok(())
 }
 
-async fn verify_posstgres_config(config: &Config) -> Result<()> {
+async fn verify_postgres_config(config: &Config) -> Result<()> {
     for host in config.get_hosts() {
         for port in config.get_ports() {
             if let Host::Tcp(host) = host {

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -79,6 +79,7 @@ impl PostgresConnectionPool {
     /// # Errors
     ///
     /// Returns an error if there is a problem creating the connection pool.
+    #[allow(clippy::too_many_lines)]
     pub async fn new(
         params: Arc<Option<HashMap<String, String>>>,
         secret: Option<Secret>,
@@ -101,13 +102,13 @@ impl PostgresConnectionPool {
                 let str_params: Vec<&str> = str.split_whitespace().collect();
                 for param in str_params {
                     let param = param.split('=').collect::<Vec<&str>>();
-                    if param.len() == 2 {
-                        match param[0] {
+                    if let (Some(&name), Some(&value)) = (param.first(), param.get(1)) {
+                        match name {
                             "sslmode" => {
-                                ssl_mode = param[1].to_string();
+                                ssl_mode = value.to_string();
                             }
                             "sslrootcert" => {
-                                let sslrootcert = param[1];
+                                let sslrootcert = value;
                                 ensure!(
                                     std::path::Path::new(sslrootcert).exists(),
                                     InvalidRootCertPathSnafu { path: sslrootcert }
@@ -116,8 +117,7 @@ impl PostgresConnectionPool {
                                 ssl_rootcert_path = Some(PathBuf::from(sslrootcert));
                             }
                             _ => {
-                                connection_string
-                                    .push_str(format!("{} ", param.join("=")).as_str());
+                                connection_string.push_str(format!("{name}={value} ").as_str());
                             }
                         }
                     }

--- a/crates/db_connection_pool/src/postgrespool.rs
+++ b/crates/db_connection_pool/src/postgrespool.rs
@@ -119,7 +119,6 @@ impl PostgresConnectionPool {
                     match pg_sslmode.to_lowercase().as_str() {
                         "disable" | "require" | "prefer" | "verify-ca" | "verify-full" => {
                             ssl_mode = pg_sslmode.as_str();
-                            connection_string.push_str(format!("sslmode={ssl_mode} ").as_str());
                         }
                         _ => {
                             InvalidParameterSnafu {


### PR DESCRIPTION
Removed invalid ssl_mode from postgres connection string.

Spice use `"disable" | "require" | "prefer" | "verify-ca" | "verify-full"` ssl modes, but underlying tokio-postgres supports only `disable`, `require` and `prefer`.

Supported mode passed to the connection string here:
https://github.com/spiceai/spiceai/blob/02801593ff48c1b9af8a6380c065d143b63eed40/crates/db_connection_pool/src/postgrespool.rs#L144-L151

Also updated the case with `pg_connection_string` param, to extract sslmode and sslrootcert to process separately.