### PR TITLE
Cast `runtime.metrics` schema, if remote (spiceai) data connector provided

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -370,6 +370,13 @@ impl DataFusion {
         self.ctx.table(table_name).await.is_ok()
     }
 
+    pub async fn get_table(
+        &self,
+        table_reference: TableReference,
+    ) -> Option<Arc<dyn TableProvider>> {
+        self.ctx.table_provider(table_reference).await.ok()
+    }
+
     pub fn register_runtime_table(
         &mut self,
         table_name: TableReference,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -798,17 +798,14 @@ impl Runtime {
 
     pub async fn start_metrics(&mut self, with_metrics: Option<SocketAddr>) -> Result<()> {
         if let Some(metrics_socket) = with_metrics {
-            let recorder = MetricsRecorder::new(metrics_socket);
+            let mut recorder = MetricsRecorder::new(metrics_socket);
 
-            // check if runtime.metrics already registered, otherwise create local table
-            let has_metrics_table = self
-                .df
-                .read()
-                .await
-                .has_table(&get_metrics_table_reference())
-                .await;
+            let table_reference = get_metrics_table_reference();
+            let metrics_table = self.df.read().await.get_table(table_reference).await;
 
-            if !has_metrics_table {
+            if let Some(metrics_table) = metrics_table {
+                recorder.set_remote_schema(Arc::new(Some(metrics_table.schema())));
+            } else {
                 tracing::debug!("Registering local metrics table");
                 MetricsRecorder::register_metrics_table(&self.df)
                     .await

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use arrow::array::{Float64Array, StringArray, TimestampNanosecondArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+use arrow_tools::record_batch::{self, try_cast_to};
 use chrono::Utc;
 use datafusion::sql::TableReference;
 use snafu::prelude::*;
@@ -41,6 +42,9 @@ pub enum Error {
     #[snafu(display("Error creating record batch: {source}",))]
     UnableToCreateRecordBatch { source: arrow::error::ArrowError },
 
+    #[snafu(display("Error casting record batch: {source}",))]
+    UnableToCastRecordBatch { source: record_batch::Error },
+
     #[snafu(display("Error queriing prometheus metrics: {source}"))]
     FailedToQueryPrometheusMetrics { source: reqwest::Error },
 
@@ -59,6 +63,7 @@ pub enum Error {
 
 pub struct MetricsRecorder {
     socket_addr: Arc<SocketAddr>,
+    remote_schema: Arc<Option<Arc<Schema>>>,
 }
 
 impl MetricsRecorder {
@@ -66,7 +71,12 @@ impl MetricsRecorder {
     pub fn new(socket_addr: SocketAddr) -> Self {
         Self {
             socket_addr: Arc::new(socket_addr),
+            remote_schema: Arc::new(None),
         }
+    }
+
+    pub fn set_remote_schema(&mut self, schema: Arc<Option<Arc<Schema>>>) {
+        self.remote_schema = schema;
     }
 
     pub async fn register_metrics_table(datafusion: &Arc<RwLock<DataFusion>>) -> Result<(), Error> {
@@ -102,6 +112,7 @@ impl MetricsRecorder {
     async fn tick(
         socket_addr: &SocketAddr,
         datafusion: &Arc<RwLock<DataFusion>>,
+        remote_schema: &Arc<Option<Arc<Schema>>>,
     ) -> Result<(), Error> {
         let body = reqwest::get(format!("http://{socket_addr}/metrics"))
             .await
@@ -141,21 +152,30 @@ impl MetricsRecorder {
             labels.push(sample.labels.to_string());
         }
 
-        let schema = get_metrics_schema();
+        let mut schema = get_metrics_schema();
+        let mut record_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(
+                    TimestampNanosecondArray::from(timestamps).with_timezone(Arc::from("UTC")),
+                ),
+                Arc::new(StringArray::from(metrics)),
+                Arc::new(Float64Array::from(values)),
+                Arc::new(StringArray::from(labels)),
+            ],
+        )
+        .context(UnableToCreateRecordBatchSnafu)?;
+
+        // If a remote schema is provided, cast the record batch to it
+        if let Some(remote_schema) = remote_schema.as_ref() {
+            schema = Arc::clone(remote_schema);
+            record_batch = try_cast_to(record_batch.clone(), Arc::clone(remote_schema))
+                .context(UnableToCastRecordBatchSnafu)?;
+        }
+
         let data_update = DataUpdate {
             schema: Arc::clone(&schema),
-            data: vec![RecordBatch::try_new(
-                Arc::clone(&schema),
-                vec![
-                    Arc::new(
-                        TimestampNanosecondArray::from(timestamps).with_timezone(Arc::from("UTC")),
-                    ),
-                    Arc::new(StringArray::from(metrics)),
-                    Arc::new(Float64Array::from(values)),
-                    Arc::new(StringArray::from(labels)),
-                ],
-            )
-            .context(UnableToCreateRecordBatchSnafu)?],
+            data: vec![record_batch],
             update_type: crate::dataupdate::UpdateType::Append,
         };
 
@@ -172,10 +192,11 @@ impl MetricsRecorder {
     pub fn start(&self, datafusion: &Arc<RwLock<DataFusion>>) {
         let addr = Arc::clone(&self.socket_addr);
         let df = Arc::clone(datafusion);
+        let schema = Arc::clone(&self.remote_schema);
 
         spawn(async move {
             loop {
-                if let Err(err) = MetricsRecorder::tick(&addr, &df).await {
+                if let Err(err) = MetricsRecorder::tick(&addr, &df, &schema).await {
                     tracing::error!("{err}");
                 }
                 tokio::time::sleep(Duration::from_secs(30)).await;


### PR DESCRIPTION
If `runtime.metrics` table registered (by spice_cloud extension) with remote data connector, it will cast local metrics schema to match the one provided by data connector.