### PR TITLE
bump duckdb rs git sha to resolve duckdb incorrect null value issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ metrics = "0.22.0"
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "be2c2c1f74823956e609a23ca38657cd76c2fcfe" }
 arrow = "52.0.0"
 arrow-flight = "52.0.0"
-duckdb = { git="https://github.com/spiceai/duckdb-rs.git", rev = "40e4a8e8c7e6e079b06da24d06a14c491c3c2f61" }
+duckdb = { git="https://github.com/spiceai/duckdb-rs.git", rev = "c7b8e22885001e2013493aebbaf190039d826c05" }
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "48173bdee3d3be04dcc579b3211662e359b72734" }
 tonic = "0.11.0"
 futures = "0.3.30"


### PR DESCRIPTION
fixes #1745 

The updated duckdb-rs gitsha contains the changes of setting proper nulls for all possible duckdb vectors, which will ensure duckdb accelerator to persist data correctly without converting nulls to default value.


data from duckdb as the source
```
D select * from test;
┌───────┬─────────┬──────────────┬────────────┬──────────────────────────────┐
│  ts   │   str   │     list     │    arr     │            struct            │
│ int32 │ varchar │   int32[]    │ integer[3] │ struct(k integer, l varchar) │
├───────┼─────────┼──────────────┼────────────┼──────────────────────────────┤
│     1 │ string  │ [1, 2, 3, 4] │ [1, 2, 3]  │ {'k': 1, 'l': l}             │
│     2 │         │              │            │                              │
│     2 │         │              │            │                              │
│     3 │         │              │            │                              │
│     2 │         │ [1]          │ [2, 3, 4]  │                              │
│     2 │ glad    │ [1]          │ [2, 3, 4]  │                              │
│     2 │ glad    │ [1]          │ [2, 3, 4]  │ {'k': 1, 'l': lll}           │
│     2 │ glad    │ [1]          │ [2, 3, 4]  │ {'k': 1, 'l': lll}           │
└───────┴─────────┴──────────────┴────────────┴──────────────────────────────┘
```

data from spice sql after a lot of append calls - using duckdb as accelerator
```
sql> select * from test;
+----+--------+--------------+-----------+----------------+
| ts | str    | list         | arr       | struct         |
+----+--------+--------------+-----------+----------------+
| 1  | string | [1, 2, 3, 4] | [1, 2, 3] | {k: 1, l: l}   |
| 2  |        |              |           |                |
| 3  |        |              |           |                |
| 2  |        | [1]          | [2, 3, 4] |                |
| 2  | glad   | [1]          | [2, 3, 4] |                |
| 2  | glad   | [1]          | [2, 3, 4] | {k: 1, l: lll} |
+----+--------+--------------+-----------+----------------+
```

Before this change, string, list, arr, struct would be stored as its default value "", [], [], `{k: l:}`; when using append_overlap, overlapping records will come in but Spice will fail to tell if there are any identical records accelerated given the null were converted to default value, hence leading to a data integrity issue.