### PR TITLE
Make it easier to construct an App programatically

### DIFF
--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -1,4 +1,5 @@
 // Copy the below to `settings.json` and tweak the `features` array to enable optional features in VSCode.
 {
-  "rust-analyzer.cargo.features": ["federation-experimental"]
+  "rust-analyzer.cargo.features": ["federation-experimental"],
+  "rust-analyzer.check.extraArgs": ["--", "-Dclippy::pedantic", "-Dclippy::unwrap_used", "-Dclippy::clone_on_ref_ptr"],
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -67,6 +67,7 @@ impl AppBuilder {
         }
     }
 
+    #[must_use]
     pub fn with_spicepod(mut self, spicepod: Spicepod) -> AppBuilder {
         self.secrets = spicepod.secrets.clone();
         self.datasets.extend(spicepod.datasets.clone());
@@ -75,21 +76,25 @@ impl AppBuilder {
         self
     }
 
+    #[must_use]
     pub fn with_secret(mut self, secret: Secrets) -> AppBuilder {
         self.secrets = secret;
         self
     }
 
+    #[must_use]
     pub fn with_dataset(mut self, dataset: Dataset) -> AppBuilder {
         self.datasets.push(dataset);
         self
     }
 
+    #[must_use]
     pub fn with_model(mut self, model: Model) -> AppBuilder {
         self.models.push(model);
         self
     }
 
+    #[must_use]
     pub fn build(self) -> App {
         App {
             name: self.name,

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -48,9 +48,59 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-impl App {
-    // This will load an app's spicepod.yaml file and all of its components and dependencies.
-    pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
+pub struct AppBuilder {
+    name: String,
+    secrets: Secrets,
+    datasets: Vec<Dataset>,
+    models: Vec<Model>,
+    spicepods: Vec<Spicepod>,
+}
+
+impl AppBuilder {
+    pub fn new(name: impl Into<String>) -> AppBuilder {
+        AppBuilder {
+            name: name.into(),
+            secrets: Secrets::default(),
+            datasets: vec![],
+            models: vec![],
+            spicepods: vec![],
+        }
+    }
+
+    pub fn with_spicepod(mut self, spicepod: Spicepod) -> AppBuilder {
+        self.secrets = spicepod.secrets.clone();
+        self.datasets.extend(spicepod.datasets.clone());
+        self.models.extend(spicepod.models.clone());
+        self.spicepods.push(spicepod);
+        self
+    }
+
+    pub fn with_secret(mut self, secret: Secrets) -> AppBuilder {
+        self.secrets = secret;
+        self
+    }
+
+    pub fn with_dataset(mut self, dataset: Dataset) -> AppBuilder {
+        self.datasets.push(dataset);
+        self
+    }
+
+    pub fn with_model(mut self, model: Model) -> AppBuilder {
+        self.models.push(model);
+        self
+    }
+
+    pub fn build(self) -> App {
+        App {
+            name: self.name,
+            secrets: self.secrets,
+            datasets: self.datasets,
+            models: self.models,
+            spicepods: self.spicepods,
+        }
+    }
+
+    pub fn build_from_filesystem_path(path: impl Into<PathBuf>) -> Result<App> {
         let path = path.into();
         let spicepod_root =
             Spicepod::load(&path).context(UnableToLoadSpicepodSnafu { path: path.clone() })?;

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -22,7 +22,7 @@ use spicepod::component::ComponentOrReference;
 use std::path::PathBuf;
 use tokio::sync::mpsc::{channel, Receiver};
 
-use app::App;
+use app::{App, AppBuilder};
 
 pub struct PodsWatcher {
     root_path: PathBuf,
@@ -66,7 +66,7 @@ impl PodsWatcher {
                             }
                         }
 
-                        match App::new(root_path.clone()) {
+                        match AppBuilder::build_from_filesystem_path(root_path.clone()) {
                             Ok(app) => {
                                 if let Err(e) = tx.blocking_send(app) {
                                     tracing::error!("Pods content watcher is unable to notify detected state change: {}", e);


### PR DESCRIPTION
This PR introduces a new `AppBuilder` struct that makes it easier to construct an `App` programatically (and from tests)

`AppBuilder` provides methods for adding spicepods, secrets, datasets, and models to the `App`.