### PR TITLE
Correctly map NullBuilder for Null arrow types

### DIFF
--- a/crates/arrow_sql_gen/src/arrow.rs
+++ b/crates/arrow_sql_gen/src/arrow.rs
@@ -17,9 +17,9 @@ use arrow::{
     array::{
         ArrayBuilder, BinaryBuilder, BooleanBuilder, Date32Builder, Decimal128Builder,
         FixedSizeBinaryBuilder, Float32Builder, Float64Builder, Int16Builder, Int32Builder,
-        Int64Builder, Int8Builder, ListBuilder, StringBuilder, TimestampMicrosecondBuilder,
-        TimestampMillisecondBuilder, TimestampNanosecondBuilder, TimestampSecondBuilder,
-        UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
+        Int64Builder, Int8Builder, ListBuilder, NullBuilder, StringBuilder,
+        TimestampMicrosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder,
+        TimestampSecondBuilder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
     },
     datatypes::{DataType, TimeUnit},
 };
@@ -82,6 +82,7 @@ pub fn map_data_type_to_array_builder(data_type: &DataType) -> Box<dyn ArrayBuil
             DataType::Boolean => Box::new(ListBuilder::new(BooleanBuilder::new())),
             _ => unimplemented!("Unsupported list value data type {:?}", data_type),
         },
+        DataType::Null => Box::new(NullBuilder::new()),
         _ => unimplemented!("Unsupported data type {:?}", data_type),
     }
 }


### PR DESCRIPTION
Maps the `NullBuilder` type when the Arrow data type is NULL