### PR TITLE
Fix refresh_sql not properly passing down filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.1.3"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=74dd1cdc3a20b989f1b272f5f6b7a1f8f0be5a46#74dd1cdc3a20b989f1b272f5f6b7a1f8f0be5a46"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=b221f4ec87ad57dc7e026fa9e5f5935bfe6b3961#b221f4ec87ad57dc7e026fa9e5f5935bfe6b3961"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation-sql"
 version = "0.1.3"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=74dd1cdc3a20b989f1b272f5f6b7a1f8f0be5a46#74dd1cdc3a20b989f1b272f5f6b7a1f8f0be5a46"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=b221f4ec87ad57dc7e026fa9e5f5935bfe6b3961#b221f4ec87ad57dc7e026fa9e5f5935bfe6b3961"
 dependencies = [
  "async-trait",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,5 +71,5 @@ arrow-odbc = { version = "9.0.0" }
 snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", folder = "snowflake-api", rev = "5dab964abef23314e7a3f27ae89b83352e315206" }
 suppaftp = { version = "5.3.1", features = ["async"] }
 ssh2 = { version = "0.9.4" }
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "74dd1cdc3a20b989f1b272f5f6b7a1f8f0be5a46" }
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "74dd1cdc3a20b989f1b272f5f6b7a1f8f0be5a46" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b221f4ec87ad57dc7e026fa9e5f5935bfe6b3961" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "b221f4ec87ad57dc7e026fa9e5f5935bfe6b3961" }


### PR DESCRIPTION
Fixes a bug when using `refresh_sql` on an accelerated table, where the filters were not being correctly applied - resulting in a large table scan of the source dataset.

PR that fixed the issue in datafusion-federation: https://github.com/spiceai/datafusion-federation/pull/2