### PR TITLE
Start runtime metrics recorder after loading secrets and extensions

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -148,7 +148,6 @@ pub async fn run(args: Args) -> Result<()> {
             };
         }),
         Box::pin(rt.init_results_cache()),
-        // Box::pin(rt.start_extensions()),
         Box::pin(rt.load_datasets()),
     ];
 


### PR DESCRIPTION
Metrics recorder can be extended by spice extensions (it checks if custom `runtime_metrics` table registered, otherwise registers local table).
For spice cloud metrics it requires to have secrets loaded and extensions started first.