### PR TITLE
Add `"cmake-build"` feature to `rdkafka` for windows

### DIFF
--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -49,6 +49,10 @@ odbc-api = { workspace = true, optional = true }
 postgres-native-tls = { version = "0.5.0", optional = true }
 r2d2 = { workspace = true, optional = true }
 rdkafka = { version = "0.36.2", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+rdkafka = { version = "0.25", features = ["cmake-build"] }
+
 regex = "1.10.4"
 reqwest = { version = "0.11.24", features = ["json"] }
 rusqlite = { workspace = true, optional = true }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -49,10 +49,6 @@ odbc-api = { workspace = true, optional = true }
 postgres-native-tls = { version = "0.5.0", optional = true }
 r2d2 = { workspace = true, optional = true }
 rdkafka = { version = "0.36.2", optional = true }
-
-[target.'cfg(windows)'.dependencies]
-rdkafka = { version = "0.36.2", features = ["cmake-build"] }
-
 regex = "1.10.4"
 reqwest = { version = "0.11.24", features = ["json"] }
 rusqlite = { workspace = true, optional = true }
@@ -74,6 +70,9 @@ tonic = { workspace = true, optional = true }
 tracing.workspace = true
 url = "2.5.0"
 uuid.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+rdkafka = { version = "0.36.2", features = ["cmake-build"], optional = true }
 
 [features]
 clickhouse = ["dep:clickhouse-rs", "arrow_sql_gen/clickhouse"]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -51,7 +51,7 @@ r2d2 = { workspace = true, optional = true }
 rdkafka = { version = "0.36.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-rdkafka = { version = "0.25", features = ["cmake-build"] }
+rdkafka = { version = "0.36.2", features = ["cmake-build"] }
 
 regex = "1.10.4"
 reqwest = { version = "0.11.24", features = ["json"] }


### PR DESCRIPTION
## 🗣 Description
- From [rdkafka-sys](https://docs.rs/crate/rdkafka-sys/latest), _"Windows is only supported when using the CMake build system via the cmake-build Cargo feature."_. This can be enabled via `rdkafka` with
```toml
[dependencies]
rdkafka = { version = "0.25", features = ["cmake-build"] }
```
- Only want to add in Cmake features for windows

## 🔨 Related Issues
- Github action to test build on windows: https://github.com/spiceai/spiceai/actions/runs/9752485392/job/26916063493#step:11:23
