### PR TITLE
Install a rustls default CryptoProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9016,6 +9016,7 @@ dependencies = [
  "metrics 0.23.0",
  "metrics-exporter-prometheus",
  "runtime",
+ "rustls 0.23.11",
  "snafu 0.8.4",
  "snmalloc-rs",
  "spice-cloud",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ pem = "3.0.4"
 r2d2 = "0.8.10"
 regex = "1.10.3"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
+rustls = "0.23"
 secrecy = "0.8.0"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.1"

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -16,6 +16,7 @@ futures = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 runtime = { path = "../../crates/runtime" }
+rustls.workspace = true
 snafu.workspace = true
 snmalloc-rs = "0.3.6"
 spice-cloud = { path = "../../crates/spice_cloud" }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -18,6 +18,7 @@ use std::net::SocketAddr;
 
 use clap::Parser;
 use metrics_exporter_prometheus::PrometheusBuilder;
+use rustls::crypto::{self, CryptoProvider};
 use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
 
@@ -68,6 +69,9 @@ fn main() {
     }
 
     tracing::trace!("Starting Spice Runtime!");
+
+    // Install the default AWS LC RS crypto provider for rusttls
+    let _ = CryptoProvider::install_default(crypto::aws_lc_rs::default_provider());
 
     if let Err(err) = tokio_runtime.block_on(start_runtime(args)) {
         tracing::error!("Spice Runtime error: {err}");


### PR DESCRIPTION
## 🗣 Description

`rustls` allows for [swapping out the underlying libraries](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider) that perform the cryptographic functions it needs to operate. The crate has two crypto providers it supports, https://crates.io/crates/aws-lc-rs and https://crates.io/crates/ring. By default `aws-lc-rs` is enabled and `ring` is optional. If one of the providers is enabled, then its unambiguous which provider to use. However, if both `aws-lc-rs` and `ring` are enabled then the library doesn't know which one to use, and requires us to tell it.

Since feature flags are additive across the dependency graph, my guess is some dependency we pulled in enabled the `ring` feature for `rustls` which led to the error message we're seeing:

`2024-07-17T05:44:57.181945Z  INFO runtime: Embedding [openai_embeddings] ready to embed
thread 'main' panicked at /Users/spice/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.11/src/crypto/mod.rs:259:14:
no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point`

By specifying which CryptoProvider we want to use, it resolves the ambiguity.