### PR TITLE
Changing the verbage of the dataset registration to say registered dataset instead of loaded

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -323,7 +323,7 @@ impl Runtime {
         .await
         {
             Ok(()) => {
-                tracing::info!("Loaded dataset {}", &ds.name);
+                tracing::info!("Registered dataset {}", &ds.name);
                 let engine = ds.acceleration.map_or_else(
                     || "None".to_string(),
                     |acc| {


### PR DESCRIPTION
Context:
https://github.com/spiceai/spiceai/issues/1249

We have a "loaded" message when we register a dataset, and then print out a message that we are loading a dataset.  Really we just registered it.  Let's make the language clear so the users knows if the data is actually ready.