### PR TITLE
Log parameter key instead of value when injecting secret

### DIFF
--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -270,7 +270,7 @@ pub async fn create_accelerator_table(
     // Inject secrets from the user-supplied params.
     // This will replace any instances of `${ store:key }` with the actual secret value.
     for (k, v) in &acceleration_settings.params {
-        let secret = secret_guard.inject_secrets(ParamStr(v)).await;
+        let secret = secret_guard.inject_secrets(k, ParamStr(v)).await;
         params_with_secrets.insert(k.clone(), secret);
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -398,7 +398,7 @@ impl Runtime {
         // Inject secrets from the user-supplied params.
         // This will replace any instances of `${ store:key }` with the actual secret value.
         for (k, v) in params {
-            let secret = secrets.inject_secrets(ParamStr(v)).await;
+            let secret = secrets.inject_secrets(k, ParamStr(v)).await;
             params_with_secrets.insert(k.clone(), secret);
         }
 

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -107,8 +107,8 @@ impl Secrets {
         Ok(())
     }
 
-    pub async fn inject_secrets(&self, param_str: ParamStr<'_>) -> SecretString {
-        tracing::trace!("Injecting secrets for: {}", param_str.0);
+    pub async fn inject_secrets(&self, key: &str, param_str: ParamStr<'_>) -> SecretString {
+        tracing::trace!("Injecting secrets for: {}", key);
         let mut result = String::new();
         let mut last_end = 0;
         for secret_replacement in SecretReplacementMatcher::new(param_str.0) {
@@ -366,9 +366,10 @@ mod tests {
         std::env::set_var("MY_SECRET_KEY", "super_secret");
 
         let result = secrets
-            .inject_secrets(super::ParamStr(
-                "This is a secret: ${ env:MY_SECRET_KEY }! 🫡",
-            ))
+            .inject_secrets(
+                "MY_SECRET_KEY",
+                super::ParamStr("This is a secret: ${ env:MY_SECRET_KEY }! 🫡"),
+            )
             .await;
         assert_eq!(
             "This is a secret: super_secret! 🫡",


### PR DESCRIPTION
## 🗣 Description

When injecting secret parameter value, the secret value is directly revealed in logs, which is a security vulnerability. We should log parameter key instead of parameter value

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->