### PR TITLE
feat: Enable ODBC JoinPushDown with hashed connection string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3057,6 +3057,7 @@ dependencies = [
  "r2d2",
  "rusqlite",
  "secrecy",
+ "sha2",
  "snafu 0.8.3",
  "snowflake-api",
  "tokio",

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -42,6 +42,7 @@ postgres-native-tls = { version = "0.5.0", optional = true }
 r2d2 = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 secrecy.workspace = true
+sha2 = { version = "0.10.8", optional = true }
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt"] }
@@ -61,7 +62,7 @@ clickhouse = [
 ]
 duckdb = ["dep:duckdb", "dep:r2d2", "datafusion-table-providers/duckdb"]
 mysql = ["dep:mysql_async", "datafusion-table-providers/mysql"]
-odbc = ["dep:odbc-api", "dep:arrow-odbc", "dep:tokio", "dep:dyn-clone"]
+odbc = ["dep:odbc-api", "dep:arrow-odbc", "dep:tokio", "dep:dyn-clone", "dep:sha2"]
 postgres = [
   "dep:bb8",
   "dep:bb8-postgres",

--- a/crates/db_connection_pool/src/odbcpool.rs
+++ b/crates/db_connection_pool/src/odbcpool.rs
@@ -120,9 +120,6 @@ where
     }
 
     fn join_push_down(&self) -> JoinPushDown {
-        // It would be technically feasible to return JoinPushDown::AllowedFor(connection_string) here,
-        // but we don't have a general way to strip out sensitive information from the connection string.
-        // We could solve this by asking the user to explicly provide a join context in the parameters.
         JoinPushDown::AllowedFor(self.connection_id.clone())
     }
 }

--- a/crates/db_connection_pool/src/odbcpool.rs
+++ b/crates/db_connection_pool/src/odbcpool.rs
@@ -82,7 +82,7 @@ impl ODBCPool {
             .map(ToString::to_string)
             .context(MissingConnectionStringSnafu)?;
 
-        // hash the connection string to get a comparible connection ID
+        // hash the connection string to get a comparable connection ID
         // we do this to prevent exposing secrets in the EXPLAIN ... plan when using federated JoinPushDown
         let connection_id = hash_string(&connection_string);
 

--- a/crates/db_connection_pool/src/odbcpool.rs
+++ b/crates/db_connection_pool/src/odbcpool.rs
@@ -82,6 +82,8 @@ impl ODBCPool {
             .map(ToString::to_string)
             .context(MissingConnectionStringSnafu)?;
 
+        // hash the connection string to get a comparible connection ID
+        // we do this to prevent exposing secrets in the EXPLAIN ... plan when using federated JoinPushDown
         let connection_id = hash_string(&connection_string);
 
         Ok(Self {


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

Enables `JoinPushDown` for ODBC connectors, using the hashed connection string from the dataset as the comparison.

This allows ODBC connections from the same source to use federated joins, preventing full table scans and loading table contents into memory first.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #1931