### PR TITLE
Support BinaryArray in DuckDB accelerations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,7 +3178,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "duckdb"
 version = "0.10.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=86b6b44f4ae401706be0cbcaa5d7d12d41443e5e#86b6b44f4ae401706be0cbcaa5d7d12d41443e5e"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=eb6a7d79f88309a70bcc52682368458bcc63bf0d#eb6a7d79f88309a70bcc52682368458bcc63bf0d"
 dependencies = [
  "arrow",
  "cast",
@@ -4874,7 +4874,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 [[package]]
 name = "libduckdb-sys"
 version = "0.10.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=86b6b44f4ae401706be0cbcaa5d7d12d41443e5e#86b6b44f4ae401706be0cbcaa5d7d12d41443e5e"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=eb6a7d79f88309a70bcc52682368458bcc63bf0d#eb6a7d79f88309a70bcc52682368458bcc63bf0d"
 dependencies = [
  "autocfg",
  "cc",
@@ -5056,6 +5056,7 @@ dependencies = [
  "candle-examples",
  "candle-transformers 0.5.0",
  "dirs",
+ "futures",
  "mistralrs",
  "mistralrs-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ metrics = "0.22.0"
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "4b6489ffd8d138b138c2049966b19d073867885f" }
 arrow = "51.0.0"
 arrow-flight = "51.0.0"
-duckdb = { git="https://github.com/spiceai/duckdb-rs.git", rev = "86b6b44f4ae401706be0cbcaa5d7d12d41443e5e" }
+duckdb = { git="https://github.com/spiceai/duckdb-rs.git", rev = "eb6a7d79f88309a70bcc52682368458bcc63bf0d" }
 tonic = "0.11.0"
 futures = "0.3.30"
 r2d2 = "0.8.10"


### PR DESCRIPTION
This fixes an issue where accelerating a table using DuckDB that stored binary data would fail with the error message:
`2024-06-03T14:24:13.644364Z  WARN runtime: Unable to attach data connector duckdb: Unable to create dataset acceleration: Acceleration creation failed: Unable to create table: External error: Unable to create duckdb table: Invalid Input Error: column Field { name: "binary_data", data_type: Binary, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} } is not supported yet, please file an issue https://github.com/wangfenjin/duckdb-rs`

This is based on the following duckdb-rs PR: https://github.com/duckdb/duckdb-rs/pull/324