### PR TITLE
Add `file_format` to helm chart sample dataset

### DIFF
--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -14,6 +14,8 @@ spicepod:
     - from: s3://spiceai-demo-datasets/taxi_trips/2024/
       name: taxi_trips
       description: Demo taxi trips in s3
+      params:
+        file_format: parquet
       acceleration:
         enabled: true
         # Uncomment to refresh the acceleration on a schedule


### PR DESCRIPTION
`file_format` needs to be specified, when spice can't detect file extension