### PR TITLE
Generate unique runtime instance name, and store in `runtime.metrics` table

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -204,7 +204,7 @@ pub type EmbeddingModelStore = HashMap<String, RwLock<Box<dyn Embed>>>;
 
 #[derive(Clone)]
 pub struct Runtime {
-    pub instance_name: String,
+    instance_name: String,
     pub app: Arc<RwLock<Option<App>>>,
     pub df: Arc<DataFusion>,
     pub models: Arc<RwLock<HashMap<String, Model>>>,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -55,6 +55,7 @@ use tokio::sync::oneshot::error::RecvError;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
 pub use util::shutdown_signal;
+use uuid::Uuid;
 
 use crate::extension::{Extension, ExtensionFactory};
 pub mod accelerated_table;
@@ -203,6 +204,7 @@ pub type EmbeddingModelStore = HashMap<String, RwLock<Box<dyn Embed>>>;
 
 #[derive(Clone)]
 pub struct Runtime {
+    pub instance_name: String,
     pub app: Arc<RwLock<Option<App>>>,
     pub df: Arc<DataFusion>,
     pub models: Arc<RwLock<HashMap<String, Model>>>,
@@ -225,7 +227,14 @@ impl Runtime {
         dataconnector::register_all().await;
         dataaccelerator::register_all().await;
 
+        let hash = Uuid::new_v4().to_string()[..8].to_string();
+        let name = match &app {
+            Some(app) => app.name.clone(),
+            None => "spice".to_string(),
+        };
+
         let mut rt = Runtime {
+            instance_name: format!("{name}-{hash}").to_string(),
             app: Arc::new(RwLock::new(app)),
             df: Arc::new(DataFusion::new()),
             models: Arc::new(RwLock::new(HashMap::new())),
@@ -912,7 +921,7 @@ impl Runtime {
                     .context(UnableToStartLocalMetricsSnafu)?;
             }
 
-            recorder.start(&self.df);
+            recorder.start(self.instance_name.clone(), &self.df);
         }
 
         Ok(())

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -108,6 +108,7 @@ impl MetricsRecorder {
 
     async fn tick(
         socket_addr: &SocketAddr,
+        instance_name: String,
         datafusion: &Arc<DataFusion>,
         remote_schema: &Arc<Option<Arc<Schema>>>,
     ) -> Result<(), Error> {
@@ -125,7 +126,8 @@ impl MetricsRecorder {
         let sample_size = scrape.samples.len();
 
         let mut timestamps: Vec<i64> = Vec::with_capacity(sample_size);
-        let mut metrics: Vec<String> = Vec::with_capacity(sample_size);
+        let mut instances: Vec<String> = Vec::with_capacity(sample_size);
+        let mut names: Vec<String> = Vec::with_capacity(sample_size);
         let mut values: Vec<f64> = Vec::with_capacity(sample_size);
         let mut labels: Vec<String> = Vec::with_capacity(sample_size);
 
@@ -144,7 +146,8 @@ impl MetricsRecorder {
             } else {
                 timestamps.push(timestamp.timestamp_micros() * 1000);
             }
-            metrics.push(sample.metric);
+            instances.push(instance_name.clone());
+            names.push(sample.metric);
             values.push(value);
             labels.push(sample.labels.to_string());
         }
@@ -156,7 +159,8 @@ impl MetricsRecorder {
                 Arc::new(
                     TimestampNanosecondArray::from(timestamps).with_timezone(Arc::from("UTC")),
                 ),
-                Arc::new(StringArray::from(metrics)),
+                Arc::new(StringArray::from(instances)),
+                Arc::new(StringArray::from(names)),
                 Arc::new(Float64Array::from(values)),
                 Arc::new(StringArray::from(labels)),
             ],
@@ -184,14 +188,16 @@ impl MetricsRecorder {
         Ok(())
     }
 
-    pub fn start(&self, datafusion: &Arc<DataFusion>) {
+    pub fn start(&self, instance_name: String, datafusion: &Arc<DataFusion>) {
         let addr = Arc::clone(&self.socket_addr);
         let df = Arc::clone(datafusion);
         let schema = Arc::clone(&self.remote_schema);
 
         spawn(async move {
             loop {
-                if let Err(err) = MetricsRecorder::tick(&addr, &df, &schema).await {
+                if let Err(err) =
+                    MetricsRecorder::tick(&addr, instance_name.clone(), &df, &schema).await
+                {
                     tracing::error!("{err}");
                 }
                 tokio::time::sleep(Duration::from_secs(30)).await;
@@ -211,6 +217,7 @@ pub fn get_metrics_schema() -> Arc<Schema> {
             ),
             false,
         ),
+        Field::new("instance", DataType::Utf8, false),
         Field::new("name", DataType::Utf8, false),
         Field::new("value", DataType::Float64, false),
         Field::new("labels", DataType::Utf8, false),


### PR DESCRIPTION
Generates unique instance name on spice runtime start, using name from spicepod (defaults to `spice`) and 8 characters uuid hash.

Added `instance` column to runtime.metrics table

![CleanShot 2024-06-11 at 23 33 40@2x](https://github.com/spiceai/spiceai/assets/827338/faad6d02-796e-4dbe-bae3-c0af93df61b6)