### PR TITLE
v0.14.0-alpha release notes

### DIFF
--- a/docs/release_notes/v0.14.0-alpha.md
+++ b/docs/release_notes/v0.14.0-alpha.md
@@ -1,0 +1,49 @@
+# Spice v0.14.0-alpha (June 17, 2024)
+
+The v0.14.0-alpha release ...
+
+## Highlights
+
+- GraphQL data connector (alpha)
+- Primary Key/Indexes for Acceleration Engines
+
+## Contributors
+
+- @Jeadie
+- @ewgenius
+- @phillipleblanc
+- @sgrebnov
+- @gloomweaver
+- @y-f-u
+- @edmondop
+
+## What's Changed
+
+### Commits
+
+- Update Helm chart for v0.13.3-alpha by @phillipleblanc in https://github.com/spiceai/spiceai/pull/1671
+- Bump version to v0.14.0-alpha by @phillipleblanc in https://github.com/spiceai/spiceai/pull/1673
+- Dependency upgrades: DataFusion 39, Arrow/Parquet 52, object_store 0.10.1, arrow-odbc 11.1.0 by @phillipleblanc in https://github.com/spiceai/spiceai/pull/1674
+- Generate unique runtime instance name and store in `runtime.metrics` table by @ewgenius in https://github.com/spiceai/spiceai/pull/1678
+- Proper support for Snowflake TIMESTAMP_NTZ by @sgrebnov in https://github.com/spiceai/spiceai/pull/1677
+- Enable tpch_q2 and tpch_q21 in the benchmark queries by @phillipleblanc in https://github.com/spiceai/spiceai/pull/1679
+- Start runtime metrics recorder after loading secrets and extensions by @ewgenius in https://github.com/spiceai/spiceai/pull/1680
+- Validate table constraints (Primary Keys/Unique Index) on accelerated tables by @phillipleblanc in https://github.com/spiceai/spiceai/pull/1658
+- Store labels as JSON string in `runtime.metrics` by @ewgenius in https://github.com/spiceai/spiceai/pull/1681
+- Atomic updates for DuckDB tables with constraints by @phillipleblanc in https://github.com/spiceai/spiceai/pull/1682
+- Rename metrics column `labels` to `properties` and make it nullable by @ewgenius in https://github.com/spiceai/spiceai/pull/1686
+- Fix federation_optimizer_rule schema error for `tpch_q7`, `tpch_q8`, `tpch_q9`, `tpch_q14` by @sgrebnov in https://github.com/spiceai/spiceai/pull/1683
+- Better prompt for /v1/assist by @Jeadie in https://github.com/spiceai/spiceai/pull/1685
+- Support stream in `v1/assist` by @Jeadie in https://github.com/spiceai/spiceai/pull/1653
+- Fix cache hit rate chart loading for Grafana v9.5 by @sgrebnov in https://github.com/spiceai/spiceai/pull/1691
+- Update ROADMAP.md to include data connector statuses by @digadeesh in https://github.com/spiceai/spiceai/pull/1684
+- Support `primary_key` in Spicepod and create in accelerated table by @phillipleblanc in https://github.com/spiceai/spiceai/pull/1687
+- Datasets with schema support for availability monitoring by @sgrebnov in https://github.com/spiceai/spiceai/pull/1690
+- Improve dataset registration output by @sgrebnov in https://github.com/spiceai/spiceai/pull/1692
+- Readme: update dataset registration traces by @sgrebnov in https://github.com/spiceai/spiceai/pull/1694
+- Improved error logging for datasets load error by @edmondop in https://github.com/spiceai/spiceai/pull/1695
+- Improve `ArrayDistance` scalar UDF by @Jeadie in https://github.com/spiceai/spiceai/pull/1697
+- Implement `on_conflict` behavior for accelerated tables with constraints by @phillipleblanc in https://github.com/spiceai/spiceai/pull/1688
+- Fix datasets live update (Spice file watcher) by @sgrebnov in https://github.com/spiceai/spiceai/pull/1702
+
+**Full Changelog**: https://github.com/spiceai/spiceai/compare/v0.13.3-alpha...v0.14.0-alpha


### PR DESCRIPTION
Closed in favor of https://github.com/spiceai/spiceai/pull/1708

Closed as this PR is based on protected branch which can't be updated directly (only via PR)
