### PR TITLE
feat: Add GraphQL unnesting

### DIFF
--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -258,7 +258,7 @@ fn unnest_json_object(unnest_parameters: &UnnestParameters, object: &Value) -> R
     } else {
         return Err(Error::InvalidObjectAccess {
             // unnesting any other type is invalid
-            message: format!("Unsupported unnest type: {object}").to_string(),
+            message: format!("Unsupported unnest type: {object}"),
         });
     }
 

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -576,11 +576,11 @@ impl GraphQL {
 
         client_builder = client_builder.default_headers(headers);
 
-        let unnest_depth = self
-            .params
-            .get("unnest_depth")
-            .unwrap_or(&"0".to_string())
-            .parse::<usize>();
+        let unnest_depth = if let Some(depth) = self.params.get("unnest_depth") {
+            depth.parse::<usize>()
+        } else {
+            Ok(0)
+        };
 
         let unnest_depth = match unnest_depth {
             Ok(depth) => Ok(depth),

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -879,12 +879,12 @@ mod tests {
     #[test]
     fn test_json_object_unnesting() {
         let unnest_parameters = super::UnnestParameters { depth: 100 };
-        let object = serde_json::from_str(r#"{"a": {"b": 1}}"#).expect("Invalid json");
-        let result = super::unnest_json_object(&unnest_parameters, &object)
-            .expect("Unnesting object failed");
+        let object = serde_json::from_str(r#"{"a": {"b": 1}}"#).expect("Valid json");
+        let result =
+            super::unnest_json_object(&unnest_parameters, &object).expect("To unnest JSON object");
         assert_eq!(result.len(), 1);
 
-        let obj = result.first().expect("Failed to get first unnested object");
+        let obj = result.first().expect("To get first unnested object");
         assert_eq!(
             obj,
             &Value::Object(serde_json::Map::from_iter(vec![(
@@ -895,12 +895,12 @@ mod tests {
 
         let unnest_parameters = super::UnnestParameters { depth: 100 };
         let object =
-            serde_json::from_str(r#"{"a": {"b": {"c": {"d": "1"}}}}"#).expect("Invalid json");
-        let result = super::unnest_json_object(&unnest_parameters, &object)
-            .expect("Unnesting object failed");
+            serde_json::from_str(r#"{"a": {"b": {"c": {"d": "1"}}}}"#).expect("Valid json");
+        let result =
+            super::unnest_json_object(&unnest_parameters, &object).expect("To unnest JSON object");
         assert_eq!(result.len(), 1);
 
-        let obj = result.first().expect("Failed to get first unnested object");
+        let obj = result.first().expect("To get first unnested object");
         assert_eq!(
             obj,
             &Value::Object(serde_json::Map::from_iter(vec![(
@@ -913,12 +913,12 @@ mod tests {
     #[test]
     fn test_json_object_unnesting_respects_unnest_depth() {
         let unnest_parameters = super::UnnestParameters { depth: 0 };
-        let object = serde_json::from_str(r#"{"a": {"b": 1}}"#).expect("Invalid json");
-        let result = super::unnest_json_object(&unnest_parameters, &object)
-            .expect("Unnesting object failed");
+        let object = serde_json::from_str(r#"{"a": {"b": 1}}"#).expect("Valid json");
+        let result =
+            super::unnest_json_object(&unnest_parameters, &object).expect("To unnest JSON object");
         assert_eq!(result.len(), 1);
 
-        let obj = result.first().expect("Failed to get first unnested object");
+        let obj = result.first().expect("To get first unnested object");
         assert_eq!(
             obj,
             &Value::Object(serde_json::Map::from_iter(vec![(
@@ -932,12 +932,12 @@ mod tests {
 
         let unnest_parameters = super::UnnestParameters { depth: 1 };
         let object =
-            serde_json::from_str(r#"{"a": {"b": {"c": {"d": "1"}}}}"#).expect("Invalid json");
-        let result = super::unnest_json_object(&unnest_parameters, &object)
-            .expect("Unnesting object failed");
+            serde_json::from_str(r#"{"a": {"b": {"c": {"d": "1"}}}}"#).expect("Valid json");
+        let result =
+            super::unnest_json_object(&unnest_parameters, &object).expect("To unnest JSON object");
         assert_eq!(result.len(), 1);
 
-        let obj = result.first().expect("Failed to get first unnested object");
+        let obj = result.first().expect("To get first unnested object");
         assert_eq!(
             obj,
             &Value::Object(serde_json::Map::from_iter(vec![(
@@ -956,18 +956,18 @@ mod tests {
     #[test]
     fn test_json_array_unnesting() {
         let unnest_parameters = super::UnnestParameters { depth: 100 };
-        let object = serde_json::from_str("[1, 2, 3]").expect("Invalid json");
-        let result = super::unnest_json_object(&unnest_parameters, &object)
-            .expect("Unnesting object failed");
+        let object = serde_json::from_str("[1, 2, 3]").expect("Valid json");
+        let result =
+            super::unnest_json_object(&unnest_parameters, &object).expect("To unnest json array");
         assert_eq!(result.len(), 3);
 
-        let obj = result.first().expect("Failed to get first unnested object");
+        let obj = result.first().expect("To get first unnested object");
         assert_eq!(obj, &Value::Number(1.into()));
 
-        let obj = result.get(1).expect("Failed to get second unnested object");
+        let obj = result.get(1).expect("To get second unnested object");
         assert_eq!(obj, &Value::Number(2.into()));
 
-        let obj = result.get(2).expect("Failed to get third unnested object");
+        let obj = result.get(2).expect("To get third unnested object");
         assert_eq!(obj, &Value::Number(3.into()));
     }
 }


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

Adds support for unnesting GraphQL response objects.

Take for example, this GraphQL dataset that reads Stargazers from the `spiceai/spiceai` repo:

```
from: graphql:https://api.github.com/graphql
    name: stargazers
    params:
        auth_token: < .. token .. >
        json_path: data.repository.stargazers.edges
        query: |
            {
                repository(name: "spiceai", owner: "spiceai") {
                    id
                    name
                    stargazers(first: 100) {
                        edges {
                            node {
                            id
                            name
                            login
                            }
                        }
                        pageInfo {
                            hasNextPage
                            endCursor
                        }
                    }
                }
            }
```

Usually, this would return rows with a single column that contains the JSON blob: `{"id": ..., "name": ..., "login": ...}`

With unnesting, it returns a row with columns for each property in the object like `id | name | login`.

By default, if no unnesting depth is specified unnesting is disabled. You can enable unnesting by adding a parameter:

```
params:
    ....
    unnest_depth: 1
```

Unnesting allows you to query columns from JSON blobs directly in your SQL:

![unnest](https://github.com/spiceai/spiceai/assets/98815791/8b4f1d15-4c03-4d7f-80da-8bdcb682606f)

Related reading: [Unnesting - DuckDB](https://duckdb.org/docs/sql/query_syntax/unnest.html)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #1802