### PR TITLE
Improve `ArrayDistance` scalar UDF

### DIFF
--- a/crates/runtime/src/embeddings/array_distance.rs
+++ b/crates/runtime/src/embeddings/array_distance.rs
@@ -454,7 +454,7 @@ mod tests {
         let array_vec = ColumnarValue::values_to_arrays(&[col_array])?;
         let array = array_vec[0]
             .as_any()
-            .downcast_ref::<Float64Array>()
+            .downcast_ref::<Float32Array>()
             .ok_or("failed downcast of result")?;
         assert_eq!(array.len(), 3);
         assert_eq!(array.value(0), 0.0);

--- a/crates/runtime/src/embeddings/array_distance.rs
+++ b/crates/runtime/src/embeddings/array_distance.rs
@@ -28,14 +28,6 @@ use std::{any::Any, sync::Arc};
 // See: https://github.com/apache/datafusion/blob/888504a8da6d20f9caf3ecb6cd1a6b7d1956e23e/datafusion/expr/src/signature.rs#L36
 pub const FIXED_SIZE_LIST_WILDCARD: i32 = i32::MIN;
 
-pub trait ArrowFloatType: ArrowPrimitiveType {}
-
-impl ArrowFloatType for Float16Type {}
-
-impl ArrowFloatType for Float32Type {}
-
-impl ArrowFloatType for Float64Type {}
-
 #[derive(Debug)]
 pub struct ArrayDistance {
     signature: Signature,

--- a/crates/runtime/src/embeddings/mod.rs
+++ b/crates/runtime/src/embeddings/mod.rs
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#![feature(f16_and_f128)]
 pub mod array_distance;
 pub mod connector;
 pub mod execution_plan;

--- a/crates/runtime/src/embeddings/mod.rs
+++ b/crates/runtime/src/embeddings/mod.rs
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+#![allow(unused_attributes)] // This is for the `f16_and_f128` feature.
 #![feature(f16_and_f128)]
 pub mod array_distance;
 pub mod connector;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 #![allow(clippy::missing_errors_doc)]
 
 use std::borrow::Borrow;


### PR DESCRIPTION
## Changes
 - Support for Float64, Float32, Float16
 - Support for FixedSizeListArray, ListArray, LargeListArray
 - Proper use of Arrow features like `cast(` and `binary(`

Resolves #1616 