### PR TITLE
Add `err_code` to `query_failures` metric

### DIFF
--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -27,7 +27,7 @@ use datafusion::{
     execution::{context::SQLOptions, SendableRecordBatchStream},
     physical_plan::{memory::MemoryStream, stream::RecordBatchStreamAdapter},
 };
-use error_code::{error_code_from_datafusion_error, ErrorCode};
+use error_code::ErrorCode;
 use snafu::Snafu;
 use tokio::time::Instant;
 use uuid::Uuid;
@@ -116,7 +116,7 @@ impl Query {
         let plan = match session.create_logical_plan(&ctx.sql).await {
             Ok(plan) => plan,
             Err(e) => {
-                let error_code = error_code_from_datafusion_error(&e);
+                let error_code = ErrorCode::from(&e);
                 handle_error!(ctx, error_code, e, UnableToExecuteQuery)
             }
         };
@@ -167,7 +167,7 @@ impl Query {
         let df = match ctx.df.ctx.execute_logical_plan(plan).await {
             Ok(df) => df,
             Err(e) => {
-                let error_code = error_code_from_datafusion_error(&e);
+                let error_code = ErrorCode::from(&e);
                 handle_error!(ctx, error_code, e, UnableToExecuteQuery)
             }
         };
@@ -177,7 +177,7 @@ impl Query {
         let res_stream: SendableRecordBatchStream = match df.execute_stream().await {
             Ok(stream) => stream,
             Err(e) => {
-                let error_code = error_code_from_datafusion_error(&e);
+                let error_code = ErrorCode::from(&e);
                 handle_error!(ctx, error_code, e, UnableToExecuteQuery)
             }
         };

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -216,6 +216,10 @@ impl Query {
     }
 
     pub async fn finish_with_error(mut self, error_message: String, error_code: ErrorCode) {
+        tracing::debug!(
+            "Query '{}' finished with error: {error_message}; code: {error_code}",
+            self.sql
+        );
         self.error_message = Some(error_message);
         self.error_code = Some(error_code);
         self.finish().await;

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -320,7 +320,10 @@ fn attach_query_context_to_stream(
                     yield batch_result
                 }
                 Err(e) => {
-                    ctx.finish_with_error(e.to_string(), ErrorCode::DataReadError).await;
+                    ctx
+                    .schema(schema_copy)
+                    .rows_produced(num_records)
+                    .finish_with_error(e.to_string(), ErrorCode::DataReadError).await;
                     yield batch_result;
                     return;
                 }

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -324,6 +324,8 @@ fn attach_query_context_to_stream(
                     .schema(schema_copy)
                     .rows_produced(num_records)
                     .finish_with_error(e.to_string(), ErrorCode::DataReadError).await;
+                    // yielding error here terminates stream processing; `return` statement` below is used
+                    // to tell rust that we stop execution and it is safe to consume ctx here and it won't be used below
                     yield batch_result;
                     return;
                 }

--- a/crates/runtime/src/datafusion/query/builder.rs
+++ b/crates/runtime/src/datafusion/query/builder.rs
@@ -85,6 +85,7 @@ impl QueryBuilder {
             results_cache_hit: None,
             restricted_sql_options: self.restricted_sql_options,
             error_message: None,
+            error_code: None,
             datasets: Arc::new(HashSet::default()),
             timer: Instant::now(),
             protocol: self.protocol,

--- a/crates/runtime/src/datafusion/query/error_code.rs
+++ b/crates/runtime/src/datafusion/query/error_code.rs
@@ -45,18 +45,18 @@ impl From<&ErrorCode> for i8 {
     }
 }
 
-#[must_use]
-#[allow(clippy::module_name_repetitions)]
-pub fn error_code_from_datafusion_error(error: &DataFusionError) -> ErrorCode {
-    match error {
-        DataFusionError::SQL(..) => ErrorCode::SyntaxError,
-        DataFusionError::Plan(..) | DataFusionError::SchemaError(..) => {
-            ErrorCode::QueryPlanningError
+impl From<&DataFusionError> for ErrorCode {
+    fn from(error: &DataFusionError) -> Self {
+        match error {
+            DataFusionError::SQL(..) => ErrorCode::SyntaxError,
+            DataFusionError::Plan(..) | DataFusionError::SchemaError(..) => {
+                ErrorCode::QueryPlanningError
+            }
+            DataFusionError::ObjectStore(..) | DataFusionError::External(..) => {
+                ErrorCode::DataReadError
+            }
+            DataFusionError::Context(_, err) => ErrorCode::from(err.as_ref()),
+            _ => ErrorCode::UnexpectedError,
         }
-        DataFusionError::ObjectStore(..) | DataFusionError::External(..) => {
-            ErrorCode::DataReadError
-        }
-        DataFusionError::Context(_, err) => error_code_from_datafusion_error(err),
-        _ => ErrorCode::UnexpectedError,
     }
 }

--- a/crates/runtime/src/datafusion/query/error_code.rs
+++ b/crates/runtime/src/datafusion/query/error_code.rs
@@ -16,11 +16,12 @@ limitations under the License.
 
 use datafusion::error::DataFusionError;
 
+#[derive(Clone)]
 pub enum ErrorCode {
     SyntaxError,
     QueryPlanningError,
-    DataReadError,
-    UnexpectedError,
+    QueryExecutionError,
+    InternalError,
 }
 
 impl std::fmt::Display for ErrorCode {
@@ -28,8 +29,8 @@ impl std::fmt::Display for ErrorCode {
         match self {
             ErrorCode::SyntaxError => write!(f, "SyntaxError"),
             ErrorCode::QueryPlanningError => write!(f, "QueryPlanningError"),
-            ErrorCode::DataReadError => write!(f, "DataReadError"),
-            ErrorCode::UnexpectedError => write!(f, "UnexpectedError"),
+            ErrorCode::QueryExecutionError => write!(f, "QueryExecutionError"),
+            ErrorCode::InternalError => write!(f, "InternalError"),
         }
     }
 }
@@ -39,8 +40,8 @@ impl From<&ErrorCode> for i8 {
         match code {
             ErrorCode::SyntaxError => -10,
             ErrorCode::QueryPlanningError => -20,
-            ErrorCode::DataReadError => -30,
-            ErrorCode::UnexpectedError => -120,
+            ErrorCode::QueryExecutionError => -30,
+            ErrorCode::InternalError => -120,
         }
     }
 }
@@ -52,11 +53,11 @@ impl From<&DataFusionError> for ErrorCode {
             DataFusionError::Plan(..) | DataFusionError::SchemaError(..) => {
                 ErrorCode::QueryPlanningError
             }
-            DataFusionError::ObjectStore(..) | DataFusionError::External(..) => {
-                ErrorCode::DataReadError
-            }
+            DataFusionError::ObjectStore(..)
+            | DataFusionError::External(..)
+            | DataFusionError::Execution(..) => ErrorCode::QueryExecutionError,
             DataFusionError::Context(_, err) => ErrorCode::from(err.as_ref()),
-            _ => ErrorCode::UnexpectedError,
+            _ => ErrorCode::InternalError,
         }
     }
 }

--- a/crates/runtime/src/datafusion/query/error_code.rs
+++ b/crates/runtime/src/datafusion/query/error_code.rs
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use datafusion::error::DataFusionError;
+
+pub enum ErrorCode {
+    SyntaxError,
+    QueryPlanningError,
+    DataReadError,
+    UnexpectedError,
+}
+
+impl std::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ErrorCode::SyntaxError => write!(f, "SyntaxError"),
+            ErrorCode::QueryPlanningError => write!(f, "QueryPlanningError"),
+            ErrorCode::DataReadError => write!(f, "DataReadError"),
+            ErrorCode::UnexpectedError => write!(f, "UnexpectedError"),
+        }
+    }
+}
+
+impl From<&ErrorCode> for i8 {
+    fn from(code: &ErrorCode) -> Self {
+        match code {
+            ErrorCode::SyntaxError => -10,
+            ErrorCode::QueryPlanningError => -20,
+            ErrorCode::DataReadError => -30,
+            ErrorCode::UnexpectedError => -120,
+        }
+    }
+}
+
+#[must_use]
+#[allow(clippy::module_name_repetitions)]
+pub fn error_code_from_datafusion_error(error: &DataFusionError) -> ErrorCode {
+    match error {
+        DataFusionError::SQL(..) => ErrorCode::SyntaxError,
+        DataFusionError::Plan(..) | DataFusionError::SchemaError(..) => {
+            ErrorCode::QueryPlanningError
+        }
+        DataFusionError::ObjectStore(..) | DataFusionError::External(..) => {
+            ErrorCode::DataReadError
+        }
+        DataFusionError::Context(_, err) => error_code_from_datafusion_error(err),
+        _ => ErrorCode::UnexpectedError,
+    }
+}

--- a/crates/runtime/src/datafusion/query/query_history.rs
+++ b/crates/runtime/src/datafusion/query/query_history.rs
@@ -175,8 +175,8 @@ impl Query {
             .boxed()
             .context(UnableToCreateRowSnafu)?;
 
-        let execution_status = match self.error_message {
-            Some(_) => -1,
+        let execution_status = match &self.error_code {
+            Some(code) => code.into(),
             None => 0,
         };
 

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::datafusion::query::error_code::error_code_from_datafusion_error;
 use crate::datafusion::query::{Protocol, QueryBuilder};
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
@@ -159,7 +160,8 @@ impl Service {
         let schema = match query.get_schema().await {
             Ok(schema) => schema,
             Err(err) => {
-                query.finish_with_error(err.to_string()).await;
+                let error_code = error_code_from_datafusion_error(&err);
+                query.finish_with_error(err.to_string(), error_code).await;
 
                 return Err(handle_datafusion_error(err));
             }

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::datafusion::query::error_code::error_code_from_datafusion_error;
+use crate::datafusion::query::error_code::ErrorCode;
 use crate::datafusion::query::{Protocol, QueryBuilder};
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
@@ -160,7 +160,7 @@ impl Service {
         let schema = match query.get_schema().await {
             Ok(schema) => schema,
             Err(err) => {
-                let error_code = error_code_from_datafusion_error(&err);
+                let error_code = ErrorCode::from(&err);
                 query.finish_with_error(err.to_string(), error_code).await;
 
                 return Err(handle_datafusion_error(err));


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1283

Add `err_code` dimension to `query_failures` metric:
- SyntaxError - sql is syntactically incorrect
- QueryPlanningError - error while planning of the query (missing table or column) or invalid operation
- QueryExecutionError - error when reading data from an object_store  or Data Connector failure while executing query
- InternalError - internal or other error

Telemetry `err_code`  is string instead of code (Int) so it is more user friendly and easy to use when it is displayed on the dashboard