### PR TITLE
Update results_cache config names per final spec

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -38,8 +38,8 @@ pub enum Error {
     #[snafu(display("Failed to parse cache_max_size value: {source}"))]
     FailedToParseCacheMaxSize { source: byte_unit::ParseError },
 
-    #[snafu(display("Failed to parse item_expire value: {source}"))]
-    FailedToParseItemExpire { source: ParseError },
+    #[snafu(display("Failed to parse item_ttl value: {source}"))]
+    FailedToParseItemTtl { source: ParseError },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -74,11 +74,9 @@ impl QueryResultCacheProvider {
             None => 128 * 1024 * 1024, // 128 MiB
         };
 
-        let ttl = match &config.item_expire {
-            Some(item_expire) => {
-                fundu::parse_duration(item_expire).context(FailedToParseItemExpireSnafu)?
-            }
-            None => fundu::parse_duration("1s").context(FailedToParseItemExpireSnafu)?,
+        let ttl = match &config.item_ttl {
+            Some(item_ttl) => fundu::parse_duration(item_ttl).context(FailedToParseItemTtlSnafu)?,
+            None => fundu::parse_duration("1s").context(FailedToParseItemTtlSnafu)?,
         };
 
         let cache_provider = QueryResultCacheProvider {

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -27,7 +27,8 @@ pub struct ResultsCache {
     #[serde(default = "default_true")]
     pub enabled: bool,
     pub cache_max_size: Option<String>,
-    pub item_expire: Option<String>,
+    pub item_ttl: Option<String>,
+    pub eviction_policy: Option<String>,
 }
 
 const fn default_true() -> bool {
@@ -39,7 +40,8 @@ impl Default for ResultsCache {
         Self {
             enabled: true,
             cache_max_size: None,
-            item_expire: None,
+            item_ttl: None,
+            eviction_policy: None,
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1358

1. Rename `item_expire` to `item_ttl` to match final spec version
2. Add `eviction_policy` (part of the spec, not currently used but will allow to change caching algorithm in the future)

