### PR TITLE
Persist metadata for Debezium connector to gracefully survive restarts (PostgreSQL)

### DIFF
--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -153,7 +153,7 @@ impl KafkaConsumer {
                 partition_metadata.id()
             );
             assignment
-                .set_partition_offset(topic, partition_metadata.id(), Offset::Offset(0))
+                .set_partition_offset(topic, partition_metadata.id(), Offset::Beginning)
                 .context(UnableToRestartTopicSnafu {
                     message: "Failed to set partition in list".to_string(),
                 })?;

--- a/crates/runtime/src/dataaccelerator/metadata.rs
+++ b/crates/runtime/src/dataaccelerator/metadata.rs
@@ -30,6 +30,8 @@ pub const METADATA_METADATA_COLUMN: &str = "metadata";
 
 #[cfg(feature = "duckdb")]
 mod duckdb;
+#[cfg(feature = "postgres")]
+mod postgres;
 #[cfg(feature = "sqlite")]
 mod sqlite;
 
@@ -110,7 +112,7 @@ async fn get_metadata_provider(
             .await?,
         )),
         #[cfg(not(feature = "duckdb"))]
-        Engine::DuckDB => Err("Spice wasn't build with DuckDB support enabled".into()),
+        Engine::DuckDB => Err("Spice wasn't built with DuckDB support enabled".into()),
         #[cfg(feature = "sqlite")]
         Engine::Sqlite => Ok(Box::new(
             crate::dataaccelerator::metadata::sqlite::AcceleratedMetadataSqlite::try_new(
@@ -120,8 +122,16 @@ async fn get_metadata_provider(
             .await?,
         )),
         #[cfg(not(feature = "sqlite"))]
-        Engine::Sqlite => Err("Spice wasn't build with Sqlite support enabled".into()),
-        Engine::PostgreSQL => todo!(),
+        Engine::Sqlite => Err("Spice wasn't built with Sqlite support enabled".into()),
+        #[cfg(feature = "postgres")]
+        Engine::PostgreSQL => Ok(Box::new(
+            crate::dataaccelerator::metadata::postgres::AcceleratedMetadataPostgres::try_new(
+                dataset,
+            )
+            .await?,
+        )),
+        #[cfg(not(feature = "postgres"))]
+        Engine::PostgreSQL => Err("Spice wasn't built with PostgreSQL support enabled".into()),
         Engine::Arrow => Err("Arrow acceleration not supported for metadata".into()),
     }
 }

--- a/crates/runtime/src/dataaccelerator/metadata/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/metadata/postgres.rs
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use data_components::util::secrets::to_secret_map;
+use db_connection_pool::postgrespool::PostgresConnectionPool;
+
+use super::AcceleratedMetadataProvider;
+use super::{METADATA_DATASET_COLUMN, METADATA_METADATA_COLUMN, METADATA_TABLE_NAME};
+use crate::component::dataset::Dataset;
+
+pub struct AcceleratedMetadataPostgres {
+    pool: PostgresConnectionPool,
+}
+
+impl AcceleratedMetadataPostgres {
+    pub async fn try_new(
+        dataset: &Dataset,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let Some(acceleration) = &dataset.acceleration else {
+            return Err("Dataset is not accelerated.".into());
+        };
+
+        let secret_map = Arc::new(to_secret_map(acceleration.params.clone()));
+
+        let pool = PostgresConnectionPool::new(secret_map)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait::async_trait]
+impl AcceleratedMetadataProvider for AcceleratedMetadataPostgres {
+    async fn get_metadata(&self, dataset: &str) -> Option<String> {
+        let query = format!(
+            "SELECT {METADATA_METADATA_COLUMN} FROM {METADATA_TABLE_NAME} WHERE {METADATA_DATASET_COLUMN} = $1",
+        );
+
+        let conn = self.pool.connect_direct().await.ok()?;
+
+        let stmt = conn.conn.prepare(&query).await.ok()?;
+        let row = conn.conn.query_one(&stmt, &[&dataset]).await.ok()?;
+
+        row.get(0)
+    }
+
+    async fn set_metadata(
+        &self,
+        dataset: &str,
+        metadata: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let conn = self.pool.connect_direct().await?;
+        let create_if_not_exists = format!(
+            "CREATE TABLE IF NOT EXISTS {METADATA_TABLE_NAME} (
+                {METADATA_DATASET_COLUMN} TEXT PRIMARY KEY,
+                {METADATA_METADATA_COLUMN} TEXT
+            );",
+        );
+
+        conn.conn.execute(&create_if_not_exists, &[]).await?;
+
+        let query = format!(
+            "INSERT INTO {METADATA_TABLE_NAME} ({METADATA_DATASET_COLUMN}, {METADATA_METADATA_COLUMN}) VALUES ($1, $2) ON CONFLICT ({METADATA_DATASET_COLUMN}) DO UPDATE SET {METADATA_METADATA_COLUMN} = $2",
+        );
+
+        conn.conn.execute(&query, &[&dataset, &metadata]).await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## 🗣 Description

Creates a new metadata table `spice_sys_metadata` in the accelerator engine with a dataset column and a metadata column which stores JSON.

Implemented for PostgreSQL, DuckDB and Sqlite were implemented in #1827.

Also fixes a bug when the Kafka topic doesn't have a message with offset `0`.

This is the final code PR to fully implement #1785

## 🔨 Related Issues

Part of #1785