### PR TITLE
Fix error when GraphQL error locations is missing

### DIFF
--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -328,7 +328,7 @@ fn handle_graphql_query_error(response: &Value, query: &str) -> Result<()> {
         let line = graphql_error["locations"][0]["line"].as_u64();
         let column = graphql_error["locations"][0]["column"].as_u64();
 
-        let location: Option<(usize, usize)> = match (line, column) {
+        let location = match (line, column) {
             (Some(line), Some(column)) => Some((
                 usize::try_from(line).unwrap_or_default(),
                 usize::try_from(column).unwrap_or_default(),

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -225,7 +225,7 @@ impl GraphQLClient {
         handle_http_error(status, &response)?;
         handle_graphql_query_error(&response, &query)?;
 
-        let exctracted_data = response
+        let extracted_data = response
             .pointer(self.pointer.as_str())
             .unwrap_or(&Value::Null)
             .to_owned();
@@ -238,7 +238,7 @@ impl GraphQLClient {
                 .and_then(|x| x.get_next_cursor_from_response(&response))
         };
 
-        let unwrapped = match exctracted_data {
+        let unwrapped = match extracted_data {
             Value::Array(val) => Ok(val.clone()),
             obj @ Value::Object(_) => Ok(vec![obj]),
             Value::Null => Err(Error::InvalidObjectAccess {


### PR DESCRIPTION
## Issue

In the official GraphQL specification, the locations attribute is a required field in error responses. However, not all GraphQL implementations strictly adhere to this requirement. 

For example, when dealing with malformed GraphQL queries, such as the one described in  https://github.com/spiceai/spiceai/issues/1714, GitHub API returns an error response without including the locations attribute.

```json
{
  "message": "Unexpected end of document"
}
```

When locations attribute is missing, the code in `format_query_with_context` will fail, specifically this line as `0 - 1 = -1` which is out of bound for `usize`.

https://github.com/spiceai/spiceai/blob/a0b4686e9829f0d75e99742c76f515bef3441c1f/crates/runtime/src/dataconnector/graphql.rs#L353

This error will cause server to crash, so this potentially closes https://github.com/spiceai/spiceai/issues/1714.

<img width="647" alt="image" src="https://github.com/spiceai/spiceai/assets/93457/68b6413e-85e3-449a-a65a-8c11496e5dc1">

## Solution

The proposed solution is to avoid formatting query when locations attribute is missing.