### PR TITLE
Dataset with acceleration enabled = false shouldn't go through accelerated dataset hot reload

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -970,6 +970,10 @@ impl Runtime {
             return false;
         };
 
+        if !acceleration.enabled {
+            return false;
+        }
+
         // Datasets that configure changes and are file-accelerated automatically keep track of changes that survive restarts.
         // Thus we don't need to "hot reload" them to try to keep their data intact.
         if connector.supports_changes_stream()


### PR DESCRIPTION
## 🗣 Description

Dataset with acceleration params,but acceleration enabled = false shouldn't go through accelerated dataset hot reload. This will fix the warning message caused by using the wrong reload approach.

## 🔨 Related Issues

- Close: https://github.com/spiceai/spiceai/issues/2082

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->