### PR TITLE
Use public.ecr.aws/docker/library/{postgres/mysql}:latest for integration test images

### DIFF
--- a/crates/runtime/tests/mysql/common.rs
+++ b/crates/runtime/tests/mysql/common.rs
@@ -50,7 +50,7 @@ pub async fn start_mysql_docker_container(
     port: u16,
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image("mysql:latest")
+        .image("ghcr.io/spiceai/mysql:latest")
         .add_port_binding(3306, port)
         .add_env_var("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
         .add_env_var("MYSQL_DATABASE", "mysqldb")

--- a/crates/runtime/tests/mysql/common.rs
+++ b/crates/runtime/tests/mysql/common.rs
@@ -50,7 +50,7 @@ pub async fn start_mysql_docker_container(
     port: u16,
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image("ghcr.io/spiceai/mysql:latest")
+        .image("public.ecr.aws/docker/library/mysql:latest")
         .add_port_binding(3306, port)
         .add_env_var("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
         .add_env_var("MYSQL_DATABASE", "mysqldb")

--- a/crates/runtime/tests/postgres/common.rs
+++ b/crates/runtime/tests/postgres/common.rs
@@ -71,7 +71,7 @@ pub(super) async fn start_postgres_docker_container(
     };
 
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image("postgres:latest")
+        .image("ghcr.io/spiceai/postgres:latest")
         .add_port_binding(5432, port)
         .add_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
         .healthcheck(HealthConfig {

--- a/crates/runtime/tests/postgres/common.rs
+++ b/crates/runtime/tests/postgres/common.rs
@@ -71,7 +71,7 @@ pub(super) async fn start_postgres_docker_container(
     };
 
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image("ghcr.io/spiceai/postgres:latest")
+        .image("public.ecr.aws/docker/library/postgres:latest")
         .add_port_binding(5432, port)
         .add_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
         .healthcheck(HealthConfig {


### PR DESCRIPTION
## 🗣 Description

Docker has finally implemented rate limits on DockerHub images, which makes our integration tests unreliable. I've published the `postgres:latest` and `mysql:latest` images to our GHCR repo and made them public.