### PR TITLE
Fix the panic on bad clickhouse connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,7 +1769,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 [[package]]
 name = "clickhouse-rs"
 version = "1.1.0-alpha.1"
-source = "git+https://github.com/spiceai/clickhouse-rs.git?branch=async-await#36a87884321fbf296876ab0b63d611f19f5f0e02"
+source = "git+https://github.com/spiceai/clickhouse-rs.git?branch=async-await-plus-hello-unwrap#6c63dff9c77b528b5fc499efafb4d00ce61d2032"
 dependencies = [
  "byteorder",
  "cfg-if",
@@ -1799,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-rs-cityhash-sys"
 version = "0.1.2"
-source = "git+https://github.com/spiceai/clickhouse-rs.git?branch=async-await#36a87884321fbf296876ab0b63d611f19f5f0e02"
+source = "git+https://github.com/spiceai/clickhouse-rs.git?branch=async-await-plus-hello-unwrap#6c63dff9c77b528b5fc499efafb4d00ce61d2032"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ rusqlite = { version = "0.31.0", features = ["bundled"] }
 tokio-rusqlite = "0.5.1"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4", "with-uuid-1"] }
-clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", branch = "async-await", features = [
+clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", branch = "async-await-plus-hello-unwrap", features = [
     "tokio_io",
     "tls",
 ] }


### PR DESCRIPTION
Closes #1227 

Instead of panicking with this message:

```
thread 'main' panicked at /Users/aurashb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clickhouse-rs-1.1.0-alpha.1/src/types/query_result/mod.rs:93:44:
called Option::unwrap() on a None value
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
exit status 101
```

This error is now shown:

```
2024-05-06T09:37:27.140455Z  WARN runtime: Failed to initialize data connector for dataset traces: Unable to attach data connector clickhouse: Unable to resolve table provider: Unable to construct SQL table: Unable to get a DB connection from the pool: ConnectionPoolRunError: Connections error: `No packet received`
```

This is still not a great error - but its better than panicking, and a full rework of the error messages from Clickhouse are coming in #1228