### PR TITLE
Spawn the metrics server in the background.

### DIFF
--- a/crates/runtime/src/metrics_server/mod.rs
+++ b/crates/runtime/src/metrics_server/mod.rs
@@ -48,7 +48,7 @@ where
     A: ToSocketAddrs + Debug + Clone + Copy,
 {
     let (Some(bind_address), Some(handle)) = (bind_address, handle) else {
-        return Ok(futures::pending!());
+        return Ok(());
     };
 
     let listener = std::net::TcpListener::bind(bind_address)


### PR DESCRIPTION
## 🗣 Description

Don't tie the lifetime of the metrics server to the other persistent server tasks.