### PR TITLE
Make `file_format` parameter required

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -338,7 +338,7 @@ pub trait ListingTableConnector: DataConnector {
             Some(format) => Err(DataConnectorError::InvalidConfiguration {
                 dataconnector: format!("{self}"),
                 message: format!(
-                    "Invalid file_format: {format}. Supported formats are: csv, parquet."
+                    "Unsupported file format '{format}'. Use csv or parquet."
                 ),
                 source: "Invalid file format".into(),
             }),

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -331,16 +331,21 @@ pub trait ListingTableConnector: DataConnector {
                 self.get_csv_format(params)?,
                 extension.unwrap_or(".csv".to_string()),
             )),
-            None | Some("parquet") => Ok((
+            Some("parquet") => Ok((
                 Arc::new(ParquetFormat::default()),
                 extension.unwrap_or(".parquet".to_string()),
             )),
             Some(format) => Err(DataConnectorError::InvalidConfiguration {
                 dataconnector: format!("{self}"),
                 message: format!(
-                    "Invalid file_format: {format}. Supported formats are: csv, parquet"
+                    "Invalid file_format: {format}. Supported formats are: csv, parquet."
                 ),
                 source: "Invalid file format".into(),
+            }),
+            None => Err(DataConnectorError::InvalidConfiguration {
+                dataconnector: format!("{self}"),
+                message: "Missing required file_format parameter.".to_string(),
+                source: "Missing file format".into(),
             }),
         }
     }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -337,9 +337,7 @@ pub trait ListingTableConnector: DataConnector {
             )),
             Some(format) => Err(DataConnectorError::InvalidConfiguration {
                 dataconnector: format!("{self}"),
-                message: format!(
-                    "Unsupported file format '{format}'. Use csv or parquet."
-                ),
+                message: format!("Unsupported file format '{format}'. Use csv or parquet."),
                 source: "Invalid file format".into(),
             }),
             None => Err(DataConnectorError::InvalidConfiguration {


### PR DESCRIPTION
closes #1454 

Require `file_format` parameter for listing table based connectors