### PR TITLE
refresh with append overlap

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -62,7 +62,7 @@ pub enum Error {
         source: datafusion::error::DataFusionError,
     },
 
-    #[snafu(display("Unable to create mem table from data update: {source}"))]
+    #[snafu(display("Unable to create MemTable from data update: {source}"))]
     UnableToCreateMemTableFromUpdate {
         source: datafusion::error::DataFusionError,
     },

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -62,6 +62,11 @@ pub enum Error {
         source: datafusion::error::DataFusionError,
     },
 
+    #[snafu(display("Unable to create mem table from data update: {source}"))]
+    UnableToCreateMemTableFromUpdate {
+        source: datafusion::error::DataFusionError,
+    },
+
     #[snafu(display("Failed to trigger table refresh: {source}"))]
     FailedToTriggerRefresh {
         source: tokio::sync::mpsc::error::SendError<()>,

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -352,7 +352,7 @@ impl Refresher {
                     "append_dataset_duration_ms",
                     vec![("dataset", dataset_name.to_string())],
                 );
-                match self.timestamp_for_append_query().await {
+                match self.timestamp_nanos_for_append_query().await {
                     Ok(timestamp) => {
                         let start = SystemTime::now();
                         match self.get_full_or_incremental_append_update(timestamp).await {
@@ -372,7 +372,7 @@ impl Refresher {
         }
     }
 
-    async fn refresh_append_overlap(&self) -> u128 {
+    async fn refresh_append_overlap_nanos(&self) -> u128 {
         self.refresh
             .read()
             .await
@@ -382,7 +382,7 @@ impl Refresher {
     }
 
     #[allow(clippy::cast_sign_loss)]
-    async fn timestamp_for_append_query(&self) -> super::Result<Option<u128>> {
+    async fn timestamp_nanos_for_append_query(&self) -> super::Result<Option<u128>> {
         let ctx = self.refresh_df_context();
         let refresh = self.refresh.read().await;
 
@@ -448,7 +448,7 @@ impl Refresher {
             }
         };
 
-        let refresh_append_value = self.refresh_append_overlap().await;
+        let refresh_append_value = self.refresh_append_overlap_nanos().await;
 
         if refresh_append_value > value {
             Ok(Some(0))
@@ -486,7 +486,7 @@ impl Refresher {
 
     #[allow(clippy::cast_possible_truncation)]
     async fn except_existing_records_from(&self, update: DataUpdate) -> super::Result<DataUpdate> {
-        let Some(value) = self.timestamp_for_append_query().await? else {
+        let Some(value) = self.timestamp_nanos_for_append_query().await? else {
             return Ok(update);
         };
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -351,7 +351,7 @@ impl Refresher {
                     "append_dataset_duration_ms",
                     vec![("dataset", dataset_name.to_string())],
                 );
-                match self.get_refresh_append_timestamp().await {
+                match self.get_timestamp_for_append_query().await {
                     Ok(timestamp) => {
                         let start = SystemTime::now();
 
@@ -382,7 +382,7 @@ impl Refresher {
     }
 
     #[allow(clippy::cast_sign_loss)]
-    async fn get_refresh_append_timestamp(&self) -> super::Result<Option<u128>> {
+    async fn get_timestamp_for_append_query(&self) -> super::Result<Option<u128>> {
         let ctx = self.get_refresh_df_context();
         let refresh = self.refresh.read().await;
 
@@ -486,7 +486,7 @@ impl Refresher {
 
     #[allow(clippy::cast_possible_truncation)]
     async fn except_existing_records(&self, update: DataUpdate) -> super::Result<DataUpdate> {
-        let Some(value) = self.get_refresh_append_timestamp().await? else {
+        let Some(value) = self.get_timestamp_for_append_query().await? else {
             return Ok(update);
         };
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -502,7 +502,7 @@ impl Refresher {
             .context(super::UnableToScanTableProviderSnafu)?;
 
         let existing_df = self
-            .accelerator_df(ctx.clone())
+            .accelerator_df(self.refresh_df_context())
             .await
             .context(super::UnableToScanTableProviderSnafu)?
             .filter(filter_converter.convert(value, Operator::Gt))

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -469,9 +469,8 @@ impl Refresher {
         )
         .alias("a");
 
-        let table_df = self.get_df(ctx).await?;
-
-        table_df
+        self.get_df(ctx)
+            .await?
             .select(vec![expr])?
             .sort(vec![col("a").sort(false, false)])?
             .limit(0, Some(1))

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -39,6 +39,7 @@ pub struct Refresh {
     pub(crate) sql: Option<String>,
     pub(crate) mode: RefreshMode,
     pub(crate) period: Option<Duration>,
+    pub(crate) append_overlap: Option<Duration>,
 }
 
 impl Refresh {
@@ -51,6 +52,7 @@ impl Refresh {
         sql: Option<String>,
         mode: RefreshMode,
         period: Option<Duration>,
+        append_overlap: Option<Duration>,
     ) -> Self {
         Self {
             time_column,
@@ -59,6 +61,7 @@ impl Refresh {
             sql,
             mode,
             period,
+            append_overlap,
         }
     }
 }
@@ -72,6 +75,7 @@ impl Default for Refresh {
             sql: None,
             mode: RefreshMode::Full,
             period: None,
+            append_overlap: None,
         }
     }
 }
@@ -650,7 +654,7 @@ mod tests {
             MemTable::try_new(schema, vec![vec![batch]]).expect("mem table should be created"),
         ) as Arc<dyn TableProvider>;
 
-        let refresh = Refresh::new(None, None, None, None, RefreshMode::Full, None);
+        let refresh = Refresh::new(None, None, None, None, RefreshMode::Full, None, None);
 
         let refresher = Refresher::new(
             TableReference::bare("test"),
@@ -829,6 +833,7 @@ mod tests {
                 None,
                 RefreshMode::Append,
                 None,
+                None,
             );
 
             let refresher = Refresher::new(
@@ -976,6 +981,7 @@ mod tests {
                 None,
                 None,
                 RefreshMode::Append,
+                None,
                 None,
             );
 

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -325,6 +325,24 @@ impl Dataset {
     }
 
     #[must_use]
+    pub fn refresh_append_overlap(&self) -> Option<Duration> {
+        if let Some(acceleration) = &self.acceleration {
+            if let Some(refresh_append_overlap) = &acceleration.refresh_append_overlap {
+                if let Ok(duration) = fundu::parse_duration(refresh_append_overlap) {
+                    return Some(duration);
+                }
+                tracing::warn!(
+                    "Unable to parse refresh append overlap for dataset {}: {}",
+                    self.name,
+                    refresh_append_overlap
+                );
+            }
+        }
+
+        None
+    }
+
+    #[must_use]
     pub fn mode(&self) -> Mode {
         self.mode
     }

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -50,6 +50,12 @@ pub enum Error {
         column_ref: String,
         source: column_reference::Error,
     },
+
+    #[snafu(display("Error parsing {field} as duration: {source}"))]
+    UnableToParseFieldAsDuration {
+        field: String,
+        source: fundu::ParseError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -324,23 +330,6 @@ impl Dataset {
         None
     }
 
-    #[must_use]
-    pub fn refresh_append_overlap(&self) -> Option<Duration> {
-        if let Some(acceleration) = &self.acceleration {
-            if let Some(refresh_append_overlap) = &acceleration.refresh_append_overlap {
-                if let Ok(duration) = fundu::parse_duration(refresh_append_overlap) {
-                    return Some(duration);
-                }
-                tracing::warn!(
-                    "Unable to parse refresh append overlap for dataset {}: {}",
-                    self.name,
-                    refresh_append_overlap
-                );
-            }
-        }
-
-        None
-    }
 
     #[must_use]
     pub fn mode(&self) -> Mode {

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -330,7 +330,6 @@ impl Dataset {
         None
     }
 
-
     #[must_use]
     pub fn mode(&self) -> Mode {
         self.mode

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -219,6 +219,8 @@ pub struct Acceleration {
 
     pub refresh_data_window: Option<String>,
 
+    pub refresh_append_overlap: Option<String>,
+
     pub params: HashMap<String, String>,
 
     pub engine_secret: Option<String>,
@@ -279,6 +281,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             refresh_check_interval: acceleration.refresh_check_interval,
             refresh_sql: acceleration.refresh_sql,
             refresh_data_window: acceleration.refresh_data_window,
+            refresh_append_overlap: acceleration.refresh_append_overlap,
             params: acceleration
                 .params
                 .as_ref()
@@ -306,6 +309,7 @@ impl Default for Acceleration {
             refresh_check_interval: None,
             refresh_sql: None,
             refresh_data_window: None,
+            refresh_append_overlap: None,
             params: HashMap::default(),
             engine_secret: None,
             retention_period: None,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -540,7 +540,7 @@ impl DataFusion {
                 refresh_sql.clone(),
                 acceleration_settings.refresh_mode,
                 dataset.refresh_data_window(),
-                None,
+                dataset.refresh_append_overlap(),
             ),
         );
         accelerated_table_builder.retention(Retention::new(

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -540,6 +540,7 @@ impl DataFusion {
                 refresh_sql.clone(),
                 acceleration_settings.refresh_mode,
                 dataset.refresh_data_window(),
+                None,
             ),
         );
         accelerated_table_builder.retention(Retention::new(

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -540,7 +540,7 @@ impl DataFusion {
                 refresh_sql.clone(),
                 acceleration_settings.refresh_mode,
                 dataset.refresh_data_window(),
-                dataset.refresh_append_overlap(),
+                acceleration_settings.refresh_append_overlap,
             ),
         );
         accelerated_table_builder.retention(Retention::new(

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -128,6 +128,7 @@ impl SpiceExtension {
             None,
             RefreshMode::Full,
             Some(Duration::from_secs(1800)), // sync only last 30 minutes from cloud
+            None,
         );
 
         let metrics_table_reference = get_metrics_table_reference();

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -225,6 +225,9 @@ pub mod acceleration {
         pub refresh_data_window: Option<String>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub refresh_append_overlap: Option<String>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub params: Option<Params>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -271,6 +274,7 @@ pub mod acceleration {
                 refresh_check_interval: None,
                 refresh_sql: None,
                 refresh_data_window: None,
+                refresh_append_overlap: None,
                 params: None,
                 engine_secret: None,
                 retention_period: None,


### PR DESCRIPTION
This adds a parameters `refresh_append_overlap` duration to indicate the incremental append will try to fetch `max_timestamp_from_acceleration - refresh_append_overlap` from the source to cover any late arrival data.