### PR TITLE
Add initial skeleton Debezium Data Connector

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -59,3 +59,6 @@
 
         - name: Build with only clickhouse
           run: cargo check --no-default-features --features clickhouse
+
+        - name: Build with only debezium
+          run: cargo check --no-default-features --features debezium

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "num_enum",
+ "num_enum 0.7.2",
  "thiserror",
 ]
 
@@ -2594,6 +2594,7 @@ dependencies = [
  "odbc-api",
  "postgres-native-tls",
  "r2d2",
+ "rdkafka",
  "regex",
  "reqwest 0.11.27",
  "rusqlite",
@@ -5972,7 +5973,7 @@ dependencies = [
  "jni-sys",
  "log",
  "ndk-sys",
- "num_enum",
+ "num_enum 0.7.2",
  "raw-window-handle",
  "thiserror",
 ]
@@ -6189,11 +6190,32 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.7.2",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7524,6 +7546,36 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1beea247b9a7600a81d4cc33f659ce1a77e1988323d7d2809c7ed1c21f4c316d"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.7.0+2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum 0.5.11",
+ "pkg-config",
 ]
 
 [[package]]
@@ -11010,7 +11062,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "indexmap 2.2.6",
- "num_enum",
+ "num_enum 0.7.2",
  "thiserror",
 ]
 

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -35,7 +35,8 @@ default = [
   "spark",
   "snowflake",
   "ftp",
-  "spice-cloud"
+  "spice-cloud",
+  "debezium",
 ]
 duckdb = ["runtime/duckdb"]
 postgres = ["runtime/postgres"]
@@ -55,3 +56,4 @@ spark = ["runtime/spark"]
 snowflake = ["runtime/snowflake"]
 models = ["runtime/models"]
 spice-cloud = []
+debezium = ["runtime/debezium"]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -59,6 +59,7 @@ itertools.workspace = true
 secrecy.workspace = true
 base64.workspace = true
 chrono.workspace = true
+rdkafka = { version = "0.36.2", optional = true }
 
 [features]
 duckdb = ["dep:duckdb", "dep:r2d2", "db_connection_pool/duckdb"]
@@ -71,7 +72,7 @@ spark_connect = ["dep:spark-connect-rs"]
 databricks = ["dep:deltalake", "spark_connect"]
 odbc = ["dep:odbc-api", "dep:arrow-odbc"]
 snowflake = ["dep:snowflake-api"]
-debezium = ["dep:serde_json"]
+debezium = ["dep:serde_json", "dep:rdkafka"]
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/crates/data_components/src/debezium/arrow.rs
+++ b/crates/data_components/src/debezium/arrow.rs
@@ -107,9 +107,9 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub fn convert_fields_to_arrow_schema(fields: &[ChangeEventField]) -> Result<Schema> {
+pub fn convert_fields_to_arrow_schema(fields: Vec<&ChangeEventField>) -> Result<Schema> {
     let arrow_fields = fields
-        .iter()
+        .into_iter()
         .map(convert_to_arrow_field)
         .collect::<Result<Vec<Field>>>()?;
 

--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -32,6 +32,20 @@ impl ChangeEvent {
     pub fn from_bytes(bytz: &[u8]) -> Result<Self, serde_json::Error> {
         serde_json::from_slice(bytz)
     }
+
+    #[must_use]
+    pub fn get_schema_fields(&self) -> Option<Vec<&Field>> {
+        self.schema
+            .fields
+            .iter()
+            .find(|field| field.field.as_ref().is_some_and(|field| field == "after"))
+            .and_then(|field| {
+                field
+                    .fields
+                    .as_ref()
+                    .map(|fields| fields.as_slice().iter().collect())
+            })
+    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/data_components/src/debezium/tests/mod.rs
+++ b/crates/data_components/src/debezium/tests/mod.rs
@@ -34,15 +34,10 @@ fn parse_arrow_schema() {
     let change_event: ChangeEvent =
         serde_json::from_str(change_event_json).expect("to deserialize change event");
 
-    let after_schema = change_event
-        .schema
-        .fields
-        .into_iter()
-        .find(|field| field.field.as_ref().is_some_and(|field| field == "after"))
-        .expect("to find after field");
-
-    let fields = after_schema.fields.expect("fields");
-    let arrow_schema = convert_fields_to_arrow_schema(&fields).expect("to convert to arrow schema");
+    let fields = change_event
+        .get_schema_fields()
+        .expect("to get schema fields");
+    let arrow_schema = convert_fields_to_arrow_schema(fields).expect("to convert to arrow schema");
 
     assert_eq!(arrow_schema.fields.len(), 24);
     assert_eq!(arrow_schema.field(0).name(), "id");
@@ -206,15 +201,10 @@ fn parse_values() {
     let change_event: ChangeEvent =
         serde_json::from_str(change_event_json).expect("to deserialize change event");
 
-    let after_schema = change_event
-        .schema
-        .fields
-        .into_iter()
-        .find(|field| field.field.as_ref().is_some_and(|field| field == "after"))
-        .expect("to find after field");
-
-    let fields = after_schema.fields.expect("fields");
-    let arrow_schema = convert_fields_to_arrow_schema(&fields).expect("to convert to arrow schema");
+    let fields = change_event
+        .get_schema_fields()
+        .expect("to get schema fields");
+    let arrow_schema = convert_fields_to_arrow_schema(fields).expect("to convert to arrow schema");
 
     let record_batch = to_record_batch(vec![change_event.payload.after], &arrow_schema)
         .expect("to convert to record batch");

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{any::Any, sync::Arc};
+
+use crate::kafka::KafkaConsumer;
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::{
+    datasource::{TableProvider, TableType},
+    error::Result as DataFusionResult,
+    execution::context::SessionState,
+    logical_expr::Expr,
+    physical_plan::{empty::EmptyExec, ExecutionPlan},
+};
+
+pub struct DebeziumKafka {
+    schema: SchemaRef,
+    _consumer: KafkaConsumer,
+}
+
+impl DebeziumKafka {
+    #[must_use]
+    pub fn new(schema: SchemaRef, consumer: KafkaConsumer) -> Self {
+        Self {
+            schema,
+            _consumer: consumer,
+        }
+    }
+}
+
+#[async_trait]
+impl TableProvider for DebeziumKafka {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &SessionState,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(EmptyExec::new(self.schema())))
+    }
+}

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -1,0 +1,155 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#![allow(clippy::module_name_repetitions)]
+
+use futures::{Stream, StreamExt};
+use rdkafka::{
+    config::RDKafkaLogLevel,
+    consumer::{Consumer, StreamConsumer},
+    message::BorrowedMessage,
+    util::get_rdkafka_version,
+    ClientConfig, Message,
+};
+use serde::de::DeserializeOwned;
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to create Kafka consumer: {source}"))]
+    UnableToCreateConsumer { source: rdkafka::error::KafkaError },
+
+    #[snafu(display("Unable to subscribe to Kafka topic '{topic}': {source}"))]
+    UnableToSubscribeToTopic {
+        topic: String,
+        source: rdkafka::error::KafkaError,
+    },
+
+    #[snafu(display("Unable to receive message from Kafka: {source}"))]
+    UnableToReceiveMessage { source: rdkafka::error::KafkaError },
+
+    #[snafu(display("Unable to deserialize JSON message from Kafka: {source}"))]
+    UnableToDeserializeJsonMessage { source: serde_json::Error },
+
+    #[snafu(display("Unable to mark Kafka message as being processed: {source}"))]
+    UnableToCommitMessage { source: rdkafka::error::KafkaError },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct KafkaConsumer {
+    consumer: StreamConsumer,
+}
+
+impl KafkaConsumer {
+    pub fn create_with_existing_group_id(
+        group_id: impl Into<String>,
+        brokers: String,
+    ) -> Result<Self> {
+        Self::create(group_id.into(), brokers)
+    }
+
+    pub fn create_with_generated_group_id(dataset: &str, brokers: String) -> Result<Self> {
+        Self::create(Self::generate_group_id(dataset), brokers)
+    }
+
+    pub fn subscribe(&self, topic: &str) -> Result<()> {
+        self.consumer
+            .subscribe(&[topic])
+            .context(UnableToSubscribeToTopicSnafu { topic })
+    }
+
+    /// Receive a JSON message from the Kafka topic.
+    pub async fn next_json<T: DeserializeOwned>(&self) -> Result<Option<KafkaMessage<T>>> {
+        let mut stream = Box::pin(self.stream_json::<T>());
+        stream.next().await.transpose()
+    }
+
+    /// Stream JSON messages from the Kafka topic.
+    pub fn stream_json<T: DeserializeOwned>(&self) -> impl Stream<Item = Result<KafkaMessage<T>>> {
+        self.consumer.stream().filter_map(move |msg| async move {
+            let msg = match msg {
+                Ok(msg) => msg,
+                Err(e) => return Some(Err(Error::UnableToReceiveMessage { source: e })),
+            };
+
+            let payload = msg.payload()?;
+
+            let value = match serde_json::from_slice(payload) {
+                Ok(value) => value,
+                Err(e) => return Some(Err(Error::UnableToDeserializeJsonMessage { source: e })),
+            };
+
+            Some(Ok(KafkaMessage::new(&self.consumer, msg, value)))
+        })
+    }
+
+    fn create(group_id: String, brokers: String) -> Result<Self> {
+        let (_, version) = get_rdkafka_version();
+        tracing::debug!("rd_kafka_version: {}", version);
+
+        let consumer: StreamConsumer = ClientConfig::new()
+            .set("group.id", group_id)
+            .set("bootstrap.servers", brokers)
+            // For new consumer groups, start reading at the beginning of the topic
+            .set("auto.offset.reset", "smallest")
+            // Commit offsets automatically
+            .set("enable.auto.commit", "true")
+            // Commit offsets every 5 seconds
+            .set("auto.commit.interval.ms", "5000")
+            // Don't automatically store offsets the library provides to us - we will store them after processing explicitly
+            // This is what gives us the "at least once" semantics
+            .set("enable.auto.offset.store", "false")
+            .set_log_level(RDKafkaLogLevel::Debug)
+            .create()
+            .context(UnableToCreateConsumerSnafu)?;
+
+        Ok(Self { consumer })
+    }
+
+    fn generate_group_id(dataset: &str) -> String {
+        format!("spice.ai-{dataset}-{}", uuid::Uuid::new_v4())
+    }
+}
+
+pub struct KafkaMessage<'a, T> {
+    consumer: &'a StreamConsumer,
+    msg: BorrowedMessage<'a>,
+    pub value: T,
+}
+
+impl<'a, T> KafkaMessage<'a, T> {
+    fn new(consumer: &'a StreamConsumer, msg: BorrowedMessage<'a>, value: T) -> Self {
+        Self {
+            consumer,
+            msg,
+            value,
+        }
+    }
+
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn take_value(self) -> T {
+        self.value
+    }
+
+    pub fn mark_processed(&self) -> Result<()> {
+        self.consumer
+            .store_offset_from_message(&self.msg)
+            .context(UnableToCommitMessageSnafu)
+    }
+}

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -21,15 +21,16 @@ use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 
 pub mod arrow;
+#[cfg(feature = "clickhouse")]
+pub mod clickhouse;
 #[cfg(feature = "databricks")]
 pub mod databricks_delta;
 #[cfg(feature = "databricks")]
 pub mod databricks_spark;
-
-#[cfg(feature = "clickhouse")]
-pub mod clickhouse;
 #[cfg(feature = "debezium")]
 pub mod debezium;
+#[cfg(feature = "debezium")]
+pub mod debezium_kafka;
 #[cfg(feature = "databricks")]
 pub mod deltatable;
 #[cfg(feature = "duckdb")]
@@ -37,19 +38,20 @@ pub mod duckdb;
 pub mod flight;
 #[cfg(feature = "flightsql")]
 pub mod flightsql;
+#[cfg(feature = "debezium")]
+pub mod kafka;
 #[cfg(feature = "mysql")]
 pub mod mysql;
 #[cfg(feature = "odbc")]
 pub mod odbc;
 #[cfg(feature = "postgres")]
 pub mod postgres;
+#[cfg(feature = "snowflake")]
+pub mod snowflake;
 #[cfg(feature = "spark_connect")]
 pub mod spark_connect;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
-
-#[cfg(feature = "snowflake")]
-pub mod snowflake;
 
 pub mod delete;
 pub mod object;

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -162,6 +162,7 @@ snowflake = [
     "data_components/snowflake",
 ]
 models = ["model_components/full", "llms/mistralrs", "llms/candle"]
+debezium = ["data_components/debezium"]
 
 [[bench]]
 name = "bench"

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -198,6 +198,9 @@ impl Builder {
                     Some(start_refresh),
                 )
             }
+            RefreshMode::Changes => {
+                todo!()
+            }
         };
 
         validate_refresh_data_window(&self.refresh, &self.dataset_name, &self.federated.schema());

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -143,6 +143,7 @@ impl RefreshTask {
             match refresh.mode {
                 RefreshMode::Full => "load_dataset_duration_ms",
                 RefreshMode::Append => "append_dataset_duration_ms",
+                RefreshMode::Changes => unreachable!("changes are handled upstream"),
             },
             vec![("dataset", dataset_name.to_string())],
         );
@@ -150,6 +151,7 @@ impl RefreshTask {
         let get_data_update_result = match refresh.mode {
             RefreshMode::Full => self.get_full_update().await,
             RefreshMode::Append => self.get_incremental_append_update().await,
+            RefreshMode::Changes => unreachable!("changes are handled upstream"),
         };
 
         let (start_time, data_update) = match get_data_update_result {
@@ -406,6 +408,7 @@ impl RefreshTask {
                     match refresh.mode {
                         RefreshMode::Full => UpdateType::Overwrite,
                         RefreshMode::Append => UpdateType::Append,
+                        RefreshMode::Changes => unreachable!("changes are handled upstream"),
                     },
                 )
             };

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -21,11 +21,11 @@ use std::{collections::HashMap, fmt::Display, time::Duration};
 pub mod constraints;
 pub mod on_conflict;
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RefreshMode {
-    #[default]
     Full,
     Append,
+    Changes,
 }
 
 impl From<spicepod_acceleration::RefreshMode> for RefreshMode {
@@ -33,6 +33,7 @@ impl From<spicepod_acceleration::RefreshMode> for RefreshMode {
         match refresh_mode {
             spicepod_acceleration::RefreshMode::Full => RefreshMode::Full,
             spicepod_acceleration::RefreshMode::Append => RefreshMode::Append,
+            spicepod_acceleration::RefreshMode::Changes => RefreshMode::Changes,
         }
     }
 }
@@ -211,7 +212,7 @@ pub struct Acceleration {
 
     pub engine: Engine,
 
-    pub refresh_mode: RefreshMode,
+    pub refresh_mode: Option<RefreshMode>,
 
     pub refresh_check_interval: Option<String>,
 
@@ -313,7 +314,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             enabled: acceleration.enabled,
             mode: Mode::from(acceleration.mode),
             engine,
-            refresh_mode: RefreshMode::from(acceleration.refresh_mode),
+            refresh_mode: acceleration.refresh_mode.map(RefreshMode::from),
             refresh_check_interval: acceleration.refresh_check_interval,
             refresh_sql: acceleration.refresh_sql,
             refresh_data_window: acceleration.refresh_data_window,
@@ -346,7 +347,7 @@ impl Default for Acceleration {
             enabled: true,
             mode: Mode::Memory,
             engine: Engine::default(),
-            refresh_mode: RefreshMode::Full,
+            refresh_mode: None,
             refresh_check_interval: None,
             refresh_sql: None,
             refresh_data_window: None,

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -1,0 +1,181 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::component::dataset::acceleration::{Engine, RefreshMode};
+use crate::component::dataset::Dataset;
+use crate::secrets::Secret;
+use async_trait::async_trait;
+use data_components::debezium;
+use data_components::debezium::change_event::ChangeEvent;
+use data_components::debezium_kafka::DebeziumKafka;
+use data_components::kafka::KafkaConsumer;
+use datafusion::datasource::TableProvider;
+use snafu::prelude::*;
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{collections::HashMap, future::Future};
+
+use super::{DataConnector, DataConnectorFactory};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Invalid value for debezium_transport. Valid values: 'kafka'"))]
+    InvalidTransport,
+
+    #[snafu(display("Invalid value for debezium_message_format: Valid values: 'json'"))]
+    InvalidMessageFormat,
+
+    #[snafu(display("Missing required parameter: kafka_bootstrap_servers"))]
+    MissingKafkaBootstrapServers,
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct Debezium {
+    kafka_brokers: String,
+}
+
+impl Debezium {
+    pub fn new(params: &Arc<HashMap<String, String>>) -> Result<Self> {
+        let transport = params
+            .get("debezium_transport")
+            .map_or("kafka", String::as_str);
+
+        let message_format = params
+            .get("debezium_message_format")
+            .map_or("json", String::as_str);
+
+        if transport != "kafka" {
+            return InvalidTransportSnafu.fail();
+        }
+        if message_format != "json" {
+            return InvalidMessageFormatSnafu.fail();
+        }
+
+        let kakfa_brokers = params
+            .get("kafka_bootstrap_servers")
+            .context(MissingKafkaBootstrapServersSnafu)?;
+
+        Ok(Self {
+            kafka_brokers: kakfa_brokers.to_string(),
+        })
+    }
+}
+
+impl DataConnectorFactory for Debezium {
+    fn create(
+        _secret: Option<Secret>,
+        params: Arc<HashMap<String, String>>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move {
+            let debezium = Debezium::new(&params)?;
+            Ok(Arc::new(debezium) as Arc<dyn DataConnector>)
+        })
+    }
+}
+
+#[async_trait]
+impl DataConnector for Debezium {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn resolve_refresh_mode(&self, refresh_mode: Option<RefreshMode>) -> RefreshMode {
+        refresh_mode.unwrap_or(RefreshMode::Changes)
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
+        ensure!(
+            dataset.is_accelerated(),
+            super::InvalidConfigurationNoSourceSnafu {
+                dataconnector: "debezium",
+                message: "The Debezium data connector only works with accelerated datasets.",
+            }
+        );
+        let Some(ref acceleration) = dataset.acceleration else {
+            unreachable!("we just checked above that the dataset is accelerated");
+        };
+        ensure!(
+            acceleration.engine != Engine::Arrow,
+            super::InvalidConfigurationNoSourceSnafu {
+                dataconnector: "debezium",
+                message:
+                    "The Debezium data connector only works with non-Arrow acceleration engines.",
+            }
+        );
+        ensure!(
+            self.resolve_refresh_mode(acceleration.refresh_mode) == RefreshMode::Changes,
+            super::InvalidConfigurationNoSourceSnafu {
+                dataconnector: "debezium",
+                message: "The Debezium data connector only works with 'changes' refresh mode.",
+            }
+        );
+
+        let topic = dataset.path();
+
+        let consumer = KafkaConsumer::create_with_generated_group_id(
+            &dataset.name.to_string(),
+            self.kafka_brokers.clone(),
+        )
+        .boxed()
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "debezium",
+        })?;
+
+        consumer
+            .subscribe(&topic)
+            .boxed()
+            .context(super::UnableToGetReadProviderSnafu {
+                dataconnector: "debezium",
+            })?;
+
+        let msg = match consumer.next_json::<ChangeEvent>().await {
+            Ok(Some(msg)) => msg,
+            Ok(None) => {
+                return Err(super::DataConnectorError::UnableToGetReadProvider {
+                    dataconnector: "debezium".to_string(),
+                    source: "No message received from Kafka".into(),
+                });
+            }
+            Err(e) => {
+                return Err(e).boxed().context(super::UnableToGetReadProviderSnafu {
+                    dataconnector: "debezium",
+                });
+            }
+        };
+
+        let Some(schema_fields) = msg.value().get_schema_fields() else {
+            return Err(super::DataConnectorError::UnableToGetReadProvider {
+                dataconnector: "debezium".to_string(),
+                source: "Could not get Arrow schema from Debezium message".into(),
+            });
+        };
+
+        let schema = debezium::arrow::convert_fields_to_arrow_schema(schema_fields)
+            .boxed()
+            .context(super::UnableToGetReadProviderSnafu {
+                dataconnector: "debezium",
+            })?;
+
+        let debezium_kafka = Arc::new(DebeziumKafka::new(Arc::new(schema), consumer));
+
+        Ok(debezium_kafka)
+    }
+}

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -538,7 +538,7 @@ impl DataFusion {
             dataset.time_format,
             dataset.refresh_check_interval(),
             refresh_sql.clone(),
-            acceleration_settings.refresh_mode,
+            source.resolve_refresh_mode(acceleration_settings.refresh_mode),
             dataset.refresh_data_window(),
             acceleration_settings.refresh_append_overlap,
         )

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -518,10 +518,9 @@ impl Runtime {
             .fail();
         }
 
-        let data_connector = Arc::clone(&data_connector);
         match Runtime::register_dataset(
             &ds,
-            data_connector,
+            Arc::clone(&data_connector),
             Arc::clone(&df),
             &source,
             Arc::clone(&shared_secrets_provider),
@@ -533,7 +532,11 @@ impl Runtime {
             Ok(()) => {
                 tracing::info!(
                     "{}",
-                    dataset_registered_trace(&ds, self.df.cache_provider().is_some())
+                    dataset_registered_trace(
+                        &data_connector,
+                        &ds,
+                        self.df.cache_provider().is_some()
+                    )
                 );
                 if let Some(datasets_health_monitor) = &self.datasets_health_monitor {
                     if let Err(err) = datasets_health_monitor.register_dataset(&ds).await {

--- a/crates/runtime/src/tracing_util.rs
+++ b/crates/runtime/src/tracing_util.rs
@@ -14,19 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::component::dataset::{
-    acceleration::{Acceleration, Mode, RefreshMode, ZeroResultsAction},
-    Dataset,
+use crate::{
+    component::dataset::{
+        acceleration::{Acceleration, Mode, RefreshMode, ZeroResultsAction},
+        Dataset,
+    },
+    dataconnector::DataConnector,
 };
+use std::sync::Arc;
 
 // Format: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb), results cache enabled.
-pub fn dataset_registered_trace(ds: &Dataset, results_cache_enabled: bool) -> String {
+pub fn dataset_registered_trace(
+    data_connector: &Arc<dyn DataConnector>,
+    ds: &Dataset,
+    results_cache_enabled: bool,
+) -> String {
     let mut info = format!("Dataset {} registered ({})", &ds.name, &ds.from);
     if let Some(acceleration) = &ds.acceleration {
         if acceleration.enabled {
             info.push_str(&format!(
                 ", acceleration ({})",
-                dataset_acceleration_info(acceleration)
+                dataset_acceleration_info(data_connector, acceleration)
             ));
         }
     }
@@ -40,15 +48,24 @@ pub fn dataset_registered_trace(ds: &Dataset, results_cache_enabled: bool) -> St
 }
 
 // Format: sqlite:file, 30s refresh, 1hr retention, fallback on source on empty result
-fn dataset_acceleration_info(acceleration: &Acceleration) -> String {
+fn dataset_acceleration_info(
+    data_connector: &Arc<dyn DataConnector>,
+    acceleration: &Acceleration,
+) -> String {
     let mut info: String = acceleration.engine.to_string();
 
     if acceleration.mode == Mode::File {
         info.push_str(":file");
     }
 
-    if acceleration.refresh_mode == RefreshMode::Append {
-        info.push_str(", append");
+    match data_connector.resolve_refresh_mode(acceleration.refresh_mode) {
+        RefreshMode::Full => {}
+        RefreshMode::Append => {
+            info.push_str(", append");
+        }
+        RefreshMode::Changes => {
+            info.push_str(", changes");
+        }
     }
 
     if let Some(refresh_interval) = &acceleration.refresh_check_interval {
@@ -69,13 +86,34 @@ fn dataset_acceleration_info(acceleration: &Acceleration) -> String {
 mod tests {
     use super::*;
     use crate::component::dataset::acceleration::Engine;
+    use crate::dataconnector::DataConnectorResult;
+    use async_trait::async_trait;
+    use datafusion::datasource::TableProvider;
+    use std::any::Any;
+
+    struct TestDataConnector {}
+
+    #[async_trait]
+    impl DataConnector for TestDataConnector {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        async fn read_provider(
+            &self,
+            _dataset: &Dataset,
+        ) -> DataConnectorResult<Arc<dyn TableProvider>> {
+            unimplemented!()
+        }
+    }
 
     #[test]
     fn test_dataset_registered_trace_no_acceleration() {
         let ds = Dataset::try_new("s3://taxi_trips/2024/".to_string(), "taxi_trips")
             .expect("to create dataset");
 
-        let info = dataset_registered_trace(&ds, false);
+        let test_data_connector: Arc<dyn DataConnector> = Arc::new(TestDataConnector {});
+        let info = dataset_registered_trace(&test_data_connector, &ds, false);
         assert_eq!(
             info,
             "Dataset taxi_trips registered (s3://taxi_trips/2024/)."
@@ -93,7 +131,8 @@ mod tests {
             .expect("to create dataset");
         ds.acceleration = Some(acceleration);
 
-        let info = dataset_registered_trace(&ds, true);
+        let test_data_connector: Arc<dyn DataConnector> = Arc::new(TestDataConnector {});
+        let info = dataset_registered_trace(&test_data_connector, &ds, true);
         assert_eq!(info, "Dataset taxi_trips registered (s3://taxi_trips/2024/), acceleration (arrow), results cache enabled.");
     }
 
@@ -103,7 +142,7 @@ mod tests {
             enabled: true,
             engine: Engine::DuckDB,
             mode: Mode::File,
-            refresh_mode: RefreshMode::Append,
+            refresh_mode: Some(RefreshMode::Append),
             refresh_check_interval: Some("30s".to_string()),
             retention_check_interval: Some("1hr".to_string()),
             retention_check_enabled: true,
@@ -115,7 +154,8 @@ mod tests {
             .expect("to create dataset");
         ds.acceleration = Some(acceleration);
 
-        let info = dataset_registered_trace(&ds, false);
+        let test_data_connector: Arc<dyn DataConnector> = Arc::new(TestDataConnector {});
+        let info = dataset_registered_trace(&test_data_connector, &ds, false);
         assert_eq!(info, "Dataset taxi_trips registered (s3://taxi_trips/2024/), acceleration (duckdb:file, append, 30s refresh, 1hr retention, fallback on source on empty result).");
     }
 }

--- a/crates/runtime/tests/odbc/mod.rs
+++ b/crates/runtime/tests/odbc/mod.rs
@@ -47,7 +47,7 @@ fn make_databricks_odbc(path: &str, name: &str, acceleration: bool, engine: &str
         enabled: acceleration,
         mode: spicepod::component::dataset::acceleration::Mode::Memory,
         engine: Some(engine.to_string()),
-        refresh_mode: spicepod::component::dataset::acceleration::RefreshMode::Full,
+        refresh_mode: Some(spicepod::component::dataset::acceleration::RefreshMode::Full),
         refresh_sql: Some(format!("SELECT * FROM {name} LIMIT 10")),
         ..Default::default()
     });

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -122,12 +122,12 @@ pub mod acceleration {
 
     use crate::component::params::Params;
 
-    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     #[serde(rename_all = "lowercase")]
     pub enum RefreshMode {
-        #[default]
         Full,
         Append,
+        Changes,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -212,8 +212,8 @@ pub mod acceleration {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub engine: Option<String>,
 
-        #[serde(default)]
-        pub refresh_mode: RefreshMode,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub refresh_mode: Option<RefreshMode>,
 
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub refresh_check_interval: Option<String>,
@@ -276,7 +276,7 @@ pub mod acceleration {
                 enabled: true,
                 mode: Mode::Memory,
                 engine: None,
-                refresh_mode: RefreshMode::Full,
+                refresh_mode: None,
                 refresh_check_interval: None,
                 refresh_sql: None,
                 refresh_data_window: None,


### PR DESCRIPTION
## 🗣 Description

Initial work on adding the Debezium Data Connector. It will register the table in DataFusion with the correct schema that it inferred by looking at the first message from the queue, but will otherwise do nothing yet.

Also adds a new `RefreshMode::Changes` variant to the `RefreshMode` enum. As part of this, we want the Debezium connector to default to `RefreshMode::Changes` (in fact, it requires it to be Changes). So I've made the `RefreshMode` optional and added a method to the DataConnector that allows it to choose what the default variant should be if not set.

I've also created a `KafkaConsumer` wrapper around the `rdkafka` crate to make it more ergonomic to work with. Messages returned by KafkaConsumers can be auto-deserialized to their expected type, and the wrapper `KafkaMessage` has a method `mark_processed()` which will allow the consuming code to control when that message is marked as "done" and Kafka can update its offsets. This is what will give us the `at-least-once` delivery guarantee.

In following PRs I will implement support for the `DebeziumKafka` TableProvider `scan` method to return Arrow records in the ChangeEvent format. The acceleration will know how to interpret that special schema and apply the changes to the acceleration engine. (Need to check if DataFusion will complain about us returning Arrow records that have a different schema from what we claim, if so then I'll need to rethink this)

Also in future PRs will be the storage of the consumer group that we selected into the acceleration engine `__spice_metadata` table.

In subsequent PRs I will also need to figure out the primary key inference.

## 🔨 Related Issues

Part of #1785