### PR TITLE
Remove SecretMap abstraction, use IndexMap for secret stores

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -52,7 +52,7 @@ fundu = { workspace = true }
 futures.workspace = true
 globset.workspace = true
 headers-accept = "0.1.3"
-indexmap = "2.2.2"
+indexmap = "2"
 itertools.workspace = true
 keyring = { version = "2.3.2", optional = true }
 lazy_static = "1.4.0"

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -41,7 +41,7 @@ use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::TableReference;
 use lazy_static::lazy_static;
 use object_store::ObjectStore;
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;
@@ -300,7 +300,7 @@ pub async fn register_all() {
 
 pub trait DataConnectorFactory {
     fn create(
-        params: Arc<HashMap<String, SecretString>>,
+        params: HashMap<String, SecretString>,
     ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>>;
 }
 
@@ -383,7 +383,7 @@ pub trait ListingTableConnector: DataConnector {
 
     fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url>;
 
-    fn get_params(&self) -> &HashMap<String, String>;
+    fn get_params(&self) -> &HashMap<String, SecretString>;
 
     #[must_use]
     fn get_session_context() -> SessionContext {
@@ -456,9 +456,15 @@ pub trait ListingTableConnector: DataConnector {
         Self: Display,
     {
         let params = self.get_params();
-        let extension = params.get("file_extension").cloned();
+        let extension = params
+            .get("file_extension")
+            .map(|f| f.expose_secret())
+            .cloned();
 
-        match params.get("file_format").map(String::as_str) {
+        match params
+            .get("file_format")
+            .map(|f| f.expose_secret().as_str())
+        {
             Some("csv") => Ok((
                 Some(self.get_csv_format(params)?),
                 extension.unwrap_or(".csv".to_string()),
@@ -495,25 +501,30 @@ pub trait ListingTableConnector: DataConnector {
 
     fn get_csv_format(
         &self,
-        params: &HashMap<String, String>,
+        params: &HashMap<String, SecretString>,
     ) -> DataConnectorResult<Arc<CsvFormat>>
     where
         Self: Display,
     {
-        let has_header = params.get("has_header").map_or(true, |f| f == "true");
-        let quote = params
-            .get("quote")
-            .map_or(b'"', |f| *f.as_bytes().first().unwrap_or(&b'"'));
+        let has_header = params.get("has_header").map_or(true, |f| {
+            f.expose_secret().as_str().eq_ignore_ascii_case("true")
+        });
+        let quote = params.get("quote").map_or(b'"', |f| {
+            *f.expose_secret().as_bytes().first().unwrap_or(&b'"')
+        });
         let escape = params
             .get("escape")
-            .and_then(|f| f.as_bytes().first().copied());
-        let schema_infer_max_rec = params
-            .get("schema_infer_max_records")
-            .map_or_else(|| 1000, |f| usize::from_str(f).map_or(1000, |f| f));
-        let delimiter = params
-            .get("delimiter")
-            .map_or(b',', |f| *f.as_bytes().first().unwrap_or(&b','));
-        let compression_type = params.get("compression_type").map_or("", |f| f);
+            .and_then(|f| f.expose_secret().as_bytes().first().copied());
+        let schema_infer_max_rec = params.get("schema_infer_max_records").map_or_else(
+            || 1000,
+            |f| usize::from_str(f.expose_secret().as_str()).map_or(1000, |f| f),
+        );
+        let delimiter = params.get("delimiter").map_or(b',', |f| {
+            *f.expose_secret().as_bytes().first().unwrap_or(&b',')
+        });
+        let compression_type = params
+            .get("compression_type")
+            .map_or("", |f| f.expose_secret().as_str());
 
         Ok(Arc::new(
             CsvFormat::default()

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -41,7 +41,7 @@ use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::TableReference;
 use lazy_static::lazy_static;
 use object_store::ObjectStore;
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::SecretString;
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;
@@ -300,7 +300,7 @@ pub async fn register_all() {
 
 pub trait DataConnectorFactory {
     fn create(
-        params: HashMap<String, SecretString>,
+        params: Arc<HashMap<String, SecretString>>,
     ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>>;
 }
 
@@ -383,7 +383,7 @@ pub trait ListingTableConnector: DataConnector {
 
     fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url>;
 
-    fn get_params(&self) -> &HashMap<String, SecretString>;
+    fn get_params(&self) -> &HashMap<String, String>;
 
     #[must_use]
     fn get_session_context() -> SessionContext {
@@ -456,15 +456,9 @@ pub trait ListingTableConnector: DataConnector {
         Self: Display,
     {
         let params = self.get_params();
-        let extension = params
-            .get("file_extension")
-            .map(ExposeSecret::expose_secret)
-            .cloned();
+        let extension = params.get("file_extension").cloned();
 
-        match params
-            .get("file_format")
-            .map(|f| f.expose_secret().as_str())
-        {
+        match params.get("file_format").map(String::as_str) {
             Some("csv") => Ok((
                 Some(self.get_csv_format(params)?),
                 extension.unwrap_or(".csv".to_string()),
@@ -501,30 +495,25 @@ pub trait ListingTableConnector: DataConnector {
 
     fn get_csv_format(
         &self,
-        params: &HashMap<String, SecretString>,
+        params: &HashMap<String, String>,
     ) -> DataConnectorResult<Arc<CsvFormat>>
     where
         Self: Display,
     {
-        let has_header = params.get("has_header").map_or(true, |f| {
-            f.expose_secret().as_str().eq_ignore_ascii_case("true")
-        });
-        let quote = params.get("quote").map_or(b'"', |f| {
-            *f.expose_secret().as_bytes().first().unwrap_or(&b'"')
-        });
+        let has_header = params.get("has_header").map_or(true, |f| f == "true");
+        let quote = params
+            .get("quote")
+            .map_or(b'"', |f| *f.as_bytes().first().unwrap_or(&b'"'));
         let escape = params
             .get("escape")
-            .and_then(|f| f.expose_secret().as_bytes().first().copied());
-        let schema_infer_max_rec = params.get("schema_infer_max_records").map_or_else(
-            || 1000,
-            |f| usize::from_str(f.expose_secret().as_str()).map_or(1000, |f| f),
-        );
-        let delimiter = params.get("delimiter").map_or(b',', |f| {
-            *f.expose_secret().as_bytes().first().unwrap_or(&b',')
-        });
-        let compression_type = params
-            .get("compression_type")
-            .map_or("", |f| f.expose_secret().as_str());
+            .and_then(|f| f.as_bytes().first().copied());
+        let schema_infer_max_rec = params
+            .get("schema_infer_max_records")
+            .map_or_else(|| 1000, |f| usize::from_str(f).map_or(1000, |f| f));
+        let delimiter = params
+            .get("delimiter")
+            .map_or(b',', |f| *f.as_bytes().first().unwrap_or(&b','));
+        let compression_type = params.get("compression_type").map_or("", |f| f);
 
         Ok(Arc::new(
             CsvFormat::default()

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -458,7 +458,7 @@ pub trait ListingTableConnector: DataConnector {
         let params = self.get_params();
         let extension = params
             .get("file_extension")
-            .map(|f| f.expose_secret())
+            .map(ExposeSecret::expose_secret)
             .cloned();
 
         match params

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -55,7 +55,7 @@ impl DataConnectorFactory for FlightSQL {
         Box::pin(async move {
             let endpoint: String = params
                 .get("endpoint")
-                .map(|s| s.expose_secret())
+                .map(ExposeSecret::expose_secret)
                 .cloned()
                 .context(MissingEndpointParameterSnafu)?;
             let flight_channel = new_tls_flight_channel(&endpoint)

--- a/crates/runtime/src/secrets/env.rs
+++ b/crates/runtime/src/secrets/env.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use async_trait::async_trait;
+use secrecy::SecretString;
 
 use super::SecretStore;
 
@@ -44,10 +45,10 @@ impl SecretStore for EnvSecretStore {
     /// <https://www.gnu.org/software/libc/manual/html_node/Environment-Variables.html>
     /// > Names of environment variables are case-sensitive and must not contain the character ‘=’. System-defined environment variables are invariably uppercase.
     #[must_use]
-    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<String>> {
+    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<SecretString>> {
         // TODO: Handle falling back to the spice generated prefix
         match std::env::var(key) {
-            Ok(value) => Ok(Some(value)),
+            Ok(value) => Ok(Some(SecretString::new(value))),
             Err(std::env::VarError::NotPresent) => Ok(None),
             Err(err) => Err(Box::new(err)),
         }

--- a/crates/runtime/src/secrets/keyring.rs
+++ b/crates/runtime/src/secrets/keyring.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use async_trait::async_trait;
 use keyring::Entry;
+use secrecy::SecretString;
 use snafu::Snafu;
 
 use super::SecretStore;
@@ -55,7 +56,7 @@ impl KeyringSecretStore {
 #[async_trait]
 impl SecretStore for KeyringSecretStore {
     #[must_use]
-    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<String>> {
+    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<SecretString>> {
         let entry = match Entry::new(key, "spiced") {
             Ok(entry) => entry,
             Err(keyring::Error::NoEntry) => {
@@ -67,7 +68,7 @@ impl SecretStore for KeyringSecretStore {
         };
 
         let secret = match entry.get_password() {
-            Ok(secret) => secret,
+            Ok(secret) => SecretString::new(secret),
             Err(keyring::Error::NoEntry) => {
                 return Ok(None);
             }

--- a/crates/runtime/src/secrets/kubernetes.rs
+++ b/crates/runtime/src/secrets/kubernetes.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine};
 use reqwest;
+use secrecy::SecretString;
 use snafu::{ResultExt, Snafu};
 
 use super::SecretStore;
@@ -190,9 +191,9 @@ impl KubernetesSecretStore {
 #[async_trait]
 impl SecretStore for KubernetesSecretStore {
     #[must_use]
-    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<String>> {
+    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<SecretString>> {
         match self.kubernetes_client.get_secret(&self.secret_name).await {
-            Ok(secret) => Ok(secret.get(key).cloned()),
+            Ok(secret) => Ok(secret.get(key).cloned().map(SecretString::new)),
             Err(err) => Err(Box::new(StoreError::UnableToGetSecret { source: err })),
         }
     }


### PR DESCRIPTION
## 🗣 Description

Removes the `SecretMap` abstraction in favor of `HashMap<String, SecretString>`.

Use an `IndexMap` to maintain the precedence order of the secret stores. This will be in reverse order in memory as it appears in the Spicepod to maintain our expected ordering.

Changes the `SecretStore` trait function `get_secret` to return a `SecureString` instead of a `String`

## 🔨 Related Issues

Part of #1701