### PR TITLE
Allow defining user for mysql data connector via secrets

### DIFF
--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -58,6 +58,7 @@ impl DataConnectorFactory for MySQL {
                 "mysql_connection_string",
             );
             secret.insert_to_params(&mut params, "mysql_pass_key", "mysql_pass");
+            secret.insert_to_params(&mut params, "mysql_user_key", "mysql_user");
         }
 
         Box::pin(async move {


### PR DESCRIPTION
## 🗣 Description

PR enables passing user for MySQL data connector via secrets (similar to password)