### PR TITLE
manual escape the snowflake dataset path before constructing table reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9443,7 +9443,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "util"
-version = "0.13.0-alpha"
+version = "0.13.1-alpha"
 dependencies = [
  "humantime",
 ]

--- a/crates/sql_provider_datafusion/src/federation.rs
+++ b/crates/sql_provider_datafusion/src/federation.rs
@@ -21,7 +21,7 @@ impl<T, P> SqlTable<T, P> {
     fn create_federated_table_source(
         self: Arc<Self>,
     ) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
-        let table_name = self.table_reference.to_string();
+        let table_name = self.table_reference.to_quoted_string();
         let schema = Arc::clone(&self.schema);
         let fed_provider = Arc::new(SQLFederationProvider::new(self));
         Ok(Arc::new(SQLTableSource::new_with_schema(


### PR DESCRIPTION
first part to fix snowflake query in federation.

now the snowflake path like `- from: snowflake:SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.LINEITEM` will be properly preserved in the query plan

```
| physical_plan | VirtualExecutionPlan name=snowflake compute_context=username=sgrebnov,account=ztyvqyb-v
gb35424,warehouse=COMPUTE_WH,role=ACCOUNTADMIN sql=SELECT "lineitem"."L_ORDERKEY", "lineitem"."L_PARTKEY"
, "lineitem"."L_SUPPKEY", "lineitem"."L_LINENUMBER", "lineitem"."L_QUANTITY", "lineitem"."L_EXTENDEDPRICE
", "lineitem"."L_DISCOUNT", "lineitem"."L_TAX", "lineitem"."L_RETURNFLAG", "lineitem"."L_LINESTATUS", "li
neitem"."L_SHIPDATE", "lineitem"."L_COMMITDATE", "lineitem"."L_RECEIPTDATE", "lineitem"."L_SHIPINSTRUCT",
 "lineitem"."L_SHIPMODE", "lineitem"."L_COMMENT" FROM "TPCH_SF1"."LINEITEM" AS "lineitem" |
```

Combining the upcoming fix for the missing catalog in `plan_to_sql`, snowflake federation will work.