### PR TITLE
Remove unused Cargo.toml fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 ] }
 datafusion = "40.0.0"
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", folder = "sources/sql", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "02081887de7b64dfd816ef86716f8b0853ae3196" }
 duckdb = "1.0.0"
 fundu = "2.0.0"
@@ -72,7 +72,7 @@ serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.1"
 serde_yaml = "0.9.30"
 snafu = "0.8.0"
-snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", folder = "snowflake-api", rev = "2991d97548b0cd7a721704165ed07f7b2818cf7b" }
+snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", rev = "2991d97548b0cd7a721704165ed07f7b2818cf7b" }
 ssh2 = { version = "0.9.4" }
 suppaftp = { version = "5.3.1", features = ["async"] }
 tokio = { version = "1.35.1", features = [


### PR DESCRIPTION
## 🗣 Description

Fixes the following warning:

```
warning: /Users/phillip/code/spiceai/spiceai/Cargo.toml: unused manifest key: workspace.dependencies.datafusion-federation-sql.folder
warning: /Users/phillip/code/spiceai/spiceai/Cargo.toml: unused manifest key: workspace.dependencies.snowflake-api.folder
```