### PR TITLE
Update version of `spiceai/duckdb-rs`, support LargeUTF8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "duckdb"
 version = "1.0.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=506c2ddb81e86ef13b75f7fa8817abefb04a123d#506c2ddb81e86ef13b75f7fa8817abefb04a123d"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=40e4a8e8c7e6e079b06da24d06a14c491c3c2f61#40e4a8e8c7e6e079b06da24d06a14c491c3c2f61"
 dependencies = [
  "arrow",
  "cast",
@@ -5171,7 +5171,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libduckdb-sys"
 version = "1.0.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=506c2ddb81e86ef13b75f7fa8817abefb04a123d#506c2ddb81e86ef13b75f7fa8817abefb04a123d"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=40e4a8e8c7e6e079b06da24d06a14c491c3c2f61#40e4a8e8c7e6e079b06da24d06a14c491c3c2f61"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ metrics = "0.22.0"
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "be2c2c1f74823956e609a23ca38657cd76c2fcfe" }
 arrow = "52.0.0"
 arrow-flight = "52.0.0"
-duckdb = { git="https://github.com/spiceai/duckdb-rs.git", rev = "506c2ddb81e86ef13b75f7fa8817abefb04a123d" }
+duckdb = { git="https://github.com/spiceai/duckdb-rs.git", rev = "40e4a8e8c7e6e079b06da24d06a14c491c3c2f61" }
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "48173bdee3d3be04dcc579b3211662e359b72734" }
 tonic = "0.11.0"
 futures = "0.3.30"


### PR DESCRIPTION
## Changes
 - Differences from [spiceai/duckdb-rs](https://github.com/spiceai/duckdb-rs)
     -  https://github.com/spiceai/duckdb-rs/pull/1