### PR TITLE
Switch the secret replacement syntax to `${ <secret>:<key> }`

### DIFF
--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -268,7 +268,7 @@ pub async fn create_accelerator_table(
     let mut params_with_secrets: HashMap<String, SecretString> = HashMap::new();
 
     // Inject secrets from the user-supplied params.
-    // This will replace any instances of `${{ store:key }}` with the actual secret value.
+    // This will replace any instances of `${ store:key }` with the actual secret value.
     for (k, v) in &acceleration_settings.params {
         let secret = secret_guard.inject_secrets(ParamStr(v)).await;
         params_with_secrets.insert(k.clone(), secret);

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -396,7 +396,7 @@ impl Runtime {
         let mut params_with_secrets: HashMap<String, SecretString> = HashMap::new();
 
         // Inject secrets from the user-supplied params.
-        // This will replace any instances of `${{ store:key }}` with the actual secret value.
+        // This will replace any instances of `${ store:key }` with the actual secret value.
         for (k, v) in params {
             let secret = secrets.inject_secrets(ParamStr(v)).await;
             params_with_secrets.insert(k.clone(), secret);

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -367,7 +367,7 @@ mod tests {
 
         let result = secrets
             .inject_secrets(super::ParamStr(
-                "This is a secret: ${{ env:MY_SECRET_KEY }}! 🫡",
+                "This is a secret: ${ env:MY_SECRET_KEY }! 🫡",
             ))
             .await;
         assert_eq!(

--- a/crates/runtime/src/secrets/lexer.rs
+++ b/crates/runtime/src/secrets/lexer.rs
@@ -95,23 +95,23 @@ mod tests {
 
     #[test]
     fn test_secret_lexer_basic() {
-        let input = "Hello ${{ secret:my_secret }} world";
+        let input = "Hello ${ secret:my_secret } world";
         let lexer = SecretReplacementMatcher::new(input);
 
         let matches: Vec<ReplacementMatch> = lexer.collect();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].store_name, "secret");
         assert_eq!(matches[0].key, "my_secret");
-        assert_eq!(matches[0].span, 6..29);
+        assert_eq!(matches[0].span, 6..27);
     }
 
     #[test]
     fn test_secret_lexer_whitespace_variations() {
         let inputs = vec![
-            ("Hello ${{secret:my_secret}} world", 27),
-            ("Hello ${{ secret: my_secret }} world", 30),
-            ("Hello ${{  secret:my_secret  }} world", 31),
-            ("Hello ${{secret :my_secret}} world", 28),
+            ("Hello ${secret:my_secret} world", 25),
+            ("Hello ${ secret: my_secret } world", 28),
+            ("Hello ${  secret:my_secret  } world", 29),
+            ("Hello ${secret :my_secret} world", 26),
         ];
 
         for (input, expected_end) in inputs {
@@ -127,29 +127,29 @@ mod tests {
 
     #[test]
     fn test_secret_lexer_multiple_matches() {
-        let input = "Start ${{ secret:my_secret1 }} middle ${{ secret:my_secret2 }} end";
+        let input = "Start ${ secret:my_secret1 } middle ${ secret:my_secret2 } end";
         let lexer = SecretReplacementMatcher::new(input);
 
         let matches: Vec<ReplacementMatch> = lexer.collect();
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].store_name, "secret");
         assert_eq!(matches[0].key, "my_secret1");
-        assert_eq!(matches[0].span, 6..30);
+        assert_eq!(matches[0].span, 6..28);
 
         assert_eq!(matches[1].store_name, "secret");
         assert_eq!(matches[1].key, "my_secret2");
-        assert_eq!(matches[1].span, 38..62);
+        assert_eq!(matches[1].span, 36..58);
     }
 
     #[test]
     fn test_secret_lexer_invalid_formats() {
         let inputs = vec![
-            "Hello ${{secret:}} world",             // Missing key
-            "Hello ${{:my_secret}} world",          // Missing store name
-            "Hello ${{ secret my_secret }} world",  // Missing colon
-            "Hello ${{ secret: my secret }} world", // Invalid key format
-            "Hello ${{secret}} world",              // Missing colon and key
-            "Hello ${ secret:my_secret } world",    // Missing outer curly braces
+            "Hello ${secret:} world",              // Missing key
+            "Hello ${:my_secret} world",           // Missing store name
+            "Hello ${ secret my_secret } world",   // Missing colon
+            "Hello ${ secret: my secret } world",  // Invalid key format
+            "Hello ${secret} world",               // Missing colon and key
+            "Hello ${{ secret:my_secret }} world", // Invalid style
         ];
 
         for input in inputs {

--- a/crates/runtime/src/secrets/lexer.rs
+++ b/crates/runtime/src/secrets/lexer.rs
@@ -25,7 +25,7 @@ pub struct ReplacementMatch {
 #[derive(Logos, Debug, PartialEq)]
 #[logos(skip r"[ \t\n\f]+")] // Ignore whitespace between tokens
 enum SecretReplacementToken {
-    #[token("${{")]
+    #[token("${")]
     Start,
 
     #[regex(r"[a-zA-Z][a-zA-Z0-9_-]*", |lex| lex.slice().to_owned())]
@@ -34,7 +34,7 @@ enum SecretReplacementToken {
     #[token(":")]
     Colon,
 
-    #[token("}}")]
+    #[token("}")]
     End,
 }
 


### PR DESCRIPTION
## 🗣 Description

Switches the secret replacement syntax from `${{ <secret>:<key> }}` to `${ <secret>:<key> }}` to match with the React style of variable replacement.

## 🔨 Related Issues

Part of #1701