### PR TITLE
Better spark data connector error

### DIFF
--- a/crates/data_components/src/spark_connect.rs
+++ b/crates/data_components/src/spark_connect.rs
@@ -23,7 +23,9 @@ use datafusion::{
     sql::TableReference,
 };
 use futures::Stream;
-use spark_connect_rs::{functions::col, DataFrame, SparkSession, SparkSessionBuilder};
+use spark_connect_rs::{
+    client::ChannelBuilder, functions::col, DataFrame, SparkSession, SparkSessionBuilder,
+};
 use sql_provider_datafusion::expr::{self, Engine};
 
 use std::error::Error;
@@ -35,6 +37,13 @@ pub struct SparkConnect {
 }
 
 impl SparkConnect {
+    pub fn validate_connection_string(
+        connection: &str,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        ChannelBuilder::parse_connection_string(connection)?;
+        Ok(())
+    }
+
     pub async fn from_connection(connection: &str) -> Result<Self, Box<dyn Error + Send + Sync>> {
         let session = Arc::new(SparkSessionBuilder::remote(connection).build().await?);
         Ok(Self { session })

--- a/crates/runtime/src/dataconnector/spark.rs
+++ b/crates/runtime/src/dataconnector/spark.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[snafu(display("Endpoint {endpoint} is invalid: {source}"))]
     InvalidEndpoint {
         endpoint: String,
-        source: ns_lookup::Error,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     #[snafu(display("{source}"))]
@@ -72,6 +72,8 @@ impl Spark {
             (Some(conn), _) => Ok(conn.as_str()),
             _ => MissingSparkRemoteSnafu.fail(),
         }?;
+        SparkConnect::validate_connection_string(conn)
+            .context(InvalidEndpointSnafu { endpoint: conn })?;
         let spark = SparkConnect::from_connection(conn)
             .await
             .context(UnableToConstructSparkConnectSnafu)?;


### PR DESCRIPTION
* Validate Spark connect endpoint before connection
* Use DataConnector Error to give better error context for spark data connector error

Before:
![image](https://github.com/spiceai/spiceai/assets/130200611/4870934d-8f84-4739-9dc1-3d01a7093d12)
![image](https://github.com/spiceai/spiceai/assets/130200611/cf2bfe9b-a78b-4659-9fbf-462b8cb996d8)
![image](https://github.com/spiceai/spiceai/assets/130200611/858c0e43-1228-4a3d-bc53-68fb63e0217f)
![image](https://github.com/spiceai/spiceai/assets/130200611/103b1d8a-6096-4fb7-9fb5-a7159b3f067c)


After:
![image](https://github.com/spiceai/spiceai/assets/130200611/4c49b46b-62d2-4d70-983d-01ae997b03c8)
![image](https://github.com/spiceai/spiceai/assets/130200611/e846bceb-3f52-4e7c-9b3e-bfab30d252ab)
![image](https://github.com/spiceai/spiceai/assets/130200611/c39afe4d-d18a-4c23-a8a5-f16344ddedcc)
![image](https://github.com/spiceai/spiceai/assets/130200611/93ed7a73-5808-4231-af91-e5fa28dc5b8d)

- close https://github.com/spiceai/spiceai/issues/1468
