### PR TITLE
feat: Add ODBC Databricks Benches

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
-      - run: cargo bench -p runtime --features postgres,spark,mysql
+      - run: cargo bench -p runtime --features postgres,spark,mysql,odbc
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
           PG_BENCHMARK_PG_HOST: ${{ secrets.SPICE_SECRET_PG_BENCHMARK_PG_HOST }}
@@ -48,3 +48,6 @@ jobs:
           MYSQL_BENCHMARK_MYSQL_USER: root
           MYSQL_BENCHMARK_MYSQL_PASS: root
           MYSQL_BENCHMARK_MYSQL_DB: tpch_sf0_01
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_ODBC_PATH: ${{ secrets.DATABRICKS_ODBC_PATH }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,6 +34,13 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+      
+      - name: Install Databricks ODBC driver
+        run: |
+          sudo apt-get install unixodbc unixodbc-dev unzip -y
+          wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
+          unzip SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
+          sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
 
       - run: cargo bench -p runtime --features postgres,spark,mysql,odbc
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,7 +37,7 @@ jobs:
       
       - name: Install Databricks ODBC driver
         run: |
-          sudo apt-get install unixodbc unixodbc-dev unzip -y
+          sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
           wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
           unzip SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
           sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -46,6 +46,7 @@ duckdb = ["datafusion-table-providers/duckdb"]
 mysql = ["datafusion-table-providers/mysql"]
 odbc = [
   "dep:odbc-api",
+  "dep:async-stream",
   "dep:arrow-odbc",
   "dep:tokio",
   "dep:dyn-clone",

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -41,6 +41,8 @@ mod setup;
 
 #[cfg(feature = "mysql")]
 mod bench_mysql;
+#[cfg(feature = "odbc")]
+mod bench_odbc_databricks;
 #[cfg(feature = "postgres")]
 mod bench_postgres;
 mod bench_s3;
@@ -57,14 +59,16 @@ async fn main() -> Result<(), String> {
     }
 
     let connectors = vec![
-        "spice.ai",
+        // "spice.ai",
+        // "s3",
         #[cfg(feature = "spark")]
         "spark",
-        "s3",
         #[cfg(feature = "postgres")]
         "postgres",
         #[cfg(feature = "mysql")]
         "mysql",
+        #[cfg(feature = "odbc")]
+        "odbc",
     ];
 
     let mut display_records = vec![];
@@ -77,18 +81,24 @@ async fn main() -> Result<(), String> {
             "spice.ai" => {
                 bench_spicecloud::run(&mut rt, &mut benchmark_results).await?;
             }
+            "s3" => {
+                bench_s3::run(&mut rt, &mut benchmark_results).await?;
+            }
             #[cfg(feature = "spark")]
             "spark" => {
                 bench_spark::run(&mut rt, &mut benchmark_results).await?;
             }
-            "s3" => {
-                bench_s3::run(&mut rt, &mut benchmark_results).await?;
-            }
             #[cfg(feature = "postgres")]
-            "postgres" => bench_postgres::run(&mut rt, &mut benchmark_results).await?,
+            "postgres" => {
+                bench_postgres::run(&mut rt, &mut benchmark_results).await?;
+            }
             #[cfg(feature = "mysql")]
             "mysql" => {
                 bench_mysql::run(&mut rt, &mut benchmark_results).await?;
+            }
+            #[cfg(feature = "odbc")]
+            "odbc" => {
+                bench_odbc_databricks::run(&mut rt, &mut benchmark_results).await?;
             }
             _ => {}
         }

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -59,8 +59,8 @@ async fn main() -> Result<(), String> {
     }
 
     let connectors = vec![
-        // "spice.ai",
-        // "s3",
+        "spice.ai",
+        "s3",
         #[cfg(feature = "spark")]
         "spark",
         #[cfg(feature = "postgres")]

--- a/crates/runtime/benches/bench_odbc_databricks/mod.rs
+++ b/crates/runtime/benches/bench_odbc_databricks/mod.rs
@@ -50,9 +50,12 @@ fn make_dataset(path: &str, name: &str) -> Dataset {
     let mut dataset = Dataset::new(format!("odbc:{path}"), name.to_string());
     // these env vars don't get auto-loaded because they're part of the connection string
     // so we need to pull them out ourselves
+    #[allow(clippy::expect_used)]
     let host_env = std::env::var("DATABRICKS_HOST").expect("DATABRICKS_HOST to be set");
+    #[allow(clippy::expect_used)]
     let http_path_env =
         std::env::var("DATABRICKS_ODBC_PATH").expect("DATABRICKS_ODBC_PATH to be set");
+    #[allow(clippy::expect_used)]
     let token_env = std::env::var("DATABRICKS_TOKEN").expect("DATABRICKS_TOKEN to be set");
 
     let connection_string = format!("Driver=/opt/simba/spark/lib/64/libsparkodbc_sb64.so;Host={host_env};Port=443;HTTPPath={http_path_env};SSL=1;ThriftTransport=2;AuthMech=3;UID=token;PWD={token_env}");

--- a/crates/runtime/benches/bench_odbc_databricks/mod.rs
+++ b/crates/runtime/benches/bench_odbc_databricks/mod.rs
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use app::AppBuilder;
+use runtime::Runtime;
+
+use crate::results::BenchmarkResultsBuilder;
+use spicepod::component::{dataset::Dataset, params::Params};
+
+pub(crate) async fn run(
+    rt: &mut Runtime,
+    benchmark_results: &mut BenchmarkResultsBuilder,
+) -> Result<(), String> {
+    let test_queries = get_test_queries();
+
+    for (query_name, query) in test_queries {
+        super::run_query_and_record_result(rt, benchmark_results, "odbc", query_name, query)
+            .await?;
+    }
+
+    Ok(())
+}
+
+pub fn build_app(app_builder: AppBuilder) -> AppBuilder {
+    app_builder
+        .with_dataset(make_dataset("samples.tpch.customer", "customer"))
+        .with_dataset(make_dataset("samples.tpch.lineitem", "lineitem"))
+        .with_dataset(make_dataset("samples.tpch.part", "part"))
+        .with_dataset(make_dataset("samples.tpch.partsupp", "partsupp"))
+        .with_dataset(make_dataset("samples.tpch.orders", "orders"))
+        .with_dataset(make_dataset("samples.tpch.nation", "nation"))
+        .with_dataset(make_dataset("samples.tpch.region", "region"))
+        .with_dataset(make_dataset("samples.tpch.supplier", "supplier"))
+}
+
+fn make_dataset(path: &str, name: &str) -> Dataset {
+    let mut dataset = Dataset::new(format!("odbc:{path}"), name.to_string());
+    // these env vars don't get auto-loaded because they're part of the connection string
+    // so we need to pull them out ourselves
+    let host_env = std::env::var("DATABRICKS_HOST").expect("DATABRICKS_HOST to be set");
+    let http_path_env =
+        std::env::var("DATABRICKS_ODBC_PATH").expect("DATABRICKS_ODBC_PATH to be set");
+    let token_env = std::env::var("DATABRICKS_TOKEN").expect("DATABRICKS_TOKEN to be set");
+
+    let connection_string = format!("Driver=/opt/simba/spark/lib/64/libsparkodbc_sb64.so;Host={host_env};Port=443;HTTPPath={http_path_env};SSL=1;ThriftTransport=2;AuthMech=3;UID=token;PWD={token_env}");
+
+    dataset.params = Some(Params::from_string_map(
+        vec![("odbc_connection_string".to_string(), connection_string)]
+            .into_iter()
+            .collect(),
+    ));
+    dataset
+}
+
+fn get_test_queries() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("tpch_q1", include_str!("../queries/tpch_q1.sql")),
+        ("tpch_q2", include_str!("../queries/tpch_q2.sql")),
+        ("tpch_q3", include_str!("../queries/tpch_q3.sql")),
+        ("tpch_q4", include_str!("../queries/tpch_q4.sql")),
+        ("tpch_q5", include_str!("../queries/tpch_q5.sql")),
+        ("tpch_q6", include_str!("../queries/tpch_q6.sql")),
+        ("tpch_q7", include_str!("../queries/tpch_q7.sql")),
+        ("tpch_q8", include_str!("../queries/tpch_q8.sql")),
+        ("tpch_q9", include_str!("../queries/tpch_q9.sql")),
+        ("tpch_q10", include_str!("../queries/tpch_q10.sql")),
+        ("tpch_q11", include_str!("../queries/tpch_q11.sql")),
+        ("tpch_q12", include_str!("../queries/tpch_q12.sql")),
+        ("tpch_q13", include_str!("../queries/tpch_q13.sql")),
+        ("tpch_q14", include_str!("../queries/tpch_q14.sql")),
+        // // tpch_q15 has a view creation which we don't support by design
+        ("tpch_q16", include_str!("../queries/tpch_q16.sql")),
+        ("tpch_q17", include_str!("../queries/tpch_q17.sql")),
+        ("tpch_q18", include_str!("../queries/tpch_q18.sql")),
+        ("tpch_q19", include_str!("../queries/tpch_q19.sql")),
+        ("tpch_q20", include_str!("../queries/tpch_q20.sql")),
+        ("tpch_q21", include_str!("../queries/tpch_q21.sql")),
+        ("tpch_q22", include_str!("../queries/tpch_q22.sql")),
+        (
+            "tpch_simple_q1",
+            include_str!("../queries/tpch_simple_q1.sql"),
+        ),
+        (
+            "tpch_simple_q2",
+            include_str!("../queries/tpch_simple_q2.sql"),
+        ),
+        (
+            "tpch_simple_q3",
+            include_str!("../queries/tpch_simple_q3.sql"),
+        ),
+        (
+            "tpch_simple_q4",
+            include_str!("../queries/tpch_simple_q4.sql"),
+        ),
+        (
+            "tpch_simple_q5",
+            include_str!("../queries/tpch_simple_q5.sql"),
+        ),
+    ]
+}

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -14,16 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#[cfg(feature = "mysql")]
-use crate::bench_mysql;
-#[cfg(feature = "postgres")]
-use crate::bench_postgres;
 use crate::{bench_s3, results::BenchmarkResultsBuilder};
 use app::{App, AppBuilder};
 use runtime::{dataupdate::DataUpdate, Runtime};
 use spicepod::component::dataset::{replication::Replication, Dataset, Mode};
 use std::process::Command;
 use tracing_subscriber::EnvFilter;
+
+#[cfg(feature = "mysql")]
+use crate::bench_mysql;
+#[cfg(feature = "odbc")]
+use crate::bench_odbc_databricks;
+#[cfg(feature = "postgres")]
+use crate::bench_postgres;
 
 /// The number of times to run each query in the benchmark.
 const ITERATIONS: i32 = 5;
@@ -88,6 +91,8 @@ fn build_app(upload_results_dataset: &Option<String>, connector: &str) -> App {
         "postgres" => bench_postgres::build_app(app_builder),
         #[cfg(feature = "mysql")]
         "mysql" => bench_mysql::build_app(app_builder),
+        #[cfg(feature = "odbc")]
+        "odbc" => bench_odbc_databricks::build_app(app_builder),
         _ => app_builder,
     };
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds benchmark tests for ODBC Databricks, configured for the AWS Databricks instance from repo secrets

Benches pass locally:

```
+--------------------------------------+---------------+---------------+----------------+--------+-----------------+-----------------+------------+----------------+-------------+----------------+
| run_id                               | started_at    | finished_at   | query_name     | status | min_duration_ms | max_duration_ms | iterations | commit_sha     | branch_name | connector_name |
+--------------------------------------+---------------+---------------+----------------+--------+-----------------+-----------------+------------+----------------+-------------+----------------+
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951360291 | 1721951390757 | tpch_q1        | passed | 5711            | 6387            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951390757 | 1721951429702 | tpch_q2        | passed | 6128            | 12162           | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951429702 | 1721951482073 | tpch_q3        | passed | 9305            | 12650           | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951482074 | 1721951506545 | tpch_q4        | passed | 3984            | 6451            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951506546 | 1721951565177 | tpch_q5        | passed | 6609            | 14171           | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951565177 | 1721951581634 | tpch_q6        | passed | 3238            | 3464            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951581634 | 1721951630554 | tpch_q7        | passed | 9510            | 9974            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951630554 | 1721951665357 | tpch_q8        | passed | 6171            | 9206            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951665357 | 1721951715388 | tpch_q9        | passed | 9761            | 10381           | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951715388 | 1721951822565 | tpch_q10       | passed | 17198           | 25996           | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951822565 | 1721951839624 | tpch_q11       | passed | 3151            | 3833            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951839624 | 1721951858298 | tpch_q12       | passed | 3520            | 4259            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951858298 | 1721951890930 | tpch_q13       | passed | 5811            | 8523            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951890930 | 1721951909609 | tpch_q14       | passed | 3589            | 4027            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951909609 | 1721951937504 | tpch_q16       | passed | 5346            | 5985            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951937504 | 1721951963922 | tpch_q17       | passed | 4396            | 8399            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721951963922 | 1721952038008 | tpch_q18       | passed | 14267           | 15401           | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952038008 | 1721952058344 | tpch_q19       | passed | 3760            | 4788            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952058344 | 1721952089691 | tpch_q20       | passed | 6078            | 6592            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952089692 | 1721952169959 | tpch_q21       | passed | 15472           | 17745           | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952169959 | 1721952189303 | tpch_q22       | passed | 3718            | 4216            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952189303 | 1721952202396 | tpch_simple_q1 | passed | 2481            | 2999            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952202396 | 1721952330836 | tpch_simple_q2 | passed | 25220           | 26207           | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952330836 | 1721952356968 | tpch_simple_q3 | passed | 4097            | 8457            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952356968 | 1721952373557 | tpch_simple_q4 | passed | 2786            | 5047            | 5          | 32b8b778-dirty | trunk       | odbc           |
| 254483d8-3ee1-4f6a-aee1-dc7ab11b4b50 | 1721952373557 | 1721952420622 | tpch_simple_q5 | passed | 9156            | 10101           | 5          | 32b8b778-dirty | trunk       | odbc           |
+--------------------------------------+---------------+---------------+----------------+--------+-----------------+-----------------+------------+----------------+-------------+----------------+
```