### PR TITLE
Strip kwarg '=' in DuckDB function parsing

### DIFF
--- a/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
@@ -114,7 +114,10 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSq
 #[must_use]
 pub fn flatten_table_function_name(table_reference: &TableReference) -> String {
     let table_name = table_reference.table();
-    let filtered_name: String = table_name.chars().filter(|c| c.is_alphanumeric() || *c == '(').collect();
+    let filtered_name: String = table_name
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '(')
+        .collect();
     let result = filtered_name.replace('(', "_");
 
     format!("{result}__view")

--- a/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
@@ -116,7 +116,7 @@ pub fn flatten_table_function_name(table_reference: &TableReference) -> String {
     let result = table_reference
         .table()
         .replace([')', '('], "_")
-        .replace(['\'', ','], "")
+        .replace(['\'', ',', '=', '"'], "")
         .replace(['.', ' '], "_");
 
     format!("{result}__view")

--- a/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
@@ -116,7 +116,7 @@ pub fn flatten_table_function_name(table_reference: &TableReference) -> String {
     let result = table_reference
         .table()
         .replace([')', '('], "_")
-        .replace(['\'', ',', '=', '"'], "")
+        .replace(['\'', ',', '=', '/', ':', '"'], "")
         .replace(['.', ' '], "_");
 
     format!("{result}__view")

--- a/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/duckdbconn.rs
@@ -113,11 +113,9 @@ impl SyncDbConnection<r2d2::PooledConnection<DuckdbConnectionManager>, &dyn ToSq
 
 #[must_use]
 pub fn flatten_table_function_name(table_reference: &TableReference) -> String {
-    let result = table_reference
-        .table()
-        .replace([')', '('], "_")
-        .replace(['\'', ',', '=', '/', ':', '"'], "")
-        .replace(['.', ' '], "_");
+    let table_name = table_reference.table();
+    let filtered_name: String = table_name.chars().filter(|c| c.is_alphanumeric() || *c == '(').collect();
+    let result = filtered_name.replace('(', "_");
 
     format!("{result}__view")
 }


### PR DESCRIPTION
## Changes
 - For parsing DuckDB functions table creation, a Kwarg in the function breaks how the DuckDB function view is created. Example spicepod 
 
 ```yaml
datasets:
  - from: duckdb:read_csv_auto('https://docs.google.com/spreadsheets/export?format=csv&id=1Q6-rPG7F_ETHEKNG03YWBdk9CYb3QnSyYIKGVP2KC74&gid=0')
    name: from_function
    acceleration:
      enabled: true
    params:
      open: './local.db'
 ```