### PR TITLE
Copy `params` into `dataset_params`

### DIFF
--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -193,7 +193,12 @@ impl DataConnector for Databricks {
         };
         let client = Arc::new(unity_catalog);
 
-        let mut dataset_params: SecretMap = catalog.dataset_params.clone().into();
+        // Copy the catalog params into the dataset params, and allow user to override
+        let mut dataset_params: SecretMap = catalog.params.clone().into();
+
+        for (key, value) in &catalog.dataset_params {
+            dataset_params.insert(key.to_string(), value.clone().into());
+        }
 
         let secrets_provider = runtime.secrets_provider();
         let dataset_secret = match secrets_provider

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -130,7 +130,12 @@ impl DataConnector for UnityCatalog {
             self.params.get("token").cloned(),
         ));
 
-        let mut dataset_params: SecretMap = catalog.dataset_params.clone().into();
+        // Copy the catalog params into the dataset params, and allow user to override
+        let mut dataset_params: SecretMap = catalog.params.clone().into();
+
+        for (key, value) in &catalog.dataset_params {
+            dataset_params.insert(key.to_string(), value.clone().into());
+        }
 
         let secrets_provider = runtime.secrets_provider();
         let dataset_secret = match secrets_provider


### PR DESCRIPTION
## 🗣 Description

A minor UX change for #1810 to not need to duplicate parameters between `params` and `dataset_params`.

For the catalog providers, the `params` section contains parameters needed for the catalog provider itself to connect and find the list of available schemas/tables. And we use the `dataset_params` as the inputs when we actually create the DataFusion TableProviders. For the `databricks` and `unity_catalog` providers, many of those parameters were the same - and so I had to duplicate them. By using the `params` map as a base and letting users override them with `dataset_params` we can reduce the duplication and have them provide only the difference.

Example:
```diff
catalogs:
  - from: databricks:spiceai_sandbox
    name: uc_db_delta
    include:
      - "*.traces"
    params:
      endpoint: dbc-f34ee0b7-90f2.cloud.databricks.com
      mode: delta_lake
-   dataset_params:
-     endpoint: dbc-f34ee0b7-90f2.cloud.databricks.com
```

## 🔨 Related Issues

#1810