### PR TITLE
Add telemetry for in-memory caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "datafusion",
  "fundu",
  "futures",
+ "metrics",
  "moka",
  "snafu 0.8.2",
  "spicepod",

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -17,6 +17,7 @@ async-stream.workspace = true
 arrow.workspace = true
 datafusion.workspace = true
 futures.workspace = true
+metrics.workspace = true
 byte-unit="5.1.4"
 fundu = { workspace = true }
 moka = {version = "0.12.7", features = ["future"]}

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -107,12 +107,12 @@ impl QueryResultCacheProvider {
     }
 
     #[must_use]
-    pub fn cache_max_size(&self) -> u64 {
+    pub fn max_size(&self) -> u64 {
         self.cache_max_size
     }
 
     #[must_use]
-    pub fn cache_size(&self) -> u64 {
+    pub fn size(&self) -> u64 {
         self.cache.size()
     }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -54,6 +54,8 @@ pub struct CachedQueryResult {
 pub trait QueryResultCache {
     async fn get(&self, plan: &LogicalPlan) -> Result<Option<CachedQueryResult>>;
     async fn put(&self, plan: &LogicalPlan, result: CachedQueryResult) -> Result<()>;
+    fn size(&self) -> u64;
+    fn item_count(&self) -> u64;
 }
 #[derive(Clone)]
 pub struct QueryResultCacheProvider {
@@ -107,6 +109,16 @@ impl QueryResultCacheProvider {
     #[must_use]
     pub fn cache_max_size(&self) -> u64 {
         self.cache_max_size
+    }
+
+    #[must_use]
+    pub fn cache_size(&self) -> u64 {
+        self.cache.size()
+    }
+
+    #[must_use]
+    pub fn item_count(&self) -> u64 {
+        self.cache.item_count()
     }
 }
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -76,7 +76,7 @@ impl QueryResultCache for LruCache {
         Ok(())
     }
 
-    fn size(&self) -> u64 {
+    fn size_bytes(&self) -> u64 {
         self.cache.weighted_size()
     }
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -74,6 +74,14 @@ impl QueryResultCache for LruCache {
         self.cache.insert(key, result).await;
         Ok(())
     }
+
+    fn size(&self) -> u64 {
+        self.cache.weighted_size()
+    }
+
+    fn item_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
 }
 
 pub fn key_for_logical_plan(plan: &LogicalPlan) -> u64 {

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -53,6 +53,7 @@ impl LruCache {
                 }
             })
             .max_capacity(cache_max_size)
+            .eviction_policy(moka::policy::EvictionPolicy::lru())
             .build();
 
         LruCache { cache }

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -30,7 +30,7 @@ use futures::StreamExt;
 
 #[must_use]
 pub fn to_cached_record_batch_stream(
-    cache_provider: Arc<QueryResultCacheProvider>,
+    cache_provider: QueryResultCacheProvider,
     mut stream: SendableRecordBatchStream,
     plan: LogicalPlan,
 ) -> SendableRecordBatchStream {

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -30,7 +30,7 @@ use futures::StreamExt;
 
 #[must_use]
 pub fn to_cached_record_batch_stream(
-    cache_provider: QueryResultCacheProvider,
+    cache_provider: Arc<QueryResultCacheProvider>,
     mut stream: SendableRecordBatchStream,
     plan: LogicalPlan,
 ) -> SendableRecordBatchStream {

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -40,7 +40,7 @@ pub fn to_cached_record_batch_stream(
     let cached_result_stream = stream! {
         let mut records: Vec<RecordBatch> = Vec::new();
         let mut records_size: usize = 0;
-        let cache_max_size: usize = cache_provider.cache_max_size().try_into().unwrap_or(usize::MAX);
+        let cache_max_size: usize = cache_provider.max_size().try_into().unwrap_or(usize::MAX);
 
         while let Some(batch_result) = stream.next().await {
             if records_size < cache_max_size {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -186,7 +186,7 @@ pub enum Table {
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     data_writers: HashSet<String>,
-    cache_provider: Option<QueryResultCacheProvider>,
+    cache_provider: Option<Arc<QueryResultCacheProvider>>,
 }
 
 impl DataFusion {
@@ -259,7 +259,7 @@ impl DataFusion {
         None
     }
 
-    pub fn set_cache_provider(&mut self, cache_provider: Option<QueryResultCacheProvider>) {
+    pub fn set_cache_provider(&mut self, cache_provider: Option<Arc<QueryResultCacheProvider>>) {
         self.cache_provider = cache_provider;
     }
 
@@ -318,7 +318,7 @@ impl DataFusion {
 
         if let Some(cache_provider) = &self.cache_provider {
             return Ok(to_cached_record_batch_stream(
-                cache_provider.clone(),
+                Arc::clone(cache_provider),
                 res_stream,
                 plan_copy,
             ));

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -186,7 +186,7 @@ pub enum Table {
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     data_writers: HashSet<String>,
-    cache_provider: Option<Arc<QueryResultCacheProvider>>,
+    cache_provider: Option<QueryResultCacheProvider>,
 }
 
 impl DataFusion {
@@ -259,7 +259,7 @@ impl DataFusion {
         None
     }
 
-    pub fn set_cache_provider(&mut self, cache_provider: Option<Arc<QueryResultCacheProvider>>) {
+    pub fn set_cache_provider(&mut self, cache_provider: Option<QueryResultCacheProvider>) {
         self.cache_provider = cache_provider;
     }
 
@@ -275,15 +275,11 @@ impl DataFusion {
             .context(UnableToExecuteQuerySnafu)?;
 
         if let Some(cache_provider) = &self.cache_provider {
-            metrics::counter!("results_cache_request_count").increment(1);
-
             if let Some(cached_result) = cache_provider
                 .get(&plan)
                 .await
                 .context(FailedToAccessCacheSnafu)?
             {
-                metrics::counter!("results_cache_hit_count").increment(1);
-
                 return Ok(Box::pin(
                     MemoryStream::try_new(
                         cached_result.records.to_vec(),
@@ -322,7 +318,7 @@ impl DataFusion {
 
         if let Some(cache_provider) = &self.cache_provider {
             return Ok(to_cached_record_batch_stream(
-                Arc::clone(cache_provider),
+                cache_provider.clone(),
                 res_stream,
                 plan_copy,
             ));

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -838,26 +838,10 @@ impl Runtime {
 
         tracing::info!("Initialized query results cache; {cache_provider}");
 
-        let shared_cache_provider = Arc::new(cache_provider);
-        let cache_copy = Arc::clone(&shared_cache_provider);
-
         self.df
             .write()
             .await
-            .set_cache_provider(Some(shared_cache_provider));
-
-        // cache metrics reporting
-        let _handle = tokio::spawn(async move {
-            loop {
-                #[allow(clippy::cast_precision_loss)]
-                metrics::gauge!("results_cache_max_size").set(cache_copy.max_size() as f64);
-                #[allow(clippy::cast_precision_loss)]
-                metrics::gauge!("results_cache_size").set(cache_copy.size() as f64);
-                #[allow(clippy::cast_precision_loss)]
-                metrics::gauge!("results_cache_item_count").set(cache_copy.item_count() as f64);
-                sleep(Duration::from_secs(10)).await;
-            }
-        });
+            .set_cache_provider(Some(cache_provider));
     }
 }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -840,7 +840,7 @@ impl Runtime {
         self.df
             .write()
             .await
-            .set_cache_provider(Some(cache_provider));
+            .set_cache_provider(Some(Arc::new(cache_provider)));
     }
 }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -850,12 +850,12 @@ impl Runtime {
         let _handle = tokio::spawn(async move {
             loop {
                 #[allow(clippy::cast_precision_loss)]
-                metrics::gauge!("results_cache_max_size").set(cache_copy.cache_max_size() as f64);
+                metrics::gauge!("results_cache_max_size").set(cache_copy.max_size() as f64);
                 #[allow(clippy::cast_precision_loss)]
-                metrics::gauge!("results_cache_size").set(cache_copy.cache_size() as f64);
+                metrics::gauge!("results_cache_size").set(cache_copy.size() as f64);
                 #[allow(clippy::cast_precision_loss)]
                 metrics::gauge!("results_cache_item_count").set(cache_copy.item_count() as f64);
-                sleep(Duration::from_secs(30)).await;
+                sleep(Duration::from_secs(10)).await;
             }
         });
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -838,10 +838,26 @@ impl Runtime {
 
         tracing::info!("Initialized query results cache; {cache_provider}");
 
+        let shared_cache_provider = Arc::new(cache_provider);
+        let cache_copy = Arc::clone(&shared_cache_provider);
+
         self.df
             .write()
             .await
-            .set_cache_provider(Some(cache_provider));
+            .set_cache_provider(Some(shared_cache_provider));
+
+        // cache metrics reporting
+        let _handle = tokio::spawn(async move {
+            loop {
+                #[allow(clippy::cast_precision_loss)]
+                metrics::gauge!("results_cache_max_size").set(cache_copy.cache_max_size() as f64);
+                #[allow(clippy::cast_precision_loss)]
+                metrics::gauge!("results_cache_size").set(cache_copy.cache_size() as f64);
+                #[allow(clippy::cast_precision_loss)]
+                metrics::gauge!("results_cache_item_count").set(cache_copy.item_count() as f64);
+                sleep(Duration::from_secs(30)).await;
+            }
+        });
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1358

Adds the following metrics:
- results_cache_request_count
- results_cache_hit_count
- results_cache_size
- results_cache_item_count
- results_cache_max_size