### PR TITLE
Switch order to look for `SPICE_` prefixed keys first

### DIFF
--- a/crates/runtime/src/secrets/stores/aws_secrets_manager.rs
+++ b/crates/runtime/src/secrets/stores/aws_secrets_manager.rs
@@ -124,13 +124,13 @@ impl SecretStore for AwsSecretsManager {
             }
         };
 
+        let prefixed_key = format!("{SPICE_KEY_PREFIX}{key}");
         if let Some(secret_str) = secret_value.secret_string() {
             let data = parse_json_to_hashmap(secret_str)?;
-            if let Some(value) = data.get(key) {
+            if let Some(value) = data.get(&prefixed_key) {
                 return Ok(Some(SecretString::new(value.clone())));
             }
-            let prefixed_key = format!("{SPICE_KEY_PREFIX}{key}");
-            return Ok(data.get(&prefixed_key).cloned().map(SecretString::new));
+            return Ok(data.get(key).cloned().map(SecretString::new));
         }
 
         Ok(None)

--- a/crates/runtime/src/secrets/stores/kubernetes.rs
+++ b/crates/runtime/src/secrets/stores/kubernetes.rs
@@ -194,13 +194,14 @@ impl KubernetesSecretStore {
 impl SecretStore for KubernetesSecretStore {
     #[must_use]
     async fn get_secret(&self, key: &str) -> crate::secrets::AnyErrorResult<Option<SecretString>> {
+        // First try looking for `spice_my_key` and then `my_key`
+        let prefixed_key = format!("{SPICE_KEY_PREFIX}{key}");
         match self.kubernetes_client.get_secret(&self.secret_name).await {
             Ok(secret) => {
-                if let Some(value) = secret.get(key) {
+                if let Some(value) = secret.get(&prefixed_key) {
                     return Ok(Some(SecretString::new(value.clone())));
                 }
-                let prefixed_key = format!("{SPICE_KEY_PREFIX}{key}");
-                Ok(secret.get(&prefixed_key).cloned().map(SecretString::new))
+                Ok(secret.get(key).cloned().map(SecretString::new))
             }
             Err(err) => Err(Box::new(StoreError::UnableToGetSecret { source: err })),
         }


### PR DESCRIPTION
## 🗣 Description

Switch the order that the secret stores look for keys - by default they will look for a `SPICE_` prefixed key, and then fallback to the explicit key. The rationale is that the `SPICE_` prefix is more specific, and thus should take precedence.

## 🔨 Related Issues

Part of #1701