### PR TITLE
Fix Unity Catalog API response for Azure Databricks

### DIFF
--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -286,21 +286,6 @@ pub struct UCColumn {
 #[derive(Debug, Clone, Deserialize)]
 pub struct UCCatalog {
     pub name: String,
-    pub owner: String,
-    pub storage_root: String,
-    pub catalog_type: String,
-    pub metastore_id: String,
-    pub created_at: i64,
-    pub created_by: String,
-    pub updated_at: i64,
-    pub updated_by: String,
-    pub storage_location: String,
-    pub isolation_mode: String,
-    pub browse_only: bool,
-    pub id: String,
-    pub full_name: String,
-    pub securable_type: String,
-    pub securable_kind: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -312,17 +297,4 @@ pub struct UCSchemaEnvelope {
 pub struct UCSchema {
     pub name: String,
     pub catalog_name: String,
-    pub owner: String,
-    pub comment: Option<String>,
-    pub metastore_id: String,
-    pub full_name: String,
-    pub created_at: i64,
-    pub created_by: String,
-    pub updated_at: i64,
-    pub updated_by: String,
-    pub catalog_type: String,
-    pub schema_id: String,
-    pub securable_type: String,
-    pub securable_kind: String,
-    pub browse_only: bool,
 }

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -313,7 +313,7 @@ pub struct UCSchema {
     pub name: String,
     pub catalog_name: String,
     pub owner: String,
-    pub comment: String,
+    pub comment: Option<String>,
     pub metastore_id: String,
     pub full_name: String,
     pub created_at: i64,


### PR DESCRIPTION
## 🗣 Description

The Azure Databricks Unity Catalog API does not serialize the `comment` field, leading to this error:

`2024-07-15T23:34:44.059771Z ERROR runtime: Unable to register catalog eth: Unable to load data connector for catalog eth: Unable to get catalog provider for databricks: Unity Catalog API request failed: error decoding response body: missing field `comment` at line 1 column 731`

Make this field optional since we don't actually consume it.