### PR TITLE
Create new HTTP endpoint to create embeddings.

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -117,6 +117,7 @@ pub async fn run(args: Args) -> Result<()> {
     if cfg!(feature = "models") {
         rt.load_models().await;
         rt.load_llms().await;
+        rt.load_embeddings().await;
     }
 
     if let Err(err) = rt.init_query_history().await {

--- a/crates/llms/src/embeddings/mod.rs
+++ b/crates/llms/src/embeddings/mod.rs
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use async_trait::async_trait;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to prepare input for embedding: {source}"))]
+    FailedToPrepareInput {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Failed to create embedding: {source}"))]
+    FailedToCreateEmbedding {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmbeddingInput {
+    String(String),
+    Tokens(Vec<u32>),
+    StringBatch(Vec<String>),
+    TokensBatch(Vec<Vec<u32>>),
+}
+
+#[async_trait]
+pub trait Embed: Sync + Send {
+    async fn embed(&mut self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>>;
+}

--- a/crates/llms/src/lib.rs
+++ b/crates/llms/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod embeddings;
 pub mod nql;
+pub mod openai;

--- a/crates/llms/src/nql/mod.rs
+++ b/crates/llms/src/nql/mod.rs
@@ -18,15 +18,13 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
-use self::openai::GPT3_5_TURBO_INSTRUCT;
+use crate::openai::{Openai, DEFAULT_LLM_MODEL};
 
 #[cfg(feature = "candle")]
 pub mod candle;
 
 #[cfg(feature = "mistralrs")]
 pub mod mistral;
-
-pub mod openai;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
@@ -49,7 +47,7 @@ pub enum Error {
     #[snafu(display("Local tokenizer, expected at {expected_path}, not found"))]
     LocalTokenizerNotFound { expected_path: String },
 
-    #[snafu(display("Failed to load model from file: {source}"))]
+    #[snafu(display("Failed to load model: {source}"))]
     FailedToLoadModel {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -68,6 +66,9 @@ pub enum Error {
     UnknownModelSource {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[snafu(display("No model from {from} currently supports {task}"))]
+    UnsupportedTaskForModel { from: String, task: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -75,32 +76,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[async_trait]
 pub trait Nql: Sync + Send {
     async fn run(&mut self, prompt: String) -> Result<Option<String>>;
-}
-
-#[must_use]
-pub fn create_openai(
-    model: Option<String>,
-    api_base: Option<String>,
-    api_key: Option<String>,
-    org_id: Option<String>,
-    project_id: Option<String>,
-) -> Box<dyn Nql> {
-    let mut cfg = OpenAIConfig::new()
-        .with_org_id(org_id.unwrap_or_default())
-        .with_project_id(project_id.unwrap_or_default());
-
-    // If an API key is provided, use it. Otherwise use default from env variables.
-    if let Some(api_key) = api_key {
-        cfg = cfg.with_api_key(api_key);
-    }
-    if let Some(api_base) = api_base {
-        cfg = cfg.with_api_base(api_base);
-    }
-
-    Box::new(openai::Openai::new(
-        cfg,
-        model.unwrap_or(GPT3_5_TURBO_INSTRUCT.to_string()),
-    ))
 }
 
 pub fn create_hf_model(

--- a/crates/llms/src/nql/mod.rs
+++ b/crates/llms/src/nql/mod.rs
@@ -13,12 +13,9 @@ limitations under the License.
 #![allow(clippy::missing_errors_doc)]
 use std::path::Path;
 
-use async_openai::config::OpenAIConfig;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
-
-use crate::openai::{Openai, DEFAULT_LLM_MODEL};
 
 #[cfg(feature = "candle")]
 pub mod candle;

--- a/crates/llms/src/openai.rs
+++ b/crates/llms/src/openai.rs
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#![allow(clippy::missing_errors_doc)]
 use crate::embeddings::{Embed, EmbeddingInput, Error as EmbedError, Result as EmbedResult};
 use crate::nql::{Error as NqlError, Nql, Result as NqlResult};
 

--- a/crates/llms/src/openai.rs
+++ b/crates/llms/src/openai.rs
@@ -10,15 +10,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use super::{FailedToLoadModelSnafu, FailedToLoadTokenizerSnafu, Nql, Result};
-use crate::nql::FailedToRunModelSnafu;
+use crate::embeddings::{Embed, EmbeddingInput, Error as EmbedError, Result as EmbedResult};
+use crate::nql::{Error as NqlError, Nql, Result as NqlResult};
 
+use async_openai::types::CreateEmbeddingRequestArgs;
 use async_openai::{
     config::OpenAIConfig,
     types::{
         ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageArgs,
         ChatCompletionResponseFormat, ChatCompletionResponseFormatType,
-        CreateChatCompletionRequestArgs,
+        CreateChatCompletionRequestArgs, EmbeddingInput as OpenAiEmbeddingInput,
     },
     Client,
 };
@@ -27,7 +28,12 @@ use serde_json::Value;
 use snafu::ResultExt;
 
 const MAX_COMPLETION_TOKENS: u16 = 1024_u16; // Avoid accidentally using infinite tokens. Should think about this more.
+
 pub(crate) const GPT3_5_TURBO_INSTRUCT: &str = "gpt-3.5-turbo";
+pub(crate) const TEXT_EMBED_3_SMALL: &str = "text-embedding-3-small";
+
+pub const DEFAULT_LLM_MODEL: &str = GPT3_5_TURBO_INSTRUCT;
+pub const DEFAULT_EMBEDDING_MODEL: &str = TEXT_EMBED_3_SMALL;
 
 pub struct Openai {
     client: Client<OpenAIConfig>,
@@ -36,51 +42,64 @@ pub struct Openai {
 
 impl Default for Openai {
     fn default() -> Self {
-        Self::new(OpenAIConfig::default(), GPT3_5_TURBO_INSTRUCT.to_string())
+        Self::new(DEFAULT_LLM_MODEL.to_string(), None, None, None, None)
     }
 }
 
 impl Openai {
     #[must_use]
-    pub fn new(client_config: OpenAIConfig, model: String) -> Self {
+    pub fn new(
+        model: String,
+        api_base: Option<String>,
+        api_key: Option<String>,
+        org_id: Option<String>,
+        project_id: Option<String>,
+    ) -> Self {
+        let mut cfg = OpenAIConfig::new()
+            .with_org_id(org_id.unwrap_or_default())
+            .with_project_id(project_id.unwrap_or_default());
+
+        // If an API key is provided, use it. Otherwise use default from env variables.
+        if let Some(api_key) = api_key {
+            cfg = cfg.with_api_key(api_key);
+        }
+        if let Some(api_base) = api_base {
+            cfg = cfg.with_api_base(api_base);
+        }
         Self {
-            client: Client::with_config(client_config),
+            client: Client::with_config(cfg),
             model,
         }
     }
 
-    #[must_use]
-    pub fn using_model(model: String) -> Self {
-        Self::new(OpenAIConfig::default(), model)
-    }
-
     /// Convert the Json object returned when using a `{ "type": "json_object" } ` response format.
     /// Expected format is `"content": "{\"arbitrary_key\": \"arbitrary_value\"}"`
-    pub fn convert_json_object_to_sql(raw_json: &str) -> Result<Option<String>> {
+    pub fn convert_json_object_to_sql(raw_json: &str) -> NqlResult<Option<String>> {
         let result: Value = serde_json::from_str(raw_json)
             .boxed()
-            .context(FailedToRunModelSnafu)?;
+            .map_err(|source| NqlError::FailedToLoadModel { source })?;
         Ok(result["sql"].as_str().map(std::string::ToString::to_string))
     }
 }
 
 #[async_trait]
 impl Nql for Openai {
-    async fn run(&mut self, prompt: String) -> Result<Option<String>> {
+    async fn run(&mut self, prompt: String) -> NqlResult<Option<String>> {
         let messages: Vec<ChatCompletionRequestMessage> = vec![
             ChatCompletionRequestSystemMessageArgs::default()
                 .content("Return JSON, with the requested SQL under 'sql'.")
                 .build()
                 .boxed()
-                .context(FailedToLoadTokenizerSnafu)?
+                .map_err(|source| NqlError::FailedToLoadTokenizer { source })?
                 .into(),
             ChatCompletionRequestSystemMessageArgs::default()
                 .content(prompt)
                 .build()
                 .boxed()
-                .context(FailedToLoadTokenizerSnafu)?
+                .map_err(|source| NqlError::FailedToLoadTokenizer { source })?
                 .into(),
         ];
+
         let request = CreateChatCompletionRequestArgs::default()
             .model(self.model.clone())
             .response_format(ChatCompletionResponseFormat {
@@ -90,7 +109,7 @@ impl Nql for Openai {
             .max_tokens(MAX_COMPLETION_TOKENS)
             .build()
             .boxed()
-            .context(FailedToLoadModelSnafu)?;
+            .map_err(|source| NqlError::FailedToLoadModel { source })?;
 
         let response = self
             .client
@@ -98,7 +117,7 @@ impl Nql for Openai {
             .create(request)
             .await
             .boxed()
-            .context(FailedToRunModelSnafu)?;
+            .map_err(|source| NqlError::FailedToRunModel { source })?;
 
         if let Some(usage) = response.usage {
             if usage.completion_tokens >= u32::from(MAX_COMPLETION_TOKENS) {
@@ -117,5 +136,40 @@ impl Nql for Openai {
             Some(json_resp) => Self::convert_json_object_to_sql(&json_resp),
             None => Ok(None),
         }
+    }
+}
+
+#[async_trait]
+impl Embed for Openai {
+    async fn embed(&mut self, input: EmbeddingInput) -> EmbedResult<Vec<Vec<f32>>> {
+        let req = CreateEmbeddingRequestArgs::default()
+            .model(self.model.clone())
+            .input(to_openai_embedding_input(input))
+            .build()
+            .boxed()
+            .map_err(|source| EmbedError::FailedToPrepareInput { source })?;
+
+        let embedding: Vec<Vec<f32>> = self
+            .client
+            .embeddings()
+            .create(req)
+            .await
+            .boxed()
+            .map_err(|source| EmbedError::FailedToCreateEmbedding { source })?
+            .data
+            .iter()
+            .map(|d| d.embedding.clone())
+            .collect();
+
+        Ok(embedding)
+    }
+}
+
+fn to_openai_embedding_input(input: EmbeddingInput) -> OpenAiEmbeddingInput {
+    match input {
+        EmbeddingInput::String(s) => OpenAiEmbeddingInput::String(s),
+        EmbeddingInput::Tokens(t) => OpenAiEmbeddingInput::IntegerArray(t),
+        EmbeddingInput::StringBatch(sb) => OpenAiEmbeddingInput::StringArray(sb),
+        EmbeddingInput::TokensBatch(tb) => OpenAiEmbeddingInput::ArrayOfIntegerArray(tb),
     }
 }

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -40,6 +40,7 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn start<A>(
     bind_address: A,
     app: Arc<RwLock<Option<App>>>,

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -24,7 +24,7 @@ use tokio::{
     sync::RwLock,
 };
 
-use crate::{config, datafusion::DataFusion, LLMModelStore};
+use crate::{config, datafusion::DataFusion, EmbeddingModelStore, LLMModelStore};
 
 mod routes;
 mod v1;
@@ -46,13 +46,14 @@ pub(crate) async fn start<A>(
     df: Arc<DataFusion>,
     models: Arc<RwLock<HashMap<String, Model>>>,
     llms: Arc<RwLock<LLMModelStore>>,
+    embeddings: Arc<RwLock<EmbeddingModelStore>>,
     config: Arc<config::Config>,
     with_metrics: Option<SocketAddr>,
 ) -> Result<()>
 where
     A: ToSocketAddrs + Debug,
 {
-    let routes = routes::routes(app, df, models, llms, config, with_metrics);
+    let routes = routes::routes(app, df, models, llms, embeddings, config, with_metrics);
 
     let listener = TcpListener::bind(&bind_address)
         .await

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::LLMModelStore;
 use crate::{config, datafusion::DataFusion};
+use crate::{EmbeddingModelStore, LLMModelStore};
 use app::App;
 use axum::routing::patch;
 use model_components::model::Model;
@@ -40,6 +40,7 @@ pub(crate) fn routes(
     df: Arc<DataFusion>,
     models: Arc<RwLock<HashMap<String, Model>>>,
     llms: Arc<RwLock<LLMModelStore>>,
+    embeddings: Arc<RwLock<EmbeddingModelStore>>,
     config: Arc<config::Config>,
     with_metrics: Option<SocketAddr>,
 ) -> Router {
@@ -65,8 +66,10 @@ pub(crate) fn routes(
             .route("/v1/models/:name/predict", get(v1::inference::get))
             .route("/v1/predict", post(v1::inference::post))
             .route("/v1/nsql", post(v1::nsql::post))
+            .route("/v1/embed", post(v1::embed::post))
             .layer(Extension(llms))
-            .layer(Extension(models));
+            .layer(Extension(models))
+            .layer(Extension(embeddings));
     }
 
     router = router

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -1128,7 +1128,7 @@ pub(crate) mod embed {
     };
     use datafusion::execution::context::SQLOptions;
     use futures::TryStreamExt;
-    
+
     use serde::{Deserialize, Serialize};
     use std::sync::Arc;
     use tokio::sync::RwLock;
@@ -1233,13 +1233,11 @@ pub(crate) mod embed {
                     Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
                 }
             }
-            None => {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Model {model} not found"),
-                )
-                    .into_response()
-            }
+            None => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Model {model} not found"),
+            )
+                .into_response(),
         }
     }
 }

--- a/crates/runtime/src/http/v1.rs
+++ b/crates/runtime/src/http/v1.rs
@@ -1118,3 +1118,127 @@ pub(crate) mod nsql {
         resp
     }
 }
+
+pub(crate) mod embed {
+    use arrow::array::{RecordBatch, StringArray};
+    use axum::{
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        Extension, Json,
+    };
+    use datafusion::execution::context::SQLOptions;
+    use futures::{StreamExt, TryStreamExt};
+    use itertools::Itertools;
+    use serde::{Deserialize, Serialize};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    use crate::{datafusion::DataFusion, EmbeddingModelStore};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    pub struct TextRequest {
+        pub text: String,
+
+        #[serde(rename = "use", default = "default_model")]
+        pub model: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    pub struct SqlRequest {
+        pub sql: String,
+
+        #[serde(rename = "use", default = "default_model")]
+        pub model: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(untagged)]
+    pub enum Request {
+        Sql(SqlRequest),
+        Text(TextRequest),
+    }
+
+    fn default_model() -> String {
+        "embed".to_string()
+    }
+
+    // For [`SqlRequest`], create the text to embed by querying [`Datafusion`].
+    async fn to_text(
+        df: Arc<DataFusion>,
+        sql: String,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let opt = SQLOptions::new()
+            .with_allow_ddl(false)
+            .with_allow_dml(false)
+            .with_allow_statements(false);
+
+        // Attempt to convert first column to String
+        let stream =
+            df.query_with_cache(&sql, Some(opt))
+                .await
+                .map(|r| r.data)?
+                .map_ok(
+                    |r| match r.column(0).as_any().downcast_ref::<StringArray>() {
+                        Some(s) => Ok(s
+                            .into_iter()
+                            .filter_map(|x| x)
+                            .map(ToString::to_string)
+                            .collect::<Vec<String>>()),
+                        None => Err("Expected first column of SQL query to return a String type"
+                            .to_string()),
+                    },
+                );
+        let result: Result<Vec<Result<Vec<String>, _>>, _> = stream.try_collect().await;
+
+        match result {
+            Ok(result) => {
+                let result = result
+                    .into_iter()
+                    .collect::<Result<Vec<Vec<String>>, _>>()?;
+                Ok(result.into_iter().flatten().collect())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub(crate) async fn post(
+        Extension(df): Extension<Arc<DataFusion>>,
+        Extension(embeddings): Extension<Arc<RwLock<EmbeddingModelStore>>>,
+        Json(payload): Json<Request>,
+    ) -> Response {
+        let (text, model) = match payload {
+            Request::Text(TextRequest { text, model }) => (vec![text], model),
+            Request::Sql(SqlRequest { sql, model }) => {
+                let text = match to_text(Arc::clone(&df), sql).await {
+                    Ok(text) => text,
+                    Err(e) => {
+                        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+                    }
+                };
+                (text, model)
+            }
+        };
+
+        match embeddings.read().await.get(&model) {
+            Some(embedding_model) => {
+                let mut embedding_model = embedding_model.write().await;
+                match embedding_model
+                    .embed(llms::embeddings::EmbeddingInput::StringBatch(text))
+                    .await
+                {
+                    Ok(embedding) => (StatusCode::OK, Json(embedding)).into_response(),
+                    Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+                }
+            }
+            None => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Model {} not found", model),
+                )
+                    .into_response()
+            }
+        }
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -38,9 +38,10 @@ use config::Config;
 use datafusion::SPICE_RUNTIME_SCHEMA;
 use futures::future::join_all;
 use futures::StreamExt;
+use llms::embeddings::Embed;
 use llms::nql::Nql;
 use metrics::SetRecorderError;
-use model::try_to_nql;
+use model::{try_to_embedding, try_to_nql};
 use model_components::{model::Model, modelsource::source as model_source};
 pub use notify::Error as NotifyError;
 use secrets::{spicepod_secret_store_type, Secret};
@@ -192,12 +193,14 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub type LLMModelStore = HashMap<String, RwLock<Box<dyn Nql>>>;
+pub type EmbeddingModelStore = HashMap<String, RwLock<Box<dyn Embed>>>;
 
 pub struct Runtime {
     pub app: Arc<RwLock<Option<App>>>,
     pub df: Arc<DataFusion>,
     pub models: Arc<RwLock<HashMap<String, Model>>>,
     pub llms: Arc<RwLock<LLMModelStore>>,
+    pub embeds: Arc<RwLock<EmbeddingModelStore>>,
     pub pods_watcher: Option<podswatcher::PodsWatcher>,
     pub secrets_provider: Arc<RwLock<secrets::SecretsProvider>>,
 
@@ -221,6 +224,7 @@ impl Runtime {
             df: Arc::new(DataFusion::new_with_cache_provider(cache_provider)),
             models: Arc::new(RwLock::new(HashMap::new())),
             llms: Arc::new(RwLock::new(HashMap::new())),
+            embeds: Arc::new(RwLock::new(HashMap::new())),
             pods_watcher: None,
             secrets_provider: Arc::new(RwLock::new(secrets::SecretsProvider::new())),
             spaced_tracer: Arc::new(tracers::SpacedTracer::new(Duration::from_secs(15))),
@@ -728,6 +732,37 @@ impl Runtime {
         }
     }
 
+    pub async fn load_embeddings(&self) {
+        let app_lock = self.app.read().await;
+        if let Some(app) = app_lock.as_ref() {
+            for in_embed in &app.llms {
+                if !in_embed.can_embed {
+                    continue;
+                }
+
+                status::update_embedding(&in_embed.name, status::ComponentStatus::Initializing);
+                match try_to_embedding(in_embed) {
+                    Ok(e) => {
+                        let mut embeds_map = self.embeds.write().await;
+                        embeds_map.insert(in_embed.name.clone(), e.into());
+                        tracing::info!("Embedding [{}] ready to embed", in_embed.name);
+                        metrics::gauge!("embeddings_count", "embeddings" => in_embed.name.clone(), "source" => in_embed.get_prefix().map(|x| x.to_string()).unwrap_or_default()).increment(1.0);
+                        status::update_embedding(&in_embed.name, status::ComponentStatus::Ready);
+                    }
+                    Err(e) => {
+                        metrics::counter!("embeddings_load_error").increment(1);
+                        status::update_embedding(&in_embed.name, status::ComponentStatus::Error);
+                        tracing::warn!(
+                            "Unable to load embedding from spicepod {}, error: {}",
+                            in_embed.name,
+                            e,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     pub async fn load_models(&self) {
         let app_lock = self.app.read().await;
         if let Some(app) = app_lock.as_ref() {
@@ -839,6 +874,7 @@ impl Runtime {
             Arc::clone(&self.df),
             Arc::clone(&self.models),
             Arc::clone(&self.llms),
+            Arc::clone(&self.embeds),
             config.clone().into(),
             with_metrics,
         );

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -56,3 +56,8 @@ pub fn update_llm(model_name: &str, status: ComponentStatus) {
     let model_name = model_name.to_string();
     gauge!("llm/status", "model" => model_name).set(f64::from(status as u32));
 }
+
+pub fn update_embedding(model_name: &str, status: ComponentStatus) {
+    let model_name = model_name.to_string();
+    gauge!("embedding/status", "model" => model_name).set(f64::from(status as u32));
+}

--- a/crates/spicepod/src/component/llms.rs
+++ b/crates/spicepod/src/component/llms.rs
@@ -27,6 +27,9 @@ pub struct Llm {
     pub from: String,
     pub name: String,
 
+    #[serde(default)]
+    pub can_embed: bool,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<HashMap<String, String>>,
 
@@ -40,6 +43,7 @@ impl WithDependsOn<Llm> for Llm {
         Llm {
             from: self.from.clone(),
             name: self.name.clone(),
+            can_embed: self.can_embed,
             depends_on: depends_on.to_vec(),
             params: self.params.clone(),
         }


### PR DESCRIPTION
## Changes
### HTTP Endpoint
- `POST /v1/embed`. Two payload options (`"use"` optional).
```json
{
  "sql": "select address_line1 from cleaned_sales_data limit 10",
  "use": "oai"
}
```
or 
```json
{
  "text": "Just standard old text"
}
```

### New trait 
- New trait defined for Embedding models
```rust
#[async_trait]
pub trait Embed: Sync + Send {
    async fn embed(&mut self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>>;
}

#[derive(Debug, Clone, PartialEq)]
pub enum EmbeddingInput {
    String(String),
    Tokens(Vec<u32>),
    StringBatch(Vec<String>),
    TokensBatch(Vec<Vec<u32>>),
}
```

### Changes to `spicepod.yaml`
- New key `can_embed: bool` for `llm` components, for example
```yaml
llms:
  - name: oai
    from: openai
    can_embed: true
```
- In long term, will need a mechanisms to:
  1. Unify models/llms/embeddings and delineate which can do what tasks
  2. A better mechanism for shared memory across them (i.e. the single in-memory model can handle both embed and chat complete inference). 
  
### Other changes
- Moved `crates/llms/src/nql/openai.rs` -> `crates/llms/src/openai.rs` 