### PR TITLE
Use TableReference for dataset name

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -28,6 +28,7 @@ use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::{Operator, TableProviderFilterPushDown};
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{collect, ExecutionPlan};
+use datafusion::sql::TableReference;
 use datafusion::{
     datasource::{TableProvider, TableType},
     execution::context::SessionContext,
@@ -83,7 +84,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 // The accelerator must support inserts.
 // AcceleratedTable::new returns an instance of the table and a oneshot receiver that will be triggered when the table is ready, right after the initial data refresh finishes.
 pub struct AcceleratedTable {
-    dataset_name: String,
+    dataset_name: TableReference,
     accelerator: Arc<dyn TableProvider>,
     federated: Arc<dyn TableProvider>,
     refresh_trigger: Option<mpsc::Sender<()>>,
@@ -92,7 +93,11 @@ pub struct AcceleratedTable {
     refresh_params: Arc<RwLock<refresh::Refresh>>,
 }
 
-fn validate_refresh_data_window(refresh: &refresh::Refresh, dataset: &str, schema: &SchemaRef) {
+fn validate_refresh_data_window(
+    refresh: &refresh::Refresh,
+    dataset: &TableReference,
+    schema: &SchemaRef,
+) {
     if refresh.period.is_some() {
         if let Some(time_column) = &refresh.time_column {
             if schema.column_with_name(time_column).is_none() {
@@ -109,7 +114,7 @@ fn validate_refresh_data_window(refresh: &refresh::Refresh, dataset: &str, schem
 }
 
 pub struct Builder {
-    dataset_name: String,
+    dataset_name: TableReference,
     federated: Arc<dyn TableProvider>,
     accelerator: Arc<dyn TableProvider>,
     refresh: refresh::Refresh,
@@ -119,7 +124,7 @@ pub struct Builder {
 
 impl Builder {
     pub fn new(
-        dataset_name: String,
+        dataset_name: TableReference,
         federated: Arc<dyn TableProvider>,
         accelerator: Arc<dyn TableProvider>,
         refresh: refresh::Refresh,
@@ -223,7 +228,7 @@ impl Builder {
 
 impl AcceleratedTable {
     pub fn builder(
-        dataset_name: String,
+        dataset_name: TableReference,
         federated: Arc<dyn TableProvider>,
         accelerator: Arc<dyn TableProvider>,
         refresh: refresh::Refresh,
@@ -288,7 +293,7 @@ impl AcceleratedTable {
     #[allow(clippy::cast_possible_wrap)]
     #[allow(clippy::cast_possible_truncation)]
     async fn start_retention_check(
-        dataset_name: String,
+        dataset_name: TableReference,
         accelerator: Arc<dyn TableProvider>,
         retention: Retention,
     ) {

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -400,7 +400,7 @@ impl Refresher {
         let filter_converter = self.get_filter_converter(&refresh);
 
         tracing::info!("Loading data for dataset {dataset_name}");
-        status::update_dataset(dataset_name.clone(), status::ComponentStatus::Refreshing);
+        status::update_dataset(&dataset_name, status::ComponentStatus::Refreshing);
         let refresh = refresh.clone();
         let mut filters = vec![];
         if let Some(converter) = filter_converter.as_ref() {
@@ -493,7 +493,7 @@ impl Refresher {
     }
 
     fn mark_dataset_status(&self, status: status::ComponentStatus) {
-        status::update_dataset(self.dataset_name.clone(), status);
+        status::update_dataset(&self.dataset_name, status);
     }
 }
 
@@ -656,7 +656,7 @@ mod tests {
         metrics::set_global_recorder(recorder).expect("recorder is set globally");
 
         status::update_dataset(
-            TableReference::bare("test"),
+            &TableReference::bare("test"),
             status::ComponentStatus::Refreshing,
         );
 
@@ -673,7 +673,7 @@ mod tests {
         ));
 
         status::update_dataset(
-            TableReference::bare("test"),
+            &TableReference::bare("test"),
             status::ComponentStatus::Refreshing,
         );
 

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -117,11 +117,10 @@ impl TryFrom<spicepod_dataset::Dataset> for Dataset {
 }
 
 impl Dataset {
-    #[must_use]
-    pub fn try_new(from: String, name: String) -> Result<Self, crate::Error> {
+    pub fn try_new(from: String, name: &str) -> Result<Self, crate::Error> {
         Ok(Dataset {
             from,
-            name: Self::parse_table_reference(&name)?,
+            name: Self::parse_table_reference(name)?,
             mode: Mode::default(),
             sql: None,
             sql_ref: None,

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -112,7 +112,7 @@ pub trait DataAccelerator: Send + Sync {
 }
 
 pub struct AcceleratorExternalTableBuilder {
-    table_name: String,
+    table_name: TableReference,
     schema: SchemaRef,
     engine: Engine,
     mode: Mode,
@@ -122,7 +122,7 @@ pub struct AcceleratorExternalTableBuilder {
 
 impl AcceleratorExternalTableBuilder {
     #[must_use]
-    pub fn new(table_name: String, schema: SchemaRef, engine: Engine) -> Self {
+    pub fn new(table_name: TableReference, schema: SchemaRef, engine: Engine) -> Self {
         Self {
             table_name,
             schema,
@@ -191,7 +191,7 @@ impl AcceleratorExternalTableBuilder {
                 }
                 .build()
             })?,
-            name: TableReference::bare(self.table_name.clone()),
+            name: self.table_name.clone(),
             location: String::new(),
             file_type: String::new(),
             has_header: false,
@@ -212,13 +212,11 @@ impl AcceleratorExternalTableBuilder {
 }
 
 pub async fn create_accelerator_table(
-    table_name: &str,
+    table_name: TableReference,
     schema: SchemaRef,
     acceleration_settings: &acceleration::Acceleration,
     acceleration_secret: Option<Secret>,
 ) -> Result<Arc<dyn TableProvider>> {
-    let table_name = table_name.to_string();
-
     let engine = acceleration_settings.engine;
 
     let accelerator_guard = DATA_ACCELERATOR_ENGINES.lock().await;

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -513,7 +513,7 @@ mod tests {
         let connector = TestConnector {
             params: params.into(),
         };
-        let dataset = Dataset::new(path, "test".to_string());
+        let dataset = Dataset::try_new(path, "test".to_string()).expect("a valid dataset");
 
         (connector, dataset)
     }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -513,7 +513,7 @@ mod tests {
         let connector = TestConnector {
             params: params.into(),
         };
-        let dataset = Dataset::try_new(path, "test".to_string()).expect("a valid dataset");
+        let dataset = Dataset::try_new(path, "test").expect("a valid dataset");
 
         (connector, dataset)
     }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -205,8 +205,7 @@ mod tests {
         ];
 
         for (input, expected) in tests {
-            let dataset =
-                Dataset::try_new(input.clone(), "bar".to_string()).expect("a valid dataset");
+            let dataset = Dataset::try_new(input.clone(), "bar").expect("a valid dataset");
             assert_eq!(SpiceAI::spice_dataset_path(dataset), expected, "{input}");
         }
     }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -205,7 +205,8 @@ mod tests {
         ];
 
         for (input, expected) in tests {
-            let dataset = Dataset::new(input.clone(), "bar".to_string());
+            let dataset =
+                Dataset::try_new(input.clone(), "bar".to_string()).expect("a valid dataset");
             assert_eq!(SpiceAI::spice_dataset_path(dataset), expected, "{input}");
         }
     }

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -478,7 +478,7 @@ impl DataFusion {
         self.ctx.table_exist(dataset_name).unwrap_or(false)
     }
 
-    pub fn remove_table(&mut self, dataset_name: TableReference) -> Result<()> {
+    pub fn remove_table(&mut self, dataset_name: &TableReference) -> Result<()> {
         if !self.ctx.table_exist(dataset_name.clone()).unwrap_or(false) {
             return Ok(());
         }
@@ -490,8 +490,8 @@ impl DataFusion {
             .fail();
         }
 
-        if self.is_writable(&dataset_name) {
-            self.data_writers.remove(&dataset_name);
+        if self.is_writable(dataset_name) {
+            self.data_writers.remove(dataset_name);
         }
 
         Ok(())

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -185,7 +185,7 @@ pub enum Table {
 
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
-    data_writers: HashSet<String>,
+    data_writers: HashSet<TableReference>,
     cache_provider: Option<Arc<QueryResultCacheProvider>>,
 }
 
@@ -330,15 +330,17 @@ impl DataFusion {
 
     pub fn register_runtime_table(
         &mut self,
-        name: &str,
+        table_name: &str,
         table: Arc<dyn datafusion::datasource::TableProvider>,
     ) -> Result<()> {
         if let Some(runtime_schema) = self.runtime_schema() {
             runtime_schema
-                .register_table(name.to_string(), table)
+                .register_table(table_name.to_string(), table)
                 .context(UnableToRegisterTableToDataFusionSchemaSnafu { schema: "runtime" })?;
 
-            self.data_writers.insert(format!("runtime.{name}"));
+            let table_reference = TableReference::partial(SPICE_RUNTIME_SCHEMA, table_name);
+
+            self.data_writers.insert(table_reference);
         }
 
         Ok(())
@@ -362,7 +364,7 @@ impl DataFusion {
                         "Registering dataset {dataset:?} with preloaded accelerated table"
                     );
                     self.ctx
-                        .register_table(&dataset.name, Arc::new(accelerated_table))
+                        .register_table(dataset.name.clone(), Arc::new(accelerated_table))
                         .context(UnableToRegisterTableToDataFusionSnafu)?;
 
                     return Ok(());
@@ -371,7 +373,7 @@ impl DataFusion {
                     .await?;
             }
             Table::Federated(source) => self.register_federated_table(dataset, source).await?,
-            Table::View(sql) => self.register_view(&dataset.name, sql)?,
+            Table::View(sql) => self.register_view(dataset.name.clone(), sql)?,
         }
 
         if matches!(dataset.mode(), Mode::ReadWrite) {
@@ -383,13 +385,7 @@ impl DataFusion {
 
     #[must_use]
     pub fn is_writable(&self, table_reference: &TableReference) -> bool {
-        let mut table_name = table_reference.table().to_string();
-
-        if let Some(schema_name) = table_reference.schema() {
-            table_name = format!("{schema_name}.{table_name}");
-        }
-
-        self.data_writers.iter().any(|s| s.as_str() == table_name)
+        self.data_writers.iter().any(|s| s == table_reference)
     }
 
     async fn get_table_provider(
@@ -478,24 +474,24 @@ impl DataFusion {
     }
 
     #[must_use]
-    pub fn table_exists(&self, dataset_name: &str) -> bool {
+    pub fn table_exists(&self, dataset_name: TableReference) -> bool {
         self.ctx.table_exist(dataset_name).unwrap_or(false)
     }
 
-    pub fn remove_table(&mut self, dataset_name: &str) -> Result<()> {
-        if !self.ctx.table_exist(dataset_name).unwrap_or(false) {
+    pub fn remove_table(&mut self, dataset_name: TableReference) -> Result<()> {
+        if !self.ctx.table_exist(dataset_name.clone()).unwrap_or(false) {
             return Ok(());
         }
 
-        if let Err(e) = self.ctx.deregister_table(dataset_name) {
+        if let Err(e) = self.ctx.deregister_table(dataset_name.clone()) {
             return UnableToDeleteTableSnafu {
                 reason: e.to_string(),
             }
             .fail();
         }
 
-        if self.is_writable(&TableReference::bare(dataset_name)) {
-            self.data_writers.remove(dataset_name);
+        if self.is_writable(&dataset_name) {
+            self.data_writers.remove(&dataset_name);
         }
 
         Ok(())
@@ -535,7 +531,7 @@ impl DataFusion {
                 })?;
 
         let accelerated_table_provider = create_accelerator_table(
-            &dataset.name,
+            dataset.name.clone(),
             source_schema,
             &acceleration_settings,
             acceleration_secret,
@@ -545,12 +541,12 @@ impl DataFusion {
 
         let refresh_sql = dataset.refresh_sql();
         if let Some(refresh_sql) = &refresh_sql {
-            refresh_sql::validate_refresh_sql(&dataset.name, refresh_sql.as_str())
+            refresh_sql::validate_refresh_sql(dataset.name.clone(), refresh_sql.as_str())
                 .context(RefreshSqlSnafu)?;
         }
 
         let mut accelerated_table_builder = AcceleratedTable::builder(
-            dataset.name.to_string(),
+            dataset.name.clone(),
             source_table_provider,
             accelerated_table_provider,
             Refresh::new(
@@ -585,7 +581,7 @@ impl DataFusion {
             .await?;
 
         self.ctx
-            .register_table(&dataset.name, Arc::new(accelerated_table))
+            .register_table(dataset.name.clone(), Arc::new(accelerated_table))
             .context(UnableToRegisterTableToDataFusionSnafu)?;
 
         Ok(())
@@ -617,16 +613,17 @@ impl DataFusion {
 
     pub async fn update_refresh_sql(
         &self,
-        dataset_name: &str,
+        dataset_name: TableReference,
         refresh_sql: Option<String>,
     ) -> Result<()> {
         if let Some(sql) = &refresh_sql {
-            refresh_sql::validate_refresh_sql(dataset_name, sql).context(RefreshSqlSnafu)?;
+            refresh_sql::validate_refresh_sql(dataset_name.clone(), sql)
+                .context(RefreshSqlSnafu)?;
         }
 
         let table = self
             .ctx
-            .table_provider(TableReference::bare(dataset_name.to_string()))
+            .table_provider(dataset_name.clone())
             .await
             .context(UnableToGetTableSnafu)?;
 
@@ -648,7 +645,7 @@ impl DataFusion {
         source: Arc<dyn DataConnector>,
     ) -> Result<()> {
         tracing::debug!("Registering federated table {dataset:?}");
-        let table_exists = self.ctx.table_exist(&dataset.name).unwrap_or(false);
+        let table_exists = self.ctx.table_exist(dataset.name.clone()).unwrap_or(false);
         if table_exists {
             return TableAlreadyExistsSnafu.fail();
         }
@@ -671,14 +668,14 @@ impl DataFusion {
         };
 
         self.ctx
-            .register_table(&dataset.name, source_table_provider)
+            .register_table(dataset.name.clone(), source_table_provider)
             .context(UnableToRegisterTableToDataFusionSnafu)?;
 
         Ok(())
     }
 
-    fn register_view(&self, table_name: &str, view: String) -> Result<()> {
-        let table_exists = self.ctx.table_exist(table_name).unwrap_or(false);
+    fn register_view(&self, table: TableReference, view: String) -> Result<()> {
+        let table_exists = self.ctx.table_exist(table.clone()).unwrap_or(false);
         if table_exists {
             return TableAlreadyExistsSnafu.fail();
         }
@@ -697,14 +694,13 @@ impl DataFusion {
         }
 
         let ctx = Arc::clone(&self.ctx);
-        let table_name = table_name.to_string();
         spawn(async move {
             // Tables are currently lazily created (i.e. not created until first data is received) so that we know the table schema.
             // This means that we can't create a view on top of a table until the first data is received for all dependent tables and therefore
             // the tables are created. To handle this, wait until all tables are created.
 
             let deadline = Instant::now() + Duration::from_secs(60);
-            let mut unresolved_dependent_table: Option<String> = None;
+            let mut unresolved_dependent_table: Option<TableReference> = None;
             let dependent_table_names = get_dependent_table_names(&statements[0]);
             for dependent_table_name in dependent_table_names {
                 let mut attempts = 0;
@@ -714,14 +710,17 @@ impl DataFusion {
                 }
 
                 loop {
-                    if !ctx.table_exist(&dependent_table_name).unwrap_or(false) {
+                    if !ctx
+                        .table_exist(dependent_table_name.clone())
+                        .unwrap_or(false)
+                    {
                         if Instant::now() >= deadline {
                             unresolved_dependent_table = Some(dependent_table_name.clone());
                             break;
                         }
 
                         if attempts % 10 == 0 {
-                            tracing::warn!("Dependent table {dependent_table_name} for view {table_name} does not exist, retrying...");
+                            tracing::warn!("Dependent table {dependent_table_name} for view {table} does not exist, retrying...");
                         }
                         attempts += 1;
                         sleep(Duration::from_secs(1)).await;
@@ -732,7 +731,7 @@ impl DataFusion {
             }
 
             if let Some(missing_table) = unresolved_dependent_table {
-                tracing::error!("Failed to create view {table_name}. Dependent table {missing_table} does not exist.");
+                tracing::error!("Failed to create view {table}. Dependent table {missing_table} does not exist.");
                 return;
             }
 
@@ -751,14 +750,11 @@ impl DataFusion {
                     return;
                 }
             };
-            if let Err(e) = ctx.register_table(
-                TableReference::bare(table_name.clone()),
-                Arc::new(view_table),
-            ) {
+            if let Err(e) = ctx.register_table(table.clone(), Arc::new(view_table)) {
                 tracing::error!("Failed to create view: {e}");
             };
 
-            tracing::info!("Created view {table_name}");
+            tracing::info!("Created view {table}");
         });
 
         Ok(())

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -357,6 +357,7 @@ pub(crate) mod datasets {
         response::{IntoResponse, Response},
         Extension, Json,
     };
+    use datafusion::sql::TableReference;
     use serde::{Deserialize, Serialize};
     use tokio::sync::RwLock;
     use tract_core::tract_data::itertools::Itertools;
@@ -550,7 +551,10 @@ pub(crate) mod datasets {
         let df_read = df.read().await;
 
         match df_read
-            .update_refresh_sql(&dataset.name, payload.refresh_sql)
+            .update_refresh_sql(
+                TableReference::parse_str(&dataset.name),
+                payload.refresh_sql,
+            )
             .await
         {
             Ok(()) => (status::StatusCode::OK).into_response(),

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -44,7 +44,7 @@ fn convert_entry_to_csv<T: Serialize>(entries: &[T]) -> Result<String, Box<dyn s
 }
 
 fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
-    if df.table_exists(ds.name.as_str()) {
+    if df.table_exists(ds.name.clone()) {
         ComponentStatus::Ready
     } else {
         ComponentStatus::Error
@@ -428,7 +428,7 @@ pub(crate) mod datasets {
             .iter()
             .map(|d| DatasetResponseItem {
                 from: d.from.clone(),
-                name: d.name.clone(),
+                name: d.name.to_quoted_string(),
                 replication_enabled: d.replication.as_ref().is_some_and(|f| f.enabled),
                 acceleration_enabled: d.acceleration.as_ref().is_some_and(|f| f.enabled),
                 status: if params.status {

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use crate::component::dataset::replication::Replication;
 use arrow::datatypes::Schema;
 use datafusion::datasource::TableProvider;
+use datafusion::sql::TableReference;
 use secrets::Secret;
 use snafu::prelude::*;
 
@@ -47,13 +48,26 @@ pub enum Error {
 
     #[snafu(display("Unable to create accelerated table provider: {source}"))]
     UnableToCreateAcceleratedTableProvider { source: dataaccelerator::Error },
+
+    #[snafu(display(
+        "An internal error occurred. Report a bug on GitHub (github.com/spiceai/spiceai) and reference the code: {code}"
+    ))]
+    Internal {
+        code: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 async fn get_local_table_provider(
-    name: &str,
+    name: TableReference,
     schema: &Arc<Schema>,
 ) -> Result<Arc<dyn TableProvider>, Error> {
-    let mut dataset = Dataset::new("localhost://internal".to_string(), name.to_string());
+    // This shouldn't error because we control the name passed in, and it shouldn't contain a catalog.
+    let mut dataset = Dataset::try_new("localhost://internal".to_string(), name.to_quoted_string())
+        .boxed()
+        .context(InternalSnafu {
+            code: "IT-GLTP-DTN".to_string(), // InternalTable - GetLocalTableProvider - DatasetTryNew
+        })?;
     dataset.mode = Mode::ReadWrite;
 
     let data_connector =
@@ -69,21 +83,21 @@ async fn get_local_table_provider(
 }
 
 pub async fn create_internal_accelerated_table(
-    name: &str,
+    name: TableReference,
     schema: Arc<Schema>,
     acceleration: Acceleration,
     refresh: Refresh,
     retention: Option<Retention>,
 ) -> Result<Arc<AcceleratedTable>, Error> {
-    let source_table_provider = get_local_table_provider(name, &schema).await?;
+    let source_table_provider = get_local_table_provider(name.clone(), &schema).await?;
 
     let accelerated_table_provider =
-        create_accelerator_table(name, Arc::clone(&schema), &acceleration, None)
+        create_accelerator_table(name.clone(), Arc::clone(&schema), &acceleration, None)
             .await
             .context(UnableToCreateAcceleratedTableProviderSnafu)?;
 
     let mut builder = AcceleratedTable::builder(
-        name.to_string(),
+        name.clone(),
         source_table_provider,
         accelerated_table_provider,
         refresh,
@@ -101,7 +115,8 @@ async fn get_spiceai_table_provider(
     cloud_dataset_path: &str,
     secret: Option<Secret>,
 ) -> Result<Arc<dyn TableProvider>, Error> {
-    let mut dataset = Dataset::new(cloud_dataset_path.to_string(), name.to_string());
+    // TODO
+    let mut dataset = Dataset::try_new(cloud_dataset_path.to_string(), name.to_string());
     dataset.mode = Mode::ReadWrite;
     dataset.replication = Some(Replication { enabled: true });
 

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -63,7 +63,7 @@ async fn get_local_table_provider(
     schema: &Arc<Schema>,
 ) -> Result<Arc<dyn TableProvider>, Error> {
     // This shouldn't error because we control the name passed in, and it shouldn't contain a catalog.
-    let mut dataset = Dataset::try_new("localhost://internal".to_string(), name.to_quoted_string())
+    let mut dataset = Dataset::try_new("localhost://internal".to_string(), &name.to_string())
         .boxed()
         .context(InternalSnafu {
             code: "IT-GLTP-DTN".to_string(), // InternalTable - GetLocalTableProvider - DatasetTryNew
@@ -111,12 +111,16 @@ pub async fn create_internal_accelerated_table(
 }
 
 async fn get_spiceai_table_provider(
-    name: &str,
+    name: TableReference,
     cloud_dataset_path: &str,
     secret: Option<Secret>,
 ) -> Result<Arc<dyn TableProvider>, Error> {
-    // TODO
-    let mut dataset = Dataset::try_new(cloud_dataset_path.to_string(), name.to_string());
+    // This shouldn't error because we control the name passed in, and it shouldn't contain a catalog.
+    let mut dataset = Dataset::try_new(cloud_dataset_path.to_string(), &name.to_string())
+        .boxed()
+        .context(InternalSnafu {
+            code: "IT-GSTP-DTN".to_string(), // InternalTable - GetSpiceaiTableProvider - DatasetTryNew
+        })?;
     dataset.mode = Mode::ReadWrite;
     dataset.replication = Some(Replication { enabled: true });
 
@@ -135,22 +139,26 @@ async fn get_spiceai_table_provider(
 }
 
 pub async fn create_synced_internal_accelerated_table(
-    name: &str,
+    name: TableReference,
     from: &str,
     secret: Option<Secret>,
     acceleration: Acceleration,
     refresh: Refresh,
     retention: Option<Retention>,
 ) -> Result<Arc<AcceleratedTable>, Error> {
-    let source_table_provider = get_spiceai_table_provider(name, from, secret).await?;
+    let source_table_provider = get_spiceai_table_provider(name.clone(), from, secret).await?;
 
-    let accelerated_table_provider =
-        create_accelerator_table(name, source_table_provider.schema(), &acceleration, None)
-            .await
-            .context(UnableToCreateAcceleratedTableProviderSnafu)?;
+    let accelerated_table_provider = create_accelerator_table(
+        name.clone(),
+        source_table_provider.schema(),
+        &acceleration,
+        None,
+    )
+    .await
+    .context(UnableToCreateAcceleratedTableProviderSnafu)?;
 
     let mut builder = AcceleratedTable::builder(
-        name.to_string(),
+        name.clone(),
         source_table_provider,
         accelerated_table_provider,
         refresh,

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -95,7 +95,7 @@ impl MetricsRecorder {
                 };
 
                 create_synced_internal_accelerated_table(
-                    "metrics",
+                    TableReference::bare("metrics"),
                     path.as_str(),
                     secret,
                     Acceleration::default(),
@@ -106,7 +106,7 @@ impl MetricsRecorder {
                 .context(UnableToCreateMetricsTableSnafu)?
             }
             None => create_internal_accelerated_table(
-                "metrics",
+                TableReference::bare("metrics"),
                 get_metrics_schema(),
                 Acceleration::default(),
                 Refresh::default(),

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::fmt::Display;
 
+use datafusion::sql::TableReference;
 use metrics::gauge;
 use serde::{Deserialize, Serialize};
 
@@ -41,8 +42,8 @@ impl Display for ComponentStatus {
     }
 }
 
-pub fn update_dataset(ds_name: &str, status: ComponentStatus) {
-    let ds_name = ds_name.to_string();
+pub fn update_dataset(dataset: TableReference, status: ComponentStatus) {
+    let ds_name = dataset.to_string();
     gauge!("dataset/status", "dataset" => ds_name).set(f64::from(status as u32));
 }
 

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -42,7 +42,7 @@ impl Display for ComponentStatus {
     }
 }
 
-pub fn update_dataset(dataset: TableReference, status: ComponentStatus) {
+pub fn update_dataset(dataset: &TableReference, status: ComponentStatus) {
     let ds_name = dataset.to_string();
     gauge!("dataset/status", "dataset" => ds_name).set(f64::from(status as u32));
 }


### PR DESCRIPTION
Another refactoring PR that changes the `name` on the Runtime's dataset struct to be a `TableReference` instead of just a string.

We validate when creating a Runtime Dataset from a Spicepod Dataset that it is either a Schema TableReference (i.e. `schema.table`) or a "bare" table (i.e. `table`), and error out on a "full" table reference, (i.e. `catalog.schema.table`).

In the next PR I will auto create schemas when they are referenced by a dataset, but catalog support will be a separate feature.

This means the following dataset registration would be allowed:
```yaml
datasets:
- from: spiceai:eth.recent_blocks
  name: eth.recent_blocks
```

And querying like this will work:
`SELECT * FROM eth.recent_blocks`