### PR TITLE
fix: flaky test - test_refresh_status_change_to_ready

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -445,7 +445,7 @@ mod tests {
                     _ => panic!("not testing this"),
                 }
 
-                sleep(Duration::from_micros(100));
+                sleep(Duration::from_millis(100));
             }
 
             false


### PR DESCRIPTION
## 🗣 Description

Fix the flaky test by changing the sleep interval to be millis rather than micros. The wait function is supposed to be wait up to 2 seconds. The method put there was from_micro which is 1_000 times off.

## 🔨 Related Issues

fixes https://github.com/spiceai/spiceai/issues/1895

