### PR TITLE
Require time_column parameter for append dataset

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -224,15 +224,11 @@ impl Builder {
 
         let (acceleration_refresh_mode, refresh_trigger) = match self.refresh.mode {
             RefreshMode::Append => {
-                if self.refresh.time_column.is_none() {
-                    (refresh::AccelerationRefreshMode::Append(None), None)
-                } else {
-                    let (start_refresh, on_start_refresh) = mpsc::channel::<()>(1);
-                    (
-                        refresh::AccelerationRefreshMode::Append(Some(on_start_refresh)),
-                        Some(start_refresh),
-                    )
-                }
+                let (start_refresh, on_start_refresh) = mpsc::channel::<()>(1);
+                (
+                    refresh::AccelerationRefreshMode::Append(on_start_refresh),
+                    Some(start_refresh),
+                )
             }
             RefreshMode::Full => {
                 let (start_refresh, on_start_refresh) = mpsc::channel::<()>(1);

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -182,6 +182,9 @@ pub enum Error {
     UnableToCreateStreamingUpdate {
         source: datafusion::error::DataFusionError,
     },
+
+    #[snafu(display("Time_column parameter missing for append dataset"))]
+    TimeColumnMissingInAppendDataset {},
 }
 
 pub enum Table {
@@ -566,6 +569,11 @@ impl DataFusion {
         }
 
         let refresh_mode = source.resolve_refresh_mode(acceleration_settings.refresh_mode);
+
+        // TODO: put check here, and return error
+        if dataset.time_column.is_none() && refresh_mode == RefreshMode::Append {
+            return Err(Error::TimeColumnMissingInAppendDataset {});
+        }
         let refresh = Refresh::new(
             dataset.time_column.clone(),
             dataset.time_format,


### PR DESCRIPTION
## 🗣 Description

Require users to provide `time_column` parameter when using append acceleration mode.
For example
```yaml
version: v1beta1
kind: Spicepod
name: spiceai
datasets:
  - from: spice.ai/eth.recent_blocks
    name: eth_recent_blocks
    time_column: timestamp
    acceleration:
      enabled: true
      refresh_mode: append
```

An append dataset without `time_column` configured will emit an runtime warning
```yaml
version: v1beta1
kind: Spicepod
name: spiceai
datasets:
  - from: spice.ai/eth.recent_blocks
    name: eth_recent_blocks
    acceleration:
      enabled: true
      refresh_mode: append
```
```
2024-07-09T04:16:25.583073Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
2024-07-09T04:16:26.421667Z  WARN runtime: Unable to attach data connector spiceai: Time_column parameter missing for append dataset
```

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/1868

## 🤔 Concerns

Review on the UX for append dataset configs