### PR TITLE
Add X-Cache header for http queries

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -45,21 +45,26 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub enum ResultCacheStatus {
-    Cached,
-    NotCached,
-    CacheDisabled,
+pub enum RetrievalResult {
+    Hit,
+    Miss,
 }
 
 pub struct QueryResult {
     pub data: SendableRecordBatchStream,
-    pub cache_status: ResultCacheStatus,
+    pub cache_retrieval_result: Option<RetrievalResult>,
 }
 
 impl QueryResult {
     #[must_use]
-    pub fn new(data: SendableRecordBatchStream, cache_status: ResultCacheStatus) -> Self {
-        QueryResult { data, cache_status }
+    pub fn new(
+        data: SendableRecordBatchStream,
+        cache_retrieval_result: Option<RetrievalResult>,
+    ) -> Self {
+        QueryResult {
+            data,
+            cache_retrieval_result,
+        }
     }
 }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -45,26 +45,15 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub enum RetrievalResult {
-    Hit,
-    Miss,
-}
-
 pub struct QueryResult {
     pub data: SendableRecordBatchStream,
-    pub cache_retrieval_result: Option<RetrievalResult>,
+    pub from_cache: Option<bool>,
 }
 
 impl QueryResult {
     #[must_use]
-    pub fn new(
-        data: SendableRecordBatchStream,
-        cache_retrieval_result: Option<RetrievalResult>,
-    ) -> Self {
-        QueryResult {
-            data,
-            cache_retrieval_result,
-        }
+    pub fn new(data: SendableRecordBatchStream, from_cache: Option<bool>) -> Self {
+        QueryResult { data, from_cache }
     }
 }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -22,6 +22,7 @@ use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
 use async_trait::async_trait;
 use byte_unit::Byte;
+use datafusion::execution::SendableRecordBatchStream;
 use datafusion::logical_expr::LogicalPlan;
 use fundu::ParseError;
 use lru_cache::LruCache;
@@ -43,6 +44,24 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub enum ResultCacheStatus {
+    Cached,
+    NotCached,
+    CacheDisabled,
+}
+
+pub struct QueryResult {
+    pub data: SendableRecordBatchStream,
+    pub cache_status: ResultCacheStatus,
+}
+
+impl QueryResult {
+    #[must_use]
+    pub fn new(data: SendableRecordBatchStream, cache_status: ResultCacheStatus) -> Self {
+        QueryResult { data, cache_status }
+    }
+}
 
 #[derive(Clone)]
 pub struct CachedQueryResult {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -27,7 +27,9 @@ use crate::get_dependent_table_names;
 use crate::object_store_registry::default_runtime_env;
 use arrow::datatypes::Schema;
 use arrow_tools::schema::verify_schema;
-use cache::{to_cached_record_batch_stream, QueryResultCacheProvider};
+use cache::{
+    to_cached_record_batch_stream, QueryResult, QueryResultCacheProvider, ResultCacheStatus,
+};
 use datafusion::catalog::schema::SchemaProvider;
 use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider};
 use datafusion::datasource::{TableProvider, ViewTable};
@@ -187,24 +189,6 @@ pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     data_writers: HashSet<String>,
     cache_provider: Option<QueryResultCacheProvider>,
-}
-
-pub struct QueryResult {
-    pub data: SendableRecordBatchStream,
-    pub cache_status: ResultCacheStatus,
-}
-
-pub enum ResultCacheStatus {
-    Cached,
-    NotCached,
-    CacheDisabled,
-}
-
-impl QueryResult {
-    #[must_use]
-    pub fn new(data: SendableRecordBatchStream, cache_status: ResultCacheStatus) -> Self {
-        QueryResult { data, cache_status }
-    }
 }
 
 impl DataFusion {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -27,9 +27,7 @@ use crate::get_dependent_table_names;
 use crate::object_store_registry::default_runtime_env;
 use arrow::datatypes::Schema;
 use arrow_tools::schema::verify_schema;
-use cache::{
-    to_cached_record_batch_stream, QueryResult, QueryResultCacheProvider, RetrievalResult,
-};
+use cache::{to_cached_record_batch_stream, QueryResult, QueryResultCacheProvider};
 use datafusion::catalog::schema::SchemaProvider;
 use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider};
 use datafusion::datasource::{TableProvider, ViewTable};
@@ -291,10 +289,7 @@ impl DataFusion {
                     .context(UnableToCreateMemoryStreamSnafu)?,
                 );
 
-                return Ok(QueryResult::new(
-                    record_batch_stream,
-                    Some(RetrievalResult::Hit),
-                ));
+                return Ok(QueryResult::new(record_batch_stream, Some(true)));
             }
         }
 
@@ -327,10 +322,7 @@ impl DataFusion {
             let record_batch_stream =
                 to_cached_record_batch_stream(cache_provider.clone(), res_stream, plan_copy);
 
-            return Ok(QueryResult::new(
-                record_batch_stream,
-                Some(RetrievalResult::Miss),
-            ));
+            return Ok(QueryResult::new(record_batch_stream, Some(false)));
         }
 
         Ok(QueryResult::new(res_stream, None))

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -28,7 +28,7 @@ use crate::object_store_registry::default_runtime_env;
 use arrow::datatypes::Schema;
 use arrow_tools::schema::verify_schema;
 use cache::{
-    to_cached_record_batch_stream, QueryResult, QueryResultCacheProvider, ResultCacheStatus,
+    to_cached_record_batch_stream, QueryResult, QueryResultCacheProvider, RetrievalResult,
 };
 use datafusion::catalog::schema::SchemaProvider;
 use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider};
@@ -293,7 +293,7 @@ impl DataFusion {
 
                 return Ok(QueryResult::new(
                     record_batch_stream,
-                    ResultCacheStatus::Cached,
+                    Some(RetrievalResult::Hit),
                 ));
             }
         }
@@ -329,14 +329,11 @@ impl DataFusion {
 
             return Ok(QueryResult::new(
                 record_batch_stream,
-                ResultCacheStatus::NotCached,
+                Some(RetrievalResult::Miss),
             ));
         }
 
-        Ok(QueryResult::new(
-            res_stream,
-            ResultCacheStatus::CacheDisabled,
-        ))
+        Ok(QueryResult::new(res_stream, None))
     }
 
     pub fn register_runtime_table(

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -189,12 +189,13 @@ impl Service {
             .await
             .map_err(to_tonic_err)?;
 
-        let schema = batches_stream.schema();
+        let schema = batches_stream.data.schema();
         let options = datafusion::arrow::ipc::writer::IpcWriteOptions::default();
         let schema_as_ipc = SchemaAsIpc::new(&schema, &options);
         let schema_flight_data = FlightData::from(schema_as_ipc);
 
         let batches_stream = batches_stream
+            .data
             .then(move |batch_result| {
                 let options_clone = options.clone();
                 async move {

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -93,12 +93,13 @@ pub(crate) mod query {
         response::{IntoResponse, Response},
         Extension,
     };
+    use cache::ResultCacheStatus;
     use datafusion::execution::context::SQLOptions;
     use futures::TryStreamExt;
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
-    use crate::datafusion::{DataFusion, ResultCacheStatus};
+    use crate::datafusion::DataFusion;
 
     pub(crate) async fn post(
         Extension(df): Extension<Arc<RwLock<DataFusion>>>,

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -89,7 +89,7 @@ pub(crate) mod query {
     use arrow::record_batch::RecordBatch;
     use axum::{
         body::Bytes,
-        http::StatusCode,
+        http::{HeaderMap, StatusCode},
         response::{IntoResponse, Response},
         Extension,
     };
@@ -98,7 +98,7 @@ pub(crate) mod query {
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
-    use crate::datafusion::DataFusion;
+    use crate::datafusion::{DataFusion, ResultCacheStatus};
 
     pub(crate) async fn post(
         Extension(df): Extension<Arc<RwLock<DataFusion>>>,
@@ -117,25 +117,23 @@ pub(crate) mod query {
             .with_allow_dml(false)
             .with_allow_statements(false);
 
-        let results: Vec<RecordBatch> = match df
+        let (data, cache_status) = match df
             .read()
             .await
             .query_with_cache(&query, Some(restricted_sql_options))
             .await
         {
-            Ok(record_batch_stream) => {
-                match record_batch_stream.try_collect::<Vec<RecordBatch>>().await {
-                    Ok(batches) => batches,
-                    Err(e) => {
-                        tracing::debug!("Error executing query: {e}");
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            format!("Error processing batch: {e}"),
-                        )
-                            .into_response();
-                    }
+            Ok(query_result) => match query_result.data.try_collect::<Vec<RecordBatch>>().await {
+                Ok(batches) => (batches, query_result.cache_status),
+                Err(e) => {
+                    tracing::debug!("Error executing query: {e}");
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        format!("Error processing batch: {e}"),
+                    )
+                        .into_response();
                 }
-            }
+            },
             Err(e) => {
                 tracing::debug!("Error executing query: {e}");
                 return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
@@ -145,8 +143,7 @@ pub(crate) mod query {
         let buf = Vec::new();
         let mut writer = arrow_json::ArrayWriter::new(buf);
 
-        if let Err(e) =
-            writer.write_batches(results.iter().collect::<Vec<&RecordBatch>>().as_slice())
+        if let Err(e) = writer.write_batches(data.iter().collect::<Vec<&RecordBatch>>().as_slice())
         {
             tracing::debug!("Error converting results to JSON: {e}");
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
@@ -165,7 +162,23 @@ pub(crate) mod query {
             }
         };
 
-        (StatusCode::OK, res).into_response()
+        let mut headers = HeaderMap::new();
+
+        match cache_status {
+            ResultCacheStatus::Cached => {
+                if let Ok(value) = "HIT".parse() {
+                    headers.insert("X-Cache", value);
+                }
+            }
+            ResultCacheStatus::NotCached => {
+                if let Ok(value) = "MISS".parse() {
+                    headers.insert("X-Cache", value);
+                }
+            }
+            ResultCacheStatus::CacheDisabled => {}
+        };
+
+        (StatusCode::OK, headers, res).into_response()
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1358

Add `X-Cache` header to indicate whether query result is from results cache (`hit`) or not(`miss`). Applied only when results cache is enabled.