### PR TITLE
Improve SQLite and DuckDB compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b045511a6b6d59f54b3ea13cf9aa26293c1c79fb#b045511a6b6d59f54b3ea13cf9aa26293c1c79fb"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=16d871e159be2360aab67a6f07faeb5e9b9bdaf7#16d871e159be2360aab67a6f07faeb5e9b9bdaf7"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "40.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b045511a6b6d59f54b3ea13cf9aa26293c1c79fb" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "16d871e159be2360aab67a6f07faeb5e9b9bdaf7" }
 duckdb = "1.0.0"
 fundu = "2.0.0"
 futures = "0.3.30"


### PR DESCRIPTION
## 🗣 Description

datafusion-table-providers upgrade to include  the following SQLite and DuckDB compatibility fixes
1. https://github.com/datafusion-contrib/datafusion-table-providers/pull/17
2. https://github.com/datafusion-contrib/datafusion-table-providers/pull/19
3. https://github.com/datafusion-contrib/datafusion-table-providers/pull/20

SHA is the last commit SHA from the main branch: https://github.com/datafusion-contrib/datafusion-table-providers/commits/main/

This fixes https://github.com/spiceai/spiceai/issues/2040, https://github.com/spiceai/spiceai/issues/2039, https://github.com/spiceai/spiceai/issues/2038