### PR TITLE
Update datafusion-table-providers to use newest head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b1645fca2b5779cce4a924f870585a91c54913f2#b1645fca2b5779cce4a924f870585a91c54913f2"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=8216e56dde181a2c49ae5be8ac6efc0798b61dc2#8216e56dde181a2c49ae5be8ac6efc0798b61dc2"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "f865563b1ae8670df21e9a054c5307112f85fbf6" }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "1becf0c961da12993009f53216ded2099c38d425" }
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "1becf0c961da12993009f53216ded2099c38d425" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b1645fca2b5779cce4a924f870585a91c54913f2" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "8216e56dde181a2c49ae5be8ac6efc0798b61dc2" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7b8e22885001e2013493aebbaf190039d826c05" }
 fundu = "2.0.0"
 futures = "0.3.30"


### PR DESCRIPTION
## 🗣 Description

Update the datafusion-table-providers dependency to include newest change made in  datafusion-table-providers repo

## 🔨 Related Issues

- Close: https://github.com/spiceai/spiceai/issues/1915
- Changes in datafusion-table-providers: https://github.com/datafusion-contrib/datafusion-table-providers/pull/10

## 🤔 Concerns