### PR TITLE
Update Spice runtime to require explicit enablement for TLS

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -22,7 +22,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use app::{App, AppBuilder};
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use flightrepl::ReplConfig;
 use metrics_exporter_prometheus::PrometheusHandle;
 use runtime::config::Config as RuntimeConfig;
@@ -90,6 +90,10 @@ pub struct Args {
 
     #[clap(flatten)]
     pub repl_config: ReplConfig,
+
+    /// Enable TLS for the runtime.
+    #[arg(long, default_value_t = false, action = ArgAction::Set)]
+    pub tls_enabled: bool,
 
     /// The TLS PEM-encoded certificate.
     #[arg(long, value_name = "-----BEGIN CERTIFICATE-----...")]

--- a/bin/spiced/src/tls.rs
+++ b/bin/spiced/src/tls.rs
@@ -31,11 +31,7 @@ pub(crate) async fn load_tls_config(
     spicepod_tls_config: Option<SpicepodTlsConfig>,
     secrets: Arc<RwLock<Secrets>>,
 ) -> std::result::Result<Option<Arc<TlsConfig>>, Box<dyn std::error::Error>> {
-    let tls_enabled = args.tls_certificate.is_some()
-        || args.tls_certificate_file.is_some()
-        || args.tls_key.is_some()
-        || args.tls_key_file.is_some()
-        || spicepod_tls_config.is_some();
+    let tls_enabled = args.tls_enabled || spicepod_tls_config.as_ref().is_some_and(|c| c.enabled);
     if !tls_enabled {
         return Ok(None);
     }

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -58,6 +58,9 @@ impl Default for ResultsCache {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct TlsConfig {
+    /// If set, the runtime will configure all endpoints to use TLS
+    pub enabled: bool,
+
     /// A filesystem path to a file containing the PEM encoded certificate
     pub certificate_file: Option<String>,
 


### PR DESCRIPTION
## 🗣 Description

This will be another breaking change for the next release, but this keeps us consistent with allowing config to remain and the feature toggled on/off with an `enabled` parameter.

`spice run -- --tls-enabled true --tls-certificate-file ./spiced.crt --tls-key-file ./spiced.key`

```yaml
runtime:
  tls:
    enabled: true
    certificate_file: ./spiced.crt
    key_file: ./spiced.key
```