### PR TITLE
Autoload secrets that Data Connectors have indicated are needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,7 +3087,6 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=02081887de7b64dfd816ef86716f8b0853ae3196#02081887de7b64dfd816ef86716f8b0853ae3196"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,6 +3087,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b045511a6b6d59f54b3ea13cf9aa26293c1c79fb#b045511a6b6d59f54b3ea13cf9aa26293c1c79fb"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,8 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "40.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "02081887de7b64dfd816ef86716f8b0853ae3196" }
+#datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "02081887de7b64dfd816ef86716f8b0853ae3196" }
+datafusion-table-providers = { path = "/Users/phillip/code/datafusion-contrib/datafusion-table-providers" }
 duckdb = "1.0.0"
 fundu = "2.0.0"
 futures = "0.3.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "40.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
-#datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "02081887de7b64dfd816ef86716f8b0853ae3196" }
-datafusion-table-providers = { path = "/Users/phillip/code/datafusion-contrib/datafusion-table-providers" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b045511a6b6d59f54b3ea13cf9aa26293c1c79fb" }
 duckdb = "1.0.0"
 fundu = "2.0.0"
 futures = "0.3.30"

--- a/crates/db_connection_pool/src/odbcpool.rs
+++ b/crates/db_connection_pool/src/odbcpool.rs
@@ -77,7 +77,7 @@ impl ODBCPool {
     /// Returns an error if there is a problem creating the connection pool.
     pub fn new(params: HashMap<String, SecretString>) -> Result<Self, Error> {
         let connection_string = params
-            .get("odbc_connection_string")
+            .get("connection_string")
             .map(Secret::expose_secret)
             .map(ToString::to_string)
             .context(MissingConnectionStringSnafu)?;

--- a/crates/db_connection_pool/src/snowflakepool.rs
+++ b/crates/db_connection_pool/src/snowflakepool.rs
@@ -91,16 +91,16 @@ impl SnowflakeConnectionPool {
         let account = account.replace('.', "-");
 
         let warehouse = params
-            .get("snowflake_warehouse")
+            .get("warehouse")
             .map(Secret::expose_secret)
             .map(ToString::to_string);
         let role = params
-            .get("snowflake_role")
+            .get("role")
             .map(Secret::expose_secret)
             .map(ToString::to_string);
 
         let auth_type = params
-            .get("snowflake_auth_type")
+            .get("auth_type")
             .map(Secret::expose_secret)
             .map_or_else(|| "snowflake".to_string(), ToString::to_string)
             .to_lowercase();
@@ -189,7 +189,7 @@ fn init_snowflake_api_with_keypair_auth(
     params: &HashMap<String, SecretString>,
 ) -> Result<SnowflakeApi, Error> {
     let private_key_path = params
-        .get("snowflake_private_key_path")
+        .get("private_key_path")
         .map(Secret::expose_secret)
         .context(MissingRequiredSecretSnafu {
             name: "snowflake_private_key_path",
@@ -205,7 +205,7 @@ fn init_snowflake_api_with_keypair_auth(
 
     if label.to_uppercase() == "ENCRYPTED PRIVATE KEY" {
         let passphrase = params
-            .get("snowflake_private_key_passphrase")
+            .get("private_key_passphrase")
             .map(Secret::expose_secret)
             .context(MissingRequiredSecretSnafu {
                 name: "snowflake_private_key_passphrase",

--- a/crates/runtime/src/dataaccelerator/metadata/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/metadata/postgres.rs
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
-
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 use datafusion_table_providers::util::secrets::to_secret_map;
 
@@ -35,7 +33,7 @@ impl AcceleratedMetadataPostgres {
             return Err("Dataset is not accelerated.".into());
         };
 
-        let secret_map = Arc::new(to_secret_map(acceleration.params.clone()));
+        let secret_map = to_secret_map(acceleration.params.clone());
 
         let pool = PostgresConnectionPool::new(secret_map)
             .await

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use crate::component::catalog::Catalog;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
+use crate::secrets::Secrets;
 use crate::Runtime;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
@@ -49,7 +50,7 @@ use std::fmt::Display;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use url::Url;
 
 use std::future::Future;
@@ -221,21 +222,17 @@ type NewDataConnectorFn = dyn Fn(
     + Send;
 
 lazy_static! {
-    static ref DATA_CONNECTOR_FACTORY_REGISTRY: Mutex<HashMap<String, Box<NewDataConnectorFn>>> =
+    static ref DATA_CONNECTOR_FACTORY_REGISTRY: Mutex<HashMap<String, Arc<dyn DataConnectorFactory>>> =
         Mutex::new(HashMap::new());
 }
 
 pub async fn register_connector_factory(
     name: &str,
-    connector_factory: impl Fn(
-            HashMap<String, SecretString>,
-        ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>>
-        + Send
-        + 'static,
+    connector_factory: Arc<dyn DataConnectorFactory>,
 ) {
     let mut registry = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
 
-    registry.insert(name.to_string(), Box::new(connector_factory));
+    registry.insert(name.to_string(), connector_factory);
 }
 
 /// Create a new `DataConnector` by name.
@@ -247,77 +244,83 @@ pub async fn register_connector_factory(
 pub async fn create_new_connector(
     name: &str,
     params: HashMap<String, SecretString>,
+    secrets: Arc<RwLock<Secrets>>,
 ) -> Option<AnyErrorResult<Arc<dyn DataConnector>>> {
     let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
 
     let connector_factory = guard.get(name);
 
     match connector_factory {
-        Some(factory) => Some(factory(params).await),
+        Some(factory) => {
+            let mut params = remove_prefix_from_hashmap_keys(params, factory.prefix());
+
+            // Try to autoload secrets that might be missing from params.
+            for secret_key in factory.autoload_secrets().into_iter().map(|s| *s) {
+                if params.contains_key(secret_key) {
+                    continue;
+                }
+                let secret = secrets.read().await.get_secret(secret_key).await;
+                if let Ok(Some(secret)) = secret {
+                    tracing::debug!("Autoloading secret for {name}: {secret_key}",);
+                    params.insert(secret_key.to_string(), secret);
+                }
+            }
+            let result = factory.create(params).await;
+            Some(result)
+        }
         None => None,
     }
 }
 
 pub async fn register_all() {
-    register_connector_factory("localhost", localhost::LocalhostConnector::create).await;
+    register_connector_factory("localhost", localhost::LocalhostConnectorFactory::new_arc()).await;
     #[cfg(feature = "databricks")]
-    register_connector_factory("databricks", databricks::Databricks::create).await;
+    register_connector_factory("databricks", databricks::DatabricksFactory::new_arc()).await;
     #[cfg(feature = "delta_lake")]
-    register_connector_factory("delta_lake", delta_lake::DeltaLake::create).await;
+    register_connector_factory("delta_lake", delta_lake::DeltaLakeFactory::new_arc()).await;
     #[cfg(feature = "dremio")]
-    register_connector_factory("dremio", dremio::Dremio::create).await;
-    register_connector_factory("file", file::File::create).await;
+    register_connector_factory("dremio", dremio::DremioFactory::new_arc()).await;
+    register_connector_factory("file", file::FileFactory::new_arc()).await;
     #[cfg(feature = "flightsql")]
-    register_connector_factory("flightsql", flightsql::FlightSQL::create).await;
-    register_connector_factory("s3", s3::S3::create).await;
+    register_connector_factory("flightsql", flightsql::FlightSQLFactory::new_arc()).await;
+    register_connector_factory("s3", s3::S3Factory::new_arc()).await;
     #[cfg(feature = "ftp")]
-    register_connector_factory("ftp", ftp::FTP::create).await;
-    register_connector_factory("http", https::Https::create).await;
-    register_connector_factory("https", https::Https::create).await;
+    register_connector_factory("ftp", ftp::FTPFactory::new_arc()).await;
+    register_connector_factory("http", https::HttpsFactory::new_arc()).await;
+    register_connector_factory("https", https::HttpsFactory::new_arc()).await;
     #[cfg(feature = "ftp")]
-    register_connector_factory("sftp", sftp::SFTP::create).await;
-    register_connector_factory("spiceai", spiceai::SpiceAI::create).await;
+    register_connector_factory("sftp", sftp::SFTPFactory::new_arc()).await;
+    register_connector_factory("spiceai", spiceai::SpiceAIFactory::new_arc()).await;
     #[cfg(feature = "mysql")]
-    register_connector_factory("mysql", mysql::MySQL::create).await;
+    register_connector_factory("mysql", mysql::MySQLFactory::new_arc()).await;
     #[cfg(feature = "postgres")]
-    register_connector_factory("postgres", postgres::Postgres::create).await;
+    register_connector_factory("postgres", postgres::PostgresFactory::new_arc()).await;
     #[cfg(feature = "duckdb")]
-    register_connector_factory("duckdb", duckdb::DuckDB::create).await;
+    register_connector_factory("duckdb", duckdb::DuckDBFactory::new_arc()).await;
     #[cfg(feature = "clickhouse")]
-    register_connector_factory("clickhouse", clickhouse::Clickhouse::create).await;
-    register_connector_factory("graphql", graphql::GraphQL::create).await;
+    register_connector_factory("clickhouse", clickhouse::ClickhouseFactory::new_arc()).await;
+    register_connector_factory("graphql", graphql::GraphQLFactory::new_arc()).await;
     #[cfg(feature = "odbc")]
-    register_connector_factory("odbc", odbc::ODBC::create).await;
+    register_connector_factory("odbc", odbc::ODBCFactory::new_arc()).await;
     #[cfg(feature = "spark")]
-    register_connector_factory("spark", spark::Spark::create).await;
+    register_connector_factory("spark", spark::SparkFactory::new_arc()).await;
     #[cfg(feature = "snowflake")]
-    register_connector_factory("snowflake", snowflake::Snowflake::create).await;
+    register_connector_factory("snowflake", snowflake::SnowflakeFactory::new_arc()).await;
     #[cfg(feature = "debezium")]
-    register_connector_factory("debezium", debezium::Debezium::create).await;
+    register_connector_factory("debezium", debezium::DebeziumFactory::new_arc()).await;
     #[cfg(feature = "delta_lake")]
-    register_connector_factory("unity_catalog", unity_catalog::UnityCatalog::create).await;
+    register_connector_factory(
+        "unity_catalog",
+        unity_catalog::UnityCatalogFactory::new_arc(),
+    )
+    .await;
 }
 
-pub trait DataConnectorFactory {
+pub trait DataConnectorFactory: Send + Sync {
     fn create(
+        &self,
         params: HashMap<String, SecretString>,
     ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>>;
-}
-
-/// A `DataConnector` knows how to retrieve and optionally write or stream data.
-#[async_trait]
-pub trait DataConnector: Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-
-    /// Resolves the default refresh mode for the data connector.
-    ///
-    /// Most data connectors should keep this as `RefreshMode::Full`.
-    fn resolve_refresh_mode(&self, refresh_mode: Option<RefreshMode>) -> RefreshMode {
-        refresh_mode.unwrap_or(RefreshMode::Full)
-    }
-
-    async fn read_provider(&self, dataset: &Dataset)
-        -> DataConnectorResult<Arc<dyn TableProvider>>;
 
     /// The prefix to use for parameters and secrets for this `DataConnector`.
     ///
@@ -337,6 +340,22 @@ pub trait DataConnector: Send + Sync {
     ///
     /// Will automatically be prefixed by `prefix`.
     fn autoload_secrets(&self) -> &'static [&'static str];
+}
+
+/// A `DataConnector` knows how to retrieve and optionally write or stream data.
+#[async_trait]
+pub trait DataConnector: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+
+    /// Resolves the default refresh mode for the data connector.
+    ///
+    /// Most data connectors should keep this as `RefreshMode::Full`.
+    fn resolve_refresh_mode(&self, refresh_mode: Option<RefreshMode>) -> RefreshMode {
+        refresh_mode.unwrap_or(RefreshMode::Full)
+    }
+
+    async fn read_provider(&self, dataset: &Dataset)
+        -> DataConnectorResult<Arc<dyn TableProvider>>;
 
     async fn read_write_provider(
         &self,
@@ -403,10 +422,6 @@ pub trait ListingTableConnector: DataConnector {
     fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url>;
 
     fn get_params(&self) -> &HashMap<String, SecretString>;
-
-    fn prefix(&self) -> &'static str;
-
-    fn autoload_secrets(&self) -> &'static [&'static str];
 
     #[must_use]
     fn get_session_context() -> SessionContext {
@@ -647,14 +662,32 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
             }
         }
     }
+}
 
-    fn prefix(&self) -> &'static str {
-        ListingTableConnector::prefix(self)
-    }
-
-    fn autoload_secrets(&self) -> &'static [&'static str] {
-        ListingTableConnector::autoload_secrets(self)
-    }
+/// Filters out keys in a hashmap that do not start with the specified prefix, and removes the prefix from the keys that remain.
+///
+/// It also logs a warning for each key that is filtered out.
+#[must_use]
+pub fn remove_prefix_from_hashmap_keys<V>(
+    hashmap: HashMap<String, V>,
+    prefix: &str,
+) -> HashMap<String, V> {
+    assert!(
+        !prefix.ends_with('_'),
+        "Prefix must not end with an underscore"
+    );
+    let prefix = format!("{prefix}_");
+    hashmap
+        .into_iter()
+        .filter_map(|(key, value)| {
+            if key.starts_with(&prefix) {
+                Some((key[prefix.len()..].to_string(), value))
+            } else {
+                tracing::warn!("Ignoring parameter {key}: does not start with `{prefix}`");
+                None
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -675,12 +708,21 @@ mod tests {
 
     impl DataConnectorFactory for TestConnector {
         fn create(
+            &self,
             params: HashMap<String, SecretString>,
         ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
             Box::pin(async move {
                 let connector = Self { params };
                 Ok(Arc::new(connector) as Arc<dyn DataConnector>)
             })
+        }
+
+        fn prefix(&self) -> &'static str {
+            "test"
+        }
+
+        fn autoload_secrets(&self) -> &'static [&'static str] {
+            &[]
         }
     }
 
@@ -700,14 +742,6 @@ mod tests {
                     dataconnector: format!("{self}"),
                     message: "Invalid URL".to_string(),
                 })
-        }
-
-        fn prefix(&self) -> &'static str {
-            "test"
-        }
-
-        fn autoload_secrets(&self) -> &'static [&'static str] {
-            &[]
         }
     }
 
@@ -787,5 +821,59 @@ mod tests {
         } else {
             panic!("Unexpected error");
         }
+    }
+
+    #[test]
+    fn test_remove_prefix() {
+        let mut hashmap = HashMap::new();
+        hashmap.insert("prefix_key1".to_string(), "value1".to_string());
+        hashmap.insert("prefix_key2".to_string(), "value2".to_string());
+        hashmap.insert("key3".to_string(), "value3".to_string());
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let mut expected = HashMap::new();
+        expected.insert("key1".to_string(), "value1".to_string());
+        expected.insert("key2".to_string(), "value2".to_string());
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_no_prefix() {
+        let mut hashmap = HashMap::new();
+        hashmap.insert("key1".to_string(), "value1".to_string());
+        hashmap.insert("key2".to_string(), "value2".to_string());
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let expected = HashMap::new();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_empty_hashmap() {
+        let hashmap: HashMap<String, String> = HashMap::new();
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let expected: HashMap<String, String> = HashMap::new();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_full_prefix() {
+        let mut hashmap = HashMap::new();
+        hashmap.insert("prefix_".to_string(), "value1".to_string());
+        hashmap.insert("prefix_key2".to_string(), "value2".to_string());
+
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+
+        let mut expected = HashMap::new();
+        expected.insert("".to_string(), "value1".to_string());
+
+        assert_eq!(result, expected);
     }
 }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -839,7 +839,7 @@ mod tests {
         hashmap.insert("prefix_key2".to_string(), "value2".to_string());
         hashmap.insert("key3".to_string(), "value3".to_string());
 
-        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix");
 
         let mut expected = HashMap::new();
         expected.insert("key1".to_string(), "value1".to_string());
@@ -854,7 +854,7 @@ mod tests {
         hashmap.insert("key1".to_string(), "value1".to_string());
         hashmap.insert("key2".to_string(), "value2".to_string());
 
-        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix");
 
         let expected = HashMap::new();
 
@@ -865,7 +865,7 @@ mod tests {
     fn test_empty_hashmap() {
         let hashmap: HashMap<String, String> = HashMap::new();
 
-        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix");
 
         let expected: HashMap<String, String> = HashMap::new();
 
@@ -878,10 +878,11 @@ mod tests {
         hashmap.insert("prefix_".to_string(), "value1".to_string());
         hashmap.insert("prefix_key2".to_string(), "value2".to_string());
 
-        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix_");
+        let result = remove_prefix_from_hashmap_keys(hashmap, "prefix");
 
         let mut expected = HashMap::new();
-        expected.insert("".to_string(), "value1".to_string());
+        expected.insert(String::new(), "value1".to_string());
+        expected.insert("key2".to_string(), "value2".to_string());
 
         assert_eq!(result, expected);
     }

--- a/crates/runtime/src/dataconnector/clickhouse.rs
+++ b/crates/runtime/src/dataconnector/clickhouse.rs
@@ -93,6 +93,14 @@ impl DataConnector for Clickhouse {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "clickhouse"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["connection_string", "pass"]
+    }
+
     async fn read_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/clickhouse.rs
+++ b/crates/runtime/src/dataconnector/clickhouse.rs
@@ -46,10 +46,12 @@ pub struct Clickhouse {
 pub struct ClickhouseFactory {}
 
 impl ClickhouseFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -132,10 +132,12 @@ impl Databricks {
 pub struct DatabricksFactory {}
 
 impl DatabricksFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -38,7 +38,7 @@ use super::{DataConnector, DataConnectorFactory};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Missing required parameter: endpoint"))]
+    #[snafu(display("Missing required parameter: databricks_endpoint"))]
     MissingEndpoint,
 
     #[snafu(display("Missing required parameter: databricks_cluster_id"))]
@@ -89,7 +89,7 @@ impl Databricks {
             };
             let user = params.get("user").map(std::borrow::ToOwned::to_owned);
             let mut databricks_use_ssl = true;
-            if let Some(databricks_use_ssl_value) = params.get("databricks_use_ssl") {
+            if let Some(databricks_use_ssl_value) = params.get("spark_use_ssl") {
                 let databricks_use_ssl_value = databricks_use_ssl_value.expose_secret();
                 databricks_use_ssl = match databricks_use_ssl_value.as_str() {
                     "true" => true,
@@ -102,10 +102,7 @@ impl Databricks {
                     }
                 };
             }
-            let ((Some(cluster_id), _) | (_, Some(cluster_id))) = (
-                params.get("databricks_cluster_id"),
-                params.get("databricks-cluster-id"),
-            ) else {
+            let Some(cluster_id) = params.get("cluster_id") else {
                 return MissingDatabricksClusterIdSnafu.fail();
             };
             let Some(token) = params.get("token") else {
@@ -146,6 +143,14 @@ impl DataConnectorFactory for Databricks {
 impl DataConnector for Databricks {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn prefix(&self) -> &'static str {
+        "databricks"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["token", "pass"]
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -128,21 +128,28 @@ impl Databricks {
     }
 }
 
-impl DataConnectorFactory for Databricks {
+#[derive(Default, Clone, Copy)]
+pub struct DatabricksFactory {}
+
+impl DatabricksFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+impl DataConnectorFactory for DatabricksFactory {
     fn create(
+        &self,
         params: HashMap<String, SecretString>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let databricks = Databricks::new(params).await?;
             Ok(Arc::new(databricks) as Arc<dyn DataConnector>)
         })
-    }
-}
-
-#[async_trait]
-impl DataConnector for Databricks {
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     fn prefix(&self) -> &'static str {
@@ -151,6 +158,13 @@ impl DataConnector for Databricks {
 
     fn autoload_secrets(&self) -> &'static [&'static str] {
         &["token", "pass"]
+    }
+}
+
+#[async_trait]
+impl DataConnector for Databricks {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -86,10 +86,12 @@ impl Debezium {
 pub struct DebeziumFactory {}
 
 impl DebeziumFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[snafu(display("Invalid value for debezium_message_format: Valid values: 'json'"))]
     InvalidMessageFormat,
 
-    #[snafu(display("Missing required parameter: kafka_bootstrap_servers"))]
+    #[snafu(display("Missing required parameter: debezium_kafka_bootstrap_servers"))]
     MissingKafkaBootstrapServers,
 }
 
@@ -57,11 +57,11 @@ impl Debezium {
     #[allow(clippy::needless_pass_by_value)]
     pub fn new(params: HashMap<String, SecretString>) -> Result<Self> {
         let transport = params
-            .get("debezium_transport")
+            .get("transport")
             .map_or("kafka", |p| p.expose_secret().as_str());
 
         let message_format = params
-            .get("debezium_message_format")
+            .get("message_format")
             .map_or("json", |p| p.expose_secret().as_str());
 
         if transport != "kafka" {
@@ -101,6 +101,14 @@ impl DataConnector for Debezium {
 
     fn resolve_refresh_mode(&self, refresh_mode: Option<RefreshMode>) -> RefreshMode {
         refresh_mode.unwrap_or(RefreshMode::Changes)
+    }
+
+    fn prefix(&self) -> &'static str {
+        "debezium"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &[]
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -45,10 +45,12 @@ impl DeltaLake {
 pub struct DeltaLakeFactory {}
 
 impl DeltaLakeFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -41,21 +41,28 @@ impl DeltaLake {
     }
 }
 
-impl DataConnectorFactory for DeltaLake {
+#[derive(Default, Copy, Clone)]
+pub struct DeltaLakeFactory {}
+
+impl DeltaLakeFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+impl DataConnectorFactory for DeltaLakeFactory {
     fn create(
+        &self,
         params: HashMap<String, SecretString>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let delta = DeltaLake::new(params);
             Ok(Arc::new(delta) as Arc<dyn DataConnector>)
         })
-    }
-}
-
-#[async_trait]
-impl DataConnector for DeltaLake {
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     fn prefix(&self) -> &'static str {
@@ -79,6 +86,13 @@ impl DataConnector for DeltaLake {
             // Google Storage Parameters
             "google_service_account",
         ]
+    }
+}
+
+#[async_trait]
+impl DataConnector for DeltaLake {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -58,6 +58,29 @@ impl DataConnector for DeltaLake {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "delta_lake"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &[
+            // S3 Parameters
+            "aws_region",
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_endpoint",
+            // Azure Parameters
+            "azure_storage_account_name",
+            "azure_storage_account_key",
+            "azure_storage_client_id",
+            "azure_storage_client_secret",
+            "azure_storage_sas_key",
+            "azure_storage_endpoint",
+            // Google Storage Parameters
+            "google_service_account",
+        ]
+    }
+
     async fn read_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -118,6 +118,14 @@ impl DataConnector for Dremio {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "dremio"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["username", "password"]
+    }
+
     async fn read_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -79,10 +79,12 @@ impl Dialect for DremioDialect {
 pub struct DremioFactory {}
 
 impl DremioFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/duckdb.rs
+++ b/crates/runtime/src/dataconnector/duckdb.rs
@@ -78,10 +78,12 @@ impl DuckDB {
 pub struct DuckDBFactory {}
 
 impl DuckDBFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/duckdb.rs
+++ b/crates/runtime/src/dataconnector/duckdb.rs
@@ -97,6 +97,14 @@ impl DataConnector for DuckDB {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "duckdb"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     async fn read_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -42,10 +42,12 @@ impl std::fmt::Display for File {
 pub struct FileFactory {}
 
 impl FileFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -34,7 +34,7 @@ pub struct File {
 
 impl std::fmt::Display for File {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "File")
+        write!(f, "file")
     }
 }
 
@@ -49,6 +49,14 @@ impl DataConnectorFactory for File {
 impl ListingTableConnector for File {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn prefix(&self) -> &'static str {
+        "file"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &[]
     }
 
     fn get_params(&self) -> &HashMap<String, SecretString> {

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -38,17 +38,25 @@ impl std::fmt::Display for File {
     }
 }
 
-impl DataConnectorFactory for File {
-    fn create(
-        params: HashMap<String, SecretString>,
-    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        Box::pin(async move { Ok(Arc::new(Self { params }) as Arc<dyn DataConnector>) })
+#[derive(Default, Copy, Clone)]
+pub struct FileFactory {}
+
+impl FileFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }
 }
 
-impl ListingTableConnector for File {
-    fn as_any(&self) -> &dyn Any {
-        self
+impl DataConnectorFactory for FileFactory {
+    fn create(
+        &self,
+        params: HashMap<String, SecretString>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move { Ok(Arc::new(File { params }) as Arc<dyn DataConnector>) })
     }
 
     fn prefix(&self) -> &'static str {
@@ -57,6 +65,12 @@ impl ListingTableConnector for File {
 
     fn autoload_secrets(&self) -> &'static [&'static str] {
         &[]
+    }
+}
+
+impl ListingTableConnector for File {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     fn get_params(&self) -> &HashMap<String, SecretString> {

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -52,10 +52,12 @@ pub struct FlightSQL {
 pub struct FlightSQLFactory {}
 
 impl FlightSQLFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -83,6 +83,14 @@ impl DataConnector for FlightSQL {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "flightsql"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["username", "password"]
+    }
+
     async fn read_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -39,10 +39,12 @@ impl std::fmt::Display for FTP {
 pub struct FTPFactory {}
 
 impl FTPFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -35,20 +35,28 @@ impl std::fmt::Display for FTP {
     }
 }
 
-impl DataConnectorFactory for FTP {
-    fn create(
-        params: HashMap<String, SecretString>,
-    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        Box::pin(async move {
-            let ftp = Self { params };
-            Ok(Arc::new(ftp) as Arc<dyn DataConnector>)
-        })
+#[derive(Default, Copy, Clone)]
+pub struct FTPFactory {}
+
+impl FTPFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }
 }
 
-impl ListingTableConnector for FTP {
-    fn as_any(&self) -> &dyn Any {
-        self
+impl DataConnectorFactory for FTPFactory {
+    fn create(
+        &self,
+        params: HashMap<String, SecretString>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move {
+            let ftp = FTP { params };
+            Ok(Arc::new(ftp) as Arc<dyn DataConnector>)
+        })
     }
 
     fn prefix(&self) -> &'static str {
@@ -57,6 +65,12 @@ impl ListingTableConnector for FTP {
 
     fn autoload_secrets(&self) -> &'static [&'static str] {
         &["user", "pass"]
+    }
+}
+
+impl ListingTableConnector for FTP {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     fn get_params(&self) -> &HashMap<String, SecretString> {

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -31,7 +31,7 @@ pub struct FTP {
 
 impl std::fmt::Display for FTP {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "FTP")
+        write!(f, "ftp")
     }
 }
 
@@ -51,6 +51,14 @@ impl ListingTableConnector for FTP {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "ftp"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["user", "pass"]
+    }
+
     fn get_params(&self) -> &HashMap<String, SecretString> {
         &self.params
     }
@@ -59,13 +67,13 @@ impl ListingTableConnector for FTP {
         let mut fragments = vec![];
         let mut fragment_builder = form_urlencoded::Serializer::new(String::new());
 
-        if let Some(ftp_port) = self.params.get("ftp_port").map(ExposeSecret::expose_secret) {
+        if let Some(ftp_port) = self.params.get("port").map(ExposeSecret::expose_secret) {
             fragment_builder.append_pair("port", ftp_port);
         }
-        if let Some(ftp_user) = self.params.get("ftp_user").map(ExposeSecret::expose_secret) {
+        if let Some(ftp_user) = self.params.get("user").map(ExposeSecret::expose_secret) {
             fragment_builder.append_pair("user", ftp_user);
         }
-        if let Some(ftp_password) = self.params.get("ftp_pass").map(ExposeSecret::expose_secret) {
+        if let Some(ftp_password) = self.params.get("pass").map(ExposeSecret::expose_secret) {
             fragment_builder.append_pair("password", ftp_password);
         }
         fragments.push(fragment_builder.finish());

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -545,10 +545,12 @@ pub struct GraphQL {
 pub struct GraphQLFactory {}
 
 impl GraphQLFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -557,17 +557,17 @@ impl GraphQL {
         let mut client_builder = reqwest::Client::builder();
         let token = self
             .params
-            .get("auth_token")
+            .get("token")
             .map(ExposeSecret::expose_secret)
             .cloned();
         let user = self
             .params
-            .get("auth_user")
+            .get("user")
             .map(ExposeSecret::expose_secret)
             .cloned();
         let pass = self
             .params
-            .get("auth_pass")
+            .get("pass")
             .map(ExposeSecret::expose_secret)
             .cloned();
 
@@ -591,10 +591,10 @@ impl GraphQL {
             .params
             .get("json_path")
             .map(ExposeSecret::expose_secret)
-            .ok_or("`json_path` not found in params".into())
+            .ok_or("`graphql_json_path` not found in params".into())
             .context(super::InvalidConfigurationSnafu {
                 dataconnector: "GraphQL",
-                message: "`json_path` not found in params",
+                message: "`graphql_json_path` not found in params",
             })?
             .clone();
         let pointer = format!("/{}", json_path.replace('.', "/"));
@@ -629,7 +629,7 @@ impl GraphQL {
             Ok(depth) => Ok(depth),
             Err(e) => Err(DataConnectorError::InvalidConfiguration {
                 dataconnector: "GraphQL".to_string(),
-                message: "`unnest_depth` is not an integer".to_string(),
+                message: "`graphql_unnest_depth` is not an integer".to_string(),
                 source: e.into(),
             }),
         }?;
@@ -661,6 +661,14 @@ impl GraphQL {
 impl DataConnector for GraphQL {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn prefix(&self) -> &'static str {
+        "graphql"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["token", "user", "pass"]
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -541,14 +541,36 @@ pub struct GraphQL {
     params: HashMap<String, SecretString>,
 }
 
-impl DataConnectorFactory for GraphQL {
+#[derive(Default, Copy, Clone)]
+pub struct GraphQLFactory {}
+
+impl GraphQLFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+impl DataConnectorFactory for GraphQLFactory {
     fn create(
+        &self,
         params: HashMap<String, SecretString>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
-            let graphql = Self { params };
+            let graphql = GraphQL { params };
             Ok(Arc::new(graphql) as Arc<dyn DataConnector>)
         })
+    }
+
+    fn prefix(&self) -> &'static str {
+        "graphql"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["token", "user", "pass"]
     }
 }
 
@@ -661,14 +683,6 @@ impl GraphQL {
 impl DataConnector for GraphQL {
     fn as_any(&self) -> &dyn Any {
         self
-    }
-
-    fn prefix(&self) -> &'static str {
-        "graphql"
-    }
-
-    fn autoload_secrets(&self) -> &'static [&'static str] {
-        &["token", "user", "pass"]
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -42,10 +42,12 @@ impl std::fmt::Display for Https {
 pub struct HttpsFactory {}
 
 impl HttpsFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -38,17 +38,25 @@ impl std::fmt::Display for Https {
     }
 }
 
-impl DataConnectorFactory for Https {
-    fn create(
-        params: HashMap<String, SecretString>,
-    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        Box::pin(async move { Ok(Arc::new(Self { params }) as Arc<dyn DataConnector>) })
+#[derive(Default, Copy, Clone)]
+pub struct HttpsFactory {}
+
+impl HttpsFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }
 }
 
-impl ListingTableConnector for Https {
-    fn as_any(&self) -> &dyn Any {
-        self
+impl DataConnectorFactory for HttpsFactory {
+    fn create(
+        &self,
+        params: HashMap<String, SecretString>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move { Ok(Arc::new(Https { params }) as Arc<dyn DataConnector>) })
     }
 
     fn prefix(&self) -> &'static str {
@@ -57,6 +65,12 @@ impl ListingTableConnector for Https {
 
     fn autoload_secrets(&self) -> &'static [&'static str] {
         &["username", "password"]
+    }
+}
+
+impl ListingTableConnector for Https {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     fn get_params(&self) -> &HashMap<String, SecretString> {

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -51,6 +51,14 @@ impl ListingTableConnector for Https {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "http"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["username", "password"]
+    }
+
     fn get_params(&self) -> &HashMap<String, SecretString> {
         &self.params
     }
@@ -64,11 +72,7 @@ impl ListingTableConnector for Https {
             }
         })?;
 
-        if let Some(p) = self
-            .params
-            .get("http_port")
-            .map(ExposeSecret::expose_secret)
-        {
+        if let Some(p) = self.params.get("port").map(ExposeSecret::expose_secret) {
             let n = match p.parse::<u16>() {
                 Ok(n) => n,
                 Err(e) => {
@@ -84,7 +88,7 @@ impl ListingTableConnector for Https {
 
         if let Some(p) = self
             .params
-            .get("http_password")
+            .get("password")
             .map(|s| s.expose_secret().as_str())
         {
             if u.set_password(Some(p)).is_err() {
@@ -98,7 +102,7 @@ impl ListingTableConnector for Https {
 
         if let Some(p) = self
             .params
-            .get("http_username")
+            .get("username")
             .map(|s| s.expose_secret().as_str())
         {
             if u.set_username(p).is_err() {

--- a/crates/runtime/src/dataconnector/localhost.rs
+++ b/crates/runtime/src/dataconnector/localhost.rs
@@ -120,6 +120,14 @@ impl DataConnector for LocalhostConnector {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "localhost"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     async fn read_provider(
         &self,
         _dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/localhost.rs
+++ b/crates/runtime/src/dataconnector/localhost.rs
@@ -83,10 +83,12 @@ impl LocalhostConnector {
 pub struct LocalhostConnectorFactory {}
 
 impl LocalhostConnectorFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -49,10 +49,12 @@ pub struct MySQL {
 pub struct MySQLFactory {}
 
 impl MySQLFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/odbc.rs
+++ b/crates/runtime/src/dataconnector/odbc.rs
@@ -77,6 +77,14 @@ where
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "odbc"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["connection_string"]
+    }
+
     async fn read_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/odbc.rs
+++ b/crates/runtime/src/dataconnector/odbc.rs
@@ -51,10 +51,12 @@ where
 pub struct ODBCFactory {}
 
 impl ODBCFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -47,10 +47,12 @@ pub struct Postgres {
 pub struct PostgresFactory {}
 
 impl PostgresFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -52,7 +52,7 @@ impl DataConnectorFactory for Postgres {
         // - pg_pass
 
         Box::pin(async move {
-            match PostgresConnectionPool::new(Arc::new(params)).await {
+            match PostgresConnectionPool::new(params).await {
                 Ok(pool) => {
                     let postgres_factory = PostgresTableFactory::new(Arc::new(pool));
                     Ok(Arc::new(Self { postgres_factory }) as Arc<dyn DataConnector>)
@@ -91,6 +91,14 @@ impl DataConnectorFactory for Postgres {
 impl DataConnector for Postgres {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn prefix(&self) -> &'static str {
+        "pg"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["connection_string", "user", "pass"]
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -68,6 +68,14 @@ impl ListingTableConnector for S3 {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "s3"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["region", "endpoint", "key", "secret"]
+    }
+
     fn get_params(&self) -> &HashMap<String, SecretString> {
         &self.params
     }

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -46,26 +46,28 @@ pub struct S3 {
     params: HashMap<String, SecretString>,
 }
 
-impl DataConnectorFactory for S3 {
+#[derive(Default, Copy, Clone)]
+pub struct S3Factory {}
+
+impl S3Factory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+impl DataConnectorFactory for S3Factory {
     fn create(
+        &self,
         params: HashMap<String, SecretString>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
-            let s3 = Self { params };
+            let s3 = S3 { params };
             Ok(Arc::new(s3) as Arc<dyn DataConnector>)
         })
-    }
-}
-
-impl std::fmt::Display for S3 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "S3")
-    }
-}
-
-impl ListingTableConnector for S3 {
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     fn prefix(&self) -> &'static str {
@@ -74,6 +76,18 @@ impl ListingTableConnector for S3 {
 
     fn autoload_secrets(&self) -> &'static [&'static str] {
         &["region", "endpoint", "key", "secret"]
+    }
+}
+
+impl std::fmt::Display for S3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "s3")
+    }
+}
+
+impl ListingTableConnector for S3 {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     fn get_params(&self) -> &HashMap<String, SecretString> {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -50,10 +50,12 @@ pub struct S3 {
 pub struct S3Factory {}
 
 impl S3Factory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -44,20 +44,28 @@ impl std::fmt::Display for SFTP {
     }
 }
 
-impl DataConnectorFactory for SFTP {
-    fn create(
-        params: HashMap<String, SecretString>,
-    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        Box::pin(async move {
-            let sftp = Self { params };
-            Ok(Arc::new(sftp) as Arc<dyn DataConnector>)
-        })
+#[derive(Default, Copy, Clone)]
+pub struct SFTPFactory {}
+
+impl SFTPFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }
 }
 
-impl ListingTableConnector for SFTP {
-    fn as_any(&self) -> &dyn Any {
-        self
+impl DataConnectorFactory for SFTPFactory {
+    fn create(
+        &self,
+        params: HashMap<String, SecretString>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move {
+            let sftp = SFTP { params };
+            Ok(Arc::new(sftp) as Arc<dyn DataConnector>)
+        })
     }
 
     fn prefix(&self) -> &'static str {
@@ -66,6 +74,12 @@ impl ListingTableConnector for SFTP {
 
     fn autoload_secrets(&self) -> &'static [&'static str] {
         &["user", "pass"]
+    }
+}
+
+impl ListingTableConnector for SFTP {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     fn get_params(&self) -> &HashMap<String, SecretString> {

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -48,10 +48,12 @@ impl std::fmt::Display for SFTP {
 pub struct SFTPFactory {}
 
 impl SFTPFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -51,16 +51,6 @@ impl DataConnectorFactory for Snowflake {
     fn create(
         params: HashMap<String, SecretString>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        // Required secrets:
-        // - username
-        // - account
-        // - snowflake_warehouse
-        // - snowflake_role
-        // - snowflake_auth_type
-        // - password
-        // - snowflake_private_key_path
-        // - snowflake_private_key_passphrase
-
         Box::pin(async move {
             let pool: Arc<
                 dyn DbConnectionPool<Arc<SnowflakeApi>, &'static (dyn Sync)> + Send + Sync,
@@ -81,6 +71,23 @@ impl DataConnectorFactory for Snowflake {
 impl DataConnector for Snowflake {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn prefix(&self) -> &'static str {
+        "snowflake"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &[
+            "username",
+            "account",
+            "warehouse",
+            "role",
+            "auth_type",
+            "password",
+            "private_key_path",
+            "private_key_passphrase",
+        ]
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -51,10 +51,12 @@ pub struct Snowflake {
 pub struct SnowflakeFactory {}
 
 impl SnowflakeFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/spark.rs
+++ b/crates/runtime/src/dataconnector/spark.rs
@@ -60,9 +60,7 @@ pub struct Spark {
 
 impl Spark {
     async fn new(params: HashMap<String, SecretString>) -> Result<Self> {
-        let conn = params
-            .get("spark_remote")
-            .map(|s| s.expose_secret().as_str());
+        let conn = params.get("remote").map(|s| s.expose_secret().as_str());
         let Some(conn) = conn else {
             return MissingSparkRemoteSnafu.fail();
         };
@@ -113,6 +111,14 @@ impl DataConnectorFactory for Spark {
 impl DataConnector for Spark {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn prefix(&self) -> &'static str {
+        "spark"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["remote"]
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/spark.rs
+++ b/crates/runtime/src/dataconnector/spark.rs
@@ -75,8 +75,22 @@ impl Spark {
     }
 }
 
-impl DataConnectorFactory for Spark {
+#[derive(Default, Copy, Clone)]
+pub struct SparkFactory {}
+
+impl SparkFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+impl DataConnectorFactory for SparkFactory {
     fn create(
+        &self,
         params: HashMap<String, SecretString>,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
@@ -105,13 +119,6 @@ impl DataConnectorFactory for Spark {
             }
         })
     }
-}
-
-#[async_trait]
-impl DataConnector for Spark {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn prefix(&self) -> &'static str {
         "spark"
@@ -119,6 +126,13 @@ impl DataConnector for Spark {
 
     fn autoload_secrets(&self) -> &'static [&'static str] {
         &["remote"]
+    }
+}
+
+#[async_trait]
+impl DataConnector for Spark {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/spark.rs
+++ b/crates/runtime/src/dataconnector/spark.rs
@@ -79,10 +79,12 @@ impl Spark {
 pub struct SparkFactory {}
 
 impl SparkFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -86,10 +86,12 @@ impl Dialect for SpiceCloudPlatformDialect {
 pub struct SpiceAIFactory {}
 
 impl SpiceAIFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -106,7 +106,7 @@ impl DataConnectorFactory for SpiceAI {
             })?;
 
             let api_key = params
-                .get("key")
+                .get("api_key")
                 .map(|s| s.expose_secret().as_str())
                 .unwrap_or_default();
             let flight_client = FlightClient::new(url.as_str(), "", api_key)
@@ -127,6 +127,14 @@ impl DataConnectorFactory for SpiceAI {
 impl DataConnector for SpiceAI {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn prefix(&self) -> &'static str {
+        "spiceai"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["api_key"]
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -77,6 +77,14 @@ impl DataConnector for UnityCatalog {
         self
     }
 
+    fn prefix(&self) -> &'static str {
+        "unity_catalog"
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        &["token"]
+    }
+
     async fn read_provider(
         &self,
         _dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -63,18 +63,25 @@ pub struct UnityCatalog {
     params: HashMap<String, SecretString>,
 }
 
-impl DataConnectorFactory for UnityCatalog {
-    fn create(
-        params: HashMap<String, SecretString>,
-    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        Box::pin(async move { Ok(Arc::new(Self { params }) as Arc<dyn DataConnector>) })
+#[derive(Default, Copy, Clone)]
+pub struct UnityCatalogFactory {}
+
+impl UnityCatalogFactory {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }
 }
 
-#[async_trait]
-impl DataConnector for UnityCatalog {
-    fn as_any(&self) -> &dyn Any {
-        self
+impl DataConnectorFactory for UnityCatalogFactory {
+    fn create(
+        &self,
+        params: HashMap<String, SecretString>,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move { Ok(Arc::new(UnityCatalog { params }) as Arc<dyn DataConnector>) })
     }
 
     fn prefix(&self) -> &'static str {
@@ -83,6 +90,13 @@ impl DataConnector for UnityCatalog {
 
     fn autoload_secrets(&self) -> &'static [&'static str] {
         &["token"]
+    }
+}
+
+#[async_trait]
+impl DataConnector for UnityCatalog {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
     async fn read_provider(

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -67,10 +67,12 @@ pub struct UnityCatalog {
 pub struct UnityCatalogFactory {}
 
 impl UnityCatalogFactory {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
 
+    #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -103,4 +103,12 @@ impl DataConnector for EmbeddingConnector {
     ) -> Option<DataConnectorResult<Arc<dyn TableProvider>>> {
         self.inner_connector.metadata_provider(dataset).await
     }
+
+    fn prefix(&self) -> &'static str {
+        self.inner_connector.prefix()
+    }
+
+    fn autoload_secrets(&self) -> &'static [&'static str] {
+        self.inner_connector.autoload_secrets()
+    }
 }

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -103,12 +103,4 @@ impl DataConnector for EmbeddingConnector {
     ) -> Option<DataConnectorResult<Arc<dyn TableProvider>>> {
         self.inner_connector.metadata_provider(dataset).await
     }
-
-    fn prefix(&self) -> &'static str {
-        self.inner_connector.prefix()
-    }
-
-    fn autoload_secrets(&self) -> &'static [&'static str] {
-        self.inner_connector.autoload_secrets()
-    }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -360,7 +360,7 @@ impl Runtime {
     ///
     /// The future returned by this function will not resolve until all components have been loaded.
     pub async fn load_components(&self) {
-        self.load_secret_stores().await;
+        self.load_secrets().await;
         self.start_extensions().await;
 
         #[cfg(feature = "models")]
@@ -414,7 +414,7 @@ impl Runtime {
         }
     }
 
-    async fn load_secret_stores(&self) {
+    async fn load_secrets(&self) {
         measure_scope_ms!("load_secret_stores");
         let mut secrets = self.secrets.write().await;
 
@@ -973,7 +973,7 @@ impl Runtime {
     ) -> Result<Arc<dyn DataConnector>> {
         let secret_map = self.get_params_with_secrets(&params).await;
 
-        match dataconnector::create_new_connector(source, secret_map).await {
+        match dataconnector::create_new_connector(source, secret_map, self.secrets()).await {
             Some(dc) => dc.context(UnableToInitializeDataConnectorSnafu {}),
             None => UnknownDataConnectorSnafu {
                 data_connector: source,

--- a/crates/runtime/src/tracing_util.rs
+++ b/crates/runtime/src/tracing_util.rs
@@ -99,14 +99,6 @@ mod tests {
             self
         }
 
-        fn prefix(&self) -> &'static str {
-            "test"
-        }
-
-        fn autoload_secrets(&self) -> &'static [&'static str] {
-            &[]
-        }
-
         async fn read_provider(
             &self,
             _dataset: &Dataset,

--- a/crates/runtime/src/tracing_util.rs
+++ b/crates/runtime/src/tracing_util.rs
@@ -99,6 +99,14 @@ mod tests {
             self
         }
 
+        fn prefix(&self) -> &'static str {
+            "test"
+        }
+
+        fn autoload_secrets(&self) -> &'static [&'static str] {
+            &[]
+        }
+
         async fn read_provider(
             &self,
             _dataset: &Dataset,

--- a/crates/runtime/tests/postgres/common.rs
+++ b/crates/runtime/tests/postgres/common.rs
@@ -14,13 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use bollard::secret::HealthConfig;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
-use secrecy::SecretString;
-// use spicepod::component::{dataset::Dataset, params::Params as DatasetParams};
 use rand::Rng;
+use secrecy::SecretString;
 use tracing::instrument;
 
 use crate::{
@@ -100,7 +99,7 @@ pub(super) async fn start_postgres_docker_container(
 pub(super) async fn get_postgres_connection_pool(
     port: usize,
 ) -> Result<PostgresConnectionPool, anyhow::Error> {
-    let pool = PostgresConnectionPool::new(Arc::new(get_pg_params(port))).await?;
+    let pool = PostgresConnectionPool::new(get_pg_params(port)).await?;
 
     Ok(pool)
 }


### PR DESCRIPTION
## 🗣 Description

Data Connectors now need to specify which secrets it might need as part of the `autoload_secrets()` function on the `DataConnectorFactory`. This list is used to try to autoload those secrets if they exist from the defined secret stores.

Each Data Connector now also needs to specify a `prefix` that is used to namespace the parameters and secrets it needs. Any parameter which does not start with that prefix is filtered out (with a warning log) and not sent to the data connector.

This PR also depends on changes in https://github.com/datafusion-contrib/datafusion-table-providers/pull/16

## 🔨 Related Issues

Part of #1701

## 🤔 Concerns

This PR does not yet handle embedding or models, as they don't follow the same model as data connectors. I think we'll need to have them follow the same model of a registry with a factory so we can enable the same semantics.