### PR TITLE
Remove v0.5.0 for EricLBuehler/candle.git

### DIFF
--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -29,7 +29,7 @@ tokenizers = {version= "0.19.1", optional = true}
 ## `mistralrs` feature packages
 mistralrs = {git = "https://github.com/spiceai/mistral.rs", optional=true}
 mistralrs-core = {git = "https://github.com/spiceai/mistral.rs", optional=true, package="mistralrs-core" }
-candle-core-rs = { package="candle-core", git = "https://github.com/EricLBuehler/candle.git", version = "0.5.0" , optional=true}
+candle-core-rs = { package="candle-core", git = "https://github.com/EricLBuehler/candle.git" , optional=true}
 tokio = { workspace = true, optional=true }
 
 [features]


### PR DESCRIPTION
## Changes
- Issue with `EricLBuehler/candle` (which is a dependency of `EricLBuehler/mistral.rs`) has a broken version.
- Long term, need to either get EricLBuehler/candle back into standard `candle-core` or fork to `spiceai`.