### PR TITLE
Support configuring TLS in the spicepod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcder"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8210,6 +8220,7 @@ dependencies = [
  "url",
  "util",
  "uuid 1.10.0",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -11102,6 +11113,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-certificate"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ tonic = { version = "0.11.0", features = ["tls"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1.9.1"
+x509-certificate = "0.23.1"
 
 [patch.crates-io]
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ffe792dfdff7a96327bcc536b55d8e9167d29e14" }

--- a/bin/spiced/src/tls.rs
+++ b/bin/spiced/src/tls.rs
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+use std::sync::Arc;
+
+use app::spicepod::component::runtime::TlsConfig as SpicepodTlsConfig;
+use runtime::secrets::{ExposeSecret, ParamStr, Secrets};
+use runtime::tls::TlsConfig;
+use tokio::sync::{RwLock, RwLockReadGuard};
+
+use crate::Args;
+
+pub(crate) async fn load_tls_config(
+    args: &Args,
+    spicepod_tls_config: Option<SpicepodTlsConfig>,
+    secrets: Arc<RwLock<Secrets>>,
+) -> std::result::Result<Option<Arc<TlsConfig>>, Box<dyn std::error::Error>> {
+    if !args.tls && spicepod_tls_config.is_none() {
+        return Ok(None);
+    }
+
+    let secrets = secrets.read().await;
+
+    let app_cert_bytes = load_spicepod_tls_param(
+        &secrets,
+        &spicepod_tls_config,
+        |tls| &tls.certificate_file,
+        |tls| &tls.certificate,
+        "certificate",
+        "certificate_path",
+    )
+    .await?;
+
+    let app_key_bytes = load_spicepod_tls_param(
+        &secrets,
+        &spicepod_tls_config,
+        |tls| &tls.key_file,
+        |tls| &tls.key,
+        "key",
+        "key_path",
+    )
+    .await?;
+
+    let cert_bytes: Vec<u8> = match (
+        &args.tls_certificate_file,
+        &args.tls_certificate,
+        app_cert_bytes,
+    ) {
+        (Some(cert_path), _, _) => load_file(Path::new(cert_path))?,
+        (_, Some(cert), _) => cert.as_bytes().to_vec(),
+        (_, _, Some(cert)) => cert,
+        (None, None, None) => return Err("TLS certificate is required (--tls-certificate)".into()),
+    };
+    let key_bytes: Vec<u8> = match (&args.tls_key_file, &args.tls_key, app_key_bytes) {
+        (Some(key_path), _, _) => load_file(Path::new(key_path))?,
+        (_, Some(key), _) => key.as_bytes().to_vec(),
+        (_, _, Some(key)) => key,
+        (None, None, None) => return Err("TLS key is required (--tls-key)".into()),
+    };
+
+    let tls_config = TlsConfig::try_new(cert_bytes, key_bytes)?;
+
+    tracing::info!("All endpoints secured with TLS");
+
+    Ok(Some(Arc::new(tls_config)))
+}
+
+async fn load_spicepod_tls_param(
+    secrets: &RwLockReadGuard<'_, Secrets>,
+    spicepod_tls_config: &Option<SpicepodTlsConfig>,
+    file_field: impl Fn(&SpicepodTlsConfig) -> &Option<String>,
+    secret_field: impl Fn(&SpicepodTlsConfig) -> &Option<String>,
+    secret_name: &str,
+    param_name: &str,
+) -> std::result::Result<Option<Vec<u8>>, Box<dyn std::error::Error>> {
+    let Some(tls) = spicepod_tls_config else {
+        return Ok(None);
+    };
+
+    let bytes = match (file_field(tls), secret_field(tls)) {
+        (Some(file_path), _) => {
+            tracing::debug!("Loading TLS {} from file: {}", secret_name, file_path);
+            let injected_path = secrets
+                .inject_secrets(param_name, ParamStr(file_path))
+                .await;
+            Some(load_file(Path::new(injected_path.expose_secret()))?)
+        }
+        (_, Some(secret)) => {
+            let injected_secret = secrets.inject_secrets(secret_name, ParamStr(secret)).await;
+            Some(injected_secret.expose_secret().as_bytes().to_vec())
+        }
+        _ => None,
+    };
+
+    Ok(bytes)
+}
+
+fn load_file(path: &Path) -> io::Result<Vec<u8>> {
+    let mut file = File::open(path)?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    Ok(buf)
+}

--- a/bin/spiced/src/tls.rs
+++ b/bin/spiced/src/tls.rs
@@ -76,8 +76,6 @@ pub(crate) async fn load_tls_config(
 
     let tls_config = TlsConfig::try_new(cert_bytes, key_bytes)?;
 
-    tracing::info!("All endpoints secured with TLS");
-
     Ok(Some(Arc::new(tls_config)))
 }
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -19,6 +19,7 @@ limitations under the License.
 use std::{collections::HashMap, path::PathBuf};
 
 use snafu::prelude::*;
+pub use spicepod;
 use spicepod::{
     component::{
         catalog::Catalog,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -101,6 +101,7 @@ tract-core = "0.21.0"
 url = "2.5.0"
 util = { path = "../util" }
 uuid.workspace = true
+x509-certificate.workspace = true
 
 [dev-dependencies]
 anyhow = "1.0.86"

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -377,6 +377,10 @@ impl Runtime {
         );
         let pods_watcher_future = self.start_pods_watcher();
 
+        if tls_config.is_some() {
+            tracing::info!("All endpoints secured with TLS");
+        }
+
         tokio::select! {
             http_res = http_server_future => http_res.context(UnableToStartHttpServerSnafu),
             flight_res = flight_server_future => flight_res.context(UnableToStartFlightServerSnafu),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -377,8 +377,17 @@ impl Runtime {
         );
         let pods_watcher_future = self.start_pods_watcher();
 
-        if tls_config.is_some() {
-            tracing::info!("All endpoints secured with TLS");
+        if let Some(tls_config) = tls_config {
+            match tls_config.subject_name() {
+                Some(subject_name) => {
+                    tracing::info!(
+                        "All endpoints secured with TLS using certificate: {subject_name}"
+                    );
+                }
+                None => {
+                    tracing::info!("All endpoints secured with TLS");
+                }
+            }
         }
 
         tokio::select! {

--- a/crates/runtime/src/tls.rs
+++ b/crates/runtime/src/tls.rs
@@ -19,11 +19,12 @@ use rustls::{
     ServerConfig,
 };
 use rustls_pemfile::{certs, private_key};
-use secrecy::Secret;
+use secrecy::{ExposeSecret, Secret};
 use std::{
     io::{self, Cursor},
     sync::Arc,
 };
+use x509_certificate::X509Certificate;
 
 pub struct TlsConfig {
     pub cert: Secret<Vec<u8>>,
@@ -48,6 +49,12 @@ impl TlsConfig {
             key: Secret::new(key_bytes),
             server_config: Arc::new(config),
         })
+    }
+
+    #[must_use]
+    pub fn subject_name(&self) -> Option<String> {
+        let x509_cert = X509Certificate::from_pem(self.cert.expose_secret()).ok()?;
+        x509_cert.subject_name().user_friendly_str().ok()
     }
 }
 

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -55,6 +55,7 @@ impl Default for ResultsCache {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct TlsConfig {
     /// A filesystem path to a file containing the PEM encoded certificate

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -24,6 +24,9 @@ pub struct Runtime {
     #[serde(default)]
     pub results_cache: ResultsCache,
     pub num_of_parallel_loading_at_start_up: Option<usize>,
+
+    /// If set, the runtime will configure all endpoints to use TLS
+    pub tls: Option<TlsConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -49,4 +52,20 @@ impl Default for ResultsCache {
             eviction_policy: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct TlsConfig {
+    /// A filesystem path to a file containing the PEM encoded certificate
+    pub certificate_file: Option<String>,
+
+    /// A PEM encoded certificate
+    pub certificate: Option<String>,
+
+    /// A filesystem path to a file containing the PEM encoded private key
+    pub key_file: Option<String>,
+
+    /// A PEM encoded private key
+    pub key: Option<String>,
 }


### PR DESCRIPTION
## 🗣 Description

Support configuring TLS via the Spicepod runtime configuration. This is lower precedence than specifying on the command line.

```yaml
runtime:
  tls:
    certificate: |
      -----BEGIN CERTIFICATE-----
     ...
      -----END CERTIFICATE-----
    key_file: ./certs/spiced_key.pem
```

Secrets replacement also works:

```yaml
runtime:
  tls:
    certificate: ${env:TLS_CERT}
    key: ${env:TLS_KEY}
```

I've moved the secrets loading from `load_components` to load as part of building the Runtime object. Now that both the server startup and component loading need secrets, it makes sense to just have it always available in the Runtime.

I also moved the code for loading the TLS configuration to its own module in `spiced`.

## 🔨 Related Issues

Part of #2071