### PR TITLE
Remove `--tls` flag

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -91,10 +91,6 @@ pub struct Args {
     #[clap(flatten)]
     pub repl_config: ReplConfig,
 
-    /// Enable TLS for all server endpoints. Requires a certificate and key.
-    #[arg(long)]
-    pub tls: bool,
-
     /// The TLS PEM-encoded certificate.
     #[arg(long, value_name = "-----BEGIN CERTIFICATE-----...")]
     pub tls_certificate: Option<String>,

--- a/bin/spiced/src/tls.rs
+++ b/bin/spiced/src/tls.rs
@@ -31,7 +31,12 @@ pub(crate) async fn load_tls_config(
     spicepod_tls_config: Option<SpicepodTlsConfig>,
     secrets: Arc<RwLock<Secrets>>,
 ) -> std::result::Result<Option<Arc<TlsConfig>>, Box<dyn std::error::Error>> {
-    if !args.tls && spicepod_tls_config.is_none() {
+    let tls_enabled = args.tls_certificate.is_some()
+        || args.tls_certificate_file.is_some()
+        || args.tls_key.is_some()
+        || args.tls_key_file.is_some()
+        || spicepod_tls_config.is_some();
+    if !tls_enabled {
         return Ok(None);
     }
 


### PR DESCRIPTION
## 🗣 Description

Removes the `--tls` command line flag from `spiced` since it can be inferred from the other parameters.

## 🔨 Related Issues

Part of #2071