### PR TITLE
Add benchmark tests for S3 data connector

### DIFF
--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -23,6 +23,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [features]
+s3 = []
 aws-secrets-manager = ["runtime/aws-secrets-manager"]
 clickhouse = ["runtime/clickhouse"]
 databricks = ["runtime/databricks"]

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -23,7 +23,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [features]
-s3 = []
 aws-secrets-manager = ["runtime/aws-secrets-manager"]
 clickhouse = ["runtime/clickhouse"]
 databricks = ["runtime/databricks"]

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 //! This is a benchmark test suite for the Spice runtime.
 //!
 //! It performs the following actions:
@@ -25,6 +41,7 @@ mod setup;
 
 #[cfg(feature = "spark")]
 mod bench_spark;
+mod bench_s3;
 mod bench_spicecloud;
 
 #[tokio::main]
@@ -39,6 +56,7 @@ async fn main() -> Result<(), String> {
         "spice.ai",
         #[cfg(feature = "spark")]
         "spark",
+        "s3",
     ];
 
     let mut display_records = vec![];
@@ -54,6 +72,9 @@ async fn main() -> Result<(), String> {
             #[cfg(feature = "spark")]
             "spark" => {
                 bench_spark::run(&mut rt, &mut benchmark_results).await?;
+            }
+            "s3" => {
+                bench_s3::run(&mut rt, &mut benchmark_results).await?;
             }
             _ => {}
         }

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -39,9 +39,9 @@ use crate::results::Status;
 mod results;
 mod setup;
 
+mod bench_s3;
 #[cfg(feature = "spark")]
 mod bench_spark;
-mod bench_s3;
 mod bench_spicecloud;
 
 #[tokio::main]

--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use runtime::Runtime;
 
 use crate::results::BenchmarkResultsBuilder;

--- a/crates/runtime/benches/results/mod.rs
+++ b/crates/runtime/benches/results/mod.rs
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use std::sync::Arc;
 
 use arrow::{

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -1,4 +1,20 @@
-use crate::results::BenchmarkResultsBuilder;
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::{bench_s3, results::BenchmarkResultsBuilder};
 use app::{App, AppBuilder};
 use runtime::{dataupdate::DataUpdate, Runtime};
 use spicepod::component::dataset::{replication::Replication, Dataset, Mode};
@@ -63,6 +79,7 @@ fn build_app(upload_results_dataset: &Option<String>, connector: &str) -> App {
             .with_dataset(make_spark_dataset("samples.tpch.nation", "nation"))
             .with_dataset(make_spark_dataset("samples.tpch.region", "region"))
             .with_dataset(make_spark_dataset("samples.tpch.supplier", "supplier")),
+        "s3" => bench_s3::build_app(app_builder),
 
         _ => app_builder,
     };


### PR DESCRIPTION
## 🗣 Description

Add benchmark tests for S3 data connector

Example benchmark tests run: https://github.com/spiceai/spiceai/actions/runs/10066737461/job/27828747324

Notes:
 - As S3 data connector does not have dedicated feature flag I'm not using it for bench test similar to spiceai data connector. We might want to add more control and distinct running bench tests for spiceai, s3, etc and add corresponding flags next. This can be done when we create final flow to run bench tests using for example parallel flow (similar to acceleration tests running in parallel)