### PR TITLE
Dataset Configure CLI - Add `file_format` prompt for s3 and ftp datasets, if no extension detected

### DIFF
--- a/bin/spice/cmd/dataset.go
+++ b/bin/spice/cmd/dataset.go
@@ -116,6 +116,31 @@ spice dataset configure
 			params["endpoint"] = endpoint
 		}
 
+		if datasetPrefix == spec.DATA_SOURCE_S3 || datasetPrefix == spec.DATA_SOURCE_FTP || datasetPrefix == spec.DATA_SOURCE_SFTP {
+			// check if `from` ends with .csv or .parquet
+			from_path := strings.ToLower(from)
+			if !strings.HasSuffix(from_path, ".csv") && !strings.HasSuffix(from_path, ".parquet") {
+				cmd.Print("file_format (parquet/csv) (parquet) ")
+				file_format, err := reader.ReadString('\n')
+				if err != nil {
+					cmd.Println(err.Error())
+					os.Exit(1)
+				}
+				file_format = strings.TrimSuffix(file_format, "\n")
+
+				if file_format == "" {
+					file_format = "parquet"
+				}
+
+				if file_format != "parquet" && file_format != "csv" {
+					cmd.Println(aurora.BrightRed("file_format must be either parquet or csv"))
+					os.Exit(1)
+				}
+
+				params["file_format"] = file_format
+			}
+		}
+
 		cmd.Print("locally accelerate (y/n)? (y) ")
 		locallyAccelerateStr, err := reader.ReadString('\n')
 		if err != nil {
@@ -134,9 +159,9 @@ spice dataset configure
 
 		if accelerateDataset {
 			dataset.Acceleration = &spec.AccelerationSpec{
-				Enabled:                   accelerateDataset,
+				Enabled:              accelerateDataset,
 				RefreshCheckInterval: time.Second * 10,
-				RefreshMode:               spec.REFRESH_MODE_FULL,
+				RefreshMode:          spec.REFRESH_MODE_FULL,
 			}
 		}
 

--- a/bin/spice/pkg/spec/dataset.go
+++ b/bin/spice/pkg/spec/dataset.go
@@ -25,6 +25,9 @@ const (
 	DATA_SOURCE_SPICEAI    = "spice.ai"
 	DATA_SOURCE_DREMIO     = "dremio"
 	DATA_SOURCE_DATABRICKS = "databricks"
+	DATA_SOURCE_S3         = "s3"
+	DATA_SOURCE_FTP        = "ftp"
+	DATA_SOURCE_SFTP       = "sftp"
 )
 
 type DatasetSpec struct {


### PR DESCRIPTION
When using `spice dataset configure`
- if dataset is from s3, ftp or sftp, and path don't have file extension, cli will prompt user for `file_format`

https://github.com/spiceai/spiceai/assets/827338/385caa61-2aaa-4803-8307-f5f37fff8db3

