### PR TITLE
Persist metadata for Debezium connector to gracefully survive restarts (DuckDB/Sqlite)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7990,7 +7990,6 @@ dependencies = [
  "rand",
  "regex",
  "reqwest 0.11.27",
- "rusqlite",
  "secrecy",
  "serde",
  "serde_json",

--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -159,7 +159,7 @@ pub struct Schema {
     pub name: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Field {
     #[serde(rename = "type")]
     pub field_type: String,

--- a/crates/data_components/src/sqlite.rs
+++ b/crates/data_components/src/sqlite.rs
@@ -107,6 +107,14 @@ impl SqliteTableFactory {
             db_path_param: "sqlite_file".to_string(),
         }
     }
+
+    #[must_use]
+    pub fn sqlite_file_path(&self, name: &str, options: &HashMap<String, String>) -> String {
+        options
+            .get(&self.db_path_param)
+            .cloned()
+            .unwrap_or_else(|| format!("{name}_sqlite.db"))
+    }
 }
 
 impl Default for SqliteTableFactory {
@@ -161,11 +169,7 @@ impl TableProviderFactory for SqliteTableFactory {
             );
         }
 
-        let db_path = cmd
-            .options
-            .get(self.db_path_param.as_str())
-            .cloned()
-            .unwrap_or(format!("{name}_sqlite.db"));
+        let db_path = self.sqlite_file_path(&name, &cmd.options);
 
         let pool: Arc<SqliteConnectionPool> = Arc::new(
             SqliteConnectionPool::new(&db_path, mode)

--- a/crates/db_connection_pool/src/sqlitepool.rs
+++ b/crates/db_connection_pool/src/sqlitepool.rs
@@ -68,6 +68,11 @@ impl SqliteConnectionPool {
             join_push_down,
         })
     }
+
+    #[must_use]
+    pub fn connect_sync(&self) -> Box<dyn DbConnection<Connection, &'static (dyn ToSql + Sync)>> {
+        Box::new(SqliteConnection::new(self.conn.clone()))
+    }
 }
 
 #[async_trait]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -77,7 +77,6 @@ prost = { version = "0.12.1", default-features = false, features = [
 r2d2 = { workspace = true, optional = true }
 regex = "1.10.3"
 reqwest = { version = "0.11.24", features = ["json"] }
-rusqlite = { workspace = true, optional = true }
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -161,7 +160,6 @@ snowflake = [
 spark = ["data_components/spark_connect"]
 spiceai-dataset-test = []
 sqlite = [
-  "dep:rusqlite",
   "dep:tokio-rusqlite",
   "db_connection_pool/sqlite",
   "sql_provider_datafusion/sqlite",

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use acceleration::Engine;
 use data_components::util::column_reference;
 use datafusion::sql::TableReference;
 use snafu::prelude::*;
@@ -363,6 +364,10 @@ impl Dataset {
     #[must_use]
     pub fn is_file_accelerated(&self) -> bool {
         if let Some(acceleration) = &self.acceleration {
+            if acceleration.engine == Engine::PostgreSQL {
+                return true;
+            }
+
             return acceleration.enabled && acceleration.mode == acceleration::Mode::File;
         }
 

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -43,12 +43,12 @@ use self::sqlite::SqliteAccelerator;
 pub mod arrow;
 #[cfg(feature = "duckdb")]
 pub mod duckdb;
-// #[cfg(feature = "mysql")]
-// pub mod mysql;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
+
+pub mod metadata;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -257,10 +257,9 @@ pub async fn create_accelerator_table(
 ) -> Result<Arc<dyn TableProvider>> {
     let engine = acceleration_settings.engine;
 
-    let accelerator_guard = DATA_ACCELERATOR_ENGINES.lock().await;
     let accelerator =
-        accelerator_guard
-            .get(&engine)
+        get_accelerator_engine(engine)
+            .await
             .ok_or_else(|| Error::InvalidConfiguration {
                 msg: format!("Unknown engine: {engine}"),
             })?;

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -25,6 +25,8 @@ use duckdb::AccessMode;
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
+use crate::component::dataset::Dataset;
+
 use super::DataAccelerator;
 
 #[derive(Debug, Snafu)]
@@ -50,6 +52,20 @@ impl DuckDBAccelerator {
                 .db_path_param("duckdb_file")
                 .access_mode(AccessMode::ReadWrite),
         }
+    }
+
+    /// Returns the `DuckDB` file path that would be used for a file-based `DuckDB` accelerator from this dataset
+    #[must_use]
+    pub fn duckdb_file_path(&self, dataset: &Dataset) -> Option<String> {
+        if !dataset.is_file_accelerated() {
+            return None;
+        }
+        let acceleration = dataset.acceleration.as_ref()?;
+
+        Some(
+            self.duckdb_factory
+                .duckdb_file_path(&dataset.name.to_string(), &acceleration.params),
+        )
     }
 }
 

--- a/crates/runtime/src/dataaccelerator/metadata.rs
+++ b/crates/runtime/src/dataaccelerator/metadata.rs
@@ -120,7 +120,7 @@ async fn get_metadata_provider(
             .await?,
         )),
         #[cfg(not(feature = "sqlite"))]
-        Engine::DuckDB => Err("Spice wasn't build with Sqlite support enabled".into()),
+        Engine::Sqlite => Err("Spice wasn't build with Sqlite support enabled".into()),
         Engine::PostgreSQL => todo!(),
         Engine::Arrow => Err("Arrow acceleration not supported for metadata".into()),
     }

--- a/crates/runtime/src/dataaccelerator/metadata.rs
+++ b/crates/runtime/src/dataaccelerator/metadata.rs
@@ -89,7 +89,6 @@ pub trait AcceleratedMetadataProvider {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }
 
-#[allow(unreachable_patterns)]
 async fn get_metadata_provider(
     dataset: &Dataset,
     create_if_file_not_exists: bool,
@@ -110,6 +109,8 @@ async fn get_metadata_provider(
             )
             .await?,
         )),
+        #[cfg(not(feature = "duckdb"))]
+        Engine::DuckDB => Err("Spice wasn't build with DuckDB support enabled".into()),
         #[cfg(feature = "sqlite")]
         Engine::Sqlite => Ok(Box::new(
             crate::dataaccelerator::metadata::sqlite::AcceleratedMetadataSqlite::try_new(
@@ -118,8 +119,9 @@ async fn get_metadata_provider(
             )
             .await?,
         )),
+        #[cfg(not(feature = "sqlite"))]
+        Engine::DuckDB => Err("Spice wasn't build with Sqlite support enabled".into()),
         Engine::PostgreSQL => todo!(),
         Engine::Arrow => Err("Arrow acceleration not supported for metadata".into()),
-        _ => Err("Unsupported acceleration engine for metadata".into()),
     }
 }

--- a/crates/runtime/src/dataaccelerator/metadata.rs
+++ b/crates/runtime/src/dataaccelerator/metadata.rs
@@ -1,0 +1,228 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Store and retrieve Spice metadata in durable accelerator tables
+//!
+//! The metadata table will be a new table `__spice_metadata` with two columns:
+//! - `dataset` (PRIMARY KEY, TEXT): The dataset the metadata entry corresponds to
+//! - `metadata` (TEXT): The metadata entry in JSON format
+
+use std::{path::Path, sync::Arc};
+
+use arrow::datatypes::SchemaRef;
+use data_components::duckdb::DuckDB;
+use duckdb::AccessMode;
+use serde::de::DeserializeOwned;
+
+use crate::component::dataset::{acceleration::Engine, Dataset};
+use crate::dataaccelerator::DuckDBAccelerator;
+use db_connection_pool::{dbconnection::SyncDbConnection, duckdbpool::DuckDbConnectionPool};
+
+use super::get_accelerator_engine;
+
+const METADATA_TABLE_NAME: &str = "spice_sys_metadata";
+const METADATA_DATASET_COLUMN: &str = "dataset";
+const METADATA_METADATA_COLUMN: &str = "metadata";
+
+pub struct AcceleratedMetadata {
+    metadata_provider: Box<dyn AcceleratedMetadataProvider>,
+    dataset_name: String,
+}
+
+impl AcceleratedMetadata {
+    pub async fn new(dataset: &Dataset) -> Option<Self> {
+        let metadata_provider = get_metadata_provider(dataset, false).await.ok()?;
+
+        Some(Self {
+            metadata_provider,
+            dataset_name: dataset.name.to_string(),
+        })
+    }
+
+    pub async fn new_create_if_not_exists(
+        dataset: &Dataset,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let metadata_provider = get_metadata_provider(dataset, true).await?;
+
+        Ok(Self {
+            metadata_provider,
+            dataset_name: dataset.name.to_string(),
+        })
+    }
+
+    #[must_use]
+    pub fn get_metadata<T: DeserializeOwned>(&self) -> Option<T> {
+        self.metadata_provider
+            .get_metadata(&self.dataset_name)
+            .map(|metadata| serde_json::from_str(&metadata))?
+            .ok()
+    }
+
+    pub fn set_metadata<T: serde::Serialize>(
+        &self,
+        metadata: &T,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let metadata = serde_json::to_string(metadata).map_err(|e| e.to_string())?;
+        self.metadata_provider
+            .set_metadata(&self.dataset_name, &metadata)
+    }
+
+    pub fn get_schema(&self) -> Result<SchemaRef, Box<dyn std::error::Error + Send + Sync>> {
+        self.metadata_provider.get_schema(&self.dataset_name)
+    }
+}
+
+pub trait AcceleratedMetadataProvider {
+    fn get_metadata(&self, dataset: &str) -> Option<String>;
+    fn set_metadata(
+        &self,
+        dataset: &str,
+        metadata: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+    fn get_schema(
+        &self,
+        dataset: &str,
+    ) -> Result<SchemaRef, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+async fn get_metadata_provider(
+    dataset: &Dataset,
+    create_if_file_not_exists: bool,
+) -> Result<Box<dyn AcceleratedMetadataProvider>, Box<dyn std::error::Error + Send + Sync>> {
+    let acceleration = dataset
+        .acceleration
+        .as_ref()
+        .ok_or("Dataset acceleration not enabled")?;
+    match acceleration.engine {
+        Engine::DuckDB => Ok(Box::new(
+            AcceleratedMetadataDuckDB::try_new(dataset, create_if_file_not_exists).await?,
+        )),
+        Engine::Sqlite => todo!(),
+        Engine::PostgreSQL => todo!(),
+        Engine::Arrow => Err("Arrow acceleration not supported for metadata".into()),
+    }
+}
+
+pub struct AcceleratedMetadataDuckDB {
+    pool: Arc<DuckDbConnectionPool>,
+}
+
+impl AcceleratedMetadataDuckDB {
+    async fn try_new(
+        dataset: &Dataset,
+        create_if_file_not_exists: bool,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let accelerator = get_accelerator_engine(Engine::DuckDB)
+            .await
+            .ok_or("DuckDB accelerator engine not available")?;
+        let duckdb_accelerator = accelerator
+            .as_any()
+            .downcast_ref::<DuckDBAccelerator>()
+            .ok_or("Accelerator is not a DuckDBAccelerator")?;
+
+        let duckdb_file = duckdb_accelerator
+            .duckdb_file_path(dataset)
+            .ok_or("Acceleration mode is not file-based.")?;
+        if !create_if_file_not_exists && !Path::new(&duckdb_file).exists() {
+            return Err("DuckDB file does not exist.".into());
+        }
+
+        let pool = DuckDbConnectionPool::new_file(&duckdb_file, &AccessMode::ReadWrite)
+            .map_err(|e| e.to_string())?;
+
+        Ok(Self {
+            pool: Arc::new(pool),
+        })
+    }
+}
+
+impl AcceleratedMetadataProvider for AcceleratedMetadataDuckDB {
+    fn get_metadata(&self, dataset: &str) -> Option<String> {
+        let mut db_conn = Arc::clone(&self.pool).connect_sync().ok()?;
+        let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn)
+            .ok()?
+            .get_underlying_conn_mut();
+        let query = format!(
+            "SELECT {METADATA_METADATA_COLUMN} FROM {METADATA_TABLE_NAME} WHERE {METADATA_DATASET_COLUMN} = ?",
+        );
+        let mut stmt = duckdb_conn.prepare(&query).ok()?;
+        let mut rows = stmt.query([dataset]).ok()?;
+
+        let metadata: Option<String> = if let Some(row) = rows.next().ok()? {
+            Some(row.get(0).ok()?)
+        } else {
+            None
+        };
+
+        metadata
+    }
+
+    fn set_metadata(
+        &self,
+        dataset: &str,
+        metadata: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let mut db_conn = Arc::clone(&self.pool)
+            .connect_sync()
+            .map_err(|e| e.to_string())?;
+        let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn)
+            .map_err(|e| e.to_string())?
+            .get_underlying_conn_mut();
+
+        let create_if_not_exists = format!(
+            "CREATE TABLE IF NOT EXISTS {METADATA_TABLE_NAME} (
+                {METADATA_DATASET_COLUMN} TEXT PRIMARY KEY,
+                {METADATA_METADATA_COLUMN} TEXT
+            );",
+        );
+
+        duckdb_conn
+            .execute(&create_if_not_exists, [])
+            .map_err(|e| e.to_string())?;
+
+        let query = format!(
+            "INSERT INTO {METADATA_TABLE_NAME} ({METADATA_DATASET_COLUMN}, {METADATA_METADATA_COLUMN}) VALUES (?, ?) ON CONFLICT ({METADATA_DATASET_COLUMN}) DO UPDATE SET {METADATA_METADATA_COLUMN} = ?",
+        );
+
+        duckdb_conn
+            .execute(&query, [dataset, metadata, metadata])
+            .map_err(|e| e.to_string())?;
+
+        Ok(())
+    }
+
+    fn get_schema(
+        &self,
+        dataset: &str,
+    ) -> Result<SchemaRef, Box<dyn std::error::Error + Send + Sync>> {
+        let mut db_conn = Arc::clone(&self.pool)
+            .connect_sync()
+            .map_err(|e| e.to_string())?;
+        let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn).map_err(|e| e.to_string())?;
+
+        let query = format!(r#"SELECT * FROM "{dataset}" LIMIT 0"#);
+
+        let stream = duckdb_conn
+            .query_arrow(&query, &[])
+            .map_err(|e| e.to_string())?;
+
+        Ok(stream.schema())
+    }
+}
+
+pub struct AcceleratedMetadataSqlite {}
+
+pub struct AcceleratedMetadataPostgres {}

--- a/crates/runtime/src/dataaccelerator/metadata.rs
+++ b/crates/runtime/src/dataaccelerator/metadata.rs
@@ -89,6 +89,7 @@ pub trait AcceleratedMetadataProvider {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }
 
+#[allow(unreachable_patterns)]
 async fn get_metadata_provider(
     dataset: &Dataset,
     create_if_file_not_exists: bool,
@@ -119,5 +120,6 @@ async fn get_metadata_provider(
         )),
         Engine::PostgreSQL => todo!(),
         Engine::Arrow => Err("Arrow acceleration not supported for metadata".into()),
+        _ => Err("Unsupported acceleration engine for metadata".into()),
     }
 }

--- a/crates/runtime/src/dataaccelerator/metadata/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/metadata/duckdb.rs
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{path::Path, sync::Arc};
+
+use data_components::duckdb::DuckDB;
+use duckdb::AccessMode;
+
+use super::AcceleratedMetadataProvider;
+use super::{METADATA_DATASET_COLUMN, METADATA_METADATA_COLUMN, METADATA_TABLE_NAME};
+use crate::component::dataset::{acceleration::Engine, Dataset};
+use crate::dataaccelerator::{get_accelerator_engine, DuckDBAccelerator};
+use db_connection_pool::duckdbpool::DuckDbConnectionPool;
+
+pub struct AcceleratedMetadataDuckDB {
+    pool: Arc<DuckDbConnectionPool>,
+}
+
+impl AcceleratedMetadataDuckDB {
+    pub async fn try_new(
+        dataset: &Dataset,
+        create_if_file_not_exists: bool,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let accelerator = get_accelerator_engine(Engine::DuckDB)
+            .await
+            .ok_or("DuckDB accelerator engine not available")?;
+        let duckdb_accelerator = accelerator
+            .as_any()
+            .downcast_ref::<DuckDBAccelerator>()
+            .ok_or("Accelerator is not a DuckDBAccelerator")?;
+
+        let duckdb_file = duckdb_accelerator
+            .duckdb_file_path(dataset)
+            .ok_or("Acceleration mode is not file-based.")?;
+        if !create_if_file_not_exists && !Path::new(&duckdb_file).exists() {
+            return Err("DuckDB file does not exist.".into());
+        }
+
+        let pool = DuckDbConnectionPool::new_file(&duckdb_file, &AccessMode::ReadWrite)
+            .map_err(|e| e.to_string())?;
+
+        Ok(Self {
+            pool: Arc::new(pool),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl AcceleratedMetadataProvider for AcceleratedMetadataDuckDB {
+    async fn get_metadata(&self, dataset: &str) -> Option<String> {
+        let mut db_conn = Arc::clone(&self.pool).connect_sync().ok()?;
+        let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn)
+            .ok()?
+            .get_underlying_conn_mut();
+        let query = format!(
+            "SELECT {METADATA_METADATA_COLUMN} FROM {METADATA_TABLE_NAME} WHERE {METADATA_DATASET_COLUMN} = ?",
+        );
+        let mut stmt = duckdb_conn.prepare(&query).ok()?;
+        let mut rows = stmt.query([dataset]).ok()?;
+
+        let metadata: Option<String> = if let Some(row) = rows.next().ok()? {
+            Some(row.get(0).ok()?)
+        } else {
+            None
+        };
+
+        metadata
+    }
+
+    async fn set_metadata(
+        &self,
+        dataset: &str,
+        metadata: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let mut db_conn = Arc::clone(&self.pool)
+            .connect_sync()
+            .map_err(|e| e.to_string())?;
+        let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn)
+            .map_err(|e| e.to_string())?
+            .get_underlying_conn_mut();
+
+        let create_if_not_exists = format!(
+            "CREATE TABLE IF NOT EXISTS {METADATA_TABLE_NAME} (
+                {METADATA_DATASET_COLUMN} TEXT PRIMARY KEY,
+                {METADATA_METADATA_COLUMN} TEXT
+            );",
+        );
+
+        duckdb_conn
+            .execute(&create_if_not_exists, [])
+            .map_err(|e| e.to_string())?;
+
+        let query = format!(
+            "INSERT INTO {METADATA_TABLE_NAME} ({METADATA_DATASET_COLUMN}, {METADATA_METADATA_COLUMN}) VALUES (?, ?) ON CONFLICT ({METADATA_DATASET_COLUMN}) DO UPDATE SET {METADATA_METADATA_COLUMN} = ?",
+        );
+
+        duckdb_conn
+            .execute(&query, [dataset, metadata, metadata])
+            .map_err(|e| e.to_string())?;
+
+        Ok(())
+    }
+}

--- a/crates/runtime/src/dataaccelerator/metadata/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/metadata/sqlite.rs
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::{METADATA_DATASET_COLUMN, METADATA_METADATA_COLUMN, METADATA_TABLE_NAME};
+use crate::{
+    component::dataset::{acceleration::Engine, Dataset},
+    dataaccelerator::{get_accelerator_engine, sqlite::SqliteAccelerator},
+};
+use std::path::Path;
+use tokio_rusqlite::Connection;
+
+use super::AcceleratedMetadataProvider;
+
+pub struct AcceleratedMetadataSqlite {
+    conn: Connection,
+}
+
+impl AcceleratedMetadataSqlite {
+    pub async fn try_new(
+        dataset: &Dataset,
+        create_if_file_not_exists: bool,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let accelerator = get_accelerator_engine(Engine::Sqlite)
+            .await
+            .ok_or("Sqlite accelerator engine not available")?;
+        let sqlite_accelerator = accelerator
+            .as_any()
+            .downcast_ref::<SqliteAccelerator>()
+            .ok_or("Accelerator is not a SqliteAccelerator")?;
+
+        let sqlite_file = sqlite_accelerator
+            .sqlite_file_path(dataset)
+            .ok_or("Acceleration mode is not file-based.")?;
+        if !create_if_file_not_exists && !Path::new(&sqlite_file).exists() {
+            return Err("Sqlite file does not exist.".into());
+        }
+
+        let conn = Connection::open(sqlite_file).await.map_err(Box::new)?;
+
+        Ok(Self { conn })
+    }
+}
+
+#[async_trait::async_trait]
+impl AcceleratedMetadataProvider for AcceleratedMetadataSqlite {
+    async fn get_metadata(&self, dataset: &str) -> Option<String> {
+        let dataset = dataset.to_string();
+        self.conn.call(move |conn| {
+            let query = format!(
+                "SELECT {METADATA_METADATA_COLUMN} FROM {METADATA_TABLE_NAME} WHERE {METADATA_DATASET_COLUMN} = ?",
+            );
+            let mut stmt = conn.prepare(&query)?;
+
+            let mut rows = stmt.query([dataset])?;
+
+            let metadata: Option<String> = if let Some(row) = rows.next()? {
+                Some(row.get(0)?)
+            } else {
+                None
+            };
+
+            Ok(metadata)
+        }).await.ok().flatten()
+    }
+
+    async fn set_metadata(
+        &self,
+        dataset: &str,
+        metadata: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let dataset = dataset.to_string();
+        let metadata = metadata.to_string();
+
+        self.conn.call(move |conn| {
+            let create_if_not_exists = format!(
+                "CREATE TABLE IF NOT EXISTS {METADATA_TABLE_NAME} (
+                    {METADATA_DATASET_COLUMN} TEXT PRIMARY KEY,
+                    {METADATA_METADATA_COLUMN} TEXT
+                );",
+            );
+
+            conn.execute(&create_if_not_exists, [])?;
+
+            let query = format!(
+                "INSERT INTO {METADATA_TABLE_NAME} ({METADATA_DATASET_COLUMN}, {METADATA_METADATA_COLUMN}) VALUES (?1, ?2) ON CONFLICT ({METADATA_DATASET_COLUMN}) DO UPDATE SET {METADATA_METADATA_COLUMN} = ?2",
+            );
+
+            conn.execute(&query, [dataset, metadata])?;
+
+            Ok(())
+        }).await.map_err(Into::into)
+    }
+}

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -24,6 +24,8 @@ use datafusion::{
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
+use crate::component::dataset::Dataset;
+
 use super::DataAccelerator;
 
 #[derive(Debug, Snafu)]
@@ -46,6 +48,20 @@ impl SqliteAccelerator {
         Self {
             sqlite_factory: SqliteTableFactory::new(),
         }
+    }
+
+    /// Returns the `Sqlite` file path that would be used for a file-based `Sqlite` accelerator from this dataset
+    #[must_use]
+    pub fn sqlite_file_path(&self, dataset: &Dataset) -> Option<String> {
+        if !dataset.is_file_accelerated() {
+            return None;
+        }
+        let acceleration = dataset.acceleration.as_ref()?;
+
+        Some(
+            self.sqlite_factory
+                .sqlite_file_path(&dataset.name.to_string(), &acceleration.params),
+        )
     }
 }
 

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -16,7 +16,9 @@ limitations under the License.
 
 use crate::component::dataset::acceleration::{Engine, RefreshMode};
 use crate::component::dataset::Dataset;
+use crate::dataaccelerator::metadata::AcceleratedMetadata;
 use crate::secrets::Secret;
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use data_components::debezium;
@@ -24,6 +26,7 @@ use data_components::debezium::change_event::{ChangeEvent, ChangeEventKey};
 use data_components::debezium_kafka::DebeziumKafka;
 use data_components::kafka::KafkaConsumer;
 use datafusion::datasource::TableProvider;
+use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use std::any::Any;
 use std::pin::Pin;
@@ -129,62 +132,50 @@ impl DataConnector for Debezium {
             }
         );
 
-        let topic = dataset.path();
-
         let dataset_name = dataset.name.to_string();
 
-        let kafka_consumer = KafkaConsumer::create_with_generated_group_id(
-            &dataset_name,
-            self.kafka_brokers.clone(),
-        )
-        .boxed()
-        .context(super::UnableToGetReadProviderSnafu {
-            dataconnector: "debezium",
-        })?;
+        if !dataset.is_file_accelerated() {
+            tracing::warn!(
+                "Dataset {dataset_name} is not file accelerated. This is not recommended as it requires replaying all changes from the beginning on restarts.",
+            );
+        }
 
-        kafka_consumer
-            .subscribe(&topic)
-            .boxed()
-            .context(super::UnableToGetReadProviderSnafu {
-                dataconnector: "debezium",
-            })?;
+        let topic = dataset.path();
 
-        let msg = match kafka_consumer
-            .next_json::<ChangeEventKey, ChangeEvent>()
-            .await
+        let (kafka_consumer, metadata, schema) = match get_metadata_from_accelerator(dataset).await
         {
-            Ok(Some(msg)) => msg,
-            Ok(None) => {
-                return Err(super::DataConnectorError::UnableToGetReadProvider {
-                    dataconnector: "debezium".to_string(),
-                    source: "No message received from Kafka".into(),
-                });
-            }
-            Err(e) => {
-                return Err(e).boxed().context(super::UnableToGetReadProviderSnafu {
+            Some((metadata, schema)) => {
+                let kafka_consumer = KafkaConsumer::create_with_existing_group_id(
+                    &metadata.consumer_group_id,
+                    self.kafka_brokers.clone(),
+                )
+                .boxed()
+                .context(super::UnableToGetReadProviderSnafu {
                     dataconnector: "debezium",
-                });
+                })?;
+
+                ensure!(
+                    topic == metadata.topic,
+                    super::InvalidConfigurationNoSourceSnafu {
+                        dataconnector: "debezium",
+                        message: format!("The topic has changed from {} to {topic} for dataset {dataset_name}. The existing accelerator data may be out of date.", metadata.topic),
+                    }
+                );
+
+                kafka_consumer.subscribe(&topic).boxed().context(
+                    super::UnableToGetReadProviderSnafu {
+                        dataconnector: "debezium",
+                    },
+                )?;
+
+                (kafka_consumer, metadata, schema)
             }
+            None => infer_metadata_from_kafka(dataset, &topic, self.kafka_brokers.clone()).await?,
         };
-
-        let primary_keys = msg.key().get_primary_key();
-
-        let Some(schema_fields) = msg.value().get_schema_fields() else {
-            return Err(super::DataConnectorError::UnableToGetReadProvider {
-                dataconnector: "debezium".to_string(),
-                source: "Could not get Arrow schema from Debezium message".into(),
-            });
-        };
-
-        let schema = debezium::arrow::convert_fields_to_arrow_schema(schema_fields)
-            .boxed()
-            .context(super::UnableToGetReadProviderSnafu {
-                dataconnector: "debezium",
-            })?;
 
         let debezium_kafka = Arc::new(DebeziumKafka::new(
-            Arc::new(schema),
-            primary_keys,
+            schema,
+            metadata.primary_keys,
             kafka_consumer,
         ));
 
@@ -196,4 +187,98 @@ impl DataConnector for Debezium {
 
         Some(debezium_kafka.stream_changes())
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DebeziumKafkaMetadata {
+    consumer_group_id: String,
+    topic: String,
+    primary_keys: Vec<String>,
+}
+
+async fn get_metadata_from_accelerator(
+    dataset: &Dataset,
+) -> Option<(DebeziumKafkaMetadata, SchemaRef)> {
+    let accelerated_metadata = AcceleratedMetadata::new(dataset).await?;
+    let metadata = accelerated_metadata.get_metadata()?;
+    let schema = accelerated_metadata.get_schema().ok()?;
+    Some((metadata, schema))
+}
+
+async fn set_metadata_to_accelerator(
+    dataset: &Dataset,
+    metadata: &DebeziumKafkaMetadata,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let accelerated_metadata = AcceleratedMetadata::new_create_if_not_exists(dataset).await?;
+    accelerated_metadata.set_metadata(metadata)
+}
+
+async fn infer_metadata_from_kafka(
+    dataset: &Dataset,
+    topic: &str,
+    kafka_brokers: String,
+) -> super::DataConnectorResult<(KafkaConsumer, DebeziumKafkaMetadata, SchemaRef)> {
+    let dataset_name = dataset.name.to_string();
+    let kafka_consumer =
+        KafkaConsumer::create_with_generated_group_id(&dataset_name, kafka_brokers)
+            .boxed()
+            .context(super::UnableToGetReadProviderSnafu {
+                dataconnector: "debezium",
+            })?;
+
+    kafka_consumer
+        .subscribe(topic)
+        .boxed()
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "debezium",
+        })?;
+
+    let msg = match kafka_consumer
+        .next_json::<ChangeEventKey, ChangeEvent>()
+        .await
+    {
+        Ok(Some(msg)) => msg,
+        Ok(None) => {
+            return Err(super::DataConnectorError::UnableToGetReadProvider {
+                dataconnector: "debezium".to_string(),
+                source: "No message received from Kafka".into(),
+            });
+        }
+        Err(e) => {
+            return Err(e).boxed().context(super::UnableToGetReadProviderSnafu {
+                dataconnector: "debezium",
+            });
+        }
+    };
+
+    let primary_keys = msg.key().get_primary_key();
+
+    let Some(schema_fields) = msg.value().get_schema_fields() else {
+        return Err(super::DataConnectorError::UnableToGetReadProvider {
+            dataconnector: "debezium".to_string(),
+            source: "Could not get Arrow schema from Debezium message".into(),
+        });
+    };
+
+    let schema = debezium::arrow::convert_fields_to_arrow_schema(schema_fields)
+        .boxed()
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "debezium",
+        })?;
+
+    let metadata = DebeziumKafkaMetadata {
+        consumer_group_id: kafka_consumer.group_id().to_string(),
+        topic: topic.to_string(),
+        primary_keys,
+    };
+
+    if dataset.is_file_accelerated() {
+        set_metadata_to_accelerator(dataset, &metadata)
+            .await
+            .context(super::UnableToGetReadProviderSnafu {
+                dataconnector: "debezium",
+            })?;
+    }
+
+    Ok((kafka_consumer, metadata, Arc::new(schema)))
 }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -178,7 +178,7 @@ impl DataConnector for Debezium {
 
                 (kafka_consumer, metadata, Arc::new(schema))
             }
-            None => infer_metadata_from_kafka(dataset, &topic, self.kafka_brokers.clone()).await?,
+            None => get_metadata_from_kafka(dataset, &topic, self.kafka_brokers.clone()).await?,
         };
 
         let debezium_kafka = Arc::new(DebeziumKafka::new(
@@ -219,7 +219,7 @@ async fn set_metadata_to_accelerator(
     accelerated_metadata.set_metadata(metadata).await
 }
 
-async fn infer_metadata_from_kafka(
+async fn get_metadata_from_kafka(
     dataset: &Dataset,
     topic: &str,
     kafka_brokers: String,

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -287,5 +287,13 @@ async fn infer_metadata_from_kafka(
             })?;
     }
 
+    // Restart the stream from the beginning
+    kafka_consumer
+        .restart_topic(topic)
+        .boxed()
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "debezium",
+        })?;
+
     Ok((kafka_consumer, metadata, Arc::new(schema)))
 }


### PR DESCRIPTION
## 🗣 Description

Creates a new metadata table `spice_sys_metadata` in the accelerator engine with a `dataset` column and a `metadata` column which stores JSON.

Implemented for DuckDB and Sqlite, the next PR will implement it for Postgres.

Also fixes a bug where we missed the first message due to not properly rewinding the offsets for the topic after doing the schema inference.

Also adds a warning when using the Debezium connector with a non-file based acceleration setting that this will cause all changes to be replayed on restart.

## 🔨 Related Issues

Part of #1785