### PR TITLE
Upgrade table providers to enable DuckDB streaming write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=149c3e9ec2cead44e66b4ca5efcb32ee77db0789#149c3e9ec2cead44e66b4ca5efcb32ee77db0789"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=6b900aa05ff962b97187fdb953f66f91ac5bc618#6b900aa05ff962b97187fdb953f66f91ac5bc618"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "f23af338e80e495b77fb38ced23f0ef88a94662c" }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "c3f696adceaad7f579af7f163cb933e08d7f8ba1" }
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "c3f696adceaad7f579af7f163cb933e08d7f8ba1" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "149c3e9ec2cead44e66b4ca5efcb32ee77db0789" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "6b900aa05ff962b97187fdb953f66f91ac5bc618" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7b8e22885001e2013493aebbaf190039d826c05" }
 fundu = "2.0.0"
 futures = "0.3.30"


### PR DESCRIPTION
## 🗣 Description

Add streaming write support for the DuckDB TableProvider, corresponding PR to datafusion-table-providers repo:
https://github.com/datafusion-contrib/datafusion-table-providers/pull/6


## 🔨 Related Issues

Implements https://github.com/spiceai/spiceai/issues/1782