### PR TITLE
Don't try to "hot reload" Debezium accelerated datasets

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -306,6 +306,10 @@ pub trait DataConnector: Send + Sync {
         None
     }
 
+    fn supports_changes_stream(&self) -> bool {
+        false
+    }
+
     fn changes_stream(&self, _table_provider: Arc<dyn TableProvider>) -> Option<ChangesStream> {
         None
     }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -190,6 +190,10 @@ impl DataConnector for Debezium {
         Ok(debezium_kafka)
     }
 
+    fn supports_changes_stream(&self) -> bool {
+        true
+    }
+
     fn changes_stream(&self, table_provider: Arc<dyn TableProvider>) -> Option<ChangesStream> {
         let debezium_kafka = table_provider.as_any().downcast_ref::<DebeziumKafka>()?;
 


### PR DESCRIPTION
## 🗣 Description

Fixes a bug when using file-accelerated Debezium datasets where changing the dataset could lead to the update failing.

This was due to the "hot reload" functionality that tries to preserve data in accelerators across dataset updates. This isn't necessary for file-accelerated Debezium datasets, as they automatically preserve data across restarts.