### PR TITLE
Use the `GITHUB_TOKEN` environment variable in the installation script, if available, to avoid rate limiting in CI workflows

### DIFF
--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -50,11 +50,15 @@ jobs:
 
     - name: install Spice (https://install.spiceai.org)
       if : matrix.target_os != 'windows'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         curl https://install.spiceai.org | /bin/bash
     
     - name: install Spice (Windows)
       if : matrix.target_os == 'windows'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         curl -L "https://install.spiceai.org/Install.ps1" -o Install.ps1 && PowerShell -ExecutionPolicy Bypass -File ./Install.ps1
 
@@ -114,12 +118,14 @@ jobs:
 
     - name: check Spice cli and runtime version
       if: matrix.target_os != 'windows'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         version=$(spice version 2>&1)
         cli_version=$(echo "$version" | grep 'CLI version:' | cut -d':' -f2 | xargs)
         runtime_version=$(echo "$version" | grep 'Runtime version:' | cut -d':' -f2 | xargs)
 
-        release_version=$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+        release_version=$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" -H "Authorization: token $GITHUB_TOKEN" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
         
         echo "Release Version: $release_version"
         echo "CLI Version: $cli_version"
@@ -137,6 +143,8 @@ jobs:
       
     - name: check Spice cli and runtime version (Windows)
       if: matrix.target_os == 'windows'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         $version = spice version 2>&1
         Write-Host "Raw version string: $version"
@@ -149,7 +157,10 @@ jobs:
         $runtimeVersion = ($runtimeVersion -split "\s+")[-1].Trim()
         Write-Host "Runtime Version: $runtimeVersion"
 
-        $response = Invoke-WebRequest -Uri "https://api.github.com/repos/spiceai/spiceai/releases/latest" -UseBasicParsing
+        $headers = @{}
+        $headers["Authorization"] = "token $env:GITHUB_TOKEN"
+
+        $response = Invoke-WebRequest -Uri "https://api.github.com/repos/spiceai/spiceai/releases/latest" -UseBasicParsing -Headers $headers
         $releaseVersion = ($response.Content | ConvertFrom-Json).tag_name
         Write-Host "Release Version: $releaseVersion"
 

--- a/install/Install.ps1
+++ b/install/Install.ps1
@@ -12,7 +12,13 @@ New-Item -Path $spiceCliInstallDir -ItemType Directory -Force > $null
 
 function Get-LatestRelease {
     $url = "https://api.github.com/repos/$spiceOrgName/$spiceRepoName/releases/latest"
-    $releaseInfo = Invoke-RestMethod -Uri $url
+
+    $headers = @{}
+    if ($env:GITHUB_TOKEN) {
+        $headers["Authorization"] = "token $env:GITHUB_TOKEN"
+    }
+
+    $releaseInfo = Invoke-RestMethod -Uri $url -Headers $headers
     return $releaseInfo.tag_name
 }
 
@@ -45,8 +51,13 @@ function Download-And-Install-Spice {
     $tempPath = [System.IO.Path]::GetTempPath()
     $tempFile = Join-Path $tempPath $artifactName
 
+    $headers = @{}
+    if ($env:GITHUB_TOKEN) {
+        $headers["Authorization"] = "token $env:GITHUB_TOKEN"
+    }
+
     Write-Host "Downloading Spice CLI from $downloadUrl..."
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile -Headers $headers
     tar -xf $tempFile -C $tempPath
 
     Move-Item -Path (Join-Path $tempPath $spiceCliFilename) -Destination $spiceCliFullPath -Force

--- a/install/install.sh
+++ b/install/install.sh
@@ -104,12 +104,12 @@ function gh_curl() {
 }
 
 function gh_wget() {
-    if [ -n "$GITHUB_TOKEN" ]
+    if [ -z "$GITHUB_TOKEN" ]
     then
-        wget --header="Authorization: token $GITHUB_TOKEN" \
+        wget \
             $@
     else
-        wget \
+        wget --header="Authorization: token $GITHUB_TOKEN" \
             $@
     fi
 }


### PR DESCRIPTION
Updated calls to github api from installation scripts, to use GITHUB_TOKEN env variable when it is set.

test run - https://github.com/spiceai/spiceai/actions/runs/8958831027