### PR TITLE
Secret keys in params should be case insensitive

### DIFF
--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -162,7 +162,7 @@ impl Secret {
             None => param_key,
         };
 
-        if let Some(secret_val) = self.data.get(secret_param_val) {
+        if let Some(secret_val) = self.data.get(secret_param_val.to_lowercase().as_str()) {
             params.insert(param_key.to_string(), secret_val.clone());
         }
     }


### PR DESCRIPTION
Secret key from params shouldn't be case sensitive.
E.g. with env secret store

```shell
SPICE_SECRET_POSTGRES_PG_PASS="my_pass" spiced
```

both spicepods should work:

```yaml
  datasets:
    - from: postgres:db
      name: mydataset
      params:
        # ...
        pg_pass_key: pg_pass
```

```yaml
  datasets:
    - from: postgres:db
      name: mydataset
      params:
        # ...
        pg_pass_key: PG_PASS
```