### PR TITLE
Allow DuckDB to load extensions in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ FROM debian:bookworm-slim
 ARG CARGO_FEATURES
 
 # Allow DuckDB to load extensions
-RUN mkdir .duckdb/ && chown 777 .duckdb/
+RUN mkdir /.duckdb/ && chmod 777 /.duckdb/
 
 RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.78
+ARG RUST_VERSION=1.79
 FROM rust:${RUST_VERSION}-slim-bookworm as build
 
 # cache mounts below may already exist and owned by root
@@ -29,6 +29,9 @@ RUN \
 FROM debian:bookworm-slim
 
 ARG CARGO_FEATURES
+
+# Allow DuckDB to load extensions
+RUN mkdir .duckdb/ && chown 777 .duckdb/
 
 RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \


### PR DESCRIPTION
## 🗣 Description

DuckDB wants to be able to write to `.duckdb` when it loads extensions. Our Docker image didn't allow the correct file permissions to enable this, and this PR fixes that.

## 🔨 Related Issues

Closes #2097