### PR TITLE
fix: Use tokio mpsc channels for ODBC streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,7 +3066,6 @@ dependencies = [
  "datafusion-table-providers",
  "duckdb",
  "dyn-clone",
- "flume",
  "futures",
  "lazy_static",
  "mysql_async",
@@ -3849,9 +3848,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
  "spin 0.9.8",
 ]
 
@@ -6117,15 +6113,6 @@ dependencies = [
  "time",
  "uuid 1.9.1",
  "zstd",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -26,7 +26,6 @@ duckdb = { workspace = true, features = [
   "vtab-arrow",
 ], optional = true }
 dyn-clone = { version = "1.0.17", optional = true }
-flume = { version = "0.11.0", optional = true }
 futures.workspace = true
 lazy_static = "1.4.0"
 mysql_async = { workspace = true, optional = true }
@@ -62,7 +61,7 @@ clickhouse = [
 ]
 duckdb = ["dep:duckdb", "dep:r2d2", "datafusion-table-providers/duckdb"]
 mysql = ["dep:mysql_async", "datafusion-table-providers/mysql"]
-odbc = ["dep:odbc-api", "dep:arrow-odbc", "dep:tokio", "dep:flume", "dep:dyn-clone"]
+odbc = ["dep:odbc-api", "dep:arrow-odbc", "dep:tokio", "dep:dyn-clone"]
 postgres = [
   "dep:bb8",
   "dep:bb8-postgres",

--- a/crates/db_connection_pool/src/dbconnection/odbcconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/odbcconn.rs
@@ -47,6 +47,7 @@ use snafu::Snafu;
 use tokio::runtime::Handle;
 
 use odbc_api::Connection;
+use tokio::sync::mpsc::Sender;
 
 type Result<T, E = GenericError> = std::result::Result<T, E>;
 
@@ -105,8 +106,8 @@ where
     }
 }
 
-fn blocking_channel_send<T>(channel: &flume::Sender<T>, item: T) -> Result<()> {
-    match channel.send(item) {
+fn blocking_channel_send<T>(channel: &Sender<T>, item: T) -> Result<()> {
+    match channel.blocking_send(item) {
         Ok(()) => Ok(()),
         Err(e) => Err(Error::ChannelError {
             message: format!("{e}"),
@@ -156,14 +157,9 @@ where
         sql: &str,
         params: &[ODBCParameter],
     ) -> Result<SendableRecordBatchStream> {
-        // prepare some flume channels to communicate query results back from the thread
-        let (batch_tx, batch_rx): (
-            flume::Sender<Option<Result<RecordBatch, Error>>>,
-            flume::Receiver<Option<Result<RecordBatch, Error>>>,
-        ) = flume::bounded(4); // at the default ODBC row count of 65_536, we buffer max 262_144 rows
-
-        let (schema_tx, schema_rx): (flume::Sender<Arc<Schema>>, flume::Receiver<Arc<Schema>>) =
-            flume::unbounded();
+        // prepare some tokio channels to communicate query results back from the thread
+        let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel::<Result<RecordBatch, Error>>(4);
+        let (schema_tx, mut schema_rx) = tokio::sync::mpsc::channel::<Arc<Schema>>(1);
 
         // clone internals and parameters to let the thread own them
         let conn = Arc::clone(&self.conn); // clones the mutex not the connection, so we can .lock a connection inside the thread
@@ -174,7 +170,7 @@ where
         let params = params.iter().map(dyn_clone::clone).collect::<Vec<_>>();
         let secrets = Arc::clone(&self.params);
 
-        tokio::task::spawn_blocking(move || {
+        let join_handle = tokio::task::spawn_blocking(move || {
             let handle = Handle::current();
             let cxn = handle.block_on(async { conn.lock().await });
 
@@ -194,39 +190,38 @@ where
 
             let reader = build_odbc_reader(cursor, &schema, &secrets)?;
             for batch in reader {
-                blocking_channel_send(&batch_tx, Some(batch.context(ArrowSnafu)))?;
+                blocking_channel_send(&batch_tx, batch.context(ArrowSnafu))?;
             }
-
-            blocking_channel_send(&batch_tx, None)?;
 
             Ok::<_, GenericError>(())
         });
 
         // we need to wait for the schema first before we can build our RecordBatchStreamAdapter
-        let schema = match schema_rx.recv_async().await {
-            Ok(s) => Ok::<_, GenericError>(s),
-            Err(e) => Err(Error::ChannelError {
-                message: format!("{e}"),
+        let schema = match schema_rx.recv().await {
+            Some(s) => Ok::<_, GenericError>(s),
+            None => Err(Error::ChannelError {
+                message: "Schema channel closed unexpectedly".to_string(),
             }
             .into()),
         }?;
 
         let output_stream = stream! {
             loop {
-                match batch_rx.recv_async().await {
-                    Ok(Some(batch)) => match batch {
-                        Ok(batch) => yield Ok(batch),
-                        Err(e) => yield Err(DataFusionError::Execution(format!(
-                            "Failed to read ODBC batch: {e}"
-                        )))
-                    },
-                    Ok(None) => break,
-                    Err(e) => {
+                match batch_rx.recv().await {
+                    Some(Ok(batch)) => yield Ok(batch),
+                    None => break,
+                    Some(Err(e)) => {
                         yield Err(DataFusionError::Execution(format!(
-                            "ODBC reader closed unexpectedly: {e}"
+                            "Failed to read ODBC batch: {e}"
                         )))
                     }
                 }
+            }
+
+            if let Err(e) = join_handle.await {
+                yield Err(DataFusionError::Execution(format!(
+                    "Failed to execute ODBC query: {e}"
+                )))
             }
         };
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -123,7 +123,7 @@ clickhouse = [
 ]
 databricks = ["data_components/databricks"]
 debezium = ["data_components/debezium"]
-default = ["keyring-secret-store", "aws-secrets-manager"]
+default = ["keyring-secret-store", "aws-secrets-manager", "odbc"]
 dev = []
 dremio = []
 duckdb = [

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -123,7 +123,7 @@ clickhouse = [
 ]
 databricks = ["data_components/databricks"]
 debezium = ["data_components/debezium"]
-default = ["keyring-secret-store", "aws-secrets-manager", "odbc"]
+default = ["keyring-secret-store", "aws-secrets-manager"]
 dev = []
 dremio = []
 duckdb = [


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Replaces `flume` with `tokio` channels for ODBC results streaming. This aligns with using `tokio` channels in other implementations, and removes introducing a new dependency.