### PR TITLE
Fix the table reference to use the full table reference, not just the table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "app"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "snafu 0.8.2",
  "spicepod",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_sql_gen"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "bigdecimal 0.3.1",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_tools"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "snafu 0.8.2",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "async-stream",
@@ -2467,7 +2467,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "data_components"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "db_connection_pool"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "arrow-odbc",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "flight_client"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "flightpublisher"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "flightrepl"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "ansi_term",
  "arrow-flight",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "flightsubscriber"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow-flight",
  "clap",
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "llms"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "model_components"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5650,7 +5650,7 @@ dependencies = [
 
 [[package]]
 name = "ns_lookup"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "snafu 0.8.2",
  "tracing",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "app",
  "arrow",
@@ -7706,7 +7706,7 @@ dependencies = [
 
 [[package]]
 name = "secrets"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8145,7 +8145,7 @@ dependencies = [
 
 [[package]]
 name = "spiced"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "app",
  "clap",
@@ -8161,7 +8161,7 @@ dependencies = [
 
 [[package]]
 name = "spicepod"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "fundu",
  "serde",
@@ -8206,7 +8206,7 @@ dependencies = [
 
 [[package]]
 name = "sql_provider_datafusion"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "arrow",
  "async-trait",

--- a/crates/sql_provider_datafusion/src/federation.rs
+++ b/crates/sql_provider_datafusion/src/federation.rs
@@ -21,7 +21,7 @@ impl<T, P> SqlTable<T, P> {
     fn create_federated_table_source(
         self: Arc<Self>,
     ) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
-        let table_name = self.table_reference.table().to_string();
+        let table_name = self.table_reference.to_string();
         let schema = Arc::clone(&self.schema);
         let fed_provider = Arc::new(SQLFederationProvider::new(self));
         Ok(Arc::new(SQLTableSource::new_with_schema(
@@ -80,7 +80,7 @@ impl<T, P> SQLExecutor for SqlTable<T, P> {
 
     async fn get_table_schema(&self, table_name: &str) -> DataFusionResult<SchemaRef> {
         let conn = self.pool.connect().await.map_err(to_execution_error)?;
-        get_schema(conn, &TableReference::bare(table_name))
+        get_schema(conn, &TableReference::from(table_name))
             .await
             .context(UnableToGetSchemaSnafu)
             .map_err(to_execution_error)


### PR DESCRIPTION
Fixes a bug in the federation push-down where only the table name is used, not the full table reference in the remote query engine