### PR TITLE
Build spiced with odbc for release binaries

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -101,6 +101,8 @@ jobs:
           }
 
       - name: Build spiced
+        env:
+          SPICED_NON_DEFAULT_FEATURES: odbc
         run: make -C bin/spiced
 
       - name: Update build cache (macOS)


### PR DESCRIPTION
## 🗣 Description

Builds the `spiced` binary in the official releases with the `odbc` feature enabled.

ODBC is becoming one of our more popular connectors, and it doesn't add too much to the final binary size - so let's enable it by default.