### PR TITLE
Add cache header to Flight API and Spice REPL indicator

### DIFF
--- a/crates/runtime/src/flight/flight_utils.rs
+++ b/crates/runtime/src/flight/flight_utils.rs
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow_flight::flight_service_server::FlightService;
+use tonic::{
+    metadata::{Ascii, MetadataValue},
+    Response,
+};
+
+use crate::flight::Service;
+
+pub fn attach_cache_metadata(
+    response: &mut Response<<Service as FlightService>::DoGetStream>,
+    from_cache: Option<bool>,
+) {
+    if let Some(from_cache) = from_cache {
+        let val: Result<MetadataValue<Ascii>, _> = if from_cache {
+            "Hit from spiceai".parse()
+        } else {
+            "Miss from spiceai".parse()
+        };
+        match val {
+            Ok(val) => {
+                response.metadata_mut().insert("x-cache", val);
+            }
+            Err(e) => {
+                tracing::error!("Failed to parse metadata value: {}", e);
+            }
+        }
+    }
+}

--- a/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
@@ -25,7 +25,7 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::{to_tonic_err, Service},
+    flight::{flight_utils::attach_cache_metadata, to_tonic_err, Service},
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -96,12 +96,14 @@ pub(crate) async fn do_get(
         Ok(sql) => {
             let start =
                 TimeMeasurement::new("flight_do_get_prepared_statement_query_duration_ms", vec![]);
-            let output =
+            let (output, from_cache) =
                 Box::pin(Service::sql_to_flight_stream(datafusion, sql.to_owned())).await?;
             let timed_output = TimedStream::new(output, move || start);
-            Ok(Response::new(
-                Box::pin(timed_output) as <Service as FlightService>::DoGetStream
-            ))
+
+            let mut response =
+                Response::new(Box::pin(timed_output) as <Service as FlightService>::DoGetStream);
+            attach_cache_metadata(&mut response, from_cache);
+            Ok(response)
         }
         Err(e) => Err(Status::invalid_argument(format!(
             "Invalid prepared statement handle: {e}"

--- a/crates/runtime/src/flight/flightsql/statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/statement_query.rs
@@ -25,7 +25,7 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::{to_tonic_err, Service},
+    flight::{flight_utils::attach_cache_metadata, to_tonic_err, Service},
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -66,9 +66,12 @@ pub(crate) async fn do_get(
     let datafusion = Arc::clone(&flight_svc.datafusion);
     tracing::trace!("do_get_statement: {cmd:?}");
     let start = TimeMeasurement::new("flight_do_get_statement_query_duration_ms", vec![]);
-    let output = Box::pin(Service::sql_to_flight_stream(datafusion, cmd.query)).await?;
+    let (output, from_cache) =
+        Box::pin(Service::sql_to_flight_stream(datafusion, cmd.query)).await?;
     let timed_output = TimedStream::new(output, move || start);
-    Ok(Response::new(
-        Box::pin(timed_output) as <Service as FlightService>::DoGetStream
-    ))
+
+    let mut response =
+        Response::new(Box::pin(timed_output) as <Service as FlightService>::DoGetStream);
+    attach_cache_metadata(&mut response, from_cache);
+    Ok(response)
 }


### PR DESCRIPTION
Add custom `x-cache` header to Flight API and cached result indication to Spice REPL

```
sql> select c_name from customer limit 1;
+--------------------+
| c_name             |
+--------------------+
| Customer#000000001 |
+--------------------+

Time: 0.0125375 seconds. 1 rows (cached).
```