### PR TITLE
Implement `spice.ai` `CatalogProvider`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8970,6 +8970,7 @@ version = "0.15.2-alpha"
 dependencies = [
  "async-trait",
  "datafusion",
+ "futures",
  "reqwest 0.11.27",
  "runtime",
  "serde",

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -43,7 +43,6 @@ default = [
   "spark",
   "snowflake",
   "ftp",
-  "spice-cloud",
   "debezium",
 ]
 dev = ["runtime/dev"]
@@ -59,5 +58,4 @@ postgres = ["runtime/postgres"]
 release = []
 snowflake = ["runtime/snowflake"]
 spark = ["runtime/spark"]
-spice-cloud = []
 sqlite = ["runtime/sqlite"]

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -100,12 +100,10 @@ pub async fn run(args: Args) -> Result<()> {
 
     let mut extension_factories: Vec<Box<dyn ExtensionFactory>> = vec![];
 
-    if cfg!(feature = "spice-cloud") {
-        if let Some(app) = &app {
-            if let Some(manifest) = app.extensions.get("spice_cloud") {
-                let spice_extension_factory = SpiceExtensionFactory::new(manifest.clone());
-                extension_factories.push(Box::new(spice_extension_factory));
-            }
+    if let Some(app) = &app {
+        if let Some(manifest) = app.extensions.get("spice_cloud") {
+            let spice_extension_factory = SpiceExtensionFactory::new(manifest.clone());
+            extension_factories.push(Box::new(spice_extension_factory));
         }
     }
 

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 #![allow(clippy::missing_errors_doc)]
 
+use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -110,7 +111,13 @@ pub async fn run(args: Args) -> Result<()> {
 
     let rt: Runtime = Runtime::builder()
         .with_app_opt(app)
+        // User configured extensions
         .with_extensions(extension_factories)
+        // Extensions that will be auto-loaded if not explicitly loaded and requested by a component
+        .with_autoload_extensions(HashMap::from([(
+            "spice_cloud".to_string(),
+            Box::new(SpiceExtensionFactory::default()) as Box<dyn ExtensionFactory>,
+        )]))
         .with_pods_watcher(pods_watcher)
         .with_datasets_health_monitor()
         .build()

--- a/crates/data_components/src/clickhouse.rs
+++ b/crates/data_components/src/clickhouse.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use clickhouse_rs::ClientHandle;
 use datafusion::{datasource::TableProvider, sql::TableReference};
@@ -55,13 +56,23 @@ impl Read for ClickhouseTableFactory {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         let pool = Arc::clone(&self.pool);
-        let table_provider = Arc::new(
-            SqlTable::new("clickhouse", &pool, table_reference, None)
-                .await
-                .context(UnableToConstructSQLTableSnafu)?,
-        );
+        let table_provider = match schema {
+            Some(schema) => Arc::new(SqlTable::new_with_schema(
+                "clickhouse",
+                &pool,
+                schema,
+                table_reference,
+                None,
+            )),
+            None => Arc::new(
+                SqlTable::new("clickhouse", &pool, table_reference, None)
+                    .await
+                    .context(UnableToConstructSQLTableSnafu)?,
+            ),
+        };
 
         let table_provider = Arc::new(
             table_provider

--- a/crates/data_components/src/databricks_delta.rs
+++ b/crates/data_components/src/databricks_delta.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
@@ -41,6 +42,7 @@ impl Read for DatabricksDelta {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        _schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         get_delta_table(table_reference, Arc::clone(&self.params)).await
     }

--- a/crates/data_components/src/databricks_spark.rs
+++ b/crates/data_components/src/databricks_spark.rs
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 use std::{error::Error, sync::Arc};
 use uuid::Uuid;
 
-use crate::{spark_connect::SparkConnect, Read, ReadWrite};
+use crate::{spark_connect::SparkConnect, Read};
 
 #[derive(Clone)]
 pub struct DatabricksSparkConnect {
@@ -43,21 +44,12 @@ impl DatabricksSparkConnect {
 }
 
 #[async_trait]
-impl ReadWrite for DatabricksSparkConnect {
-    async fn table_provider(
-        &self,
-        table_reference: TableReference,
-    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>> {
-        Ok(ReadWrite::table_provider(&self.spark_connect, table_reference).await?)
-    }
-}
-
-#[async_trait]
 impl Read for DatabricksSparkConnect {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>> {
-        Ok(Read::table_provider(&self.spark_connect, table_reference).await?)
+        Ok(Read::table_provider(&self.spark_connect, table_reference, schema).await?)
     }
 }

--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -18,6 +18,7 @@ use crate::{
     delete::{DeletionExec, DeletionSink, DeletionTableProvider},
     Read, ReadWrite,
 };
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{
     datasource::TableProvider, execution::context::SessionState, logical_expr::Expr,
@@ -96,6 +97,7 @@ impl Read for DuckDBTableFactory {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        _schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         self.table_provider(table_reference).await
     }
@@ -106,6 +108,7 @@ impl ReadWrite for DuckDBTableFactory {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        _schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         self.read_write_table_provider(table_reference).await
     }

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -17,6 +17,7 @@ limitations under the License.
 #![allow(clippy::missing_errors_doc)]
 use std::{error::Error, sync::Arc};
 
+use ::arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 
@@ -62,6 +63,7 @@ pub trait Read: Send + Sync {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>>;
 }
 
@@ -70,5 +72,6 @@ pub trait ReadWrite: Send + Sync {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>>;
 }

--- a/crates/data_components/src/mysql.rs
+++ b/crates/data_components/src/mysql.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 use datafusion_table_providers::mysql::MySQLTableFactory;
@@ -26,6 +27,7 @@ impl Read for MySQLTableFactory {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        _schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         self.table_provider(table_reference).await
     }

--- a/crates/data_components/src/odbc.rs
+++ b/crates/data_components/src/odbc.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 use datafusion_table_providers::sql::{
@@ -76,6 +77,7 @@ where
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        _schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         let pool = Arc::clone(&self.pool);
         let dyn_pool: Arc<ODBCDbConnectionPool<'a>> = pool;

--- a/crates/data_components/src/postgres.rs
+++ b/crates/data_components/src/postgres.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{
     datasource::TableProvider, execution::context::SessionState, logical_expr::Expr,
@@ -37,6 +38,7 @@ impl Read for PostgresTableFactory {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        _schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         self.table_provider(table_reference).await
     }
@@ -47,6 +49,7 @@ impl ReadWrite for PostgresTableFactory {
     async fn table_provider(
         &self,
         table_reference: TableReference,
+        _schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         self.read_write_table_provider(table_reference).await
     }

--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -14,17 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use datafusion::sql::TableReference;
 use spicepod::component::{catalog as spicepod_catalog, params::Params};
 use std::collections::HashMap;
-
-use super::dataset::Dataset;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Catalog {
     pub provider: String,
     pub catalog_id: Option<String>,
-    pub name: TableReference,
+    pub name: String,
     pub params: HashMap<String, String>,
     pub dataset_params: HashMap<String, String>,
 }
@@ -33,14 +30,13 @@ impl TryFrom<spicepod_catalog::Catalog> for Catalog {
     type Error = crate::Error;
 
     fn try_from(catalog: spicepod_catalog::Catalog) -> std::result::Result<Self, Self::Error> {
-        let table_reference = Dataset::parse_table_reference(&catalog.name)?;
         let provider = Catalog::provider(&catalog.from);
         let catalog_id = Catalog::catalog_id(&catalog.from).map(String::from);
 
         Ok(Catalog {
             provider: provider.to_string(),
             catalog_id,
-            name: table_reference,
+            name: catalog.name,
             params: catalog
                 .params
                 .as_ref()
@@ -60,7 +56,7 @@ impl Catalog {
         Ok(Catalog {
             provider: Catalog::provider(from).to_string(),
             catalog_id: Catalog::catalog_id(from).map(String::from),
-            name: Dataset::parse_table_reference(name)?,
+            name: name.into(),
             params: HashMap::default(),
             dataset_params: HashMap::default(),
         })

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use acceleration::Engine;
+use arrow::datatypes::SchemaRef;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::util::column_reference;
 use snafu::prelude::*;
@@ -113,6 +114,7 @@ pub struct Dataset {
     pub time_format: Option<TimeFormat>,
     pub acceleration: Option<acceleration::Acceleration>,
     pub embeddings: Vec<ColumnEmbeddingConfig>,
+    schema: Option<SchemaRef>,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for Dataset {
@@ -143,6 +145,7 @@ impl TryFrom<spicepod_dataset::Dataset> for Dataset {
             time_format: dataset.time_format.map(TimeFormat::from),
             embeddings: dataset.embeddings,
             acceleration,
+            schema: None,
         })
     }
 }
@@ -160,7 +163,19 @@ impl Dataset {
             time_format: None,
             acceleration: None,
             embeddings: Vec::default(),
+            schema: None,
         })
+    }
+
+    #[must_use]
+    pub fn with_schema(mut self, schema: SchemaRef) -> Self {
+        self.schema = Some(schema);
+        self
+    }
+
+    #[must_use]
+    pub fn schema(&self) -> Option<SchemaRef> {
+        self.schema.clone()
     }
 
     #[must_use]

--- a/crates/runtime/src/dataconnector/clickhouse.rs
+++ b/crates/runtime/src/dataconnector/clickhouse.rs
@@ -109,12 +109,14 @@ impl DataConnector for Clickhouse {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        Ok(
-            Read::table_provider(&self.clickhouse_factory, dataset.path().into())
-                .await
-                .context(super::UnableToGetReadProviderSnafu {
-                    dataconnector: "clickhouse",
-                })?,
+        Ok(Read::table_provider(
+            &self.clickhouse_factory,
+            dataset.path().into(),
+            dataset.schema(),
         )
+        .await
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "clickhouse",
+        })?)
     }
 }

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -156,7 +156,7 @@ impl DataConnector for Databricks {
         let table_reference = TableReference::from(dataset.path());
         Ok(self
             .read_provider
-            .table_provider(table_reference)
+            .table_provider(table_reference, dataset.schema())
             .await
             .context(super::UnableToGetReadProviderSnafu {
                 dataconnector: "databricks",

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -97,25 +97,30 @@ impl DataConnector for Dremio {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        Ok(
-            Read::table_provider(&self.flight_factory, dataset.path().into())
-                .await
-                .context(super::UnableToGetReadProviderSnafu {
-                    dataconnector: "dremio",
-                })?,
+        Ok(Read::table_provider(
+            &self.flight_factory,
+            dataset.path().into(),
+            dataset.schema(),
         )
+        .await
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "dremio",
+        })?)
     }
 
     async fn read_write_provider(
         &self,
         dataset: &Dataset,
     ) -> Option<super::DataConnectorResult<Arc<dyn TableProvider>>> {
-        let read_write_result =
-            ReadWrite::table_provider(&self.flight_factory, dataset.path().into())
-                .await
-                .context(super::UnableToGetReadWriteProviderSnafu {
-                    dataconnector: "dremio",
-                });
+        let read_write_result = ReadWrite::table_provider(
+            &self.flight_factory,
+            dataset.path().into(),
+            dataset.schema(),
+        )
+        .await
+        .context(super::UnableToGetReadWriteProviderSnafu {
+            dataconnector: "dremio",
+        });
 
         Some(read_write_result)
     }

--- a/crates/runtime/src/dataconnector/duckdb.rs
+++ b/crates/runtime/src/dataconnector/duckdb.rs
@@ -110,10 +110,12 @@ impl DataConnector for DuckDB {
             });
         }
 
-        Ok(Read::table_provider(&self.duckdb_factory, path)
-            .await
-            .context(super::UnableToGetReadProviderSnafu {
-                dataconnector: "duckdb",
-            })?)
+        Ok(
+            Read::table_provider(&self.duckdb_factory, path, dataset.schema())
+                .await
+                .context(super::UnableToGetReadProviderSnafu {
+                    dataconnector: "duckdb",
+                })?,
+        )
     }
 }

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -84,12 +84,14 @@ impl DataConnector for FlightSQL {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        Ok(
-            Read::table_provider(&self.flightsql_factory, dataset.path().into())
-                .await
-                .context(super::UnableToGetReadProviderSnafu {
-                    dataconnector: "flightsql",
-                })?,
+        Ok(Read::table_provider(
+            &self.flightsql_factory,
+            dataset.path().into(),
+            dataset.schema(),
         )
+        .await
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "flightsql",
+        })?)
     }
 }

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -90,7 +90,7 @@ impl DataConnector for MySQL {
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         Ok(
-            Read::table_provider(&self.mysql_factory, dataset.path().into())
+            Read::table_provider(&self.mysql_factory, dataset.path().into(), dataset.schema())
                 .await
                 .context(super::UnableToGetReadProviderSnafu {
                     dataconnector: "mysql",

--- a/crates/runtime/src/dataconnector/odbc.rs
+++ b/crates/runtime/src/dataconnector/odbc.rs
@@ -91,7 +91,7 @@ where
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         Ok(
-            Read::table_provider(&self.odbc_factory, dataset.path().into())
+            Read::table_provider(&self.odbc_factory, dataset.path().into(), dataset.schema())
                 .await
                 .context(super::UnableToGetReadProviderSnafu {
                     dataconnector: "odbc",

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -104,7 +104,13 @@ impl DataConnector for Postgres {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        match Read::table_provider(&self.postgres_factory, dataset.path().into()).await {
+        match Read::table_provider(
+            &self.postgres_factory,
+            dataset.path().into(),
+            dataset.schema(),
+        )
+        .await
+        {
             Ok(provider) => Ok(provider),
             Err(e) => {
                 if let Some(err_source) = e.source() {

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -119,10 +119,12 @@ impl DataConnector for Snowflake {
             })
             .join(".");
 
-        Ok(Read::table_provider(&self.table_factory, path.into())
-            .await
-            .context(super::UnableToGetReadProviderSnafu {
-                dataconnector: "snowflake",
-            })?)
+        Ok(
+            Read::table_provider(&self.table_factory, path.into(), dataset.schema())
+                .await
+                .context(super::UnableToGetReadProviderSnafu {
+                    dataconnector: "snowflake",
+                })?,
+        )
     }
 }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -110,6 +110,7 @@ impl DataConnector for SpiceAI {
         Ok(Read::table_provider(
             &self.flight_factory,
             SpiceAI::spice_dataset_path(dataset).into(),
+            dataset.schema(),
         )
         .await
         .context(super::UnableToGetReadProviderSnafu {
@@ -124,6 +125,7 @@ impl DataConnector for SpiceAI {
         let read_write_result = ReadWrite::table_provider(
             &self.flight_factory,
             SpiceAI::spice_dataset_path(dataset).into(),
+            dataset.schema(),
         )
         .await
         .context(super::UnableToGetReadWriteProviderSnafu {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -167,6 +167,9 @@ pub enum Error {
     #[snafu(display("Table {schema}.{table} not registered"))]
     TableMissing { schema: String, table: String },
 
+    #[snafu(display("Catalog already exists: {catalog}"))]
+    CatalogAlreadyExists { catalog: String },
+
     #[snafu(display("Unable to get object store configuration: {source}"))]
     UnableToGetSchemaTable {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -337,6 +340,19 @@ impl DataFusion {
                 .map_err(|_| Error::UnableToLockDataWriters {})?
                 .insert(table_name);
         }
+
+        Ok(())
+    }
+
+    pub fn register_catalog(&self, name: &str, catalog: Arc<dyn CatalogProvider>) -> Result<()> {
+        if self.ctx.catalog(name).is_some() {
+            CatalogAlreadyExistsSnafu {
+                catalog: name.to_string(),
+            }
+            .fail()?;
+        }
+
+        self.ctx.register_catalog(name, catalog);
 
         Ok(())
     }

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -41,6 +41,10 @@ impl Display for ComponentStatus {
     }
 }
 
+pub fn update_catalog(catalog_name: impl Into<String>, status: ComponentStatus) {
+    gauge!("catalog/status", "catalog" => catalog_name.into()).set(f64::from(status as u32));
+}
+
 pub fn update_dataset(dataset: &TableReference, status: ComponentStatus) {
     let ds_name = dataset.to_string();
     gauge!("dataset/status", "dataset" => ds_name).set(f64::from(status as u32));

--- a/crates/spice_cloud/Cargo.toml
+++ b/crates/spice_cloud/Cargo.toml
@@ -19,3 +19,4 @@ snafu.workspace = true
 spicepod = { path = "../spicepod" }
 tokio.workspace = true
 tracing.workspace = true
+futures.workspace = true

--- a/crates/spice_cloud/src/catalog.rs
+++ b/crates/spice_cloud/src/catalog.rs
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use datafusion::catalog::{schema::SchemaProvider, CatalogProvider};
+use runtime::dataconnector::DataConnector;
+use serde::Deserialize;
+use snafu::prelude::*;
+use std::{any::Any, sync::Arc};
+
+use crate::SpiceExtension;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to retrieve available datasets from Spice AI: {source}"))]
+    UnableToRetrieveDatasets { source: super::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct SpiceAICatalogProvider {
+    datasets: Vec<DatasetSchemaResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DatasetSchemaResponse {
+    name: String,
+}
+
+impl SpiceAICatalogProvider {
+    /// Creates a new instance of the [`SpiceAICatalogProvider`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the list of available datasets cannot be retrieved from the Spice AI platform.
+    pub async fn try_new(
+        extension: &SpiceExtension,
+        data_connector: Arc<dyn DataConnector>,
+    ) -> Result<Self> {
+        let datasets: Vec<DatasetSchemaResponse> = extension
+            .get_json("/v1/schemas")
+            .await
+            .context(UnableToRetrieveDatasetsSnafu)?;
+
+        Ok(Self { datasets })
+    }
+}
+
+impl CatalogProvider for SpiceAICatalogProvider {
+    /// Returns the catalog provider as [`Any`]
+    /// so that it can be downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Retrieves the list of available schema names in this catalog.
+    fn schema_names(&self) -> Vec<String> {
+        todo!();
+    }
+
+    /// Retrieves a specific schema from the catalog by name, provided it exists.
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        todo!();
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     #[tokio::test]
+//     async fn test_creation() {
+//         let spice_extension = SpiceExtension::default();
+//         let provider = SpiceAICatalogProvider::try_new(&spice_extension)
+//             .await
+//             .expect("to create provider");
+
+//         dbg!(&provider.datasets);
+//     }
+// }

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -1,8 +1,24 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use datafusion::{datasource::TableProvider, sql::TableReference};
-use serde::Deserialize;
+use datafusion::{catalog::CatalogProvider, datasource::TableProvider, sql::TableReference};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use snafu::prelude::*;
 
@@ -14,12 +30,15 @@ use runtime::{
         Dataset, Mode, TimeFormat,
     },
     dataaccelerator::{self, create_accelerator_table},
-    dataconnector::{create_new_connector, DataConnectorError},
-    extension::{Extension, ExtensionFactory, ExtensionManifest, Result},
+    dataconnector::{create_new_connector, DataConnector, DataConnectorError},
+    extension::{Error as ExtensionError, Extension, ExtensionFactory, ExtensionManifest, Result},
     secrets::Secret,
     spice_metrics::get_metrics_table_reference,
     Runtime,
 };
+
+pub mod catalog;
+pub mod schema;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -54,12 +73,27 @@ pub enum Error {
 
 pub struct SpiceExtension {
     manifest: ExtensionManifest,
+    api_key: String,
 }
 
 impl SpiceExtension {
     #[must_use]
     pub fn new(manifest: ExtensionManifest) -> Self {
-        SpiceExtension { manifest }
+        SpiceExtension {
+            manifest,
+            api_key: String::new(),
+        }
+    }
+
+    fn metrics_enabled(&self) -> bool {
+        if !self.manifest.enabled {
+            return false;
+        }
+
+        self.manifest
+            .params
+            .get("metrics")
+            .map_or_else(|| false, |v| v.eq_ignore_ascii_case("true"))
     }
 
     fn spice_http_url(&self) -> String {
@@ -88,19 +122,43 @@ impl SpiceExtension {
         Ok(api_key.to_string())
     }
 
-    async fn connect(&self, runtime: &Runtime) -> Result<SpiceCloudConnectResponse, Error> {
-        let api_key = self.get_spice_api_key(runtime).await?;
+    async fn connect(&self) -> Result<SpiceCloudConnectResponse, Error> {
+        self.post_json("/v1/connect", json!({})).await
+    }
+
+    async fn post_json<Req: Serialize, Resp: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: Req,
+    ) -> Result<Resp, Error> {
         let client = reqwest::Client::new();
         let response = client
-            .post(format!("{}/v1/connect", self.spice_http_url()))
-            .json(&json!({}))
+            .post(format!("{}{path}", self.spice_http_url()))
+            .json(&body)
             .header("Content-Type", "application/json")
-            .header("X-API-Key", api_key)
+            .header("X-API-Key", &self.api_key)
             .send()
             .await
             .context(UnableToConnectToSpiceCloudSnafu)?;
 
-        let response: SpiceCloudConnectResponse = response
+        let response: Resp = response
+            .json()
+            .await
+            .context(UnableToConnectToSpiceCloudSnafu)?;
+
+        Ok(response)
+    }
+
+    async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T, Error> {
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}{path}", self.spice_http_url()))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context(UnableToConnectToSpiceCloudSnafu)?;
+
+        let response: T = response
             .json()
             .await
             .context(UnableToConnectToSpiceCloudSnafu)?;
@@ -109,7 +167,7 @@ impl SpiceExtension {
     }
 
     async fn register_runtime_metrics_table(
-        &mut self,
+        &self,
         runtime: &Runtime,
         from: String,
         secret: Secret,
@@ -154,6 +212,36 @@ impl SpiceExtension {
 
         Ok(())
     }
+
+    async fn start_metrics(&self, runtime: &Runtime) -> Result<()> {
+        if !self.metrics_enabled() {
+            return Ok(());
+        }
+
+        let secret = self
+            .get_spice_secret(runtime)
+            .await
+            .boxed()
+            .map_err(|e| runtime::extension::Error::UnableToStartExtension { source: e })?;
+
+        let connection = self
+            .connect()
+            .await
+            .boxed()
+            .map_err(|e| runtime::extension::Error::UnableToStartExtension { source: e })?;
+
+        let spiceai_metrics_dataset_path = format!(
+            "spice.ai/{}/{}/{}",
+            connection.org_name, connection.app_name, connection.metrics_dataset_name
+        );
+
+        let from = spiceai_metrics_dataset_path.to_string();
+        self.register_runtime_metrics_table(runtime, from.clone(), secret)
+            .await?;
+        tracing::info!("Enabled metrics sync from runtime.metrics to {from}");
+
+        Ok(())
+    }
 }
 
 impl Default for SpiceExtension {
@@ -168,45 +256,36 @@ impl Extension for SpiceExtension {
         "spice_cloud"
     }
 
-    async fn initialize(&mut self, _runtime: &mut Runtime) -> Result<()> {
+    async fn initialize(&mut self, runtime: &Runtime) -> Result<()> {
         if !self.manifest.enabled {
             return Ok(());
         }
+
+        let api_key = self
+            .get_spice_api_key(runtime)
+            .await
+            .boxed()
+            .map_err(|source| ExtensionError::UnableToInitializeExtension { source })?;
+        self.api_key = api_key;
 
         Ok(())
     }
 
-    async fn on_start(&mut self, runtime: &Runtime) -> Result<()> {
-        if !self.manifest.enabled {
-            return Ok(());
-        }
-
-        let secret = self
-            .get_spice_secret(runtime)
-            .await
-            .boxed()
-            .map_err(|e| runtime::extension::Error::UnableToStartExtension { source: e })?;
-
-        let connection = self
-            .connect(runtime)
-            .await
-            .boxed()
-            .map_err(|e| runtime::extension::Error::UnableToStartExtension { source: e })?;
-
-        let spiceai_metrics_dataset_path = format!(
-            "spice.ai/{}/{}/{}",
-            connection.org_name, connection.app_name, connection.metrics_dataset_name
-        );
-
-        let from = spiceai_metrics_dataset_path.to_string();
-        self.register_runtime_metrics_table(runtime, from.clone(), secret)
-            .await?;
-        tracing::info!("Enabled metrics sync from runtime.metrics to {from}",);
+    async fn on_start(&self, runtime: &Runtime) -> Result<()> {
+        self.start_metrics(runtime).await?;
 
         Ok(())
+    }
+
+    async fn catalog_provider(
+        &self,
+        data_connector: Arc<dyn DataConnector>,
+    ) -> Option<Result<Arc<dyn CatalogProvider>>> {
+        None
     }
 }
 
+#[derive(Clone, Default)]
 pub struct SpiceExtensionFactory {
     manifest: ExtensionManifest,
 }
@@ -222,6 +301,7 @@ impl ExtensionFactory for SpiceExtensionFactory {
     fn create(&self) -> Box<dyn Extension> {
         Box::new(SpiceExtension {
             manifest: self.manifest.clone(),
+            api_key: String::new(),
         })
     }
 }

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use catalog::SpiceAICatalogProvider;
 use datafusion::{catalog::CatalogProvider, datasource::TableProvider, sql::TableReference};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
@@ -281,7 +282,13 @@ impl Extension for SpiceExtension {
         &self,
         data_connector: Arc<dyn DataConnector>,
     ) -> Option<Result<Arc<dyn CatalogProvider>>> {
-        None
+        Some(
+            SpiceAICatalogProvider::try_new(self, data_connector)
+                .await
+                .map(|c| Arc::new(c) as Arc<dyn CatalogProvider>)
+                .boxed()
+                .map_err(|source| ExtensionError::UnableToGetCatalogProvider { source }),
+        )
     }
 }
 

--- a/crates/spice_cloud/src/schema.rs
+++ b/crates/spice_cloud/src/schema.rs
@@ -18,12 +18,54 @@ use async_trait::async_trait;
 use datafusion::{
     catalog::schema::SchemaProvider, datasource::TableProvider, error::DataFusionError,
 };
-use runtime::{component::dataset::Dataset, dataconnector::DataConnector};
+use futures::{stream::FuturesUnordered, StreamExt};
+use runtime::{
+    component::dataset::Dataset,
+    dataconnector::{DataConnector, DataConnectorError},
+};
 use std::{any::Any, collections::HashMap, sync::Arc};
+use tracing::instrument;
 
 pub struct SpiceAISchemaProvider {
-    tables: HashMap<String, Dataset>,
-    data_connector: Arc<dyn DataConnector>,
+    tables: HashMap<String, Arc<dyn TableProvider>>,
+}
+
+impl SpiceAISchemaProvider {
+    /// Creates a new instance of the [`SpiceAISchemaProvider`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the schema cannot be created.
+    #[instrument(level = "debug", skip(data_connector, tables))]
+    pub async fn try_new(
+        schema: &str,
+        data_connector: Arc<dyn DataConnector>,
+        tables: HashMap<String, Dataset>,
+    ) -> Result<Self, DataConnectorError> {
+        let futures: Vec<_> = tables
+            .into_iter()
+            .map(|(name, dataset)| {
+                let data_connector = Arc::clone(&data_connector);
+                async move {
+                    let table_provider = data_connector.read_provider(&dataset).await?;
+                    Ok((name, table_provider))
+                }
+            })
+            .collect();
+
+        tracing::debug!("Creating {} tables for schema '{schema}'", futures.len());
+        let mut futures_unordered = FuturesUnordered::new();
+        futures_unordered.extend(futures);
+
+        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
+        while let Some(table_result) = futures_unordered.next().await {
+            let (name, table_provider) = table_result?;
+            tables.insert(name, table_provider);
+            tracing::debug!("{} tables processed", tables.len());
+        }
+
+        Ok(SpiceAISchemaProvider { tables })
+    }
 }
 
 #[async_trait]
@@ -42,19 +84,15 @@ impl SchemaProvider for SpiceAISchemaProvider {
     /// Retrieves a specific table from the schema by name, if it exists,
     /// otherwise returns `None`.
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
-        let Some(dataset) = self.tables.get(name) else {
+        let Some(table) = self.tables.get(name) else {
             return Ok(None);
         };
 
-        self.data_connector
-            .read_provider(dataset)
-            .await
-            .map_err(|e| DataFusionError::Execution(e.to_string()))
-            .map(Some)
+        Ok(Some(Arc::clone(table)))
     }
 
     /// Returns true if table exist in the schema provider, false otherwise.
-    fn table_exist(&self, _name: &str) -> bool {
-        todo!();
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables.contains_key(name)
     }
 }

--- a/crates/spice_cloud/src/schema.rs
+++ b/crates/spice_cloud/src/schema.rs
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use async_trait::async_trait;
+use datafusion::{
+    catalog::schema::SchemaProvider, datasource::TableProvider, error::DataFusionError,
+};
+use runtime::{component::dataset::Dataset, dataconnector::DataConnector};
+use std::{any::Any, collections::HashMap, sync::Arc};
+
+pub struct SpiceAISchemaProvider {
+    tables: HashMap<String, Dataset>,
+    data_connector: Arc<dyn DataConnector>,
+}
+
+#[async_trait]
+impl SchemaProvider for SpiceAISchemaProvider {
+    /// Returns this `SchemaProvider` as [`Any`] so that it can be downcast to a
+    /// specific implementation.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Retrieves the list of available table names in this schema.
+    fn table_names(&self) -> Vec<String> {
+        self.tables.keys().cloned().collect()
+    }
+
+    /// Retrieves a specific table from the schema by name, if it exists,
+    /// otherwise returns `None`.
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
+        let Some(dataset) = self.tables.get(name) else {
+            return Ok(None);
+        };
+
+        self.data_connector
+            .read_provider(dataset)
+            .await
+            .map_err(|e| DataFusionError::Execution(e.to_string()))
+            .map(Some)
+    }
+
+    /// Returns true if table exist in the schema provider, false otherwise.
+    fn table_exist(&self, _name: &str) -> bool {
+        todo!();
+    }
+}

--- a/crates/spice_cloud/src/schema.rs
+++ b/crates/spice_cloud/src/schema.rs
@@ -61,7 +61,7 @@ impl SpiceAISchemaProvider {
         while let Some(table_result) = futures_unordered.next().await {
             let (name, table_provider) = table_result?;
             tables.insert(name, table_provider);
-            tracing::debug!("{} tables processed", tables.len());
+            tracing::trace!("{} tables processed", tables.len());
         }
 
         Ok(SpiceAISchemaProvider { tables })

--- a/crates/spice_cloud/src/schema.rs
+++ b/crates/spice_cloud/src/schema.rs
@@ -82,7 +82,7 @@ impl SchemaProvider for SpiceAISchemaProvider {
     }
 
     /// Retrieves a specific table from the schema by name, if it exists,
-    /// otherwise returns `None`.
+    /// otherwise returns `Ok(None)`.
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
         let Some(table) = self.tables.get(name) else {
             return Ok(None);


### PR DESCRIPTION
## 🗣 Description

Implements a Catalog Provider for the hosted Spice.ai data platform. By performing a `spice login` and then creating a Spicepod with:

```yaml
version: v1beta1
kind: Spicepod
name: catalog_test

catalogs:
  - from: spiceai
    name: spiceai
```

Spice will now load all of the tables under the `spiceai` namespace and make them available for federated query.

Here is a screenshot of DBeaver connected to my local Spice runtime with the spiceai catalog loaded:
<img width="364" alt="Screenshot 2024-07-10 at 5 22 51 PM" src="https://github.com/spiceai/spiceai/assets/879445/7db0ce49-db12-4bbc-9f96-e009beda0001">

### ⚠️ Breaking Change
I chose to put the logic that implements the Catalog Provider into the `spice_cloud` extension. Normally this extension is only loaded if the user adds an `extension` field to their yaml like this:

```yaml
version: v1beta1
kind: Spicepod
name: catalog

extensions:
  spice_cloud:
    enabled: true
    params:
       <optional params>
```

But I've allowed that extension to "autoload" if its required and it isn't explicitly loaded.

Normally when the `spice_cloud` extension is loaded, it will register a metrics table to start replicating to the Spice.ai cloud platform. I didn't want that behavior by default, so I made a breaking change to only enable the metrics if `metrics: "true"` is specified in the params. i.e.

```yaml
extensions:
  spice_cloud:
    enabled: true
    params:
       metrics: "true"
```

### Details
- Added ` .with_autoload_extensions` to the Runtime builder to specify which extensions we want to autoload if not present. I've added the `spice_cloud` extension to this list.
- In order to prevent the default schema inference behavior, I added a `.with_schema` method to the runtime `Dataset` struct. I modified the `Read` and `ReadWrite` traits to accept an optional schema. If a schema is specified, then we can skip the schema inference step (which saves a lot of time if we're loading a lot of tables)
- I added a `catalog_provider` method to the `DataConnector` trait. It returns None for all connectors except SpiceAI right now.
- I noticed the `ReadWrite` trait was implemented for Databricks - this isn't correct as we don't support writing to Databricks via Spark Connect, so while I was in the code I decided to remove it.

## 🔨 Related Issues

Part of #1810

## 🤔 Concerns

The normal way we do schema inference was too slow - so I took the limited schema information returned by the `https://data.spiceai.io/v1/schemas` API and used that to construct Arrow schemas. This isn't perfect, since there isn't enough information to reconstruct the full type information - but it works well enough in practice. Once we implement FlightSQL support on the Spice AI cloud side, then we could remove that and replace it with a FlightSQL-based schema inference.