### PR TITLE
Update Helm chart for v0.13.3-alpha

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: spiceai
 description: Spice.ai OSS
-version: 0.1.12
+version: 0.1.13

--- a/deploy/chart/templates/spiceai.yaml
+++ b/deploy/chart/templates/spiceai.yaml
@@ -67,7 +67,7 @@ spec:
               port: 3000
           readinessProbe:
             httpGet:
-              path: /health
+              path: /v1/ready
               port: 3000
           startupProbe:
             httpGet:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: spiceai/spiceai
-  tag: 0.13.2-alpha
+  tag: 0.13.3-alpha
 replicaCount: 1
 monitoring:
   podMonitor:


### PR DESCRIPTION
Updates the Helm chart to point to v0.13.3-alpha

Also tweaks the chart to use the new `/v1/ready` API for the readiness probe