### PR TITLE
Initial working E2E of Debezium CDC

### DIFF
--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -54,6 +54,7 @@ reqwest = { version = "0.11.24", features = ["json"] }
 rusqlite = { workspace = true, optional = true }
 secrecy.workspace = true
 serde.workspace = true
+serde_json = { workspace = true, optional = true }
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "d937df525d7c237c717b42e6146494c524dbf267", features = [

--- a/crates/data_components/README.md
+++ b/crates/data_components/README.md
@@ -5,4 +5,3 @@ This crate implements DataFusion TableProviders for reading, writing and streami
 Each component has up to 3 capabilities:
 - **Read**: **Required** Read data from the component, implemented via TableProvider.scan().
 - **Write**: **Optional** Write data to the component, implemented via TableProvider.insert_into().
-- **Stream**: **Optional** Stream data from the component, implemented via a TableProvider.scan() that returns an ExecutionPlan with `unbounded_output` set to `true`.

--- a/crates/data_components/README.md
+++ b/crates/data_components/README.md
@@ -2,6 +2,6 @@
 
 This crate implements DataFusion TableProviders for reading, writing and streaming Arrow data to/from various systems.
 
-Each component has up to 3 capabilities:
+Each component has up to 2 capabilities:
 - **Read**: **Required** Read data from the component, implemented via TableProvider.scan().
 - **Write**: **Optional** Write data to the component, implemented via TableProvider.insert_into().

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -15,9 +15,12 @@ limitations under the License.
 */
 
 use arrow::array::RecordBatch;
+use futures::stream::BoxStream;
 use snafu::prelude::*;
 
 use crate::kafka::KafkaMessage;
+
+pub type ChangesStream = BoxStream<'static, Result<ChangeEnvelope, StreamError>>;
 
 #[derive(Debug, Snafu)]
 pub enum CommitError {

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -23,8 +23,6 @@ use arrow::{
 use futures::stream::BoxStream;
 use snafu::prelude::*;
 
-use crate::kafka::KafkaMessage;
-
 pub type ChangesStream = BoxStream<'static, Result<ChangeEnvelope, StreamError>>;
 
 #[derive(Debug, Snafu)]
@@ -79,15 +77,6 @@ impl ChangeEnvelope {
 
     pub fn commit(self) -> Result<(), CommitError> {
         self.change_committer.commit()
-    }
-}
-
-impl<K, V> CommitChange for KafkaMessage<'_, K, V> {
-    fn commit(&self) -> Result<(), CommitError> {
-        self.mark_processed()
-            .boxed()
-            .context(UnableToCommitChangeSnafu)?;
-        Ok(())
     }
 }
 

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -14,7 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow::array::RecordBatch;
+use std::sync::Arc;
+
+use arrow::{
+    array::{Array, ListArray, RecordBatch, StringArray, StructArray},
+    datatypes::{DataType, Field, Schema, SchemaRef},
+};
 use futures::stream::BoxStream;
 use snafu::prelude::*;
 
@@ -28,6 +33,12 @@ pub enum CommitError {
     UnableToCommitChange {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+}
+
+#[derive(Debug, Snafu)]
+pub enum ChangeBatchError {
+    #[snafu(display("Schema didn't match expected change batch format {detail} schema={schema}"))]
+    SchemaMismatch { detail: String, schema: SchemaRef },
 }
 
 #[derive(Debug)]
@@ -54,15 +65,15 @@ pub trait CommitChange {
 
 pub struct ChangeEnvelope {
     change_committer: Box<dyn CommitChange + Send>,
-    pub rb: RecordBatch,
+    pub change_batch: ChangeBatch,
 }
 
 impl ChangeEnvelope {
     #[must_use]
-    pub fn new(change_committer: Box<dyn CommitChange + Send>, rb: RecordBatch) -> Self {
+    pub fn new(change_committer: Box<dyn CommitChange + Send>, change_batch: ChangeBatch) -> Self {
         Self {
             change_committer,
-            rb,
+            change_batch,
         }
     }
 
@@ -76,6 +87,140 @@ impl<K, V> CommitChange for KafkaMessage<'_, K, V> {
         self.mark_processed()
             .boxed()
             .context(UnableToCommitChangeSnafu)?;
+        Ok(())
+    }
+}
+
+/// The Arrow schema that represents a `ChangeEvent`
+#[must_use]
+pub fn changes_schema(table_schema: &Schema) -> Schema {
+    Schema::new(vec![
+        Field::new("op", DataType::Utf8, false),
+        Field::new(
+            "primary_keys",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, false))),
+            true,
+        ),
+        Field::new(
+            "data",
+            DataType::Struct(table_schema.fields().clone()),
+            true,
+        ),
+    ])
+}
+
+#[derive(Clone)]
+pub struct ChangeBatch {
+    pub record: RecordBatch,
+    op_idx: usize,
+    primary_keys_idx: usize,
+    data_idx: usize,
+}
+
+impl ChangeBatch {
+    pub fn try_new(record: RecordBatch) -> Result<Self, ChangeBatchError> {
+        let schema = record.schema();
+        Self::validate_schema(Arc::clone(&schema))?;
+
+        let Some((op_idx, _)) = schema.column_with_name("op") else {
+            unreachable!("The schema is validated to have an 'op' field")
+        };
+        let Some((primary_keys_idx, _)) = schema.column_with_name("primary_keys") else {
+            unreachable!("The schema is validated to have a 'primary_keys' field")
+        };
+        let Some((data_idx, _)) = schema.column_with_name("data") else {
+            unreachable!("The schema is validated to have a 'data' field")
+        };
+
+        Ok(Self {
+            record,
+            op_idx,
+            primary_keys_idx,
+            data_idx,
+        })
+    }
+
+    #[must_use]
+    pub fn op(&self, row: usize) -> &str {
+        let Some(op_col) = self
+            .record
+            .column(self.op_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+        else {
+            unreachable!("The schema is validated to have an 'op' field which is a StringArray");
+        };
+        op_col.value(row)
+    }
+
+    #[must_use]
+    pub fn primary_keys(&self, row: usize) -> Vec<String> {
+        let Some(primary_keys_col) = self
+            .record
+            .column(self.primary_keys_idx)
+            .as_any()
+            .downcast_ref::<ListArray>()
+        else {
+            unreachable!(
+                "The schema is validated to have a 'primary_keys' field which is a ListArray"
+            );
+        };
+        let primary_keys_values = primary_keys_col.value(row);
+        let Some(primary_keys_values) = primary_keys_values.as_any().downcast_ref::<StringArray>()
+        else {
+            unreachable!("The schema is validated to have a 'primary_keys' field which is a ListArray of StringArray");
+        };
+        let num_keys = primary_keys_values.len();
+        let mut primary_keys: Vec<String> = Vec::with_capacity(num_keys);
+        for i in 0..num_keys {
+            primary_keys.push(primary_keys_values.value(i).to_string());
+        }
+
+        primary_keys
+    }
+
+    #[must_use]
+    pub fn data(&self, row: usize) -> RecordBatch {
+        let Some(data_col) = self
+            .record
+            .column(self.data_idx)
+            .as_any()
+            .downcast_ref::<StructArray>()
+        else {
+            unreachable!("The schema is validated to have a 'data' field which is a StructArray");
+        };
+        data_col.slice(row, 1).into()
+    }
+
+    fn validate_schema(schema: SchemaRef) -> Result<(), ChangeBatchError> {
+        let Some(data_col) = schema.fields().iter().find(|field| field.name() == "data") else {
+            return SchemaMismatchSnafu {
+                detail: "Missing 'data' field",
+                schema,
+            }
+            .fail();
+        };
+
+        let data_schema = match data_col.data_type() {
+            DataType::Struct(fields) => Schema::new(fields.clone()),
+            _ => {
+                return SchemaMismatchSnafu {
+                    detail: "Unexpected data type for 'data' field, expected Struct",
+                    schema,
+                }
+                .fail();
+            }
+        };
+
+        let expected_schema = changes_schema(&data_schema);
+        if *schema != expected_schema {
+            return SchemaMismatchSnafu {
+                detail: "Schema didn't match expected change batch format",
+                schema,
+            }
+            .fail();
+        }
+
         Ok(())
     }
 }

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow::array::RecordBatch;
+use snafu::prelude::*;
+
+use crate::kafka::KafkaMessage;
+
+#[derive(Debug, Snafu)]
+pub enum CommitError {
+    #[snafu(display("Unable to commit change: {source}"))]
+    UnableToCommitChange {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+#[derive(Debug)]
+pub enum StreamError {
+    Kafka(String),
+    SerdeJsonError(String),
+}
+
+impl std::error::Error for StreamError {}
+
+impl std::fmt::Display for StreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StreamError::Kafka(e) => write!(f, "Kafka error: {e}"),
+            StreamError::SerdeJsonError(e) => write!(f, "Serde JSON error: {e}"),
+        }
+    }
+}
+
+/// Allows to commit a change that has been processed.
+pub trait CommitChange {
+    fn commit(&self) -> Result<(), CommitError>;
+}
+
+pub struct ChangeEnvelope {
+    change_committer: Box<dyn CommitChange + Send>,
+    pub rb: RecordBatch,
+}
+
+impl ChangeEnvelope {
+    #[must_use]
+    pub fn new(change_committer: Box<dyn CommitChange + Send>, rb: RecordBatch) -> Self {
+        Self {
+            change_committer,
+            rb,
+        }
+    }
+
+    pub fn commit(self) -> Result<(), CommitError> {
+        self.change_committer.commit()
+    }
+}
+
+impl<K, V> CommitChange for KafkaMessage<'_, K, V> {
+    fn commit(&self) -> Result<(), CommitError> {
+        self.mark_processed()
+            .boxed()
+            .context(UnableToCommitChangeSnafu)?;
+        Ok(())
+    }
+}

--- a/crates/data_components/src/debezium/arrow/changes.rs
+++ b/crates/data_components/src/debezium/arrow/changes.rs
@@ -29,7 +29,7 @@ use arrow::{
 use snafu::prelude::*;
 
 /// Converts a `ChangeEvent` into a `ChangeBatch`
-pub fn to_record_batch(
+pub fn to_change_batch(
     table_schema: &SchemaRef,
     primary_key: &[String],
     change: &ChangeEvent,

--- a/crates/data_components/src/debezium/arrow/changes.rs
+++ b/crates/data_components/src/debezium/arrow/changes.rs
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use std::sync::Arc;
+
+use crate::{
+    arrow::struct_builder::StructBuilder,
+    debezium::{
+        arrow::downcast_builder,
+        change_event::{ChangeEvent, Op},
+    },
+};
+use arrow::{
+    array::{ArrayBuilder, ListBuilder, RecordBatch, StringBuilder},
+    datatypes::{DataType, Field, Schema, SchemaRef},
+};
+use snafu::prelude::*;
+
+/// Converts a `ChangeEvent` into an Arrow `RecordBatch`
+pub fn to_record_batch(
+    table_schema: &SchemaRef,
+    primary_key: &[String],
+    change: &ChangeEvent,
+) -> super::Result<RecordBatch> {
+    let schema = changes_schema(table_schema);
+
+    let mut struct_builder = StructBuilder::from_fields(schema.fields().clone(), 1);
+
+    struct_builder.append(true);
+
+    for (idx, field) in schema.fields().iter().enumerate() {
+        let field_builder = struct_builder.field_builder_array(idx);
+        match field.name().as_str() {
+            "op" => {
+                let str_builder = downcast_builder::<StringBuilder>(field_builder)?;
+                str_builder.append_value(change.payload.op.to_string());
+            }
+            "primary_key" => {
+                let list_builder =
+                    downcast_builder::<ListBuilder<Box<dyn ArrayBuilder>>>(field_builder)?;
+                if primary_key.is_empty() {
+                    list_builder.append(false);
+                } else {
+                    let str_builder = downcast_builder::<StringBuilder>(list_builder.values())?;
+                    for key in primary_key {
+                        str_builder.append_value(key);
+                    }
+                    list_builder.append(true);
+                }
+            }
+            "data" => {
+                let change_data = match change.payload.op {
+                    Op::Delete => change
+                        .payload
+                        .before
+                        .clone()
+                        .context(super::DeleteOpWithoutBeforeFieldSnafu)?,
+                    _ => change.payload.after.clone(),
+                };
+
+                let data_struct_builder = downcast_builder::<StructBuilder>(field_builder)?;
+
+                super::append_value_to_struct_builder(change_data, data_struct_builder)?;
+            }
+            _ => unreachable!("Unexpected field in changes schema"),
+        }
+    }
+
+    let struct_array = struct_builder.finish();
+    Ok(struct_array.into())
+}
+
+#[must_use]
+pub fn changes_schema(table_schema: &Schema) -> Schema {
+    Schema::new(vec![
+        Field::new("op", DataType::Utf8, false),
+        Field::new(
+            "primary_key",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, false))),
+            true,
+        ),
+        Field::new(
+            "data",
+            DataType::Struct(table_schema.fields().clone()),
+            true,
+        ),
+    ])
+}

--- a/crates/data_components/src/debezium/arrow/changes.rs
+++ b/crates/data_components/src/debezium/arrow/changes.rs
@@ -47,7 +47,7 @@ pub fn to_record_batch(
                 let str_builder = downcast_builder::<StringBuilder>(field_builder)?;
                 str_builder.append_value(change.payload.op.to_string());
             }
-            "primary_key" => {
+            "primary_keys" => {
                 let list_builder =
                     downcast_builder::<ListBuilder<Box<dyn ArrayBuilder>>>(field_builder)?;
                 if primary_key.is_empty() {
@@ -74,7 +74,7 @@ pub fn to_record_batch(
 
                 super::append_value_to_struct_builder(change_data, data_struct_builder)?;
             }
-            _ => unreachable!("Unexpected field in changes schema"),
+            _ => unreachable!("Unexpected field in changes schema {}", field.name()),
         }
     }
 

--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -89,12 +89,12 @@ pub enum Op {
 impl Display for Op {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Op::Create => write!(f, "create"),
-            Op::Update => write!(f, "update"),
-            Op::Delete => write!(f, "delete"),
-            Op::Read => write!(f, "read"),
-            Op::Truncate => write!(f, "truncate"),
-            Op::Message => write!(f, "message"),
+            Op::Create => write!(f, "c"),
+            Op::Update => write!(f, "u"),
+            Op::Delete => write!(f, "d"),
+            Op::Read => write!(f, "r"),
+            Op::Truncate => write!(f, "t"),
+            Op::Message => write!(f, "m"),
         }
     }
 }

--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -133,7 +133,6 @@ pub struct Schema {
     pub fields: Vec<Field>,
     pub optional: bool,
     pub name: String,
-    pub version: i64,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -33,6 +33,30 @@ impl ChangeEventKey {
         serde_json::from_slice(bytz)
     }
 
+    /// Gets the primary key fields from the schema.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// {
+    ///     "schema": {
+    ///         "type": "struct",
+    ///         "fields": [
+    ///             {
+    ///                 "type": "int32",
+    ///                 "optional": false,
+    ///                 "default": 0,
+    ///                 "field": "id"
+    ///             }
+    ///         ],
+    ///         "optional": false,
+    ///         "name": "acceleration.public.customer_addresses2.Key"
+    ///     },
+    ///     "payload": {
+    ///         "id": 4
+    ///     }
+    /// }
+    /// ```
     #[must_use]
     pub fn get_primary_key(&self) -> Vec<String> {
         self.schema

--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -21,7 +21,29 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-/// A representation of a Debezium Change Event.
+/// A representation of a Debezium Change Event Key.
+#[derive(Serialize, Deserialize)]
+pub struct ChangeEventKey {
+    pub schema: Schema,
+    pub payload: serde_json::Value,
+}
+
+impl ChangeEventKey {
+    pub fn from_bytes(bytz: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytz)
+    }
+
+    #[must_use]
+    pub fn get_primary_key(&self) -> Vec<String> {
+        self.schema
+            .fields
+            .iter()
+            .filter_map(|field| field.field.clone())
+            .collect()
+    }
+}
+
+/// A representation of a Debezium Change Event Value.
 #[derive(Serialize, Deserialize)]
 pub struct ChangeEvent {
     pub schema: Schema,

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -14,31 +14,70 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{any::Any, sync::Arc};
-
-use crate::kafka::KafkaConsumer;
+use crate::{
+    debezium::{
+        arrow::changes::{self, changes_schema},
+        change_event::ChangeEvent,
+    },
+    kafka::KafkaConsumer,
+};
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{
+    common::{Constraints, DFSchema},
     datasource::{TableProvider, TableType},
-    error::Result as DataFusionResult,
-    execution::context::SessionState,
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::{context::SessionState, SendableRecordBatchStream, TaskContext},
     logical_expr::Expr,
-    physical_plan::{empty::EmptyExec, ExecutionPlan},
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionMode,
+        ExecutionPlan, Partitioning, PlanProperties,
+    },
+    sql::sqlparser::ast::{Ident, TableConstraint},
 };
+use futures::StreamExt;
+use std::{any::Any, fmt, sync::Arc};
 
 pub struct DebeziumKafka {
     schema: SchemaRef,
-    _consumer: KafkaConsumer,
+    primary_keys: Vec<String>,
+    constraints: Option<Constraints>,
+    consumer: &'static KafkaConsumer,
 }
 
 impl DebeziumKafka {
     #[must_use]
-    pub fn new(schema: SchemaRef, consumer: KafkaConsumer) -> Self {
+    pub fn new(schema: SchemaRef, primary_keys: Vec<String>, consumer: KafkaConsumer) -> Self {
+        let Ok(df_schema) = DFSchema::try_from(Arc::clone(&schema)) else {
+            unreachable!("DFSchema::try_from is infallible as of DataFusion 38")
+        };
+        let constraints = Constraints::new_from_table_constraints(
+            &[TableConstraint::PrimaryKey {
+                name: None,
+                index_name: None,
+                index_type: None,
+                columns: primary_keys
+                    .iter()
+                    .map(|col| Ident::new(col.clone()))
+                    .collect(),
+                index_options: vec![],
+                characteristics: None,
+            }],
+            &Arc::new(df_schema),
+        )
+        .ok();
         Self {
             schema,
-            _consumer: consumer,
+            primary_keys,
+            constraints,
+            consumer: Box::leak(Box::new(consumer)),
         }
+    }
+
+    #[must_use]
+    pub fn get_primary_keys(&self) -> &Vec<String> {
+        &self.primary_keys
     }
 }
 
@@ -49,11 +88,15 @@ impl TableProvider for DebeziumKafka {
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
+        Arc::new(changes_schema(&self.schema))
     }
 
     fn table_type(&self) -> TableType {
         TableType::Base
+    }
+
+    fn constraints(&self) -> Option<&Constraints> {
+        self.constraints.as_ref()
     }
 
     async fn scan(
@@ -63,6 +106,122 @@ impl TableProvider for DebeziumKafka {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(EmptyExec::new(self.schema())))
+        Ok(Arc::new(DebeziumKafkaExec::new(
+            self.schema(),
+            self.primary_keys.clone(),
+            self.consumer,
+        )))
+    }
+}
+
+#[derive(Clone)]
+pub struct DebeziumKafkaExec {
+    schema: SchemaRef,
+    primary_keys: Vec<String>,
+    consumer: &'static KafkaConsumer,
+    properties: PlanProperties,
+}
+
+impl DebeziumKafkaExec {
+    #[must_use]
+    pub fn new(
+        schema: SchemaRef,
+        primary_keys: Vec<String>,
+        consumer: &'static KafkaConsumer,
+    ) -> Self {
+        Self {
+            schema: Arc::clone(&schema),
+            primary_keys,
+            consumer,
+            properties: PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(0),
+                ExecutionMode::Unbounded,
+            ),
+        }
+    }
+}
+
+impl std::fmt::Debug for DebeziumKafkaExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "DebeziumKafkaExec primary_keys={}",
+            self.primary_keys.join(",")
+        )
+    }
+}
+
+impl DisplayAs for DebeziumKafkaExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "DebeziumKafkaExec primary_keys={}",
+            self.primary_keys.join(",")
+        )
+    }
+}
+
+impl ExecutionPlan for DebeziumKafkaExec {
+    fn name(&self) -> &'static str {
+        "DebeziumKafkaExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let consumer: &'static KafkaConsumer = self.consumer;
+        let schema = Arc::clone(&self.schema());
+        let primary_keys = self.primary_keys.clone();
+        let stream = consumer
+            .stream_json::<ChangeEvent>()
+            .filter_map(move |msg| {
+                let schema = Arc::clone(&schema);
+                let pk = primary_keys.clone();
+                async move {
+                    let Ok(msg) = msg else { return None };
+
+                    let val = msg.value();
+                    let rb = changes::to_record_batch(&schema, &pk, val)
+                        .map_err(|e| DataFusionError::Execution(e.to_string()));
+
+                    if let Err(e) = msg.mark_processed() {
+                        return Some(Err(DataFusionError::Execution(format!(
+                            "Unable to mark Kafka message as being processed: {e}",
+                        ))));
+                    };
+
+                    Some(rb)
+                }
+            });
+
+        let stream_adapter = RecordBatchStreamAdapter::new(self.schema(), stream);
+
+        Ok(Box::pin(stream_adapter))
     }
 }

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -94,7 +94,7 @@ impl DebeziumKafka {
                 };
 
                 let val = msg.value();
-                changes::to_record_batch(&schema, &pk, val)
+                changes::to_change_batch(&schema, &pk, val)
                     .map(|rb| ChangeEnvelope::new(Box::new(msg), rb))
                     .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))
             });

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::module_name_repetitions)]
 
 use futures::{Stream, StreamExt};
 use rdkafka::{

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -149,10 +149,6 @@ impl<'a, T> KafkaMessage<'a, T> {
         &self.value
     }
 
-    pub fn take_value(self) -> T {
-        self.value
-    }
-
     pub fn mark_processed(&self) -> Result<()> {
         self.consumer
             .store_offset_from_message(&self.msg)

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -53,6 +53,7 @@ pub mod spark_connect;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+pub mod cdc;
 pub mod delete;
 pub mod object;
 pub mod util;
@@ -67,15 +68,6 @@ pub trait Read: Send + Sync {
 
 #[async_trait]
 pub trait ReadWrite: Send + Sync {
-    async fn table_provider(
-        &self,
-        table_reference: TableReference,
-    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>>;
-}
-
-/// Similar to the `Read` trait above, but the `TableProvider.scan()` method returns ExecutionPlans that are unbounded (i.e. streaming).
-#[async_trait]
-pub trait Stream: Send + Sync {
     async fn table_provider(
         &self,
         table_reference: TableReference,

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -93,6 +93,27 @@ pub enum Error {
     FailedToWriteData {
         source: datafusion::error::DataFusionError,
     },
+
+    #[snafu(display("The accelerated table does not support delete operations"))]
+    AcceleratedTableDoesntSupportDelete {},
+
+    #[snafu(display("Expected schema to have field '{field_name}' schema={schema}"))]
+    ExpectedSchemaToHaveField {
+        field_name: String,
+        schema: SchemaRef,
+    },
+
+    #[snafu(display("Expected field in schema '{field_name}' to have type '{expected_data_type}' schema={schema}"))]
+    ArrayDataTypeMismatch {
+        field_name: String,
+        expected_data_type: String,
+        schema: SchemaRef,
+    },
+
+    #[snafu(display(
+        "The type of the primary key '{data_type}' is not yet supported for change deletion."
+    ))]
+    PrimaryKeyTypeNotYetSupported { data_type: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -407,7 +407,9 @@ impl RefreshTask {
                                 panic!("Failed to insert data: {e}");
                             };
                         }
-                        _ => panic!("Unknown operation"),
+                        _ => {
+                            tracing::error!("Unknown operation {op} for {dataset_name}");
+                        }
                     }
                 }
             }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -289,7 +289,6 @@ impl RefreshTask {
         let ctx = SessionContext::new();
 
         if data_update.update_type == UpdateType::Changes {
-            tracing::info!("Processing changes for {dataset_name}");
             let Some(deletion_provider) = get_deletion_provider(Arc::clone(&self.accelerator))
             else {
                 panic!("Failed to get deletion provider");

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow::array::{Int32Array, Int64Array, ListArray, RecordBatch, StringArray};
 use arrow::compute::{filter_record_batch, SortOptions};
 use arrow::{
     array::{make_comparator, StructArray, TimestampNanosecondArray},
@@ -21,6 +22,10 @@ use arrow::{
 };
 use async_stream::stream;
 use cache::QueryResultsCacheProvider;
+use data_components::cdc::{self, ChangeEnvelope};
+use data_components::delete::get_deletion_provider;
+use datafusion::logical_expr::lit;
+use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use snafu::{OptionExt, ResultExt};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
@@ -78,6 +83,65 @@ impl RefreshTask {
             refresh,
             accelerator,
         }
+    }
+
+    pub async fn start_changes_stream(
+        &self,
+        mut changes_stream: BoxStream<
+            'static,
+            std::result::Result<ChangeEnvelope, cdc::StreamError>,
+        >,
+        cache_provider: Option<Arc<QueryResultsCacheProvider>>,
+        ready_sender: Option<oneshot::Sender<()>>,
+    ) -> super::Result<()> {
+        self.mark_dataset_status(status::ComponentStatus::Refreshing)
+            .await;
+
+        let dataset_name = self.dataset_name.clone();
+
+        let mut ready_sender = ready_sender;
+
+        while let Some(update) = changes_stream.next().await {
+            match update {
+                Ok(change_envelope) => {
+                    let data_update = DataUpdate {
+                        schema: change_envelope.rb.schema(),
+                        data: vec![change_envelope.rb.clone()],
+                        update_type: UpdateType::Changes,
+                    };
+
+                    // write_data_update updates dataset status and logs errors so we don't do this here
+                    if self.write_data_update(None, data_update).await.is_ok() {
+                        if let Some(ready_sender) = ready_sender.take() {
+                            ready_sender.send(()).ok();
+                        }
+
+                        if let Err(e) = change_envelope.commit() {
+                            tracing::debug!("Failed to commit CDC change envelope: {e}");
+                        }
+
+                        if let Some(cache_provider) = &cache_provider {
+                            if let Err(e) = cache_provider
+                                .invalidate_for_table(&dataset_name.to_string())
+                                .await
+                            {
+                                tracing::error!(
+                                    "Failed to invalidate cached results for dataset {}: {e}",
+                                    &dataset_name.to_string()
+                                );
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Changes error for {dataset_name}: {e}");
+                    self.mark_dataset_status(status::ComponentStatus::Error)
+                        .await;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     pub async fn start_streaming_append(
@@ -198,6 +262,7 @@ impl RefreshTask {
         self.get_data_update(filters).await
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn write_data_update(
         &self,
         start_time: Option<SystemTime>,
@@ -222,6 +287,133 @@ impl RefreshTask {
         };
 
         let ctx = SessionContext::new();
+
+        if data_update.update_type == UpdateType::Changes {
+            tracing::info!("Processing changes for {dataset_name}");
+            let Some(deletion_provider) = get_deletion_provider(Arc::clone(&self.accelerator))
+            else {
+                panic!("Failed to get deletion provider");
+            };
+
+            for data_batch in &data_update.data {
+                let Some(op_col) = data_batch.column(0).as_any().downcast_ref::<StringArray>()
+                else {
+                    panic!("Failed to get op column");
+                };
+                let Some(primary_keys_col) =
+                    data_batch.column(1).as_any().downcast_ref::<ListArray>()
+                else {
+                    panic!("Failed to get primary keys column");
+                };
+                let Some(data_col) = data_batch.column(2).as_any().downcast_ref::<StructArray>()
+                else {
+                    panic!("Failed to get data column");
+                };
+                for row in 0..data_batch.num_rows() {
+                    let op = op_col.value(row);
+                    match op {
+                        "d" => {
+                            let inner_data: RecordBatch = data_col.slice(row, 1).into();
+                            let primary_keys_col_dyn_arr = primary_keys_col.value(row);
+                            let Some(primary_key) = primary_keys_col_dyn_arr
+                                .as_any()
+                                .downcast_ref::<StringArray>()
+                            else {
+                                panic!("Failed to get primary key column");
+                            };
+                            let primary_key = primary_key.value(0);
+                            let inner_data_schema = inner_data.schema();
+                            let Some((primary_key_idx, field)) =
+                                inner_data_schema.column_with_name(primary_key)
+                            else {
+                                panic!("Failed to get primary key column");
+                            };
+                            let key_col = inner_data.column(primary_key_idx);
+                            let delete_where_expr = match field.data_type() {
+                                DataType::Int32 => {
+                                    let Some(key_col) =
+                                        key_col.as_any().downcast_ref::<Int32Array>()
+                                    else {
+                                        panic!(
+                                            "Failed to get id column as Int32Array, {inner_data:?}"
+                                        );
+                                    };
+                                    col(primary_key).eq(lit(key_col.value(0)))
+                                }
+                                DataType::Int64 => {
+                                    let Some(key_col) =
+                                        key_col.as_any().downcast_ref::<Int64Array>()
+                                    else {
+                                        panic!(
+                                            "Failed to get id column as Int64Array, {inner_data:?}"
+                                        );
+                                    };
+                                    col(primary_key).eq(lit(key_col.value(0)))
+                                }
+                                DataType::Utf8 => {
+                                    let Some(key_col) =
+                                        key_col.as_any().downcast_ref::<StringArray>()
+                                    else {
+                                        panic!(
+                                            "Failed to get id column as Int64Array, {inner_data:?}"
+                                        );
+                                    };
+                                    col(primary_key).eq(lit(key_col.value(0)))
+                                }
+                                _ => panic!("Unsupported primary key type {}", field.data_type()),
+                            };
+                            tracing::info!(
+                                "Deleting data for {dataset_name} where {delete_where_expr}"
+                            );
+
+                            let ctx = SessionContext::new();
+                            let session_state = ctx.state();
+
+                            let Ok(delete_plan) = deletion_provider
+                                .delete_from(&session_state, &[delete_where_expr])
+                                .await
+                            else {
+                                panic!("Failed to create delete plan");
+                            };
+
+                            if let Err(e) = collect(delete_plan, ctx.task_ctx()).await {
+                                panic!("Failed to delete data: {e}");
+                            };
+                        }
+                        "c" | "u" | "r" => {
+                            let inner_data: RecordBatch = data_col.slice(row, 1).into();
+                            let ctx = SessionContext::new();
+                            let session_state = ctx.state();
+
+                            tracing::info!("Inserting data row for {dataset_name}");
+
+                            let Ok(insert_plan) = self
+                                .accelerator
+                                .insert_into(
+                                    &session_state,
+                                    Arc::new(DataUpdateExecutionPlan::new(DataUpdate {
+                                        schema: inner_data.schema(),
+                                        data: vec![inner_data],
+                                        update_type: UpdateType::Append,
+                                    })),
+                                    false,
+                                )
+                                .await
+                            else {
+                                panic!("Failed to create insert plan");
+                            };
+
+                            if let Err(e) = collect(insert_plan, ctx.task_ctx()).await {
+                                panic!("Failed to insert data: {e}");
+                            };
+                        }
+                        _ => panic!("Unknown operation"),
+                    }
+                }
+            }
+
+            return Ok(());
+        }
 
         let overwrite = data_update.update_type == UpdateType::Overwrite;
         match self

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow::array::{Int32Array, Int64Array, RecordBatch, StringArray};
 use arrow::compute::{filter_record_batch, SortOptions};
 use arrow::{
     array::{make_comparator, StructArray, TimestampNanosecondArray},
@@ -22,9 +21,6 @@ use arrow::{
 };
 use async_stream::stream;
 use cache::QueryResultsCacheProvider;
-use data_components::cdc::{ChangeBatch, ChangesStream};
-use data_components::delete::get_deletion_provider;
-use datafusion::logical_expr::lit;
 use futures::{Stream, StreamExt};
 use snafu::{OptionExt, ResultExt};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
@@ -61,6 +57,9 @@ use datafusion::{
 use datafusion::{execution::context::SessionContext, physical_plan::collect};
 
 use super::refresh::Refresh;
+
+mod changes;
+
 pub struct RefreshTask {
     dataset_name: TableReference,
     federated: Arc<dyn TableProvider>,
@@ -82,67 +81,6 @@ impl RefreshTask {
             refresh,
             accelerator,
         }
-    }
-
-    pub async fn start_changes_stream(
-        &self,
-        mut changes_stream: ChangesStream,
-        cache_provider: Option<Arc<QueryResultsCacheProvider>>,
-        ready_sender: Option<oneshot::Sender<()>>,
-    ) -> super::Result<()> {
-        self.mark_dataset_status(status::ComponentStatus::Refreshing)
-            .await;
-
-        let dataset_name = self.dataset_name.clone();
-
-        let mut ready_sender = ready_sender;
-
-        while let Some(update) = changes_stream.next().await {
-            match update {
-                Ok(change_envelope) => {
-                    match self
-                        .write_change(change_envelope.change_batch.clone())
-                        .await
-                    {
-                        Ok(()) => {
-                            if let Some(ready_sender) = ready_sender.take() {
-                                ready_sender.send(()).ok();
-                            }
-
-                            if let Err(e) = change_envelope.commit() {
-                                tracing::debug!("Failed to commit CDC change envelope: {e}");
-                            }
-
-                            if let Some(cache_provider) = &cache_provider {
-                                if let Err(e) = cache_provider
-                                    .invalidate_for_table(&dataset_name.to_string())
-                                    .await
-                                {
-                                    tracing::error!(
-                                        "Failed to invalidate cached results for dataset {}: {e}",
-                                        &dataset_name.to_string()
-                                    );
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            self.mark_dataset_status(status::ComponentStatus::Error)
-                                .await;
-                            tracing::error!("Error writing change for {dataset_name}: {e}");
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("Changes stream error for {dataset_name}: {e}");
-                    self.mark_dataset_status(status::ComponentStatus::Error)
-                        .await;
-                }
-            }
-        }
-
-        tracing::warn!("Changes stream ended for dataset {dataset_name}");
-
-        Ok(())
     }
 
     pub async fn start_streaming_append(
@@ -261,202 +199,6 @@ impl RefreshTask {
         };
 
         self.get_data_update(filters).await
-    }
-
-    async fn write_change(&self, change_batch: ChangeBatch) -> super::Result<()> {
-        let dataset_name = self.dataset_name.clone();
-        let deletion_provider = get_deletion_provider(Arc::clone(&self.accelerator))
-            .context(super::AcceleratedTableDoesntSupportDeleteSnafu)?;
-
-        for row in 0..change_batch.record.num_rows() {
-            let op = change_batch.op(row);
-            match op {
-                "d" => {
-                    let inner_data: RecordBatch = change_batch.data(row);
-                    let primary_keys = change_batch.primary_keys(row);
-                    let delete_where_exprs =
-                        Self::get_delete_where_expr(&inner_data, primary_keys)?;
-
-                    tracing::info!(
-                        "Deleting data for {dataset_name} where {}",
-                        delete_where_exprs
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(" AND ")
-                    );
-
-                    let ctx = SessionContext::new();
-                    let session_state = ctx.state();
-
-                    let delete_plan = deletion_provider
-                        .delete_from(&session_state, &delete_where_exprs)
-                        .await
-                        .context(super::FailedToWriteDataSnafu)?;
-
-                    collect(delete_plan, ctx.task_ctx())
-                        .await
-                        .context(super::FailedToWriteDataSnafu)?;
-                }
-                "c" | "u" | "r" => {
-                    let inner_data: RecordBatch = change_batch.data(row);
-                    let primary_keys = change_batch.primary_keys(row);
-                    let ctx = SessionContext::new();
-                    let session_state = ctx.state();
-
-                    tracing::info!(
-                        "Inserting data row for {dataset_name} with {}",
-                        Self::get_primary_key_log_fmt(&inner_data, &primary_keys)?
-                    );
-
-                    let insert_plan = self
-                        .accelerator
-                        .insert_into(
-                            &session_state,
-                            Arc::new(DataUpdateExecutionPlan::new(DataUpdate {
-                                schema: inner_data.schema(),
-                                data: vec![inner_data],
-                                update_type: UpdateType::Append,
-                            })),
-                            false,
-                        )
-                        .await
-                        .context(super::FailedToWriteDataSnafu)?;
-
-                    collect(insert_plan, ctx.task_ctx())
-                        .await
-                        .context(super::FailedToWriteDataSnafu)?;
-                }
-                _ => {
-                    tracing::error!("Unknown operation {op} for {dataset_name}");
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn get_primary_key_log_fmt(
-        data: &RecordBatch,
-        primary_keys: &[String],
-    ) -> super::Result<String> {
-        let data_schema = data.schema();
-        primary_keys
-            .iter()
-            .map(|key| {
-                let Some((primary_key_idx, field)) = data_schema.column_with_name(key) else {
-                    return super::ExpectedSchemaToHaveFieldSnafu {
-                        field_name: key.clone(),
-                        schema: Arc::clone(&data_schema),
-                    }
-                    .fail();
-                };
-                let key_col = data.column(primary_key_idx);
-                match field.data_type() {
-                    DataType::Int32 => {
-                        let key_col = key_col.as_any().downcast_ref::<Int32Array>().context(
-                            super::ArrayDataTypeMismatchSnafu {
-                                field_name: key.clone(),
-                                expected_data_type: "Int32".to_string(),
-                                schema: Arc::clone(&data_schema),
-                            },
-                        )?;
-                        Ok(format!("{key}={value}", value = key_col.value(0)))
-                    }
-                    DataType::Int64 => {
-                        let key_col = key_col.as_any().downcast_ref::<Int64Array>().context(
-                            super::ArrayDataTypeMismatchSnafu {
-                                field_name: key.clone(),
-                                expected_data_type: "Int64".to_string(),
-                                schema: Arc::clone(&data_schema),
-                            },
-                        )?;
-                        Ok(format!(
-                            "{key}={value}",
-                            key = key,
-                            value = key_col.value(0)
-                        ))
-                    }
-                    DataType::Utf8 => {
-                        let key_col = key_col.as_any().downcast_ref::<StringArray>().context(
-                            super::ArrayDataTypeMismatchSnafu {
-                                field_name: key.clone(),
-                                expected_data_type: "String".to_string(),
-                                schema: Arc::clone(&data_schema),
-                            },
-                        )?;
-                        Ok(format!(
-                            "{key}={value}",
-                            key = key,
-                            value = key_col.value(0)
-                        ))
-                    }
-                    _ => super::PrimaryKeyTypeNotYetSupportedSnafu {
-                        data_type: field.data_type().to_string(),
-                    }
-                    .fail(),
-                }
-            })
-            .collect::<super::Result<Vec<String>>>()
-            .map(|keys| keys.join(", "))
-    }
-
-    fn get_delete_where_expr(
-        data: &RecordBatch,
-        primary_keys: Vec<String>,
-    ) -> super::Result<Vec<Expr>> {
-        let mut delete_where_exprs: Vec<Expr> = vec![];
-        let data_schema = data.schema();
-        for primary_key in primary_keys {
-            let Some((primary_key_idx, field)) = data_schema.column_with_name(&primary_key) else {
-                return super::ExpectedSchemaToHaveFieldSnafu {
-                    field_name: primary_key.clone(),
-                    schema: Arc::clone(&data_schema),
-                }
-                .fail();
-            };
-            let key_col = data.column(primary_key_idx);
-            let delete_where_expr = match field.data_type() {
-                DataType::Int32 => {
-                    let key_col = key_col.as_any().downcast_ref::<Int32Array>().context(
-                        super::ArrayDataTypeMismatchSnafu {
-                            field_name: primary_key.clone(),
-                            expected_data_type: "Int32".to_string(),
-                            schema: Arc::clone(&data_schema),
-                        },
-                    )?;
-                    col(primary_key).eq(lit(key_col.value(0)))
-                }
-                DataType::Int64 => {
-                    let key_col = key_col.as_any().downcast_ref::<Int64Array>().context(
-                        super::ArrayDataTypeMismatchSnafu {
-                            field_name: primary_key.clone(),
-                            expected_data_type: "Int64".to_string(),
-                            schema: Arc::clone(&data_schema),
-                        },
-                    )?;
-                    col(primary_key).eq(lit(key_col.value(0)))
-                }
-                DataType::Utf8 => {
-                    let key_col = key_col.as_any().downcast_ref::<StringArray>().context(
-                        super::ArrayDataTypeMismatchSnafu {
-                            field_name: primary_key.clone(),
-                            expected_data_type: "String".to_string(),
-                            schema: Arc::clone(&data_schema),
-                        },
-                    )?;
-                    col(primary_key).eq(lit(key_col.value(0)))
-                }
-                _ => {
-                    return super::PrimaryKeyTypeNotYetSupportedSnafu {
-                        data_type: field.data_type().to_string(),
-                    }
-                    .fail()
-                }
-            };
-            delete_where_exprs.push(delete_where_expr);
-        }
-        Ok(delete_where_exprs)
     }
 
     async fn write_data_update(

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -22,10 +22,9 @@ use arrow::{
 };
 use async_stream::stream;
 use cache::QueryResultsCacheProvider;
-use data_components::cdc::{self, ChangeEnvelope};
+use data_components::cdc::ChangesStream;
 use data_components::delete::get_deletion_provider;
 use datafusion::logical_expr::lit;
-use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use snafu::{OptionExt, ResultExt};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
@@ -87,10 +86,7 @@ impl RefreshTask {
 
     pub async fn start_changes_stream(
         &self,
-        mut changes_stream: BoxStream<
-            'static,
-            std::result::Result<ChangeEnvelope, cdc::StreamError>,
-        >,
+        mut changes_stream: ChangesStream,
         cache_provider: Option<Arc<QueryResultsCacheProvider>>,
         ready_sender: Option<oneshot::Sender<()>>,
     ) -> super::Result<()> {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow::array::{Int32Array, Int64Array, ListArray, RecordBatch, StringArray};
+use arrow::array::{Int32Array, Int64Array, RecordBatch, StringArray};
 use arrow::compute::{filter_record_batch, SortOptions};
 use arrow::{
     array::{make_comparator, StructArray, TimestampNanosecondArray},
@@ -22,7 +22,7 @@ use arrow::{
 };
 use async_stream::stream;
 use cache::QueryResultsCacheProvider;
-use data_components::cdc::ChangesStream;
+use data_components::cdc::{ChangeBatch, ChangesStream};
 use data_components::delete::get_deletion_provider;
 use datafusion::logical_expr::lit;
 use futures::{Stream, StreamExt};
@@ -100,42 +100,47 @@ impl RefreshTask {
         while let Some(update) = changes_stream.next().await {
             match update {
                 Ok(change_envelope) => {
-                    let data_update = DataUpdate {
-                        schema: change_envelope.rb.schema(),
-                        data: vec![change_envelope.rb.clone()],
-                        update_type: UpdateType::Changes,
-                    };
-
-                    // write_data_update updates dataset status and logs errors so we don't do this here
-                    if self.write_data_update(None, data_update).await.is_ok() {
-                        if let Some(ready_sender) = ready_sender.take() {
-                            ready_sender.send(()).ok();
-                        }
-
-                        if let Err(e) = change_envelope.commit() {
-                            tracing::debug!("Failed to commit CDC change envelope: {e}");
-                        }
-
-                        if let Some(cache_provider) = &cache_provider {
-                            if let Err(e) = cache_provider
-                                .invalidate_for_table(&dataset_name.to_string())
-                                .await
-                            {
-                                tracing::error!(
-                                    "Failed to invalidate cached results for dataset {}: {e}",
-                                    &dataset_name.to_string()
-                                );
+                    match self
+                        .write_change(change_envelope.change_batch.clone())
+                        .await
+                    {
+                        Ok(()) => {
+                            if let Some(ready_sender) = ready_sender.take() {
+                                ready_sender.send(()).ok();
                             }
+
+                            if let Err(e) = change_envelope.commit() {
+                                tracing::debug!("Failed to commit CDC change envelope: {e}");
+                            }
+
+                            if let Some(cache_provider) = &cache_provider {
+                                if let Err(e) = cache_provider
+                                    .invalidate_for_table(&dataset_name.to_string())
+                                    .await
+                                {
+                                    tracing::error!(
+                                        "Failed to invalidate cached results for dataset {}: {e}",
+                                        &dataset_name.to_string()
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            self.mark_dataset_status(status::ComponentStatus::Error)
+                                .await;
+                            tracing::error!("Error writing change for {dataset_name}: {e}");
                         }
                     }
                 }
                 Err(e) => {
-                    tracing::error!("Changes error for {dataset_name}: {e}");
+                    tracing::error!("Changes stream error for {dataset_name}: {e}");
                     self.mark_dataset_status(status::ComponentStatus::Error)
                         .await;
                 }
             }
         }
+
+        tracing::warn!("Changes stream ended for dataset {dataset_name}");
 
         Ok(())
     }
@@ -258,7 +263,133 @@ impl RefreshTask {
         self.get_data_update(filters).await
     }
 
-    #[allow(clippy::too_many_lines)]
+    async fn write_change(&self, change_batch: ChangeBatch) -> super::Result<()> {
+        let dataset_name = self.dataset_name.clone();
+        let deletion_provider = get_deletion_provider(Arc::clone(&self.accelerator))
+            .context(super::AcceleratedTableDoesntSupportDeleteSnafu)?;
+
+        for row in 0..change_batch.record.num_rows() {
+            let op = change_batch.op(row);
+            match op {
+                "d" => {
+                    let inner_data: RecordBatch = change_batch.data(row);
+                    let primary_keys = change_batch.primary_keys(row);
+                    let delete_where_exprs =
+                        Self::get_delete_where_expr(&inner_data, primary_keys)?;
+
+                    tracing::info!(
+                        "Deleting data for {dataset_name} where {}",
+                        delete_where_exprs
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join(" AND ")
+                    );
+
+                    let ctx = SessionContext::new();
+                    let session_state = ctx.state();
+
+                    let delete_plan = deletion_provider
+                        .delete_from(&session_state, &delete_where_exprs)
+                        .await
+                        .context(super::FailedToWriteDataSnafu)?;
+
+                    collect(delete_plan, ctx.task_ctx())
+                        .await
+                        .context(super::FailedToWriteDataSnafu)?;
+                }
+                "c" | "u" | "r" => {
+                    let inner_data: RecordBatch = change_batch.data(row);
+                    let ctx = SessionContext::new();
+                    let session_state = ctx.state();
+
+                    tracing::info!("Inserting data row for {dataset_name}");
+
+                    let insert_plan = self
+                        .accelerator
+                        .insert_into(
+                            &session_state,
+                            Arc::new(DataUpdateExecutionPlan::new(DataUpdate {
+                                schema: inner_data.schema(),
+                                data: vec![inner_data],
+                                update_type: UpdateType::Append,
+                            })),
+                            false,
+                        )
+                        .await
+                        .context(super::FailedToWriteDataSnafu)?;
+
+                    collect(insert_plan, ctx.task_ctx())
+                        .await
+                        .context(super::FailedToWriteDataSnafu)?;
+                }
+                _ => {
+                    tracing::error!("Unknown operation {op} for {dataset_name}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_delete_where_expr(
+        data: &RecordBatch,
+        primary_keys: Vec<String>,
+    ) -> super::Result<Vec<Expr>> {
+        let mut delete_where_exprs: Vec<Expr> = vec![];
+        let data_schema = data.schema();
+        for primary_key in primary_keys {
+            let Some((primary_key_idx, field)) = data_schema.column_with_name(&primary_key) else {
+                return super::ExpectedSchemaToHaveFieldSnafu {
+                    field_name: primary_key.clone(),
+                    schema: Arc::clone(&data_schema),
+                }
+                .fail();
+            };
+            let key_col = data.column(primary_key_idx);
+            let delete_where_expr = match field.data_type() {
+                DataType::Int32 => {
+                    let key_col = key_col.as_any().downcast_ref::<Int32Array>().context(
+                        super::ArrayDataTypeMismatchSnafu {
+                            field_name: primary_key.clone(),
+                            expected_data_type: "Int32".to_string(),
+                            schema: Arc::clone(&data_schema),
+                        },
+                    )?;
+                    col(primary_key).eq(lit(key_col.value(0)))
+                }
+                DataType::Int64 => {
+                    let key_col = key_col.as_any().downcast_ref::<Int64Array>().context(
+                        super::ArrayDataTypeMismatchSnafu {
+                            field_name: primary_key.clone(),
+                            expected_data_type: "Int64".to_string(),
+                            schema: Arc::clone(&data_schema),
+                        },
+                    )?;
+                    col(primary_key).eq(lit(key_col.value(0)))
+                }
+                DataType::Utf8 => {
+                    let key_col = key_col.as_any().downcast_ref::<StringArray>().context(
+                        super::ArrayDataTypeMismatchSnafu {
+                            field_name: primary_key.clone(),
+                            expected_data_type: "String".to_string(),
+                            schema: Arc::clone(&data_schema),
+                        },
+                    )?;
+                    col(primary_key).eq(lit(key_col.value(0)))
+                }
+                _ => {
+                    return super::PrimaryKeyTypeNotYetSupportedSnafu {
+                        data_type: field.data_type().to_string(),
+                    }
+                    .fail()
+                }
+            };
+            delete_where_exprs.push(delete_where_expr);
+        }
+        Ok(delete_where_exprs)
+    }
+
     async fn write_data_update(
         &self,
         start_time: Option<SystemTime>,
@@ -283,134 +414,6 @@ impl RefreshTask {
         };
 
         let ctx = SessionContext::new();
-
-        if data_update.update_type == UpdateType::Changes {
-            let Some(deletion_provider) = get_deletion_provider(Arc::clone(&self.accelerator))
-            else {
-                panic!("Failed to get deletion provider");
-            };
-
-            for data_batch in &data_update.data {
-                let Some(op_col) = data_batch.column(0).as_any().downcast_ref::<StringArray>()
-                else {
-                    panic!("Failed to get op column");
-                };
-                let Some(primary_keys_col) =
-                    data_batch.column(1).as_any().downcast_ref::<ListArray>()
-                else {
-                    panic!("Failed to get primary keys column");
-                };
-                let Some(data_col) = data_batch.column(2).as_any().downcast_ref::<StructArray>()
-                else {
-                    panic!("Failed to get data column");
-                };
-                for row in 0..data_batch.num_rows() {
-                    let op = op_col.value(row);
-                    match op {
-                        "d" => {
-                            let inner_data: RecordBatch = data_col.slice(row, 1).into();
-                            let primary_keys_col_dyn_arr = primary_keys_col.value(row);
-                            let Some(primary_key) = primary_keys_col_dyn_arr
-                                .as_any()
-                                .downcast_ref::<StringArray>()
-                            else {
-                                panic!("Failed to get primary key column");
-                            };
-                            let primary_key = primary_key.value(0);
-                            let inner_data_schema = inner_data.schema();
-                            let Some((primary_key_idx, field)) =
-                                inner_data_schema.column_with_name(primary_key)
-                            else {
-                                panic!("Failed to get primary key column");
-                            };
-                            let key_col = inner_data.column(primary_key_idx);
-                            let delete_where_expr = match field.data_type() {
-                                DataType::Int32 => {
-                                    let Some(key_col) =
-                                        key_col.as_any().downcast_ref::<Int32Array>()
-                                    else {
-                                        panic!(
-                                            "Failed to get id column as Int32Array, {inner_data:?}"
-                                        );
-                                    };
-                                    col(primary_key).eq(lit(key_col.value(0)))
-                                }
-                                DataType::Int64 => {
-                                    let Some(key_col) =
-                                        key_col.as_any().downcast_ref::<Int64Array>()
-                                    else {
-                                        panic!(
-                                            "Failed to get id column as Int64Array, {inner_data:?}"
-                                        );
-                                    };
-                                    col(primary_key).eq(lit(key_col.value(0)))
-                                }
-                                DataType::Utf8 => {
-                                    let Some(key_col) =
-                                        key_col.as_any().downcast_ref::<StringArray>()
-                                    else {
-                                        panic!(
-                                            "Failed to get id column as Int64Array, {inner_data:?}"
-                                        );
-                                    };
-                                    col(primary_key).eq(lit(key_col.value(0)))
-                                }
-                                _ => panic!("Unsupported primary key type {}", field.data_type()),
-                            };
-                            tracing::info!(
-                                "Deleting data for {dataset_name} where {delete_where_expr}"
-                            );
-
-                            let ctx = SessionContext::new();
-                            let session_state = ctx.state();
-
-                            let Ok(delete_plan) = deletion_provider
-                                .delete_from(&session_state, &[delete_where_expr])
-                                .await
-                            else {
-                                panic!("Failed to create delete plan");
-                            };
-
-                            if let Err(e) = collect(delete_plan, ctx.task_ctx()).await {
-                                panic!("Failed to delete data: {e}");
-                            };
-                        }
-                        "c" | "u" | "r" => {
-                            let inner_data: RecordBatch = data_col.slice(row, 1).into();
-                            let ctx = SessionContext::new();
-                            let session_state = ctx.state();
-
-                            tracing::info!("Inserting data row for {dataset_name}");
-
-                            let Ok(insert_plan) = self
-                                .accelerator
-                                .insert_into(
-                                    &session_state,
-                                    Arc::new(DataUpdateExecutionPlan::new(DataUpdate {
-                                        schema: inner_data.schema(),
-                                        data: vec![inner_data],
-                                        update_type: UpdateType::Append,
-                                    })),
-                                    false,
-                                )
-                                .await
-                            else {
-                                panic!("Failed to create insert plan");
-                            };
-
-                            if let Err(e) = collect(insert_plan, ctx.task_ctx()).await {
-                                panic!("Failed to insert data: {e}");
-                            };
-                        }
-                        _ => {
-                            tracing::error!("Unknown operation {op} for {dataset_name}");
-                        }
-                    }
-                }
-            }
-
-            return Ok(());
-        }
 
         let overwrite = data_update.update_type == UpdateType::Overwrite;
         match self

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -32,6 +32,20 @@ use snafu::{OptionExt, ResultExt};
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
+/// Extracts the primary key value from the data, as a tuple of (String, Expr).
+///
+/// # Example
+///
+/// ```ignore
+/// let data: RecordBatch = get_record_batch();
+/// let key = "id";
+/// let key_col = data.column(0);
+/// let result = extract_primary_key!(key_col, key, data_schema, Int32Array, "Int32");
+/// if let Ok((str_value, expr_value)) = result {
+///    println!("Primary key value as String: {}", str_value);
+///    println!("Primary key value as DataFusion expression: {}", expr_value);
+/// }
+/// ```
 macro_rules! extract_primary_key {
     ($key_col:expr, $key:expr, $data_schema:expr, $array_type:ty, $data_type_str:expr) => {{
         let key_col = $key_col.as_any().downcast_ref::<$array_type>().context(

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -1,0 +1,247 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::RefreshTask;
+use crate::{
+    dataupdate::{DataUpdate, DataUpdateExecutionPlan, UpdateType},
+    status,
+};
+use arrow::array::{Int32Array, Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::DataType;
+use cache::QueryResultsCacheProvider;
+use data_components::cdc::{ChangeBatch, ChangesStream};
+use data_components::delete::get_deletion_provider;
+use datafusion::logical_expr::lit;
+use datafusion::logical_expr::{col, Expr};
+use datafusion::{execution::context::SessionContext, physical_plan::collect};
+use futures::StreamExt;
+use snafu::{OptionExt, ResultExt};
+use std::sync::Arc;
+use tokio::sync::oneshot;
+
+impl RefreshTask {
+    pub async fn start_changes_stream(
+        &self,
+        mut changes_stream: ChangesStream,
+        cache_provider: Option<Arc<QueryResultsCacheProvider>>,
+        ready_sender: Option<oneshot::Sender<()>>,
+    ) -> crate::accelerated_table::Result<()> {
+        self.mark_dataset_status(status::ComponentStatus::Refreshing)
+            .await;
+
+        let dataset_name = self.dataset_name.clone();
+
+        let mut ready_sender = ready_sender;
+
+        while let Some(update) = changes_stream.next().await {
+            match update {
+                Ok(change_envelope) => {
+                    match self
+                        .write_change(change_envelope.change_batch.clone())
+                        .await
+                    {
+                        Ok(()) => {
+                            if let Some(ready_sender) = ready_sender.take() {
+                                ready_sender.send(()).ok();
+                            }
+
+                            if let Err(e) = change_envelope.commit() {
+                                tracing::debug!("Failed to commit CDC change envelope: {e}");
+                            }
+
+                            if let Some(cache_provider) = &cache_provider {
+                                if let Err(e) = cache_provider
+                                    .invalidate_for_table(&dataset_name.to_string())
+                                    .await
+                                {
+                                    tracing::error!(
+                                        "Failed to invalidate cached results for dataset {}: {e}",
+                                        &dataset_name.to_string()
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            self.mark_dataset_status(status::ComponentStatus::Error)
+                                .await;
+                            tracing::error!("Error writing change for {dataset_name}: {e}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Changes stream error for {dataset_name}: {e}");
+                    self.mark_dataset_status(status::ComponentStatus::Error)
+                        .await;
+                }
+            }
+        }
+
+        tracing::warn!("Changes stream ended for dataset {dataset_name}");
+
+        Ok(())
+    }
+
+    async fn write_change(
+        &self,
+        change_batch: ChangeBatch,
+    ) -> crate::accelerated_table::Result<()> {
+        let dataset_name = self.dataset_name.clone();
+        let deletion_provider = get_deletion_provider(Arc::clone(&self.accelerator))
+            .context(crate::accelerated_table::AcceleratedTableDoesntSupportDeleteSnafu)?;
+
+        for row in 0..change_batch.record.num_rows() {
+            let op = change_batch.op(row);
+            match op {
+                "d" => {
+                    let inner_data: RecordBatch = change_batch.data(row);
+                    let primary_keys = change_batch.primary_keys(row);
+                    let primary_key_log_fmt =
+                        Self::get_primary_key_log_fmt(&inner_data, &primary_keys)?;
+                    let delete_where_exprs =
+                        Self::get_delete_where_expr(&inner_data, primary_keys)?;
+
+                    tracing::info!("Deleting data for {dataset_name} where {primary_key_log_fmt}");
+
+                    let ctx = SessionContext::new();
+                    let session_state = ctx.state();
+
+                    let delete_plan = deletion_provider
+                        .delete_from(&session_state, &delete_where_exprs)
+                        .await
+                        .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
+
+                    collect(delete_plan, ctx.task_ctx())
+                        .await
+                        .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
+                }
+                "c" | "u" | "r" => {
+                    let inner_data: RecordBatch = change_batch.data(row);
+                    let primary_keys = change_batch.primary_keys(row);
+                    let ctx = SessionContext::new();
+                    let session_state = ctx.state();
+
+                    tracing::info!(
+                        "Upserting data row for {dataset_name} with {}",
+                        Self::get_primary_key_log_fmt(&inner_data, &primary_keys)?
+                    );
+
+                    let insert_plan = self
+                        .accelerator
+                        .insert_into(
+                            &session_state,
+                            Arc::new(DataUpdateExecutionPlan::new(DataUpdate {
+                                schema: inner_data.schema(),
+                                data: vec![inner_data],
+                                update_type: UpdateType::Append,
+                            })),
+                            false,
+                        )
+                        .await
+                        .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
+
+                    collect(insert_plan, ctx.task_ctx())
+                        .await
+                        .context(crate::accelerated_table::FailedToWriteDataSnafu)?;
+                }
+                _ => {
+                    tracing::error!("Unknown operation {op} for {dataset_name}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_primary_key_log_fmt(
+        data: &RecordBatch,
+        primary_keys: &[String],
+    ) -> crate::accelerated_table::Result<String> {
+        primary_keys
+            .iter()
+            .map(|key| {
+                let (value, _) = Self::get_primary_key_value(data, key)?;
+                Ok(format!("{key}={value}"))
+            })
+            .collect::<crate::accelerated_table::Result<Vec<String>>>()
+            .map(|keys| keys.join(", "))
+    }
+
+    fn get_delete_where_expr(
+        data: &RecordBatch,
+        primary_keys: Vec<String>,
+    ) -> crate::accelerated_table::Result<Vec<Expr>> {
+        let mut delete_where_exprs: Vec<Expr> = vec![];
+
+        for primary_key in primary_keys {
+            let (_, expr_val) = Self::get_primary_key_value(data, &primary_key)?;
+            delete_where_exprs.push(col(primary_key).eq(expr_val));
+        }
+
+        Ok(delete_where_exprs)
+    }
+
+    fn get_primary_key_value(
+        data: &RecordBatch,
+        key: &str,
+    ) -> crate::accelerated_table::Result<(String, Expr)> {
+        let data_schema = data.schema();
+        let (primary_key_idx, field) = data_schema.column_with_name(key).ok_or_else(|| {
+            crate::accelerated_table::ExpectedSchemaToHaveFieldSnafu {
+                field_name: key.to_string(),
+                schema: Arc::clone(&data_schema),
+            }
+            .build()
+        })?;
+
+        let key_col = data.column(primary_key_idx);
+        match field.data_type() {
+            DataType::Int32 => {
+                let key_col = key_col.as_any().downcast_ref::<Int32Array>().context(
+                    crate::accelerated_table::ArrayDataTypeMismatchSnafu {
+                        field_name: key.to_string(),
+                        expected_data_type: "Int32".to_string(),
+                        schema: Arc::clone(&data_schema),
+                    },
+                )?;
+                Ok((key_col.value(0).to_string(), lit(key_col.value(0))))
+            }
+            DataType::Int64 => {
+                let key_col = key_col.as_any().downcast_ref::<Int64Array>().context(
+                    crate::accelerated_table::ArrayDataTypeMismatchSnafu {
+                        field_name: key.to_string(),
+                        expected_data_type: "Int64".to_string(),
+                        schema: Arc::clone(&data_schema),
+                    },
+                )?;
+                Ok((key_col.value(0).to_string(), lit(key_col.value(0))))
+            }
+            DataType::Utf8 => {
+                let key_col = key_col.as_any().downcast_ref::<StringArray>().context(
+                    crate::accelerated_table::ArrayDataTypeMismatchSnafu {
+                        field_name: key.to_string(),
+                        expected_data_type: "String".to_string(),
+                        schema: Arc::clone(&data_schema),
+                    },
+                )?;
+                Ok((key_col.value(0).to_string(), lit(key_col.value(0))))
+            }
+            _ => crate::accelerated_table::PrimaryKeyTypeNotYetSupportedSnafu {
+                data_type: field.data_type().to_string(),
+            }
+            .fail(),
+        }
+    }
+}

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -18,7 +18,7 @@ use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use data_components::cdc::{self, ChangeEnvelope};
+use data_components::cdc::ChangesStream;
 use data_components::object::metadata::ObjectStoreMetadataTable;
 use data_components::object::text::ObjectStoreTextTable;
 use datafusion::dataframe::DataFrame;
@@ -35,7 +35,6 @@ use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::TableReference;
-use futures::stream::BoxStream;
 use lazy_static::lazy_static;
 use object_store::ObjectStore;
 use snafu::prelude::*;
@@ -307,10 +306,7 @@ pub trait DataConnector: Send + Sync {
         None
     }
 
-    fn changes_stream(
-        &self,
-        _table_provider: Arc<dyn TableProvider>,
-    ) -> Option<BoxStream<'_, Result<ChangeEnvelope, cdc::StreamError>>> {
+    fn changes_stream(&self, _table_provider: Arc<dyn TableProvider>) -> Option<ChangesStream> {
         None
     }
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -18,6 +18,7 @@ use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
+use data_components::cdc::{self, ChangeEnvelope};
 use data_components::object::metadata::ObjectStoreMetadataTable;
 use data_components::object::text::ObjectStoreTextTable;
 use datafusion::dataframe::DataFrame;
@@ -34,6 +35,7 @@ use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::TableReference;
+use futures::stream::BoxStream;
 use lazy_static::lazy_static;
 use object_store::ObjectStore;
 use snafu::prelude::*;
@@ -305,10 +307,10 @@ pub trait DataConnector: Send + Sync {
         None
     }
 
-    async fn stream_provider(
+    fn changes_stream(
         &self,
-        _dataset: &Dataset,
-    ) -> Option<AnyErrorResult<Arc<dyn TableProvider>>> {
+        _table_provider: Arc<dyn TableProvider>,
+    ) -> Option<BoxStream<'_, Result<ChangeEnvelope, cdc::StreamError>>> {
         None
     }
 

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -163,11 +163,6 @@ impl DataConnector for Debezium {
         };
         drop(existing_group_id_map);
 
-        tracing::info!(
-            "Subscribing to topic: {topic} with group_id: {}",
-            consumer.group_id()
-        );
-
         consumer
             .subscribe(&topic)
             .boxed()

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -173,7 +173,7 @@ pub enum Error {
     #[snafu(display("Unable to get the lock of data writers"))]
     UnableToLockDataWriters {},
 
-    #[snafu(display("The schema returned by the data connector for refresh_mode: changes does not contain a data field"))]
+    #[snafu(display("The schema returned by the data connector for 'refresh_mode: changes' does not contain a data field"))]
     ChangeSchemaWithoutDataField { source: ArrowError },
 }
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -513,19 +513,7 @@ impl DataFusion {
                 .context(UnableToResolveTableProviderSnafu)?,
         };
 
-        let mut source_schema = source_table_provider.schema();
-
-        // TODO: Not sure about this.
-        if let Some(acceleration) = dataset.acceleration {
-            if source.resolve_refresh_mode(acceleration.refresh_mode) == RefreshMode::Changes {
-                let data = source_schema
-                    .field_with_name("data")
-                    .context(ChangeSchemaWithoutDataFieldSnafu)?;
-                if let DataType::Struct(data_fields) = data.data_type() {
-                    source_schema = Arc::new(Schema::new(data_fields.clone()));
-                }
-            }
-        }
+        let source_schema = source_table_provider.schema();
 
         let acceleration_settings =
             dataset

--- a/crates/runtime/src/dataupdate.rs
+++ b/crates/runtime/src/dataupdate.rs
@@ -31,7 +31,6 @@ use futures::stream;
 pub enum UpdateType {
     Append,
     Overwrite,
-    Changes,
 }
 
 #[derive(Debug, Clone)]
@@ -41,7 +40,6 @@ pub struct DataUpdate {
     /// The type of update to perform.
     /// If `UpdateType::Append`, the runtime will append the data to the existing dataset.
     /// If `UpdateType::Overwrite`, the runtime will overwrite the existing data with the new data.
-    /// If `UpdateType::Changes`, the runtime will apply the changes to the existing data.
     pub update_type: UpdateType,
 }
 

--- a/crates/runtime/src/dataupdate.rs
+++ b/crates/runtime/src/dataupdate.rs
@@ -31,6 +31,7 @@ use futures::stream;
 pub enum UpdateType {
     Append,
     Overwrite,
+    Changes,
 }
 
 #[derive(Debug, Clone)]
@@ -40,6 +41,7 @@ pub struct DataUpdate {
     /// The type of update to perform.
     /// If `UpdateType::Append`, the runtime will append the data to the existing dataset.
     /// If `UpdateType::Overwrite`, the runtime will overwrite the existing data with the new data.
+    /// If `UpdateType::Changes`, the runtime will apply the changes to the existing data.
     pub update_type: UpdateType,
 }
 

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use crate::component::dataset::Dataset;
-use crate::dataconnector::AnyErrorResult;
 use crate::EmbeddingModelStore;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
@@ -94,17 +93,6 @@ impl DataConnector for EmbeddingConnector {
         match self.inner_connector.read_write_provider(dataset).await {
             Some(Ok(inner)) => Some(self.wrap(inner, dataset).await),
             Some(Err(e)) => Some(Err(e)),
-            None => None,
-        }
-    }
-
-    async fn stream_provider(
-        &self,
-        dataset: &Dataset,
-    ) -> Option<AnyErrorResult<Arc<dyn TableProvider>>> {
-        match self.inner_connector.read_write_provider(dataset).await {
-            Some(Ok(inner)) => Some(self.wrap(inner, dataset).await.map_err(Into::into)),
-            Some(Err(e)) => Some(Err(e.into())),
             None => None,
         }
     }


### PR DESCRIPTION
## 🗣 Description

This wires up all of the pieces to have a fully working E2E experience of consuming changes and upserting them to the accelerated table.

This fully supports the `at-least-once` semantics we need to guarantee data consistency.

Other notable changes:
- Adds a `cdc` module which defines some generic traits and structs for working with change data that doesn't depend on Kafka or Debezium. This sets us up to be able to consume any changes that matches that format.
- Infers the primary keys from the Debezium Key message
- Adds a `ChangeBatch` struct that wraps a `RecordBatch` with schema validation and helper methods for extracting out the pieces needed to consume a change.
- Adds logic for turning a Debezium `ChangeEvent` message into a `RecordBatch` compatible with `ChangeBatch`
- Adds a method on the DataConnector to get a `ChangesStream` if the `refresh_mode` is `Changes`
- Logic for passing the `ChangesStream` to the `AcceleratedTable` and the logic for starting the stream and consuming the changes, and marking them as processed once we've validated no errors inserting to the table.
- Added logging when processing a change to show the primary key of the data, to make it easier to understand which change happened.

Some limitations that will be addressed in upcoming PRs:
- Right now, the spicepod needs to set the primary key and upsert `on_conflict` behavior to match what we receive from Debezium. We can auto-configure this to make it less error-prone.
- This will create an unused consumer group because the runtime calls `read_provider` twice, one to test the dataset connectivity and once to actually create the table.
- This still doesn't persist the consumer group id, so it will create a new one on startup, replaying all changes.

## 🔨 Related Issues

Part of #1785