### PR TITLE
Enable TLS on the Flight GRPC endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ tokio-postgres = { version = "0.7.10", features = [
   "with-uuid-1",
 ] }
 tokio-rusqlite = "0.5.1"
-tonic = "0.11.0"
+tonic = { version = "0.11.0", features = ["tls"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1.9.1"

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -17,7 +17,6 @@ limitations under the License.
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use metrics_exporter_prometheus::PrometheusHandle;
-use rustls::ServerConfig;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -26,7 +25,9 @@ use crate::{
     datafusion::DataFusion,
     datasets_health_monitor::DatasetsHealthMonitor,
     extension::{Extension, ExtensionFactory},
-    podswatcher, secrets, tracers, Runtime,
+    podswatcher, secrets,
+    tls::TlsConfig,
+    tracers, Runtime,
 };
 
 pub struct RuntimeBuilder {
@@ -38,7 +39,7 @@ pub struct RuntimeBuilder {
     metrics_endpoint: Option<SocketAddr>,
     metrics_handle: Option<PrometheusHandle>,
     datafusion: Option<Arc<DataFusion>>,
-    tls_config: Option<Arc<ServerConfig>>,
+    tls_config: Option<Arc<TlsConfig>>,
 }
 
 impl RuntimeBuilder {
@@ -115,12 +116,12 @@ impl RuntimeBuilder {
         self
     }
 
-    pub fn with_tls_config(mut self, tls_config: Arc<ServerConfig>) -> Self {
+    pub fn with_tls_config(mut self, tls_config: Arc<TlsConfig>) -> Self {
         self.tls_config = Some(tls_config);
         self
     }
 
-    pub fn with_tls_config_opt(mut self, tls_config: Option<Arc<ServerConfig>>) -> Self {
+    pub fn with_tls_config_opt(mut self, tls_config: Option<Arc<TlsConfig>>) -> Self {
         self.tls_config = tls_config;
         self
     }

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -24,7 +24,6 @@ use hyper_util::{
     service::TowerToHyperService,
 };
 use model_components::model::Model;
-use rustls::ServerConfig;
 use snafu::prelude::*;
 use tokio::{
     net::{TcpListener, TcpStream, ToSocketAddrs},
@@ -37,6 +36,7 @@ use crate::{
     datafusion::DataFusion,
     embeddings::vector_search::{self, compute_primary_keys},
     model::LLMModelStore,
+    tls::TlsConfig,
     EmbeddingModelStore,
 };
 
@@ -64,7 +64,7 @@ pub(crate) async fn start<A>(
     embeddings: Arc<RwLock<EmbeddingModelStore>>,
     config: Arc<config::Config>,
     with_metrics: Option<SocketAddr>,
-    tls_config: Option<Arc<ServerConfig>>,
+    tls_config: Option<Arc<TlsConfig>>,
 ) -> Result<()>
 where
     A: ToSocketAddrs + Debug,
@@ -103,7 +103,7 @@ where
 
         match tls_config {
             Some(ref config) => {
-                let acceptor = TlsAcceptor::from(Arc::clone(config));
+                let acceptor = TlsAcceptor::from(Arc::clone(&config.server_config));
                 process_tls_tcp_stream(stream, acceptor, routes.clone());
             }
             None => {

--- a/crates/runtime/src/metrics_server/mod.rs
+++ b/crates/runtime/src/metrics_server/mod.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::tls::TlsConfig;
 use bytes::Bytes;
 use http::{HeaderValue, Request, Response};
 use http_body_util::Full;
@@ -24,7 +25,6 @@ use hyper::{
 };
 use hyper_util::rt::TokioIo;
 use metrics_exporter_prometheus::PrometheusHandle;
-use rustls::ServerConfig;
 use snafu::prelude::*;
 use std::net::ToSocketAddrs;
 use std::{fmt::Debug, sync::Arc};
@@ -46,7 +46,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 pub(crate) async fn start<A>(
     bind_address: Option<A>,
     handle: Option<PrometheusHandle>,
-    tls_config: Option<Arc<ServerConfig>>,
+    tls_config: Option<Arc<TlsConfig>>,
 ) -> Result<()>
 where
     A: ToSocketAddrs + Debug + Clone + Copy,
@@ -77,7 +77,7 @@ where
 
         match tls_config {
             Some(ref config) => {
-                let acceptor = TlsAcceptor::from(Arc::clone(config));
+                let acceptor = TlsAcceptor::from(Arc::clone(&config.server_config));
                 process_tls_tcp_stream(stream, acceptor.clone(), handle.clone());
             }
             None => {

--- a/crates/runtime/src/tls.rs
+++ b/crates/runtime/src/tls.rs
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use rustls::{
+    pki_types::{CertificateDer, PrivateKeyDer},
+    ServerConfig,
+};
+use rustls_pemfile::{certs, private_key};
+use secrecy::Secret;
+use std::{
+    io::{self, Cursor},
+    sync::Arc,
+};
+
+pub struct TlsConfig {
+    pub cert: Secret<Vec<u8>>,
+    pub key: Secret<Vec<u8>>,
+    pub server_config: Arc<ServerConfig>,
+}
+
+impl TlsConfig {
+    pub fn try_new(
+        cert_bytes: Vec<u8>,
+        key_bytes: Vec<u8>,
+    ) -> std::result::Result<Self, Box<dyn std::error::Error>> {
+        let certs = load_certs(&cert_bytes)?;
+        let key = load_key(&key_bytes)?;
+
+        let config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)?;
+
+        Ok(Self {
+            cert: Secret::new(cert_bytes),
+            key: Secret::new(key_bytes),
+            server_config: Arc::new(config),
+        })
+    }
+}
+
+fn load_certs(cert_bytes: &[u8]) -> io::Result<Vec<CertificateDer<'static>>> {
+    let mut cursor = Cursor::new(cert_bytes);
+    certs(&mut cursor).collect()
+}
+
+fn load_key(
+    key_bytes: &[u8],
+) -> std::result::Result<PrivateKeyDer<'static>, Box<dyn std::error::Error>> {
+    let mut cursor = Cursor::new(key_bytes);
+    private_key(&mut cursor)?.ok_or_else(|| "No private key found in provided TLS key".into())
+}


### PR DESCRIPTION
## 🗣 Description

Enables TLS on the Flight GRPC endpoint. Unfortunately, tonic (the gRPC library) made the decision to remove `rustls` from their public API (ref: https://github.com/hyperium/tonic/issues/891) which means we can't pass in the `rustls::ServerConfig` we're using for the other endpoints. We need to save the certificate and key bytes and pass it to tonic (which internally just uses it to create the exact same ServerConfig we already have...)

To support this, I created a new `TlsConfig` object that stores the raw bytes along with the `ServerConfig` we construct. Since its a secret parameter, I wrapped it in a `Secret<_>`.

## 🔨 Related Issues

Part of #2071