### PR TITLE
fix: Use odbc-api fork for decimal conversion fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6688,8 +6688,7 @@ dependencies = [
 [[package]]
 name = "odbc-api"
 version = "8.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8725f2ab306c5650783eff4e22f846ec1536aa242f0d3045842fd277e4e804"
+source = "git+https://github.com/spiceai/odbc-api.git?rev=9807702dafdd8679d6bcecb0730b17e55c13e2e1#9807702dafdd8679d6bcecb0730b17e55c13e2e1"
 dependencies = [
  "atoi",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ version = "0.17.0-beta"
 arrow = "52.0.0"
 arrow-buffer = "52.0.0"
 arrow-flight = "52.0.0"
-arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdfc2c482f1ce84c595ab1202530a37815d6" }
+arrow-odbc = "11.2.0"
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "48173bdee3d3be04dcc579b3211662e359b72734" }
 async-stream = "0.3.5"
 async-trait = "0.1.77"
@@ -97,3 +97,5 @@ x509-certificate = "0.23.1"
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ffe792dfdff7a96327bcc536b55d8e9167d29e14" }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "85935dbbc64d2af1ca132ad7e2309a9d87bf3115" }
+odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }
+arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdfc2c482f1ce84c595ab1202530a37815d6" }


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Uses the `odbc-api` Spice fork to bring in the decimal conversion fix

## 🔨 Related Issues

* Closes #1907