### PR TITLE
use epoch_ms to replace epoch to work with timestamptz

### DIFF
--- a/crates/data_components/src/duckdb/write.rs
+++ b/crates/data_components/src/duckdb/write.rs
@@ -249,7 +249,10 @@ mod tests {
             arrow::datatypes::Field::new("time_int", DataType::Int64, false),
             arrow::datatypes::Field::new(
                 "time_with_zone",
-                DataType::Timestamp(arrow::datatypes::TimeUnit::Second, Some("Etc/UTC".to_string().into())),
+                DataType::Timestamp(
+                    arrow::datatypes::TimeUnit::Second,
+                    Some("Etc/UTC".to_string().into()),
+                ),
                 false,
             ),
         ]));
@@ -285,10 +288,22 @@ mod tests {
         ]);
         let arr2 = TimestampSecondArray::from(vec![0, 1354360271, 1354360272]);
         let arr3 = Int64Array::from(vec![0, 1354360271, 1354360272]);
-        let arr4 = arrow::compute::cast(&arr2, &DataType::Timestamp(arrow::datatypes::TimeUnit::Second, Some("Etc/UTC".to_string().into()))).expect("casting works");
+        let arr4 = arrow::compute::cast(
+            &arr2,
+            &DataType::Timestamp(
+                arrow::datatypes::TimeUnit::Second,
+                Some("Etc/UTC".to_string().into()),
+            ),
+        )
+        .expect("casting works");
         let data = RecordBatch::try_new(
             Arc::clone(&schema),
-            vec![Arc::new(arr1), Arc::new(arr2), Arc::new(arr3), Arc::new(arr4)],
+            vec![
+                Arc::new(arr1),
+                Arc::new(arr2),
+                Arc::new(arr3),
+                Arc::new(arr4),
+            ],
         )
         .expect("data should be created");
 

--- a/crates/data_components/src/duckdb/write.rs
+++ b/crates/data_components/src/duckdb/write.rs
@@ -247,6 +247,11 @@ mod tests {
                 false,
             ),
             arrow::datatypes::Field::new("time_int", DataType::Int64, false),
+            arrow::datatypes::Field::new(
+                "time_with_zone",
+                DataType::Timestamp(arrow::datatypes::TimeUnit::Second, Some("Etc/UTC".to_string().into())),
+                false,
+            ),
         ]));
         let df_schema = ToDFSchema::to_dfschema_ref(Arc::clone(&schema)).expect("df schema");
         let external_table = CreateExternalTable {
@@ -280,9 +285,10 @@ mod tests {
         ]);
         let arr2 = TimestampSecondArray::from(vec![0, 1354360271, 1354360272]);
         let arr3 = Int64Array::from(vec![0, 1354360271, 1354360272]);
+        let arr4 = arrow::compute::cast(&arr2, &DataType::Timestamp(arrow::datatypes::TimeUnit::Second, Some("Etc/UTC".to_string().into()))).expect("casting works");
         let data = RecordBatch::try_new(
             Arc::clone(&schema),
-            vec![Arc::new(arr1), Arc::new(arr2), Arc::new(arr3)],
+            vec![Arc::new(arr1), Arc::new(arr2), Arc::new(arr3), Arc::new(arr4)],
         )
         .expect("data should be created");
 
@@ -346,7 +352,7 @@ mod tests {
         assert_eq!(actual, &expected);
 
         let insertion = table
-            .insert_into(&ctx.state(), exec, false)
+            .insert_into(&ctx.state(), Arc::<MockExec>::clone(&exec), false)
             .await
             .expect("insertion should be successful");
 
@@ -358,6 +364,40 @@ mod tests {
             .expect("table should be returned as deletion provider");
 
         let filter = col("time").lt(lit(ScalarValue::TimestampMillisecond(
+            Some(1354360272000),
+            None,
+        )));
+        let plan = delete_table
+            .delete_from(&ctx.state(), &vec![filter])
+            .await
+            .expect("deletion should be successful");
+
+        let result = collect(plan, ctx.task_ctx())
+            .await
+            .expect("deletion successful");
+        let actual = result
+            .first()
+            .expect("result should have at least one batch")
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("result should be UInt64Array");
+        let expected = UInt64Array::from(vec![2]);
+        assert_eq!(actual, &expected);
+
+        let insertion = table
+            .insert_into(&ctx.state(), exec, false)
+            .await
+            .expect("insertion should be successful");
+
+        collect(insertion, ctx.task_ctx())
+            .await
+            .expect("insert successful");
+
+        let delete_table = get_deletion_provider(Arc::clone(&table))
+            .expect("table should be returned as deletion provider");
+
+        let filter = col("time_with_zone").lt(lit(ScalarValue::TimestampMillisecond(
             Some(1354360272000),
             None,
         )));

--- a/crates/sql_provider_datafusion/src/expr.rs
+++ b/crates/sql_provider_datafusion/src/expr.rs
@@ -48,11 +48,11 @@ pub fn to_sql_with_engine(expr: &Expr, engine: Option<Engine>) -> Result<String>
             let right = to_sql_with_engine(&binary_expr.right, engine)?;
 
             if let Some(Engine::DuckDB) = engine {
-                // TODO: DuckDB doesn't support comparison between timestamp_s /timestamp_ms with timestampz as of v0.10.2
+                // TODO: DuckDB doesn't support comparison between timestamp_s /timestamp_ms with timestampz as of v1
                 // Revisit in future DuckDB versions
                 if right.starts_with("TO_TIMESTAMP") && !left.starts_with("TO_TIMESTAMP") {
                     return Ok(format!(
-                        "TO_TIMESTAMP(EPOCH({})) {} {}",
+                        "TO_TIMESTAMP(EPOCH_MS({}) / 1000) {} {}",
                         left, binary_expr.op, right
                     ));
                 }


### PR DESCRIPTION
in duckdb 1.0, epoch is supposed to be working with both timestamptz and timestamp; however, the duckdb-rs binding still has some issues. 

Will create a separate issue to track the issue once duckdb releases duckdb-rs with 1.0 support.

Also added a new section of test in duckdb/write to cover this case.

New query plan

```
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                    |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Filter: test_utc.a > TimestampMicrosecond(946774800000000, Some("Australia/Melbourne"))                                                 |
|               |   TableScan: test_utc projection=[a], partial_filters=[test_utc.a > TimestampMicrosecond(946774800000000, Some("Australia/Melbourne"))] |
| physical_plan | CoalesceBatchesExec: target_batch_size=8192                                                                                             |
|               |   FilterExec: a@0 > 946774800000000                                                                                                     |
|               |     SchemaCastScanExec                                                                                                                  |
|               |       RepartitionExec: partitioning=RoundRobinBatch(14), input_partitions=1                                                             |
|               |         SqlExec sql=SELECT "a" FROM test_utc WHERE TO_TIMESTAMP(EPOCH_MS("a") / 1000) > TO_TIMESTAMP(946774800)                         |
|               |                                                                                                                                         |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```