### PR TITLE
For windows, move `symlink` -> `symlink_file`.

### DIFF
--- a/crates/llms/src/embeddings/candle/mod.rs
+++ b/crates/llms/src/embeddings/candle/mod.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 #[cfg(target_os = "windows")]
-use std::os::windows::fs::symlink;
+use std::os::windows::fs::symlink_file as symlink;
 
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::symlink;


### PR DESCRIPTION
## Changes
 - Fix `build_and_release` GH action for windows OS. See passing windows run --> https://github.com/spiceai/spiceai/actions/runs/9670879545/job/26680433903
 - Typo in windows `symlink` support