### PR TITLE
MySQL timestamp, int64 casting, date part extraction and intervals support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2845,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "tokio",
 ]
@@ -2853,7 +2853,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "arrow",
  "chrono",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -2940,7 +2940,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2957,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "40.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=69c868168d2792a9137348d57d1ea6856e878164#69c868168d2792a9137348d57d1ea6856e878164"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ffe792dfdff7a96327bcc536b55d8e9167d29e14#ffe792dfdff7a96327bcc536b55d8e9167d29e14"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1.9.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "69c868168d2792a9137348d57d1ea6856e878164" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ffe792dfdff7a96327bcc536b55d8e9167d29e14" }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "85935dbbc64d2af1ca132ad7e2309a9d87bf3115" }


### PR DESCRIPTION
## 🗣 Description

Datafusion upgrade to include  the following MySQL compatibility fixes
1. [Alternate format support for Timestamp casting (DATETIME for MySQL)](https://github.com/spiceai/datafusion/commit/ffe792dfdff7a96327bcc536b55d8e9167d29e14)
1. [Alternate format support for date part extraction (EXTRACT for MySQL)](https://github.com/spiceai/datafusion/pull/21)
1. [Add support for IntervalStyle::MySQL](https://github.com/spiceai/datafusion/commit/d0943b9e0c2568fa422ac4776b341ad6378520aa)
1. [Alternate format support for Int64 unparsing (SIGNED for MySQL)](https://github.com/spiceai/datafusion/commit/790f9c640253b83e66452ba939e7e0d2f454742b)

SHA is the last commit SHA from spiceai-40 branch: https://github.com/spiceai/datafusion/commits/spiceai-40/

## 🔨 Related Issues

Fixes https://github.com/spiceai/spiceai/issues/1950, https://github.com/spiceai/spiceai/issues/1951, https://github.com/spiceai/spiceai/issues/1953, https://github.com/spiceai/spiceai/issues/1860

