### PR TITLE
Enable TLS on the OpenTelemetry GRPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9887,6 +9887,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum 0.6.20",
  "base64 0.21.7",
@@ -9902,7 +9903,9 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.11.9",
+ "rustls-pemfile 1.0.4",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -95,7 +95,7 @@ tokio-rustls = "0.26.0"
 tokio.workspace = true
 tonic-health = "0.9.0"
 tonic.workspace = true
-tonic_0_9_0 = { version = "0.9.0", package = "tonic", features = ["gzip"] }
+tonic_0_9_0 = { version = "0.9.0", package = "tonic", features = ["gzip", "tls"] }
 tracing.workspace = true
 tract-core = "0.21.0"
 url = "2.5.0"

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -367,8 +367,11 @@ impl Runtime {
             Arc::clone(&self.df),
             self.tls_config.clone(),
         );
-        let open_telemetry_server_future =
-            opentelemetry::start(config.open_telemetry_bind_address, Arc::clone(&self.df));
+        let open_telemetry_server_future = opentelemetry::start(
+            config.open_telemetry_bind_address,
+            Arc::clone(&self.df),
+            self.tls_config.clone(),
+        );
         let pods_watcher_future = self.start_pods_watcher();
 
         tokio::select! {


### PR DESCRIPTION
## 🗣 Description

Enables TLS on the OpenTelemetry GRPC endpoint. A simple follow-up to #2110

## 🔨 Related Issues

Part of #2071