### PR TITLE
Make integration tests more stable by using logged-in registry during CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,12 +9,29 @@ on:
 
   workflow_dispatch:
 
+env:
+  CONTAINER_REGISTRY: spiceaitestimages.azurecr.io/
+
 jobs:
   build:
     name: Integration Tests
     runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to ACR
+        uses: docker/login-action@v3
+        # This will fail for forks, so we only run it for the main repo
+        if: github.repository == 'spiceai/spiceai'
+        with:
+          registry: spiceaitestimages.azurecr.io
+          username: spiceai-repo-pull
+          password: ${{ secrets.AZCR_PASSWORD }}
+
+      # Change the CONTAINER_REGISTRY to public.ecr.aws/docker/library/ if this is a fork
+      - name: Use public ECR for forks
+        if: github.repository != 'spiceai/spiceai'
+        run: echo "CONTAINER_REGISTRY=public.ecr.aws/docker/library/" >> $GITHUB_ENV
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,8 +35,9 @@ jobs:
 
       - name: Pull the Postgres/MySQL images
         run: |
-          docker pull $CONTAINER_REGISTRY/postgres:latest
-          docker pull $CONTAINER_REGISTRY/mysql:latest
+          echo ${{ env.CONTAINER_REGISTRY }}
+          docker pull ${{ env.CONTAINER_REGISTRY }}postgres:latest
+          docker pull ${{ env.CONTAINER_REGISTRY }}mysql:latest
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,11 @@ jobs:
         if: github.repository != 'spiceai/spiceai'
         run: echo "CONTAINER_REGISTRY=public.ecr.aws/docker/library/" >> $GITHUB_ENV
 
+      - name: Pull the Postgres/MySQL images
+        run: |
+          docker pull $CONTAINER_REGISTRY/postgres:latest
+          docker pull $CONTAINER_REGISTRY/mysql:latest
+
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/crates/runtime/tests/docker/mod.rs
+++ b/crates/runtime/tests/docker/mod.rs
@@ -53,7 +53,7 @@ pub async fn start(docker: &Docker, name: &str) -> Result<(), anyhow::Error> {
 
 pub struct ContainerRunnerBuilder<'a> {
     name: &'a str,
-    image: Option<&'a str>,
+    image: Option<String>,
     port_bindings: Vec<(u16, u16)>,
     env_vars: Vec<(String, String)>,
     healthcheck: Option<HealthConfig>,
@@ -70,7 +70,7 @@ impl<'a> ContainerRunnerBuilder<'a> {
         }
     }
 
-    pub fn image(mut self, image: &'a str) -> Self {
+    pub fn image(mut self, image: String) -> Self {
         self.image = Some(image);
         self
     }
@@ -108,7 +108,7 @@ impl<'a> ContainerRunnerBuilder<'a> {
 pub struct ContainerRunner<'a> {
     name: &'a str,
     docker: Docker,
-    image: &'a str,
+    image: String,
     port_bindings: Vec<(u16, u16)>,
     env_vars: Vec<(String, String)>,
     healthcheck: Option<HealthConfig>,
@@ -158,7 +158,7 @@ impl<'a> ContainerRunner<'a> {
         let env_vars_str = env_vars.iter().map(String::as_str).collect::<Vec<&str>>();
 
         let config = Config::<&str> {
-            image: Some(self.image),
+            image: Some(&self.image),
             env: Some(env_vars_str),
             host_config,
             healthcheck: self.healthcheck,
@@ -205,7 +205,7 @@ impl<'a> ContainerRunner<'a> {
 
     async fn pull_image(&self) -> Result<(), anyhow::Error> {
         let options = Some(CreateImageOptions::<&str> {
-            from_image: self.image,
+            from_image: &self.image,
             ..Default::default()
         });
 

--- a/crates/runtime/tests/docker/mod.rs
+++ b/crates/runtime/tests/docker/mod.rs
@@ -204,6 +204,15 @@ impl<'a> ContainerRunner<'a> {
     }
 
     async fn pull_image(&self) -> Result<(), anyhow::Error> {
+        // Check if image is already pulled
+        let images = self.docker.list_images::<&str>(None).await?;
+        for image in images {
+            if image.repo_tags.iter().any(|t| t == &self.image) {
+                tracing::debug!("Docker image {} already pulled", self.image);
+                return Ok(());
+            }
+        }
+
         let options = Some(CreateImageOptions::<&str> {
             from_image: &self.image,
             ..Default::default()

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -147,3 +147,8 @@ where
 
     false
 }
+
+fn container_registry() -> String {
+    std::env::var("CONTAINER_REGISTRY")
+        .unwrap_or_else(|_| "public.ecr.aws/docker/library/".to_string())
+}

--- a/crates/runtime/tests/mysql/common.rs
+++ b/crates/runtime/tests/mysql/common.rs
@@ -23,7 +23,10 @@ use spicepod::component::{
 };
 use tracing::instrument;
 
-use crate::docker::{ContainerRunnerBuilder, RunningContainer};
+use crate::{
+    container_registry,
+    docker::{ContainerRunnerBuilder, RunningContainer},
+};
 
 pub fn make_mysql_dataset(path: &str, name: &str, port: u16, accelerated: bool) -> Dataset {
     let mut dataset = Dataset::new(format!("mysql:{path}"), name.to_string());
@@ -50,7 +53,7 @@ pub async fn start_mysql_docker_container(
     port: u16,
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image("public.ecr.aws/docker/library/mysql:latest")
+        .image(format!("{}mysql:latest", container_registry()))
         .add_port_binding(3306, port)
         .add_env_var("MYSQL_ROOT_PASSWORD", MYSQL_ROOT_PASSWORD)
         .add_env_var("MYSQL_DATABASE", "mysqldb")

--- a/crates/runtime/tests/postgres/common.rs
+++ b/crates/runtime/tests/postgres/common.rs
@@ -23,7 +23,10 @@ use secrecy::SecretString;
 use rand::Rng;
 use tracing::instrument;
 
-use crate::docker::{ContainerRunnerBuilder, RunningContainer};
+use crate::{
+    container_registry,
+    docker::{ContainerRunnerBuilder, RunningContainer},
+};
 
 const PG_PASSWORD: &str = "runtime-integration-test-pw";
 const PG_DOCKER_CONTAINER: &str = "runtime-integration-test-postgres";
@@ -71,7 +74,7 @@ pub(super) async fn start_postgres_docker_container(
     };
 
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image("public.ecr.aws/docker/library/postgres:latest")
+        .image(format!("{}postgres:latest", container_registry()))
         .add_port_binding(5432, port)
         .add_env_var("POSTGRES_PASSWORD", PG_PASSWORD)
         .healthcheck(HealthConfig {


### PR DESCRIPTION
## 🗣 Description

We are still seeing rate limits causing integration test failures, even after switching to `public.ecr.aws`.

In CI for non-fork PRs we can bypass the rate limits by pulling from our own authenticated registry. I've created an Azure Container Registry with a cache rule set up to automatically pull the latest postgres/mysql image from Docker Hub.