### PR TITLE
Remove `clippy::module_name_repetitions` lint

### DIFF
--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -1,5 +1,5 @@
 // Copy the below to `settings.json` and tweak the `features` array to enable optional features in VSCode.
 {
   "rust-analyzer.cargo.features": [],
-  "rust-analyzer.check.extraArgs": ["--", "-Dclippy::pedantic", "-Dclippy::unwrap_used", "-Dclippy::clone_on_ref_ptr"],
+  "rust-analyzer.check.extraArgs": ["--", "-Dclippy::pedantic", "-Dclippy::unwrap_used", "-Dclippy::clone_on_ref_ptr", "-Aclippy::module_name_repetitions"],
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ To configure VSCode to automatically apply the rustfmt style on save and to use 
   },
   "rust-analyzer.check.command": "clippy",
   "rust-analyzer.check.features": "all",
-  "rust-analyzer.check.extraArgs": ["--", "-Dclippy::pedantic", "-Dclippy::unwrap_used", "-Dclippy::clone_on_ref_ptr"]
+  "rust-analyzer.check.extraArgs": ["--", "-Dclippy::pedantic", "-Dclippy::unwrap_used", "-Dclippy::clone_on_ref_ptr", "-Aclippy::module_name_repetitions"]
 ```
 
 By default, `rust-analyzer` will attempt to rebuild all dependencies when a change is made to a `cargo.toml` file. To prevent this and only rebuild what has changed, add the following in your User Settings JSON file, setting the value to your architecture:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ lint-rust:
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \
 		-Dclippy::expect_used \
-		-Dclippy::clone_on_ref_ptr
+		-Dclippy::clone_on_ref_ptr \
+		-Aclippy::module_name_repetitions
 
 lint-go:
 	go vet ./...

--- a/crates/arrow_sql_gen/src/postgres/builder.rs
+++ b/crates/arrow_sql_gen/src/postgres/builder.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 
 use arrow::datatypes::Fields;
 use sea_query::{Alias, ColumnDef, PostgresQueryBuilder, TableBuilder};

--- a/crates/arrow_sql_gen/src/postgres/composite.rs
+++ b/crates/arrow_sql_gen/src/postgres/composite.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt};
 use fallible_iterator::FallibleIterator;

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -24,7 +24,6 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 ///
 /// This function will return an error if the fields of the expected schema don't
 /// match the fields of the actual schema.
-#[allow(clippy::module_name_repetitions)]
 pub fn verify_schema(
     expected: &arrow::datatypes::Fields,
     actual: &arrow::datatypes::Fields,

--- a/crates/data_components/src/arrow.rs
+++ b/crates/data_components/src/arrow.rs
@@ -30,7 +30,6 @@ use self::write::MemTable;
 
 pub mod write;
 
-#[allow(clippy::module_name_repetitions)]
 pub struct ArrowFactory {}
 
 impl ArrowFactory {

--- a/crates/data_components/src/clickhouse.rs
+++ b/crates/data_components/src/clickhouse.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#![allow(clippy::module_name_repetitions)]
 use async_trait::async_trait;
 use clickhouse_rs::ClientHandle;
 use datafusion::{datasource::TableProvider, sql::TableReference};

--- a/crates/data_components/src/databricks_spark.rs
+++ b/crates/data_components/src/databricks_spark.rs
@@ -22,7 +22,6 @@ use uuid::Uuid;
 use crate::{spark_connect::SparkConnect, Read, ReadWrite};
 
 #[derive(Clone)]
-#[allow(clippy::module_name_repetitions)]
 pub struct DatabricksSparkConnect {
     spark_connect: SparkConnect,
 }

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#![allow(clippy::module_name_repetitions)]
 use crate::{Read, ReadWrite};
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use arrow_flight::error::FlightError;

--- a/crates/data_components/src/mysql.rs
+++ b/crates/data_components/src/mysql.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#![allow(clippy::module_name_repetitions)]
 use async_trait::async_trait;
 use datafusion::{
     datasource::TableProvider,

--- a/crates/data_components/src/object/metadata.rs
+++ b/crates/data_components/src/object/metadata.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 
 use std::{any::Any, fmt, sync::Arc};
 

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 
 use arrow::{
     array::{ArrayRef, RecordBatch, StringArray},

--- a/crates/data_components/src/odbc.rs
+++ b/crates/data_components/src/odbc.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#![allow(clippy::module_name_repetitions)]
 use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 use db_connection_pool::dbconnection::odbcconn::ODBCDbConnectionPool;

--- a/crates/data_components/src/postgres.rs
+++ b/crates/data_components/src/postgres.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#![allow(clippy::module_name_repetitions)]
 use arrow::{
     array::RecordBatch,
     datatypes::{Schema, SchemaRef},

--- a/crates/data_components/src/snowflake.rs
+++ b/crates/data_components/src/snowflake.rs
@@ -1,4 +1,19 @@
-#![allow(clippy::module_name_repetitions)]
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 use db_connection_pool::DbConnectionPool;

--- a/crates/data_components/src/spark_connect.rs
+++ b/crates/data_components/src/spark_connect.rs
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use std::fmt;
 use std::sync::Arc;
 
@@ -31,7 +47,6 @@ use sql_provider_datafusion::expr::{self, Engine};
 use std::error::Error;
 
 #[derive(Clone)]
-#[allow(clippy::module_name_repetitions)]
 pub struct SparkConnect {
     session: Arc<SparkSession>,
 }

--- a/crates/data_components/src/sqlite.rs
+++ b/crates/data_components/src/sqlite.rs
@@ -96,7 +96,6 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[allow(clippy::module_name_repetitions)]
 pub struct SqliteTableFactory {
     db_path_param: String,
 }

--- a/crates/data_components/src/util/constraints.rs
+++ b/crates/data_components/src/util/constraints.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use datafusion::{

--- a/crates/data_components/src/util/indexes.rs
+++ b/crates/data_components/src/util/indexes.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/crates/data_components/src/util/on_conflict.rs
+++ b/crates/data_components/src/util/on_conflict.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 use arrow::datatypes::SchemaRef;
 use arrow_sql_gen::sea_query::{self, Alias};
 use itertools::Itertools;

--- a/crates/llms/src/chat/candle.rs
+++ b/crates/llms/src/chat/candle.rs
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::module_name_repetitions)]
 use std::path::Path;
 
 use async_trait::async_trait;

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
-#![allow(clippy::module_name_repetitions)]
 #![allow(clippy::borrowed_box)]
 #![allow(clippy::needless_pass_by_value)]
 

--- a/crates/llms/src/embeddings/candle/mod.rs
+++ b/crates/llms/src/embeddings/candle/mod.rs
@@ -10,7 +10,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 #![allow(clippy::missing_errors_doc)]
 
 use super::{

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -26,7 +26,6 @@ use std::{any::Any, sync::Arc};
 
 use super::DataAccelerator;
 
-#[allow(clippy::module_name_repetitions)]
 pub struct ArrowAccelerator {
     arrow_factory: ArrowFactory,
 }

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -36,7 +36,6 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[allow(clippy::module_name_repetitions)]
 pub struct PostgresAccelerator {
     postgres_factory: PostgresTableProviderFactory,
 }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -36,7 +36,6 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[allow(clippy::module_name_repetitions)]
 pub struct SqliteAccelerator {
     sqlite_factory: SqliteTableFactory,
 }

--- a/crates/runtime/src/dataconnector/localhost.rs
+++ b/crates/runtime/src/dataconnector/localhost.rs
@@ -67,7 +67,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// A no-op connector that allows for Spice to act as a "sink" for data.
 ///
 /// Configure an accelerator to store data - the localhost connector itself does nothing.
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
 pub struct LocalhostConnector {
     schema: SchemaRef,

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -33,9 +33,7 @@ use tokio::time::Instant;
 use uuid::Uuid;
 
 pub mod builder;
-#[allow(clippy::module_name_repetitions)]
 pub mod query_history;
-#[allow(clippy::module_name_repetitions)]
 pub use builder::QueryBuilder;
 
 pub mod error_code;

--- a/crates/runtime/src/datafusion/query/builder.rs
+++ b/crates/runtime/src/datafusion/query/builder.rs
@@ -24,7 +24,6 @@ use crate::datafusion::DataFusion;
 
 use super::{Protocol, Query};
 
-#[allow(clippy::module_name_repetitions)]
 pub struct QueryBuilder {
     df: Arc<DataFusion>,
     sql: String,

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -42,7 +42,6 @@ pub enum Error {
     MissingStatement,
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub fn validate_refresh_sql(expected_table: TableReference, refresh_sql: &str) -> Result<()> {
     let mut statements = DFParser::parse_sql_with_dialect(refresh_sql, &PostgreSqlDialect {})
         .context(UnableToParseSqlSnafu)?;

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 use crate::component::dataset::Dataset;
 use crate::dataconnector::AnyErrorResult;
 use crate::EmbeddingModelStore;

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 
 use std::collections::HashMap;
 use std::{any::Any, sync::Arc};

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
+++ b/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
@@ -39,7 +39,6 @@ use super::TableScanParams;
 /// If the input `ExecutionPlan` returns 0 rows, the fallback `TableProvider.scan()` is executed.
 ///
 /// The input and fallback `ExecutionPlan` must have the same schema, execution modes and equivalence properties.
-#[allow(clippy::module_name_repetitions)]
 pub struct FallbackOnZeroResultsScanExec {
     table_name: TableReference,
     /// The input execution plan.

--- a/crates/runtime/src/execution_plan/schema_cast.rs
+++ b/crates/runtime/src/execution_plan/schema_cast.rs
@@ -33,7 +33,6 @@ use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
 
-#[allow(clippy::module_name_repetitions)]
 pub struct SchemaCastScanExec {
     input: Arc<dyn ExecutionPlan>,
     schema: SchemaRef,

--- a/crates/runtime/src/execution_plan/slice.rs
+++ b/crates/runtime/src/execution_plan/slice.rs
@@ -27,7 +27,6 @@ use std::fmt;
 use std::sync::Arc;
 
 /// `SliceExec` slices an `ExecutionPlan` and returns output from a single partition.
-#[allow(clippy::module_name_repetitions)]
 pub struct SliceExec {
     /// The input execution plan.
     input: Arc<dyn ExecutionPlan>,

--- a/crates/runtime/src/execution_plan/tee.rs
+++ b/crates/runtime/src/execution_plan/tee.rs
@@ -28,7 +28,6 @@ use std::fmt;
 use std::sync::Arc;
 
 /// `TeeExec` duplicates the output of an execution plan into N partitions.
-#[allow(clippy::module_name_repetitions)]
 pub struct TeeExec {
     /// The input execution plan.
     input: Arc<dyn ExecutionPlan>,

--- a/crates/runtime/src/extension.rs
+++ b/crates/runtime/src/extension.rs
@@ -4,7 +4,6 @@ use snafu::prelude::*;
 use crate::Runtime;
 use spicepod::component::extension::Extension as ExtensionComponent;
 
-#[allow(clippy::module_name_repetitions)]
 pub type ExtensionManifest = ExtensionComponent;
 
 #[derive(Debug, Snafu)]
@@ -27,7 +26,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 ///
 /// This trait is used to define the interface for extensions to the Spice runtime.
 #[async_trait]
-#[allow(clippy::module_name_repetitions)]
 pub trait Extension: Send + Sync {
     fn name(&self) -> &'static str;
     // fn metrics_connector(&self) -> Option<Box<dyn MetricsConnector>> {
@@ -39,7 +37,6 @@ pub trait Extension: Send + Sync {
     async fn on_start(&mut self, runtime: &Runtime) -> Result<()>;
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub trait ExtensionFactory: Send + Sync {
     fn create(&self) -> Box<dyn Extension>;
 }

--- a/crates/runtime/src/model.rs
+++ b/crates/runtime/src/model.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 use arrow::record_batch::RecordBatch;
 use llms::chat::{Chat, Error as LlmError};
 use llms::embeddings::{candle::CandleEmbedding, Embed, Error as EmbedError};

--- a/crates/runtime/src/object_store_registry.rs
+++ b/crates/runtime/src/object_store_registry.rs
@@ -30,7 +30,7 @@ use url::{form_urlencoded::parse, Url};
 use crate::objectstore::ftp::FTPObjectStore;
 #[cfg(feature = "ftp")]
 use crate::objectstore::sftp::SFTPObjectStore;
-#[allow(clippy::module_name_repetitions)]
+
 #[derive(Debug, Default)]
 pub struct SpiceObjectStoreRegistry {
     inner: DefaultObjectStoreRegistry,

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -193,7 +193,6 @@ pub fn spicepod_secret_store_type(store: &SpiceSecretStore) -> Option<SecretStor
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub struct SecretsProvider {
     pub store: SecretStoreType,
 

--- a/crates/runtime/src/secrets/aws_secrets_manager.rs
+++ b/crates/runtime/src/secrets/aws_secrets_manager.rs
@@ -51,7 +51,6 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Copy, Clone)]
 pub struct AwsSecretsManager {}
 

--- a/crates/runtime/src/secrets/env.rs
+++ b/crates/runtime/src/secrets/env.rs
@@ -22,7 +22,6 @@ use super::{Secret, SecretStore};
 
 const ENV_SECRET_PREFIX: &str = "SPICE_SECRET_";
 
-#[allow(clippy::module_name_repetitions)]
 pub struct EnvSecretStore {
     secrets: HashMap<String, Secret>,
 }

--- a/crates/runtime/src/secrets/file.rs
+++ b/crates/runtime/src/secrets/file.rs
@@ -42,16 +42,13 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[allow(clippy::module_name_repetitions)]
 pub type AuthConfigs = HashMap<String, AuthConfig>;
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Default, Deserialize, Clone)]
 pub struct AuthConfig {
     pub params: HashMap<String, String>,
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub struct FileSecretStore {
     secrets: HashMap<String, Secret>,
 }

--- a/crates/runtime/src/secrets/keyring.rs
+++ b/crates/runtime/src/secrets/keyring.rs
@@ -39,7 +39,6 @@ pub enum Error {
     InvalidJsonFormat {},
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub struct KeyringSecretStore {}
 
 impl Default for KeyringSecretStore {

--- a/crates/runtime/src/secrets/kubernetes.rs
+++ b/crates/runtime/src/secrets/kubernetes.rs
@@ -157,7 +157,6 @@ impl KubernetesClient {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub struct KubernetesSecretStore {
     kubernetes_client: KubernetesClient,
 }

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -20,7 +20,6 @@ use datafusion::sql::TableReference;
 use metrics::gauge;
 use serde::{Deserialize, Serialize};
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum ComponentStatus {
     Initializing = 1,

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 #![allow(clippy::missing_errors_doc)]
-#![allow(clippy::module_name_repetitions)]
 
 use component::view::View;
 use serde::{Deserialize, Serialize};

--- a/crates/util/src/fibonacci_backoff.rs
+++ b/crates/util/src/fibonacci_backoff.rs
@@ -89,7 +89,6 @@ fn get_random_value_from_interval(
     nanos_to_duration(nanos)
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub struct FibonacciBackoffBuilder {
     randomization_factor: f64,
     max_retries: Option<usize>,


### PR DESCRIPTION
## ❓ What type of PR is this?

<!-- mark what type of change this pull request is -->

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [x] 🚩 Other

## 🗣 Description

Remove the `clippy::module_name_repetitions` from being run. As evidenced by the code, it wasn't a very useful lint.