### PR TITLE
fix: suffix delta kernel table location with slash if none

### DIFF
--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -94,6 +94,12 @@ impl DeltaTable {
         table_location: String,
         storage_options: HashMap<String, SecretString>,
     ) -> Result<Self> {
+        let table_location = if table_location.ends_with('/') {
+            table_location
+        } else {
+            format!("{table_location}/")
+        };
+
         let table = Table::try_from_uri(table_location).context(DeltaTableSnafu)?;
 
         let storage_options: HashMap<String, String> = storage_options

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -94,13 +94,8 @@ impl DeltaTable {
         table_location: String,
         storage_options: HashMap<String, SecretString>,
     ) -> Result<Self> {
-        let table_location = if table_location.ends_with('/') {
-            table_location
-        } else {
-            format!("{table_location}/")
-        };
-
-        let table = Table::try_from_uri(table_location).context(DeltaTableSnafu)?;
+        let table =
+            Table::try_from_uri(ensure_folder_location(table_location)).context(DeltaTableSnafu)?;
 
         let storage_options: HashMap<String, String> = storage_options
             .into_iter()
@@ -149,6 +144,14 @@ impl DeltaTable {
         }
 
         Schema::new(fields)
+    }
+}
+
+fn ensure_folder_location(table_location: String) -> String {
+    if table_location.ends_with('/') {
+        table_location
+    } else {
+        format!("{table_location}/")
     }
 }
 
@@ -534,6 +537,18 @@ mod tests {
         assert_eq!(
             row_group_access,
             RowGroupAccess::Selection(selectors.into())
+        );
+    }
+
+    #[test]
+    fn test_get_table_location() {
+        assert_eq!(
+            ensure_folder_location("s3://my_bucket/".to_string()),
+            "s3://my_bucket/"
+        );
+        assert_eq!(
+            ensure_folder_location("s3://my_bucket".to_string()),
+            "s3://my_bucket/"
         );
     }
 }


### PR DESCRIPTION
## 🗣 Description

Fix broken aws s3 databricks delta integration. Without `/` at the end, delta-kernel tries to replace the last part of the uri with `_delta...` which points to a wrong s3 location.

## 🤔 Concerns

A test is put in plus a method is created to ensure this is not removed accidentally (linting and warning).

There will also be benchmark test to cover this later.