### PR TITLE
[append] Refresher::get_latest_timestamp / get_df to add refresh_sql predicates to scan

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -431,7 +431,11 @@ impl Refresher {
     }
 
     #[allow(clippy::needless_pass_by_value)]
-    async fn get_df(&self, ctx: SessionContext, column: &str) -> Result<DataFrame, DataFusionError> {
+    async fn get_df(
+        &self,
+        ctx: SessionContext,
+        column: &str,
+    ) -> Result<DataFrame, DataFusionError> {
         let expr = cast(
             col(column),
             DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None),

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -372,8 +372,10 @@ impl Refresher {
                 .context(super::FailedToFindLatestTimestampSnafu {
                     reason: "Failed to get latest timestamp due to time column not specified",
                 })?;
+
         let df = self
             .get_df(ctx, &column)
+            .await
             .context(super::UnableToScanTableProviderSnafu)?;
         let result = &df
             .collect()
@@ -429,13 +431,20 @@ impl Refresher {
     }
 
     #[allow(clippy::needless_pass_by_value)]
-    fn get_df(&self, ctx: SessionContext, column: &str) -> Result<DataFrame, DataFusionError> {
+    async fn get_df(&self, ctx: SessionContext, column: &str) -> Result<DataFrame, DataFusionError> {
         let expr = cast(
             col(column),
             DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None),
         )
         .alias("a");
-        ctx.read_table(Arc::clone(&self.accelerator))?
+
+        let table_df = if let Some(sql) = &self.refresh.read().await.sql {
+            ctx.sql(sql.as_str()).await?
+        } else {
+            ctx.read_table(Arc::clone(&self.accelerator))?
+        };
+
+        table_df
             .select(vec![expr])?
             .sort(vec![col("a").sort(false, false)])?
             .limit(0, Some(1))


### PR DESCRIPTION
Suppose we desire to constrain our refresh SQL to scan a specific partition key:

```sql
select * from foo_raw where tenant_id = 'foo';
```

Without this change, we push down:

```sql
2024-06-05T15:46:09.863132Z DEBUG sql_provider_datafusion: SqlExec sql: SELECT "my_ts_col" FROM foo_raw
```

With this change, we start building the latest timestamp DF around the refresh SQL if it is provided:

```sql
2024-06-05T15:47:57.998119Z DEBUG sql_provider_datafusion: SqlExec sql: SELECT my_ts_col FROM foo_raw WHERE tenant_id = 'foo'
```
