### PR TITLE
Add FlightSQL federation provider

### DIFF
--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -49,6 +49,9 @@ use tonic::transport::{channel, Channel};
 
 use crate::Read;
 
+#[cfg(feature = "federation-experimental")]
+pub mod federation;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Unable to connect to FlightSQL Server"))]
@@ -78,12 +81,13 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Clone)]
 pub struct FlightSQLFactory {
     client: FlightSqlServiceClient<Channel>,
+    endpoint: String,
 }
 
 impl FlightSQLFactory {
     #[must_use]
-    pub fn new(client: FlightSqlServiceClient<Channel>) -> Self {
-        Self { client }
+    pub fn new(client: FlightSqlServiceClient<Channel>, endpoint: String) -> Self {
+        Self { client, endpoint }
     }
 }
 
@@ -93,14 +97,30 @@ impl Read for FlightSQLFactory {
         &self,
         table_reference: TableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
-        FlightSQLTable::create(self.client.clone(), table_reference)
-            .await
-            .map(|f| Arc::new(f) as Arc<dyn TableProvider + 'static>)
-            .boxed()
+        let table_provider = Arc::new(
+            FlightSQLTable::create(
+                "flightsql",
+                &self.endpoint,
+                self.client.clone(),
+                table_reference,
+            )
+            .await?,
+        );
+
+        #[cfg(feature = "federation-experimental")]
+        let table_provider = Arc::new(
+            table_provider
+                .create_federated_table_provider()
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?,
+        );
+
+        Ok(table_provider)
     }
 }
 
 pub struct FlightSQLTable {
+    name: &'static str,
+    join_push_down_context: String,
     client: FlightSqlServiceClient<Channel>,
     table_reference: TableReference,
     schema: SchemaRef,
@@ -109,15 +129,19 @@ pub struct FlightSQLTable {
 #[allow(clippy::needless_pass_by_value)]
 impl FlightSQLTable {
     pub async fn create(
+        name: &'static str,
+        endpoint: &str,
         client: FlightSqlServiceClient<Channel>,
         table_reference: impl Into<TableReference>,
     ) -> Result<Self> {
         let table_reference: TableReference = table_reference.into();
         let schema = Self::get_schema(client.clone(), table_reference.clone()).await?;
         Ok(Self {
+            name,
             client,
             table_reference,
             schema,
+            join_push_down_context: format!("endpoint={endpoint}"),
         })
     }
 
@@ -129,7 +153,13 @@ impl FlightSQLTable {
             .connect()
             .await
             .context(UnableToConnectToServerSnafu)?;
-        Self::create(FlightSqlServiceClient::new(channel), table_reference.into()).await
+        Self::create(
+            "flightsql",
+            s,
+            FlightSqlServiceClient::new(channel),
+            table_reference.into(),
+        )
+        .await
     }
 
     fn get_str_from_record_batch(b: &RecordBatch, row: usize, col_name: &str) -> Option<String> {

--- a/crates/data_components/src/flightsql/federation.rs
+++ b/crates/data_components/src/flightsql/federation.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+use datafusion_federation::{FederatedTableProviderAdaptor, FederatedTableSource};
+use datafusion_federation_sql::{SQLExecutor, SQLFederationProvider, SQLTableSource};
+use std::sync::Arc;
+
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    error::{DataFusionError, Result as DataFusionResult},
+    physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream},
+    sql::{
+        sqlparser::dialect::{Dialect, GenericDialect},
+        TableReference,
+    },
+};
+
+use super::{query_to_stream, FlightSQLTable};
+
+impl FlightSQLTable {
+    fn create_federated_table_source(
+        self: Arc<Self>,
+    ) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
+        let table_name = self.table_reference.to_string();
+        tracing::trace!(
+            table_name,
+            %self.table_reference,
+            "create_federated_table_source"
+        );
+        let schema = Arc::clone(&self.schema);
+        let fed_provider = Arc::new(SQLFederationProvider::new(self));
+        Ok(Arc::new(SQLTableSource::new_with_schema(
+            fed_provider,
+            table_name,
+            schema,
+        )?))
+    }
+
+    pub fn create_federated_table_provider(
+        self: Arc<Self>,
+    ) -> DataFusionResult<FederatedTableProviderAdaptor> {
+        let table_source = Self::create_federated_table_source(Arc::clone(&self))?;
+        Ok(FederatedTableProviderAdaptor::new_with_provider(
+            table_source,
+            self,
+        ))
+    }
+}
+
+#[async_trait]
+impl SQLExecutor for FlightSQLTable {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn compute_context(&self) -> Option<String> {
+        Some(self.join_push_down_context.clone())
+    }
+
+    fn dialect(&self) -> Arc<dyn Dialect> {
+        Arc::new(GenericDialect {})
+    }
+
+    fn execute(
+        &self,
+        query: &str,
+        schema: SchemaRef,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            query_to_stream(self.client.clone(), query),
+        )))
+    }
+
+    async fn table_names(&self) -> DataFusionResult<Vec<String>> {
+        Err(DataFusionError::NotImplemented(
+            "table inference not implemented".to_string(),
+        ))
+    }
+
+    async fn get_table_schema(&self, table_name: &str) -> DataFusionResult<SchemaRef> {
+        FlightSQLTable::get_schema(self.client.clone(), TableReference::bare(table_name))
+            .await
+            .map_err(|e| DataFusionError::Execution(e.to_string()))
+    }
+}

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -69,7 +69,7 @@ impl DataConnectorFactory for FlightSQL {
                     )
                     .await;
             };
-            let flightsql_factory = FlightSQLFactory::new(client);
+            let flightsql_factory = FlightSQLFactory::new(client, endpoint);
             Ok(Arc::new(Self { flightsql_factory }) as Arc<dyn DataConnector>)
         })
     }


### PR DESCRIPTION
Closes #1348

With this implemented, all data connectors (except Spark/Databricks) support improved federated push-down. The remaining work will be a bunch of testing to ensure its stable, benchmarking to see the improvement and implementing the Spark Connect federation provider.