### PR TITLE
Add `/v1/ready` API that returns 200 when all datasets have loaded

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::borrow::Borrow;
 use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use crate::accelerated_table::{refresh::Refresh, AcceleratedTable, Retention};
@@ -50,6 +50,7 @@ use tokio::time::{sleep, Instant};
 pub mod query;
 
 pub mod filter_converter;
+pub mod initial_load;
 pub mod refresh_sql;
 pub mod schema;
 
@@ -183,7 +184,10 @@ pub enum Table {
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     data_writers: RwLock<HashSet<TableReference>>,
-    pub cache_provider: RwLock<Option<Arc<QueryResultsCacheProvider>>>,
+    cache_provider: RwLock<Option<Arc<QueryResultsCacheProvider>>>,
+
+    /// Has the initial load of the data been completed? It is the responsibility of the caller to call `mark_initial_load_complete` when the initial load is complete.
+    initial_load_complete: Mutex<bool>,
 }
 
 impl DataFusion {
@@ -248,6 +252,7 @@ impl DataFusion {
             ctx: Arc::new(ctx),
             data_writers: RwLock::new(HashSet::new()),
             cache_provider: RwLock::new(cache_provider),
+            initial_load_complete: Mutex::new(false),
         }
     }
 

--- a/crates/runtime/src/datafusion/initial_load.rs
+++ b/crates/runtime/src/datafusion/initial_load.rs
@@ -1,0 +1,22 @@
+use std::sync::MutexGuard;
+
+use crate::DataFusion;
+
+impl DataFusion {
+    pub fn mark_initial_load_complete(&self) {
+        let mut guard = self.get_initial_load_guard();
+        *guard = true;
+    }
+
+    pub fn is_initial_load_complete(&self) -> bool {
+        let guard = self.get_initial_load_guard();
+        *guard
+    }
+
+    fn get_initial_load_guard(&self) -> MutexGuard<bool> {
+        match self.initial_load_complete.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -61,6 +61,7 @@ pub(crate) fn routes(
             patch(v1::datasets::acceleration),
         )
         .route("/v1/spicepods", get(v1::spicepods::get))
+        .route("/v1/ready", get(v1::ready::get))
         .route_layer(middleware::from_fn(track_metrics));
 
     if cfg!(feature = "models") {

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -21,6 +21,7 @@ pub mod inference;
 pub mod models;
 pub mod nsql;
 pub mod query;
+pub mod ready;
 pub mod spicepods;
 pub mod status;
 

--- a/crates/runtime/src/http/v1/ready.rs
+++ b/crates/runtime/src/http/v1/ready.rs
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use crate::datafusion::DataFusion;
+use axum::{
+    http::status,
+    response::{IntoResponse, Response},
+    Extension,
+};
+
+pub(crate) async fn get(Extension(df): Extension<Arc<DataFusion>>) -> Response {
+    if df.is_initial_load_complete() {
+        return (status::StatusCode::OK, "Ready").into_response();
+    }
+    (status::StatusCode::SERVICE_UNAVAILABLE, "Not Ready").into_response()
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -357,6 +357,8 @@ impl Runtime {
 
         // After all datasets have loaded, load the views.
         self.load_views(app, &valid_datasets);
+
+        self.df.mark_initial_load_complete();
     }
 
     fn load_views(&self, app: &App, valid_datasets: &[Dataset]) {


### PR DESCRIPTION
Closes #1588

Adds a new HTTP API `/v1/ready` that returns 200 OK when all datasets have finished initial loading, otherwise it return 523 Not Ready. This makes it suitable for use in a K8s readiness probe to ensure traffic doesn't go to this instance until it has finished loading.