### PR TITLE
Parse postgres table schema from prepare statement, to support empty tables

### DIFF
--- a/crates/arrow_sql_gen/src/postgres.rs
+++ b/crates/arrow_sql_gen/src/postgres.rs
@@ -46,8 +46,7 @@ use bigdecimal::ToPrimitive;
 use snafu::prelude::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio_postgres::types::FromSql;
-use tokio_postgres::Column;
-use tokio_postgres::{types::Type, Row};
+use tokio_postgres::{types::Type, Column, Row};
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/db_connection_pool/src/dbconnection/postgresconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/postgresconn.rs
@@ -106,9 +106,9 @@ impl<'a>
             .await
         {
             Ok(statement) => {
-                return Ok(columns_to_schema(statement.columns())
+                return columns_to_schema(statement.columns())
                     .boxed()
-                    .context(super::UnableToGetSchemaSnafu)?)
+                    .context(super::UnableToGetSchemaSnafu)
             }
             Err(err) => {
                 if let Some(error_source) = err.source() {


### PR DESCRIPTION
closes #1351 

Postgres data connector will parse schema from prepare statement, for proper empty table support.

Before - dataset from empty postgres table is registered, but schema is empty:

![CleanShot 2024-05-21 at 11 03 55@2x](https://github.com/spiceai/spiceai/assets/827338/a6790cb4-a311-40ec-bd69-284d7704972d)

After:

https://github.com/spiceai/spiceai/assets/827338/73fad196-328b-469a-b12c-d84a7a6b2ff1

