### PR TITLE
Implement refresh retry based on fibonacci backoff (not enabled)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10112,7 +10112,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 name = "util"
 version = "0.14.1-alpha"
 dependencies = [
+ "backoff",
  "humantime",
+ "rand",
  "tokio",
  "tracing",
 ]

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -26,7 +26,7 @@ use arrow::error::ArrowError;
 use async_trait::async_trait;
 use cache::QueryResultsCacheProvider;
 use data_components::delete::get_deletion_provider;
-use datafusion::error::Result as DataFusionResult;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::{Operator, TableProviderFilterPushDown};
 use datafusion::physical_plan::union::UnionExec;
@@ -43,7 +43,6 @@ use tokio::time::interval;
 
 use tokio::sync::{mpsc, oneshot, RwLock};
 
-use crate::dataconnector;
 use crate::datafusion::filter_converter::TimestampFilterConvert;
 use crate::execution_plan::fallback_on_zero_results::FallbackOnZeroResultsScanExec;
 use crate::execution_plan::schema_cast::SchemaCastScanExec;
@@ -58,7 +57,7 @@ mod refresh_task_runner;
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Unable to get data from connector: {source}"))]
-    UnableToGetDataFromConnector { source: dataconnector::Error },
+    UnableToGetDataFromConnector { source: DataFusionError },
 
     #[snafu(display("Unable to scan table provider: {source}"))]
     UnableToScanTableProvider {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -155,7 +155,7 @@ impl RefreshTask {
         let (start_time, data_update) = match get_data_update_result {
             Ok((start_time, data_update)) => (start_time, data_update),
             Err(e) => {
-                tracing::warn!("Error getting update for dataset {dataset_name}: {e}");
+                tracing::error!("Failed to load data for dataset{dataset_name}: {e}");
                 self.mark_dataset_status(status::ComponentStatus::Error)
                     .await;
                 return Err(e);
@@ -193,13 +193,7 @@ impl RefreshTask {
             }
         };
 
-        match self.get_data_update(filters).await {
-            Ok(data) => Ok(data),
-            Err(e) => {
-                tracing::error!("Failed to load data for dataset {dataset_name}: {e}");
-                Err(e)
-            }
-        }
+        self.get_data_update(filters).await
     }
 
     async fn write_data_update(

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -55,6 +55,8 @@ impl RefreshTaskRunner {
     }
 
     pub fn start(&mut self) -> (Sender<()>, Receiver<super::Result<()>>) {
+        assert!(self.task.is_none());
+
         let (start_refresh, mut on_start_refresh) = mpsc::channel::<()>(1);
 
         let (notify_refresh_complete, on_refresh_complete) = mpsc::channel::<super::Result<()>>(1);

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -28,6 +28,7 @@ use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
 use datafusion::datasource::{DefaultTableSource, TableProvider};
+use datafusion::error::DataFusionError;
 use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
@@ -306,28 +307,23 @@ pub async fn get_data(
     table_provider: Arc<dyn TableProvider>,
     sql: Option<String>,
     filters: Vec<Expr>,
-) -> Result<(SchemaRef, Vec<arrow::record_batch::RecordBatch>)> {
+) -> Result<(SchemaRef, Vec<arrow::record_batch::RecordBatch>), DataFusionError> {
     let mut df = match sql {
         None => {
             let table_source = Arc::new(DefaultTableSource::new(Arc::clone(&table_provider)));
-            let logical_plan = LogicalPlanBuilder::scan(table_name.clone(), table_source, None)
-                .context(UnableToConstructLogicalPlanBuilderSnafu {})?
-                .build()
-                .context(UnableToBuildLogicalPlanSnafu {})?;
+            let logical_plan =
+                LogicalPlanBuilder::scan(table_name.clone(), table_source, None)?.build()?;
 
             DataFrame::new(ctx.state(), logical_plan)
         }
-        Some(sql) => ctx
-            .sql(&sql)
-            .await
-            .context(UnableToCreateDataFrameSnafu {})?,
+        Some(sql) => ctx.sql(&sql).await?,
     };
 
     for filter in filters {
-        df = df.filter(filter).context(UnableToFilterDataFrameSnafu {})?;
+        df = df.filter(filter)?;
     }
 
-    let batches = df.collect().await.context(UnableToScanTableProviderSnafu)?;
+    let batches = df.collect().await?;
 
     Ok((table_provider.schema(), batches))
 }

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -12,3 +12,5 @@ exclude.workspace = true
 humantime = "2.1.0"
 tokio = { workspace = true }
 tracing = { workspace = true }
+backoff= "0.4.0"
+rand = "0.8.5"

--- a/crates/util/src/fibonacci_backoff.rs
+++ b/crates/util/src/fibonacci_backoff.rs
@@ -1,0 +1,206 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::time::Duration;
+
+use backoff::backoff::Backoff;
+
+// Fibonacci-based backoff delay intervals capped at 5 mins
+const BACKOFF_INTERVALS_MS: [u64; 14] = [
+    1000, 1000, 2000, 3000, 5000, 8000, 13000, 21000, 34000, 55000, 89000, 144_000, 233_000,
+    300_000,
+];
+
+#[derive(Debug)]
+pub struct FibonacciBackoff {
+    num_retries: usize,
+    pub randomization_factor: f64,
+    pub max_retries: Option<usize>,
+}
+
+impl Default for FibonacciBackoff {
+    fn default() -> FibonacciBackoff {
+        FibonacciBackoff {
+            num_retries: 0,
+            randomization_factor: 0.3,
+            max_retries: None,
+        }
+    }
+}
+
+impl Backoff for FibonacciBackoff {
+    fn reset(&mut self) {
+        self.num_retries = 0;
+    }
+
+    fn next_backoff(&mut self) -> Option<Duration> {
+        self.num_retries += 1;
+
+        if let Some(max_retries) = self.max_retries {
+            if self.num_retries > max_retries {
+                return None;
+            }
+        }
+
+        let interval = if self.num_retries >= BACKOFF_INTERVALS_MS.len() {
+            Duration::from_millis(BACKOFF_INTERVALS_MS[BACKOFF_INTERVALS_MS.len() - 1])
+        } else {
+            Duration::from_millis(BACKOFF_INTERVALS_MS[self.num_retries])
+        };
+
+        let randomized_interval = get_random_value_from_interval(
+            self.randomization_factor,
+            rand::random::<f64>(),
+            interval,
+        );
+
+        Some(randomized_interval)
+    }
+}
+
+fn get_random_value_from_interval(
+    randomization_factor: f64,
+    random: f64,
+    current_interval: Duration,
+) -> Duration {
+    let current_interval_nanos = duration_to_nanos(current_interval);
+
+    let delta = randomization_factor * current_interval_nanos;
+    let min_interval = current_interval_nanos - delta;
+    let max_interval = current_interval_nanos + delta;
+    // Get a random value from the range [minInterval, maxInterval].
+    // The formula used below has a +1 because if the minInterval is 1 and the maxInterval is 3 then
+    // we want a 33% chance for selecting either 1, 2 or 3.
+    let diff = max_interval - min_interval;
+    let nanos = min_interval + (random * (diff + 1.0));
+    nanos_to_duration(nanos)
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct FibonacciBackoffBuilder {
+    randomization_factor: f64,
+    max_retries: Option<usize>,
+}
+
+impl FibonacciBackoffBuilder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            randomization_factor: 0.3,
+            max_retries: None,
+        }
+    }
+
+    #[must_use]
+    pub fn randomization_factor(mut self, value: f64) -> Self {
+        self.randomization_factor = value;
+        self
+    }
+
+    #[must_use]
+    pub fn max_retries(mut self, value: Option<usize>) -> Self {
+        self.max_retries = value;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> FibonacciBackoff {
+        FibonacciBackoff {
+            randomization_factor: self.randomization_factor,
+            max_retries: self.max_retries,
+            ..FibonacciBackoff::default()
+        }
+    }
+}
+
+impl Default for FibonacciBackoffBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn duration_to_nanos(d: Duration) -> f64 {
+    d.as_secs() as f64 * 1_000_000_000.0 + f64::from(d.subsec_nanos())
+}
+
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+fn nanos_to_duration(nanos: f64) -> Duration {
+    let secs = nanos / 1_000_000_000.0;
+    let nanos = nanos as u64 % 1_000_000_000;
+    Duration::new(secs as u64, nanos as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_within_range() {
+        let tests = vec![
+            (1000, 900, 1100),
+            (13000, 11700, 14300),
+            (300_000, 270_000, 330_000),
+        ];
+
+        for (duration_ms, expected_min_ms, expected_max_ms) in tests {
+            let target_duration = Duration::from_millis(duration_ms);
+            let expected_min = Duration::from_millis(expected_min_ms);
+            let expected_max = Duration::from_millis(expected_max_ms);
+            let result =
+                get_random_value_from_interval(0.1, rand::random::<f64>(), target_duration);
+
+            assert!(
+                result >= expected_min && result <= expected_max,
+                "Result out of range for target duration {target_duration:?}: got {result:?}, expected between {expected_min:?} and {expected_max:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_zero_randomization_factor() {
+        let interval = Duration::from_millis(1000);
+        let factor = 0.0;
+        let random = 0.5;
+        let result = get_random_value_from_interval(factor, random, interval);
+
+        assert_eq!(
+            result, interval,
+            "Randomization factor of 0 should return the original interval"
+        );
+    }
+
+    #[test]
+    fn test_max_retries() {
+        let mut backoff = FibonacciBackoffBuilder::new().max_retries(Some(5)).build();
+
+        for _ in 0..5 {
+            assert!(backoff.next_backoff().is_some());
+        }
+
+        assert!(backoff.next_backoff().is_none());
+    }
+
+    #[test]
+    fn test_unlimited_max_retries() {
+        let mut backoff = FibonacciBackoffBuilder::new().max_retries(None).build();
+
+        for _ in 0..100 {
+            assert!(backoff.next_backoff().is_some());
+        }
+    }
+}

--- a/crates/util/src/fibonacci_backoff.rs
+++ b/crates/util/src/fibonacci_backoff.rs
@@ -150,7 +150,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_within_range() {
+    fn test_backoff_interval_within_range() {
         let tests = vec![
             (1000, 900, 1100),
             (13000, 11700, 14300),
@@ -196,7 +196,14 @@ mod tests {
     }
 
     #[test]
-    fn test_unlimited_max_retries() {
+    fn test_zero_max_retries() {
+        let mut backoff = FibonacciBackoffBuilder::new().max_retries(Some(0)).build();
+
+        assert!(backoff.next_backoff().is_none());
+    }
+
+    #[test]
+    fn test_undefined_max_retries() {
         let mut backoff = FibonacciBackoffBuilder::new().max_retries(None).build();
 
         for _ in 0..100 {

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -21,6 +21,10 @@ use std::{
 
 use tokio::signal;
 
+pub mod fibonacci_backoff;
+pub use backoff::future::retry;
+pub use backoff::Error as RetryError;
+
 #[allow(clippy::cast_precision_loss)]
 #[allow(clippy::cast_sign_loss)]
 #[allow(clippy::cast_possible_truncation)]


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1712

Add refresh retry based on fibonacci backoff.
 - Currently limited to max 0 retries (retries are disabled). This will be changed to default (unlimited retries) next with support of `refresh_retry_max_attempts` and `refresh_retry_enabled ` configuration.
 - Implementation does not retry for schema, sql syntax, planning errors

Example trace:

```bash
2024-06-22T19:39:43.027369Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset nation
2024-06-22T19:39:43.029913Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T19:39:43.029989Z ERROR runtime::accelerated_table::refresh_task: Failed to load data for dataset nation: Unable to get data from connector: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
```

Trace for 5 max_retries:

```bash
2024-06-22T00:06:37.697064Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset nation
2024-06-22T00:06:37.700505Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:06:38.674725Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:06:40.937146Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:06:43.255718Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:06:49.360528Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:06:55.306215Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:06:55.306529Z ERROR runtime::accelerated_table::refresh_task: Failed to load data for datasetnation: Unable to get data from connector: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
```

Trace for successfully completion during retries:
```bash
2024-06-22T00:06:59.559324Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset nation
2024-06-22T00:06:59.562795Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:07:00.538041Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:07:02.251606Z  WARN runtime::accelerated_table::refresh_task: Failed to get refresh data for dataset nation: Execution error: Unable to query arrow: db error: ERROR: relation "nation" does not exist
2024-06-22T00:07:04.992075Z  INFO runtime::accelerated_table::refresh_task: Loaded 25 rows (19.55 kiB) for dataset nation in 5s 432ms.
```