### PR TITLE
Add API to set Refresh SQL for accelerated table

### DIFF
--- a/bin/spice/cmd/refresh.go
+++ b/bin/spice/cmd/refresh.go
@@ -44,7 +44,7 @@ spice refresh taxi_trips
 
 		rtcontext := context.NewContext()
 
-		url := fmt.Sprintf("/v1/datasets/%s/refresh", dataset)
+		url := fmt.Sprintf("/v1/datasets/%s/acceleration/refresh", dataset)
 		res, err := api.PostRuntime[DatasetRefreshApiResponse](rtcontext, url)
 		if err != nil {
 			cmd.PrintErrln(err.Error())

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -230,7 +230,7 @@ impl AcceleratedTable {
     pub async fn update_refresh_sql(&self, refresh_sql: Option<String>) -> Result<()> {
         let dataset_name = &self.dataset_name;
 
-        if let Some(sql_str) = refresh_sql {
+        if let Some(sql_str) = &refresh_sql {
             tracing::info!("[refresh] Updating refresh SQL for {dataset_name} to {sql_str}");
         } else {
             tracing::info!("[refresh] Removing refresh SQL for {dataset_name}");

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -230,7 +230,7 @@ impl AcceleratedTable {
     pub async fn update_refresh_sql(&self, refresh_sql: Option<String>) -> Result<()> {
         let dataset_name = &self.dataset_name;
 
-        if refresh_sql.is_some() {
+        if let Some(sql_str) = refresh_sql {
             tracing::info!("[refresh] Updating refresh SQL for {dataset_name} to {sql_str}");
         } else {
             tracing::info!("[refresh] Removing refresh SQL for {dataset_name}");

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -26,7 +26,7 @@ use tokio::task::JoinHandle;
 use tokio::time::interval;
 
 use tokio::sync::mpsc::Receiver;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::datafusion::filter_converter::TimestampFilterConvert;
@@ -78,6 +78,7 @@ pub struct AcceleratedTable {
     refresh_trigger: Option<mpsc::Sender<()>>,
     handlers: Vec<JoinHandle<()>>,
     zero_results_action: ZeroResultsAction,
+    refresh: Arc<RwLock<Refresh>>,
 }
 
 enum AccelerationRefreshMode {
@@ -157,10 +158,13 @@ impl Builder {
         };
 
         validate_refresh_data_window(&self.refresh, &self.dataset_name, &self.federated.schema());
+
+        let refresh = Arc::new(RwLock::new(self.refresh));
+
         let refresh_handle = tokio::spawn(AcceleratedTable::start_refresh(
             self.dataset_name.clone(),
             Arc::clone(&self.federated),
-            self.refresh,
+            Arc::clone(&refresh),
             acceleration_refresh_mode,
             Arc::clone(&self.accelerator),
             ready_sender,
@@ -190,6 +194,7 @@ impl Builder {
                 refresh_trigger,
                 handlers,
                 zero_results_action: self.zero_results_action,
+                refresh,
             },
             is_ready,
         )
@@ -219,6 +224,19 @@ impl AcceleratedTable {
             }
         }
 
+        Ok(())
+    }
+
+    pub async fn update_refresh_sql(&self, refresh_sql: Option<String>) -> Result<()> {
+        let dataset_name = &self.dataset_name;
+
+        if refresh_sql.is_some() {
+            tracing::info!("[refresh] Updating refresh SQL for {dataset_name}");
+        } else {
+            tracing::info!("[refresh] Removing refresh SQL for {dataset_name}");
+        }
+        let mut refresh = self.refresh.write().await;
+        refresh.sql = refresh_sql;
         Ok(())
     }
 
@@ -330,7 +348,7 @@ impl AcceleratedTable {
     async fn start_refresh(
         dataset_name: String,
         federated: Arc<dyn TableProvider>,
-        refresh: Refresh,
+        refresh: Arc<RwLock<Refresh>>,
         acceleration_refresh_mode: AccelerationRefreshMode,
         accelerator: Arc<dyn TableProvider>,
         ready_sender: oneshot::Sender<()>,
@@ -386,7 +404,7 @@ impl AcceleratedTable {
     fn stream_updates<'a>(
         dataset_name: String,
         federated: Arc<dyn TableProvider>,
-        refresh: Refresh,
+        refresh: Arc<RwLock<Refresh>>,
         acceleration_refresh_mode: AccelerationRefreshMode,
     ) -> BoxStream<'a, Result<DataUpdate>> {
         let mut ctx = SessionContext::new_with_config_rt(
@@ -434,18 +452,29 @@ impl AcceleratedTable {
                     }
                 }
                 AccelerationRefreshMode::Full(receiver) => {
+
+                    let refresh_lock = refresh.read().await;
+                    let refresh_settings = refresh_lock.clone();
+                    drop(refresh_lock);
+
                     let schema = federated.schema();
-                    let column = refresh.time_column.as_deref().unwrap_or_default();
+                    let column = refresh_settings.time_column.as_deref().unwrap_or_default();
                     let field = schema.column_with_name(column).map(|(_, f)| f);
-                    let filter_converter = TimestampFilterConvert::create(field, refresh.time_column, refresh.time_format);
+                    let filter_converter = TimestampFilterConvert::create(field, refresh_settings.time_column, refresh_settings.time_format);
 
                     let mut refresh_stream = ReceiverStream::new(receiver);
 
                     while refresh_stream.next().await.is_some() {
                         tracing::info!("[refresh] Loading data for dataset {dataset_name}");
                         status::update_dataset(&dataset_name, status::ComponentStatus::Refreshing);
+
+                        let refresh_lock = refresh.read().await;
+                        let refresh_settings = refresh_lock.clone();
+                        drop(refresh_lock);
+
+
                         let timer = TimeMeasurement::new("load_dataset_duration_ms", vec![("dataset", dataset_name.clone())]);
-                        let filters = match (refresh.period, filter_converter.as_ref()){
+                        let filters = match (refresh_settings.period, filter_converter.as_ref()){
                             (Some(period), Some(converter)) => {
                                 let start = SystemTime::now() - period;
 
@@ -458,7 +487,7 @@ impl AcceleratedTable {
                             _ => vec![],
                         };
 
-                        let data = match get_data(&mut ctx, OwnedTableReference::bare(dataset_name.clone()), Arc::clone(&federated), refresh.sql.clone(), filters).await {
+                        let data = match get_data(&mut ctx, OwnedTableReference::bare(dataset_name.clone()), Arc::clone(&federated), refresh_settings.sql.clone(), filters).await {
                             Ok(data) => data,
                             Err(e) => {
                                 tracing::error!("[refresh] Failed to load data for dataset {dataset_name}: {e}");

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -231,7 +231,7 @@ impl AcceleratedTable {
         let dataset_name = &self.dataset_name;
 
         if refresh_sql.is_some() {
-            tracing::info!("[refresh] Updating refresh SQL for {dataset_name}");
+            tracing::info!("[refresh] Updating refresh SQL for {dataset_name} to {sql_str}");
         } else {
             tracing::info!("[refresh] Removing refresh SQL for {dataset_name}");
         }

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -417,9 +417,31 @@ impl DataFusion {
 
         Ok(())
     }
-    
-    pub async fn update_refresh_sql(&self, _dataset_name: &str, _refresh_sql: &str) -> Result<()> {
-       Ok(())
+
+    pub async fn update_refresh_sql(
+        &self,
+        dataset_name: &str,
+        refresh_sql: Option<String>,
+    ) -> Result<()> {
+        if let Some(sql) = &refresh_sql {
+            refresh_sql::validate_refresh_sql(dataset_name, sql).context(RefreshSqlSnafu)?;
+        }
+
+        let table = self
+            .ctx
+            .table_provider(OwnedTableReference::bare(dataset_name.to_string()))
+            .await
+            .context(UnableToGetTableSnafu)?;
+
+        if let Some(accelerated_table) = table.as_any().downcast_ref::<AcceleratedTable>() {
+            accelerated_table
+                .update_refresh_sql(refresh_sql)
+                .await
+                .context(UnableToTriggerRefreshSnafu {
+                    table_name: dataset_name.to_string(),
+                })?;
+        }
+        Ok(())
     }
 
     /// Federated tables are attached directly as tables visible in the public `DataFusion` context.

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -417,6 +417,10 @@ impl DataFusion {
 
         Ok(())
     }
+    
+    pub async fn update_refresh_sql(&self, _dataset_name: &str, _refresh_sql: &str) -> Result<()> {
+       Ok(())
+    }
 
     /// Federated tables are attached directly as tables visible in the public `DataFusion` context.
     async fn register_federated_table(

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -46,7 +46,10 @@ pub(crate) fn routes(
         .route("/v1/sql", post(v1::query::post))
         .route("/v1/status", get(v1::status::get))
         .route("/v1/datasets", get(v1::datasets::get))
-        .route("/v1/datasets/:name/refresh", post(v1::datasets::refresh))
+        .route(
+            "/v1/datasets/:name/acceleration/refresh",
+            post(v1::datasets::refresh),
+        )
         .route(
             "/v1/datasets/:name/acceleration",
             patch(v1::datasets::acceleration),

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -47,7 +47,10 @@ pub(crate) fn routes(
         .route("/v1/status", get(v1::status::get))
         .route("/v1/datasets", get(v1::datasets::get))
         .route("/v1/datasets/:name/refresh", post(v1::datasets::refresh))
-        .route("/v1/datasets/:name/acceleration", patch(v1::datasets::acceleration))
+        .route(
+            "/v1/datasets/:name/acceleration",
+            patch(v1::datasets::acceleration),
+        )
         .route("/v1/spicepods", get(v1::spicepods::get))
         .route_layer(middleware::from_fn(track_metrics))
         .layer(Extension(app))

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use crate::{config, datafusion::DataFusion};
 use app::App;
+use axum::routing::patch;
 use model_components::model::Model;
 use std::net::SocketAddr;
 use std::{collections::HashMap, sync::Arc};
@@ -46,7 +47,7 @@ pub(crate) fn routes(
         .route("/v1/status", get(v1::status::get))
         .route("/v1/datasets", get(v1::datasets::get))
         .route("/v1/datasets/:name/refresh", post(v1::datasets::refresh))
-        .route("/v1/datasets/:name/acceleration", post(v1::datasets::acceleration))
+        .route("/v1/datasets/:name/acceleration", patch(v1::datasets::acceleration))
         .route("/v1/spicepods", get(v1::spicepods::get))
         .route_layer(middleware::from_fn(track_metrics))
         .layer(Extension(app))

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -46,6 +46,7 @@ pub(crate) fn routes(
         .route("/v1/status", get(v1::status::get))
         .route("/v1/datasets", get(v1::datasets::get))
         .route("/v1/datasets/:name/refresh", post(v1::datasets::refresh))
+        .route("/v1/datasets/:name/acceleration", post(v1::datasets::acceleration))
         .route("/v1/spicepods", get(v1::spicepods::get))
         .route_layer(middleware::from_fn(track_metrics))
         .layer(Extension(app))

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -492,14 +492,14 @@ pub(crate) mod datasets {
                 .into_response();
         };
 
-        let Some(refresh_sql) = payload.refresh_sql else {
+        if payload.refresh_sql.is_none() {
             return (status::StatusCode::OK).into_response();
-        };
+        }
 
         let df_read = df.read().await;
 
         match df_read
-            .update_refresh_sql(&dataset.name, Some(refresh_sql))
+            .update_refresh_sql(&dataset.name, payload.refresh_sql)
             .await
         {
             Ok(()) => (status::StatusCode::OK).into_response(),


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1354

Add `PATCH` `/datasets/table-name/acceleration` API to update `refresh_sql` value for a table.
- This modification is non-persistent and will revert to the original value at the next runtime restart. A separate PR will be submitted to make this change persistent.
-  As the change is not persistent yet the modification will have no effect if the table does not have acceleration enabled.

Example request
```
curl -i -X PATCH \
     -H "Content-Type: application/json" \
     -d '{
           "refresh_sql": "select * from taxi_trips limit 100;"
         }' \
     127.0.0.1:3000/v1/datasets/taxi_trips/acceleration
```

Breaking change: refresh api endpoint is now `/v1/datasets/:name/acceleration/refresh`