### PR TITLE
Enable other cloud providers for delta_lake integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6503,6 +6503,7 @@ dependencies = [
  "rand",
  "reqwest 0.12.5",
  "ring",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "snafu 0.7.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d03705612cd0e82f05d3694127f11e01ea60b6ed#d03705612cd0e82f05d3694127f11e01ea60b6ed"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b1645fca2b5779cce4a924f870585a91c54913f2#b1645fca2b5779cce4a924f870585a91c54913f2"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "f865563b1ae8670df21e9a054c5307112f85fbf6" }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "1becf0c961da12993009f53216ded2099c38d425" }
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "1becf0c961da12993009f53216ded2099c38d425" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d03705612cd0e82f05d3694127f11e01ea60b6ed" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b1645fca2b5779cce4a924f870585a91c54913f2" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7b8e22885001e2013493aebbaf190039d826c05" }
 fundu = "2.0.0"
 futures = "0.3.30"

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -29,7 +29,7 @@ datafusion-federation = { workspace = true }
 datafusion-federation-sql = { workspace = true }
 datafusion-table-providers = { workspace = true }
 db_connection_pool = { path = "../db_connection_pool" }
-delta_kernel = { version = "0.1.1", features = ["default-engine"], optional = true }
+delta_kernel = { version = "0.1.1", features = ["default-engine", "cloud"], optional = true }
 duckdb = { workspace = true, features = [
   "bundled",
   "r2d2",


### PR DESCRIPTION
## 🗣 Description

Turn on the [`cloud`](https://github.com/delta-incubator/delta-kernel-rs/blob/main/kernel/Cargo.toml#L59C1-L59C6) feature for `delta-kernel-rs` to enable Azure/GCP support for delta tables.

This now works:
```yaml
  - from: delta_lake:abfss://databricks@spiceaidatabrickstest.dfs.core.windows.net/spiceai_azure_metastore/eth/__unitystorage/catalogs/6435b915-9003-4b35-9fef-67b12b53132f/tables/e3a9e0cd-7502-4054-8a90-49f7fe3a75bb
    name: traces
    params:
      account_name: spiceaidatabrickstest
      access_key: {access_key}
```

## 🔨 Related Issues

Part of #1696