### PR TITLE
cargo.lock file update with #1747 duckdb-rs sha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "duckdb"
 version = "1.0.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=40e4a8e8c7e6e079b06da24d06a14c491c3c2f61#40e4a8e8c7e6e079b06da24d06a14c491c3c2f61"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=c7b8e22885001e2013493aebbaf190039d826c05#c7b8e22885001e2013493aebbaf190039d826c05"
 dependencies = [
  "arrow",
  "cast",
@@ -5171,7 +5171,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libduckdb-sys"
 version = "1.0.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=40e4a8e8c7e6e079b06da24d06a14c491c3c2f61#40e4a8e8c7e6e079b06da24d06a14c491c3c2f61"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=c7b8e22885001e2013493aebbaf190039d826c05#c7b8e22885001e2013493aebbaf190039d826c05"
 dependencies = [
  "autocfg",
  "cc",


### PR DESCRIPTION
missed check-in from duckdb-rs sha change #1747
