### PR TITLE
Don't cache queries for runtime tables

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -37,8 +37,8 @@ use spicepod::component::runtime::ResultsCache;
 mod lru_cache;
 mod utils;
 
+pub use utils::cache_is_enabled_for_plan;
 pub use utils::get_logical_plan_input_tables;
-pub use utils::is_cache_allowed_for_query;
 pub use utils::to_cached_record_batch_stream;
 
 #[derive(Debug, Snafu)]

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -38,6 +38,7 @@ mod lru_cache;
 mod utils;
 
 pub use utils::get_logical_plan_input_tables;
+pub use utils::is_cache_allowed_for_query;
 pub use utils::to_cached_record_batch_stream;
 
 #[derive(Debug, Snafu)]

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -38,7 +38,7 @@ mod lru_cache;
 mod utils;
 
 pub use utils::get_logical_plan_input_tables;
-pub use utils::is_cache_allowed_for_query;
+pub use utils:: cache_is_enabled_for_plan;
 pub use utils::to_cached_record_batch_stream;
 
 #[derive(Debug, Snafu)]

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -106,7 +106,7 @@ pub fn cache_is_enabled_for_plan(plan: &LogicalPlan) -> bool {
     }
 
     for input in plan.inputs() {
-        if !is_cache_allowed_for_query(input) {
+        if ! cache_is_enabled_for_plan(input) {
             return false;
         }
     }

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -91,7 +91,7 @@ fn collect_table_names(plan: &LogicalPlan, table_names: &mut HashSet<String>) {
 }
 
 #[must_use]
-pub fn is_cache_allowed_for_query(plan: &LogicalPlan) -> bool {
+pub fn cache_is_enabled_for_plan(plan: &LogicalPlan) -> bool {
     match plan {
         LogicalPlan::TableScan(source, ..) => {
             let table_name = source.table_name.to_string();

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -34,7 +34,6 @@ pub fn to_cached_record_batch_stream(
     cache_provider: Arc<QueryResultsCacheProvider>,
     mut stream: SendableRecordBatchStream,
     plan: LogicalPlan,
-    input_tables: HashSet<String>,
 ) -> SendableRecordBatchStream {
     let schema = stream.schema();
     let schema_copy = Arc::clone(&schema);
@@ -59,7 +58,7 @@ pub fn to_cached_record_batch_stream(
             let cached_result = CachedQueryResult {
                 records: Arc::new(records),
                 schema: schema_copy,
-                input_tables: Arc::new(input_tables),
+                input_tables: Arc::new(get_logical_plan_input_tables(&plan)),
             };
 
             if let Err(e) = cache_provider.put(&plan, cached_result).await {
@@ -89,6 +88,30 @@ fn collect_table_names(plan: &LogicalPlan, table_names: &mut HashSet<String>) {
     plan.inputs().iter().for_each(|input| {
         collect_table_names(input, table_names);
     });
+}
+
+#[must_use]
+pub fn is_cache_allowed_for_query(plan: &LogicalPlan) -> bool {
+    match plan {
+        LogicalPlan::TableScan(source, ..) => {
+            let table_name = source.table_name.to_string();
+            return !(table_name.starts_with("information_schema.")
+                || table_name.starts_with("runtime."));
+        }
+        LogicalPlan::Explain { .. }
+        | LogicalPlan::Analyze { .. }
+        | LogicalPlan::DescribeTable { .. }
+        | LogicalPlan::Statement(..) => return false,
+        _ => {}
+    }
+
+    for input in plan.inputs() {
+        if !is_cache_allowed_for_query(input) {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[cfg(test)]

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -76,39 +76,41 @@ pub fn to_cached_record_batch_stream(
 #[must_use]
 pub fn get_logical_plan_input_tables(plan: &LogicalPlan) -> HashSet<String> {
     let mut table_names: HashSet<String> = HashSet::new();
-    collect_table_names(plan, &mut table_names);
+    let mut plan_stack = vec![plan];
+
+    while let Some(current_plan) = plan_stack.pop() {
+        if let LogicalPlan::TableScan(source, ..) = current_plan {
+            table_names.insert(source.table_name.to_string().to_lowercase());
+        }
+
+        plan_stack.extend(current_plan.inputs());
+    }
+
     table_names
 }
 
-fn collect_table_names(plan: &LogicalPlan, table_names: &mut HashSet<String>) {
-    if let LogicalPlan::TableScan(source, ..) = plan {
-        table_names.insert(source.table_name.to_string().to_lowercase());
-    }
-
-    plan.inputs().iter().for_each(|input| {
-        collect_table_names(input, table_names);
-    });
-}
-
 #[must_use]
-pub fn is_cache_allowed_for_query(plan: &LogicalPlan) -> bool {
-    match plan {
-        LogicalPlan::TableScan(source, ..) => {
-            let table_name = source.table_name.to_string();
-            return !(table_name.starts_with("information_schema.")
-                || table_name.starts_with("runtime."));
-        }
-        LogicalPlan::Explain { .. }
-        | LogicalPlan::Analyze { .. }
-        | LogicalPlan::DescribeTable { .. }
-        | LogicalPlan::Statement(..) => return false,
-        _ => {}
-    }
+pub fn cache_is_enabled_for_plan(plan: &LogicalPlan) -> bool {
+    let mut plan_stack = vec![plan];
 
-    for input in plan.inputs() {
-        if !is_cache_allowed_for_query(input) {
-            return false;
+    while let Some(current_plan) = plan_stack.pop() {
+        match current_plan {
+            LogicalPlan::TableScan(source, ..) => {
+                let table_name = source.table_name.to_string();
+                if table_name.starts_with("information_schema.")
+                    || table_name.starts_with("runtime.")
+                {
+                    return false;
+                }
+            }
+            LogicalPlan::Explain { .. }
+            | LogicalPlan::Analyze { .. }
+            | LogicalPlan::DescribeTable { .. }
+            | LogicalPlan::Statement(..) => return false,
+            _ => {}
         }
+
+        plan_stack.extend(current_plan.inputs());
     }
 
     true
@@ -256,9 +258,34 @@ mod tests {
         assert_eq!(table_names, expected);
     }
 
+    #[tokio::test]
+    async fn test_cache_is_enabled_for_system_query_describe() {
+        let sql = "describe customer";
+        let logical_plan = parse_sql_to_logical_plan(sql).await;
+
+        assert!(!cache_is_enabled_for_plan(&logical_plan));
+    }
+
+    #[tokio::test]
+    async fn test_cache_is_enabled_for_show_tables() {
+        let sql = "show tables";
+        let logical_plan = parse_sql_to_logical_plan(sql).await;
+
+        assert!(!cache_is_enabled_for_plan(&logical_plan));
+    }
+
+    #[tokio::test]
+    async fn test_cache_is_enabled_for_simple_select() {
+        let sql = "SELECT * FROM customer";
+        let logical_plan = parse_sql_to_logical_plan(sql).await;
+
+        assert!(cache_is_enabled_for_plan(&logical_plan));
+    }
+
     fn create_session_context() -> SessionContext {
         let config = SessionConfig::new().with_information_schema(true);
         let ctx = SessionContext::new_with_config(config);
+
         register_tables(&ctx);
 
         ctx

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::SystemTime};
 
 use arrow::datatypes::Schema;
 use arrow_tools::schema::verify_schema;
-use cache::{is_cache_allowed_for_query, to_cached_record_batch_stream, QueryResult};
+use cache::{cache_is_enabled_for_plan, to_cached_record_batch_stream, QueryResult};
 use datafusion::{
     error::DataFusionError,
     execution::{context::SQLOptions, SendableRecordBatchStream},
@@ -129,7 +129,7 @@ impl Query {
 
         verify_schema(df_schema.fields(), res_schema.fields()).context(SchemaMismatchSnafu)?;
 
-        if is_cache_allowed_for_query(&plan_copy) {
+        if cache_is_enabled_for_plan(&plan_copy) {
             if let Some(cache_provider) = &self.df.cache_provider {
                 let record_batch_stream = to_cached_record_batch_stream(
                     Arc::clone(cache_provider),

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -129,7 +129,7 @@ impl Query {
 
         verify_schema(df_schema.fields(), res_schema.fields()).context(SchemaMismatchSnafu)?;
 
-        if is_cache_allowed_for_query(&plan_copy) {
+        if cache_is_enabled_for_plan(&plan_copy) {
             if let Some(cache_provider) = &self.df.cache_provider {
                 let record_batch_stream = to_cached_record_batch_stream(
                     Arc::clone(cache_provider),

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::SystemTime};
 
 use arrow::datatypes::Schema;
 use arrow_tools::schema::verify_schema;
-use cache::{is_cache_allowed_for_query, to_cached_record_batch_stream, QueryResult};
+use cache::{cache_is_enabled_for_plan, to_cached_record_batch_stream, QueryResult};
 use datafusion::{
     error::DataFusionError,
     execution::{context::SQLOptions, SendableRecordBatchStream},


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1389

Don't cache queries for runtime tables (`runtime.query_history`, etc).

`is_cache_allowed_for_query` scans for the first table and decides based on the table name whether it is a system table or not. It does not perform a full scan of the entire LogicalPlan.