### PR TITLE
Add `UnityCatalog` catalog provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,6 +2659,7 @@ dependencies = [
  "duckdb",
  "flight_client",
  "futures",
+ "globset",
  "itertools 0.12.1",
  "mysql_async",
  "object_store",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -39,6 +39,7 @@ duckdb = { workspace = true, features = [
 ], optional = true }
 flight_client = { path = "../flight_client" }
 futures.workspace = true
+globset.workspace = true
 itertools.workspace = true
 mysql_async = { workspace = true, optional = true }
 object_store = { workspace = true }

--- a/crates/data_components/src/databricks_delta.rs
+++ b/crates/data_components/src/databricks_delta.rs
@@ -77,7 +77,14 @@ pub async fn resolve_table_uri(
     let table_opt = uc_client.get_table(&table_reference).await.boxed()?;
 
     if let Some(table) = table_opt {
-        Ok(table.storage_location)
+        if let Some(storage_location) = table.storage_location {
+            Ok(storage_location)
+        } else {
+            Err(
+                format!("Databricks table {table_reference} does not have a storage location")
+                    .into(),
+            )
+        }
     } else {
         Err(format!("Databricks table {table_reference} does not exist").into())
     }

--- a/crates/data_components/src/databricks_delta.rs
+++ b/crates/data_components/src/databricks_delta.rs
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::delta_lake::DeltaTable;
+use crate::unity_catalog::UnityCatalog;
+use crate::Read;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use secrecy::SecretString;
+use snafu::prelude::*;
 use std::{collections::HashMap, sync::Arc};
-
-use crate::delta_lake::DeltaTable;
-use crate::unity_catalog::UnityCatalog;
-use crate::Read;
 
 #[derive(Clone)]
 pub struct DatabricksDelta {
@@ -72,9 +72,9 @@ pub async fn resolve_table_uri(
     table_reference: TableReference,
     params: Arc<HashMap<String, SecretString>>,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    let uc_client = UnityCatalog::from_params(&params)?;
+    let uc_client = UnityCatalog::from_params(&params).boxed()?;
 
-    let table_opt = uc_client.get_table(&table_reference).await?;
+    let table_opt = uc_client.get_table(&table_reference).await.boxed()?;
 
     if let Some(table) = table_opt {
         Ok(table.storage_location)

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -53,6 +53,7 @@ pub mod snowflake;
 pub mod spark_connect;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
+pub mod unity_catalog;
 
 pub mod cdc;
 pub mod delete;

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use secrecy::{ExposeSecret, SecretString};
+use snafu::prelude::*;
+use std::collections::HashMap;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Missing required parameter: {parameter}"))]
+    MissingParameter { parameter: String },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// An ergonomic wrapper around calling Unity Catalog APIs.
+///
+/// Could be replaced once <https://crates.io/crates/unitycatalog-client> is available.
+pub struct UnityCatalog {
+    endpoint: String,
+    token: SecretString,
+}
+
+impl UnityCatalog {
+    pub fn new(endpoint: impl Into<String>, token: SecretString) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            token,
+        }
+    }
+
+    pub fn from_params(params: &HashMap<String, SecretString>) -> Result<Self, Error> {
+        let endpoint = params
+            .get("endpoint")
+            .ok_or(Error::MissingParameter {
+                parameter: "endpoint".into(),
+            })?
+            .expose_secret()
+            .to_string();
+
+        let token = params
+            .get("token")
+            .ok_or(Error::MissingDatabricksToken {
+                parameter: "token".into(),
+            })?
+            .clone();
+
+        Ok(Self::new(endpoint, token))
+    }
+}

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -38,7 +38,7 @@ impl UnityCatalogProvider {
         client: Arc<UnityCatalog>,
         catalog_id: CatalogId,
         table_creator: Arc<dyn Read>,
-        table_reference_creator: fn(UCTable) -> TableReference,
+        table_reference_creator: fn(UCTable) -> Option<TableReference>,
         include: Option<GlobSet>,
     ) -> Result<Self> {
         let schemas =
@@ -104,7 +104,7 @@ impl UnityCatalogSchemaProvider {
         client: Arc<UnityCatalog>,
         schema: &UCSchema,
         table_creator: Arc<dyn Read>,
-        table_reference_creator: fn(UCTable) -> TableReference,
+        table_reference_creator: fn(UCTable) -> Option<TableReference>,
         include: Option<Arc<GlobSet>>,
     ) -> Result<Self> {
         let tables = client
@@ -119,6 +119,10 @@ impl UnityCatalogSchemaProvider {
         for table in tables {
             let table_name = table.name.to_string();
             let table_reference = table_reference_creator(table);
+
+            let Some(table_reference) = table_reference else {
+                continue;
+            };
 
             if let Some(include) = &include {
                 if !include.is_match(&table_name) {

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -1,0 +1,160 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use async_trait::async_trait;
+use datafusion::{
+    catalog::{schema::SchemaProvider, CatalogProvider},
+    datasource::TableProvider,
+    error::DataFusionError,
+    sql::TableReference,
+};
+use snafu::prelude::*;
+use std::{any::Any, collections::HashMap, sync::Arc};
+
+use super::{Result, UCSchema, UnityCatalog};
+
+pub type TableCreatorFn =
+    dyn Fn(
+        TableReference,
+    )
+        -> std::result::Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
+
+pub struct UnityCatalogProvider {
+    schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+}
+
+impl UnityCatalogProvider {
+    pub async fn try_new(
+        client: Arc<UnityCatalog>,
+        catalog_id: &str,
+        table_creator: Arc<TableCreatorFn>,
+    ) -> Result<Self> {
+        let schemas =
+            client
+                .list_schemas(catalog_id)
+                .await?
+                .context(super::CatalogDoesntExistSnafu {
+                    catalog_id: catalog_id.to_string(),
+                })?;
+
+        let mut schemas_map = HashMap::new();
+        for schema in schemas {
+            let schema_provider = UnityCatalogSchemaProvider::try_new(
+                Arc::clone(&client),
+                &schema,
+                Arc::clone(&table_creator),
+            )
+            .await?;
+            schemas_map.insert(
+                schema.name,
+                Arc::new(schema_provider) as Arc<dyn SchemaProvider>,
+            );
+        }
+        Ok(Self {
+            schemas: schemas_map,
+        })
+    }
+}
+
+impl CatalogProvider for UnityCatalogProvider {
+    /// Returns the catalog provider as [`Any`]
+    /// so that it can be downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Retrieves the list of available schema names in this catalog.
+    fn schema_names(&self) -> Vec<String> {
+        self.schemas.keys().cloned().collect()
+    }
+
+    /// Retrieves a specific schema from the catalog by name, provided it exists.
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        self.schemas.get(name).cloned()
+    }
+}
+
+pub struct UnityCatalogSchemaProvider {
+    tables: HashMap<String, Arc<dyn TableProvider>>,
+}
+
+impl UnityCatalogSchemaProvider {
+    /// Creates a new instance of the [`UnityCatalogSchemaProvider`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the schema cannot be created.
+    pub async fn try_new(
+        client: Arc<UnityCatalog>,
+        schema: &UCSchema,
+        table_creator: Arc<TableCreatorFn>,
+    ) -> Result<Self> {
+        let tables = client
+            .list_tables(&schema.catalog_name, &schema.name)
+            .await?
+            .context(super::SchemaDoesntExistSnafu {
+                schema: schema.name.to_string(),
+                catalog_id: schema.catalog_name.to_string(),
+            })?;
+
+        let mut tables_map = HashMap::new();
+        for table in tables {
+            let table_reference = TableReference::Full {
+                catalog: table.catalog_name.into(),
+                schema: table.schema_name.into(),
+                table: table.name.into(),
+            };
+            let table_name = table_reference.table().to_string();
+            let table_provider = table_creator(table_reference.clone()).context(
+                super::UnableToGetTableProviderSnafu {
+                    table_reference: table_reference.to_string(),
+                },
+            )?;
+            tables_map.insert(table_name, table_provider);
+        }
+
+        Ok(Self { tables: tables_map })
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for UnityCatalogSchemaProvider {
+    /// Returns this `SchemaProvider` as [`Any`] so that it can be downcast to a
+    /// specific implementation.
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    /// Retrieves the list of available table names in this schema.
+    fn table_names(&self) -> Vec<String> {
+        self.tables.keys().cloned().collect()
+    }
+
+    /// Retrieves a specific table from the schema by name, if it exists,
+    /// otherwise returns `Ok(None)`.
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
+        let Some(table) = self.tables.get(name) else {
+            return Ok(None);
+        };
+
+        Ok(Some(Arc::clone(table)))
+    }
+
+    /// Returns true if table exist in the schema provider, false otherwise.
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables.contains_key(name)
+    }
+}

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -124,8 +124,11 @@ impl UnityCatalogSchemaProvider {
                 continue;
             };
 
+            let schema_with_table = format!("{}.{}", schema.name, table_name);
+            tracing::debug!("Checking if table {} should be included", schema_with_table);
             if let Some(include) = &include {
-                if !include.is_match(&table_name) {
+                if !include.is_match(&schema_with_table) {
+                    tracing::debug!("Table {} is not included", schema_with_table);
                     continue;
                 }
             }

--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -24,9 +24,21 @@ pub struct Catalog {
     pub provider: String,
     pub catalog_id: Option<String>,
     pub name: String,
+    orig_include: Vec<String>,
     pub include: Option<GlobSet>,
     pub params: HashMap<String, String>,
     pub dataset_params: HashMap<String, String>,
+}
+
+impl PartialEq for Catalog {
+    fn eq(&self, other: &Self) -> bool {
+        self.provider == other.provider
+            && self.catalog_id == other.catalog_id
+            && self.name == other.name
+            && self.orig_include == other.orig_include
+            && self.params == other.params
+            && self.dataset_params == other.dataset_params
+    }
 }
 
 impl TryFrom<spicepod_catalog::Catalog> for Catalog {
@@ -57,6 +69,7 @@ impl TryFrom<spicepod_catalog::Catalog> for Catalog {
             provider: provider.to_string(),
             catalog_id,
             name: catalog.name,
+            orig_include: catalog.include.clone(),
             include: globset_opt,
             params: catalog
                 .params
@@ -78,6 +91,7 @@ impl Catalog {
             provider: Catalog::provider(from).to_string(),
             catalog_id: Catalog::catalog_id(from).map(String::from),
             name: name.into(),
+            orig_include: Vec::default(),
             include: None,
             params: HashMap::default(),
             dataset_params: HashMap::default(),

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -62,7 +62,7 @@ pub mod clickhouse;
 pub mod databricks;
 #[cfg(feature = "debezium")]
 pub mod debezium;
-#[cfg(feature = "databricks")]
+#[cfg(feature = "delta_lake")]
 pub mod delta_lake;
 #[cfg(feature = "dremio")]
 pub mod dremio;
@@ -90,6 +90,7 @@ pub mod snowflake;
 #[cfg(feature = "spark")]
 pub mod spark;
 pub mod spiceai;
+#[cfg(feature = "delta_lake")]
 pub mod unity_catalog;
 
 #[derive(Debug, Snafu)]
@@ -160,6 +161,12 @@ pub enum DataConnectorError {
 
     #[snafu(display("Unable to get catalog provider for {dataconnector}: {source}"))]
     UnableToGetCatalogProvider {
+        dataconnector: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Unable to read the secrets for {dataconnector}: {source}"))]
+    UnableToReadSecrets {
         dataconnector: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -258,7 +258,7 @@ pub async fn register_all() {
     register_connector_factory("localhost", localhost::LocalhostConnector::create).await;
     #[cfg(feature = "databricks")]
     register_connector_factory("databricks", databricks::Databricks::create).await;
-    #[cfg(feature = "databricks")]
+    #[cfg(feature = "delta_lake")]
     register_connector_factory("delta_lake", delta_lake::DeltaLake::create).await;
     #[cfg(feature = "dremio")]
     register_connector_factory("dremio", dremio::Dremio::create).await;
@@ -290,6 +290,7 @@ pub async fn register_all() {
     register_connector_factory("snowflake", snowflake::Snowflake::create).await;
     #[cfg(feature = "debezium")]
     register_connector_factory("debezium", debezium::Debezium::create).await;
+    #[cfg(feature = "delta_lake")]
     register_connector_factory("unity_catalog", unity_catalog::UnityCatalog::create).await;
 }
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::catalog::Catalog;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
 use crate::Runtime;
@@ -38,7 +39,6 @@ use datafusion::execution::context::SessionContext;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::TableReference;
-use globset::GlobSet;
 use lazy_static::lazy_static;
 use object_store::ObjectStore;
 use snafu::prelude::*;
@@ -90,6 +90,7 @@ pub mod snowflake;
 #[cfg(feature = "spark")]
 pub mod spark;
 pub mod spiceai;
+pub mod unity_catalog;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -339,8 +340,7 @@ pub trait DataConnector: Send + Sync {
     async fn catalog_provider(
         self: Arc<Self>,
         _runtime: &Runtime,
-        _catalog_id: Option<&str>,
-        _filter: Option<GlobSet>,
+        _catalog: &Catalog,
     ) -> Option<DataConnectorResult<Arc<dyn CatalogProvider>>> {
         None
     }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -290,6 +290,7 @@ pub async fn register_all() {
     register_connector_factory("snowflake", snowflake::Snowflake::create).await;
     #[cfg(feature = "debezium")]
     register_connector_factory("debezium", debezium::Debezium::create).await;
+    register_connector_factory("unity_catalog", unity_catalog::UnityCatalog::create).await;
 }
 
 pub trait DataConnectorFactory {

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
 use crate::secrets::{Secret, SecretMap};
 use crate::Runtime;
@@ -24,7 +25,6 @@ use data_components::Read;
 use datafusion::catalog::CatalogProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
-use globset::GlobSet;
 use snafu::prelude::*;
 use std::any::Any;
 use std::pin::Pin;
@@ -168,25 +168,9 @@ impl DataConnector for Databricks {
 
     async fn catalog_provider(
         self: Arc<Self>,
-        runtime: &Runtime,
-        catalog_id: Option<&str>,
-        include: Option<GlobSet>,
+        _runtime: &Runtime,
+        _catalog: &Catalog,
     ) -> Option<super::DataConnectorResult<Arc<dyn CatalogProvider>>> {
-        if catalog_id.is_some() {
-            return Some(Err(
-                super::DataConnectorError::InvalidConfigurationNoSource {
-                    dataconnector: "spiceai".into(),
-                    message: "Catalog ID is not supported for SpiceAI data connector".into(),
-                },
-            ));
-        }
-
-        let spice_extension = runtime.extension("spice_cloud").await?;
-        let catalog_provider = spice_extension
-            .catalog_provider(self, include)
-            .await?
-            .ok()?;
-
-        Some(Ok(catalog_provider))
+        todo!();
     }
 }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use super::DataConnector;
 use super::DataConnectorFactory;
+use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
 use crate::secrets::Secret;
 use crate::Runtime;
@@ -25,7 +26,6 @@ use data_components::{Read, ReadWrite};
 use datafusion::catalog::CatalogProvider;
 use datafusion::datasource::TableProvider;
 use flight_client::FlightClient;
-use globset::GlobSet;
 use ns_lookup::verify_endpoint_connection;
 use snafu::prelude::*;
 use std::any::Any;
@@ -139,10 +139,9 @@ impl DataConnector for SpiceAI {
     async fn catalog_provider(
         self: Arc<Self>,
         runtime: &Runtime,
-        catalog_id: Option<&str>,
-        include: Option<GlobSet>,
+        catalog: &Catalog,
     ) -> Option<super::DataConnectorResult<Arc<dyn CatalogProvider>>> {
-        if catalog_id.is_some() {
+        if catalog.catalog_id.is_some() {
             return Some(Err(
                 super::DataConnectorError::InvalidConfigurationNoSource {
                     dataconnector: "spiceai".into(),
@@ -153,7 +152,7 @@ impl DataConnector for SpiceAI {
 
         let spice_extension = runtime.extension("spice_cloud").await?;
         let catalog_provider = spice_extension
-            .catalog_provider(self, include)
+            .catalog_provider(self, catalog.include.clone())
             .await?
             .ok()?;
 

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -77,7 +77,6 @@ impl DataConnectorFactory for UnityCatalog {
             }
         }
         Box::pin(async move {
-            // let (endpoint, catalog_id) = UnityCatalogClient::parse_catalog_url(url);
             let unity_catalog = Self { params };
             Ok(Arc::new(unity_catalog) as Arc<dyn DataConnector>)
         })
@@ -158,6 +157,7 @@ impl DataConnector for UnityCatalog {
     }
 }
 
-fn table_reference_creator(uc_table: UCTable) -> TableReference {
-    TableReference::bare(uc_table.storage_location)
+fn table_reference_creator(uc_table: UCTable) -> Option<TableReference> {
+    let storage_location = uc_table.storage_location?;
+    Some(TableReference::bare(format!("{storage_location}/")))
 }

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -1,0 +1,154 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::DataConnector;
+use super::DataConnectorFactory;
+use crate::component::catalog::Catalog;
+use crate::component::dataset::Dataset;
+use crate::secrets::Secret;
+use crate::secrets::SecretMap;
+use crate::Runtime;
+use async_trait::async_trait;
+use data_components::unity_catalog::provider::UnityCatalogProvider;
+use data_components::unity_catalog::UnityCatalog as UnityCatalogClient;
+use datafusion::catalog::CatalogProvider;
+use datafusion::datasource::TableProvider;
+use datafusion::sql::TableReference;
+use snafu::prelude::*;
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{collections::HashMap, future::Future};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to parse SpiceAI dataset path: {dataset_path}"))]
+    UnableToParseDatasetPath { dataset_path: String },
+
+    #[snafu(display("Unable to publish data to SpiceAI: {source}"))]
+    UnableToPublishData { source: flight_client::Error },
+
+    #[snafu(display("Missing required secrets"))]
+    MissingRequiredSecrets,
+
+    #[snafu(display(r#"Unable to connect to endpoint "{endpoint}": {source}"#))]
+    UnableToVerifyEndpointConnection {
+        source: ns_lookup::Error,
+        endpoint: String,
+    },
+
+    #[snafu(display("Unable to create flight client: {source}"))]
+    UnableToCreateFlightClient { source: flight_client::Error },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Clone)]
+pub struct UnityCatalog {
+    params: SecretMap,
+}
+
+impl DataConnectorFactory for UnityCatalog {
+    fn create(
+        secret: Option<Secret>,
+        params: Arc<HashMap<String, String>>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        let mut params: SecretMap = params.as_ref().into();
+
+        if let Some(secret) = secret {
+            for (key, value) in secret.iter() {
+                params.insert(key.to_string(), value.clone());
+            }
+        }
+        Box::pin(async move {
+            // let (endpoint, catalog_id) = UnityCatalogClient::parse_catalog_url(url);
+            let unity_catalog = Self { params };
+            Ok(Arc::new(unity_catalog) as Arc<dyn DataConnector>)
+        })
+    }
+}
+
+#[async_trait]
+impl DataConnector for UnityCatalog {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        _dataset: &Dataset,
+    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
+        Err(super::DataConnectorError::UnableToGetReadProvider {
+            dataconnector: "unity_catalog".to_string(),
+            source: "Unity Catalog only support catalogs, not individual datasets.".into(),
+        })
+    }
+
+    async fn catalog_provider(
+        self: Arc<Self>,
+        _runtime: &Runtime,
+        catalog: &Catalog,
+    ) -> Option<super::DataConnectorResult<Arc<dyn CatalogProvider>>> {
+        let Some(catalog_id) = catalog.catalog_id.clone() else {
+            return Some(Err(
+                super::DataConnectorError::InvalidConfigurationNoSource {
+                    dataconnector: "unity_catalog".into(),
+                    message: "Catalog ID is required for Unity Catalog".into(),
+                },
+            ));
+        };
+
+        // The catalog_id for the unity_catalog provider is the full URL to the catalog like:
+        // https://<host>/api/2.1/unity-catalog/catalogs/<catalog_id>
+        let (endpoint, catalog_id) = match UnityCatalogClient::parse_catalog_url(&catalog_id)
+            .map_err(|e| super::DataConnectorError::InvalidConfiguration {
+                dataconnector: "unity_catalog".to_string(),
+                message: e.to_string(),
+                source: Box::new(e),
+            }) {
+            Ok((endpoint, catalog_id)) => (endpoint, catalog_id),
+            Err(e) => return Some(Err(e)),
+        };
+
+        let client = Arc::new(UnityCatalogClient::new(
+            endpoint,
+            self.params.get("token").cloned(),
+        ));
+
+        let table_creator = Arc::new(|table_reference: TableReference| {
+            todo!();
+        });
+
+        let catalog_provider = match UnityCatalogProvider::try_new(
+            client,
+            catalog_id,
+            table_creator,
+            catalog.include.clone(),
+        )
+        .await
+        {
+            Ok(provider) => provider,
+            Err(e) => {
+                return Some(Err(super::DataConnectorError::UnableToGetCatalogProvider {
+                    dataconnector: "unity_catalog".to_string(),
+                    source: Box::new(e),
+                }))
+            }
+        };
+
+        Some(Ok(Arc::new(catalog_provider) as Arc<dyn CatalogProvider>))
+    }
+}

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -168,9 +168,6 @@ pub enum Error {
     #[snafu(display("Table {schema}.{table} not registered"))]
     TableMissing { schema: String, table: String },
 
-    #[snafu(display("Catalog already exists: {catalog}"))]
-    CatalogAlreadyExists { catalog: String },
-
     #[snafu(display("Unable to get object store configuration: {source}"))]
     UnableToGetSchemaTable {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -349,13 +346,6 @@ impl DataFusion {
     }
 
     pub fn register_catalog(&self, name: &str, catalog: Arc<dyn CatalogProvider>) -> Result<()> {
-        if self.ctx.catalog(name).is_some() {
-            CatalogAlreadyExistsSnafu {
-                catalog: name.to_string(),
-            }
-            .fail()?;
-        }
-
         self.ctx.register_catalog(name, catalog);
 
         Ok(())
@@ -513,6 +503,11 @@ impl DataFusion {
     #[must_use]
     pub fn table_exists(&self, dataset_name: TableReference) -> bool {
         self.ctx.table_exist(dataset_name).unwrap_or(false)
+    }
+
+    #[must_use]
+    pub fn catalog_exists(&self, catalog: &str) -> bool {
+        self.ctx.catalog(catalog).is_some()
     }
 
     pub fn remove_table(&self, dataset_name: &TableReference) -> Result<()> {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -697,10 +697,8 @@ impl Runtime {
         catalog: &Catalog,
         data_connector: Arc<dyn DataConnector>,
     ) -> Result<()> {
-        let include: Option<GlobSet> = catalog.include.clone();
-
         let catalog_provider = data_connector
-            .catalog_provider(self, catalog.catalog_id.as_deref(), include)
+            .catalog_provider(self, catalog)
             .await
             .context(UnableToLoadCatalogConnectorSnafu {
                 catalog: catalog.name.clone(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -46,7 +46,6 @@ use embeddings::connector::EmbeddingConnector;
 use extension::ExtensionFactory;
 use futures::future::join_all;
 use futures::{Future, StreamExt};
-use globset::GlobSet;
 use llms::chat::Chat;
 use llms::embeddings::Embed;
 use metrics::SetRecorderError;

--- a/crates/spicepod/src/component/catalog.rs
+++ b/crates/spicepod/src/component/catalog.rs
@@ -23,12 +23,11 @@ use super::{params::Params, WithDependsOn};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Catalog {
-    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub from: String,
 
     pub name: String,
 
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub include: Vec<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## 🗣 Description

Adds a `UnityCatalog` catalog provider that will automatically register `delta_lake` tables.

Example:
```yaml
version: v1beta1
kind: Spicepod
name: catalog

catalogs:
  - from: unity_catalog:https://uc_host.com/api/2.1/unity-catalog/catalogs/spiceai_sandbox
    name: uc
    params:
      token: {token_for_uc_api}
    dataset_params:
      # This UC provider stores delta tables in S3, so we need to provide those creds here.
      access_key_id: {access_key_id}
      secret_access_key: {secret_access_key}
```

## 🔨 Related Issues

Part of #1810

## 🤔 Concerns

~~I'm not loading the secret for the delta lake table from the runtime. So the `dataset_params` will need to be specified inline, I will fix that either in this PR the next one.~~

Added in this PR