### PR TITLE
Handle TLS in the spice CLI when connecting to the runtime

### DIFF
--- a/bin/spice/cmd/catalogs.go
+++ b/bin/spice/cmd/catalogs.go
@@ -31,7 +31,7 @@ spice catalogs
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+		if rootCertPath, err := cmd.Flags().GetString("tls-root-certificate-file"); err == nil && rootCertPath != "" {
 			rtcontext = context.NewHttpsContext(rootCertPath)
 		}
 
@@ -48,6 +48,6 @@ spice catalogs
 }
 
 func init() {
-	catalogsCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
+	catalogsCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(catalogsCmd)
 }

--- a/bin/spice/cmd/catalogs.go
+++ b/bin/spice/cmd/catalogs.go
@@ -31,6 +31,9 @@ spice catalogs
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
+		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+			rtcontext = context.NewHttpsContext(rootCertPath)
+		}
 
 		catalogs, err := api.GetData[api.Catalog](rtcontext, "/v1/catalogs")
 		if err != nil {
@@ -45,5 +48,6 @@ spice catalogs
 }
 
 func init() {
+	catalogsCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(catalogsCmd)
 }

--- a/bin/spice/cmd/datasets.go
+++ b/bin/spice/cmd/datasets.go
@@ -31,7 +31,10 @@ spice datasets
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		_, dataset_statuses, err := api.GetComponentStatuses(PROM_ENDPOINT)
+		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+			rtcontext = context.NewHttpsContext(rootCertPath)
+		}
+		_, dataset_statuses, err := api.GetComponentStatuses(rtcontext)
 		if err != nil {
 			cmd.PrintErrln(err.Error())
 		}
@@ -53,5 +56,6 @@ spice datasets
 }
 
 func init() {
+	datasetsCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(datasetsCmd)
 }

--- a/bin/spice/cmd/datasets.go
+++ b/bin/spice/cmd/datasets.go
@@ -31,7 +31,7 @@ spice datasets
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+		if rootCertPath, err := cmd.Flags().GetString("tls-root-certificate-file"); err == nil && rootCertPath != "" {
 			rtcontext = context.NewHttpsContext(rootCertPath)
 		}
 		_, dataset_statuses, err := api.GetComponentStatuses(rtcontext)
@@ -56,6 +56,6 @@ spice datasets
 }
 
 func init() {
-	datasetsCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
+	datasetsCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(datasetsCmd)
 }

--- a/bin/spice/cmd/models.go
+++ b/bin/spice/cmd/models.go
@@ -31,7 +31,7 @@ spice models
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+		if rootCertPath, err := cmd.Flags().GetString("tls-root-certificate-file"); err == nil && rootCertPath != "" {
 			rtcontext = context.NewHttpsContext(rootCertPath)
 		}
 		model_statuses, _, err := api.GetComponentStatuses(rtcontext)
@@ -57,6 +57,6 @@ spice models
 }
 
 func init() {
-	modelsCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
+	modelsCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(modelsCmd)
 }

--- a/bin/spice/cmd/models.go
+++ b/bin/spice/cmd/models.go
@@ -31,7 +31,10 @@ spice models
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		model_statuses, _, err := api.GetComponentStatuses(PROM_ENDPOINT)
+		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+			rtcontext = context.NewHttpsContext(rootCertPath)
+		}
+		model_statuses, _, err := api.GetComponentStatuses(rtcontext)
 		if err != nil {
 			cmd.PrintErrln(err.Error())
 		}
@@ -54,5 +57,6 @@ spice models
 }
 
 func init() {
+	modelsCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(modelsCmd)
 }

--- a/bin/spice/cmd/pods.go
+++ b/bin/spice/cmd/pods.go
@@ -31,6 +31,9 @@ spice pods
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
+		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+			rtcontext = context.NewHttpsContext(rootCertPath)
+		}
 
 		spicepods, err := api.GetData[api.Spicepod](rtcontext, "/v1/spicepods")
 		if err != nil {
@@ -52,5 +55,6 @@ spice pods
 }
 
 func init() {
+	podsCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(podsCmd)
 }

--- a/bin/spice/cmd/pods.go
+++ b/bin/spice/cmd/pods.go
@@ -31,7 +31,7 @@ spice pods
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+		if rootCertPath, err := cmd.Flags().GetString("tls-root-certificate-file"); err == nil && rootCertPath != "" {
 			rtcontext = context.NewHttpsContext(rootCertPath)
 		}
 
@@ -55,6 +55,6 @@ spice pods
 }
 
 func init() {
-	podsCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
+	podsCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(podsCmd)
 }

--- a/bin/spice/cmd/refresh.go
+++ b/bin/spice/cmd/refresh.go
@@ -43,7 +43,7 @@ spice refresh taxi_trips
 		cmd.Printf("Refreshing dataset %s ...\n", dataset)
 
 		rtcontext := context.NewContext()
-		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+		if rootCertPath, err := cmd.Flags().GetString("tls-root-certificate-file"); err == nil && rootCertPath != "" {
 			rtcontext = context.NewHttpsContext(rootCertPath)
 		}
 
@@ -60,6 +60,6 @@ spice refresh taxi_trips
 
 func init() {
 	refreshCmd.Flags().BoolP("help", "h", false, "Print this help message")
-	refreshCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
+	refreshCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(refreshCmd)
 }

--- a/bin/spice/cmd/refresh.go
+++ b/bin/spice/cmd/refresh.go
@@ -43,6 +43,9 @@ spice refresh taxi_trips
 		cmd.Printf("Refreshing dataset %s ...\n", dataset)
 
 		rtcontext := context.NewContext()
+		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+			rtcontext = context.NewHttpsContext(rootCertPath)
+		}
 
 		url := fmt.Sprintf("/v1/datasets/%s/acceleration/refresh", dataset)
 		res, err := api.PostRuntime[DatasetRefreshApiResponse](rtcontext, url)
@@ -57,5 +60,6 @@ spice refresh taxi_trips
 
 func init() {
 	refreshCmd.Flags().BoolP("help", "h", false, "Print this help message")
+	refreshCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(refreshCmd)
 }

--- a/bin/spice/cmd/spice.go
+++ b/bin/spice/cmd/spice.go
@@ -24,8 +24,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-const PROM_ENDPOINT = "http://localhost:9090"
-
 var RootCmd = &cobra.Command{
 	Use:   "spice",
 	Short: "Spice.ai CLI",

--- a/bin/spice/cmd/status.go
+++ b/bin/spice/cmd/status.go
@@ -30,6 +30,9 @@ spice status
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
+		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+			rtcontext = context.NewHttpsContext(rootCertPath)
+		}
 		err := api.WriteDataTable(rtcontext, "/v1/status", api.Service{})
 		if err != nil {
 			cmd.PrintErrln(err.Error())
@@ -38,5 +41,6 @@ spice status
 }
 
 func init() {
+	statusCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(statusCmd)
 }

--- a/bin/spice/cmd/status.go
+++ b/bin/spice/cmd/status.go
@@ -30,7 +30,7 @@ spice status
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		if rootCertPath, err := cmd.Flags().GetString("tls-ca-certificate-path"); err == nil && rootCertPath != "" {
+		if rootCertPath, err := cmd.Flags().GetString("tls-root-certificate-file"); err == nil && rootCertPath != "" {
 			rtcontext = context.NewHttpsContext(rootCertPath)
 		}
 		err := api.WriteDataTable(rtcontext, "/v1/status", api.Service{})
@@ -41,6 +41,6 @@ spice status
 }
 
 func init() {
-	statusCmd.Flags().String("tls-ca-certificate-path", "", "The path to the CA certificate file used to verify the Spice.ai runtime server certificate")
+	statusCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	RootCmd.AddCommand(statusCmd)
 }

--- a/bin/spice/pkg/api/status.go
+++ b/bin/spice/pkg/api/status.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 )
 
 type ComponentStatus int
@@ -61,13 +62,13 @@ func (cs ComponentStatus) String() string {
 const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`
 
 // Get the status of all models and datasets (respectively).
-func GetComponentStatuses(spiced_addr string) (map[string]ComponentStatus, map[string]ComponentStatus, error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/metrics", spiced_addr), nil)
+func GetComponentStatuses(rtContext *context.RuntimeContext) (map[string]ComponentStatus, map[string]ComponentStatus, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/metrics", rtContext.MetricsEndpoint()), nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Add("Accept", acceptHeader)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := rtContext.Client().Do(req)
 	if err != nil {
 		if strings.HasSuffix(err.Error(), "connection refused") {
 			return nil, nil, nil

--- a/bin/spice/pkg/api/util.go
+++ b/bin/spice/pkg/api/util.go
@@ -38,24 +38,24 @@ func doRuntimeApiRequest[T interface{}](rtcontext *context.RuntimeContext, metho
 
 	switch method {
 	case GET:
-		resp, err = http.Get(url)
+		resp, err = rtcontext.Client().Get(url)
 	case POST:
-		resp, err = http.Post(url, "application/json", nil)
+		resp, err = rtcontext.Client().Post(url, "application/json", nil)
 	default:
-		return *new(T), fmt.Errorf("Unsupported method: %s", method)
+		return *new(T), fmt.Errorf("unsupported method: %s", method)
 	}
 
 	if err != nil {
 		if strings.HasSuffix(err.Error(), "connection refused") {
 			return *new(T), rtcontext.RuntimeUnavailableError()
 		}
-		return *new(T), fmt.Errorf("Error performing request to %s: %w", url, err)
+		return *new(T), fmt.Errorf("error performing request to %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	var result T
 	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return *new(T), fmt.Errorf("Error decoding response: %w", err)
+		return *new(T), fmt.Errorf("error decoding response: %w", err)
 	}
 	return result, nil
 }
@@ -77,7 +77,7 @@ func WriteDataTable[T interface{}](rtcontext *context.RuntimeContext, path strin
 	items, err := doRuntimeApiRequest[[]T](rtcontext, GET, path)
 
 	if err != nil {
-		return fmt.Errorf("Error fetching runtime information: %w", err)
+		return fmt.Errorf("error fetching runtime information: %w", err)
 	}
 
 	var table []interface{}


### PR DESCRIPTION
## 🗣 Description

Adds a new parameter `--tls-root-certificate-file` to the spice CLI commands that connect to the runtime. This parameter changes to connect over TLS and uses the provided CA certificate path to verify the runtime certificate is valid.

i.e.:

`spice refresh taxi_trips --tls-root-certificate-file ~/code/spiceai/samples/tls/ca.pem`
`spice catalogs --tls-root-certificate-file ~/code/spiceai/samples/tls/ca.pem`
`spice datasets --tls-root-certificate-file ~/code/spiceai/samples/tls/ca.pem`
`spice models --tls-root-certificate-file ~/code/spiceai/samples/tls/ca.pem`

It would nice to eventually have the context as part of the `~/spice` folder so it doesn't need to be passed everytime.

## 🔨 Related Issues

Part of #2071