### PR TITLE
Generate Spicepod JSON Schema

### DIFF
--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -1,0 +1,41 @@
+
+name: Generate Spicepod JSON schema
+
+on:
+  push:
+    branches: [ trunk ]
+  pull_request:
+    branches: [ trunk ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+
+    - name: Build Cargo project
+      run: cargo build --manifest-path tools/spicepodschema/Cargo.toml
+
+    - name: Run Cargo project
+      run: cargo run --manifest-path tools/spicepodschema/Cargo.toml
+
+    - name: Verify JSON schema file
+      run: |
+        if [ -f "spicepod_schema.json" ]; then
+          echo "spicepod_schema.json file was successfully created."
+          cat spicepod_schema.json
+        else
+          echo "spicepod_schema.json file was not created."
+          exit 1
+        fi

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -8,8 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-
+  generate_schema:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,10 +25,10 @@ jobs:
     - name: Verify JSON schema file
       run: |
         if [ -f "spicepod-schema.json" ]; then
-          echo "spicepod_schema.json file was successfully created."
-          cat spicepod_schema.json
+          echo "spicepod-schema.json file was successfully created."
+          cat spicepod-schema.json
         else
-          echo "spicepod_schema.json file was not created."
+          echo "spicepod-schema.json file was not created."
           exit 1
         fi
 

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -1,4 +1,3 @@
-
 name: Generate Spicepod JSON schema
 
 on:
@@ -14,28 +13,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Set up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+    - run: rustup toolchain install stable --profile minimal
 
     - name: Build Cargo project
       run: cargo build --manifest-path tools/spicepodschema/Cargo.toml
 
     - name: Run Cargo project
-      run: cargo run --manifest-path tools/spicepodschema/Cargo.toml
+      run: cargo run --manifest-path tools/spicepodschema/Cargo.toml -- spicepod-schema.json
 
     - name: Verify JSON schema file
       run: |
-        if [ -f "spicepod_schema.json" ]; then
+        if [ -f "spicepod-schema.json" ]; then
           echo "spicepod_schema.json file was successfully created."
           cat spicepod_schema.json
         else
           echo "spicepod_schema.json file was not created."
           exit 1
         fi
+
+    - name: Upload JSON schema artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: spicepod-schema
+        path: spicepod-schema.json

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -3,8 +3,6 @@ name: Generate Spicepod JSON schema
 on:
   push:
     branches: [ trunk ]
-  pull_request:
-    branches: [ trunk ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -3,6 +3,9 @@ name: Generate Spicepod JSON schema
 on:
   push:
     branches: [ trunk ]
+    paths:
+      - 'crates/spicepod/**'
+
   workflow_dispatch:
 
 jobs:
@@ -18,20 +21,38 @@ jobs:
       run: cargo build --manifest-path tools/spicepodschema/Cargo.toml
 
     - name: Run Cargo project
-      run: cargo run --manifest-path tools/spicepodschema/Cargo.toml -- spicepod-schema.json
+      run: cargo run --manifest-path tools/spicepodschema/Cargo.toml -- .schema/spicepod.schema.json
 
     - name: Verify JSON schema file
       run: |
-        if [ -f "spicepod-schema.json" ]; then
-          echo "spicepod-schema.json file was successfully created."
-          cat spicepod-schema.json
+        if [ -f ".schema/spicepod.schema.json" ]; then
+          echo ".schema/spicepod.schema.json file was successfully created."
+          cat .schema/spicepod.schema.json
         else
-          echo "spicepod-schema.json file was not created."
+          echo ".schema/spicepod.schema.json file was not created."
           exit 1
         fi
 
     - name: Upload JSON schema artifact
       uses: actions/upload-artifact@v3
       with:
-        name: spicepod-schema
-        path: spicepod-schema.json
+        name: spicepod.schema
+        path: .schema/spicepod.schema.json
+
+    - name: Create PR
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        git config --global user.name 'Spice Schema Bot'
+        git config --global user.email 'schema-bot@spice.ai'
+        git checkout -b schema/${GITHUB_RUN_ID}
+        git diff .schema/spicepod.schema.json
+        if [[ $(git diff --exit-code .schema/spicepod.schema.json) ]]; then
+          git add .schema/spicepod.schema.json
+          git commit -m "Update spicepod.schema.json"
+          git push origin schema/${GITHUB_RUN_ID}
+          gh pr create --title "Update spicepod.schema.json" --body "Updated Spicepod Schema" --base trunk --head schema/${GITHUB_RUN_ID}
+        else
+          echo "No changes detected"
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -1,0 +1,735 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Spicepod Definition",
+  "description": "A Spicepod definition is a YAML file that describes a Spicepod.",
+  "type": "object",
+  "required": [
+    "kind",
+    "name",
+    "version"
+  ],
+  "properties": {
+    "datasets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ComponentOrReference_for_Dataset"
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "embeddings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ComponentOrReference_for_Embeddings"
+      }
+    },
+    "extensions": {
+      "description": "Optional extensions configuration",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Extension"
+      }
+    },
+    "kind": {
+      "description": "The kind of Spicepod",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SpicepodKind"
+        }
+      ]
+    },
+    "models": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ComponentOrReference_for_Model"
+      }
+    },
+    "name": {
+      "description": "The name of the Spicepod",
+      "type": "string"
+    },
+    "runtime": {
+      "description": "Optional runtime configuration",
+      "default": {
+        "num_of_parallel_loading_at_start_up": null,
+        "results_cache": {
+          "cache_max_size": null,
+          "enabled": true,
+          "eviction_policy": null,
+          "item_ttl": null
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Runtime"
+        }
+      ]
+    },
+    "secrets": {
+      "description": "Optional spicepod secrets configuration Default value is `store: file`",
+      "default": {
+        "store": "file"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Secrets"
+        }
+      ]
+    },
+    "version": {
+      "description": "The version of the Spicepod",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SpicepodVersion"
+        }
+      ]
+    },
+    "views": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ComponentOrReference_for_View"
+      }
+    }
+  },
+  "definitions": {
+    "Acceleration": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "engine": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "engine_secret": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "indexes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/IndexType"
+          }
+        },
+        "mode": {
+          "default": "memory",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Mode2"
+            }
+          ]
+        },
+        "on_conflict": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OnConflictBehavior"
+          }
+        },
+        "on_zero_results": {
+          "default": "return_empty",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZeroResultsAction"
+            }
+          ]
+        },
+        "params": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Params"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "primary_key": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_append_overlap": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_check_interval": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_data_window": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RefreshMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "refresh_retry_enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "refresh_retry_max_attempts": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "refresh_sql": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "retention_check_enabled": {
+          "type": "boolean"
+        },
+        "retention_check_interval": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "retention_period": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "ColumnEmbeddingConfig": {
+      "description": "Configuration for if and how a dataset's column should be embedded.",
+      "type": "object",
+      "required": [
+        "column"
+      ],
+      "properties": {
+        "column": {
+          "type": "string"
+        },
+        "column_pk": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "use": {
+          "default": "",
+          "type": "string"
+        }
+      }
+    },
+    "ComponentOrReference_for_Dataset": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Dataset"
+        },
+        {
+          "$ref": "#/definitions/ComponentReference"
+        }
+      ]
+    },
+    "ComponentOrReference_for_Embeddings": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Embeddings"
+        },
+        {
+          "$ref": "#/definitions/ComponentReference"
+        }
+      ]
+    },
+    "ComponentOrReference_for_Model": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Model"
+        },
+        {
+          "$ref": "#/definitions/ComponentReference"
+        }
+      ]
+    },
+    "ComponentOrReference_for_View": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/View"
+        },
+        {
+          "$ref": "#/definitions/ComponentReference"
+        }
+      ]
+    },
+    "ComponentReference": {
+      "type": "object",
+      "required": [
+        "ref"
+      ],
+      "properties": {
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ref": {
+          "type": "string"
+        }
+      }
+    },
+    "Dataset": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "acceleration": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Acceleration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "embeddings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ColumnEmbeddingConfig"
+          }
+        },
+        "from": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "mode": {
+          "default": "read",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Mode"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "params": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Params"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "replication": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Replication"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "time_column": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "time_format": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TimeFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Embeddings": {
+      "type": "object",
+      "required": [
+        "from",
+        "name"
+      ],
+      "properties": {
+        "datasets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ModelFile"
+          }
+        },
+        "from": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Extension": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "IndexType": {
+      "type": "string",
+      "enum": [
+        "enabled",
+        "unique"
+      ]
+    },
+    "Mode": {
+      "type": "string",
+      "enum": [
+        "read",
+        "read_write"
+      ]
+    },
+    "Mode2": {
+      "type": "string",
+      "enum": [
+        "memory",
+        "file"
+      ]
+    },
+    "Model": {
+      "type": "object",
+      "required": [
+        "from",
+        "name"
+      ],
+      "properties": {
+        "datasets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ModelFile"
+          }
+        },
+        "from": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ModelFile": {
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "description": "Should use [`Self::file_type`] to access.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelFileType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ModelFileType": {
+      "type": "string",
+      "enum": [
+        "weights",
+        "config",
+        "tokenizer",
+        "tokenizerConfig"
+      ]
+    },
+    "OnConflictBehavior": {
+      "type": "string",
+      "enum": [
+        "drop",
+        "upsert"
+      ]
+    },
+    "ParamValue": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "Params": {
+      "type": "object"
+    },
+    "RefreshMode": {
+      "type": "string",
+      "enum": [
+        "full",
+        "append",
+        "changes"
+      ]
+    },
+    "Replication": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "ResultsCache": {
+      "type": "object",
+      "properties": {
+        "cache_max_size": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "eviction_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "item_ttl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Runtime": {
+      "type": "object",
+      "properties": {
+        "num_of_parallel_loading_at_start_up": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "results_cache": {
+          "default": {
+            "cache_max_size": null,
+            "enabled": true,
+            "eviction_policy": null,
+            "item_ttl": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ResultsCache"
+            }
+          ]
+        }
+      }
+    },
+    "Secrets": {
+      "description": "The secrets configuration for a Spicepod.\n\nExample: ```yaml secrets: store: file ```",
+      "type": "object",
+      "required": [
+        "store"
+      ],
+      "properties": {
+        "store": {
+          "$ref": "#/definitions/SpiceSecretStore"
+        }
+      }
+    },
+    "SpiceSecretStore": {
+      "type": "string",
+      "enum": [
+        "file",
+        "env",
+        "kubernetes",
+        "keyring",
+        "aws_secrets_manager"
+      ]
+    },
+    "SpicepodKind": {
+      "type": "string",
+      "enum": [
+        "Spicepod"
+      ]
+    },
+    "SpicepodVersion": {
+      "type": "string",
+      "enum": [
+        "v1beta1"
+      ]
+    },
+    "TimeFormat": {
+      "type": "string",
+      "enum": [
+        "unix_seconds",
+        "unix_millis",
+        "ISO8601"
+      ]
+    },
+    "View": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "sql": {
+          "description": "Inline SQL that describes a view.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sql_ref": {
+          "description": "Reference to a SQL file that describes a view.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "ZeroResultsAction": {
+      "description": "Behavior when a query on an accelerated table returns zero results.",
+      "oneOf": [
+        {
+          "description": "Return an empty result set. This is the default.",
+          "type": "string",
+          "enum": [
+            "return_empty"
+          ]
+        },
+        {
+          "description": "Fallback to querying the source table.",
+          "type": "string",
+          "enum": [
+            "use_source"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8461,6 +8461,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8597,6 +8621,17 @@ name = "serde_derive"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9040,11 +9075,21 @@ dependencies = [
 name = "spicepod"
 version = "0.15.1-alpha"
 dependencies = [
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
  "snafu 0.8.3",
  "tracing",
+]
+
+[[package]]
+name = "spicepodschema"
+version = "0.15.1-alpha"
+dependencies = [
+ "schemars",
+ "serde_json",
+ "spicepod",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/spice_cloud",
   "tools/flightpublisher/",
   "tools/flightsubscriber/",
+  "tools/spicepodschema/",
 ]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -13,3 +13,8 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+schemars = { version = "0.8.19", optional = true }
+
+[features]
+default = []
+schemars = ["dep:schemars"]

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -17,6 +17,8 @@ limitations under the License.
 use std::fmt::Debug;
 use std::path::PathBuf;
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use snafu::prelude::*;
 
@@ -35,6 +37,7 @@ pub trait WithDependsOn<T> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ComponentReference {
     pub r#ref: String,
 
@@ -44,6 +47,7 @@ pub struct ComponentReference {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(untagged)]
 pub enum ComponentOrReference<T> {
     Component(T),

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{embeddings::ColumnEmbeddingConfig, params::Params, WithDependsOn};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum Mode {
     #[default]
@@ -27,6 +30,7 @@ pub enum Mode {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum TimeFormat {
     #[default]
@@ -43,6 +47,7 @@ impl std::fmt::Display for TimeFormat {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Dataset {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub from: String,
@@ -117,12 +122,15 @@ impl WithDependsOn<Dataset> for Dataset {
 }
 
 pub mod acceleration {
+    #[cfg(feature = "schemars")]
+    use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
     use std::{collections::HashMap, fmt::Display};
 
     use crate::component::params::Params;
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    #[cfg_attr(feature = "schemars", derive(JsonSchema))]
     #[serde(rename_all = "lowercase")]
     pub enum RefreshMode {
         Full,
@@ -131,6 +139,7 @@ pub mod acceleration {
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+    #[cfg_attr(feature = "schemars", derive(JsonSchema))]
     #[serde(rename_all = "lowercase")]
     pub enum Mode {
         #[default]
@@ -149,6 +158,7 @@ pub mod acceleration {
 
     /// Behavior when a query on an accelerated table returns zero results.
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+    #[cfg_attr(feature = "schemars", derive(JsonSchema))]
     #[serde(rename_all = "snake_case")]
     pub enum ZeroResultsAction {
         /// Return an empty result set. This is the default.
@@ -168,6 +178,7 @@ pub mod acceleration {
     }
 
     #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
+    #[cfg_attr(feature = "schemars", derive(JsonSchema))]
     #[serde(rename_all = "lowercase")]
     pub enum IndexType {
         #[default]
@@ -185,6 +196,7 @@ pub mod acceleration {
     }
 
     #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
+    #[cfg_attr(feature = "schemars", derive(JsonSchema))]
     #[serde(rename_all = "lowercase")]
     pub enum OnConflictBehavior {
         #[default]
@@ -202,6 +214,7 @@ pub mod acceleration {
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    #[cfg_attr(feature = "schemars", derive(JsonSchema))]
     pub struct Acceleration {
         #[serde(default = "default_true")]
         pub enabled: bool,
@@ -298,9 +311,12 @@ pub mod acceleration {
 }
 
 pub mod replication {
+    #[cfg(feature = "schemars")]
+    use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    #[cfg_attr(feature = "schemars", derive(JsonSchema))]
     pub struct Replication {
         #[serde(default)]
         pub enabled: bool,

--- a/crates/spicepod/src/component/embeddings.rs
+++ b/crates/spicepod/src/component/embeddings.rs
@@ -20,9 +20,12 @@ use super::{
     model::{ModelFile, ModelFileType},
     WithDependsOn,
 };
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Embeddings {
     pub from: String,
     pub name: String,
@@ -130,6 +133,7 @@ impl Display for EmbeddingPrefix {
 
 /// Configuration for if and how a dataset's column should be embedded.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ColumnEmbeddingConfig {
     pub column: String,
 

--- a/crates/spicepod/src/component/extension.rs
+++ b/crates/spicepod/src/component/extension.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Extension {
     #[serde(default = "default_true")]
     pub enabled: bool,

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -17,9 +17,12 @@ limitations under the License.
 use std::{collections::HashMap, fmt::Display, path::Path};
 
 use super::WithDependsOn;
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Model {
     pub from: String,
     pub name: String,
@@ -54,6 +57,7 @@ impl WithDependsOn<Model> for Model {
 
 /// Describe where the [`Model`] is sourced from.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum ModelSource {
     OpenAi,
     HuggingFace,
@@ -93,6 +97,7 @@ impl Display for ModelSource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum ModelType {
     Llm,
     Ml,
@@ -217,6 +222,7 @@ impl Model {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ModelFile {
     pub path: String,
     pub name: Option<String>,
@@ -246,6 +252,7 @@ impl ModelFile {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum ModelFileType {
     Weights,

--- a/crates/spicepod/src/component/params.rs
+++ b/crates/spicepod/src/component/params.rs
@@ -45,7 +45,7 @@ impl ParamValue {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Params {
-    #[schemars(flatten)]
+    #[cfg_attr(feature = "schemars", schemars(flatten))]
     pub data: HashMap<String, ParamValue>,
 }
 

--- a/crates/spicepod/src/component/params.rs
+++ b/crates/spicepod/src/component/params.rs
@@ -16,9 +16,12 @@ limitations under the License.
 
 use std::collections::HashMap;
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(untagged)]
 pub enum ParamValue {
     String(String),
@@ -40,7 +43,9 @@ impl ParamValue {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Params {
+    #[schemars(flatten)]
     pub data: HashMap<String, ParamValue>,
 }
 

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Runtime {
     #[serde(default)]
     pub results_cache: ResultsCache,
@@ -24,6 +27,7 @@ pub struct Runtime {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ResultsCache {
     #[serde(default = "default_true")]
     pub enabled: bool,

--- a/crates/spicepod/src/component/secrets.rs
+++ b/crates/spicepod/src/component/secrets.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// The secrets configuration for a Spicepod.
@@ -24,6 +26,7 @@ use serde::{Deserialize, Serialize};
 ///   store: file
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Secrets {
     pub store: SpiceSecretStore,
 }
@@ -37,6 +40,7 @@ impl Default for Secrets {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum SpiceSecretStore {
     File,

--- a/crates/spicepod/src/component/view.rs
+++ b/crates/spicepod/src/component/view.rs
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::WithDependsOn;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct View {
     pub name: String,
 

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -32,7 +32,7 @@ use spec::{SpicepodDefinition, SpicepodVersion};
 
 pub mod component;
 pub mod reader;
-mod spec;
+pub mod spec;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_yaml::{self, Value};
 use std::fmt::{self, Display, Formatter};
 use std::{collections::HashMap, fmt::Debug};
 
@@ -27,6 +28,7 @@ use crate::component::{
 };
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum SpicepodVersion {
     V1Beta1,
@@ -38,12 +40,19 @@ impl Display for SpicepodVersion {
     }
 }
 
+/// # Spicepod Definition
+///
+/// A Spicepod definition is a YAML file that describes a Spicepod.
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct SpicepodDefinition {
+    /// The name of the Spicepod
     pub name: String,
 
+    /// The version of the Spicepod
     pub version: SpicepodVersion,
 
+    /// The kind of Spicepod
     pub kind: SpicepodKind,
 
     /// Optional runtime configuration
@@ -60,10 +69,9 @@ pub struct SpicepodDefinition {
     #[serde(default)]
     pub secrets: Secrets,
 
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    #[serde(default)]
-    pub metadata: HashMap<String, Value>,
-
+    // #[serde(skip_serializing_if = "HashMap::is_empty")]
+    // #[serde(default)]
+    // pub metadata: HashMap<String, Value>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
     pub datasets: Vec<ComponentOrReference<Dataset>>,
@@ -86,6 +94,7 @@ pub struct SpicepodDefinition {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum SpicepodKind {
     Spicepod,
 }

--- a/tools/spicepodschema/Cargo.toml
+++ b/tools/spicepodschema/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "spicepodschema"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Spice OSS Spicepod schema"
+
+[dependencies]
+schemars = "0.8.19"
+serde_json = "1.0.117"
+spicepod = { path = "../../crates/spicepod", features = ["schemars"]}

--- a/tools/spicepodschema/src/main.rs
+++ b/tools/spicepodschema/src/main.rs
@@ -31,9 +31,19 @@ fn main() {
     let output_filename = &args[1];
 
     let schema = schema_for!(SpicepodDefinition);
-    let json_schema = serde_json::to_string_pretty(&schema).unwrap();
 
-    let mut file = File::create(output_filename).expect("Unable to create file");
-    file.write_all(json_schema.as_bytes())
-        .expect("Unable to write data");
+    let Ok(json_schema) = serde_json::to_string_pretty(&schema) else {
+        eprintln!("Unable to serialize schema");
+        std::process::exit(1);
+    };
+
+    let Ok(mut file) = File::create(output_filename) else {
+        eprintln!("Unable to create file {output_filename}");
+        std::process::exit(1);
+    };
+
+    if file.write_all(json_schema.as_bytes()).is_err() {
+        eprintln!("Unable to write to file {output_filename}");
+        std::process::exit(1);
+    }
 }

--- a/tools/spicepodschema/src/main.rs
+++ b/tools/spicepodschema/src/main.rs
@@ -16,14 +16,24 @@ limitations under the License.
 
 use schemars::schema_for;
 use spicepod::spec::SpicepodDefinition;
+use std::env;
 use std::fs::File;
 use std::io::Write;
 
 fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Usage: {} <output_filename>", args[0]);
+        std::process::exit(1);
+    }
+
+    let output_filename = &args[1];
+
     let schema = schema_for!(SpicepodDefinition);
     let json_schema = serde_json::to_string_pretty(&schema).unwrap();
 
-    let mut file = File::create("spicepod_schema.json").expect("Unable to create file");
+    let mut file = File::create(output_filename).expect("Unable to create file");
     file.write_all(json_schema.as_bytes())
         .expect("Unable to write data");
 }

--- a/tools/spicepodschema/src/main.rs
+++ b/tools/spicepodschema/src/main.rs
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use schemars::schema_for;
+use spicepod::spec::SpicepodDefinition;
+use std::fs::File;
+use std::io::Write;
+
+fn main() {
+    let schema = schema_for!(SpicepodDefinition);
+    let json_schema = serde_json::to_string_pretty(&schema).unwrap();
+
+    let mut file = File::create("spicepod_schema.json").expect("Unable to create file");
+    file.write_all(json_schema.as_bytes())
+        .expect("Unable to write data");
+}


### PR DESCRIPTION
Generates JSON schema for spicepod.yaml spec. [Sample CI run](https://github.com/spiceai/spiceai/actions/runs/9775773584)

Schemars included only under the feature flag, which is enabled only for schema generation tool

Allows to enable validation and completions for spice.yaml in code editors with schema support.

E.g. in vscode, can be used together with [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and schema comment

![CleanShot 2024-07-03 at 19 06 20@2x](https://github.com/spiceai/spiceai/assets/827338/0d2dfba3-d486-4cdf-9a4d-d38d023619a5)

