### PR TITLE
Cache invalidation for accelerated tables

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -115,11 +115,11 @@ pub async fn run(args: Args) -> Result<()> {
 
     rt.load_secrets().await;
 
+    rt.init_results_cache().await;
+
     rt.load_datasets().await;
 
     rt.load_models().await;
-
-    rt.init_results_cache().await;
 
     if args.spice_cloud_connect {
         if let Err(err) = rt

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::atomic::Ordering;
@@ -45,6 +46,12 @@ pub enum Error {
 
     #[snafu(display("Failed to parse item_ttl value: {source}"))]
     FailedToParseItemTtl { source: ParseError },
+
+    #[snafu(display("Cache invalidation for dataset {table_name} failed with error: {source}"))]
+    FailedToInvalidateCache {
+        source: moka::PredicateError,
+        table_name: String,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -65,12 +72,14 @@ impl QueryResult {
 pub struct CachedQueryResult {
     pub records: Arc<Vec<RecordBatch>>,
     pub schema: Arc<Schema>,
+    pub input_tables: Arc<HashSet<String>>,
 }
 
 #[async_trait]
 pub trait QueryResultCache {
     async fn get(&self, plan: &LogicalPlan) -> Result<Option<CachedQueryResult>>;
     async fn put(&self, plan: &LogicalPlan, result: CachedQueryResult) -> Result<()>;
+    async fn invalidate_for_table(&self, table_name: &str) -> Result<()>;
     fn size_bytes(&self) -> u64;
     fn item_count(&self) -> u64;
 }
@@ -147,6 +156,13 @@ impl QueryResultCacheProvider {
             #[allow(clippy::cast_precision_loss)]
             metrics::gauge!("results_cache_item_count").set(self.item_count() as f64);
         }
+    }
+
+    /// # Errors
+    ///
+    /// Will return `Err` if method fails to invalidate cache for the table provided
+    pub async fn invalidate_for_table(&self, table_name: &str) -> Result<()> {
+        self.cache.invalidate_for_table(table_name).await
     }
 
     #[must_use]

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use crate::CachedQueryResult;
+use crate::FailedToInvalidateCacheSnafu;
 use crate::QueryResultCache;
 use crate::Result;
 use async_trait::async_trait;
 use datafusion::logical_expr::LogicalPlan;
 use moka::future::Cache;
+use snafu::ResultExt;
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -54,6 +56,7 @@ impl LruCache {
             })
             .max_capacity(cache_max_size)
             .eviction_policy(moka::policy::EvictionPolicy::lru())
+            .support_invalidation_closures()
             .build();
 
         LruCache { cache }
@@ -73,6 +76,15 @@ impl QueryResultCache for LruCache {
     async fn put(&self, plan: &LogicalPlan, result: CachedQueryResult) -> Result<()> {
         let key = key_for_logical_plan(plan);
         self.cache.insert(key, result).await;
+        Ok(())
+    }
+
+    async fn invalidate_for_table(&self, table_name: &str) -> Result<()> {
+        let name = table_name.to_string().to_lowercase();
+        self.cache
+            .invalidate_entries_if(move |_key, value| value.input_tables.contains(&name))
+            .context(FailedToInvalidateCacheSnafu { table_name })?;
+
         Ok(())
     }
 

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use arrow::array::RecordBatch;
 use datafusion::{
@@ -56,7 +56,8 @@ pub fn to_cached_record_batch_stream(
         if records_size < cache_max_size {
             let cached_result = CachedQueryResult {
                 records: Arc::new(records),
-                schema: schema_copy
+                schema: schema_copy,
+                input_tables: Arc::new(get_logical_plan_input_tables(&plan)),
             };
 
             if let Err(e) = cache_provider.put(&plan, cached_result).await {
@@ -69,4 +70,21 @@ pub fn to_cached_record_batch_stream(
         schema,
         Box::pin(cached_result_stream),
     ))
+}
+
+#[must_use]
+pub fn get_logical_plan_input_tables(plan: &LogicalPlan) -> HashSet<String> {
+    let mut table_names: HashSet<String> = HashSet::new();
+    collect_table_names(plan, &mut table_names);
+    table_names
+}
+
+fn collect_table_names(plan: &LogicalPlan, table_names: &mut HashSet<String>) {
+    if let LogicalPlan::TableScan(source, ..) = plan {
+        table_names.insert(source.table_name.to_string().to_lowercase());
+    }
+
+    plan.inputs().iter().for_each(|input| {
+        collect_table_names(input, table_names);
+    });
 }

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -22,7 +22,7 @@ use crate::component::dataset::TimeFormat;
 use arrow::array::UInt64Array;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use cache::QueryResultCacheProvider;
+use cache::QueryResultsCacheProvider;
 use data_components::delete::get_deletion_provider;
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::context::SessionState;
@@ -121,7 +121,7 @@ pub struct Builder {
     refresh: refresh::Refresh,
     retention: Option<Retention>,
     zero_results_action: ZeroResultsAction,
-    cache_provider: Option<Arc<QueryResultCacheProvider>>,
+    cache_provider: Option<Arc<QueryResultsCacheProvider>>,
 }
 
 impl Builder {
@@ -154,7 +154,7 @@ impl Builder {
 
     pub fn cache_provider(
         &mut self,
-        cache_provider: Option<Arc<QueryResultCacheProvider>>,
+        cache_provider: Option<Arc<QueryResultsCacheProvider>>,
     ) -> &mut Self {
         self.cache_provider = cache_provider;
         self
@@ -308,7 +308,7 @@ impl AcceleratedTable {
         dataset_name: TableReference,
         accelerator: Arc<dyn TableProvider>,
         retention: Retention,
-        cache_provider: Option<Arc<QueryResultCacheProvider>>,
+        cache_provider: Option<Arc<QueryResultsCacheProvider>>,
     ) {
         let time_column = retention.time_column;
         let retention_period = retention.period;
@@ -375,10 +375,11 @@ impl AcceleratedTable {
 
                                 if num_records > 0 {
                                     if let Some(cache_provider) = &cache_provider {
-                                        if let Err(e) =
-                                            cache_provider.invalidate_for_table(&dataset_name).await
+                                        if let Err(e) = cache_provider
+                                            .invalidate_for_table(&dataset_name.to_string())
+                                            .await
                                         {
-                                            tracing::error!("Failed to invalidate cached results for dataset {dataset_name}: {e}");
+                                            tracing::error!("Failed to invalidate cached results for dataset {}: {e}", &dataset_name.to_string());
                                         }
                                     }
                                 }

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -188,13 +188,14 @@ impl Builder {
 
         validate_refresh_data_window(&self.refresh, &self.dataset_name, &self.federated.schema());
         let refresh_params = Arc::new(RwLock::new(self.refresh));
-        let refresher = refresh::Refresher::new(
+        let mut refresher = refresh::Refresher::new(
             self.dataset_name.clone(),
             Arc::clone(&self.federated),
             Arc::clone(&refresh_params),
             Arc::clone(&self.accelerator),
-            self.cache_provider.clone(),
         );
+        refresher.cache_provider(self.cache_provider.clone());
+
         let refresh_handle = tokio::spawn(async move {
             refresher
                 .start(acceleration_refresh_mode, ready_sender)

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -15,7 +15,7 @@ use crate::{
 use arrow::array::TimestampNanosecondArray;
 use arrow::datatypes::DataType;
 use async_stream::stream;
-use cache::QueryResultCacheProvider;
+use cache::QueryResultsCacheProvider;
 use datafusion::common::TableReference;
 use datafusion::error::DataFusionError;
 use datafusion::execution::config::SessionConfig;
@@ -86,7 +86,7 @@ pub(crate) struct Refresher {
     federated: Arc<dyn TableProvider>,
     refresh: Arc<RwLock<Refresh>>,
     accelerator: Arc<dyn TableProvider>,
-    cache_provider: Option<Arc<QueryResultCacheProvider>>,
+    cache_provider: Option<Arc<QueryResultsCacheProvider>>,
 }
 
 impl Refresher {
@@ -107,7 +107,7 @@ impl Refresher {
 
     pub fn cache_provider(
         &mut self,
-        cache_provider: Option<Arc<QueryResultCacheProvider>>,
+        cache_provider: Option<Arc<QueryResultsCacheProvider>>,
     ) -> &mut Self {
         self.cache_provider = cache_provider;
         self
@@ -187,10 +187,11 @@ impl Refresher {
                                     }
 
                                     if let Some(cache_provider) = &self.cache_provider {
-                                        if let Err(e) =
-                                            cache_provider.invalidate_for_table(&dataset_name).await
+                                        if let Err(e) = cache_provider
+                                            .invalidate_for_table(&dataset_name.to_string())
+                                            .await
                                         {
-                                            tracing::error!("Failed to invalidate cached results for dataset {dataset_name}: {e}");
+                                            tracing::error!("Failed to invalidate cached results for dataset {}: {e}", &dataset_name.to_string());
                                         }
                                     }
                                 }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -96,15 +96,22 @@ impl Refresher {
         federated: Arc<dyn TableProvider>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
-        cache_provider: Option<Arc<QueryResultCacheProvider>>,
     ) -> Self {
         Self {
             dataset_name,
             federated,
             refresh,
             accelerator,
-            cache_provider,
+            cache_provider: None,
         }
+    }
+
+    pub fn cache_provider(
+        &mut self,
+        cache_provider: Option<Arc<QueryResultCacheProvider>>,
+    ) -> &mut Self {
+        self.cache_provider = cache_provider;
+        self
     }
 
     pub(crate) async fn start(
@@ -574,7 +581,6 @@ mod tests {
             federated,
             Arc::new(RwLock::new(refresh)),
             Arc::clone(&accelerator),
-            None,
         );
 
         let (trigger, receiver) = mpsc::channel::<()>(1);
@@ -748,7 +754,6 @@ mod tests {
                 federated,
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
-                None,
             );
 
             let (trigger, receiver) = mpsc::channel::<()>(1);
@@ -897,7 +902,6 @@ mod tests {
                 federated,
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
-                None,
             );
 
             let (trigger, receiver) = mpsc::channel::<()>(1);

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -569,7 +569,10 @@ impl DataFusion {
             dataset.retention_check_interval(),
             acceleration_settings.retention_check_enabled,
         ));
+
         accelerated_table_builder.zero_results_action(acceleration_settings.on_zero_results);
+
+        accelerated_table_builder.cache_provider(self.cache_provider.clone());
 
         Ok(accelerated_table_builder.build().await)
     }

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -166,12 +166,12 @@ pub(crate) mod query {
 
         match is_data_from_cache {
             Some(true) => {
-                if let Ok(value) = "HIT".parse() {
+                if let Ok(value) = "Hit from spiceai".parse() {
                     headers.insert("X-Cache", value);
                 }
             }
             Some(false) => {
-                if let Ok(value) = "MISS".parse() {
+                if let Ok(value) = "Miss from spiceai".parse() {
                     headers.insert("X-Cache", value);
                 }
             }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use std::{
     cmp,
     time::{Duration, SystemTime, SystemTimeError},


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1358

Remove cached results for accelerated dataset after data is updated (refresh and retention logic).