### PR TITLE
pass table_reference full string into spark_session table so it can query across schemas or catalogs

### DIFF
--- a/crates/data_components/src/spark_connect.rs
+++ b/crates/data_components/src/spark_connect.rs
@@ -76,15 +76,7 @@ async fn get_table_provider(
     spark_session: Arc<SparkSession>,
     table_reference: TableReference,
 ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>> {
-    if let Some(catalog_name) = table_reference.catalog() {
-        let spark_session = Arc::clone(&spark_session);
-        spark_session.setCatalog(catalog_name).collect().await?;
-    }
-    if let Some(database) = table_reference.schema() {
-        let spark_session = Arc::clone(&spark_session);
-        spark_session.setDatabase(database).collect().await?;
-    }
-    let dataframe = spark_session.table(table_reference.table())?;
+    let dataframe = spark_session.table(table_reference.to_string().as_str())?;
     let arrow_schema = dataframe.clone().limit(0).collect().await?.schema();
     Ok(Arc::new(SparkConnectTableProvider {
         dataframe,


### PR DESCRIPTION
fix #1308 .

The issue was caused by using bare name of the table reference when fetching data from spark. In this case, the spark session will only look for tables within current catalog/database. Passing the full string of the table reference will enable spark session to do the correct lookup.

<img width="1115" alt="image" src="https://github.com/spiceai/spiceai/assets/561715/3b98ae37-cbf5-4db0-b20b-874a87322343">
