### PR TITLE
Handle loading secrets in precedence order when using `${{ secrets:<key> }}`

### DIFF
--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -1,10 +1,7 @@
 use crate::results::BenchmarkResultsBuilder;
 use app::{App, AppBuilder};
 use runtime::{dataupdate::DataUpdate, Runtime};
-use spicepod::component::{
-    dataset::{replication::Replication, Dataset, Mode},
-    secret::SpiceSecretStore,
-};
+use spicepod::component::dataset::{replication::Replication, Dataset, Mode};
 use std::process::Command;
 use tracing_subscriber::EnvFilter;
 
@@ -45,7 +42,6 @@ pub(crate) async fn write_benchmark_results(
 
 fn build_app(upload_results_dataset: &Option<String>) -> App {
     let mut app_builder = AppBuilder::new("runtime_benchmark_test")
-        .with_secret_store(SpiceSecretStore::File)
         .with_dataset(make_spiceai_dataset("tpch.customer", "customer"))
         .with_dataset(make_spiceai_dataset("tpch.lineitem", "lineitem"))
         .with_dataset(make_spiceai_dataset("tpch.part", "part"))

--- a/crates/runtime/tests/catalog/mod.rs
+++ b/crates/runtime/tests/catalog/mod.rs
@@ -23,7 +23,6 @@ use runtime::Runtime;
 use runtime::{datafusion::query::Protocol, extension::ExtensionFactory};
 use spice_cloud::SpiceExtensionFactory;
 use spicepod::component::catalog::Catalog;
-use spicepod::component::secret::SpiceSecretStore;
 use std::collections::HashMap;
 
 #[tokio::test]
@@ -31,7 +30,6 @@ use std::collections::HashMap;
 async fn spiceai_catalog_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(None);
     let app = AppBuilder::new("spiceai_catalog_test")
-        .with_secret_store(SpiceSecretStore::File)
         .with_catalog(Catalog::new("spiceai".to_string(), "spiceai".to_string()))
         .build();
 
@@ -85,7 +83,6 @@ async fn spiceai_catalog_test_include() -> Result<(), anyhow::Error> {
         "eth.recent_transactions".to_string(),
     ];
     let app = AppBuilder::new("spiceai_catalog_test")
-        .with_secret_store(SpiceSecretStore::File)
         .with_catalog(catalog)
         .build();
 

--- a/crates/runtime/tests/federation/mod.rs
+++ b/crates/runtime/tests/federation/mod.rs
@@ -18,7 +18,7 @@ use app::AppBuilder;
 use arrow::array::{Int64Array, RecordBatch};
 use datafusion::assert_batches_eq;
 use runtime::Runtime;
-use spicepod::component::{dataset::Dataset, secret::SpiceSecretStore};
+use spicepod::component::dataset::Dataset;
 
 use crate::{get_test_datafusion, init_tracing, run_query_and_check_results, ValidateFn};
 
@@ -36,7 +36,6 @@ async fn single_source_federation_push_down() -> Result<(), String> {
     type QueryTests<'a> = Vec<(&'a str, Vec<&'a str>, Option<Box<ValidateFn>>)>;
     let _tracing = init_tracing(None);
     let app = AppBuilder::new("basic_federation_push_down")
-        .with_secret_store(SpiceSecretStore::File)
         .with_dataset(make_spiceai_dataset("eth.recent_blocks", "blocks"))
         .with_dataset(make_spiceai_dataset("eth.blocks", "full_blocks"))
         .with_dataset(make_spiceai_dataset("eth.recent_transactions", "tx"))

--- a/crates/runtime/tests/refresh_sql/mod.rs
+++ b/crates/runtime/tests/refresh_sql/mod.rs
@@ -18,10 +18,7 @@ use std::sync::Arc;
 
 use app::AppBuilder;
 use runtime::{accelerated_table::AcceleratedTable, Runtime};
-use spicepod::component::{
-    dataset::{acceleration::Acceleration, Dataset},
-    secret::SpiceSecretStore,
-};
+use spicepod::component::dataset::{acceleration::Acceleration, Dataset};
 
 use crate::init_tracing;
 
@@ -43,7 +40,6 @@ async fn refresh_sql_pushdown() -> Result<(), String> {
 
     let _tracing = init_tracing(None);
     let app = AppBuilder::new("refresh_sql_pushdown")
-        .with_secret_store(SpiceSecretStore::File)
         .with_dataset(make_spiceai_dataset(
             "eth.traces",
             "traces",

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -21,9 +21,7 @@ use runtime::{
     datafusion::query::{Protocol, QueryBuilder},
     Runtime,
 };
-use spicepod::component::{
-    dataset::Dataset, params::Params, runtime::ResultsCache, secret::SpiceSecretStore,
-};
+use spicepod::component::{dataset::Dataset, params::Params, runtime::ResultsCache};
 
 use crate::init_tracing;
 
@@ -52,7 +50,6 @@ async fn results_cache_system_queries() -> Result<(), String> {
 
     let app = AppBuilder::new("cache_test")
         .with_results_cache(results_cache)
-        .with_secret_store(SpiceSecretStore::File)
         .with_dataset(make_s3_tpch_dataset("customer"))
         .build();
 


### PR DESCRIPTION
## 🗣 Description

Allows users to specify a secret identifier of `${{ secrets:<key> }}` in their Spicepod and have it try to load the secret from all of the configured stores, looking in precedence order until it finds the key it wants.

```yaml
secrets:
- from: kubernetes:pg_secret
  name: k8s_pg
- from: env
  name: env

datasets:
- from: postgres:uuid_table
  name: uuid_table
  params:
    pg_host: localhost
    pg_port: 5432
    pg_user: postgres
    pg_pass: ${{ secrets:pg_pass }}
    pg_db: spice
    pg_sslmode: disable
```

Would attempt to load `pg_pass` from `env:PG_PASS` and then `k8s_pg:pg_pass`

## 🔨 Related Issues

Part of #1701