### PR TITLE
Enable in-memory results caching by default

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -71,7 +71,7 @@ impl QueryResultCacheProvider {
             Some(cache_max_size) => Byte::parse_str(cache_max_size, true)
                 .context(FailedToParseCacheMaxSizeSnafu)?
                 .as_u64(),
-            None => 128 * 1024 * 1024, // 128MB
+            None => 128 * 1024 * 1024, // 128 MiB
         };
 
         let ttl = match &config.item_expire {
@@ -115,7 +115,7 @@ impl Display for QueryResultCacheProvider {
         write!(
             f,
             "max size: {:.2}, item expire duration: {:?}",
-            Byte::from_u64(self.cache_max_size).get_adjusted_unit(byte_unit::Unit::MB),
+            Byte::from_u64(self.cache_max_size).get_adjusted_unit(byte_unit::Unit::MiB),
             self.ttl
         )
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -817,12 +817,11 @@ impl Runtime {
     pub async fn init_results_cache(&self) {
         let app_lock = self.app.read().await;
 
-        let Some(cache_config) = app_lock
-            .as_ref()
-            .and_then(|app| app.runtime.results_cache.as_ref())
-        else {
+        let Some(app) = app_lock.as_ref() else {
             return;
         };
+
+        let cache_config = &app.runtime.results_cache;
 
         if !cache_config.enabled {
             return;

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -18,7 +18,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct Runtime {
-    pub results_cache: Option<ResultsCache>,
+    #[serde(default)]
+    pub results_cache: ResultsCache,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -31,4 +32,14 @@ pub struct ResultsCache {
 
 const fn default_true() -> bool {
     true
+}
+
+impl Default for ResultsCache {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cache_max_size: None,
+            item_expire: None,
+        }
+    }
 }


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1358

PR enables in-memory results caching by default with the following configuration: 
 - cache_max_size: 128MiB
 - item_expire: 1s

```yaml
2024-05-22T06:01:12.319069Z  INFO runtime: Initialized query results cache; max size: 128.00 MiB, item expire duration: 1s
```