### PR TITLE
Retry logic for accelerated table refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5286,6 +5286,7 @@ name = "llms"
 version = "0.14.0-alpha"
 dependencies = [
  "async-openai",
+ "async-stream",
  "async-trait",
  "candle-core 0.5.0",
  "candle-core 0.5.1",
@@ -5295,6 +5296,7 @@ dependencies = [
  "futures",
  "mistralrs",
  "mistralrs-core",
+ "rand",
  "serde",
  "serde_json",
  "snafu 0.8.2",
@@ -7599,6 +7601,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.7.5",
+ "backoff",
  "bb8",
  "bb8-postgres",
  "bollard",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -94,6 +94,7 @@ metrics-exporter-prometheus = "0.13.0"
 prometheus-parse = "0.2.5"
 async-openai = "0.21.0"
 derive_builder = "0.20.0"
+backoff="0.4.0"
 
 [dev-dependencies]
 bollard = "0.16.1"

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -54,11 +54,8 @@ pub mod refresh;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to get data from connector after {num_attempts} attempts: {source}"))]
-    UnableToGetDataFromConnector {
-        source: dataconnector::Error,
-        num_attempts: usize,
-    },
+    #[snafu(display("Unable to get data from connector: {source}"))]
+    UnableToGetDataFromConnector { source: dataconnector::Error },
 
     #[snafu(display("Unable to scan table provider: {source}"))]
     UnableToScanTableProvider {

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -54,8 +54,11 @@ pub mod refresh;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to get data from connector: {source}"))]
-    UnableToGetDataFromConnector { source: dataconnector::Error },
+    #[snafu(display("Unable to get data from connector after {num_attempts} attempts: {source}"))]
+    UnableToGetDataFromConnector {
+        source: dataconnector::Error,
+        num_attempts: usize,
+    },
 
     #[snafu(display("Unable to scan table provider: {source}"))]
     UnableToScanTableProvider {

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -547,7 +547,7 @@ impl Refresher {
             }
         })
         .await
-        .map_err(|e| super::Error::UnableToGetDataFromConnector { source: e })
+        .context(super::UnableToGetDataFromConnectorSnafu)
     }
 
     fn get_refresh_df_context(&self) -> SessionContext {

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -534,6 +534,9 @@ impl Refresher {
                         dataset_name,
                         e
                     );
+                    let labels = [("dataset", dataset_name.to_string())];
+                    metrics::counter!("datasets_acceleration_refresh_errors", &labels).increment(1);
+
                     Err(backoff::Error::Transient {
                         err: e,
                         retry_after: None,


### PR DESCRIPTION
Implements https://github.com/spiceai/spiceai/issues/1693

Adds exponential retry for accelerated dataset refresh:
 - Retries stop if it is time for the next scheduled refresh (`refresh_check_interval`)
 - With exponential delay between retries with 5 min max
 - With default randomization factor 0.5 which results in a random period ranging between 50% below and 50% above the retry interval.

Example log when refresh is failed to complete before next scheduled refresh
```bash
2024-06-16T20:38:48.344802Z  INFO runtime::accelerated_table::refresh: Loading data for dataset nation
2024-06-16T20:38:48.351890Z  WARN runtime::accelerated_table::refresh: Failed to get refresh data for dataset nation: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-16T20:38:49.567026Z  WARN runtime::accelerated_table::refresh: Failed to get refresh data for dataset nation: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-16T20:38:50.870828Z  WARN runtime::accelerated_table::refresh: Failed to get refresh data for dataset nation: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-16T20:38:54.525582Z  WARN runtime::accelerated_table::refresh: Failed to get refresh data for dataset nation: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-16T20:39:03.765287Z  WARN runtime::accelerated_table::refresh: Failed to get refresh data for dataset nation: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-16T20:39:03.765540Z ERROR runtime::accelerated_table::refresh: Failed to load data for dataset nation: Unable to get data from connector: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
```

Example log with successful refresh after few retries
```bash
2024-06-16T20:39:18.344671Z  INFO runtime::accelerated_table::refresh: Loading data for dataset nation
2024-06-16T20:39:18.350844Z  WARN runtime::accelerated_table::refresh: Failed to get refresh data for dataset nation: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-16T20:39:19.722206Z  WARN runtime::accelerated_table::refresh: Failed to get refresh data for dataset nation: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-16T20:39:21.976772Z  WARN runtime::accelerated_table::refresh: Failed to get refresh data for dataset nation: Unable to scan table provider: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-16T20:39:26.867761Z  INFO runtime::accelerated_table::refresh: Loaded 25 rows (19.55 kiB) for dataset nation in 8s 523ms.
```

### Next steps:
1. Add logic to not reply on errors related to invalid yaml configuration (refresh sql)
2. Update dataset registration to rely on similar exponential retry approach