### PR TITLE
feat: Add sql_dialect parameter for overriding ODBC dialect

### DIFF
--- a/crates/runtime/src/dataconnector/odbc.rs
+++ b/crates/runtime/src/dataconnector/odbc.rs
@@ -110,8 +110,7 @@ where
 
         Box::pin(async move {
             let dialect = if let Some(sql_dialect) = params.get("sql_dialect") {
-                let driver: ODBCDriver =
-                    Into::<ODBCDriver>::into(sql_dialect.expose_secret().as_str());
+                let driver: ODBCDriver = ODBCDriver::from(sql_dialect.expose_secret().as_str());
                 if driver == ODBCDriver::Unknown {
                     Err(Error::InvalidParameter {
                         param: "sql_dialect".to_string(),
@@ -135,7 +134,7 @@ where
                     .find(|s| s.starts_with("driver="))
                     .context(NoDriverSpecifiedSnafu)?;
 
-                Ok(Into::<ODBCDriver>::into(driver).into())
+                Ok(ODBCDriver::from(driver).into())
             }?;
 
             let pool: Arc<ODBCDbConnectionPool<'a>> = Arc::new(


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds a parameter, `sql_dialect`, to override the detected dialect for an ODBC connection
* Refactors driver detection to use an enum and `From` implementations for cleaner, more reusable code.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #1989