### PR TITLE
Ensure tonic package is in duckdb feature

### DIFF
--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -57,7 +57,7 @@ itertools.workspace = true
 secrecy.workspace = true
 
 [features]
-duckdb = ["dep:duckdb", "dep:r2d2", "db_connection_pool/duckdb"]
+duckdb = ["dep:duckdb", "dep:r2d2", "db_connection_pool/duckdb", "dep:tonic"]
 flightsql = ["dep:tonic", "dep:r2d2"]
 postgres = ["dep:bb8", "dep:bb8-postgres", "dep:postgres-native-tls", "arrow_sql_gen/postgres", "dep:tokio-postgres"]
 mysql = ["dep:mysql_async", "arrow_sql_gen/mysql"]


### PR DESCRIPTION
## Changes
- Previous PR #1742 added the import of tonic for `tonic::async_trait`. 
    - See https://github.com/spiceai/spiceai/pull/1742/files#diff-0037f65bdc2c70b1092727fd8affd0e2c13d764df78d1a72c848ec06873aa645R26
- Since it didn't change `Cargo.toml`, PR did not check individual features. 
- Explicitly import tonic for `duckdb` feature.