### PR TITLE
add timeout parameters for object store client options

### DIFF
--- a/crates/data_components/src/databricks_delta.rs
+++ b/crates/data_components/src/databricks_delta.rs
@@ -54,10 +54,17 @@ impl DatabricksDelta {
 
         let mut storage_options = HashMap::new();
         for (key, value) in &self.storage_options {
-            if key == "token" || key == "endpoint" {
-                continue;
+            match key.as_ref() {
+                "token" | "endpoint" => {
+                    continue;
+                }
+                "client_timeout" => {
+                    storage_options.insert("timeout".into(), value.clone());
+                }
+                _ => {
+                    storage_options.insert(key.to_string(), value.clone());
+                }
             }
-            storage_options.insert(key.to_string(), value.clone());
         }
 
         let delta_table = DeltaTable::from(table_uri, storage_options)?;

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -242,6 +242,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("mode")
         .description("The execution mode for querying against Databricks.")
         .default("spark_connect"),
+    ParameterSpec::runtime("client_timeout")
+        .description("The timeout setting for object store client."),
     ParameterSpec::connector("cluster_id").description("The ID of the compute cluster in Databricks to use for the query. Only valid when mode is spark_connect."),
     ParameterSpec::connector("use_ssl").description("Use a TLS connection to connect to the Databricks Spark Connect endpoint.").default("true"),
 
@@ -284,10 +286,6 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("Filesystem path to the Google service account JSON key file.")
         .secret(),
 
-    // Common options - client
-    ParameterSpec::connector("timeout")
-        .description("The request timeout setting for fetching remote objects")
-        .secret(),
 ];
 
 impl DataConnectorFactory for DatabricksFactory {

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -283,6 +283,11 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("google_service_account")
         .description("Filesystem path to the Google service account JSON key file.")
         .secret(),
+
+    // Common options - client
+    ParameterSpec::connector("timeout")
+        .description("The request timeout setting for fetching remote objects")
+        .secret(),
 ];
 
 impl DataConnectorFactory for DatabricksFactory {

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -285,7 +285,6 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("google_service_account")
         .description("Filesystem path to the Google service account JSON key file.")
         .secret(),
-
 ];
 
 impl DataConnectorFactory for DatabricksFactory {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -68,7 +68,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("endpoint").secret(),
     ParameterSpec::connector("key").secret(),
     ParameterSpec::connector("secret").secret(),
-    ParameterSpec::runtime("client_timeout"),
+    ParameterSpec::runtime("client_timeout")
+        .description("The timeout setting for S3 client."),
 
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),


### PR DESCRIPTION
## 🗣 Description

Add `databricks_timeout` option to databricks delta connector. For large files, 30s default timeout is not enough, errors like "response body closed" could be observed if configured too short

## 🔨 Related Issues

Fix #2106 

