### PR TITLE
add a TLS error message in data connector and implement it for clickhouse

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -127,6 +127,9 @@ pub enum DataConnectorError {
     #[snafu(display("Cannot connect to {dataconnector}. Authentication failed. Ensure that the username and password are correctly configured in the spicepod."))]
     UnableToConnectInvalidUsernameOrPassword { dataconnector: String },
 
+    #[snafu(display("Cannot connect to {dataconnector}. Ensure that the corresponding secure option is configured to match the data connector's TLS security requirements."))]
+    UnableToConnectTlsError { dataconnector: String },
+
     #[snafu(display("Unable to get read provider for {dataconnector}: {source}"))]
     UnableToGetReadProvider {
         dataconnector: String,

--- a/crates/runtime/src/dataconnector/clickhouse.rs
+++ b/crates/runtime/src/dataconnector/clickhouse.rs
@@ -70,6 +70,12 @@ impl DataConnectorFactory for Clickhouse {
                         port,
                     }
                     .into()),
+                    clickhousepool::Error::ConnectionTlsError { source: _ } => {
+                        Err(DataConnectorError::UnableToConnectTlsError {
+                            dataconnector: "clickhouse".to_string(),
+                        }
+                        .into())
+                    }
                     _ => Err(DataConnectorError::UnableToConnectInternal {
                         dataconnector: "clickhouse".to_string(),
                         source: Box::new(e),


### PR DESCRIPTION
Add a new common dataconnector error message about TLS Error. This error will give user more specific information what is being wrong on TLS.

Currently it's implemented in clickhouse connector.
