### PR TITLE
Add missing dependency on arrow_sql_gen from duckdb data_component

### DIFF
--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -56,7 +56,7 @@ bytes = "1.6.0"
 url = "2.5.0"
 
 [features]
-duckdb = ["dep:duckdb", "dep:r2d2"]
+duckdb = ["dep:duckdb", "dep:r2d2", "arrow_sql_gen"]
 flightsql = ["dep:tonic", "dep:r2d2"]
 postgres = ["dep:bb8", "dep:bb8-postgres", "dep:postgres-native-tls", "arrow_sql_gen/postgres", "dep:tokio-postgres"]
 mysql = ["dep:mysql_async", "arrow_sql_gen/mysql"]


### PR DESCRIPTION
Fixes an issue with building the data_components crate with just the `duckdb` feature. i.e. https://github.com/spiceai/spiceai/actions/runs/9456837209/job/26049512984