### PR TITLE
Add an integration test for federation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ nextest:
 	@cargo nextest run --all
 
 .PHONY: test-integration
-nextest:
+test-integration:
 	@cargo test -p runtime --test integration --features federation-experimental -- --nocapture
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ci:
 
 .PHONY: test
 test:
-	@cargo test --all
+	@cargo test --all --lib
 
 .PHONY: nextest
 nextest:

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,13 @@ ci:
 test:
 	@cargo test --all
 
-.PHONY: test
+.PHONY: nextest
 nextest:
 	@cargo nextest run --all
+
+.PHONY: test-integration
+nextest:
+	@cargo test -p runtime --test integration --features federation-experimental -- --nocapture
 
 .PHONY: lint
 lint:

--- a/crates/runtime/tests/federation/mod.rs
+++ b/crates/runtime/tests/federation/mod.rs
@@ -1,0 +1,11 @@
+use spicepod::component::dataset::Dataset;
+
+fn make_spiceai_dataset(path: &str, name: &str) -> Dataset {
+    Dataset::new(format!("spiceai:{}", path), name.to_string())
+}
+
+#[test]
+fn basic_federation_push_down() -> Result<(), String> {
+    let eth_blocks_ds = make_spiceai_dataset("eth.recent_blocks", "blocks");
+    let eth_tx_ds = make_spiceai_dataset("eth.recent_transactions", "tx");
+}

--- a/crates/runtime/tests/federation/mod.rs
+++ b/crates/runtime/tests/federation/mod.rs
@@ -1,14 +1,61 @@
-use app::App;
-use spicepod::component::dataset::Dataset;
+use std::sync::Arc;
+
+use app::AppBuilder;
+use datafusion::assert_batches_eq;
+use runtime::{datafusion::DataFusion, Runtime};
+use spicepod::component::{
+    dataset::Dataset,
+    secrets::{Secrets, SpiceSecretStore},
+};
+use tokio::sync::RwLock;
 
 fn make_spiceai_dataset(path: &str, name: &str) -> Dataset {
-    Dataset::new(format!("spiceai:{}", path), name.to_string())
+    Dataset::new(format!("spiceai:{path}"), name.to_string())
 }
 
-#[test]
-fn basic_federation_push_down() -> Result<(), String> {
+#[tokio::test]
+async fn basic_federation_push_down() -> Result<(), String> {
     let eth_blocks_ds = make_spiceai_dataset("eth.recent_blocks", "blocks");
     let eth_tx_ds = make_spiceai_dataset("eth.recent_transactions", "tx");
 
-    let app = App::new()
+    let app = AppBuilder::new("basic_federation_push_down")
+        .with_secret(Secrets {
+            store: SpiceSecretStore::File,
+        })
+        .with_dataset(eth_blocks_ds)
+        .with_dataset(eth_tx_ds)
+        .build();
+
+    let df = Arc::new(RwLock::new(DataFusion::new()));
+
+    let rt = Runtime::new(Some(app), df).await;
+
+    rt.load_secrets().await;
+    rt.load_datasets().await;
+
+    let df = &mut *rt.df.write().await;
+
+    let results = df
+        .ctx
+        .sql("EXPLAIN SELECT MAX(number) as max_num FROM blocks UNION ALL SELECT MAX(block_number) as max_num FROM tx")
+        .await
+        .expect("EXPLAIN query to plan")
+        .collect()
+        .await
+        .expect("to collect results");
+
+    #[rustfmt::skip]
+    let expected = 
+    [
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "| plan_type     | plan                                                                                                                                                                                                                                                                                                                                                                                                                             |",
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "| logical_plan  | TableScan: blocks projection=[number, hash, parent_hash, nonce, sha3_uncles, logs_bloom, transactions_root, state_root, receipts_root, miner, difficulty, total_difficulty, size, extra_data, gas_limit, gas_used, timestamp, transaction_count, base_fee_per_gas, withdrawals_root, withdrawal_count, parent_beacon_block_root, blob_gas_used, excess_blob_gas]                                                                 |",
+        "| physical_plan | FlightExec sql=SELECT \"number\", \"hash\", \"parent_hash\", \"nonce\", \"sha3_uncles\", \"logs_bloom\", \"transactions_root\", \"state_root\", \"receipts_root\", \"miner\", \"difficulty\", \"total_difficulty\", \"size\", \"extra_data\", \"gas_limit\", \"gas_used\", \"timestamp\", \"transaction_count\", \"base_fee_per_gas\", \"withdrawals_root\", \"withdrawal_count\", \"parent_beacon_block_root\", \"blob_gas_used\", \"excess_blob_gas\" FROM eth.recent_blocks   |",
+        "|               |                                                                                                                                                                                                                                                                                                                                                                                                                                  |",
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
 }

--- a/crates/runtime/tests/federation/mod.rs
+++ b/crates/runtime/tests/federation/mod.rs
@@ -1,3 +1,4 @@
+use app::App;
 use spicepod::component::dataset::Dataset;
 
 fn make_spiceai_dataset(path: &str, name: &str) -> Dataset {
@@ -8,4 +9,6 @@ fn make_spiceai_dataset(path: &str, name: &str) -> Dataset {
 fn basic_federation_push_down() -> Result<(), String> {
     let eth_blocks_ds = make_spiceai_dataset("eth.recent_blocks", "blocks");
     let eth_tx_ds = make_spiceai_dataset("eth.recent_transactions", "tx");
+
+    let app = App::new()
 }

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Run all tests in the `federation` module
+mod federation;


### PR DESCRIPTION
Adds a basic integration test for federation.

Requires that an API key is set via `spice login` before executing.

Run with `make test-integration` from the repo root.