### PR TITLE
fix spiceai connector lengthy error

### DIFF
--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -49,7 +49,10 @@ pub enum Error {
     #[snafu(display("Unable to generate SQL: {source}"))]
     UnableToGenerateSQL { source: expr::Error },
 
-    #[snafu(display("Unable to get schema from Arrow Flight for table {table}: {source}"))]
+    #[snafu(display("Unable to query Arrow Flight: {source}"))]
+    Flight { source: flight_client::Error },
+
+    #[snafu(display("Unable to get schema from Flight for table {table}: {source}"))]
     UnableToGetSchema {
         source: flight_client::Error,
         table: String,
@@ -416,7 +419,7 @@ fn query_to_stream(
                     }
                 }
             }
-            Err(error) => yield Err(to_execution_error(Error::ArrowFlight{ source: error}))
+            Err(error) => yield Err(to_execution_error(Error::Flight{ source: error}))
         }
     }
 }

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -52,7 +52,7 @@ pub enum Error {
     #[snafu(display("Unable to query Arrow Flight: {source}"))]
     Flight { source: flight_client::Error },
 
-    #[snafu(display("Unable to get schema from Flight for table {table}: {source}"))]
+    #[snafu(display("Unable to get schema from Arrow Flight for table {table}: {source}"))]
     UnableToGetSchema {
         source: flight_client::Error,
         table: String,

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -49,16 +49,13 @@ pub enum Error {
     #[snafu(display("Unable to generate SQL: {source}"))]
     UnableToGenerateSQL { source: expr::Error },
 
-    #[snafu(display("Unable to query Flight: {source}"))]
-    Flight { source: flight_client::Error },
-
-    #[snafu(display("Unable to get schema from Flight for table {table}: {source}"))]
+    #[snafu(display("Unable to get schema from Arrow Flight for table {table}: {source}"))]
     UnableToGetSchema {
         source: flight_client::Error,
         table: String,
     },
 
-    #[snafu(display("Unable to query Flight: {source}"))]
+    #[snafu(display("Unable to query Arrow Flight: {source}"))]
     ArrowFlight { source: FlightError },
 
     #[snafu(display("Unable to retrieve schema"))]
@@ -419,7 +416,7 @@ fn query_to_stream(
                     }
                 }
             }
-            Err(error) => yield Err(to_execution_error(Error::Flight{ source: error}))
+            Err(error) => yield Err(to_execution_error(Error::ArrowFlight{ source: error}))
         }
     }
 }

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -52,6 +52,12 @@ pub enum Error {
     #[snafu(display("Unable to query Flight: {source}"))]
     Flight { source: flight_client::Error },
 
+    #[snafu(display("Unable to get schema from Flight for table {table}: {source}"))]
+    UnableToGetSchema {
+        source: flight_client::Error,
+        table: String,
+    },
+
     #[snafu(display("Unable to query Flight: {source}"))]
     ArrowFlight { source: FlightError },
 
@@ -194,7 +200,9 @@ impl FlightTable {
                 .as_str(),
             )
             .await
-            .context(FlightSnafu)?;
+            .context(UnableToGetSchemaSnafu {
+                table: table_reference.to_quoted_string(),
+            })?;
 
         if stream.next().await.is_some() {
             if let Some(schema) = stream.schema() {

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -194,6 +194,15 @@ pub enum DataConnectorError {
         table_name: String,
     },
 
+    #[snafu(display(
+        "Failed to get schema for {dataconnector} dataset {dataset_name}. Ensure the table '{table_name}' exists in the data source."
+    ))]
+    UnableToGetSchema {
+        dataconnector: String,
+        dataset_name: String,
+        table_name: String,
+    },
+
     #[snafu(display("{dataconnector} Data Connector Error: {source}"))]
     InternalWithSource {
         dataconnector: String,

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -181,7 +181,7 @@ impl DataConnector for SpiceAI {
                 }
 
                 return Err(DataConnectorError::UnableToGetReadProvider {
-                    dataconnector: "spic.ai".to_string(),
+                    dataconnector: "spice.ai".to_string(),
                     source: e,
                 });
             }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use super::DataConnector;
+use super::DataConnectorError;
 use super::DataConnectorFactory;
 use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
@@ -157,15 +158,34 @@ impl DataConnector for SpiceAI {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        Ok(Read::table_provider(
+        match Read::table_provider(
             &self.flight_factory,
             SpiceAI::spice_dataset_path(dataset).into(),
             dataset.schema(),
         )
         .await
-        .context(super::UnableToGetReadProviderSnafu {
-            dataconnector: "spiceai",
-        })?)
+        {
+            Ok(provider) => Ok(provider),
+            Err(e) => {
+                if let Some(data_components::flight::Error::UnableToGetSchema {
+                    source: _,
+                    table,
+                }) = e.downcast_ref::<data_components::flight::Error>()
+                {
+                    tracing::debug!("{e}");
+                    return Err(DataConnectorError::UnableToGetSchema {
+                        dataconnector: "spice.ai".to_string(),
+                        dataset_name: dataset.name.to_string(),
+                        table_name: table.clone(),
+                    });
+                }
+
+                return Err(DataConnectorError::UnableToGetReadProvider {
+                    dataconnector: "spic.ai".to_string(),
+                    source: e,
+                });
+            }
+        }
     }
 
     async fn read_write_provider(


### PR DESCRIPTION
## 🗣 Description

Intentionally capture readprovider error when querying schema for `spice.ai` and `dremio` and print a nicer format of message.

now the error message is like `2024-07-19T05:59:23.390889Z  WARN runtime: Failed to get schema for spice.ai dataset a. Ensure the table 'this.is.a' exists in the data source.`

## 🔨 Related Issues

Fix #1462 

## 🤔 Concerns