### PR TITLE
Trace on debug level for tables in `runtime` schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,6 +1783,7 @@ dependencies = [
  "moka",
  "snafu 0.8.2",
  "spicepod",
+ "tokio",
  "tracing",
 ]
 

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -34,6 +34,7 @@ default = [
   "spark",
   "snowflake",
   "ftp",
+  "spice-cloud"
 ]
 duckdb = ["runtime/duckdb"]
 postgres = ["runtime/postgres"]

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -84,7 +84,7 @@ fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
     let filter = if let Ok(env_log) = std::env::var("SPICED_LOG") {
         EnvFilter::new(env_log)
     } else {
-        EnvFilter::new("spiced=INFO,runtime=INFO,secrets=INFO,sql_provider_datafusion=INFO,data_components=INFO,cache=INFO,extensions=INFO,spiceai_extension=INFO")
+        EnvFilter::new("spiced=INFO,runtime=INFO,secrets=INFO,sql_provider_datafusion=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO")
     };
 
     let subscriber = tracing_subscriber::FmtSubscriber::builder()

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -350,13 +350,13 @@ impl AcceleratedTable {
                     tracing::warn!("[retention] Unable to convert timestamp");
                     continue;
                 };
-                if dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
-                    tracing::info!(
+                if dataset_name.schema() == Some(SPICE_RUNTIME_SCHEMA) {
+                    tracing::debug!(
                         "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
                         timestamp
                     );
                 } else {
-                    tracing::debug!(
+                    tracing::info!(
                         "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
                         timestamp
                     );
@@ -381,10 +381,10 @@ impl AcceleratedTable {
                                         .map_or(0, |v| v.values().first().map_or(0, |f| *f))
                                 });
 
-                                if dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
-                                    tracing::info!("[retention] Evicted {num_records} records for {dataset_name}");
-                                } else {
+                                if dataset_name.schema() == Some(SPICE_RUNTIME_SCHEMA) {
                                     tracing::debug!("[retention] Evicted {num_records} records for {dataset_name}");
+                                } else {
+                                    tracing::info!("[retention] Evicted {num_records} records for {dataset_name}");
                                 }
 
                                 if num_records > 0 {

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -19,6 +19,7 @@ use std::{any::Any, sync::Arc, time::Duration};
 
 use crate::component::dataset::acceleration::{RefreshMode, ZeroResultsAction};
 use crate::component::dataset::TimeFormat;
+use crate::datafusion::SPICE_RUNTIME_SCHEMA;
 use arrow::array::UInt64Array;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
@@ -267,10 +268,12 @@ impl AcceleratedTable {
     pub async fn update_refresh_sql(&self, refresh_sql: Option<String>) -> Result<()> {
         let dataset_name = &self.dataset_name;
 
-        if let Some(sql_str) = &refresh_sql {
-            tracing::info!("[refresh] Updating refresh SQL for {dataset_name} to {sql_str}");
-        } else {
-            tracing::info!("[refresh] Removing refresh SQL for {dataset_name}");
+        if self.dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
+            if let Some(sql_str) = &refresh_sql {
+                tracing::info!("[refresh] Updating refresh SQL for {dataset_name} to {sql_str}");
+            } else {
+                tracing::info!("[refresh] Removing refresh SQL for {dataset_name}");
+            }
         }
         let mut refresh = self.refresh_params.write().await;
         refresh.sql = refresh_sql;
@@ -338,17 +341,26 @@ impl AcceleratedTable {
 
                 let timestamp = refresh::get_timestamp(start);
                 let expr = timestamp_filter_converter.convert(timestamp, Operator::Lt);
-                tracing::info!(
-                    "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
-                    if let Some(value) =
-                        chrono::DateTime::from_timestamp((timestamp / 1_000_000_000) as i64, 0)
-                    {
-                        value.to_rfc3339()
-                    } else {
-                        tracing::warn!("[retention] Unable to convert timestamp");
-                        continue;
-                    }
-                );
+
+                let timestamp = if let Some(value) =
+                    chrono::DateTime::from_timestamp((timestamp / 1_000_000_000) as i64, 0)
+                {
+                    value.to_rfc3339()
+                } else {
+                    tracing::warn!("[retention] Unable to convert timestamp");
+                    continue;
+                };
+                if dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
+                    tracing::info!(
+                        "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
+                        timestamp
+                    );
+                } else {
+                    tracing::debug!(
+                        "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
+                        timestamp
+                    );
+                }
 
                 tracing::debug!("[retention] Expr {expr:?}");
 
@@ -369,9 +381,11 @@ impl AcceleratedTable {
                                         .map_or(0, |v| v.values().first().map_or(0, |f| *f))
                                 });
 
-                                tracing::info!(
-                                    "[retention] Evicted {num_records} records for {dataset_name}",
-                                );
+                                if dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
+                                    tracing::info!("[retention] Evicted {num_records} records for {dataset_name}");
+                                } else {
+                                    tracing::debug!("[retention] Evicted {num_records} records for {dataset_name}");
+                                }
 
                                 if num_records > 0 {
                                     if let Some(cache_provider) = &cache_provider {

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -142,12 +142,12 @@ impl Refresher {
                     {
                         if let Some(start_time) = start_time {
                             if let Ok(elapse) = util::humantime_elapsed(start_time) {
-                                if dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
-                                    tracing::info!(
+                                if dataset_name.schema() == Some(SPICE_RUNTIME_SCHEMA) {
+                                    tracing::debug!(
                                         "Loaded 0 rows for dataset {dataset_name} in {elapse}."
                                     );
                                 } else {
-                                    tracing::debug!(
+                                    tracing::info!(
                                         "Loaded 0 rows for dataset {dataset_name} in {elapse}."
                                     );
                                 }
@@ -189,10 +189,10 @@ impl Refresher {
                                     );
 
                                     if let Ok(elapse) = util::humantime_elapsed(start_time) {
-                                        if dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
-                                            tracing::info!("Loaded {num_rows} rows ({memory_size}) for dataset {dataset_name} in {elapse}.");
-                                        } else {
+                                        if dataset_name.schema() == Some(SPICE_RUNTIME_SCHEMA) {
                                             tracing::debug!("Loaded {num_rows} rows ({memory_size}) for dataset {dataset_name} in {elapse}.");
+                                        } else {
+                                            tracing::info!("Loaded {num_rows} rows ({memory_size}) for dataset {dataset_name} in {elapse}.");
                                         }
                                     }
 
@@ -430,10 +430,10 @@ impl Refresher {
         let refresh = self.refresh.read().await;
         let filter_converter = self.get_filter_converter(&refresh);
 
-        if dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
-            tracing::info!("Loading data for dataset {dataset_name}");
-        } else {
+        if dataset_name.schema() == Some(SPICE_RUNTIME_SCHEMA) {
             tracing::debug!("Loading data for dataset {dataset_name}");
+        } else {
+            tracing::info!("Loading data for dataset {dataset_name}");
         }
         status::update_dataset(&dataset_name, status::ComponentStatus::Refreshing);
         let refresh = refresh.clone();


### PR DESCRIPTION
If table is in `runtime` schema, use debug level for traces.

> note: that won't silence logs from `runtime.metrics` for now because that table manually registered in runtime schema. That will be updated in separate PR, after refactoring in #1523 