### PR TITLE
Update spice_cloud extension params, and remove logging

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -232,7 +232,6 @@ impl Runtime {
                 tracing::warn!("Failed to initialize extension {extension_name}: {err}");
             } else {
                 extensions.push(extension);
-                tracing::info!("Loaded extension {extension_name}");
             };
         }
 

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -65,7 +65,7 @@ impl SpiceExtension {
     fn spice_http_url(&self) -> String {
         self.manifest
             .params
-            .get("api_url")
+            .get("endpoint")
             .unwrap_or(&"https://data.spiceai.io".to_string())
             .to_string()
     }
@@ -176,8 +176,6 @@ impl Extension for SpiceExtension {
             return Ok(());
         }
 
-        tracing::info!("Initializing Spice.ai Cloud Extension");
-
         Ok(())
     }
 
@@ -185,8 +183,6 @@ impl Extension for SpiceExtension {
         if !self.manifest.enabled {
             return Ok(());
         }
-
-        tracing::info!("Starting Spice.ai Cloud Extension");
 
         let secret = self
             .get_spice_secret(runtime)


### PR DESCRIPTION
Updated spice_cloud endpoint param:

```
extensions:
  spice_cloud:
    params:
      endpoint: https://dev-data.spiceai.io
```

Removed extension loaded/started traces