### PR TITLE
Spice cli `spice chat` command, to interact with deployed spiced instance in spice.ai cloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ all: build
 build-cli:
 	make -C bin/spice
 
+.PHONY: build-cli-dev
+build-cli-dev:
+	export DEV=true; make -C bin/spice
+
 .PHONY: build-runtime
 build-runtime:
 	make -C bin/spiced
@@ -125,6 +129,11 @@ install-dev: build-dev
 	mkdir -p ~/.spice/bin
 	install -m 755 target/release/spice ~/.spice/bin/spice
 	install -m 755 target/debug/spiced ~/.spice/bin/spiced
+
+.PHONY: install-cli-dev
+install-cli-dev: build-cli-dev
+	mkdir -p ~/.spice/bin
+	install -m 755 target/release/spice ~/.spice/bin/spice
 
 ################################################################################
 # Target: modtidy                                                              #

--- a/bin/spice/Makefile
+++ b/bin/spice/Makefile
@@ -3,6 +3,8 @@ BASE_PACKAGE_NAME := github.com/spiceai/spiceai
 GIT_SHA := $(shell git rev-parse --short HEAD)
 FILE_VERSION := $(shell cat ../../version.txt)
 
+TAGS := $(if $(SPICE_CLI_FEATURES),--tags $(SPICE_CLI_FEATURES),)
+
 ifdef REL_VERSION
 	SPICE_VERSION := $(REL_VERSION)
 	SPICED_FEATURES := --features release
@@ -22,5 +24,5 @@ ifeq ($(OS),Windows_NT)
 	go build -v -ldflags=$(LDFLAGS) -o ..\..\target\release\spice.exe
 else
 	mkdir -p ../../target/release 2> /dev/null || true
-	go build -v -ldflags=$(LDFLAGS) -o ../../target/release/spice
+	go build -v -ldflags=$(LDFLAGS) -o ../../target/release/spice $(TAGS)
 endif

--- a/bin/spice/cmd/cloud.go
+++ b/bin/spice/cmd/cloud.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spiceai/spiceai/bin/spice/pkg/api"
+)
+
+var cloudCmd = &cobra.Command{
+	Use:   "cloud",
+	Short: "Spice.ai Cloud commands",
+}
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatRequestBody struct {
+	Messages []Message `json:"messages"`
+}
+
+type ChatRequesResponse struct {
+	Content string `json:"content"`
+	Role    string `json:"role"`
+}
+
+var chatCmd = &cobra.Command{
+	Use:   "chat",
+	Short: "Chat with the Spice.ai LLM agent",
+	Example: `
+...
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		reader := bufio.NewReader(os.Stdin)
+
+		spiceApiClient := api.NewSpiceApiClient()
+		err := spiceApiClient.Init()
+		if err != nil {
+			cmd.Println(err)
+			os.Exit(1)
+		}
+
+		spiceBaseUrl := spiceApiClient.GetBaseUrl()
+		githubToken := os.Getenv("GITHUB_TOKEN")
+
+		client := &http.Client{}
+
+		var messages []Message = []Message{}
+
+		for {
+			cmd.Print(">>> ")
+
+			message, err := reader.ReadString('\n')
+			if err != nil {
+				cmd.Println(err.Error())
+				os.Exit(1)
+			}
+
+			messages = append(messages, Message{Role: "user", Content: message})
+
+			done := make(chan bool)
+			go func() {
+				spinner(done)
+			}()
+
+			url := fmt.Sprintf("%s/api/integrations/github/copilot/agent-callback", spiceBaseUrl)
+			body := ChatRequestBody{Messages: messages}
+			jsonBody, err := json.Marshal(body)
+			if err != nil {
+				cmd.Println(err)
+				os.Exit(1)
+			}
+
+			request, err := http.NewRequest("POST", url, bytes.NewReader(jsonBody))
+			if err != nil {
+				cmd.Println(err)
+				os.Exit(1)
+			}
+
+			request.Header.Set("X-GitHub-Token", githubToken)
+			response, err := client.Do(request)
+			if err != nil {
+				cmd.Println(err)
+				os.Exit(1)
+			}
+
+			var chatResponse ChatRequesResponse
+			err = json.NewDecoder(response.Body).Decode(&chatResponse)
+			if err != nil {
+				cmd.Println(err)
+				os.Exit(1)
+			}
+
+			message = strings.TrimSpace(chatResponse.Content)
+			if strings.ToLower(message) == "exit" {
+				fmt.Println("Goodbye!")
+				break
+			}
+
+			done <- true
+
+			for _, char := range message {
+				cmd.Printf("%c", char)
+				time.Sleep(30 * time.Millisecond)
+			}
+
+			messages = append(messages, Message{Role: "assistant", Content: message})
+
+			cmd.Print("\n\n")
+		}
+	},
+}
+
+func spinner(done chan bool) {
+	chars := []rune{'⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'}
+	for {
+		for _, char := range chars {
+			select {
+			case <-done:
+				fmt.Print("\r") // Clear the spinner
+				return
+			default:
+				fmt.Printf("\r%c ", char)
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}
+}
+
+func init() {
+	cloudCmd.AddCommand(chatCmd)
+	RootCmd.AddCommand(cloudCmd)
+}

--- a/bin/spice/cmd/cloud.go
+++ b/bin/spice/cmd/cloud.go
@@ -110,7 +110,6 @@ var chatCmd = &cobra.Command{
 
 			for _, char := range message {
 				cmd.Printf("%c", char)
-				time.Sleep(10 * time.Millisecond)
 			}
 
 			messages = append(messages, Message{Role: "assistant", Content: message})

--- a/bin/spice/cmd/cloud.go
+++ b/bin/spice/cmd/cloud.go
@@ -110,7 +110,7 @@ var chatCmd = &cobra.Command{
 
 			for _, char := range message {
 				cmd.Printf("%c", char)
-				time.Sleep(30 * time.Millisecond)
+				time.Sleep(10 * time.Millisecond)
 			}
 
 			messages = append(messages, Message{Role: "assistant", Content: message})

--- a/bin/spice/pkg/api/client.go
+++ b/bin/spice/pkg/api/client.go
@@ -73,6 +73,10 @@ func (s *SpiceApiClient) Init() error {
 	return nil
 }
 
+func (s *SpiceApiClient) GetBaseUrl() string {
+	return s.baseUrl
+}
+
 func (s *SpiceApiClient) GetAuthUrl(authCode string) string {
 	return fmt.Sprintf("%s/auth/token?code=%s", s.baseUrl, authCode)
 }


### PR DESCRIPTION
Experimental cli feature, hidden under cli feature fag `cloud`.

Run `SPICE_CLI_FEATURES="cloud" make install-cli-dev` to enable and build.