### PR TITLE
Streaming refresh: logic to retry on data retrieval errors

### DIFF
--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -41,7 +41,7 @@ use futures::StreamExt;
 use tokio::sync::RwLock;
 
 use crate::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
-use crate::util::retriable_error::detect_retriable_data_retrieval_error;
+use crate::util::retriable_error::check_and_mark_retriable_error;
 
 /// Type alias for partition data
 pub type PartitionData = Arc<RwLock<Vec<RecordBatch>>>;
@@ -256,7 +256,7 @@ impl DataSink for MemSink {
             .next()
             .await
             .transpose()
-            .map_err(detect_retriable_data_retrieval_error)?
+            .map_err(check_and_mark_retriable_error)?
         {
             row_count += batch.num_rows();
             new_batches[i].push(batch);

--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -41,7 +41,7 @@ use futures::StreamExt;
 use tokio::sync::RwLock;
 
 use crate::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
-use crate::util::transient_error::detect_transient_data_retrieval_error;
+use crate::util::retriable_error::detect_retriable_data_retrieval_error;
 
 /// Type alias for partition data
 pub type PartitionData = Arc<RwLock<Vec<RecordBatch>>>;
@@ -256,7 +256,7 @@ impl DataSink for MemSink {
             .next()
             .await
             .transpose()
-            .map_err(detect_transient_data_retrieval_error)?
+            .map_err(detect_retriable_data_retrieval_error)?
         {
             row_count += batch.num_rows();
             new_batches[i].push(batch);

--- a/crates/data_components/src/deltatable/write.rs
+++ b/crates/data_components/src/deltatable/write.rs
@@ -32,7 +32,7 @@ use deltalake::{protocol::SaveMode, DeltaOps, DeltaTable, DeltaTableError};
 use futures::StreamExt;
 use snafu::prelude::*;
 
-use crate::util::transient_error::detect_transient_data_retrieval_error;
+use crate::util::retriable_error::detect_retriable_data_retrieval_error;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -134,7 +134,7 @@ impl DataSink for DeltaTableDataSink {
     ) -> datafusion::common::Result<u64> {
         let mut num_rows = 0;
         while let Some(batch) = data.next().await {
-            let batch = batch.map_err(detect_transient_data_retrieval_error)?;
+            let batch = batch.map_err(detect_retriable_data_retrieval_error)?;
             num_rows += batch.num_rows() as u64;
             let _ = DeltaOps(self.delta_table.clone())
                 .write([batch])

--- a/crates/data_components/src/deltatable/write.rs
+++ b/crates/data_components/src/deltatable/write.rs
@@ -32,7 +32,7 @@ use deltalake::{protocol::SaveMode, DeltaOps, DeltaTable, DeltaTableError};
 use futures::StreamExt;
 use snafu::prelude::*;
 
-use crate::util::retriable_error::detect_retriable_data_retrieval_error;
+use crate::util::retriable_error::check_and_mark_retriable_error;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -134,7 +134,7 @@ impl DataSink for DeltaTableDataSink {
     ) -> datafusion::common::Result<u64> {
         let mut num_rows = 0;
         while let Some(batch) = data.next().await {
-            let batch = batch.map_err(detect_retriable_data_retrieval_error)?;
+            let batch = batch.map_err(check_and_mark_retriable_error)?;
             num_rows += batch.num_rows() as u64;
             let _ = DeltaOps(self.delta_table.clone())
                 .write([batch])

--- a/crates/data_components/src/deltatable/write.rs
+++ b/crates/data_components/src/deltatable/write.rs
@@ -32,6 +32,8 @@ use deltalake::{protocol::SaveMode, DeltaOps, DeltaTable, DeltaTableError};
 use futures::StreamExt;
 use snafu::prelude::*;
 
+use crate::util::transient_error::detect_transient_data_retrieval_error;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to get Delta Lake table state"))]
@@ -132,7 +134,7 @@ impl DataSink for DeltaTableDataSink {
     ) -> datafusion::common::Result<u64> {
         let mut num_rows = 0;
         while let Some(batch) = data.next().await {
-            let batch = batch?;
+            let batch = batch.map_err(detect_transient_data_retrieval_error)?;
             num_rows += batch.num_rows() as u64;
             let _ = DeltaOps(self.delta_table.clone())
                 .write([batch])

--- a/crates/data_components/src/duckdb/write.rs
+++ b/crates/data_components/src/duckdb/write.rs
@@ -20,7 +20,7 @@ use crate::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
 use crate::duckdb::DuckDB;
 use crate::util::constraints;
 use crate::util::on_conflict::OnConflict;
-use crate::util::retriable_error::detect_retriable_data_retrieval_error;
+use crate::util::retriable_error::check_and_mark_retriable_error;
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
 use datafusion::common::Constraints;
@@ -143,7 +143,7 @@ impl DataSink for DuckDBDataSink {
         let data_batches: Vec<RecordBatch> = data_batches_result
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .map_err(detect_retriable_data_retrieval_error)?;
+            .map_err(check_and_mark_retriable_error)?;
 
         constraints::validate_batch_with_constraints(&data_batches, self.duckdb.constraints())
             .await

--- a/crates/data_components/src/duckdb/write.rs
+++ b/crates/data_components/src/duckdb/write.rs
@@ -20,7 +20,7 @@ use crate::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
 use crate::duckdb::DuckDB;
 use crate::util::constraints;
 use crate::util::on_conflict::OnConflict;
-use crate::util::transient_error::detect_transient_data_retrieval_error;
+use crate::util::retriable_error::detect_retriable_data_retrieval_error;
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
 use datafusion::common::Constraints;
@@ -143,7 +143,7 @@ impl DataSink for DuckDBDataSink {
         let data_batches: Vec<RecordBatch> = data_batches_result
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .map_err(detect_transient_data_retrieval_error)?;
+            .map_err(detect_retriable_data_retrieval_error)?;
 
         constraints::validate_batch_with_constraints(&data_batches, self.duckdb.constraints())
             .await

--- a/crates/data_components/src/duckdb/write.rs
+++ b/crates/data_components/src/duckdb/write.rs
@@ -20,6 +20,7 @@ use crate::delete::{DeletionExec, DeletionSink, DeletionTableProvider};
 use crate::duckdb::DuckDB;
 use crate::util::constraints;
 use crate::util::on_conflict::OnConflict;
+use crate::util::transient_error::detect_transient_data_retrieval_error;
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
 use datafusion::common::Constraints;
@@ -141,7 +142,8 @@ impl DataSink for DuckDBDataSink {
 
         let data_batches: Vec<RecordBatch> = data_batches_result
             .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(detect_transient_data_retrieval_error)?;
 
         constraints::validate_batch_with_constraints(&data_batches, self.duckdb.constraints())
             .await

--- a/crates/data_components/src/flight/write.rs
+++ b/crates/data_components/src/flight/write.rs
@@ -33,7 +33,7 @@ use futures::StreamExt;
 use snafu::prelude::*;
 use std::{any::Any, fmt, sync::Arc};
 
-use crate::util::transient_error::detect_transient_data_retrieval_error;
+use crate::util::retriable_error::detect_retriable_data_retrieval_error;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -132,7 +132,7 @@ impl DataSink for FlightDataSink {
         let mut flight_client = self.flight_client.clone();
 
         while let Some(batch) = data.next().await {
-            let batch = batch.map_err(detect_transient_data_retrieval_error)?;
+            let batch = batch.map_err(detect_retriable_data_retrieval_error)?;
             num_rows += batch.num_rows() as u64;
 
             flight_client

--- a/crates/data_components/src/flight/write.rs
+++ b/crates/data_components/src/flight/write.rs
@@ -33,7 +33,7 @@ use futures::StreamExt;
 use snafu::prelude::*;
 use std::{any::Any, fmt, sync::Arc};
 
-use crate::util::retriable_error::detect_retriable_data_retrieval_error;
+use crate::util::retriable_error::check_and_mark_retriable_error;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -132,7 +132,7 @@ impl DataSink for FlightDataSink {
         let mut flight_client = self.flight_client.clone();
 
         while let Some(batch) = data.next().await {
-            let batch = batch.map_err(detect_retriable_data_retrieval_error)?;
+            let batch = batch.map_err(check_and_mark_retriable_error)?;
             num_rows += batch.num_rows() as u64;
 
             flight_client

--- a/crates/data_components/src/postgres/write.rs
+++ b/crates/data_components/src/postgres/write.rs
@@ -34,7 +34,10 @@ use snafu::prelude::*;
 
 use crate::{
     delete::{DeletionExec, DeletionSink, DeletionTableProvider},
-    util::{constraints, on_conflict::OnConflict},
+    util::{
+        constraints, on_conflict::OnConflict,
+        transient_error::detect_transient_data_retrieval_error,
+    },
 };
 
 use super::{to_datafusion_error, Postgres};
@@ -203,7 +206,7 @@ impl DataSink for PostgresDataSink {
         }
 
         while let Some(batch) = data.next().await {
-            let batch = batch?;
+            let batch = batch.map_err(detect_transient_data_retrieval_error)?;
             let batch_num_rows = batch.num_rows();
 
             if batch_num_rows == 0 {

--- a/crates/data_components/src/postgres/write.rs
+++ b/crates/data_components/src/postgres/write.rs
@@ -34,10 +34,7 @@ use snafu::prelude::*;
 
 use crate::{
     delete::{DeletionExec, DeletionSink, DeletionTableProvider},
-    util::{
-        constraints, on_conflict::OnConflict,
-        retriable_error::detect_retriable_data_retrieval_error,
-    },
+    util::{constraints, on_conflict::OnConflict, retriable_error::check_and_mark_retriable_error},
 };
 
 use super::{to_datafusion_error, Postgres};
@@ -206,7 +203,7 @@ impl DataSink for PostgresDataSink {
         }
 
         while let Some(batch) = data.next().await {
-            let batch = batch.map_err(detect_retriable_data_retrieval_error)?;
+            let batch = batch.map_err(check_and_mark_retriable_error)?;
             let batch_num_rows = batch.num_rows();
 
             if batch_num_rows == 0 {

--- a/crates/data_components/src/postgres/write.rs
+++ b/crates/data_components/src/postgres/write.rs
@@ -36,7 +36,7 @@ use crate::{
     delete::{DeletionExec, DeletionSink, DeletionTableProvider},
     util::{
         constraints, on_conflict::OnConflict,
-        transient_error::detect_transient_data_retrieval_error,
+        retriable_error::detect_retriable_data_retrieval_error,
     },
 };
 
@@ -206,7 +206,7 @@ impl DataSink for PostgresDataSink {
         }
 
         while let Some(batch) = data.next().await {
-            let batch = batch.map_err(detect_transient_data_retrieval_error)?;
+            let batch = batch.map_err(detect_retriable_data_retrieval_error)?;
             let batch_num_rows = batch.num_rows();
 
             if batch_num_rows == 0 {

--- a/crates/data_components/src/sqlite/write.rs
+++ b/crates/data_components/src/sqlite/write.rs
@@ -38,7 +38,7 @@ use crate::{
     delete::{DeletionExec, DeletionSink, DeletionTableProvider},
     util::{
         constraints, on_conflict::OnConflict,
-        transient_error::detect_transient_data_retrieval_error,
+        retriable_error::detect_retriable_data_retrieval_error,
     },
 };
 
@@ -147,7 +147,7 @@ impl DataSink for SqliteDataSink {
         let data_batches: Vec<RecordBatch> = data_batches_result
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .map_err(detect_transient_data_retrieval_error)?;
+            .map_err(detect_retriable_data_retrieval_error)?;
 
         constraints::validate_batch_with_constraints(&data_batches, self.sqlite.constraints())
             .await

--- a/crates/data_components/src/sqlite/write.rs
+++ b/crates/data_components/src/sqlite/write.rs
@@ -36,10 +36,7 @@ use sql_provider_datafusion::expr::Engine;
 
 use crate::{
     delete::{DeletionExec, DeletionSink, DeletionTableProvider},
-    util::{
-        constraints, on_conflict::OnConflict,
-        retriable_error::detect_retriable_data_retrieval_error,
-    },
+    util::{constraints, on_conflict::OnConflict, retriable_error::check_and_mark_retriable_error},
 };
 
 use super::{to_datafusion_error, Sqlite};
@@ -147,7 +144,7 @@ impl DataSink for SqliteDataSink {
         let data_batches: Vec<RecordBatch> = data_batches_result
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
-            .map_err(detect_retriable_data_retrieval_error)?;
+            .map_err(check_and_mark_retriable_error)?;
 
         constraints::validate_batch_with_constraints(&data_batches, self.sqlite.constraints())
             .await

--- a/crates/data_components/src/util.rs
+++ b/crates/data_components/src/util.rs
@@ -23,8 +23,8 @@ pub mod column_reference;
 pub mod constraints;
 pub mod indexes;
 pub mod on_conflict;
+pub mod retriable_error;
 pub mod secrets;
-pub mod transient_error;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/data_components/src/util.rs
+++ b/crates/data_components/src/util.rs
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use datafusion::logical_expr::Expr;
 use snafu::prelude::*;
 use sql_provider_datafusion::expr::{self, Engine};
@@ -8,6 +24,7 @@ pub mod constraints;
 pub mod indexes;
 pub mod on_conflict;
 pub mod secrets;
+pub mod transient_error;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/data_components/src/util/retriable_error.rs
+++ b/crates/data_components/src/util/retriable_error.rs
@@ -26,23 +26,25 @@ pub enum RetriableError {
 }
 
 #[must_use]
-pub fn is_df_retriable_error(err: &DataFusionError) -> bool {
+pub fn is_retriable_error(err: &DataFusionError) -> bool {
     match err {
         DataFusionError::External(err) => return err.downcast_ref::<RetriableError>().is_some(),
-        DataFusionError::Context(_, err) => is_df_retriable_error(err.as_ref()),
+        DataFusionError::Context(_, err) => is_retriable_error(err.as_ref()),
         _ => false,
     }
 }
-
+/// Checks if the data retrieval error is NOT related to invalid input (e.g., SQL, plan creation, schema issues).
+/// In this case, the error is wrapped as `RetriableError::DataRetrievalError`
+/// so we can detect this error and retry later at a higher level
 #[must_use]
-pub fn detect_retriable_data_retrieval_error(err: DataFusionError) -> DataFusionError {
+pub fn check_and_mark_retriable_error(err: DataFusionError) -> DataFusionError {
     // don't wrap as retriable errors related to invalid SQL, schema, query plan, etc.
     if is_invalid_query_error(&err) {
         return err;
     }
 
     // already wrapped RetriableError
-    if is_df_retriable_error(&err) {
+    if is_retriable_error(&err) {
         return err;
     }
 

--- a/crates/data_components/src/util/transient_error.rs
+++ b/crates/data_components/src/util/transient_error.rs
@@ -20,7 +20,7 @@ use snafu::Snafu;
 #[derive(Debug, Snafu)]
 pub enum TransientError {
     #[snafu(display("{source}"))]
-    DataSourceConnectivityError {
+    DataRetrievalError {
         source: datafusion::error::DataFusionError,
     },
 }
@@ -46,9 +46,7 @@ pub fn detect_transient_data_retrieval_error(err: DataFusionError) -> DataFusion
         return err;
     }
 
-    DataFusionError::External(Box::new(TransientError::DataSourceConnectivityError {
-        source: err,
-    }))
+    DataFusionError::External(Box::new(TransientError::DataRetrievalError { source: err }))
 }
 
 fn is_invalid_query_error(error: &DataFusionError) -> bool {

--- a/crates/data_components/src/util/transient_error.rs
+++ b/crates/data_components/src/util/transient_error.rs
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use datafusion::error::DataFusionError;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum TransientError {
+    #[snafu(display("{source}"))]
+    DataSourceConnectivityError {
+        source: datafusion::error::DataFusionError,
+    },
+}
+
+#[must_use]
+pub fn is_df_transient_error(err: &DataFusionError) -> bool {
+    match err {
+        DataFusionError::External(err) => return err.downcast_ref::<TransientError>().is_some(),
+        DataFusionError::Context(_, err) => is_df_transient_error(err.as_ref()),
+        _ => false,
+    }
+}
+
+#[must_use]
+pub fn detect_transient_data_retrieval_error(err: DataFusionError) -> DataFusionError {
+    // don't wrap as transient errors related to invalid SQL, schema, query plan, etc.
+    if is_invalid_query_error(&err) {
+        return err;
+    }
+
+    // already wrapped transient error
+    if is_df_transient_error(&err) {
+        return err;
+    }
+
+    DataFusionError::External(Box::new(TransientError::DataSourceConnectivityError {
+        source: err,
+    }))
+}
+
+fn is_invalid_query_error(error: &DataFusionError) -> bool {
+    match error {
+        DataFusionError::Context(_, err) => is_invalid_query_error(err.as_ref()),
+        DataFusionError::SQL(..) | DataFusionError::Plan(..) | DataFusionError::SchemaError(..) => {
+            true
+        }
+        _ => false,
+    }
+}

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -59,6 +59,9 @@ pub enum Error {
     #[snafu(display("Unable to get data from connector: {source}"))]
     UnableToGetDataFromConnector { source: DataFusionError },
 
+    #[snafu(display("Dataset refresh failed with error: {source}"))]
+    FailedToRefreshDataset { source: DataFusionError },
+
     #[snafu(display("Unable to scan table provider: {source}"))]
     UnableToScanTableProvider {
         source: datafusion::error::DataFusionError,

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -21,8 +21,8 @@ use arrow::{
 };
 use async_stream::stream;
 use cache::QueryResultsCacheProvider;
-use data_components::util::transient_error::{
-    detect_transient_data_retrieval_error, is_df_transient_error,
+use data_components::util::retriable_error::{
+    detect_retriable_data_retrieval_error, is_df_retriable_error,
 };
 use futures::{stream, Stream, StreamExt};
 use snafu::{OptionExt, ResultExt};
@@ -501,7 +501,7 @@ impl RefreshTask {
             filters.clone(),
         )
         .await
-        .map_err(detect_transient_data_retrieval_error);
+        .map_err(detect_retriable_data_retrieval_error);
 
         match get_data_result {
             Ok(data) => Ok(StreamingDataUpdate::new(data.0, data.1, update_type)),
@@ -770,7 +770,7 @@ fn filter_records(
 }
 
 fn retry_from_df_error(error: DataFusionError) -> RetryError<super::Error> {
-    if is_df_transient_error(&error) {
+    if is_df_retriable_error(&error) {
         return RetryError::transient(super::Error::UnableToGetDataFromConnector { source: error });
     }
     RetryError::permanent(super::Error::FailedToRefreshDataset { source: error })


### PR DESCRIPTION
## 🗣 Description

Adds logic for 
1. Data components to detect and report data retrieval retriable errors
2. Refresh functionality to unwrap/detect transient data retrieval errors and perform retry.

Currently includes single `DataRetrievalError` error. This could be extended by adding other errors that should be retried, for example writing data to PostgreSQL (as acceleration engine).

PR is targeting to refresh refactoring feature branch

## 🔨 Related Issues

https://github.com/spiceai/spiceai/issues/1797
