### PR TITLE
Remove redundant [refresh] in log

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -345,7 +345,7 @@ impl Refresher {
         let refresh = self.refresh.read().await;
         let filter_converter = self.get_filter_converter(&refresh);
 
-        tracing::info!("[refresh] Loading data for dataset {dataset_name}");
+        tracing::info!("Loading data for dataset {dataset_name}");
         status::update_dataset(dataset_name.as_str(), status::ComponentStatus::Refreshing);
         let refresh = refresh.clone();
         let mut filters = vec![];


### PR DESCRIPTION
Component is already displayed: `2024-05-14T20:09:32.021863Z  INFO runtime::accelerated_table::refresh: [refresh] Loading data for dataset taxi_trips`