### PR TITLE
Provide ability to specify timeout for s3 data connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6315,6 +6315,7 @@ dependencies = [
  "dirs",
  "duckdb",
  "flight_client",
+ "fundu",
  "futures",
  "indexmap 2.2.6",
  "itertools 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", branch =
 ] }
 uuid = "1.6.1"
 pem = "3.0.4"
+fundu = "2.0.0"
 odbc-api = { version = "7.0.0" }
 arrow-odbc = { version = "9.0.0" }
 snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", folder = "snowflake-api", rev = "5dab964abef23314e7a3f27ae89b83352e315206" }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -43,7 +43,7 @@ duckdb = { workspace = true, features = [
     "vtab-arrow",
 ], optional = true }
 sql_provider_datafusion = { path = "../sql_provider_datafusion", optional = true }
-model_components = { path = "../model_components"}
+model_components = { path = "../model_components" }
 r2d2 = { workspace = true, optional = true }
 opentelemetry-proto = { version = "0.4.0", features = [
     "gen-tonic-messages",
@@ -85,6 +85,7 @@ dashmap = "5.5.3"
 snowflake-api = { workspace = true, optional = true }
 suppaftp = { workspace = true, optional = true }
 datafusion-federation = { workspace = true, optional = true }
+fundu = { workspace = true }
 
 [features]
 default = ["keyring-secret-store", "aws-secrets-manager"]

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -95,6 +95,9 @@ impl ListingTableConnector for S3 {
                 fragment_builder.append_pair("secret", secret);
             };
         }
+        if let Some(timeout) = self.params.get("timeout") {
+            fragment_builder.append_pair("timeout", timeout);
+        }
         fragments.push(fragment_builder.finish());
 
         let mut s3_url =

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
 snafu.workspace = true
 tracing.workspace = true
-fundu = "2.0.0"
+fundu.workspace = true
 
 [features]
 duckdb = []


### PR DESCRIPTION
- Had issues with timing out when fetching large files. This provides ability to specify timeout for s3 connection. 

Example:
```yaml
from: s3://spiceai-demo-datasets/taxi_trips_csv/2024/
name: taxi_trips
params:
  file_format: csv
  timeout: 300s
description: eth recent blocks
acceleration:
  enabled: true
  refresh_mode: full
  refresh_check_interval: 300s
````