### PR TITLE
Automatically apply constraints to accelerated table if federated table defines them.

### DIFF
--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -20,6 +20,7 @@ use crate::secrets::Secret;
 use ::arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use data_components::util::{column_reference::ColumnReference, on_conflict::OnConflict};
+use datafusion::common::Constraint;
 use datafusion::{
     common::{Constraints, TableReference, ToDFSchema},
     datasource::TableProvider,
@@ -250,6 +251,7 @@ impl AcceleratorExternalTableBuilder {
 pub async fn create_accelerator_table(
     table_name: TableReference,
     schema: SchemaRef,
+    constraints: Option<&Constraints>,
     acceleration_settings: &acceleration::Acceleration,
     acceleration_secret: Option<Secret>,
 ) -> Result<Arc<dyn TableProvider>> {
@@ -276,6 +278,15 @@ pub async fn create_accelerator_table(
             .options(acceleration_settings.params.clone())
             .indexes(acceleration_settings.indexes.clone())
             .secret(acceleration_secret);
+
+    // If there are constraints from the federated table, then add them to the accelerated table
+    // and automatically configure upsert behavior for them. This can be overridden by the user.
+    if let Some(constraints) = constraints {
+        external_table_builder = external_table_builder.constraints(constraints.clone());
+        let primary_keys: Vec<String> = get_primary_keys_from_constraints(constraints, &schema);
+        external_table_builder = external_table_builder
+            .on_conflict(OnConflict::Upsert(ColumnReference::new(primary_keys)));
+    }
 
     if let Some(on_conflict) =
         acceleration_settings
@@ -308,4 +319,22 @@ pub async fn create_accelerator_table(
         .context(AccelerationCreationFailedSnafu)?;
 
     Ok(table_provider)
+}
+
+fn get_primary_keys_from_constraints(constraints: &Constraints, schema: &SchemaRef) -> Vec<String> {
+    constraints
+        .iter()
+        .filter_map(|constraint| {
+            if let Constraint::PrimaryKey(col_indexes) = constraint {
+                Some(
+                    col_indexes
+                        .iter()
+                        .map(|&col_index| schema.field(col_index).name().to_string()),
+                )
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .collect()
 }

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -541,6 +541,7 @@ impl DataFusion {
         let accelerated_table_provider = create_accelerator_table(
             dataset.name.clone(),
             source_schema,
+            source_table_provider.constraints(),
             &acceleration_settings,
             acceleration_secret,
         )

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -89,7 +89,7 @@ pub async fn create_internal_accelerated_table(
     let source_table_provider = get_local_table_provider(name.clone(), &schema).await?;
 
     let accelerated_table_provider =
-        create_accelerator_table(name.clone(), Arc::clone(&schema), &acceleration, None)
+        create_accelerator_table(name.clone(), Arc::clone(&schema), None, &acceleration, None)
             .await
             .context(UnableToCreateAcceleratedTableProviderSnafu)?;
 

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -270,6 +270,7 @@ pub async fn create_synced_internal_accelerated_table(
     let accelerated_table_provider = create_accelerator_table(
         table_reference.clone(),
         source_table_provider.schema(),
+        None,
         &acceleration,
         None,
     )


### PR DESCRIPTION
## 🗣 Description

Fixes another issue raised in #1819 around automatically applying the primary key and upsert behavior for accelerated tables if the federated table defines those constraints. In a previous PR I changed the DebeziumKafka table to define constraints for the primary keys it was able to infer from the Kafka stream.

## 🔨 Related Issues

Part of #1785