### PR TITLE
Store local runtime metrics in Timestamp with nanoseconds precision and UTC time

### DIFF
--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -18,9 +18,10 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use arrow::array::{Float64Array, Int64Array, StringArray};
+use arrow::array::{Float64Array, StringArray, TimestampNanosecondArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+use chrono::Utc;
 use datafusion::sql::TableReference;
 use snafu::prelude::*;
 use tokio::spawn;
@@ -129,7 +130,12 @@ impl MetricsRecorder {
                 prometheus_parse::Value::Summary(v) => v.into_iter().map(|v| v.count).sum(),
             };
 
-            timestamps.push(sample.timestamp.timestamp());
+            let timestamp = sample.timestamp.with_timezone(&Utc);
+            if let Some(timestamp_nano) = timestamp.timestamp_nanos_opt() {
+                timestamps.push(timestamp_nano);
+            } else {
+                timestamps.push(timestamp.timestamp_micros() * 1000);
+            }
             metrics.push(sample.metric);
             values.push(value);
             labels.push(sample.labels.to_string());
@@ -141,7 +147,9 @@ impl MetricsRecorder {
             data: vec![RecordBatch::try_new(
                 Arc::clone(&schema),
                 vec![
-                    Arc::new(Int64Array::from(timestamps)),
+                    Arc::new(
+                        TimestampNanosecondArray::from(timestamps).with_timezone(Arc::from("UTC")),
+                    ),
                     Arc::new(StringArray::from(metrics)),
                     Arc::new(Float64Array::from(values)),
                     Arc::new(StringArray::from(labels)),
@@ -179,13 +187,14 @@ impl MetricsRecorder {
 #[must_use]
 pub fn get_metrics_schema() -> Arc<Schema> {
     let fields = vec![
-        // TODO: Use timestamp
-        // Field::new(
-        //     "timestamp",
-        //     DataType::Timestamp(TimeUnit::Second, None),
-        //     false,
-        // ),
-        Field::new("timestamp", DataType::Int64, false),
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(
+                arrow::datatypes::TimeUnit::Nanosecond,
+                Some(Arc::from("UTC")),
+            ),
+            false,
+        ),
         Field::new("name", DataType::Utf8, false),
         Field::new("value", DataType::Float64, false),
         Field::new("labels", DataType::Utf8, false),


### PR DESCRIPTION
Updated `spice.runtime.metrics` to use Timestamp with nanoseconds and UTC for timestamp column

![CleanShot 2024-05-29 at 12 07 36@2x](https://github.com/spiceai/spiceai/assets/827338/6423cec7-f3a2-4336-be4c-3fcbd695757b)
