### PR TITLE
enable more tpch benchmark queries as a result of decimal unparsing

### DIFF
--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -54,7 +54,6 @@ fn get_test_queries() -> Vec<(&'static str, &'static str)> {
 
         // Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Table 'tpch.supplier' not found
         // ("tpch_q16", include_str!("tpch_q16.sql")),
-
         ("tpch_q17", include_str!("tpch_q17.sql")),
         ("tpch_q18", include_str!("tpch_q18.sql")),
         ("tpch_q19", include_str!("tpch_q19.sql")),

--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -17,27 +17,26 @@ pub(crate) async fn run(
 
 fn get_test_queries() -> Vec<(&'static str, &'static str)> {
     vec![
-        // Error: "query `tpch_q1` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
+        // Error: "query `tpch_q1` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
         // ("tpch_q1", include_str!("tpch_q1.sql")),
         ("tpch_q2", include_str!("tpch_q2.sql")),
-        // Error: "query `tpch_q3` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
+        // Error: "query `tpch_q3` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
         // ("tpch_q3", include_str!("tpch_q3.sql")),
-        // Error: "query `tpch_q4` to results: External error: This feature is not implemented: Unsupported scalar: IntervalMonthDayNano(\"237684487542793012780631851008\")"
+        // Error: "query `tpch_q4` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Encountered \\\")\\\" at line 1, column 276.\\nWas expecting one of:\\n    \\\"YEAR\\\" ...\\n    \\\"MONTH\\\" ...\\n    \\\"DAY\\\" ...\\n    \\\"HOUR\\\" ...\\n    \\\"MINUTE\\\" ...\\n    \\\"SECOND\\\" ...\\n    \\nstartLine 1\\nstartColumn 276\\nendLine 1\\nendColumn 276\\nSQL Query SELECT tpch.orders.o_orderpriority, COUNT(1) AS order_count FROM tpch.orders WHERE (((tpch.orders.o_orderdate >= CAST('1993-07-01' AS DATETIME)) AND (tpch.orders.o_orderdate < CAST((CAST('1993-07-01' AS DATE) + INTERVAL '0 YEARS 3 MONS 0 DAYS 0 HOURS 0 MINS 0.000000000 SECS') AS DATETIME)))
         // ("tpch_q4", include_str!("tpch_q4.sql")),
-        // Error: "query `tpch_q5` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
+        // Error: "query `tpch_q5` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
         // ("tpch_q5", include_str!("tpch_q5.sql")),
-        // Error: "query `tpch_q6` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(30, 15)"
+        // Error: "query `tpch_q6` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
         // ("tpch_q6", include_str!("tpch_q6.sql")),
-        // Error: "query `tpch_q7` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
+        // Error: "query `tpch_q7` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
         // ("tpch_q7", include_str!("tpch_q7.sql")),
-        // Error: "query `tpch_q8` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
+        // Error: "query `tpch_q8` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
         // ("tpch_q8", include_str!("tpch_q8.sql")),
-        // Error: "query `tpch_q9` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
-        //("tpch_q9", include_str!("tpch_q9.sql")),
-        // Error: "query `tpch_q10` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
+        // Error: "query `tpch_q9` to results: federation_optimizer_rule\ncaused by\nfederate_sql\ncaused by\nSchema error: No field named profit.\"tpch.nation\". Valid fields are profit.nation, profit.o_year, profit.amount."
+        // ("tpch_q9", include_str!("tpch_q9.sql")),
+        // Error: "query `tpch_q10` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
         // ("tpch_q10", include_str!("tpch_q10.sql")),
-        // Error: "query `tpch_q11` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(10, 0)"
-        // ("tpch_q11", include_str!("tpch_q11.sql")),
+        ("tpch_q11", include_str!("tpch_q11.sql")),
         // Error: "query `tpch_q12` to results: External error: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'\\nstartLine 1\\nstartColumn 751\\nendLine 1\\nendColumn 758\\n
         //        SQL Query SELECT \\\"tpch\\\".\\\"lineitem\\\".\\\"l_shipmode\\\", SUM(CASE WHEN ((\\\"tpch\\\".\\\"orders\\\".\\\"o_orderpriority\\\" = '1-URGENT') OR (\\\"tpch\\\".\\\"orders\\\".\\\"o_orderpriority\\\" = '2-HIGH')) THEN 1 ELSE 0 END)
         //        AS \\\"high_line_count\\\", SUM(CASE WHEN ((\\\"tpch\\\".\\\"orders\\\".\\\"o_orderpriority\\\" <> '1-URGENT') AND (\\\"tpch\\\".\\\"orders\\\".\\\"o_orderpriority\\\" <> '2-HIGH')) THEN 1 ELSE 0 END) AS \\\"low_line_count\\\" FROM
@@ -48,23 +47,21 @@ fn get_test_queries() -> Vec<(&'static str, &'static str)> {
         // ("tpch_q12", include_str!("tpch_q12.sql")),
         // Error: "query `tpch_q13` to results: External error: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Table 'tpch.customer' not found ...
         // ("tpch_q13", include_str!("tpch_q13.sql")),
-        // Error: "query `tpch_q14` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
-        //("tpch_q14", include_str!("tpch_q14.sql")),
+        // Error: "query `tpch_q14` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
+        // ("tpch_q14", include_str!("tpch_q14.sql")),
 
         // tpch_q15 has a view creation which we don't support by design
 
-        // Error: "query `tpch_q16` to results: External error: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Table 'tpch.supplier' not found
+        // Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Table 'tpch.supplier' not found
         // ("tpch_q16", include_str!("tpch_q16.sql")),
-        // Error: "query `tpch_q17` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(30, 15)"
-        // ("tpch_q17", include_str!("tpch_q17.sql")),
-        // Error: "query `tpch_q18` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(22, 2)"
-        // ("tpch_q18", include_str!("tpch_q18.sql")),
-        // Error: "query `tpch_q19` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(20, 0)"
-        // ("tpch_q19", include_str!("tpch_q19.sql")),
-        // Error: "query `tpch_q20` to results: External error: This feature is not implemented: Unsupported scalar: IntervalMonthDayNano(\"IntervalMonthDayNano { months: 12, days: 0, nanoseconds: 0 }\")"
+
+        ("tpch_q17", include_str!("tpch_q17.sql")),
+        ("tpch_q18", include_str!("tpch_q18.sql")),
+        ("tpch_q19", include_str!("tpch_q19.sql")),
+        // Error: "query `tpch_q20` to results: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Unknown identifier 'DATETIME'
         // ("tpch_q20", include_str!("tpch_q20.sql")),
         ("tpch_q21", include_str!("tpch_q21.sql")),
-        // Error: "query `tpch_q22` to results: External error: This feature is not implemented: Unsupported DataType: conversion: Decimal128(19, 6)"
+        // Error: "query `tpch_q22` to results: External error: Execution error: Unable to query Flight: Unable to query: status: InvalidArgument, message: \"Table 'tpch.orders' not found
         // ("tpch_q22", include_str!("tpch_q22.sql")),
         ("tpch_simple_q1", include_str!("tpch_simple_q1.sql")),
         ("tpch_simple_q2", include_str!("tpch_simple_q2.sql")),


### PR DESCRIPTION
After introducing the decimal unparsing, enable tpch 11,17,18,19 queries for benchmark. Also update the error message for queries not affected for decimal parsing.


closes #1578.