### PR TITLE
Use `/app` as a default workdir in spiceai docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,6 @@ COPY --from=build /root/spiced /usr/local/bin/spiced
 
 EXPOSE 3000 50051
 
+WORKDIR /app
+
 ENTRYPOINT ["/usr/local/bin/spiced"]


### PR DESCRIPTION
Setting default workdir to `/app`

By default docker image was using root folder for running spiced, and that was preventing runtime to start properly (most likely podwatcher hanged due to security)