### PR TITLE
Improved error logging for datasets load error

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -400,9 +400,10 @@ impl Runtime {
             let connector = match self.load_dataset_connector(ds).await {
                 Ok(connector) => connector,
                 Err(err) => {
-                    status::update_dataset(&ds.name, status::ComponentStatus::Error);
+                    let ds_name = &ds.name;
+                    status::update_dataset(&ds_name, status::ComponentStatus::Error);
                     metrics::counter!("datasets_load_error").increment(1);
-                    warn_spaced!(spaced_tracer, "{}{err}", "");
+                    warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                     sleep(Duration::from_secs(1)).await;
                     continue;
                 }
@@ -459,9 +460,10 @@ impl Runtime {
         {
             Ok(data_connector) => data_connector,
             Err(err) => {
-                status::update_dataset(&ds.name, status::ComponentStatus::Error);
+                let ds_name = &ds.name;
+                status::update_dataset(ds_name, status::ComponentStatus::Error);
                 metrics::counter!("datasets_load_error").increment(1);
-                warn_spaced!(spaced_tracer, "{}{err}", "");
+                warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                 return UnableToLoadDatasetConnectorSnafu {
                     dataset: ds.name.clone(),
                 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -401,7 +401,7 @@ impl Runtime {
                 Ok(connector) => connector,
                 Err(err) => {
                     let ds_name = &ds.name;
-                    status::update_dataset(&ds_name, status::ComponentStatus::Error);
+                    status::update_dataset(ds_name, status::ComponentStatus::Error);
                     metrics::counter!("datasets_load_error").increment(1);
                     warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
                     sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
When secrets are not found, it's useful to have a debug message that provides more information about what dataset failed to load