### PR TITLE
Update enforce-labels.yml so it accepts depdenabot updates with kind/…

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
     - uses: yogevbd/enforce-label-action@2.1.0
       with:
-        REQUIRED_LABELS_ANY: "kind/refactor,kind/bug,kind/enhancement,kind/documentation,kind/optimization"
-        REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['kind/refactor','kind/bug','kind/enhancement','kind/documentation', 'kind/optimization']"
+        REQUIRED_LABELS_ANY: "kind/refactor,kind/bug,kind/enhancement,kind/documentation,kind/optimization,kind/dependencies"
+        REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['kind/refactor','kind/bug','kind/enhancement','kind/documentation', 'kind/optimization', 'kind/dependencies']"
         BANNED_LABELS: "invalid,wontfix,nomerge,duplicate"


### PR DESCRIPTION
…dependencies

## 🗣 Description

The enforce label workflow doesn't like the kind/dependencies label which appropriate for dependabot and dependency updates.  This just adds that option.

