### PR TITLE
Support loading from `.env` files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8091,6 +8097,7 @@ dependencies = [
  "db_connection_pool",
  "derive_builder",
  "dirs",
+ "dotenvy",
  "duckdb",
  "flight_client",
  "fundu",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -47,6 +47,7 @@ duckdb = { workspace = true, features = [
   "vtab",
   "vtab-arrow",
 ], optional = true }
+dotenvy = "0.15"
 flight_client = { path = "../flight_client" }
 fundu = { workspace = true }
 futures.workspace = true

--- a/crates/runtime/src/secrets/stores/env.rs
+++ b/crates/runtime/src/secrets/stores/env.rs
@@ -63,12 +63,24 @@ impl EnvSecretStore {
             match dotenvy::from_path(path) {
                 Ok(()) => return,
                 Err(err) => {
-                    tracing::warn!("Error opening path {}: {err}", path.display());
+                    if matches!(err, dotenvy::Error::LineParse(_, _)) {
+                        tracing::warn!("{err}");
+                    } else {
+                        tracing::warn!("Error opening path {}: {err}", path.display());
+                    }
                 }
             };
         }
-        dotenvy::from_filename(".env.local").ok();
-        dotenvy::from_filename(".env").ok();
+        if let Err(err) = dotenvy::from_filename(".env.local") {
+            if matches!(err, dotenvy::Error::LineParse(_, _)) {
+                tracing::warn!(".env.local: {err}");
+            }
+        };
+        if let Err(err) = dotenvy::from_filename(".env") {
+            if matches!(err, dotenvy::Error::LineParse(_, _)) {
+                tracing::warn!(".env: {err}");
+            }
+        };
     }
 }
 


### PR DESCRIPTION
## 🗣 Description

Improves the Env secret store to load `.env` files. By default it will look for `.env` or `.env.local` files in the working directory of the spice runtime. An optional `file_path` param can be specified to point to a custom `.env` file.

Manually load from `.env.production`
```yaml
secrets:
  - from: env
    name: env
    params:
      file_path: .env.production
```

Load the default `.env` and `.env.local` files.
```yaml
secrets:
  - from: env
    name: env
```

Also tweaks the secret loading logic to fallback to a Spice-prefixed key if the key that was specified didn't exist. This will be useful in the next PR when I add support for auto-loading required secrets if the user didn't specify it in their params. i.e. if we need a `pg_password` then we will automatically search for an environment variable called `PG_PASSWORD` or `SPICE_PG_PASSWORD`

## 🔨 Related Issues

Part of #1701

## 🤔 Concerns

By default the `dotenvy` crate will load the contents of the `.env` file into the process environment variables. This is usually the desired behavior, but that would mean if you defined multiple `env` secrets that each loaded a different `.env` file, then they would all be added to the global process namespace, and could be accessed from any of the `env` defined secrets. I think that is a fine tradeoff for now since that seems like an edge case, and would probably still result in the behavior the user wanted anyway.