### PR TITLE
Support loading multiple secrets in the Spicepod

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -27,7 +27,7 @@ use spicepod::{
         extension::Extension,
         model::Model,
         runtime::{ResultsCache, Runtime},
-        secret_stores::SecretStore,
+        secret::Secret,
         view::View,
     },
     Spicepod,
@@ -37,7 +37,7 @@ use spicepod::{
 pub struct App {
     pub name: String,
 
-    pub secret_stores: Vec<SecretStore>,
+    pub secrets: Vec<Secret>,
 
     pub extensions: HashMap<String, Extension>,
 
@@ -69,7 +69,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct AppBuilder {
     name: String,
-    secret_stores: Vec<SecretStore>,
+    secrets: Vec<Secret>,
     extensions: HashMap<String, Extension>,
     catalogs: Vec<Catalog>,
     datasets: Vec<Dataset>,
@@ -84,7 +84,7 @@ impl AppBuilder {
     pub fn new(name: impl Into<String>) -> AppBuilder {
         AppBuilder {
             name: name.into(),
-            secret_stores: vec![],
+            secrets: vec![],
             extensions: HashMap::new(),
             catalogs: vec![],
             datasets: vec![],
@@ -98,7 +98,7 @@ impl AppBuilder {
 
     #[must_use]
     pub fn with_spicepod(mut self, spicepod: Spicepod) -> AppBuilder {
-        self.secret_stores.extend(spicepod.secret_stores.clone());
+        self.secrets.extend(spicepod.secrets.clone());
         self.extensions.extend(spicepod.extensions.clone());
         self.catalogs.extend(spicepod.catalogs.clone());
         self.datasets.extend(spicepod.datasets.clone());
@@ -116,8 +116,8 @@ impl AppBuilder {
     }
 
     #[must_use]
-    pub fn with_secret_store(mut self, secret_store: SecretStore) -> AppBuilder {
-        self.secret_stores.push(secret_store);
+    pub fn with_secret(mut self, secret: Secret) -> AppBuilder {
+        self.secrets.push(secret);
         self
     }
 
@@ -161,7 +161,7 @@ impl AppBuilder {
     pub fn build(self) -> App {
         App {
             name: self.name,
-            secret_stores: self.secret_stores,
+            secrets: self.secrets,
             extensions: self.extensions,
             catalogs: self.catalogs,
             datasets: self.datasets,
@@ -177,7 +177,7 @@ impl AppBuilder {
         let path = path.into();
         let spicepod_root =
             Spicepod::load(&path).context(UnableToLoadSpicepodSnafu { path: path.clone() })?;
-        let secret_stores = spicepod_root.secret_stores.clone();
+        let secrets = spicepod_root.secrets.clone();
         let runtime = spicepod_root.runtime.clone();
         let extensions = spicepod_root.extensions.clone();
         let mut catalogs: Vec<Catalog> = vec![];
@@ -237,7 +237,7 @@ impl AppBuilder {
 
         Ok(App {
             name: root_spicepod_name,
-            secret_stores,
+            secrets,
             extensions,
             catalogs,
             datasets,

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -3,7 +3,7 @@ use app::{App, AppBuilder};
 use runtime::{dataupdate::DataUpdate, Runtime};
 use spicepod::component::{
     dataset::{replication::Replication, Dataset, Mode},
-    secrets::SpiceSecretStore,
+    secret_stores::SpiceSecretStore,
 };
 use std::process::Command;
 use tracing_subscriber::EnvFilter;

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -3,7 +3,7 @@ use app::{App, AppBuilder};
 use runtime::{dataupdate::DataUpdate, Runtime};
 use spicepod::component::{
     dataset::{replication::Replication, Dataset, Mode},
-    secret_stores::SpiceSecretStore,
+    secret::SpiceSecretStore,
 };
 use std::process::Command;
 use tracing_subscriber::EnvFilter;

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -130,7 +130,7 @@ impl RuntimeBuilder {
             llms: Arc::new(RwLock::new(HashMap::new())),
             embeds: Arc::new(RwLock::new(HashMap::new())),
             pods_watcher: Arc::new(RwLock::new(self.pods_watcher)),
-            secrets_provider: Arc::new(RwLock::new(secrets::SecretsProvider::new())),
+            secrets: Arc::new(RwLock::new(secrets::Secrets::new())),
             spaced_tracer: Arc::new(tracers::SpacedTracer::new(Duration::from_secs(15))),
             autoload_extensions: Arc::new(self.autoload_extensions),
             extensions: Arc::new(RwLock::new(HashMap::new())),

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -628,10 +628,12 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
 
 #[cfg(test)]
 mod tests {
+    use datafusion_table_providers::util::secrets::to_secret_map;
+
     use super::*;
 
     struct TestConnector {
-        params: Arc<HashMap<String, String>>,
+        params: HashMap<String, SecretString>,
     }
 
     impl std::fmt::Display for TestConnector {
@@ -642,8 +644,7 @@ mod tests {
 
     impl DataConnectorFactory for TestConnector {
         fn create(
-            _secret: Option<Secret>,
-            params: Arc<HashMap<String, String>>,
+            params: HashMap<String, SecretString>,
         ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
             Box::pin(async move {
                 let connector = Self { params };
@@ -657,7 +658,7 @@ mod tests {
             self
         }
 
-        fn get_params(&self) -> &HashMap<String, String> {
+        fn get_params(&self) -> &HashMap<String, SecretString> {
             &self.params
         }
 
@@ -673,7 +674,7 @@ mod tests {
 
     fn setup_connector(path: String, params: HashMap<String, String>) -> (TestConnector, Dataset) {
         let connector = TestConnector {
-            params: params.into(),
+            params: to_secret_map(params),
         };
         let dataset = Dataset::try_new(path, "test").expect("a valid dataset");
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -402,7 +402,7 @@ impl Runtime {
 
         let app_lock = self.app.read().await;
         if let Some(app) = app_lock.as_ref() {
-            if let Err(e) = secrets.load_from(&app.secret_stores).await {
+            if let Err(e) = secrets.load_from(&app.secrets).await {
                 tracing::error!("Error loading secret stores: {e}");
             };
         }

--- a/crates/runtime/tests/catalog/mod.rs
+++ b/crates/runtime/tests/catalog/mod.rs
@@ -23,7 +23,7 @@ use runtime::Runtime;
 use runtime::{datafusion::query::Protocol, extension::ExtensionFactory};
 use spice_cloud::SpiceExtensionFactory;
 use spicepod::component::catalog::Catalog;
-use spicepod::component::secrets::SpiceSecretStore;
+use spicepod::component::secret_stores::SpiceSecretStore;
 use std::collections::HashMap;
 
 #[tokio::test]

--- a/crates/runtime/tests/catalog/mod.rs
+++ b/crates/runtime/tests/catalog/mod.rs
@@ -23,7 +23,7 @@ use runtime::Runtime;
 use runtime::{datafusion::query::Protocol, extension::ExtensionFactory};
 use spice_cloud::SpiceExtensionFactory;
 use spicepod::component::catalog::Catalog;
-use spicepod::component::secret_stores::SpiceSecretStore;
+use spicepod::component::secret::SpiceSecretStore;
 use std::collections::HashMap;
 
 #[tokio::test]

--- a/crates/runtime/tests/federation/mod.rs
+++ b/crates/runtime/tests/federation/mod.rs
@@ -18,7 +18,7 @@ use app::AppBuilder;
 use arrow::array::{Int64Array, RecordBatch};
 use datafusion::assert_batches_eq;
 use runtime::Runtime;
-use spicepod::component::{dataset::Dataset, secrets::SpiceSecretStore};
+use spicepod::component::{dataset::Dataset, secret_stores::SpiceSecretStore};
 
 use crate::{get_test_datafusion, init_tracing, run_query_and_check_results, ValidateFn};
 

--- a/crates/runtime/tests/federation/mod.rs
+++ b/crates/runtime/tests/federation/mod.rs
@@ -18,7 +18,7 @@ use app::AppBuilder;
 use arrow::array::{Int64Array, RecordBatch};
 use datafusion::assert_batches_eq;
 use runtime::Runtime;
-use spicepod::component::{dataset::Dataset, secret_stores::SpiceSecretStore};
+use spicepod::component::{dataset::Dataset, secret::SpiceSecretStore};
 
 use crate::{get_test_datafusion, init_tracing, run_query_and_check_results, ValidateFn};
 

--- a/crates/runtime/tests/refresh_sql/mod.rs
+++ b/crates/runtime/tests/refresh_sql/mod.rs
@@ -20,7 +20,7 @@ use app::AppBuilder;
 use runtime::{accelerated_table::AcceleratedTable, Runtime};
 use spicepod::component::{
     dataset::{acceleration::Acceleration, Dataset},
-    secret_stores::SpiceSecretStore,
+    secret::SpiceSecretStore,
 };
 
 use crate::init_tracing;

--- a/crates/runtime/tests/refresh_sql/mod.rs
+++ b/crates/runtime/tests/refresh_sql/mod.rs
@@ -20,7 +20,7 @@ use app::AppBuilder;
 use runtime::{accelerated_table::AcceleratedTable, Runtime};
 use spicepod::component::{
     dataset::{acceleration::Acceleration, Dataset},
-    secrets::SpiceSecretStore,
+    secret_stores::SpiceSecretStore,
 };
 
 use crate::init_tracing;

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -22,7 +22,7 @@ use runtime::{
     Runtime,
 };
 use spicepod::component::{
-    dataset::Dataset, params::Params, runtime::ResultsCache, secrets::SpiceSecretStore,
+    dataset::Dataset, params::Params, runtime::ResultsCache, secret_stores::SpiceSecretStore,
 };
 
 use crate::init_tracing;

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -22,7 +22,7 @@ use runtime::{
     Runtime,
 };
 use spicepod::component::{
-    dataset::Dataset, params::Params, runtime::ResultsCache, secret_stores::SpiceSecretStore,
+    dataset::Dataset, params::Params, runtime::ResultsCache, secret::SpiceSecretStore,
 };
 
 use crate::init_tracing;

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -30,7 +30,7 @@ pub mod extension;
 pub mod model;
 pub mod params;
 pub mod runtime;
-pub mod secret_stores;
+pub mod secret;
 pub mod view;
 
 pub trait Nameable {

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -30,7 +30,7 @@ pub mod extension;
 pub mod model;
 pub mod params;
 pub mod runtime;
-pub mod secrets;
+pub mod secret_stores;
 pub mod view;
 
 pub trait Nameable {
@@ -63,11 +63,13 @@ pub enum ComponentOrReference<T> {
 pub enum Error {
     #[snafu(display("Unable to convert the path into a string"))]
     UnableToConvertPath,
+
     #[snafu(display("Unable to parse spicepod component {}: {source}", path.display()))]
     UnableToParseSpicepodComponent {
         source: serde_yaml::Error,
         path: PathBuf,
     },
+
     #[snafu(display("The component referenced by {} does not exist", path.display()))]
     InvalidComponentReference { path: PathBuf },
 }

--- a/crates/spicepod/src/component/secret.rs
+++ b/crates/spicepod/src/component/secret.rs
@@ -24,7 +24,7 @@ use super::{params::Params, Nameable};
 ///
 /// Example:
 /// ```yaml
-/// secret_stores:
+/// secrets:
 ///   - from: env
 ///     name: env
 ///   - from: kubernetes:my_secret_name
@@ -32,7 +32,7 @@ use super::{params::Params, Nameable};
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct SecretStore {
+pub struct Secret {
     pub from: String,
 
     pub name: String,
@@ -41,7 +41,7 @@ pub struct SecretStore {
     pub params: Option<Params>,
 }
 
-impl Nameable for SecretStore {
+impl Nameable for Secret {
     fn name(&self) -> &str {
         &self.name
     }

--- a/crates/spicepod/src/component/secret_stores.rs
+++ b/crates/spicepod/src/component/secret_stores.rs
@@ -18,34 +18,31 @@ limitations under the License.
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::{params::Params, Nameable};
+
 /// The secrets configuration for a Spicepod.
 ///
 /// Example:
 /// ```yaml
-/// secrets:
-///   store: env
+/// secret_stores:
+///   - from: env
+///     name: env
+///   - from: kubernetes:my_secret_name
+///     name: k8s
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub struct Secrets {
-    pub store: SpiceSecretStore,
+pub struct SecretStore {
+    pub from: String,
+
+    pub name: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Params>,
 }
 
-impl Default for Secrets {
-    fn default() -> Self {
-        Self {
-            store: SpiceSecretStore::Env,
-        }
+impl Nameable for SecretStore {
+    fn name(&self) -> &str {
+        &self.name
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[serde(rename_all = "lowercase")]
-pub enum SpiceSecretStore {
-    Env,
-    Kubernetes,
-    Keyring,
-    #[serde(rename = "aws_secrets_manager")]
-    AwsSecretsManager,
 }

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -23,7 +23,7 @@ use std::{fmt::Debug, path::PathBuf};
 
 use component::{
     catalog::Catalog, dataset::Dataset, embeddings::Embeddings, extension::Extension, model::Model,
-    runtime::Runtime, secret_stores::SecretStore, view::View,
+    runtime::Runtime, secret::Secret, view::View,
 };
 
 use spec::{SpicepodDefinition, SpicepodVersion};
@@ -60,7 +60,7 @@ pub struct Spicepod {
 
     pub extensions: HashMap<String, Extension>,
 
-    pub secret_stores: Vec<SecretStore>,
+    pub secrets: Vec<Secret>,
 
     pub catalogs: Vec<Catalog>,
 
@@ -149,7 +149,7 @@ impl Spicepod {
         )
         .context(UnableToResolveSpicepodComponentsSnafu { path: path.clone() })?;
 
-        detect_duplicate_component_names("secret_stores", &spicepod_definition.secret_stores[..])?;
+        detect_duplicate_component_names("secrets", &spicepod_definition.secrets[..])?;
         detect_duplicate_component_names("dataset", &resolved_datasets[..])?;
         detect_duplicate_component_names("view", &resolved_views[..])?;
         detect_duplicate_component_names("model", &resolved_models[..])?;
@@ -200,7 +200,7 @@ fn from_definition(
         name: spicepod_definition.name,
         version: spicepod_definition.version,
         extensions: spicepod_definition.extensions,
-        secret_stores: spicepod_definition.secret_stores,
+        secrets: spicepod_definition.secrets,
         catalogs,
         datasets,
         views,

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, fmt::Debug};
 use crate::component::catalog::Catalog;
 use crate::component::embeddings::Embeddings;
 use crate::component::runtime::Runtime;
-use crate::component::secret_stores::SecretStore;
+use crate::component::secret::Secret;
 use crate::component::{
     dataset::Dataset, extension::Extension, model::Model, view::View, ComponentOrReference,
 };
@@ -69,12 +69,12 @@ pub struct SpicepodDefinition {
     /// Optional spicepod secrets configuration
     /// Default value is:
     /// ```yaml
-    /// secret_stores:
+    /// secrets:
     ///   - from: env
     ///     name: env
     /// ```
     #[serde(default)]
-    pub secret_stores: Vec<SecretStore>,
+    pub secrets: Vec<Secret>,
 
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, fmt::Debug};
 use crate::component::catalog::Catalog;
 use crate::component::embeddings::Embeddings;
 use crate::component::runtime::Runtime;
-use crate::component::secrets::Secrets;
+use crate::component::secret_stores::SecretStore;
 use crate::component::{
     dataset::Dataset, extension::Extension, model::Model, view::View, ComponentOrReference,
 };
@@ -67,9 +67,14 @@ pub struct SpicepodDefinition {
     pub extensions: HashMap<String, Extension>,
 
     /// Optional spicepod secrets configuration
-    /// Default value is `store: file`
+    /// Default value is:
+    /// ```yaml
+    /// secret_stores:
+    ///   - from: env
+    ///     name: env
+    /// ```
     #[serde(default)]
-    pub secrets: Secrets,
+    pub secret_stores: Vec<SecretStore>,
 
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]


### PR DESCRIPTION
## 🗣 Description

Supports loading multiple secrets in the Spicepod in the same format that other components are defined.

```yaml
secrets:
  - from: kubernetes:my_secret
    name: k8s
  - from: keyring
    name: keyring
  - from: env
    name: my_env
```

The precedence order for looking for secrets will be `my_env`, `keyring` and then `k8s`. Searching for a secret based on precedence isn't implemented yet.

The next PR will implement the string replacement of `${{ store:key }}` tokens with the actual secrets.

## 🔨 Related Issues

Part of #1701