### PR TITLE
fix: validate time column and time format when constructing accelerated table refresh

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -116,6 +116,9 @@ pub enum Error {
         "The type of the primary key '{data_type}' is not yet supported for change deletion."
     ))]
     PrimaryKeyTypeNotYetSupported { data_type: String },
+
+    #[snafu(display("{source}"))]
+    InvalidTimeColumnTimeFormat { source: refresh::Error },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -143,7 +143,7 @@ impl Refresh {
                 }
             }
             arrow::datatypes::DataType::Timestamp(_, Some(_)) => {
-                if time_format != TimeFormat::Timestampz {
+                if time_format != TimeFormat::Timestamptz {
                     invalid = true;
                 }
             }
@@ -1165,7 +1165,7 @@ mod tests {
             TimeFormat::UnixSeconds,
             TimeFormat::UnixMillis,
             TimeFormat::Timestamp,
-            TimeFormat::Timestampz,
+            TimeFormat::Timestamptz,
         ] {
             let refresh = Refresh::new(
                 Some("time".to_string()),
@@ -1188,7 +1188,7 @@ mod tests {
     fn test_validate_time_column_when_unix_timestamp_mismatch() {
         for format in [
             TimeFormat::Timestamp,
-            TimeFormat::Timestampz,
+            TimeFormat::Timestamptz,
             TimeFormat::ISO8601,
         ] {
             let refresh = Refresh::new(
@@ -1217,7 +1217,7 @@ mod tests {
         for format in [
             TimeFormat::UnixMillis,
             TimeFormat::UnixSeconds,
-            TimeFormat::Timestampz,
+            TimeFormat::Timestamptz,
             TimeFormat::ISO8601,
         ] {
             let refresh = Refresh::new(
@@ -1335,7 +1335,7 @@ mod tests {
     fn test_validate_time_column_when_timestampz_match() {
         let refresh = Refresh::new(
             Some("time".to_string()),
-            Some(TimeFormat::Timestampz),
+            Some(TimeFormat::Timestamptz),
             None,
             None,
             RefreshMode::Full,

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -38,7 +38,7 @@ use super::refresh_task_runner::RefreshTaskRunner;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display(r#"time_column "{time_column}" in dataset {table_name} has data type "{actual_time_format}", but time_format is configured as "{expected_time_format}""#))]
+    #[snafu(display(r#"time_column '{time_column}' in dataset {table_name} has data type '{actual_time_format}', but time_format is configured as '{expected_time_format}'"#))]
     TimeFormatMismatch {
         table_name: String,
         time_column: String,
@@ -46,7 +46,7 @@ pub enum Error {
         actual_time_format: String,
     },
 
-    #[snafu(display(r#"time_column "{time_column}" is not found in dataset {table_name}"#))]
+    #[snafu(display(r#"time_column '{time_column}' is not found in dataset {table_name}"#))]
     NoTimeColumnFound {
         table_name: String,
         time_column: String,

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -46,7 +46,7 @@ pub enum Error {
         actual_time_format: String,
     },
 
-    #[snafu(display(r#"time_column '{time_column}' is not found in dataset {table_name}"#))]
+    #[snafu(display(r#"time_column '{time_column}' was not found in dataset {table_name}"#))]
     NoTimeColumnFound {
         table_name: String,
         time_column: String,

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1242,7 +1242,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_time_column_when_timestampz_mismatch() {
+    fn test_validate_time_column_when_timestamptz_mismatch() {
         for format in [
             TimeFormat::UnixMillis,
             TimeFormat::UnixSeconds,
@@ -1332,7 +1332,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_time_column_when_timestampz_match() {
+    fn test_validate_time_column_when_timestamptz_match() {
         let refresh = Refresh::new(
             Some("time".to_string()),
             Some(TimeFormat::Timestamptz),

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -21,11 +21,13 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::accelerated_table::refresh_task::RefreshTask;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::TimeFormat;
+use arrow::datatypes::Schema;
 use cache::QueryResultsCacheProvider;
 use data_components::cdc::ChangesStream;
 use datafusion::common::TableReference;
 use datafusion::datasource::TableProvider;
 use futures::future::BoxFuture;
+use snafu::prelude::*;
 use tokio::select;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot;
@@ -33,6 +35,23 @@ use tokio::sync::RwLock;
 use tokio::time::sleep;
 
 use super::refresh_task_runner::RefreshTaskRunner;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(r#"time_column "{time_column}" in dataset {table_name} has data type "{actual_time_format}", but time_format is configured as "{expected_time_format}""#))]
+    TimeFormatMismatch {
+        table_name: String,
+        time_column: String,
+        expected_time_format: String,
+        actual_time_format: String,
+    },
+
+    #[snafu(display(r#"time_column "{time_column}" is not found in dataset {table_name}"#))]
+    NoTimeColumnFound {
+        table_name: String,
+        time_column: String,
+    },
+}
 
 #[derive(Clone, Debug)]
 pub struct Refresh {
@@ -75,6 +94,98 @@ impl Refresh {
         self.refresh_retry_enabled = enabled;
         self.refresh_retry_max_attempts = max_attempts;
         self
+    }
+
+    pub(crate) fn validate_time_format(
+        &self,
+        dataset_name: String,
+        schema: &Arc<Schema>,
+    ) -> Result<(), Error> {
+        let Some(time_column) = self.time_column.clone() else {
+            return Ok(());
+        };
+
+        let Some((_, field)) = schema.column_with_name(&time_column) else {
+            return Err(Error::NoTimeColumnFound {
+                table_name: dataset_name,
+                time_column,
+            });
+        };
+
+        let time_format = self.time_format.unwrap_or(TimeFormat::Timestamp);
+        let data_type = field.data_type().clone();
+
+        let mut invalid = false;
+        match data_type {
+            arrow::datatypes::DataType::Utf8 | arrow::datatypes::DataType::LargeUtf8 => {
+                if time_format != TimeFormat::ISO8601 {
+                    invalid = true;
+                }
+            }
+            arrow::datatypes::DataType::Int8
+            | arrow::datatypes::DataType::Int16
+            | arrow::datatypes::DataType::Int32
+            | arrow::datatypes::DataType::Int64
+            | arrow::datatypes::DataType::UInt8
+            | arrow::datatypes::DataType::UInt16
+            | arrow::datatypes::DataType::UInt32
+            | arrow::datatypes::DataType::UInt64
+            | arrow::datatypes::DataType::Float16
+            | arrow::datatypes::DataType::Float32
+            | arrow::datatypes::DataType::Float64 => {
+                if time_format != TimeFormat::UnixSeconds && time_format != TimeFormat::UnixMillis {
+                    invalid = true;
+                }
+            }
+            arrow::datatypes::DataType::Timestamp(_, None) => {
+                if time_format != TimeFormat::Timestamp {
+                    invalid = true;
+                }
+            }
+            arrow::datatypes::DataType::Timestamp(_, Some(_)) => {
+                if time_format != TimeFormat::Timestampz {
+                    invalid = true;
+                }
+            }
+            arrow::datatypes::DataType::Null
+            | arrow::datatypes::DataType::Boolean
+            | arrow::datatypes::DataType::Date32
+            | arrow::datatypes::DataType::Date64
+            | arrow::datatypes::DataType::Time32(_)
+            | arrow::datatypes::DataType::Time64(_)
+            | arrow::datatypes::DataType::Duration(_)
+            | arrow::datatypes::DataType::Interval(_)
+            | arrow::datatypes::DataType::Binary
+            | arrow::datatypes::DataType::FixedSizeBinary(_)
+            | arrow::datatypes::DataType::LargeBinary
+            | arrow::datatypes::DataType::BinaryView
+            | arrow::datatypes::DataType::Utf8View
+            | arrow::datatypes::DataType::List(_)
+            | arrow::datatypes::DataType::ListView(_)
+            | arrow::datatypes::DataType::FixedSizeList(_, _)
+            | arrow::datatypes::DataType::LargeList(_)
+            | arrow::datatypes::DataType::LargeListView(_)
+            | arrow::datatypes::DataType::Struct(_)
+            | arrow::datatypes::DataType::Union(_, _)
+            | arrow::datatypes::DataType::Dictionary(_, _)
+            | arrow::datatypes::DataType::Decimal128(_, _)
+            | arrow::datatypes::DataType::Decimal256(_, _)
+            | arrow::datatypes::DataType::Map(_, _)
+            | arrow::datatypes::DataType::RunEndEncoded(_, _) => {
+                invalid = true;
+            }
+        };
+
+        if invalid {
+            return Err(Error::TimeFormatMismatch {
+                table_name: dataset_name,
+                time_column,
+                expected_time_format: time_format.to_string(),
+                actual_time_format: data_type.to_string(),
+            });
+        };
+
+        Ok(())
     }
 }
 
@@ -521,7 +632,7 @@ mod tests {
 
             let refresh = Refresh::new(
                 Some("time_in_string".to_string()),
-                None,
+                Some(TimeFormat::ISO8601),
                 None,
                 None,
                 RefreshMode::Append,
@@ -796,15 +907,6 @@ mod tests {
         test(
             vec![4, 5, 6, 7, 8, 9, 10],
             vec![1, 2, 3, 9],
-            7, // 1, 2, 3, 7, 8, 9, 10
-            None,
-            Some(Duration::from_secs(3)),
-            "should default to time unix seconds",
-        )
-        .await;
-        test(
-            vec![4, 5, 6, 7, 8, 9, 10],
-            vec![1, 2, 3, 9],
             10, // all the data
             Some(TimeFormat::UnixMillis),
             Some(Duration::from_secs(3)),
@@ -1008,16 +1110,6 @@ mod tests {
         )
         .await;
 
-        test(
-            vec![4, 5, 6, 7, 8, 9, 10],
-            vec![1, 2, 3, 9],
-            7, // 1, 2, 3, 7, 8, 9, 10
-            None,
-            Some(Duration::from_secs(3)),
-            false,
-            "should default to time unix seconds",
-        )
-        .await;
         test(
             vec![4, 5, 6, 7, 8, 9, 10],
             vec![1, 2, 3, 9],

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1272,21 +1272,19 @@ mod tests {
 
     #[test]
     fn test_validate_time_column_when_iso8601_match() {
-        for format in [TimeFormat::ISO8601] {
-            let refresh = Refresh::new(
-                Some("time".to_string()),
-                Some(format),
-                None,
-                None,
-                RefreshMode::Full,
-                None,
-                None,
-            );
-            let schema = Arc::new(Schema::new(vec![Field::new("time", DataType::Utf8, false)]));
-            assert!(refresh
-                .validate_time_format("dataset_name".to_string(), &schema)
-                .is_ok());
-        }
+        let refresh = Refresh::new(
+            Some("time".to_string()),
+            Some(TimeFormat::ISO8601),
+            None,
+            None,
+            RefreshMode::Full,
+            None,
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new("time", DataType::Utf8, false)]));
+        assert!(refresh
+            .validate_time_format("dataset_name".to_string(), &schema)
+            .is_ok());
     }
 
     #[test]
@@ -1314,47 +1312,43 @@ mod tests {
 
     #[test]
     fn test_validate_time_column_when_timestamp_match() {
-        for format in [TimeFormat::Timestamp] {
-            let refresh = Refresh::new(
-                Some("time".to_string()),
-                Some(format),
-                None,
-                None,
-                RefreshMode::Full,
-                None,
-                None,
-            );
-            let schema = Arc::new(Schema::new(vec![Field::new(
-                "time",
-                DataType::Timestamp(arrow::datatypes::TimeUnit::Second, None),
-                false,
-            )]));
-            assert!(refresh
-                .validate_time_format("dataset_name".to_string(), &schema)
-                .is_ok());
-        }
+        let refresh = Refresh::new(
+            Some("time".to_string()),
+            Some(TimeFormat::Timestamp),
+            None,
+            None,
+            RefreshMode::Full,
+            None,
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "time",
+            DataType::Timestamp(arrow::datatypes::TimeUnit::Second, None),
+            false,
+        )]));
+        assert!(refresh
+            .validate_time_format("dataset_name".to_string(), &schema)
+            .is_ok());
     }
 
     #[test]
     fn test_validate_time_column_when_timestampz_match() {
-        for format in [TimeFormat::Timestampz] {
-            let refresh = Refresh::new(
-                Some("time".to_string()),
-                Some(format),
-                None,
-                None,
-                RefreshMode::Full,
-                None,
-                None,
-            );
-            let schema = Arc::new(Schema::new(vec![Field::new(
-                "time",
-                DataType::Timestamp(arrow::datatypes::TimeUnit::Second, Some("+00:00".into())),
-                false,
-            )]));
-            assert!(refresh
-                .validate_time_format("dataset_name".to_string(), &schema)
-                .is_ok());
-        }
+        let refresh = Refresh::new(
+            Some("time".to_string()),
+            Some(TimeFormat::Timestampz),
+            None,
+            None,
+            RefreshMode::Full,
+            None,
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "time",
+            DataType::Timestamp(arrow::datatypes::TimeUnit::Second, Some("+00:00".into())),
+            false,
+        )]));
+        assert!(refresh
+            .validate_time_format("dataset_name".to_string(), &schema)
+            .is_ok());
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -638,6 +638,10 @@ impl RefreshTask {
         let ctx = self.refresh_df_context();
         let refresh = self.refresh.read().await;
 
+        refresh
+            .validate_time_format(self.dataset_name.to_string(), &self.accelerator.schema())
+            .context(super::InvalidTimeColumnTimeFormatSnafu)?;
+
         let column =
             refresh
                 .time_column
@@ -693,10 +697,11 @@ impl RefreshTask {
                 Some(TimeFormat::UnixMillis) => {
                     value *= 1_000_000;
                 }
-                Some(TimeFormat::UnixSeconds) | None => {
+                Some(TimeFormat::UnixSeconds) => {
                     value *= 1_000_000_000;
                 }
-                Some(TimeFormat::ISO8601) => (),
+                Some(TimeFormat::ISO8601 | TimeFormat::Timestamp | TimeFormat::Timestampz)
+                | None => unreachable!(),
             }
         };
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -700,7 +700,7 @@ impl RefreshTask {
                 Some(TimeFormat::UnixSeconds) => {
                     value *= 1_000_000_000;
                 }
-                Some(TimeFormat::ISO8601 | TimeFormat::Timestamp | TimeFormat::Timestampz)
+                Some(TimeFormat::ISO8601 | TimeFormat::Timestamp | TimeFormat::Timestamptz)
                 | None => unreachable!(),
             }
         };

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -701,7 +701,7 @@ impl RefreshTask {
                     value *= 1_000_000_000;
                 }
                 Some(TimeFormat::ISO8601 | TimeFormat::Timestamp | TimeFormat::Timestamptz)
-                | None => unreachable!(),
+                | None => unreachable!("refresh.validate_time_format should've returned error"),
             }
         };
 

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -80,6 +80,8 @@ impl From<spicepod_dataset::Mode> for Mode {
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum TimeFormat {
     #[default]
+    Timestamp,
+    Timestampz,
     UnixSeconds,
     UnixMillis,
     ISO8601,
@@ -91,6 +93,8 @@ impl From<spicepod_dataset::TimeFormat> for TimeFormat {
             spicepod_dataset::TimeFormat::UnixSeconds => TimeFormat::UnixSeconds,
             spicepod_dataset::TimeFormat::UnixMillis => TimeFormat::UnixMillis,
             spicepod_dataset::TimeFormat::ISO8601 => TimeFormat::ISO8601,
+            spicepod_dataset::TimeFormat::Timestamp => TimeFormat::Timestamp,
+            spicepod_dataset::TimeFormat::Timestampz => TimeFormat::Timestampz,
         }
     }
 }

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -81,7 +81,7 @@ impl From<spicepod_dataset::Mode> for Mode {
 pub enum TimeFormat {
     #[default]
     Timestamp,
-    Timestampz,
+    Timestamptz,
     UnixSeconds,
     UnixMillis,
     ISO8601,
@@ -94,7 +94,7 @@ impl From<spicepod_dataset::TimeFormat> for TimeFormat {
             spicepod_dataset::TimeFormat::UnixMillis => TimeFormat::UnixMillis,
             spicepod_dataset::TimeFormat::ISO8601 => TimeFormat::ISO8601,
             spicepod_dataset::TimeFormat::Timestamp => TimeFormat::Timestamp,
-            spicepod_dataset::TimeFormat::Timestampz => TimeFormat::Timestampz,
+            spicepod_dataset::TimeFormat::Timestamptz => TimeFormat::Timestamptz,
         }
     }
 }

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -19,6 +19,7 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
+use crate::accelerated_table::refresh;
 use crate::accelerated_table::{refresh::Refresh, AcceleratedTable, Retention};
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::{Dataset, Mode};
@@ -182,6 +183,9 @@ pub enum Error {
     UnableToCreateStreamingUpdate {
         source: datafusion::error::DataFusionError,
     },
+
+    #[snafu(display("{source}"))]
+    InvalidTimeColumnTimeFormat { source: refresh::Error },
 }
 
 pub enum Table {
@@ -551,7 +555,7 @@ impl DataFusion {
 
         let accelerated_table_provider = create_accelerator_table(
             dataset.name.clone(),
-            source_schema,
+            Arc::clone(&source_schema),
             source_table_provider.constraints(),
             &acceleration_settings,
             acceleration_secret,
@@ -579,6 +583,10 @@ impl DataFusion {
             dataset.refresh_retry_enabled(),
             dataset.refresh_retry_max_attempts(),
         );
+
+        refresh
+            .validate_time_format(dataset.name.to_string(), &source_schema)
+            .context(InvalidTimeColumnTimeFormatSnafu)?;
 
         let mut accelerated_table_builder = AcceleratedTable::builder(
             dataset.name.clone(),

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -35,7 +35,7 @@ pub enum Mode {
 pub enum TimeFormat {
     #[default]
     Timestamp,
-    Timestampz,
+    Timestamptz,
     UnixSeconds,
     UnixMillis,
     #[serde(rename = "ISO8601")]

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -34,6 +34,8 @@ pub enum Mode {
 #[serde(rename_all = "snake_case")]
 pub enum TimeFormat {
     #[default]
+    Timestamp,
+    Timestampz,
     UnixSeconds,
     UnixMillis,
     #[serde(rename = "ISO8601")]


### PR DESCRIPTION
## 🗣 Description

This introduces two more formats: `timestamp` and `timestampz`. Also changed the default time_format to timestamp.

Error messages:
``` 
2024-07-10T10:22:08.548273Z  WARN runtime: Unable to attach data connector s3: time_column 'tpep_pickup_datetime' in dataset taxi.trips has data type 'Timestamp(Microsecond, None)', but time_format is configured as 'ISO8601'
```

```
2024-07-10T10:19:01.076100Z  WARN runtime: Unable to attach data connector s3: time_column "tpep_pickup_datetime1" is not found in dataset taxi.trips
```

## 🔨 Related Issues

fixes #1917 

## 🤔 Concerns

BREAKING change: time_format default changed from unix_seconds to timestamp. Any spicepod utilise the default time_format value for unix_timestamp based column, will see a warning of mismatch time format.