### PR TITLE
Add refresh_retry_enabled/max_attempts acceleration params

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -40,6 +40,8 @@ pub struct Refresh {
     pub(crate) mode: RefreshMode,
     pub(crate) period: Option<Duration>,
     pub(crate) append_overlap: Option<Duration>,
+    pub(crate) refresh_retry_enabled: bool,
+    pub(crate) refresh_retry_max_attempts: Option<usize>,
 }
 
 impl Refresh {
@@ -62,7 +64,14 @@ impl Refresh {
             mode,
             period,
             append_overlap,
+            ..Default::default()
         }
+    }
+    #[must_use]
+    pub fn with_retry(mut self, enabled: bool, max_attempts: Option<usize>) -> Self {
+        self.refresh_retry_enabled = enabled;
+        self.refresh_retry_max_attempts = max_attempts;
+        self
     }
 }
 
@@ -76,6 +85,8 @@ impl Default for Refresh {
             mode: RefreshMode::Full,
             period: None,
             append_overlap: None,
+            refresh_retry_enabled: false,
+            refresh_retry_max_attempts: None,
         }
     }
 }

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -331,6 +331,22 @@ impl Dataset {
     }
 
     #[must_use]
+    pub fn refresh_retry_enabled(&self) -> bool {
+        if let Some(acceleration) = &self.acceleration {
+            return acceleration.refresh_retry_enabled;
+        }
+        false
+    }
+
+    #[must_use]
+    pub fn refresh_retry_max_attempts(&self) -> Option<usize> {
+        if let Some(acceleration) = &self.acceleration {
+            return acceleration.refresh_retry_max_attempts;
+        }
+        None
+    }
+
+    #[must_use]
     pub fn mode(&self) -> Mode {
         self.mode
     }

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -221,6 +221,10 @@ pub struct Acceleration {
 
     pub refresh_append_overlap: Option<Duration>,
 
+    pub refresh_retry_enabled: bool,
+
+    pub refresh_retry_max_attempts: Option<usize>,
+
     pub params: HashMap<String, String>,
 
     pub engine_secret: Option<String>,
@@ -317,6 +321,8 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
                 "refresh_append_overlap",
                 acceleration.refresh_append_overlap,
             )?,
+            refresh_retry_enabled: acceleration.refresh_retry_enabled,
+            refresh_retry_max_attempts: acceleration.refresh_retry_max_attempts,
             params: acceleration
                 .params
                 .as_ref()
@@ -345,6 +351,8 @@ impl Default for Acceleration {
             refresh_sql: None,
             refresh_data_window: None,
             refresh_append_overlap: None,
+            refresh_retry_enabled: true,
+            refresh_retry_max_attempts: None,
             params: HashMap::default(),
             engine_secret: None,
             retention_period: None,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -533,19 +533,25 @@ impl DataFusion {
                 .context(RefreshSqlSnafu)?;
         }
 
+        let refresh = Refresh::new(
+            dataset.time_column.clone(),
+            dataset.time_format,
+            dataset.refresh_check_interval(),
+            refresh_sql.clone(),
+            acceleration_settings.refresh_mode,
+            dataset.refresh_data_window(),
+            acceleration_settings.refresh_append_overlap,
+        )
+        .with_retry(
+            dataset.refresh_retry_enabled(),
+            dataset.refresh_retry_max_attempts(),
+        );
+
         let mut accelerated_table_builder = AcceleratedTable::builder(
             dataset.name.clone(),
             source_table_provider,
             accelerated_table_provider,
-            Refresh::new(
-                dataset.time_column.clone(),
-                dataset.time_format,
-                dataset.refresh_check_interval(),
-                refresh_sql.clone(),
-                acceleration_settings.refresh_mode,
-                dataset.refresh_data_window(),
-                acceleration_settings.refresh_append_overlap,
-            ),
+            refresh,
         );
         accelerated_table_builder.retention(Retention::new(
             dataset.time_column.clone(),

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -227,6 +227,12 @@ pub mod acceleration {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub refresh_append_overlap: Option<String>,
 
+        #[serde(default = "default_true")]
+        pub refresh_retry_enabled: bool,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub refresh_retry_max_attempts: Option<usize>,
+
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub params: Option<Params>,
 
@@ -275,6 +281,8 @@ pub mod acceleration {
                 refresh_sql: None,
                 refresh_data_window: None,
                 refresh_append_overlap: None,
+                refresh_retry_enabled: true,
+                refresh_retry_max_attempts: None,
                 params: None,
                 engine_secret: None,
                 retention_period: None,


### PR DESCRIPTION
Part of https://github.com/spiceai/spiceai/issues/1712

Add refresh retries configuration parameters to `dataset.acceleration`. Note: parameters are not currently used - awaiting [Implement refresh retry based on fibonacci backoff (not enabled)](https://github.com/spiceai/spiceai/pull/1752) PR to be merged.

```yaml
- from: s3://spiceai-demo-datasets/taxi_trips/2024/
  ...
  acceleration:
    refresh_retry_enabled: true,
    refresh_retry_max_attempts: 10,
    ...
```
- `refresh_retry_enabled`: bool  - whether retry logic is enabled. Default is true. 
- `refresh_retry_max_attempts` - maximum retry attempts to perform (if specified). default is undefined (unlimited attempts)