### PR TITLE
Add `spice install` CLI command

### DIFF
--- a/bin/spice/cmd/install.go
+++ b/bin/spice/cmd/install.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spiceai/spiceai/bin/spice/pkg/runtime"
+	"github.com/spiceai/spiceai/bin/spice/pkg/util"
+)
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install the Spice.ai runtime",
+	Example: `
+spice install
+
+# See more at: https://docs.spiceai.org/
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := checkLatestCliReleaseVersion()
+		if err != nil && util.IsDebug() {
+			cmd.PrintErrf("failed to check for latest CLI release version: %s\n", err.Error())
+		}
+
+		installed, err := runtime.EnsureInstalled()
+		if err != nil {
+			cmd.PrintErrln(err.Error())
+			os.Exit(1)
+		}
+
+		if !installed {
+			cmd.Println("Spice.ai runtime already installed")
+		}
+	},
+}
+
+func init() {
+	installCmd.Flags().BoolP("help", "h", false, "Print this help message")
+	RootCmd.AddCommand(installCmd)
+}

--- a/bin/spice/pkg/runtime/runtime.go
+++ b/bin/spice/pkg/runtime/runtime.go
@@ -25,11 +25,9 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
 
-func Run() error {
-	fmt.Println("Spice.ai runtime starting...")
-
+// Ensures the runtime is installed. Returns true if the runtime was installed or upgraded, false if it was already installed.
+func EnsureInstalled() (bool, error) {
 	rtcontext := context.NewContext()
-
 	err := rtcontext.Init()
 	if err != nil {
 		fmt.Println(err.Error())
@@ -39,7 +37,6 @@ func Run() error {
 	shouldInstall := false
 	var upgradeVersion string
 	if installRequired := rtcontext.IsRuntimeInstallRequired(); installRequired {
-		fmt.Println("The Spice.ai runtime has not yet been installed.")
 		shouldInstall = true
 	} else {
 		upgradeVersion, err = rtcontext.IsRuntimeUpgradeAvailable()
@@ -53,8 +50,27 @@ func Run() error {
 	if shouldInstall {
 		err = rtcontext.InstallOrUpgradeRuntime()
 		if err != nil {
-			return err
+			return shouldInstall, err
 		}
+	}
+
+	return shouldInstall, nil
+}
+
+func Run() error {
+	fmt.Println("Spice.ai runtime starting...")
+
+	rtcontext := context.NewContext()
+
+	err := rtcontext.Init()
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	_, err = EnsureInstalled()
+	if err != nil {
+		return err
 	}
 
 	cmd, err := rtcontext.GetRunCmd()


### PR DESCRIPTION
## 🗣 Description

Adds the `spice install` CLI command for installing the runtime without starting it. Useful for use in Dockerfiles or just updating to the latest runtime.

## 🔨 Related Issues

Part of #2085