### PR TITLE
fix: Install `unixodbc` for E2E test release installation

### DIFF
--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -46,7 +46,18 @@ jobs:
       if: matrix.target_os == 'linux' && matrix.target_arch == 'aarch64'
       run: |
         sudo apt-get update
-        sudo apt install jq -y
+        sudo apt install jq unixodbc unixodbc-dev -y
+    
+    # The x86_64 runner does not unixodbc pre-installed
+    - name: Install missing tools (Linux x86_64)
+      if: matrix.target_os == 'linux' && matrix.target_arch == 'x86_64'
+      run: |
+        sudo apt-get install unixodbc unixodbc-dev -y
+    
+    - name: Install missing tools (Mac)
+      if: matrix.target_os == 'darwin'
+      run: |
+        brew install unixodbc
 
     - name: install Spice (https://install.spiceai.org)
       if : matrix.target_os != 'windows'


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Install `unixodbc` for E2E test release installation, because it's a required dependency for runtime with ODBC feature enabled.