### PR TITLE
Separate runtime Dataset from spicepod Dataset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8246,6 +8246,7 @@ version = "0.13.1-alpha"
 dependencies = [
  "fundu",
  "serde",
+ "serde_json",
  "serde_yaml",
  "snafu 0.8.2",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8244,7 +8244,6 @@ dependencies = [
 name = "spicepod"
 version = "0.13.1-alpha"
 dependencies = [
- "fundu",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,7 +2897,6 @@ dependencies = [
  "secrets",
  "snafu 0.8.2",
  "snowflake-api",
- "spicepod",
  "tokio",
  "tokio-postgres",
  "tokio-rusqlite",

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -34,10 +34,10 @@ default = [
   "snowflake",
   "ftp",
 ]
-duckdb = ["runtime/duckdb", "spicepod/duckdb", "app/duckdb"]
-postgres = ["runtime/postgres", "spicepod/postgres", "app/postgres"]
-sqlite = ["runtime/sqlite", "spicepod/sqlite", "app/sqlite"]
-mysql = ["runtime/mysql", "spicepod/mysql", "app/mysql"]
+duckdb = ["runtime/duckdb"]
+postgres = ["runtime/postgres"]
+sqlite = ["runtime/sqlite"]
+mysql = ["runtime/mysql"]
 ftp = ["runtime/ftp"]
 clickhouse = ["runtime/clickhouse"]
 release = []

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -12,9 +12,3 @@ description = "All loaded components from the root Spicepod and its dependencies
 snafu.workspace = true
 spicepod = { path = "../spicepod" }
 tracing.workspace = true
-
-[features]
-duckdb = ["spicepod/duckdb"]
-postgres = ["spicepod/postgres"]
-sqlite = ["spicepod/sqlite"]
-mysql = ["spicepod/mysql"]

--- a/crates/data_components/src/databricks_delta.rs
+++ b/crates/data_components/src/databricks_delta.rs
@@ -30,12 +30,12 @@ use crate::deltatable::write::DeltaTableWriter;
 #[derive(Clone)]
 pub struct DatabricksDelta {
     pub secret: Arc<Option<Secret>>,
-    pub params: Arc<Option<HashMap<String, String>>>,
+    pub params: Arc<HashMap<String, String>>,
 }
 
 impl DatabricksDelta {
     #[must_use]
-    pub fn new(secret: Arc<Option<Secret>>, params: Arc<Option<HashMap<String, String>>>) -> Self {
+    pub fn new(secret: Arc<Option<Secret>>, params: Arc<HashMap<String, String>>) -> Self {
         Self { secret, params }
     }
 }
@@ -75,7 +75,7 @@ impl ReadWrite for DatabricksDelta {
 async fn get_delta_table(
     secret: Arc<Option<Secret>>,
     table_reference: TableReference,
-    params: Arc<Option<HashMap<String, String>>>,
+    params: Arc<HashMap<String, String>>,
 ) -> Result<Arc<dyn TableProvider>, Box<dyn Error + Send + Sync>> {
     // Needed to be able to load the s3:// scheme
     deltalake::aws::register_handlers(None);
@@ -107,13 +107,8 @@ struct DatabricksTablesApiResponse {
 pub async fn resolve_table_uri(
     table_reference: TableReference,
     secret: &Arc<Option<Secret>>,
-    params: Arc<Option<HashMap<String, String>>>,
+    params: Arc<HashMap<String, String>>,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    let params = match params.as_ref() {
-        None => return Err("Dataset params not found".into()),
-        Some(params) => params,
-    };
-
     let Some(endpoint) = params.get("endpoint") else {
         return Err("Endpoint not found in dataset params".into());
     };

--- a/crates/data_components/src/postgres.rs
+++ b/crates/data_components/src/postgres.rs
@@ -196,7 +196,7 @@ impl TableProviderFactory for PostgresTableProviderFactory {
         let options = cmd.options.clone();
         let schema: Schema = cmd.schema.as_ref().into();
 
-        let params = Arc::new(Some(options));
+        let params = Arc::new(options);
 
         let pool = Arc::new(
             PostgresConnectionPool::new(params, None)

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -22,7 +22,6 @@ arrow_sql_gen = { path = "../arrow_sql_gen", optional = true }
 arrow.workspace = true
 pem = { workspace = true, optional = true }
 secrets = { path = "../secrets" }
-spicepod = { path = "../spicepod" }
 rusqlite = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 tokio-rusqlite = { workspace = true, optional = true }
@@ -44,7 +43,7 @@ url = "2.5.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [features]
-duckdb = ["dep:duckdb", "dep:r2d2", "spicepod/duckdb"]
+duckdb = ["dep:duckdb", "dep:r2d2"]
 postgres = [
     "dep:bb8",
     "dep:bb8-postgres",
@@ -53,11 +52,10 @@ postgres = [
     "dep:pem",
     "dep:tokio",
     "arrow_sql_gen/postgres",
-    "spicepod/postgres",
     "dep:tokio-postgres",
 ]
-sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "arrow_sql_gen/sqlite", "spicepod/sqlite"]
-mysql = ["dep:mysql_async", "arrow_sql_gen/mysql", "spicepod/mysql"]
+sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "arrow_sql_gen/sqlite"]
+mysql = ["dep:mysql_async", "arrow_sql_gen/mysql"]
 clickhouse = ["dep:clickhouse-rs", "arrow_sql_gen/clickhouse", "dep:async-stream"]
 odbc = ["dep:odbc-api", "dep:arrow-odbc", "dep:tokio"]
 snowflake = ["dep:snowflake-api", "dep:pkcs8"]

--- a/crates/db_connection_pool/src/lib.rs
+++ b/crates/db_connection_pool/src/lib.rs
@@ -16,7 +16,6 @@ limitations under the License.
 
 use crate::dbconnection::DbConnection;
 use async_trait::async_trait;
-use spicepod::component::dataset::acceleration;
 
 #[cfg(feature = "clickhouse")]
 pub mod clickhousepool;
@@ -69,15 +68,6 @@ impl From<&str> for Mode {
             "file" => Mode::File,
             "memory" => Mode::Memory,
             _ => Mode::default(),
-        }
-    }
-}
-
-impl From<acceleration::Mode> for Mode {
-    fn from(m: acceleration::Mode) -> Self {
-        match m {
-            acceleration::Mode::File => Mode::File,
-            acceleration::Mode::Memory => Mode::Memory,
         }
     }
 }

--- a/crates/db_connection_pool/src/mysqlpool.rs
+++ b/crates/db_connection_pool/src/mysqlpool.rs
@@ -58,66 +58,61 @@ impl MySQLConnectionPool {
     ///
     /// Returns an error if there is a problem creating the connection pool.
     #[allow(clippy::unused_async)]
-    pub async fn new(
-        params: Arc<Option<HashMap<String, String>>>,
-        secret: Option<Secret>,
-    ) -> Result<Self> {
+    pub async fn new(params: Arc<HashMap<String, String>>, secret: Option<Secret>) -> Result<Self> {
         let mut connection_string = mysql_async::OptsBuilder::default();
         let mut ssl_mode = "required";
         let mut ssl_rootcert_path: Option<PathBuf> = None;
 
-        if let Some(params) = params.as_ref() {
-            if let Some(mysql_connection_string) = get_secret_or_param(
-                Some(params),
-                &secret,
-                "mysql_connection_string_key",
-                "mysql_connection_string",
-            ) {
-                connection_string = mysql_async::OptsBuilder::from_opts(
-                    mysql_async::Opts::from_url(mysql_connection_string.as_str())?,
-                );
-            } else {
-                if let Some(mysql_host) = params.get("mysql_host") {
-                    connection_string = connection_string.ip_or_hostname(mysql_host.as_str());
-                }
-                if let Some(mysql_user) = params.get("mysql_user") {
-                    connection_string = connection_string.user(Some(mysql_user));
-                }
-                if let Some(mysql_db) = params.get("mysql_db") {
-                    connection_string = connection_string.db_name(Some(mysql_db));
-                }
-                if let Some(mysql_pass) =
-                    get_secret_or_param(Some(params), &secret, "mysql_pass_key", "mysql_pass")
-                {
-                    connection_string = connection_string.pass(Some(mysql_pass));
-                }
-                if let Some(mysql_tcp_port) = params.get("mysql_tcp_port") {
-                    connection_string =
-                        connection_string.tcp_port(mysql_tcp_port.parse::<u16>().unwrap_or(3306));
-                }
-                if let Some(mysql_sslmode) = params.get("mysql_sslmode") {
-                    match mysql_sslmode.to_lowercase().as_str() {
-                        "disabled" | "required" | "preferred" => {
-                            ssl_mode = mysql_sslmode.as_str();
-                        }
-                        _ => {
-                            InvalidParameterSnafu {
-                                parameter_name: "mysql_sslmode".to_string(),
-                            }
-                            .fail()?;
-                        }
+        if let Some(mysql_connection_string) = get_secret_or_param(
+            &params,
+            &secret,
+            "mysql_connection_string_key",
+            "mysql_connection_string",
+        ) {
+            connection_string = mysql_async::OptsBuilder::from_opts(mysql_async::Opts::from_url(
+                mysql_connection_string.as_str(),
+            )?);
+        } else {
+            if let Some(mysql_host) = params.get("mysql_host") {
+                connection_string = connection_string.ip_or_hostname(mysql_host.as_str());
+            }
+            if let Some(mysql_user) = params.get("mysql_user") {
+                connection_string = connection_string.user(Some(mysql_user));
+            }
+            if let Some(mysql_db) = params.get("mysql_db") {
+                connection_string = connection_string.db_name(Some(mysql_db));
+            }
+            if let Some(mysql_pass) =
+                get_secret_or_param(&params, &secret, "mysql_pass_key", "mysql_pass")
+            {
+                connection_string = connection_string.pass(Some(mysql_pass));
+            }
+            if let Some(mysql_tcp_port) = params.get("mysql_tcp_port") {
+                connection_string =
+                    connection_string.tcp_port(mysql_tcp_port.parse::<u16>().unwrap_or(3306));
+            }
+            if let Some(mysql_sslmode) = params.get("mysql_sslmode") {
+                match mysql_sslmode.to_lowercase().as_str() {
+                    "disabled" | "required" | "preferred" => {
+                        ssl_mode = mysql_sslmode.as_str();
                     }
-                }
-                if let Some(mysql_sslrootcert) = params.get("mysql_sslrootcert") {
-                    if !std::path::Path::new(mysql_sslrootcert).exists() {
-                        InvalidRootCertPathSnafu {
-                            path: mysql_sslrootcert,
+                    _ => {
+                        InvalidParameterSnafu {
+                            parameter_name: "mysql_sslmode".to_string(),
                         }
                         .fail()?;
                     }
-
-                    ssl_rootcert_path = Some(PathBuf::from(mysql_sslrootcert));
                 }
+            }
+            if let Some(mysql_sslrootcert) = params.get("mysql_sslrootcert") {
+                if !std::path::Path::new(mysql_sslrootcert).exists() {
+                    InvalidRootCertPathSnafu {
+                        path: mysql_sslrootcert,
+                    }
+                    .fail()?;
+                }
+
+                ssl_rootcert_path = Some(PathBuf::from(mysql_sslrootcert));
             }
         }
 

--- a/crates/db_connection_pool/src/snowflakepool.rs
+++ b/crates/db_connection_pool/src/snowflakepool.rs
@@ -74,16 +74,11 @@ pub struct SnowflakeConnectionPool {
 }
 
 fn get_param(
-    params: &Arc<Option<HashMap<String, String>>>,
+    params: &HashMap<String, String>,
     secret: &Option<Secret>,
     param_name: &str,
 ) -> Option<String> {
-    return get_secret_or_param(
-        params.as_ref().as_ref(),
-        secret,
-        &format!("{param_name}_key"),
-        param_name,
-    );
+    get_secret_or_param(params, secret, &format!("{param_name}_key"), param_name)
 }
 
 impl SnowflakeConnectionPool {
@@ -92,10 +87,7 @@ impl SnowflakeConnectionPool {
     /// # Errors
     ///
     /// Returns an error if there is a problem creating the connection pool.
-    pub async fn new(
-        params: &Arc<Option<HashMap<String, String>>>,
-        secret: &Option<Secret>,
-    ) -> Result<Self> {
+    pub async fn new(params: &HashMap<String, String>, secret: &Option<Secret>) -> Result<Self> {
         let username = get_param(params, secret, "username")
             .context(MissingRequiredSecretSnafu { name: "username" })?;
 
@@ -167,7 +159,7 @@ fn init_snowflake_api_with_password_auth(
     username: &str,
     warehouse: &Option<String>,
     role: &Option<String>,
-    params: &Arc<Option<HashMap<String, String>>>,
+    params: &HashMap<String, String>,
     secret: &Option<Secret>,
 ) -> Result<SnowflakeApi> {
     let password = get_param(params, secret, "password")
@@ -191,7 +183,7 @@ fn init_snowflake_api_with_keypair_auth(
     username: &str,
     warehouse: &Option<String>,
     role: &Option<String>,
-    params: &Arc<Option<HashMap<String, String>>>,
+    params: &HashMap<String, String>,
     secret: &Option<Secret>,
 ) -> Result<SnowflakeApi> {
     let private_key_path = get_param(params, secret, "snowflake_private_key_path").context(

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -106,7 +106,6 @@ duckdb = [
     "dep:duckdb",
     "r2d2",
     "db_connection_pool/duckdb",
-    "spicepod/duckdb",
     "data_components/duckdb",
 ]
 postgres = [

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -17,6 +17,8 @@ limitations under the License.
 use std::time::SystemTime;
 use std::{any::Any, sync::Arc, time::Duration};
 
+use crate::component::dataset::acceleration::{RefreshMode, ZeroResultsAction};
+use crate::component::dataset::TimeFormat;
 use arrow::array::UInt64Array;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
@@ -32,8 +34,6 @@ use datafusion::{
     logical_expr::Expr,
 };
 use snafu::prelude::*;
-use spicepod::component::dataset::acceleration::{RefreshMode, ZeroResultsAction};
-use spicepod::component::dataset::TimeFormat;
 use tokio::task::JoinHandle;
 use tokio::time::interval;
 

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -1,0 +1,1 @@
+pub mod dataset;

--- a/crates/runtime/src/dataaccelerator/mysql.rs
+++ b/crates/runtime/src/dataaccelerator/mysql.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::{collections::HashMap, mem, sync::Arc};
 
+use crate::component::dataset::Dataset;
 use arrow::array::RecordBatch;
 use arrow_sql_gen::statement::{CreateTableBuilder, InsertBuilder};
 use datafusion::{execution::context::SessionContext, sql::TableReference};
@@ -29,7 +30,6 @@ use mysql_async::{
 };
 use secrets::Secret;
 use snafu::{prelude::*, ResultExt};
-use spicepod::component::dataset::Dataset;
 use sql_provider_datafusion::SqlTable;
 use tract_core::downcast_rs::Downcast;
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::dataset::Dataset;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::dataframe::DataFrame;
@@ -31,7 +32,6 @@ use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::TableReference;
 use lazy_static::lazy_static;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -175,7 +175,7 @@ type NewDataConnectorResult = AnyErrorResult<Arc<dyn DataConnector>>;
 
 type NewDataConnectorFn = dyn Fn(
         Option<Secret>,
-        Arc<Option<HashMap<String, String>>>,
+        Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>>
     + Send;
 
@@ -188,7 +188,7 @@ pub async fn register_connector_factory(
     name: &str,
     connector_factory: impl Fn(
             Option<Secret>,
-            Arc<Option<HashMap<String, String>>>,
+            Arc<HashMap<String, String>>,
         ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>>
         + Send
         + 'static,
@@ -207,7 +207,7 @@ pub async fn register_connector_factory(
 pub async fn create_new_connector(
     name: &str,
     secret: Option<Secret>,
-    params: Arc<Option<HashMap<String, String>>>,
+    params: Arc<HashMap<String, String>>,
 ) -> Option<AnyErrorResult<Arc<dyn DataConnector>>> {
     let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
 
@@ -252,7 +252,7 @@ pub async fn register_all() {
 pub trait DataConnectorFactory {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>>;
 }
 
@@ -469,7 +469,7 @@ mod tests {
     use super::*;
 
     struct TestConnector {
-        params: HashMap<String, String>,
+        params: Arc<HashMap<String, String>>,
     }
 
     impl std::fmt::Display for TestConnector {
@@ -481,12 +481,10 @@ mod tests {
     impl DataConnectorFactory for TestConnector {
         fn create(
             _secret: Option<Secret>,
-            params: Arc<Option<HashMap<String, String>>>,
+            params: Arc<HashMap<String, String>>,
         ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
             Box::pin(async move {
-                let connector = Self {
-                    params: params.as_ref().clone().map_or_else(HashMap::new, |x| x),
-                };
+                let connector = Self { params };
                 Ok(Arc::new(connector) as Arc<dyn DataConnector>)
             })
         }
@@ -512,7 +510,9 @@ mod tests {
     }
 
     fn setup_connector(path: String, params: HashMap<String, String>) -> (TestConnector, Dataset) {
-        let connector = TestConnector { params };
+        let connector = TestConnector {
+            params: params.into(),
+        };
         let dataset = Dataset::new(path, "test".to_string());
 
         (connector, dataset)

--- a/crates/runtime/src/dataconnector/clickhouse.rs
+++ b/crates/runtime/src/dataconnector/clickhouse.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::clickhouse::ClickhouseTableFactory;
 use data_components::Read;
@@ -21,7 +22,6 @@ use datafusion::datasource::TableProvider;
 use db_connection_pool::clickhousepool::{self, ClickhouseConnectionPool};
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -44,7 +44,7 @@ pub struct Clickhouse {
 impl DataConnectorFactory for Clickhouse {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             match ClickhouseConnectionPool::new(params, secret).await {

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use super::DataConnector;
 use super::DataConnectorFactory;
+use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::flight::FlightFactory;
 use data_components::Read;
@@ -25,7 +26,6 @@ use flight_client::FlightClient;
 use ns_lookup::verify_endpoint_connection;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -58,16 +58,15 @@ pub struct Dremio {
 impl DataConnectorFactory for Dremio {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let secret = secret.context(MissingSecretsSnafu)?;
 
             let endpoint: String = params
-                .as_ref() // &Option<HashMap<String, String>>
-                .as_ref() // Option<&HashMap<String, String>>
-                .and_then(|params| params.get("endpoint").cloned())
-                .context(MissingEndpointParameterSnafu)?;
+                .get("endpoint")
+                .context(MissingEndpointParameterSnafu)?
+                .clone();
 
             verify_endpoint_connection(&endpoint)
                 .await

--- a/crates/runtime/src/dataconnector/duckdb.rs
+++ b/crates/runtime/src/dataconnector/duckdb.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::duckdb::DuckDBTableFactory;
 use data_components::Read;
@@ -22,7 +23,6 @@ use db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use duckdb::AccessMode;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -48,19 +48,19 @@ pub struct DuckDB {
 impl DataConnectorFactory for DuckDB {
     fn create(
         _secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
-            let params = params.as_ref().as_ref();
-
             // data connector requires valid "open" parameter
-            let db_path: String = params.and_then(|p| p.get("open").cloned()).ok_or(
-                DataConnectorError::InvalidConfiguration {
-                    dataconnector: "duckdb".to_string(),
-                    message: "Missing required open parameter.".to_string(),
-                    source: "Missing open".into(),
-                },
-            )?;
+            let db_path: String =
+                params
+                    .get("open")
+                    .cloned()
+                    .ok_or(DataConnectorError::InvalidConfiguration {
+                        dataconnector: "duckdb".to_string(),
+                        message: "Missing required open parameter.".to_string(),
+                        source: "Missing open".into(),
+                    })?;
 
             // TODO: wire to dataset.mode once readwrite implemented for duckdb
             let pool = Arc::new(

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use super::{DataConnector, DataConnectorFactory};
+use crate::component::dataset::Dataset;
 use arrow_flight::sql::client::FlightSqlServiceClient;
 use async_trait::async_trait;
 use data_components::flightsql::FlightSQLFactory;
@@ -23,7 +24,6 @@ use datafusion::datasource::TableProvider;
 use flight_client::tls::new_tls_flight_channel;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -48,13 +48,12 @@ pub struct FlightSQL {
 impl DataConnectorFactory for FlightSQL {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let endpoint: String = params
-                .as_ref() // &Option<HashMap<String, String>>
-                .as_ref() // Option<&HashMap<String, String>>
-                .and_then(|params| params.get("endpoint").cloned())
+                .get("endpoint")
+                .cloned()
                 .context(MissingEndpointParameterSnafu)?;
             let flight_channel = new_tls_flight_channel(&endpoint)
                 .await

--- a/crates/runtime/src/dataconnector/localhost.rs
+++ b/crates/runtime/src/dataconnector/localhost.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 
 use std::{any::Any, collections::HashMap, pin::Pin, sync::Arc};
 
+use crate::component::dataset::Dataset;
 use datafusion::{
     config::ConfigOptions,
     datasource::{TableProvider, TableType},
@@ -35,7 +36,6 @@ use datafusion::{
 use futures::Future;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 
 use super::{DataConnector, DataConnectorFactory};
 
@@ -83,13 +83,9 @@ impl LocalhostConnector {
 impl DataConnectorFactory for LocalhostConnector {
     fn create(
         _secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
-            let Some(params) = params.as_ref() else {
-                return Err(Error::MissingSchemaParameter.into());
-            };
-
             let schema = params.get("schema").ok_or(Error::MissingSchemaParameter)?;
 
             let statements = Parser::parse_sql(&PostgreSqlDialect {}, schema).context(

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::mysql::MySQLTableFactory;
 use data_components::Read;
@@ -23,7 +24,6 @@ use db_connection_pool::DbConnectionPool;
 use mysql_async::prelude::ToValue;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -46,7 +46,7 @@ pub struct MySQL {
 impl DataConnectorFactory for MySQL {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let pool: Arc<

--- a/crates/runtime/src/dataconnector/odbc.rs
+++ b/crates/runtime/src/dataconnector/odbc.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::odbc::ODBCTableFactory;
 use data_components::Read;
@@ -22,7 +23,6 @@ use db_connection_pool::dbconnection::odbcconn::ODBCDbConnectionPool;
 use db_connection_pool::odbcpool::ODBCPool;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -51,11 +51,11 @@ where
 {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let pool: Arc<ODBCDbConnectionPool<'a>> = Arc::new(
-                ODBCPool::new(&params, &secret).context(UnableToCreateODBCConnectionPoolSnafu)?,
+                ODBCPool::new(params, &secret).context(UnableToCreateODBCConnectionPoolSnafu)?,
             );
 
             let odbc_factory = ODBCTableFactory::new(pool);

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::postgres::PostgresTableFactory;
 use data_components::Read;
@@ -21,7 +22,6 @@ use datafusion::datasource::TableProvider;
 use db_connection_pool::postgrespool::{self, PostgresConnectionPool};
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -42,7 +42,7 @@ pub struct Postgres {
 impl DataConnectorFactory for Postgres {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             match PostgresConnectionPool::new(params, secret).await {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -16,9 +16,9 @@ limitations under the License.
 
 use super::{DataConnector, DataConnectorFactory, DataConnectorResult, ListingTableConnector};
 
+use crate::component::dataset::Dataset;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::clone::Clone;
 use std::pin::Pin;
@@ -44,19 +44,16 @@ pub enum Error {
 
 pub struct S3 {
     secret: Option<Secret>,
-    params: HashMap<String, String>,
+    params: Arc<HashMap<String, String>>,
 }
 
 impl DataConnectorFactory for S3 {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
-            let s3 = Self {
-                secret,
-                params: params.as_ref().clone().map_or_else(HashMap::new, |x| x),
-            };
+            let s3 = Self { secret, params };
             Ok(Arc::new(s3) as Arc<dyn DataConnector>)
         })
     }

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use data_components::snowflake::SnowflakeTableFactory;
 use data_components::Read;
 
+use crate::component::dataset::Dataset;
 use datafusion::datasource::TableProvider;
 use db_connection_pool::snowflakepool::SnowflakeConnectionPool;
 use db_connection_pool::DbConnectionPool;
@@ -27,7 +28,6 @@ use itertools::Itertools;
 use secrets::Secret;
 use snafu::prelude::*;
 use snowflake_api::SnowflakeApi;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -48,7 +48,7 @@ pub struct Snowflake {
 impl DataConnectorFactory for Snowflake {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let pool: Arc<

--- a/crates/runtime/src/dataconnector/spark.rs
+++ b/crates/runtime/src/dataconnector/spark.rs
@@ -16,13 +16,13 @@ limitations under the License.
 
 use async_trait::async_trait;
 
+use crate::component::dataset::Dataset;
 use data_components::spark_connect::SparkConnect;
 use data_components::{Read, ReadWrite};
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -62,10 +62,10 @@ pub struct Spark {
 impl Spark {
     async fn new(
         secret: Arc<Option<Secret>>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Result<Self> {
-        let plain_text_connection = params.as_ref().as_ref().and_then(|x| x.get("spark_remote"));
-        let secret_connection = secret.as_ref().as_ref().and_then(|x| x.get("spark_remote"));
+        let plain_text_connection = params.get("spark_remote");
+        let secret_connection = secret.as_ref().as_ref().and_then(|s| s.get("spark_remote"));
         let conn = match (plain_text_connection, secret_connection) {
             (Some(_), Some(_)) => DuplicatedSparkRemoteSnafu.fail(),
             (_, Some(conn)) => Ok(conn),
@@ -85,7 +85,7 @@ impl Spark {
 impl DataConnectorFactory for Spark {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let spark_connector = Spark::new(Arc::new(secret), params).await?;

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use super::DataConnector;
 use super::DataConnectorFactory;
+use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::flight::FlightFactory;
 use data_components::{Read, ReadWrite};
@@ -24,7 +25,6 @@ use flight_client::FlightClient;
 use ns_lookup::verify_endpoint_connection;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
 use std::any::Any;
 use std::borrow::Borrow;
 use std::pin::Pin;
@@ -62,7 +62,7 @@ pub struct SpiceAI {
 impl DataConnectorFactory for SpiceAI {
     fn create(
         secret: Option<Secret>,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         let default_flight_url = if cfg!(feature = "dev") {
             "https://dev-flight.spiceai.io".to_string()
@@ -73,9 +73,8 @@ impl DataConnectorFactory for SpiceAI {
             let secret = secret.context(MissingRequiredSecretsSnafu)?;
 
             let url: String = params
-                .as_ref() // &Option<HashMap<String, String>>
-                .as_ref() // Option<&HashMap<String, String>>
-                .and_then(|params| params.get("endpoint").cloned())
+                .get("endpoint")
+                .cloned()
                 .unwrap_or(default_flight_url);
             tracing::trace!("Connecting to SpiceAI with flight url: {url}");
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::accelerated_table::{refresh::Refresh, AcceleratedTable, Retention};
+use crate::component::dataset::{Dataset, Mode};
 use crate::dataaccelerator::{self, create_accelerator_table};
 use crate::dataconnector::{DataConnector, DataConnectorError};
 use crate::dataupdate::{DataUpdate, DataUpdateExecutionPlan, UpdateType};
@@ -42,7 +43,6 @@ use datafusion::sql::{sqlparser, TableReference};
 use datafusion_federation::{FederatedQueryPlanner, FederationAnalyzerRule};
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::{Dataset, Mode};
 use tokio::spawn;
 use tokio::sync::oneshot;
 use tokio::time::{sleep, Instant};
@@ -555,16 +555,16 @@ impl DataFusion {
             accelerated_table_provider,
             Refresh::new(
                 dataset.time_column.clone(),
-                dataset.time_format.clone(),
+                dataset.time_format,
                 dataset.refresh_check_interval(),
                 refresh_sql.clone(),
-                acceleration_settings.refresh_mode.clone(),
+                acceleration_settings.refresh_mode,
                 dataset.refresh_data_window(),
             ),
         );
         accelerated_table_builder.retention(Retention::new(
             dataset.time_column.clone(),
-            dataset.time_format.clone(),
+            dataset.time_format,
             dataset.retention_period(),
             dataset.retention_check_interval(),
             acceleration_settings.retention_check_enabled,

--- a/crates/runtime/src/datafusion/filter_converter.rs
+++ b/crates/runtime/src/datafusion/filter_converter.rs
@@ -1,9 +1,9 @@
+use crate::component::dataset::TimeFormat;
 use arrow::datatypes::DataType;
 use datafusion::{
     logical_expr::{binary_expr, cast, col, lit, Expr, Operator},
     scalar::ScalarValue,
 };
-use spicepod::component::dataset::TimeFormat;
 
 #[derive(Debug, Clone)]
 enum ExprTimeFormat {

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -14,22 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::component::dataset::replication::Replication;
 use arrow::datatypes::Schema;
 use datafusion::datasource::TableProvider;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::replication::Replication;
 
 use crate::accelerated_table::Retention;
+use crate::component::dataset::{acceleration::Acceleration, Dataset, Mode};
 use crate::dataconnector::create_new_connector;
 use crate::{
     accelerated_table::{refresh::Refresh, AcceleratedTable},
     dataaccelerator::{self, create_accelerator_table},
     dataconnector::{localhost::LocalhostConnector, DataConnector, DataConnectorError},
 };
-use spicepod::component::dataset::{acceleration::Acceleration, Dataset, Mode};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -104,7 +105,7 @@ async fn get_spiceai_table_provider(
     dataset.mode = Mode::ReadWrite;
     dataset.replication = Some(Replication { enabled: true });
 
-    let data_connector = create_new_connector("spiceai", secret, Arc::new(None))
+    let data_connector = create_new_connector("spiceai", secret, Arc::new(HashMap::new()))
         .await
         .ok_or_else(|| NoReadWriteProviderSnafu {}.build())?
         .context(UnableToCreateDataConnectorSnafu)?;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -19,8 +19,11 @@ limitations under the License.
 use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
+use crate::spice_metrics::MetricsRecorder;
+use crate::{dataconnector::DataConnector, datafusion::DataFusion};
 use ::datafusion::error::DataFusionError;
 use ::datafusion::sql::parser::{self, DFParser};
 use ::datafusion::sql::sqlparser::ast::{SetExpr, TableFactor};
@@ -29,23 +32,20 @@ use ::datafusion::sql::sqlparser::{self, ast};
 use accelerated_table::AcceleratedTable;
 use app::App;
 use cache::QueryResultCacheProvider;
+use component::dataset::{self, Dataset};
 use config::Config;
 use metrics::SetRecorderError;
 use model_components::{model::Model, modelsource::source as model_source};
 pub use notify::Error as NotifyError;
 use secrets::{spicepod_secret_store_type, Secret};
 use snafu::prelude::*;
-use spicepod::component::dataset::Dataset;
-use spicepod::component::dataset::Mode;
 use spicepod::component::model::Model as SpicepodModel;
-use std::time::Duration;
 use tokio::sync::oneshot::error::RecvError;
 use tokio::time::sleep;
 use tokio::{signal, sync::RwLock};
 
-use crate::spice_metrics::MetricsRecorder;
-use crate::{dataconnector::DataConnector, datafusion::DataFusion};
 mod accelerated_table;
+pub mod component;
 pub mod config;
 pub mod dataaccelerator;
 pub mod dataconnector;
@@ -107,7 +107,7 @@ pub enum Error {
 
     #[snafu(display("Unable to create view: {source}"))]
     InvalidSQLView {
-        source: spicepod::component::dataset::Error,
+        source: crate::component::dataset::Error,
     },
 
     #[snafu(display("Unable to attach data connector {data_connector}: {source}"))]
@@ -138,8 +138,16 @@ pub enum Error {
     #[snafu(display("Expected acceleration settings for {name}, found None"))]
     ExpectedAccelerationSettings { name: String },
 
-    #[snafu(display("The accelerator engine {name} is not available"))]
-    AcceleratorEngineNotAvailable { name: Arc<str> },
+    #[snafu(display("The accelerator engine {name} is not available. Valid engines are arrow, duckdb, sqlite, and postgres."))]
+    AcceleratorEngineNotAvailable { name: String },
+
+    #[snafu(display(
+        "Dataset names should not include a catalog. Unexpected '{}' in '{}'. Remove '{}' from the dataset name and try again.",
+        catalog,
+        name,
+        catalog,
+    ))]
+    DatasetNameIncludesCatalog { catalog: Arc<str>, name: Arc<str> },
 
     #[snafu(display("Unable to load dataset connector: {dataset}"))]
     UnableToLoadDatasetConnector { dataset: String },
@@ -218,13 +226,36 @@ impl Runtime {
         }
     }
 
+    fn datasets_iter(app: &App) -> impl Iterator<Item = Result<Dataset>> + '_ {
+        app.datasets.iter().cloned().map(Dataset::try_from)
+    }
+
+    /// Returns a list of valid datasets from the given App, skipping any that fail to parse and logging an error for them.
+    fn get_valid_datasets(app: &App) -> Vec<Dataset> {
+        Self::datasets_iter(app)
+            .zip(&app.datasets)
+            .filter_map(|(ds, spicepod_ds)| match ds {
+                Ok(ds) => Some(ds),
+                Err(e) => {
+                    status::update_dataset(&spicepod_ds.name, status::ComponentStatus::Error);
+                    metrics::counter!("datasets_load_error").increment(1);
+                    tracing::error!(dataset = &spicepod_ds.name, "{e}");
+                    None
+                }
+            })
+            .collect()
+    }
+
     pub async fn load_datasets(&self) {
         let app_lock = self.app.read().await;
-        if let Some(app) = app_lock.as_ref() {
-            for ds in &app.datasets {
-                status::update_dataset(&ds.name, status::ComponentStatus::Initializing);
-                self.load_dataset(ds, &app.datasets).await;
-            }
+        let Some(app) = app_lock.as_ref() else {
+            return;
+        };
+
+        let valid_datasets = Self::get_valid_datasets(app);
+        for ds in &valid_datasets {
+            status::update_dataset(&ds.name, status::ComponentStatus::Initializing);
+            self.load_dataset(ds, &valid_datasets).await;
         }
     }
 
@@ -283,7 +314,7 @@ impl Runtime {
         }
 
         let source = ds.source();
-        let params = Arc::new(ds.params.clone().map(|params| params.as_string_map()));
+        let params = Arc::new(ds.params.clone());
         let data_connector: Arc<dyn DataConnector> = match Runtime::get_dataconnector_from_source(
             &source,
             &secrets_provider,
@@ -347,7 +378,7 @@ impl Runtime {
                     || "None".to_string(),
                     |acc| {
                         if acc.enabled {
-                            acc.engine().to_string()
+                            acc.engine.to_string()
                         } else {
                             "None".to_string()
                         }
@@ -390,7 +421,7 @@ impl Runtime {
             || "None".to_string(),
             |acc| {
                 if acc.enabled {
-                    acc.engine().to_string()
+                    acc.engine.to_string()
                 } else {
                     "None".to_string()
                 }
@@ -466,7 +497,7 @@ impl Runtime {
     async fn get_dataconnector_from_source(
         source: &str,
         secrets_provider: &secrets::SecretsProvider,
-        params: Arc<Option<HashMap<String, String>>>,
+        params: Arc<HashMap<String, String>>,
     ) -> Result<Arc<dyn DataConnector>> {
         let secret = secrets_provider.get_secret(source).await.context(
             UnableToGetSecretForDataConnectorSnafu {
@@ -497,11 +528,11 @@ impl Runtime {
                     name: ds.name.to_string(),
                 })?;
 
-        if ds.mode() == Mode::ReadWrite && !replicate {
+        if ds.mode() == dataset::Mode::ReadWrite && !replicate {
             AcceleratedReadWriteTableWithoutReplicationSnafu.fail()?;
         }
 
-        let accelerator_engine = acceleration_settings.engine();
+        let accelerator_engine = acceleration_settings.engine;
         let secret_key = acceleration_settings
             .engine_secret
             .clone()
@@ -545,7 +576,7 @@ impl Runtime {
 
         // FEDERATED TABLE
         if !ds.is_accelerated() {
-            if ds.mode() == Mode::ReadWrite && !replicate {
+            if ds.mode() == dataset::Mode::ReadWrite && !replicate {
                 // A federated dataset was configured as ReadWrite, but the replication setting wasn't set - error out.
                 FederatedReadWriteTableWithoutReplicationSnafu.fail()?;
             }
@@ -566,13 +597,13 @@ impl Runtime {
                 .ok_or_else(|| Error::ExpectedAccelerationSettings {
                     name: ds.name.to_string(),
                 })?;
-        let accelerator_engine = acceleration_settings.engine();
+        let accelerator_engine = acceleration_settings.engine;
         let acceleration_secret = Runtime::get_acceleration_secret(ds, secrets_provider).await?;
 
-        dataaccelerator::get_accelerator_engine(&accelerator_engine)
+        dataaccelerator::get_accelerator_engine(accelerator_engine)
             .await
             .context(AcceleratorEngineNotAvailableSnafu {
-                name: accelerator_engine,
+                name: accelerator_engine.to_string(),
             })?;
 
         Runtime::register_table(
@@ -762,16 +793,17 @@ impl Runtime {
                 tracing::debug!("Previous pods information: {:?}", current_app);
 
                 // check for new and updated datasets
-                for ds in &new_app.datasets {
+                let valid_datasets = Self::get_valid_datasets(&new_app);
+                for ds in &valid_datasets {
                     if let Some(current_ds) =
                         current_app.datasets.iter().find(|d| d.name == ds.name)
                     {
-                        if current_ds != ds {
-                            self.update_dataset(ds, &new_app.datasets).await;
+                        if current_ds.name != ds.name {
+                            self.update_dataset(ds, &valid_datasets).await;
                         }
                     } else {
                         status::update_dataset(&ds.name, status::ComponentStatus::Initializing);
-                        self.load_dataset(ds, &new_app.datasets).await;
+                        self.load_dataset(ds, &valid_datasets).await;
                     }
                 }
 
@@ -801,7 +833,14 @@ impl Runtime {
                 for ds in &current_app.datasets {
                     if !new_app.datasets.iter().any(|d| d.name == ds.name) {
                         status::update_dataset(&ds.name, status::ComponentStatus::Disabled);
-                        self.remove_dataset(ds).await;
+                        let ds = match Dataset::try_from(ds.clone()) {
+                            Ok(ds) => ds,
+                            Err(e) => {
+                                tracing::error!("Could not remove dataset {}: {e}", ds.name);
+                                continue;
+                            }
+                        };
+                        self.remove_dataset(&ds).await;
                     }
                 }
 

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -18,6 +18,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::component::dataset::acceleration::{Acceleration, RefreshMode};
+use crate::component::dataset::TimeFormat;
 use arrow::array::{Float64Array, Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
@@ -25,8 +27,6 @@ use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use secrets::Secret;
 use snafu::prelude::*;
-use spicepod::component::dataset::acceleration::{Acceleration, RefreshMode};
-use spicepod::component::dataset::TimeFormat;
 use tokio::spawn;
 use tokio::sync::RwLock;
 

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -200,12 +200,12 @@ impl SecretsProvider {
 #[must_use]
 #[allow(clippy::implicit_hasher)]
 pub fn get_secret_or_param(
-    params: Option<&HashMap<String, String>>,
+    params: &HashMap<String, String>,
     secret: &Option<Secret>,
     secret_param_key: &str,
     param_key: &str,
 ) -> Option<String> {
-    let secret_param_val = match params.and_then(|p| p.get(secret_param_key)) {
+    let secret_param_val = match params.get(secret_param_key) {
         Some(val) => val,
         None => param_key,
     };
@@ -216,7 +216,7 @@ pub fn get_secret_or_param(
         };
     };
 
-    if let Some(param_val) = params.and_then(|p| p.get(param_key)) {
+    if let Some(param_val) = params.get(param_key) {
         return Some(param_val.to_string());
     };
 

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -13,9 +13,3 @@ serde_yaml.workspace = true
 snafu.workspace = true
 tracing.workspace = true
 fundu.workspace = true
-
-[features]
-duckdb = []
-postgres = []
-sqlite = []
-mysql = []

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -13,4 +13,3 @@ serde_yaml.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
 tracing.workspace = true
-fundu.workspace = true

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -14,30 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{fs, time::Duration};
-
 use serde::{Deserialize, Serialize};
 
 use super::{params::Params, WithDependsOn};
-use snafu::prelude::*;
-
-#[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(display("Unable to load SQL file {file}: {source}"))]
-    UnableToLoadSqlFile {
-        file: String,
-        source: std::io::Error,
-    },
-    // #[snafu(display(
-    //     "Dataset names should not include a catalog. Unexpected '{}' in '{}'. Remove '{}' from the dataset name and try again.",
-    //     catalog,
-    //     name,
-    //     catalog,
-    // ))]
-    // DatasetNameIncludesCatalog { catalog: Arc<str>, name: Arc<str> },
-}
-
-pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -104,15 +83,6 @@ pub struct Dataset {
 impl Dataset {
     #[must_use]
     pub fn new(from: String, name: String) -> Self {
-        // let name = name.into();
-        // let name = match TableReference::parse_str(&name) {
-        //     table_ref @ (TableReference::Bare { .. } | TableReference::Partial { .. }) => table_ref,
-        //     TableReference::Full { catalog, .. } => DatasetNameIncludesCatalogSnafu {
-        //         catalog,
-        //         name: Arc::clone(&name),
-        //     }
-        //     .fail()?,
-        // };
         Dataset {
             from,
             name,
@@ -126,200 +96,6 @@ impl Dataset {
             acceleration: None,
             depends_on: Vec::default(),
         }
-    }
-
-    /// Returns the dataset source - the first part of the `from` field before the first `:`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use spicepod::component::dataset::Dataset;
-    ///
-    /// let dataset = Dataset::new("foo:bar".to_string(), "bar".to_string());
-    ///
-    /// assert_eq!(dataset.source(), "foo".to_string());
-    /// ```
-    ///
-    /// ```
-    /// use spicepod::component::dataset::Dataset;
-    ///
-    /// let dataset = Dataset::new("foo".to_string(), "bar".to_string());
-    ///
-    /// assert_eq!(dataset.source(), "spiceai");
-    /// ```
-    #[must_use]
-    pub fn source(&self) -> String {
-        let parts: Vec<&str> = self.from.splitn(2, ':').collect();
-        if parts.len() > 1 {
-            parts[0].to_string()
-        } else {
-            if self.from == "localhost" || self.from.is_empty() {
-                return "localhost".to_string();
-            }
-            "spiceai".to_string()
-        }
-    }
-
-    /// Returns the dataset path - the remainder of the `from` field after the first `:` or the whole string if no `:`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use spicepod::component::dataset::Dataset;
-    ///
-    /// let dataset = Dataset::new("foo:bar".to_string(), "bar".to_string());
-    ///
-    /// assert_eq!(dataset.path(), "bar".to_string());
-    /// ```
-    ///
-    /// ```
-    /// use spicepod::component::dataset::Dataset;
-    ///
-    /// let dataset = Dataset::new("foo".to_string(), "bar".to_string());
-    ///
-    /// assert_eq!(dataset.path(), "foo".to_string());
-    /// ```
-    #[must_use]
-    pub fn path(&self) -> String {
-        match self.from.find(':') {
-            Some(index) => self.from[index + 1..].to_string(),
-            None => self.from.clone(),
-        }
-    }
-
-    #[must_use]
-    pub fn engine_secret(&self) -> Option<String> {
-        if let Some(acceleration) = &self.acceleration {
-            return acceleration.engine_secret.clone();
-        }
-
-        None
-    }
-
-    #[must_use]
-    pub fn refresh_check_interval(&self) -> Option<Duration> {
-        if let Some(acceleration) = &self.acceleration {
-            if let Some(refresh_check_interval) = &acceleration.refresh_check_interval {
-                if let Ok(duration) = fundu::parse_duration(refresh_check_interval) {
-                    return Some(duration);
-                }
-                tracing::warn!(
-                    "Unable to parse refresh interval for dataset {}: {}",
-                    self.name,
-                    refresh_check_interval
-                );
-            }
-        }
-
-        None
-    }
-
-    pub fn retention_check_interval(&self) -> Option<Duration> {
-        if let Some(acceleration) = &self.acceleration {
-            if let Some(retention_check_interval) = &acceleration.retention_check_interval {
-                if let Ok(duration) = fundu::parse_duration(retention_check_interval) {
-                    return Some(duration);
-                }
-                tracing::warn!(
-                    "Unable to parse retention check interval for dataset {}: {}",
-                    self.name,
-                    retention_check_interval
-                );
-            }
-        }
-
-        None
-    }
-
-    pub fn retention_period(&self) -> Option<Duration> {
-        if let Some(acceleration) = &self.acceleration {
-            if let Some(retention_period) = &acceleration.retention_period {
-                if let Ok(duration) = fundu::parse_duration(retention_period) {
-                    return Some(duration);
-                }
-                tracing::warn!(
-                    "Unable to parse retention period for dataset {}: {}",
-                    self.name,
-                    retention_period
-                );
-            }
-        }
-
-        None
-    }
-
-    #[must_use]
-    pub fn refresh_sql(&self) -> Option<String> {
-        if let Some(acceleration) = &self.acceleration {
-            return acceleration.refresh_sql.clone();
-        }
-
-        None
-    }
-
-    #[must_use]
-    pub fn refresh_data_window(&self) -> Option<Duration> {
-        if let Some(acceleration) = &self.acceleration {
-            if let Some(refresh_data_window) = &acceleration.refresh_data_window {
-                if let Ok(duration) = fundu::parse_duration(refresh_data_window) {
-                    return Some(duration);
-                }
-                tracing::warn!(
-                    "Unable to parse refresh period for dataset {}: {}",
-                    self.name,
-                    refresh_data_window
-                );
-            }
-        }
-
-        None
-    }
-
-    #[must_use]
-    pub fn is_view(&self) -> bool {
-        self.sql.is_some() || self.sql_ref.is_some()
-    }
-
-    #[must_use]
-    pub fn view_sql(&self) -> Option<Result<String>> {
-        if let Some(sql) = &self.sql {
-            return Some(Ok(sql.clone()));
-        }
-
-        if let Some(sql_ref) = &self.sql_ref {
-            return Some(Self::load_sql_ref(sql_ref));
-        }
-
-        None
-    }
-
-    fn load_sql_ref(sql_ref: &str) -> Result<String> {
-        let sql =
-            fs::read_to_string(sql_ref).context(UnableToLoadSqlFileSnafu { file: sql_ref })?;
-        Ok(sql)
-    }
-
-    #[must_use]
-    pub fn mode(&self) -> Mode {
-        self.mode.clone()
-    }
-
-    #[must_use]
-    pub fn is_accelerated(&self) -> bool {
-        if let Some(acceleration) = &self.acceleration {
-            return acceleration.enabled;
-        }
-
-        false
-    }
-
-    #[must_use]
-    pub fn is_file_accelerated(&self) -> bool {
-        if let Some(acceleration) = &self.acceleration {
-            return acceleration.enabled && acceleration.mode == acceleration::Mode::File;
-        }
-
-        false
     }
 }
 
@@ -343,7 +119,7 @@ impl WithDependsOn<Dataset> for Dataset {
 
 pub mod acceleration {
     use serde::{Deserialize, Serialize};
-    use std::{fmt::Display, sync::Arc};
+    use std::fmt::Display;
 
     use crate::component::params::Params;
 
@@ -441,21 +217,6 @@ pub mod acceleration {
 
     const fn default_true() -> bool {
         true
-    }
-
-    impl Acceleration {
-        #[must_use]
-        pub fn mode(&self) -> Mode {
-            self.mode.clone()
-        }
-
-        #[must_use]
-        pub fn engine(&self) -> Arc<str> {
-            self.engine
-                .as_ref()
-                .map_or_else(|| "arrow", String::as_str)
-                .into()
-        }
     }
 
     impl Default for Acceleration {

--- a/crates/sql_provider_datafusion/tests/postgres_integration_test.rs
+++ b/crates/sql_provider_datafusion/tests/postgres_integration_test.rs
@@ -19,14 +19,14 @@ use sql_provider_datafusion::SqlTable;
 async fn test_postgres_types() {
     let db = PgTempDB::async_new().await;
     let ctx = SessionContext::new();
-    let params = Arc::new(Some(HashMap::from([
+    let params = Arc::new(HashMap::from([
         ("pg_host".to_string(), "localhost".into()),
         ("pg_port".to_string(), format!("{}", db.db_port())),
         ("pg_user".to_string(), db.db_user().into()),
         ("pg_pass".to_string(), db.db_pass().into()),
         ("pg_db".to_string(), db.db_name().into()),
         ("pg_sslmode".to_string(), "disable".into()),
-    ])));
+    ]));
     let pool: Arc<dyn DbConnectionPool<_, _> + Send + Sync> = Arc::new(
         PostgresConnectionPool::new(params, None)
             .await


### PR DESCRIPTION
This is a refactoring/removing tech debt PR that:
1. Separates the concerns of the spicepod crate and the runtime crate with respect to the `Dataset` struct. Previously we had the spicepod crate handle both the serialization/deserialization - but it also encoded the runtime logic/validation. The spicepod crate should only be concerned with how to parse a spicepod from an external representation. The semantics of interpreting the Spicepod should live in the runtime crate.
2. Changes the parameters for a dataset from `Option<HashMap<String, String>>` to just a `HashMap<String, String>`. It was unnecessary and made the code more complicated than it needed to be.
3. Removes unnecessary feature flags from the spicepod crate

This is a pre-req PR for changing the `runtime::component::dataset::Dataset.name` type from `String` to `TableReference`. At which point we can support dataset names with schemas (i.e. `eth.recent_blocks`) which will lazily register the schema into the default catalog. The validation of parsing the name will be encoded into the new Runtime Dataset struct.