### PR TITLE
Pass through arguments from `spice run` and `spice sql` to runtime

### DIFF
--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -32,14 +32,14 @@ spice run
 
 # See more at: https://docs.spiceai.org/
 `,
+	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		err := checkLatestCliReleaseVersion()
 		if err != nil && util.IsDebug() {
 			cmd.PrintErrf("failed to check for latest CLI release version: %s\n", err.Error())
 		}
 
-		err = runtime.Run()
+		err = runtime.Run(args)
 		if err != nil {
 			cmd.PrintErrln(err.Error())
 			os.Exit(1)

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -43,15 +43,18 @@ sql> show tables
 | datafusion    | information_schema | df_settings   | VIEW       |
 +---------------+--------------------+---------------+------------+
 `,
+	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		execCmd, err := rtcontext.GetRunCmd()
+
+		spiceArgs := []string{"--repl"}
+		args = append(spiceArgs, args...)
+
+		execCmd, err := rtcontext.GetRunCmd(args)
 		if err != nil {
 			cmd.Println(err)
 			os.Exit(1)
 		}
-
-		execCmd.Args = append(execCmd.Args, "--repl")
 
 		execCmd.Stderr = os.Stderr
 		execCmd.Stdout = os.Stdout

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -170,10 +170,13 @@ func (c *RuntimeContext) GetSpiceAppRelativePath(absolutePath string) string {
 	return absolutePath
 }
 
-func (c *RuntimeContext) GetRunCmd() (*exec.Cmd, error) {
+func (c *RuntimeContext) GetRunCmd(args []string) (*exec.Cmd, error) {
 	spiceCMD := c.binaryFilePath("spiced")
 
-	cmd := exec.Command(spiceCMD, "--metrics", "127.0.0.1:9090")
+	spiceArgs := []string{"--metrics", "127.0.0.1:9090"}
+	args = append(spiceArgs, args...)
+
+	cmd := exec.Command(spiceCMD, args...)
 
 	return cmd, nil
 }

--- a/bin/spice/pkg/runtime/runtime.go
+++ b/bin/spice/pkg/runtime/runtime.go
@@ -57,7 +57,7 @@ func EnsureInstalled() (bool, error) {
 	return shouldInstall, nil
 }
 
-func Run() error {
+func Run(args []string) error {
 	fmt.Println("Spice.ai runtime starting...")
 
 	rtcontext := context.NewContext()
@@ -73,7 +73,7 @@ func Run() error {
 		return err
 	}
 
-	cmd, err := rtcontext.GetRunCmd()
+	cmd, err := rtcontext.GetRunCmd(args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 🗣 Description

Pass through any arguments to `spice run` and `spice sql` to the underlying runtime.

This allows specifying the TLS CLI arguments using `spice run` directly, i.e.:
`spice run -- --tls --tls-certificate-file ./cert.pem --tls-key-file ./key.pem`

## 🔨 Related Issues

Indirectly related to #2071
