### PR TITLE
Fix issue with querying accelerated tables where the dataset name has a schema

### DIFF
--- a/crates/sql_provider_datafusion/src/lib.rs
+++ b/crates/sql_provider_datafusion/src/lib.rs
@@ -293,7 +293,7 @@ impl<T, P> SqlExec<T, P> {
 
         Ok(format!(
             "SELECT {columns} FROM {table_reference} {where_expr} {limit_expr}",
-            table_reference = self.table_reference
+            table_reference = self.table_reference.to_quoted_string()
         ))
     }
 }


### PR DESCRIPTION
## 🗣 Description

Fixes a bug with querying accelerated tables where the dataset name has a schema part.

i.e.

```yaml
from: eth.recent_blocks
name: eth.recent_blocks
acceleration:
  enabled: true
  engine: duckdb
```
