### PR TITLE
Allow datasets to specify a schema

### DIFF
--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -144,7 +144,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                 continue;
             }
             "show tables" | "show tables;" => {
-                "select table_name, table_type from information_schema.tables where table_schema = 'public'"
+                "select table_catalog, table_schema, table_name, table_type from information_schema.tables where table_schema != 'information_schema'"
             }
             line if line.to_lowercase().starts_with(NQL_LINE_PREFIX) => {
                 let _ = rl.add_history_entry(line);

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -353,6 +353,8 @@ impl DataFusion {
     ) -> Result<()> {
         let dataset = dataset.borrow();
 
+        schema::ensure_schema_exists(&self.ctx, SPICE_DEFAULT_CATALOG, &dataset.name)?;
+
         match table {
             Table::Accelerated {
                 source,

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -27,6 +27,7 @@ use bytes::Bytes;
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SQLOptions;
 use datafusion::sql::sqlparser::parser::ParserError;
+use datafusion::sql::TableReference;
 use futures::stream::{self, BoxStream, StreamExt};
 use futures::{Stream, TryStreamExt};
 use snafu::prelude::*;
@@ -53,7 +54,7 @@ use arrow_flight::{
 
 pub struct Service {
     datafusion: Arc<RwLock<DataFusion>>,
-    channel_map: Arc<RwLock<HashMap<String, Arc<Sender<DataUpdate>>>>>,
+    channel_map: Arc<RwLock<HashMap<TableReference, Arc<Sender<DataUpdate>>>>>,
 }
 
 #[tonic::async_trait]

--- a/crates/runtime/src/flight/do_exchange.rs
+++ b/crates/runtime/src/flight/do_exchange.rs
@@ -62,14 +62,9 @@ pub(crate) async fn handle(
         ));
     };
 
-    let data_path = flight_descriptor.path.join(".");
+    let data_path = TableReference::parse_str(&flight_descriptor.path.join("."));
 
-    if !flight_svc
-        .datafusion
-        .read()
-        .await
-        .is_writable(&TableReference::bare(data_path.to_string()))
-    {
+    if !flight_svc.datafusion.read().await.is_writable(&data_path) {
         return Err(Status::invalid_argument(format!(
             r#"Unknown dataset: "{data_path}""#,
         )));
@@ -137,7 +132,7 @@ pub(crate) async fn handle(
             .read()
             .await
             .ctx
-            .sql(&format!(r#"SELECT * FROM "{data_path}""#))
+            .sql(&format!(r#"SELECT * FROM {data_path}"#))
             .await
         else {
             return;


### PR DESCRIPTION
Changes the behavior to allow datasets to specify a schema (i.e. `schema.table`) in the dataset name.

NOTE: This still has a bug where the column identifiers will reference the schema on federation push down, which is incorrect

i.e. it will try to generate SQL:
`SELECT foo.tbl.id, foo.tbl.col_a FROM real_table AS tbl`
from the following dataset:
```yaml
datasets:
- from: real_table
  name: foo.tbl
```

when doing `SELECT * FROM foo.tbl`, which is incorrect, it should be:


```diff
--- SELECT foo.tbl.id, foo.tbl.col_a FROM real_table AS tbl
+++ SELECT tbl.id, tbl.col_a FROM real_table AS tbl
```

This is a bug in DataFusion's unparsing logic.