### PR TITLE
Add VSCode debug target to debug runtime benchmark test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,15 @@
       "name": "[Rust] Attack to spiced",
       "program": "~/.spice/bin/spiced",
       "pid": "${input:pid}"
+    },
+    {
+      "name": "[Rust] Debug runtime benchmark",
+      "type": "lldb",
+      "request": "launch",
+      "cargo": {
+        "args": ["build", "--package", "runtime", "--bench", "bench"],
+        "problemMatcher": "$rustc"
+      }
     }
   ],
   "inputs": [


### PR DESCRIPTION
Adds a VSCode task to launch a debug session for the runtime benchmark tests.