### PR TITLE
Add branching policy & updated endgame instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -40,6 +40,7 @@ assignees: ''
 - [ ] Merge [Samples PRs](https://github.com/spiceai/samples/pulls)
 - [ ] Merge [Quickstarts PRs](https://github.com/spiceai/quickstarts/pulls)
 - [ ] Update release notes
+  - [ ] Ensure any external contributors have been acknowledged.
 - [ ] Update acknowledgements by triggering [Generate Acknowledgements](https://github.com/spiceai/spiceai/actions/workflows/generate_acknowledgements.yml) workflow
 - [ ] Verify `version.txt` and version in `Cargo.toml` are correct using [docs/RELEASE.md](https://github.com/spiceai/spiceai/blob/trunk/docs/RELEASE.md#version-update)
 - [ ] Ensure [E2E Test CI](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_ci.yml) is green on the release branch.

--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -54,7 +54,7 @@ assignees: ''
 - [ ] Update `version.txt` and version in `Cargo.toml` to the next release version.
 - [ ] Update versions in [brew taps](https://github.com/spiceai/homebrew-spiceai)
 - [ ] Remove the released version from the [ROADMAP](https://github.com/spiceai/spiceai/blob/trunk/docs/ROADMAP.md)
-- [ ] Create a new branch `release-v[semver]` for the next release version. E.g. `release-v0.14.0-alpha`
+- [ ] Create a new branch `release-v[semver]` for the next release version from the current release branch. E.g. `release-v0.14.0-alpha`
 
 ## Announcement Checklist
 

--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -29,11 +29,12 @@ assignees: ''
 
 ## Release Checklist
 
-- [ ] All outstanding `spiceai` feature PRs are merged
-- [ ] Full test pass and update if necessary over README.md (please get screenshots!)
-- [ ] Full test pass and update if necessary over Docs (please get screenshots!)
-- [ ] Full test pass and update if necessary over existing and new Samples (please get screenshots/videos!)
-- [ ] Full test pass and update if necessary over existing and new Quickstarts (please get screenshots/videos!)
+- [ ] All features/bugfixes to be included in the release have been merged to the release branch (e.g. `release-v0.14.0-alpha`) following the [Branching Policy]
+  - [ ] Verify all commits that should be included are in by viewing the GitHub compare view: i.e. https://github.com/spiceai/spiceai/compare/trunk...release-v0.13.2-alpha
+- [ ] Full test pass and update if necessary over README.md
+- [ ] Full test pass and update if necessary over Docs
+- [ ] Full test pass and update if necessary over existing and new Samples
+- [ ] Full test pass and update if necessary over existing and new Quickstarts
 - [ ] Merge [Docs PRs](https://github.com/spiceai/docs/pulls)
 - [ ] Merge Registry PRs
 - [ ] Merge [Samples PRs](https://github.com/spiceai/samples/pulls)
@@ -41,10 +42,9 @@ assignees: ''
 - [ ] Update release notes
 - [ ] Update acknowledgements by triggering [Generate Acknowledgements](https://github.com/spiceai/spiceai/actions/workflows/generate_acknowledgements.yml) workflow
 - [ ] Verify `version.txt` and version in `Cargo.toml` are correct using [docs/RELEASE.md](https://github.com/spiceai/spiceai/blob/trunk/docs/RELEASE.md#version-update)
-- [ ] Ensure [E2E Test CI](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_ci.yml) is green on trunk branch
+- [ ] Ensure [E2E Test CI](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_ci.yml) is green on the release branch.
 - [ ] QA DRI sign-off
 - [ ] Docs DRI sign-off
-- [ ] Create a new branch `release-v[semver]` and merge all relevant changes into it. E.g. `release-v0.9.1-alpha`
 - [ ] Release the new version by creating a `pre-release` [GitHub Release](https://github.com/spiceai/spiceai/releases/new) with the tag from the release branch. E.g. `v0.9.1-alpha`
 - [ ] Release any docs updates by creating a `v[semver]` tag.
 - [ ] Trigger algolia search crawler [workflow](https://github.com/spiceai/docs/actions/workflows/trigger_search_reindex.yml), to reindex updated docs.
@@ -54,6 +54,7 @@ assignees: ''
 - [ ] Update `version.txt` and version in `Cargo.toml` to the next release version.
 - [ ] Update versions in [brew taps](https://github.com/spiceai/homebrew-spiceai)
 - [ ] Remove the released version from the [ROADMAP](https://github.com/spiceai/spiceai/blob/trunk/docs/ROADMAP.md)
+- [ ] Create a new branch `release-v[semver]` for the next release version. E.g. `release-v0.14.0-alpha`
 
 ## Announcement Checklist
 
@@ -68,3 +69,5 @@ assignees: ''
 - PR 1.
 - PR 2.
 - etc.
+
+[Branching Policy]: https://github.com/spiceai/spiceai/blob/trunk/docs/RELEASE.md

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,19 +1,23 @@
 # Spice.ai Release Process
 
-## Release environments
+Spice.ai releases once per week.
 
-|                     | Production                     | Development                 | Local                         |
-| ------------------- | ------------------------------ | --------------------------- | ----------------------------- |
-| Short name          | prod                           | dev                         | local                         |
-| spiced Docker image | ghcr.io/spiceai/spiceai:latest | ghcr.io/spiceai/spiceai:dev | ghcr.io/spiceai/spiceai:local |
+## Branching Policy
+
+- At the beginning of the milestone for a target release a release branch is created, i.e. `release-v0.14.0-alpha`, in the main spiceai repository (not in a fork).
+- PRs are merged to the trunk branch incrementally as work is completed on individual features/bugs.
+- Once a feature/bugfix is considered "done" and ready to be included in the release, a new branch is created from the current release branch, all commits related to the feature/bugfix are cherry-picked into the new branch. And then a PR is created from the new branch into the release branch. That PR will be a regular merge, not a squash merge (IMPORTANT).
+- Any commits made directly to a release branch should be merged to the trunk branch.
+- If the decision to re-number the release is made by the release DRI, a new release branch with the correct version number is made from the existing release branch. The existing release branch is then deleted.
+
+At release time, we ensure all features/bug fixes we want from trunk have been included via the policy outlined above. Commits that should be not part of the release are not brought into the release branch. Each feature will be a single commit in the release branch, regardless of how many commits/PRs were made to the trunk branch.
 
 ## Endgame issue
 
-Create a [Milestone Endgame](https://github.com/spiceai/spiceai/issues/new?assignees=&labels=endgame&projects=&template=end_game.md&title=v0.x.x-alpha+Endgame) issue.
+Create a [Milestone Endgame](https://github.com/spiceai/spiceai/issues/new?assignees=&labels=endgame&projects=&template=end_game.md&title=v0.x.x-alpha+Endgame) issue to track the checklist needed for a specific milestone release.
 
 ## Version update
 
-- Major and minor updates can drop the patch. i.e. `v0.3` not `v0.3.0`
 - Create a PR updating version.txt to the next planned version number.
   - i.e. `0.2.1-alpha` -> `0.3-alpha`
 - Ensure the release notes at `docs/release_notes/v{version}.md` exist

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,6 +9,7 @@ Spice.ai releases once per week.
 - Once a feature/bugfix is considered "done" and ready to be included in the release, a new branch is created from the current release branch, all commits related to the feature/bugfix are cherry-picked into the new branch. And then a PR is created from the new branch into the release branch. That PR will be a regular merge, not a squash merge (IMPORTANT).
 - Any commits made directly to a release branch should be merged to the trunk branch.
 - If the decision to re-number the release is made by the release DRI, a new release branch with the correct version number is made from the existing release branch. The existing release branch is then deleted.
+- The engineer responsible for a given feature/bugfix is responsible for ensuring that the feature/bugfix is included in the release branch.
 
 At release time, we ensure all features/bug fixes we want from trunk have been included via the policy outlined above. Commits that should be not part of the release are not brought into the release branch. Each feature will be a single commit in the release branch, regardless of how many commits/PRs were made to the trunk branch.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -19,8 +19,9 @@ Create a [Milestone Endgame](https://github.com/spiceai/spiceai/issues/new?assig
 
 ## Version update
 
+- Major and minor updates can drop the patch in documentation and release notes. i.e. `v0.3` not `v0.3.0`. The actual version number in version.txt and Cargo.toml needs to be the full semver.
 - Create a PR updating version.txt to the next planned version number.
-  - i.e. `0.2.1-alpha` -> `0.3-alpha`
+  - i.e. `0.2.1-alpha` -> `0.3.0-alpha`
 - Ensure the release notes at `docs/release_notes/v{version}.md` exist
 - Create a new pre-release [GitHub release](https://github.com/spiceai/spiceai/releases/new) with placeholder information. Create a tag that matches the version to be released. The details of the release will be filled in by the automation.
   - Alternatively push a new tag via the git command line to the GitHub repository, and the release automation will be triggered.


### PR DESCRIPTION
Implements the new branching policy for releases going forward.

Most of the day-to-day work remains the same - but we will have a more explicit process for bringing features/bugs into a given release.