### PR TITLE
Avoid more unnecessary allocations in the query path

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -444,10 +444,10 @@ impl AcceleratedTable {
                                 if num_records > 0 {
                                     if let Some(cache_provider) = &cache_provider {
                                         if let Err(e) = cache_provider
-                                            .invalidate_for_table(&dataset_name.to_string())
+                                            .invalidate_for_table(dataset_name.clone())
                                             .await
                                         {
-                                            tracing::error!("Failed to invalidate cached results for dataset {}: {e}", &dataset_name.to_string());
+                                            tracing::error!("Failed to invalidate cached results for dataset {}: {e}", &dataset_name);
                                         }
                                     }
                                 }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -316,7 +316,7 @@ impl Refresher {
 
                             if let Some(cache_provider) = &cache_provider {
                                 if let Err(e) = cache_provider
-                                    .invalidate_for_table(&dataset_name.to_string())
+                                    .invalidate_for_table(dataset_name.clone())
                                     .await
                                 {
                                     tracing::error!("Failed to invalidate cached results for dataset {}: {e}", &dataset_name.to_string());

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -122,7 +122,7 @@ impl RefreshTask {
 
                         if let Some(cache_provider) = &cache_provider {
                             if let Err(e) = cache_provider
-                                .invalidate_for_table(&dataset_name.to_string())
+                                .invalidate_for_table(dataset_name.clone())
                                 .await
                             {
                                 tracing::error!(

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -89,7 +89,7 @@ impl RefreshTask {
 
                             if let Some(cache_provider) = &cache_provider {
                                 if let Err(e) = cache_provider
-                                    .invalidate_for_table(&dataset_name.to_string())
+                                    .invalidate_for_table(dataset_name.clone())
                                     .await
                                 {
                                     tracing::error!(

--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use std::{collections::HashSet, sync::Arc, time::SystemTime};
 
 use arrow::datatypes::SchemaRef;
+use datafusion::sql::TableReference;
 use tokio::time::Instant;
 use uuid::Uuid;
 
@@ -36,7 +37,7 @@ pub(crate) struct QueryTracker {
     pub(crate) error_message: Option<String>,
     pub(crate) error_code: Option<ErrorCode>,
     pub(crate) timer: Instant,
-    pub(crate) datasets: Arc<HashSet<String>>,
+    pub(crate) datasets: Arc<HashSet<TableReference>>,
     pub(crate) protocol: Protocol,
 }
 
@@ -118,7 +119,7 @@ impl QueryTracker {
     }
 
     #[must_use]
-    pub(crate) fn datasets(mut self, datasets: Arc<HashSet<String>>) -> Self {
+    pub(crate) fn datasets(mut self, datasets: Arc<HashSet<TableReference>>) -> Self {
         self.datasets = datasets;
         self
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1401,7 +1401,10 @@ impl Runtime {
             return;
         }
 
-        match QueryResultsCacheProvider::new(cache_config) {
+        match QueryResultsCacheProvider::try_new(
+            cache_config,
+            Box::new([SPICE_RUNTIME_SCHEMA.into(), "information_schema".into()]),
+        ) {
             Ok(cache_provider) => {
                 tracing::info!("Initialized results cache; {cache_provider}");
                 self.datafusion().set_cache_provider(cache_provider);


### PR DESCRIPTION
## 🗣 Description

Another pass on the query path to remove unnecessary allocations and improve performance. The major win from this PR is avoiding the clone of the `LogicalPlan`, which is potentially expensive. One of the only reasons we cloned the `LogicalPlan` previously was so we could pass it to the hash function to get a `u64`. We can just calculate that hash up front and avoid an expensive clone.

I reworked the input tables scanner to work directly with `TableReference`s instead of `String`. This also avoid some more allocations, and it was what we had originally - which meant another unnecessary allocation to convert from TableReference -> String. The only place where we "needed" a string was in an error message, which I changed to use the `table` name from the TableReference directly, which is a cheap clone of a pointer rather than a clone of a string.

I also noticed that the `cache` crate had implicit knowledge about which schemas we didn't want to cache (`runtime` and `information_schema`) - that is specific to the Spice runtime, and thus it doesn't belong in that generic cache crate. I've reworked the constructor to take a reference to a slice of `str` to use when filtering.

## 🔨 Related Issues

Closes #1534

<!-- 
## 🤔 Concerns

list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->