### PR TITLE
Add cfg flag to properly support build w / wo feature in benchmark tests

### DIFF
--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::{bench_mysql, bench_postgres, bench_s3, results::BenchmarkResultsBuilder};
+#[cfg(feature = "mysql")]
+use crate::bench_mysql;
+#[cfg(feature = "postgres")]
+use crate::bench_postgres;
+use crate::{bench_s3, results::BenchmarkResultsBuilder};
 use app::{App, AppBuilder};
 use runtime::{dataupdate::DataUpdate, Runtime};
 use spicepod::component::dataset::{replication::Replication, Dataset, Mode};
@@ -80,7 +84,9 @@ fn build_app(upload_results_dataset: &Option<String>, connector: &str) -> App {
             .with_dataset(make_spark_dataset("samples.tpch.region", "region"))
             .with_dataset(make_spark_dataset("samples.tpch.supplier", "supplier")),
         "s3" => bench_s3::build_app(app_builder),
+        #[cfg(feature = "postgres")]
         "postgres" => bench_postgres::build_app(app_builder),
+        #[cfg(feature = "mysql")]
         "mysql" => bench_mysql::build_app(app_builder),
         _ => app_builder,
     };


### PR DESCRIPTION
## 🗣 Description

Add cfg flags so the bench test can successfully run with `cargo bench -p runtime --features postgres` or `cargo bench -p runtime --features spark`

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->