### PR TITLE
Remove ODBC from default released binaries

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -109,8 +109,6 @@ jobs:
           }
 
       - name: Build spiced
-        env:
-          SPICED_NON_DEFAULT_FEATURES: odbc
         run: make -C bin/spiced
 
       - name: Update build cache (macOS)


### PR DESCRIPTION
## 🗣 Description

Remove ODBC from the statically compiled release binaries. Once #2085 is enabled, that will be the official way to enable ODBC without having to compile the project from source.

## 🔨 Related Issues

#2085