### PR TITLE
Update Default ports

### DIFF
--- a/.github/actions/verify-dataset/action.yml
+++ b/.github/actions/verify-dataset/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Ensure datasets loaded
       shell: bash
       run: |
-        response=$(curl http://localhost:3000/v1/datasets)
+        response=$(curl http://localhost:8090/v1/datasets)
         echo $response | jq
         length=$(echo $response | jq 'if type=="array" then length else empty end')
         if [[ $length -ne 1 ]]; then
@@ -27,7 +27,7 @@ runs:
         response=$(curl -X POST \
           -H "Content-Type: text/plain" \
           -d "show tables;" \
-          http://localhost:3000/v1/sql
+          http://localhost:8090/v1/sql
         )
         echo $response | jq
 

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -186,7 +186,7 @@ jobs:
   #       working-directory: test_app
   #       timeout-minutes: 1
   #       run: |
-  #         while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+  #         while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done
 
   #     - name: Add spiceai/quickstart
   #       working-directory: test_app

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -258,7 +258,7 @@ jobs:
         working-directory: test_app
         timeout-minutes: 1
         run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+          while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -335,7 +335,7 @@ jobs:
         working-directory: test_app
         timeout-minutes: 1
         run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+          while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -432,7 +432,7 @@ jobs:
         working-directory: test_app
         timeout-minutes: 1
         run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+          while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -530,7 +530,7 @@ jobs:
         working-directory: test_app
         timeout-minutes: 1
         run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+          while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -612,7 +612,7 @@ jobs:
         working-directory: duckdb-app
         timeout-minutes: 1
         run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+          while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -723,7 +723,7 @@ jobs:
         working-directory: test_app
         timeout-minutes: 1
         run: |
-          while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+          while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done
 
       - name: Manually refresh dataset
         working-directory: test_app
@@ -810,13 +810,13 @@ jobs:
           working-directory: test_app
           timeout-minutes: 1
           run: |
-            while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done
+            while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done
 
 
         - name: Run SQL query and check Miss cache header
           working-directory: test_app
           run: |
-            response=$(curl -i -XPOST "127.0.0.1:3000/v1/sql" --data "SELECT c_name FROM (SELECT * FROM customer)")
+            response=$(curl -i -XPOST "127.0.0.1:8090/v1/sql" --data "SELECT c_name FROM (SELECT * FROM customer)")
             echo "$response"
             if echo "$response" | grep -q "x-cache: Miss from spiceai"; then
               echo "Cache miss detected as expected"
@@ -828,7 +828,7 @@ jobs:
         - name: Run SQL query and check Hit cache header
           working-directory: test_app
           run: |
-            response=$(curl -i -XPOST "127.0.0.1:3000/v1/sql" --data "select c_name from (select * from customer)")
+            response=$(curl -i -XPOST "127.0.0.1:8090/v1/sql" --data "select c_name from (select * from customer)")
             echo "$response"
             if echo "$response" | grep -q "x-cache: Hit from spiceai"; then
               echo "Cache hit detected as expected"
@@ -853,7 +853,7 @@ jobs:
         - name: Run SQL query and check Miss cache header
           working-directory: test_app
           run: |
-            response=$(curl -i -XPOST "127.0.0.1:3000/v1/sql" --data "SELECT c_name FROM (SELECT * FROM customer)")
+            response=$(curl -i -XPOST "127.0.0.1:8090/v1/sql" --data "SELECT c_name FROM (SELECT * FROM customer)")
             echo "$response"
             if echo "$response" | grep -q "x-cache: Miss from spiceai"; then
               echo "Cache miss detected as expected"

--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -95,7 +95,7 @@ jobs:
     - name: wait for Spice runtime healthy
       if: matrix.target_os != 'windows'
       run: |
-        bash -c 'while [[ "$(curl -s http://localhost:3000/health)" != "ok" ]]; do sleep 1; done' || false
+        bash -c 'while [[ "$(curl -s http://localhost:8090/health)" != "ok" ]]; do sleep 1; done' || false
       timeout-minutes: 1
 
     - name: wait for Spice runtime healthy
@@ -104,7 +104,7 @@ jobs:
         do {
           try {
             Start-Sleep -Seconds 1
-            $response = Invoke-WebRequest -Uri "http://127.0.0.1:3000/health" -UseBasicParsing
+            $response = Invoke-WebRequest -Uri "http://127.0.0.1:8090/health" -UseBasicParsing
             $res = $response.Content.Trim()
 
             Write-Host "Status: $($response.StatusCode)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ fi
 
 COPY --from=build /root/spiced /usr/local/bin/spiced
 
-EXPOSE 8090 50051
+EXPOSE 8090 50090
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ fi
 
 COPY --from=build /root/spiced /usr/local/bin/spiced
 
-EXPOSE 3000 50051
+EXPOSE 8090 50051
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ docker:
 .PHONY: docker-run
 docker-run:
 	docker stop spiceai && docker rm spiceai || true
-	docker run --name spiceai -p 3000:3000 -p 50051:50051 spiceai-rust:local-dev
+	docker run --name spiceai -p 8090:8090 -p 50051:50051 spiceai-rust:local-dev
 
 .PHONY: deps-licenses
 dep-licenses:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ docker:
 .PHONY: docker-run
 docker-run:
 	docker stop spiceai && docker rm spiceai || true
-	docker run --name spiceai -p 8090:8090 -p 50051:50051 spiceai-rust:local-dev
+	docker run --name spiceai -p 8090:8090 -p 50090:50090 spiceai-rust:local-dev
 
 .PHONY: deps-licenses
 dep-licenses:

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ Example output will be shown as follows:
 ```bash
 Spice.ai runtime starting...
 Using latest 'local' runtime version.
-2024-06-03T23:21:26.819978Z  INFO spiced: Metrics listening on 127.0.0.1:9000
+2024-06-03T23:21:26.819978Z  INFO spiced: Metrics listening on 127.0.0.1:9090
 2024-06-03T23:21:26.821863Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-06-03T23:21:26.821898Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2024-06-03T23:21:26.821898Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50090
 2024-06-03T23:21:26.821958Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-06-03T23:21:26.822128Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
 ```

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Using latest 'local' runtime version.
 2024-06-03T23:21:26.819978Z  INFO spiced: Metrics listening on 127.0.0.1:9090
 2024-06-03T23:21:26.821863Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-06-03T23:21:26.821898Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50090
-2024-06-03T23:21:26.821958Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
+2024-06-03T23:21:26.821958Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50091
 2024-06-03T23:21:26.822128Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
 ```
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Example output will be shown as follows:
 Spice.ai runtime starting...
 Using latest 'local' runtime version.
 2024-06-03T23:21:26.819978Z  INFO spiced: Metrics listening on 127.0.0.1:9000
-2024-06-03T23:21:26.821863Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:3000
+2024-06-03T23:21:26.821863Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-06-03T23:21:26.821898Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-06-03T23:21:26.821958Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-06-03T23:21:26.822128Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s

--- a/bin/spice/cmd/cloud.go
+++ b/bin/spice/cmd/cloud.go
@@ -86,7 +86,7 @@ spice chat --model <model> --cloud
 			if cloud {
 				httpEndpoint = "https://data.spiceai.io"
 			} else {
-				httpEndpoint = "http://localhost:3000"
+				httpEndpoint = "http://localhost:8090"
 			}
 		}
 
@@ -229,7 +229,7 @@ func callCloudChat(baseUrl string, apiKey string, client *http.Client, body *Cha
 func init() {
 	chatCmd.Flags().Bool(cloudKeyFlag, false, "Use cloud instance for chat (default: false)")
 	chatCmd.Flags().String(modelKeyFlag, "", "Model to chat with")
-	chatCmd.Flags().String(httpEndpointKeyFlag, "", "HTTP endpoint for chat (default: http://localhost:3000)")
+	chatCmd.Flags().String(httpEndpointKeyFlag, "", "HTTP endpoint for chat (default: http://localhost:8090)")
 
 	RootCmd.AddCommand(chatCmd)
 }

--- a/bin/spice/cmd/spice.go
+++ b/bin/spice/cmd/spice.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const PROM_ENDPOINT = "http://localhost:9000"
+const PROM_ENDPOINT = "http://localhost:9090"
 
 var RootCmd = &cobra.Command{
 	Use:   "spice",

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -40,7 +40,7 @@ type RuntimeContext struct {
 
 func NewContext() *RuntimeContext {
 	rtcontext := &RuntimeContext{
-		httpEndpoint: "http://127.0.0.1:3000",
+		httpEndpoint: "http://127.0.0.1:8090",
 	}
 	err := rtcontext.Init()
 	if err != nil {

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -173,7 +173,7 @@ func (c *RuntimeContext) GetSpiceAppRelativePath(absolutePath string) string {
 func (c *RuntimeContext) GetRunCmd() (*exec.Cmd, error) {
 	spiceCMD := c.binaryFilePath("spiced")
 
-	cmd := exec.Command(spiceCMD, "--metrics", "127.0.0.1:9000")
+	cmd := exec.Command(spiceCMD, "--metrics", "127.0.0.1:9090")
 
 	return cmd, nil
 }

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -55,7 +55,7 @@ pub struct ReplConfig {
     #[arg(
         long,
         value_name = "HTTP_ENDPOINT",
-        default_value = "http://localhost:3000",
+        default_value = "http://localhost:8090",
         help_heading = "SQL REPL"
     )]
     pub http_endpoint: String,

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -47,7 +47,7 @@ pub struct ReplConfig {
     #[arg(
         long,
         value_name = "FLIGHT_ENDPOINT",
-        default_value = "http://localhost:50051",
+        default_value = "http://localhost:50090",
         help_heading = "SQL REPL"
     )]
     pub repl_flight_endpoint: String,

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -31,7 +31,7 @@ pub struct Config {
     #[arg(
         long = "flight",
         value_name = "FLIGHT_BIND_ADDRESS",
-        default_value = "127.0.0.1:50051",
+        default_value = "127.0.0.1:50090",
         action
     )]
     pub flight_bind_address: SocketAddr,

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -40,7 +40,7 @@ pub struct Config {
     #[arg(
         long = "open_telemetry",
         value_name = "OPEN_TELEMETRY_BIND_ADDRESS",
-        default_value = "127.0.0.1:50052",
+        default_value = "127.0.0.1:50091",
         action
     )]
     pub open_telemetry_bind_address: SocketAddr,

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -22,7 +22,7 @@ pub struct Config {
     #[arg(
         long = "http",
         value_name = "BIND_ADDRESS",
-        default_value = "127.0.0.1:3000",
+        default_value = "127.0.0.1:8090",
         action
     )]
     pub http_bind_address: SocketAddr,

--- a/deploy/chart/templates/podmonitor.yaml
+++ b/deploy/chart/templates/podmonitor.yaml
@@ -8,7 +8,7 @@ spec:
   - interval: 10s
     path: /metrics
     scheme: http
-    targetPort: 9000
+    targetPort: 9090
   selector:
     matchLabels:
       app: {{ .Release.Name }}

--- a/deploy/chart/templates/spiceai.yaml
+++ b/deploy/chart/templates/spiceai.yaml
@@ -40,7 +40,7 @@ spec:
             [
               "/usr/local/bin/spiced",
               "--http",
-              "0.0.0.0:3000",
+              "0.0.0.0:8090",
               "--metrics",
               "0.0.0.0:9000",
               "--flight",
@@ -53,7 +53,7 @@ spec:
             {{- .Values.additionalEnv | toYaml | nindent 12 }}
             {{- end }}
           ports:
-            - containerPort: 3000
+            - containerPort: 8090
               name: http
             - containerPort: 9000
               name: metrics
@@ -64,15 +64,15 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 3000
+              port: 8090
           readinessProbe:
             httpGet:
               path: /v1/ready
-              port: 3000
+              port: 8090
           startupProbe:
             httpGet:
               path: /health
-              port: 3000
+              port: 8090
           volumeMounts:
             {{- if .Values.volumeMounts }}
             {{- .Values.volumeMounts | toYaml | nindent 12 }}
@@ -99,7 +99,7 @@ metadata:
     app: {{ .Release.Name }}
 spec:
   ports:
-    - port: 3000
+    - port: 8090
       name: http
     - port: 9000
       name: metrics

--- a/deploy/chart/templates/spiceai.yaml
+++ b/deploy/chart/templates/spiceai.yaml
@@ -42,9 +42,9 @@ spec:
               "--http",
               "0.0.0.0:8090",
               "--metrics",
-              "0.0.0.0:9000",
+              "0.0.0.0:9090",
               "--flight",
-              "0.0.0.0:50051",
+              "0.0.0.0:50090",
               "--open_telemetry",
               "0.0.0.0:50052"
             ]
@@ -55,9 +55,9 @@ spec:
           ports:
             - containerPort: 8090
               name: http
-            - containerPort: 9000
+            - containerPort: 9090
               name: metrics
-            - containerPort: 50051
+            - containerPort: 50090
               name: flight
             - containerPort: 50052
               name: otel
@@ -101,9 +101,9 @@ spec:
   ports:
     - port: 8090
       name: http
-    - port: 9000
+    - port: 9090
       name: metrics
-    - port: 50051
+    - port: 50090
       name: flight
     - port: 50052
       name: otel

--- a/deploy/chart/templates/spiceai.yaml
+++ b/deploy/chart/templates/spiceai.yaml
@@ -46,7 +46,7 @@ spec:
               "--flight",
               "0.0.0.0:50090",
               "--open_telemetry",
-              "0.0.0.0:50052"
+              "0.0.0.0:50091"
             ]
           env:
             {{- if .Values.additionalEnv }}
@@ -59,7 +59,7 @@ spec:
               name: metrics
             - containerPort: 50090
               name: flight
-            - containerPort: 50052
+            - containerPort: 50091
               name: otel
           livenessProbe:
             httpGet:
@@ -105,7 +105,7 @@ spec:
       name: metrics
     - port: 50090
       name: flight
-    - port: 50052
+    - port: 50091
       name: otel
   selector:
     app: {{ .Release.Name }}

--- a/examples/runtime_demo.py
+++ b/examples/runtime_demo.py
@@ -24,7 +24,7 @@ exit()
 ########################################
 #   DO NOT COMMENT OUT THE LINE BELOW  #
 ########################################
-client = Client(API_KEY, 'grpc://127.0.0.1:50051')
+client = Client(API_KEY, 'grpc://127.0.0.1:50090')
 
 ###########################
 #   Spice AI Datasource   #
@@ -98,7 +98,7 @@ while True:
 def simulate_runtime_duckdb(user_id):
     #print("User " + str(user_id) + " started")
     # make a new client for each user
-    client = Client(API_KEY, 'grpc://127.0.0.1:50051')
+    client = Client(API_KEY, 'grpc://127.0.0.1:50090')
     start = time.time()
     # make a query
     data = client.query('SELECT * FROM eth_recent_blocks_duckdb DESC;')
@@ -111,7 +111,7 @@ def simulate_runtime_duckdb(user_id):
 def simulate_runtime_arrow_mem(user_id):
     #print("User " + str(user_id) + " started")
     # make a new client for each user
-    client = Client(API_KEY, 'grpc://127.0.0.1:50051')
+    client = Client(API_KEY, 'grpc://127.0.0.1:50090')
     start = time.time()
     # make a query
     data = client.query('SELECT * FROM eth_recent_blocks DESC;')

--- a/tools/flightpublisher/src/main.rs
+++ b/tools/flightpublisher/src/main.rs
@@ -33,7 +33,7 @@ pub struct Args {
     #[arg(
         long,
         value_name = "FLIGHT_ENDPOINT",
-        default_value = "http://localhost:50051"
+        default_value = "http://localhost:50090"
     )]
     pub flight_endpoint: String,
 

--- a/tools/flightsubscriber/src/main.rs
+++ b/tools/flightsubscriber/src/main.rs
@@ -31,7 +31,7 @@ pub struct Args {
     #[arg(
         long,
         value_name = "FLIGHT_ENDPOINT",
-        default_value = "http://localhost:50051"
+        default_value = "http://localhost:50090"
     )]
     pub flight_endpoint: String,
 


### PR DESCRIPTION
## 🗣 Description

Change the default ports to the following:

HTTP: 8090 - Moved from port 3000
Metrics (HTTP): 9090 - Moved from port 9000
gRPC (Flight): 50090 - moved from 50051
gRPC (OpenTelemetry): 50091 - Moved from 50052


## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/1972

## 🤔 Concerns

This is a breaking change.  Spice users will have to update their applications for the default ports.
