### PR TITLE
Expose nodeselector and affinity keys in Helm chart

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: spiceai
 description: Spice.ai OSS
-version: 0.1.7
+version: 0.1.8

--- a/deploy/chart/templates/spiceai.yaml
+++ b/deploy/chart/templates/spiceai.yaml
@@ -23,6 +23,14 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{ toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: spiceai
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION
I want to deploy Spice on its own K8S nodegroup. To do so, I need to be able to set the node selector key to match my [Karpenter](https://karpenter.sh/) provisioner.

Example value:

```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
      - matchExpressions:
          - key: karpenter.sh/provisioner-name
            operator: In
            values:
              - spice
```

`helm template`:

```yaml
# Source: spiceai/templates/spiceai.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name
  labels:
    app: release-name
spec:
  replicas: 1
  selector:
    matchLabels:
      app: release-name
  template:
    metadata:
      labels:
        app: release-name
      annotations:
        checksum/spicepod: d78b43d9c95e511b38cc1449cb06d3c7e2139705f05014f45c01c0d65ba2e327
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: karpenter.sh/provisioner-name
                operator: In
                values:
                - spice
      containers:
        - name: spiceai
          image: spiceai/spiceai:0.12.1-alpha
          imagePullPolicy: Always
```