### PR TITLE
Add support for filtering tables included by a catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "btoi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4163,6 +4173,19 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
 
 [[package]]
 name = "gloo-timers"
@@ -8037,6 +8060,7 @@ dependencies = [
  "flight_client",
  "fundu",
  "futures",
+ "globset",
  "indexmap 2.2.6",
  "itertools 0.12.1",
  "keyring",
@@ -8971,6 +8995,7 @@ dependencies = [
  "async-trait",
  "datafusion",
  "futures",
+ "globset",
  "reqwest 0.11.27",
  "runtime",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7b8e22885001e2013493aebbaf190039d826c05" }
 fundu = "2.0.0"
 futures = "0.3.30"
+globset = "0.4.14"
 itertools = "0.12"
 metrics = { git = "https://github.com/spiceai/metrics.git", rev = "b7aa6388e08f395fc6e361a5ff13174ebd4562fe"}
 metrics-exporter-prometheus = { git = "https://github.com/spiceai/metrics.git", rev = "b7aa6388e08f395fc6e361a5ff13174ebd4562fe"}
@@ -64,6 +65,7 @@ object_store = { version = "0.10.1" }
 odbc-api = { version = "7.0.0" }
 pem = "3.0.4"
 r2d2 = "0.8.10"
+regex = "1.10.3"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 secrecy = "0.8.0"
 serde = { version = "1.0.195", features = ["derive"] }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -49,6 +49,7 @@ duckdb = { workspace = true, features = [
 flight_client = { path = "../flight_client" }
 fundu = { workspace = true }
 futures.workspace = true
+globset.workspace = true
 indexmap = "2.2.2"
 itertools.workspace = true
 keyring = { version = "2.3.2", optional = true }
@@ -76,7 +77,7 @@ prost = { version = "0.12.1", default-features = false, features = [
   "prost-derive",
 ] }
 r2d2 = { workspace = true, optional = true }
-regex = "1.10.3"
+regex.workspace = true
 reqwest = { version = "0.11.24", features = ["json"] }
 secrecy.workspace = true
 serde.workspace = true

--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -84,11 +84,6 @@ impl Catalog {
         })
     }
 
-    #[must_use]
-    pub fn should_include(&self, dataset_name: &str) -> bool {
-        self.include.iter().any(|i| i.is_match(dataset_name))
-    }
-
     /// Returns the catalog provider - the first part of the `from` field before the first `:`.
     ///
     /// # Examples

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -38,6 +38,7 @@ use datafusion::execution::context::SessionContext;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::TableReference;
+use globset::GlobSet;
 use lazy_static::lazy_static;
 use object_store::ObjectStore;
 use snafu::prelude::*;
@@ -339,6 +340,7 @@ pub trait DataConnector: Send + Sync {
         self: Arc<Self>,
         _runtime: &Runtime,
         _catalog_id: Option<&str>,
+        _filter: Option<GlobSet>,
     ) -> Option<DataConnectorResult<Arc<dyn CatalogProvider>>> {
         None
     }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -25,6 +25,7 @@ use data_components::{Read, ReadWrite};
 use datafusion::catalog::CatalogProvider;
 use datafusion::datasource::TableProvider;
 use flight_client::FlightClient;
+use globset::GlobSet;
 use ns_lookup::verify_endpoint_connection;
 use snafu::prelude::*;
 use std::any::Any;
@@ -139,6 +140,7 @@ impl DataConnector for SpiceAI {
         self: Arc<Self>,
         runtime: &Runtime,
         catalog_id: Option<&str>,
+        include: Option<GlobSet>,
     ) -> Option<super::DataConnectorResult<Arc<dyn CatalogProvider>>> {
         if catalog_id.is_some() {
             return Some(Err(
@@ -150,7 +152,10 @@ impl DataConnector for SpiceAI {
         }
 
         let spice_extension = runtime.extension("spice_cloud").await?;
-        let catalog_provider = spice_extension.catalog_provider(self).await?.ok()?;
+        let catalog_provider = spice_extension
+            .catalog_provider(self, include)
+            .await?
+            .ok()?;
 
         Some(Ok(catalog_provider))
     }

--- a/crates/runtime/src/extension.rs
+++ b/crates/runtime/src/extension.rs
@@ -16,11 +16,11 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use crate::{dataconnector::DataConnector, Runtime};
 use async_trait::async_trait;
 use datafusion::catalog::CatalogProvider;
+use globset::GlobSet;
 use snafu::prelude::*;
-
-use crate::{dataconnector::DataConnector, Runtime};
 use spicepod::component::extension::Extension as ExtensionComponent;
 
 pub type ExtensionManifest = ExtensionComponent;
@@ -60,6 +60,7 @@ pub trait Extension: Send + Sync {
     async fn catalog_provider(
         &self,
         _data_connector: Arc<dyn DataConnector>,
+        _filter: Option<GlobSet>,
     ) -> Option<Result<Arc<dyn CatalogProvider>>> {
         None
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -53,7 +53,6 @@ use metrics::SetRecorderError;
 use model::{try_to_chat_model, try_to_embedding, LLMModelStore};
 use model_components::model::Model;
 pub use notify::Error as NotifyError;
-use regex::Regex;
 use secrets::{spicepod_secret_store_type, Secret, SecretMap};
 use snafu::prelude::*;
 use spice_metrics::get_metrics_table_reference;
@@ -235,7 +234,10 @@ pub enum Error {
     },
 
     #[snafu(display("Invalid glob pattern {pattern}: {source}"))]
-    InvalidGlobPattern { source: globset::Error },
+    InvalidGlobPattern {
+        pattern: String,
+        source: globset::Error,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -692,7 +694,7 @@ impl Runtime {
         catalog: &Catalog,
         data_connector: Arc<dyn DataConnector>,
     ) -> Result<()> {
-        let include: Option<GlobSet> = Some(catalog.include.clone());
+        let include: Option<GlobSet> = catalog.include.clone();
 
         let catalog_provider = data_connector
             .catalog_provider(self, catalog.catalog_id.as_deref(), include)

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -238,6 +238,9 @@ pub enum Error {
         pattern: String,
         source: globset::Error,
     },
+
+    #[snafu(display("Error converting GlobSet to Regex: {source}"))]
+    ErrorConvertingGlobSetToRegex { source: globset::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/spice_cloud/Cargo.toml
+++ b/crates/spice_cloud/Cargo.toml
@@ -20,3 +20,4 @@ spicepod = { path = "../spicepod" }
 tokio.workspace = true
 tracing.workspace = true
 futures.workspace = true
+globset.workspace = true

--- a/crates/spice_cloud/src/catalog.rs
+++ b/crates/spice_cloud/src/catalog.rs
@@ -18,6 +18,7 @@ use datafusion::{
     arrow::{self, datatypes::TimeUnit},
     catalog::{schema::SchemaProvider, CatalogProvider},
 };
+use regex::Regex;
 use runtime::{
     component::dataset::Dataset,
     dataconnector::{DataConnector, DataConnectorError},
@@ -94,6 +95,7 @@ impl SpiceAICatalogProvider {
     pub async fn try_new(
         extension: &SpiceExtension,
         data_connector: Arc<dyn DataConnector>,
+        filters: Option<Vec<Regex>>,
     ) -> Result<Self> {
         let datasets: Vec<DatasetSchemaResponse> = extension
             .get_json("/v1/schemas")
@@ -111,10 +113,15 @@ impl SpiceAICatalogProvider {
                     return acc;
                 };
 
-                let Ok(dataset) = Dataset::try_new(
-                    format!("spiceai:{}", &ds.name),
-                    &format!("{schema_name}.{table_name}"),
-                ) else {
+                let dataset_name = format!("{schema_name}.{table_name}");
+                if let Some(filters) = &filters {
+                    if !filters.iter().any(|i| i.is_match(&dataset_name)) {
+                        return acc;
+                    }
+                }
+
+                let Ok(dataset) = Dataset::try_new(format!("spiceai:{}", &ds.name), &dataset_name)
+                else {
                     return acc;
                 };
 

--- a/crates/spice_cloud/src/catalog.rs
+++ b/crates/spice_cloud/src/catalog.rs
@@ -18,7 +18,7 @@ use datafusion::{
     arrow::{self, datatypes::TimeUnit},
     catalog::{schema::SchemaProvider, CatalogProvider},
 };
-use regex::Regex;
+use globset::GlobSet;
 use runtime::{
     component::dataset::Dataset,
     dataconnector::{DataConnector, DataConnectorError},
@@ -95,7 +95,7 @@ impl SpiceAICatalogProvider {
     pub async fn try_new(
         extension: &SpiceExtension,
         data_connector: Arc<dyn DataConnector>,
-        filters: Option<Vec<Regex>>,
+        filters: Option<GlobSet>,
     ) -> Result<Self> {
         let datasets: Vec<DatasetSchemaResponse> = extension
             .get_json("/v1/schemas")
@@ -115,7 +115,7 @@ impl SpiceAICatalogProvider {
 
                 let dataset_name = format!("{schema_name}.{table_name}");
                 if let Some(filters) = &filters {
-                    if !filters.iter().any(|i| i.is_match(&dataset_name)) {
+                    if !filters.is_match(&dataset_name) {
                         return acc;
                     }
                 }

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -19,6 +19,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use catalog::SpiceAICatalogProvider;
 use datafusion::{catalog::CatalogProvider, datasource::TableProvider, sql::TableReference};
+use globset::GlobSet;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use snafu::prelude::*;
@@ -281,9 +282,10 @@ impl Extension for SpiceExtension {
     async fn catalog_provider(
         &self,
         data_connector: Arc<dyn DataConnector>,
+        filters: Option<GlobSet>,
     ) -> Option<Result<Arc<dyn CatalogProvider>>> {
         Some(
-            SpiceAICatalogProvider::try_new(self, data_connector)
+            SpiceAICatalogProvider::try_new(self, data_connector, filters)
                 .await
                 .map(|c| Arc::new(c) as Arc<dyn CatalogProvider>)
                 .boxed()

--- a/crates/spicepod/src/component/catalog.rs
+++ b/crates/spicepod/src/component/catalog.rs
@@ -28,6 +28,9 @@ pub struct Catalog {
 
     pub name: String,
 
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<Params>,
 
@@ -45,6 +48,7 @@ impl Catalog {
         Catalog {
             from,
             name,
+            include: Vec::default(),
             params: None,
             dataset_params: None,
             depends_on: Vec::default(),
@@ -57,6 +61,7 @@ impl WithDependsOn<Catalog> for Catalog {
         Catalog {
             from: self.from.clone(),
             name: self.name.clone(),
+            include: self.include.clone(),
             params: self.params.clone(),
             dataset_params: self.dataset_params.clone(),
             depends_on: depends_on.to_vec(),


### PR DESCRIPTION
## 🗣 Description

Adds support for filtering tables included by a catalog with a [Unix glob style](https://en.wikipedia.org/wiki/Glob_(programming)) filter. This allows specifying filters like `*.blocks` to register all tables named `blocks` in any schema. Or to only include tables in a specific schema with `eth.*`.

Adding multiple filter is an OR operation - if a dataset matches any of them, it will be included.

Example:
```yaml
version: v1beta1
kind: Spicepod
name: catalog

catalogs:
  - from: spiceai
    name: spiceai
    include:
      - "*.blocks"
      - "eth.*"
```

## 🔨 Related Issues

Part of #1810