### PR TITLE
fix: Stream PostgreSQL data in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,6 +2979,7 @@ dependencies = [
  "secrecy",
  "snafu 0.8.3",
  "snowflake-api",
+ "sysinfo",
  "tokio",
  "tokio-postgres",
  "tokio-rusqlite",
@@ -6066,6 +6067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9113,6 +9123,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10461,6 +10486,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7947,6 +7947,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "serial_test",
  "snafu 0.8.3",
  "snowflake-api",
  "spicepod",
@@ -8251,6 +8252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ad2bbb0ae5100a07b7a6f2ed7ab5fd0045551a4c507989b7a620046ea3efdc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8294,6 +8304,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "sea-query"
@@ -8501,6 +8517,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,7 +2979,6 @@ dependencies = [
  "secrecy",
  "snafu 0.8.3",
  "snowflake-api",
- "sysinfo",
  "tokio",
  "tokio-postgres",
  "tokio-rusqlite",
@@ -6067,15 +6066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7941,13 +7931,13 @@ dependencies = [
  "prometheus-parse",
  "prost 0.12.6",
  "r2d2",
+ "rand",
  "regex",
  "reqwest 0.11.27",
  "rusqlite",
  "secrecy",
  "serde",
  "serde_json",
- "serial_test",
  "snafu 0.8.3",
  "snowflake-api",
  "spicepod",
@@ -8252,15 +8242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ad2bbb0ae5100a07b7a6f2ed7ab5fd0045551a4c507989b7a620046ea3efdc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8304,12 +8285,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "sdd"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "sea-query"
@@ -8517,31 +8492,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot 0.12.3",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -9161,21 +9111,6 @@ dependencies = [
  "libc",
  "thiserror",
  "walkdir",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.30.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "windows",
 ]
 
 [[package]]
@@ -10527,16 +10462,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.5",
-]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,4 @@ datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-feder
 object_store = { version = "0.10.1" }
 itertools = "0.12"
 secrecy = "0.8.0"
+sysinfo = "0.30.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,4 +78,3 @@ datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-feder
 object_store = { version = "0.10.1" }
 itertools = "0.12"
 secrecy = "0.8.0"
-sysinfo = "0.30.12"

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -35,6 +35,7 @@ clickhouse-rs = { workspace = true, optional = true }
 tokio-postgres = { workspace = true , optional = true}
 async-stream = { workspace = true, optional = true }
 snowflake-api = { workspace = true, optional = true }
+sysinfo = { workspace = true, optional = true }
 pkcs8 = { version = "0.10.2",  features = ["encryption", "pem", "3des"], optional = true }
 url = "2.5.0"
 secrecy.workspace = true
@@ -54,6 +55,7 @@ postgres = [
     "arrow_sql_gen/postgres",
     "dep:tokio-postgres",
     "dep:async-stream",
+    "dep:sysinfo",
 ]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "arrow_sql_gen/sqlite"]
 mysql = ["dep:mysql_async", "arrow_sql_gen/mysql"]

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -53,6 +53,7 @@ postgres = [
     "dep:tokio",
     "arrow_sql_gen/postgres",
     "dep:tokio-postgres",
+    "dep:async-stream",
 ]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "arrow_sql_gen/sqlite"]
 mysql = ["dep:mysql_async", "arrow_sql_gen/mysql"]

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -35,7 +35,6 @@ clickhouse-rs = { workspace = true, optional = true }
 tokio-postgres = { workspace = true , optional = true}
 async-stream = { workspace = true, optional = true }
 snowflake-api = { workspace = true, optional = true }
-sysinfo = { workspace = true, optional = true }
 pkcs8 = { version = "0.10.2",  features = ["encryption", "pem", "3des"], optional = true }
 url = "2.5.0"
 secrecy.workspace = true
@@ -55,7 +54,6 @@ postgres = [
     "arrow_sql_gen/postgres",
     "dep:tokio-postgres",
     "dep:async-stream",
-    "dep:sysinfo",
 ]
 sqlite = ["dep:rusqlite", "dep:tokio-rusqlite", "arrow_sql_gen/sqlite"]
 mysql = ["dep:mysql_async", "arrow_sql_gen/mysql"]

--- a/crates/db_connection_pool/src/dbconnection/postgresconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/postgresconn.rs
@@ -33,7 +33,6 @@ use futures::stream;
 use futures::StreamExt;
 use postgres_native_tls::MakeTlsConnector;
 use snafu::prelude::*;
-use sysinfo::System;
 
 use super::AsyncDbConnection;
 use super::DbConnection;
@@ -151,19 +150,15 @@ impl<'a>
             .await
             .context(QuerySnafu)?;
 
-        // chunk the stream into groups of rows based on available system memory
-        let chunk_size = determine_chunk_size();
-        let mut stream = streamable
-            .chunks(chunk_size.try_into()?)
-            .boxed()
-            .map(|rows| {
-                let rows = rows
-                    .into_iter()
-                    .collect::<std::result::Result<Vec<_>, _>>()
-                    .context(QuerySnafu)?;
-                let rec = rows_to_arrow(rows.as_slice()).context(ConversionSnafu)?;
-                Ok::<_, PostgresError>(rec)
-            });
+        // chunk the stream into groups of rows
+        let mut stream = streamable.chunks(4_000).boxed().map(|rows| {
+            let rows = rows
+                .into_iter()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .context(QuerySnafu)?;
+            let rec = rows_to_arrow(rows.as_slice()).context(ConversionSnafu)?;
+            Ok::<_, PostgresError>(rec)
+        });
 
         let Some(first_chunk) = stream.next().await else {
             return Ok(Box::pin(RecordBatchStreamAdapter::new(
@@ -199,20 +194,4 @@ impl<'a>
     async fn execute(&self, sql: &str, params: &[&'a (dyn ToSql + Sync)]) -> Result<u64> {
         Ok(self.conn.execute(sql, params).await?)
     }
-}
-
-const BYTES_PER_KILOBYTE: u64 = 1_024;
-const BYTES_PER_MEGABYTE: u64 = 1_024 * BYTES_PER_KILOBYTE;
-const ROWS_PER_MB: u64 = 1; // 1024 rows per GB
-
-fn determine_chunk_size() -> u64 {
-    let mut sys = System::new_all();
-    sys.refresh_all();
-
-    let mem = sys.available_memory() / BYTES_PER_MEGABYTE; // available memory in MB
-                                                           // available includes cached memory available for flushing
-                                                           // this is a safe calculation method for available system memory
-                                                           // use MB as the unit of reference, as we might be running on low memory systems
-
-    ROWS_PER_MB * mem
 }

--- a/crates/db_connection_pool/src/dbconnection/postgresconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/postgresconn.rs
@@ -211,7 +211,7 @@ fn determine_chunk_size() -> u64 {
 
     let mem = sys.free_memory() / MEGABYTE; // free memory in MB
                                             // free includes cached memory available for flushing
-                                            // this is the safest calculation method for available system memory
+                                            // this is a safe calculation method for available system memory
                                             // use MB as the unit of reference, as we might be running on low memory systems
 
     REFERENCE_CHUNKS_PER_MB * mem

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -108,7 +108,7 @@ anyhow = "1.0.86"
 tracing-subscriber.workspace = true
 async-graphql = "7.0.5"
 async-graphql-axum = "7.0.5"
-serial_test = "3.1.1"
+rand = "0.8.5"
 
 [features]
 default = ["keyring-secret-store", "aws-secrets-manager"]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -108,6 +108,7 @@ anyhow = "1.0.86"
 tracing-subscriber.workspace = true
 async-graphql = "7.0.5"
 async-graphql-axum = "7.0.5"
+serial_test = "3.1.1"
 
 [features]
 default = ["keyring-secret-store", "aws-secrets-manager"]

--- a/crates/runtime/tests/postgres/common.rs
+++ b/crates/runtime/tests/postgres/common.rs
@@ -64,13 +64,15 @@ pub(super) async fn start_postgres_docker_container(
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
     let container_name = format!("{PG_DOCKER_CONTAINER}-{port}");
     let container_name: &'static str = Box::leak(container_name.into_boxed_str());
+    let port = if let Ok(port) = port.try_into() {
+        port
+    } else {
+        15432
+    };
+
     let running_container = ContainerRunnerBuilder::new(container_name)
         .image("postgres:latest")
-        .add_port_binding(
-            5432,
-            #[allow(clippy::expect_used)]
-            port.try_into().expect("Port number should fit into u16"),
-        )
+        .add_port_binding(5432, port)
         .add_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
         .healthcheck(HealthConfig {
             test: Some(vec![

--- a/crates/runtime/tests/postgres/common.rs
+++ b/crates/runtime/tests/postgres/common.rs
@@ -68,6 +68,7 @@ pub(super) async fn start_postgres_docker_container(
         .image("postgres:latest")
         .add_port_binding(
             5432,
+            #[allow(clippy::expect_used)]
             port.try_into().expect("Port number should fit into u16"),
         )
         .add_env_var("POSTGRES_PASSWORD", PG_PASSWORD)

--- a/crates/runtime/tests/postgres/common.rs
+++ b/crates/runtime/tests/postgres/common.rs
@@ -20,6 +20,7 @@ use bollard::secret::HealthConfig;
 use db_connection_pool::postgrespool::PostgresConnectionPool;
 use secrecy::SecretString;
 // use spicepod::component::{dataset::Dataset, params::Params as DatasetParams};
+use rand::Rng;
 use tracing::instrument;
 
 use crate::docker::{ContainerRunnerBuilder, RunningContainer};
@@ -27,16 +28,13 @@ use crate::docker::{ContainerRunnerBuilder, RunningContainer};
 const PG_PASSWORD: &str = "runtime-integration-test-pw";
 const PG_DOCKER_CONTAINER: &str = "runtime-integration-test-postgres";
 
-fn get_pg_params() -> HashMap<String, SecretString> {
+fn get_pg_params(port: usize) -> HashMap<String, SecretString> {
     let mut params = HashMap::new();
     params.insert(
         "pg_host".to_string(),
         SecretString::from("localhost".to_string()),
     );
-    params.insert(
-        "pg_port".to_string(),
-        SecretString::from("15432".to_string()),
-    );
+    params.insert("pg_port".to_string(), SecretString::from(port.to_string()));
     params.insert(
         "pg_user".to_string(),
         SecretString::from("postgres".to_string()),
@@ -56,12 +54,22 @@ fn get_pg_params() -> HashMap<String, SecretString> {
     params
 }
 
+pub(super) fn get_random_port() -> usize {
+    rand::thread_rng().gen_range(15432..65535)
+}
+
 #[instrument]
 pub(super) async fn start_postgres_docker_container(
+    port: usize,
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
-    let running_container = ContainerRunnerBuilder::new(PG_DOCKER_CONTAINER)
+    let container_name = format!("{PG_DOCKER_CONTAINER}-{port}");
+    let container_name: &'static str = Box::leak(container_name.into_boxed_str());
+    let running_container = ContainerRunnerBuilder::new(container_name)
         .image("postgres:latest")
-        .add_port_binding(5432, 15432)
+        .add_port_binding(
+            5432,
+            port.try_into().expect("Port number should fit into u16"),
+        )
         .add_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
         .healthcheck(HealthConfig {
             test: Some(vec![
@@ -83,9 +91,10 @@ pub(super) async fn start_postgres_docker_container(
 }
 
 #[instrument]
-pub(super) async fn get_postgres_connection_pool() -> Result<PostgresConnectionPool, anyhow::Error>
-{
-    let pool = PostgresConnectionPool::new(Arc::new(get_pg_params())).await?;
+pub(super) async fn get_postgres_connection_pool(
+    port: usize,
+) -> Result<PostgresConnectionPool, anyhow::Error> {
+    let pool = PostgresConnectionPool::new(Arc::new(get_pg_params(port))).await?;
 
     Ok(pool)
 }

--- a/crates/runtime/tests/postgres/mod.rs
+++ b/crates/runtime/tests/postgres/mod.rs
@@ -22,6 +22,7 @@ use arrow::{
 };
 use data_components::postgres::DynPostgresConnectionPool;
 use datafusion::execution::context::SessionContext;
+use serial_test::serial;
 use sql_provider_datafusion::SqlTable;
 
 use crate::init_tracing;
@@ -29,6 +30,7 @@ use crate::init_tracing;
 mod common;
 
 #[tokio::test]
+#[serial]
 async fn test_postgres_types() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     let running_container = common::start_postgres_docker_container().await?;
@@ -100,6 +102,75 @@ CREATE TABLE test (
             .downcast_ref::<TimestampMillisecondArray>()
             .expect("array can be cast")
             .value(0)
+    );
+
+    running_container.remove().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_postgres_chunking_performance() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let running_container = common::start_postgres_docker_container().await?;
+
+    let ctx = SessionContext::new();
+    let pool = common::get_postgres_connection_pool().await?;
+    let db_conn = pool
+        .connect_direct()
+        .await
+        .expect("connection can be established");
+    db_conn
+        .conn
+        .execute(
+            "
+CREATE TABLE test (
+    id INTEGER PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);",
+            &[],
+        )
+        .await
+        .expect("table is created");
+
+    let mut values: Vec<String> = Vec::new();
+    for i in 0..250_000 {
+        values.push(format!("('{i}')"));
+    }
+
+    let values = values.join(",");
+    db_conn
+        .conn
+        .execute(&format!("INSERT INTO test (id) VALUES {values};"), &[])
+        .await
+        .expect("inserted data");
+
+    let sqltable_pool: Arc<DynPostgresConnectionPool> = Arc::new(pool);
+    let table = SqlTable::new("postgres", &sqltable_pool, "test", None)
+        .await
+        .expect("table can be created");
+    ctx.register_table("test_datafusion", Arc::new(table))
+        .expect("Table should be registered");
+    let sql = "SELECT id, created_at FROM test_datafusion";
+    let start = std::time::Instant::now();
+    let df = ctx
+        .sql(sql)
+        .await
+        .expect("DataFrame can be created from query");
+    let record_batch = df.collect().await.expect("RecordBatch can be collected");
+    let end = std::time::Instant::now();
+    let duration = end - start;
+    let duration_ms = duration.as_millis();
+    let num_rows = record_batch
+        .iter()
+        .map(arrow::array::RecordBatch::num_rows)
+        .sum::<usize>();
+    assert_eq!(num_rows, 250_000);
+
+    assert!(
+        duration_ms < 600,
+        "Duration {duration_ms}ms was higher than 600ms",
     );
 
     running_container.remove().await?;

--- a/crates/runtime/tests/postgres/mod.rs
+++ b/crates/runtime/tests/postgres/mod.rs
@@ -169,8 +169,8 @@ CREATE TABLE test (
     assert_eq!(num_rows, 250_000);
 
     assert!(
-        duration_ms < 600,
-        "Duration {duration_ms}ms was higher than 600ms",
+        duration_ms < 700,
+        "Duration {duration_ms}ms was higher than 700ms",
     );
 
     running_container.remove().await?;

--- a/crates/runtime/tests/postgres/mod.rs
+++ b/crates/runtime/tests/postgres/mod.rs
@@ -22,7 +22,6 @@ use arrow::{
 };
 use data_components::postgres::DynPostgresConnectionPool;
 use datafusion::execution::context::SessionContext;
-use serial_test::serial;
 use sql_provider_datafusion::SqlTable;
 
 use crate::init_tracing;
@@ -30,13 +29,13 @@ use crate::init_tracing;
 mod common;
 
 #[tokio::test]
-#[serial]
 async fn test_postgres_types() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
-    let running_container = common::start_postgres_docker_container().await?;
+    let port = common::get_random_port();
+    let running_container = common::start_postgres_docker_container(port).await?;
 
     let ctx = SessionContext::new();
-    let pool = common::get_postgres_connection_pool().await?;
+    let pool = common::get_postgres_connection_pool(port).await?;
     let db_conn = pool
         .connect_direct()
         .await
@@ -110,13 +109,13 @@ CREATE TABLE test (
 }
 
 #[tokio::test]
-#[serial]
 async fn test_postgres_chunking_performance() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
-    let running_container = common::start_postgres_docker_container().await?;
+    let port = common::get_random_port();
+    let running_container = common::start_postgres_docker_container(port).await?;
 
     let ctx = SessionContext::new();
-    let pool = common::get_postgres_connection_pool().await?;
+    let pool = common::get_postgres_connection_pool(port).await?;
     let db_conn = pool
         .connect_direct()
         .await


### PR DESCRIPTION
## ❓ What type of PR is this?

<!-- mark what type of change this pull request is -->

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

Converts PostgreSQL queries from using `.query()` to using `.query_raw()` so we can stream rows out in chunks instead of collecting all of the rows all at once in memory.

This should avoid high memory usage (and OOM errors) when loading large PostgreSQL data sources.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #1570