### PR TITLE
Register runtime tables with runtime schema

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -360,17 +360,15 @@ impl DataFusion {
 
     pub fn register_runtime_table(
         &mut self,
-        table_name: &str,
+        table_name: TableReference,
         table: Arc<dyn datafusion::datasource::TableProvider>,
     ) -> Result<()> {
         if let Some(runtime_schema) = self.runtime_schema() {
             runtime_schema
-                .register_table(table_name.to_string(), table)
+                .register_table(table_name.table().to_string(), table)
                 .context(UnableToRegisterTableToDataFusionSchemaSnafu { schema: "runtime" })?;
 
-            let table_reference = TableReference::partial(SPICE_RUNTIME_SCHEMA, table_name);
-
-            self.data_writers.insert(table_reference);
+            self.data_writers.insert(table_name);
         }
 
         Ok(())

--- a/crates/runtime/src/query_history.rs
+++ b/crates/runtime/src/query_history.rs
@@ -19,8 +19,8 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use crate::component::dataset::acceleration::Acceleration;
 use crate::component::dataset::TimeFormat;
+use crate::{component::dataset::acceleration::Acceleration, datafusion::SPICE_RUNTIME_SCHEMA};
 use arrow::{
     array::{BooleanArray, RecordBatch, StringArray, TimestampNanosecondArray, UInt64Array},
     datatypes::{DataType, Field, Schema, TimeUnit},
@@ -49,8 +49,10 @@ pub async fn instantiate_query_history_table() -> Result<Arc<AcceleratedTable>, 
         Some(Duration::from_secs(300)),
         true,
     );
+    let query_history_table_reference =
+        TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_QUERY_HISTORY_TABLE);
     create_internal_accelerated_table(
-        DEFAULT_QUERY_HISTORY_TABLE.into(),
+        query_history_table_reference,
         Arc::new(table_schema()),
         Acceleration::default(),
         Refresh::default(),

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -80,8 +80,7 @@ impl MetricsRecorder {
         );
 
         let table = create_internal_accelerated_table(
-            // we don't support register with custom schema yet
-            TableReference::bare(metrics_table_reference.table()),
+            metrics_table_reference.clone(),
             get_metrics_schema(),
             Acceleration::default(),
             Refresh::default(),
@@ -93,7 +92,7 @@ impl MetricsRecorder {
         datafusion
             .write()
             .await
-            .register_runtime_table(metrics_table_reference.table(), table)
+            .register_runtime_table(metrics_table_reference, table)
             .context(UnableToRegisterToMetricsTableSnafu)?;
 
         Ok(())

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -119,7 +119,7 @@ impl Extension for SpiceExtension {
                 .datafusion()
                 .write()
                 .await
-                .register_runtime_table(metrics_table_reference.table(), table)
+                .register_runtime_table(metrics_table_reference, table)
                 .boxed()
                 .map_err(|e| runtime::extension::Error::UnableToStartExtension { source: e })?;
 


### PR DESCRIPTION
Removes the logging for the internal tables (metrics, query history) by default.

<img width="784" alt="Screenshot 2024-05-28 at 8 23 17 AM" src="https://github.com/spiceai/spiceai/assets/879445/1afa22a7-9f78-46cf-9c99-cab7d9e7ee12">
