### PR TITLE
Fix Cache Hit Rate chart loading for Grafana v9.5

### DIFF
--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -913,8 +913,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "dark-green",
-            "mode": "shades"
+            "fixedColor": "dark-green"
           },
           "custom": {
             "axisCenteredZero": false,


### PR DESCRIPTION
"mode": "shades" requires Grafana v10.x+