### PR TITLE
Check only the latest published release to avoid installing pre-release versions

### DIFF
--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -91,7 +91,7 @@ checkJqInstalled() {
 }
 
 getLatestRelease() {
-    local spiceReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases"
+    local spiceReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest"
     local latest_release=""
 
     if [ "$SPICE_HTTP_REQUEST_CLI" == "curl" ]; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -93,7 +93,7 @@ checkJqInstalled() {
 }
 
 getLatestRelease() {
-    local spiceReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases"
+    local spiceReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest"
     local latest_release=""
 
     if [ "$SPICE_HTTP_REQUEST_CLI" == "curl" ]; then


### PR DESCRIPTION
Using [`releases/latest`](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release) to get only most recent **published**, non-prerelease version

Currently install script gets all available releases, including pre-releases, which breaks installation flow during the time when we publish new release (pre-release and tag published in github, but binaries not ready yet)