### PR TITLE
Enable datasets from local filesystem

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -74,6 +74,7 @@ pub mod sftp;
 #[cfg(feature = "spark")]
 pub mod spark;
 pub mod spiceai;
+pub mod file;
 
 #[cfg(feature = "snowflake")]
 pub mod snowflake;
@@ -228,6 +229,7 @@ pub async fn register_all() {
     register_connector_factory("databricks", databricks::Databricks::create).await;
     #[cfg(feature = "dremio")]
     register_connector_factory("dremio", dremio::Dremio::create).await;
+    register_connector_factory("file",file::File::create).await;
     #[cfg(feature = "flightsql")]
     register_connector_factory("flightsql", flightsql::FlightSQL::create).await;
     register_connector_factory("s3", s3::S3::create).await;

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -57,6 +57,7 @@ pub mod databricks;
 pub mod dremio;
 #[cfg(feature = "duckdb")]
 pub mod duckdb;
+pub mod file;
 #[cfg(feature = "flightsql")]
 pub mod flightsql;
 #[cfg(feature = "ftp")]
@@ -74,7 +75,6 @@ pub mod sftp;
 #[cfg(feature = "spark")]
 pub mod spark;
 pub mod spiceai;
-pub mod file;
 
 #[cfg(feature = "snowflake")]
 pub mod snowflake;
@@ -229,7 +229,7 @@ pub async fn register_all() {
     register_connector_factory("databricks", databricks::Databricks::create).await;
     #[cfg(feature = "dremio")]
     register_connector_factory("dremio", dremio::Dremio::create).await;
-    register_connector_factory("file",file::File::create).await;
+    register_connector_factory("file", file::File::create).await;
     #[cfg(feature = "flightsql")]
     register_connector_factory("flightsql", flightsql::FlightSQL::create).await;
     register_connector_factory("s3", s3::S3::create).await;

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -23,7 +23,10 @@ use std::sync::Arc;
 use std::{collections::HashMap, future::Future};
 use url::Url;
 
-use super::{DataConnector, DataConnectorFactory, DataConnectorResult, InvalidConfigurationSnafu, ListingTableConnector};
+use super::{
+    DataConnector, DataConnectorFactory, DataConnectorResult, InvalidConfigurationSnafu,
+    ListingTableConnector,
+};
 
 pub struct File {
     params: Arc<HashMap<String, String>>,
@@ -40,9 +43,7 @@ impl DataConnectorFactory for File {
         _secret: Option<Secret>,
         params: Arc<HashMap<String, String>>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        Box::pin(async move {
-            Ok(Arc::new(Self { params }) as Arc<dyn DataConnector>)
-        })
+        Box::pin(async move { Ok(Arc::new(Self { params }) as Arc<dyn DataConnector>) })
     }
 }
 
@@ -56,9 +57,11 @@ impl ListingTableConnector for File {
     }
 
     fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
-        Url::parse(&dataset.from).boxed().context(InvalidConfigurationSnafu{
-            dataconnector: "File".to_string(),
-            message: "Invalid URL".to_string(),
-        })
+        Url::parse(&dataset.from)
+            .boxed()
+            .context(InvalidConfigurationSnafu {
+                dataconnector: "File".to_string(),
+                message: "Invalid URL".to_string(),
+            })
     }
 }

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::component::dataset::Dataset;
+use secrets::Secret;
+use snafu::prelude::*;
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{collections::HashMap, future::Future};
+use url::Url;
+
+use super::{DataConnector, DataConnectorFactory, DataConnectorResult, InvalidConfigurationSnafu, ListingTableConnector};
+
+pub struct File {
+    params: Arc<HashMap<String, String>>,
+}
+
+impl std::fmt::Display for File {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "File")
+    }
+}
+
+impl DataConnectorFactory for File {
+    fn create(
+        _secret: Option<Secret>,
+        params: Arc<HashMap<String, String>>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move {
+            Ok(Arc::new(Self { params }) as Arc<dyn DataConnector>)
+        })
+    }
+}
+
+impl ListingTableConnector for File {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_params(&self) -> &HashMap<String, String> {
+        &self.params
+    }
+
+    fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
+        Url::parse(&dataset.from).boxed().context(InvalidConfigurationSnafu{
+            dataconnector: "File".to_string(),
+            message: "Invalid URL".to_string(),
+        })
+    }
+}


### PR DESCRIPTION
## Changes
- Enable datasets from local filesystem
```yaml
datasets:
  - from: file:/Users/jeadie/Github/jalaipeno/data_Q2_2023.parquet
    name: local_data
```
- New trait `ListingTableConnector for File` 
- Based on [object_store](https://docs.rs/object_store/latest/object_store/) crate's [LocalFileSystem](https://docs.rs/object_store/latest/object_store/local/struct.LocalFileSystem.html)