### PR TITLE
Refactor dbconnection errors, and catch invalid postgres table name case

### DIFF
--- a/crates/db_connection_pool/src/dbconnection.rs
+++ b/crates/db_connection_pool/src/dbconnection.rs
@@ -49,6 +49,12 @@ pub enum Error {
 
     #[snafu(display("Unable to query arrow: {source}"))]
     UnableToQueryArrow { source: GenericError },
+
+    #[snafu(display("Table {table_name} not found. Ensure the table name is correctly spelled."))]
+    UndefinedTable {
+        table_name: String,
+        source: GenericError,
+    },
 }
 
 pub trait SyncDbConnection<T, P>: DbConnection<T, P> {
@@ -65,7 +71,7 @@ pub trait SyncDbConnection<T, P>: DbConnection<T, P> {
     /// # Errors
     ///
     /// Returns an error if the schema cannot be retrieved.
-    fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef>;
+    fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef, Error>;
 
     /// Query the database with the given SQL statement and parameters, returning a `Result` of `SendableRecordBatchStream`.
     ///
@@ -97,7 +103,7 @@ pub trait AsyncDbConnection<T, P>: DbConnection<T, P> + Sync {
     fn new(conn: T) -> Self
     where
         Self: Sized;
-    async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef>;
+    async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef, Error>;
     async fn query_arrow(&self, sql: &str, params: &[P]) -> Result<SendableRecordBatchStream>;
     async fn execute(&self, sql: &str, params: &[P]) -> Result<u64>;
 }
@@ -129,12 +135,9 @@ pub async fn get_schema<T, P>(
     table_reference: &datafusion::sql::TableReference<'_>,
 ) -> Result<Arc<arrow::datatypes::Schema>, Error> {
     let schema = if let Some(conn) = conn.as_sync() {
-        conn.get_schema(table_reference)
-            .context(UnableToGetSchemaSnafu)?
+        conn.get_schema(table_reference)?
     } else if let Some(conn) = conn.as_async() {
-        conn.get_schema(table_reference)
-            .await
-            .context(UnableToGetSchemaSnafu)?
+        conn.get_schema(table_reference).await?
     } else {
         return Err(Error::UnableToDowncastConnection {});
     };

--- a/crates/db_connection_pool/src/dbconnection/postgresconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/postgresconn.rs
@@ -43,12 +43,6 @@ pub enum PostgresError {
         source: arrow_sql_gen::postgres::Error,
     },
 
-    #[snafu(display("Table {table_name} not found. Ensure the table name is correctly spelled."))]
-    UndefinedTableError {
-        source: Box<tokio_postgres::error::DbError>,
-        table_name: String,
-    },
-
     #[snafu(display("{source}"))]
     InternalError {
         source: tokio_postgres::error::Error,

--- a/crates/db_connection_pool/src/dbconnection/postgresconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/postgresconn.rs
@@ -98,7 +98,10 @@ impl<'a>
         PostgresConnection { conn }
     }
 
-    async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef> {
+    async fn get_schema(
+        &self,
+        table_reference: &TableReference,
+    ) -> Result<SchemaRef, super::Error> {
         match self
             .conn
             .query(
@@ -111,26 +114,29 @@ impl<'a>
             .await
         {
             Ok(rows) => {
-                let rec = rows_to_arrow(rows.as_slice()).context(ConversionSnafu)?;
+                let rec = rows_to_arrow(rows.as_slice())
+                    .boxed()
+                    .context(super::UnableToGetSchemaSnafu)?;
+
                 Ok(rec.schema())
             }
             Err(err) => {
-                let Some(error_source) = err.source() else {
-                    return Err(Box::new(PostgresError::InternalError { source: err }));
-                };
-
-                if let Some(pg_error) =
-                    error_source.downcast_ref::<tokio_postgres::error::DbError>()
-                {
-                    if pg_error.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE {
-                        return Err(Box::new(PostgresError::UndefinedTableError {
-                            source: Box::new(pg_error.clone()),
-                            table_name: table_reference.to_string(),
-                        }));
+                if let Some(error_source) = err.source() {
+                    if let Some(pg_error) =
+                        error_source.downcast_ref::<tokio_postgres::error::DbError>()
+                    {
+                        if pg_error.code() == &tokio_postgres::error::SqlState::UNDEFINED_TABLE {
+                            return Err(super::Error::UndefinedTable {
+                                source: Box::new(pg_error.clone()),
+                                table_name: table_reference.to_string(),
+                            });
+                        }
                     }
                 }
 
-                return Err(Box::new(PostgresError::InternalError { source: err }));
+                return Err(super::Error::UnableToGetSchema {
+                    source: Box::new(err),
+                });
             }
         }
     }

--- a/crates/db_connection_pool/src/dbconnection/sqliteconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/sqliteconn.rs
@@ -68,7 +68,10 @@ impl AsyncDbConnection<Connection, &'static (dyn ToSql + Sync)> for SqliteConnec
         SqliteConnection { conn }
     }
 
-    async fn get_schema(&self, table_reference: &TableReference) -> Result<SchemaRef> {
+    async fn get_schema(
+        &self,
+        table_reference: &TableReference,
+    ) -> Result<SchemaRef, super::Error> {
         let table_reference = table_reference.to_quoted_string();
         let schema = self
             .conn
@@ -83,7 +86,9 @@ impl AsyncDbConnection<Connection, &'static (dyn ToSql + Sync)> for SqliteConnec
                 Ok(schema)
             })
             .await
-            .context(ConnectionSnafu)?;
+            .boxed()
+            .context(super::UnableToGetSchemaSnafu)?;
+
         Ok(schema)
     }
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -127,6 +127,14 @@ pub enum DataConnectorError {
         message: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[snafu(display(
+        "Failed to get data connector from source for dataset {dataconnector}. Table {table_name} not found. Ensure the table name is correctly spelled in the spicepod."
+    ))]
+    InvalidTableName {
+        dataconnector: String,
+        table_name: String,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -129,10 +129,11 @@ pub enum DataConnectorError {
     },
 
     #[snafu(display(
-        "Failed to get data connector from source for dataset {dataconnector}. Table {table_name} not found. Ensure the table name is correctly spelled in the spicepod."
+        "Failed to get {dataconnector} data connector for dataset {dataset_name}. Table {table_name} not found. Ensure the table name is correctly spelled in the spicepod."
     ))]
     InvalidTableName {
         dataconnector: String,
+        dataset_name: String,
         table_name: String,
     },
 }

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -101,6 +101,7 @@ impl DataConnector for Postgres {
                     {
                         return Err(DataConnectorError::InvalidTableName {
                             dataconnector: "postgres".to_string(),
+                            dataset_name: dataset.name.to_string(),
                             table_name: table_name.clone(),
                         });
                     }


### PR DESCRIPTION
closes #1328 

- refactored return types for DbConnection::get_schema to use common error
- added separate connection check for loaded data connector, to catch invalid postgres table name before registering in datafusion

![CleanShot 2024-05-10 at 11 38 13@2x](https://github.com/spiceai/spiceai/assets/827338/e8534ea8-b177-4b7b-a2e6-607f59f37e70)

