### PR TITLE
Find and replace secrets identifiers in params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5464,6 +5470,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.4",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lrtable"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8063,6 +8102,7 @@ dependencies = [
  "keyring",
  "lazy_static",
  "llms",
+ "logos",
  "mediatype",
  "metrics 0.23.0",
  "metrics-exporter-prometheus",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -57,6 +57,7 @@ itertools.workspace = true
 keyring = { version = "2.3.2", optional = true }
 lazy_static = "1.4.0"
 llms = { path = "../llms" }
+logos = "0.14.0"
 mediatype = "0.19.18"
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true

--- a/crates/runtime/src/secrets/lexer.rs
+++ b/crates/runtime/src/secrets/lexer.rs
@@ -16,6 +16,12 @@ limitations under the License.
 
 use logos::Logos;
 
+pub struct ReplacementMatch {
+    pub store_name: String,
+    pub key: String,
+    pub span: std::ops::Range<usize>,
+}
+
 #[derive(Logos, Debug, PartialEq)]
 #[logos(skip r"[ \t\n\f]+")] // Ignore whitespace between tokens
 enum SecretReplacementToken {
@@ -30,4 +36,136 @@ enum SecretReplacementToken {
 
     #[token("}}")]
     End,
+}
+
+pub struct SecretReplacementMatcher<'a> {
+    lexer: logos::Lexer<'a, SecretReplacementToken>,
+}
+
+impl<'a> SecretReplacementMatcher<'a> {
+    pub fn new(input: &'a str) -> Self {
+        Self {
+            lexer: SecretReplacementToken::lexer(input),
+        }
+    }
+}
+
+impl<'a> Iterator for SecretReplacementMatcher<'a> {
+    type Item = ReplacementMatch;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(Ok(token)) = self.lexer.next() {
+            let SecretReplacementToken::Start = token else {
+                continue;
+            };
+
+            let start_span = self.lexer.span().start;
+
+            let SecretReplacementToken::Identifier(store_name) = self.lexer.next()?.ok()? else {
+                continue;
+            };
+
+            if self.lexer.next()?.ok()? != SecretReplacementToken::Colon {
+                continue;
+            }
+
+            let SecretReplacementToken::Identifier(key) = self.lexer.next()?.ok()? else {
+                continue;
+            };
+
+            if self.lexer.next()?.ok()? != SecretReplacementToken::End {
+                continue;
+            }
+
+            let end_span = self.lexer.span().end;
+            return Some(ReplacementMatch {
+                store_name,
+                key,
+                span: start_span..end_span,
+            });
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_secret_lexer_basic() {
+        let input = "Hello ${{ secret:my_secret }} world";
+        let lexer = SecretReplacementMatcher::new(input);
+
+        let matches: Vec<ReplacementMatch> = lexer.collect();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].store_name, "secret");
+        assert_eq!(matches[0].key, "my_secret");
+        assert_eq!(matches[0].span, 6..29);
+    }
+
+    #[test]
+    fn test_secret_lexer_whitespace_variations() {
+        let inputs = vec![
+            ("Hello ${{secret:my_secret}} world", 27),
+            ("Hello ${{ secret: my_secret }} world", 30),
+            ("Hello ${{  secret:my_secret  }} world", 31),
+            ("Hello ${{secret :my_secret}} world", 28),
+        ];
+
+        for (input, expected_end) in inputs {
+            let lexer = SecretReplacementMatcher::new(input);
+
+            let matches: Vec<ReplacementMatch> = lexer.collect();
+            assert_eq!(matches.len(), 1);
+            assert_eq!(matches[0].store_name, "secret");
+            assert_eq!(matches[0].key, "my_secret");
+            assert!(matches[0].span.start == 6 && matches[0].span.end == expected_end);
+        }
+    }
+
+    #[test]
+    fn test_secret_lexer_multiple_matches() {
+        let input = "Start ${{ secret:my_secret1 }} middle ${{ secret:my_secret2 }} end";
+        let lexer = SecretReplacementMatcher::new(input);
+
+        let matches: Vec<ReplacementMatch> = lexer.collect();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].store_name, "secret");
+        assert_eq!(matches[0].key, "my_secret1");
+        assert_eq!(matches[0].span, 6..30);
+
+        assert_eq!(matches[1].store_name, "secret");
+        assert_eq!(matches[1].key, "my_secret2");
+        assert_eq!(matches[1].span, 38..62);
+    }
+
+    #[test]
+    fn test_secret_lexer_invalid_formats() {
+        let inputs = vec![
+            "Hello ${{secret:}} world",             // Missing key
+            "Hello ${{:my_secret}} world",          // Missing store name
+            "Hello ${{ secret my_secret }} world",  // Missing colon
+            "Hello ${{ secret: my secret }} world", // Invalid key format
+            "Hello ${{secret}} world",              // Missing colon and key
+            "Hello ${ secret:my_secret } world",    // Missing outer curly braces
+        ];
+
+        for input in inputs {
+            let lexer = SecretReplacementMatcher::new(input);
+
+            let matches: Vec<ReplacementMatch> = lexer.collect();
+            assert_eq!(matches.len(), 0);
+        }
+    }
+
+    #[test]
+    fn test_secret_lexer_no_matches() {
+        let input = "Hello world";
+        let lexer = SecretReplacementMatcher::new(input);
+
+        let matches: Vec<ReplacementMatch> = lexer.collect();
+        assert_eq!(matches.len(), 0);
+    }
 }

--- a/crates/runtime/src/secrets/lexer.rs
+++ b/crates/runtime/src/secrets/lexer.rs
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use logos::Logos;
+
+#[derive(Logos, Debug, PartialEq)]
+#[logos(skip r"[ \t\n\f]+")] // Ignore whitespace between tokens
+enum SecretReplacementToken {
+    #[token("${{")]
+    Start,
+
+    #[regex(r"[a-zA-Z][a-zA-Z0-9_-]*", |lex| lex.slice().to_owned())]
+    Identifier(String),
+
+    #[token(":")]
+    Colon,
+
+    #[token("}}")]
+    End,
+}

--- a/crates/runtime/src/secrets/stores.rs
+++ b/crates/runtime/src/secrets/stores.rs
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#[cfg(feature = "aws-secrets-manager")]
+pub mod aws_secrets_manager;
+pub mod env;
+#[cfg(feature = "keyring-secret-store")]
+pub mod keyring;
+pub mod kubernetes;

--- a/crates/runtime/src/secrets/stores/aws_secrets_manager.rs
+++ b/crates/runtime/src/secrets/stores/aws_secrets_manager.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use aws_sdk_sts::operation::get_caller_identity::GetCallerIdentityError;
 use secrecy::SecretString;
 
-use super::SecretStore;
+use crate::secrets::SecretStore;
 
 use aws_sdk_secretsmanager::{error::SdkError, operation::get_secret_value::GetSecretValueError};
 
@@ -90,7 +90,7 @@ impl AwsSecretsManager {
 #[async_trait]
 impl SecretStore for AwsSecretsManager {
     #[must_use]
-    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<SecretString>> {
+    async fn get_secret(&self, key: &str) -> crate::secrets::AnyErrorResult<Option<SecretString>> {
         tracing::trace!(
             "Getting secret {} from AWS Secrets Manager",
             self.secret_name

--- a/crates/runtime/src/secrets/stores/env.rs
+++ b/crates/runtime/src/secrets/stores/env.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use async_trait::async_trait;
 use secrecy::SecretString;
 
-use super::SecretStore;
+use crate::secrets::SecretStore;
 
 const ENV_SECRET_PREFIX: &str = "SPICE_SECRET_";
 
@@ -45,7 +45,7 @@ impl SecretStore for EnvSecretStore {
     /// <https://www.gnu.org/software/libc/manual/html_node/Environment-Variables.html>
     /// > Names of environment variables are case-sensitive and must not contain the character ‘=’. System-defined environment variables are invariably uppercase.
     #[must_use]
-    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<SecretString>> {
+    async fn get_secret(&self, key: &str) -> crate::secrets::AnyErrorResult<Option<SecretString>> {
         // TODO: Handle falling back to the spice generated prefix
         match std::env::var(key) {
             Ok(value) => Ok(Some(SecretString::new(value))),

--- a/crates/runtime/src/secrets/stores/keyring.rs
+++ b/crates/runtime/src/secrets/stores/keyring.rs
@@ -19,7 +19,7 @@ use keyring::Entry;
 use secrecy::SecretString;
 use snafu::Snafu;
 
-use super::SecretStore;
+use crate::secrets::SecretStore;
 
 const KEYRING_SECRET_PREFIX: &str = "spice_secret_";
 
@@ -56,7 +56,7 @@ impl KeyringSecretStore {
 #[async_trait]
 impl SecretStore for KeyringSecretStore {
     #[must_use]
-    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<SecretString>> {
+    async fn get_secret(&self, key: &str) -> crate::secrets::AnyErrorResult<Option<SecretString>> {
         let entry = match Entry::new(key, "spiced") {
             Ok(entry) => entry,
             Err(keyring::Error::NoEntry) => {

--- a/crates/runtime/src/secrets/stores/kubernetes.rs
+++ b/crates/runtime/src/secrets/stores/kubernetes.rs
@@ -22,7 +22,7 @@ use reqwest;
 use secrecy::SecretString;
 use snafu::{ResultExt, Snafu};
 
-use super::SecretStore;
+use crate::secrets::SecretStore;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -191,7 +191,7 @@ impl KubernetesSecretStore {
 #[async_trait]
 impl SecretStore for KubernetesSecretStore {
     #[must_use]
-    async fn get_secret(&self, key: &str) -> super::AnyErrorResult<Option<SecretString>> {
+    async fn get_secret(&self, key: &str) -> crate::secrets::AnyErrorResult<Option<SecretString>> {
         match self.kubernetes_client.get_secret(&self.secret_name).await {
             Ok(secret) => Ok(secret.get(key).cloned().map(SecretString::new)),
             Err(err) => Err(Box::new(StoreError::UnableToGetSecret { source: err })),


### PR DESCRIPTION
## 🗣 Description

Implements the `inject_secrets` method to find and replace secret identifiers in param strings with the actual secret values.

Handles multiple replacements in a single string, to allow embedding secrets within a larger parameter, i.e. for connection strings.

Uses the [`logos`](https://crates.io/crates/logos) crate to implement efficient lexing of the parameter string, returning matches that are used to construct the replacement string without any unnecessary string copies.

Also moves the secret stores into a `stores` submodule.

Currently only explicitly named secret stores can be used - the next PR will implement the precedence searching when `${{ secrets.<key> }}` is specified.

i.e. this is now working:

```yaml
secrets:
  - from: env
    name: env1

datasets:
- from: postgres:my_table
  name: my_table
  params:
    pg_host: localhost
    pg_port: 5432
    pg_user: postgres
    pg_pass: ${{ env1:PG_PASS }}
    pg_db: spice
    pg_sslmode: disable
```

## 🔨 Related Issues

Part of #1701