### PR TITLE
Update MSRV to 1.78 and remove unused Rust Version parameter in CI

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,10 +1,6 @@
 name: Sets up the Rust toolchain
 description: 'composite action'
 inputs:
-  rust-version:
-    description: 'Rust version to setup'
-    default: '1.76'
-    required: false
   os:
     description: 'Operating system to set up the toolchain for'
     default: 'linux' # 'linux', 'darwin', 'windows'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 [workspace.package]
 version = "0.14.0-alpha"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.78"
 license = "Apache-2.0"
 homepage = "https://spice.ai"
 repository = "https://github.com/spiceai/spiceai"

--- a/crates/sql_provider_datafusion/src/lib.rs
+++ b/crates/sql_provider_datafusion/src/lib.rs
@@ -127,7 +127,7 @@ impl<T, P> SqlTable<T, P> {
 
     // Return the current memory location of the object as a unique identifier
     fn unique_id(&self) -> usize {
-        self as *const _ as usize
+        std::ptr::from_ref(self) as usize
     }
 }
 


### PR DESCRIPTION
Updates the MSRV (Minimum Supported Rust Version) to 1.78 and removes an unused parameter to specify a Rust version in CI.