### PR TITLE
fix hanging spiced when odbc loading data and received a cancel signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,6 +3161,7 @@ dependencies = [
  "snafu 0.8.4",
  "snowflake-api",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,6 +3164,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "util",
 ]
 
 [[package]]

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = { version = "0.10.8", optional = true }
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt"] }
+tokio-util = "0.7.11"
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -32,6 +32,7 @@ snowflake-api = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt"] }
 tokio-util = "0.7.11"
 tracing.workspace = true
+util = { path = "../util" }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/crates/db_connection_pool/src/dbconnection/odbcconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/odbcconn.rs
@@ -184,9 +184,8 @@ where
                     tracing::error!(
                         "Failed to listen to shutdown signal in ODBC data fetching: {err}"
                     );
-                } else {
-                    cancellation_token.clone().cancel();
                 }
+                cancellation_token.clone().cancel();
             };
             tokio::select! {
                 () = cancellation_token.cancelled() => {},

--- a/crates/db_connection_pool/src/dbconnection/odbcconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/odbcconn.rs
@@ -181,7 +181,9 @@ where
             let ctrl_c = async {
                 let signal_result = signal::ctrl_c().await;
                 if let Err(err) = signal_result {
-                    tracing::error!("Failed to listen to shutdown signal in ODBC data fetching: {err}");
+                    tracing::error!(
+                        "Failed to listen to shutdown signal in ODBC data fetching: {err}"
+                    );
                 } else {
                     cancellation_token.clone().cancel();
                 }


### PR DESCRIPTION
## 🗣 Description

`spawn_blocking` will prevent the tokio runtime to shutdown as
> When you shut down the executor, it will wait indefinitely for all blocking operations to finish.

Alternatively, a force shutdown can be done however that will potential leave things in a bad state. Opt for using `CancellationToken` from tokio to coordinate between a dedicated ctrl-c listening task and the data fetch task.

## 🔨 Related Issues

Fixes #2083 

## 🤔 Concerns

