### PR TITLE
fix: Add support for varying duplicate columns behavior in GraphQL unnesting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,10 +132,10 @@ rm -rf /tmp/spice
 mkdir -p /tmp/spice
 cd /tmp/spice
 wget https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz
-tar xcvf go$GO_VERSION.linux-amd64.tar.gz
-mv ./go /usr/local/go
+tar xvfz go$GO_VERSION.linux-amd64.tar.gz
+sudo mv ./go /usr/local/go
 echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.profile
-source $HOME/.PROFILE
+source $HOME/.profile
 cd $HOME
 rm -rf /tmp/spice
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ spice run
 ```bash
 # Install system dependencies
 sudo apt update
-sudo apt install build-essential curl openssl libssl-dev pkg-config protobuf-compiler
+sudo apt install build-essential curl openssl libssl-dev pkg-config protobuf-compiler cmake
 
 # Install Go
 export GO_VERSION="1.22.4"


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

Adds a new parameter for GraphQL data connectors, `unnest_duplicate_columns`.

This is a string parameter field, which accepts the values `error`, `overwrite`, and `rename` each identifying different duplicate column handling behavior:

* `error`: The default behavior when the parameter isn't specified. If a duplicate column is identified during unnesting, the data connector errors
* `overwrite`: Duplicate columns overwrite any existing column with the same name. The last visited column is the data that remains after unnesting.
* `rename`: Duplicate columns are renamed if they are identified. For example, two objects each with a sub-field of `name` would be renamed as unnested fields `name_1` and `name_2`.

_Misc:_ Also includes some contributor guide updates after I reinstalled my OS and tried using the guide.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #1802 