### PR TITLE
Add CI to build makefile install targets

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -1,67 +1,71 @@
----
-  name: check all features
-  
-  on:
-    push:
-      branches:
-        - trunk
-      paths:
-        - "**/Cargo.toml"
-    pull_request:
-      paths:
-        - "**/Cargo.toml"
-    workflow_dispatch:
-  
-  jobs:
-    build:
-      name: Features Check
-      runs-on: rust
-  
-      steps:
-        - uses: actions/checkout@v4
-  
-        - name: Set up Rust
-          uses: ./.github/actions/setup-rust
-          with:
-            os: 'linux'
-  
-        # Putting this into a GitHub Actions matrix will run a separate job per matrix item, whereas in theory 
-        # this can re-use the existing build cache to go faster.
-        - name: Build without default features
-          run: cargo check --no-default-features
-  
-        - name: Build with only duckdb
-          run: cargo check --no-default-features --features duckdb
-  
-        - name: Build with only postgres
-          run: cargo check --no-default-features --features postgres
-  
-        - name: Build with only sqlite
-          run: cargo check --no-default-features --features sqlite
-  
-        - name: Build with only mysql
-          run: cargo check --no-default-features --features mysql
-  
-        - name: Build with only keyring-secret-store
-          run: cargo check --no-default-features --features keyring-secret-store
-  
-        - name: Build with only flightsql
-          run: cargo check --no-default-features --features flightsql
-  
-        - name: Build with only aws-secrets-manager
-          run: cargo check --no-default-features --features aws-secrets-manager
-  
-        - name: Build with only databricks
-          run: cargo check --no-default-features --features databricks
-  
-        - name: Build with only delta_lake
-          run: cargo check --no-default-features --features delta_lake
-  
-        - name: Build with only dremio
-          run: cargo check --no-default-features --features dremio
+name: check all features
 
-        - name: Build with only clickhouse
-          run: cargo check --no-default-features --features clickhouse
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - "**/Cargo.toml"
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+  workflow_dispatch:
 
-        - name: Build with only debezium
-          run: cargo check --no-default-features --features debezium
+concurrency:
+  # Allow only one workflow per any non-trunk branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Features Check
+    runs-on: rust
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: 'linux'
+
+      # Putting this into a GitHub Actions matrix will run a separate job per matrix item, whereas in theory 
+      # this can re-use the existing build cache to go faster.
+      - name: Build without default features
+        run: cargo check --no-default-features
+
+      - name: Build with only duckdb
+        run: cargo check --no-default-features --features duckdb
+
+      - name: Build with only postgres
+        run: cargo check --no-default-features --features postgres
+
+      - name: Build with only sqlite
+        run: cargo check --no-default-features --features sqlite
+
+      - name: Build with only mysql
+        run: cargo check --no-default-features --features mysql
+
+      - name: Build with only keyring-secret-store
+        run: cargo check --no-default-features --features keyring-secret-store
+
+      - name: Build with only flightsql
+        run: cargo check --no-default-features --features flightsql
+
+      - name: Build with only aws-secrets-manager
+        run: cargo check --no-default-features --features aws-secrets-manager
+
+      - name: Build with only databricks
+        run: cargo check --no-default-features --features databricks
+
+      - name: Build with only delta_lake
+        run: cargo check --no-default-features --features delta_lake
+
+      - name: Build with only dremio
+        run: cargo check --no-default-features --features dremio
+
+      - name: Build with only clickhouse
+        run: cargo check --no-default-features --features clickhouse
+
+      - name: Build with only debezium
+        run: cargo check --no-default-features --features debezium

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,11 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  # Allow only one workflow per any non-trunk branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+  cancel-in-progress: true
+
 env:
   CONTAINER_REGISTRY: spiceaitestimages.azurecr.io/
 

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -13,7 +13,7 @@
     jobs:
       make_install:
         name: make install*
-        runs-on: ubuntu-latest-32-cores
+        runs-on: ubuntu-latest-64-cores
         env:
           GOVER: 1.22.0
     

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -1,0 +1,58 @@
+---
+    name: Makefile Targets
+    
+    on:
+      pull_request:
+        branches:
+          - trunk
+          - release-*
+          - feature-*
+    
+      workflow_dispatch:
+    
+    jobs:
+      make_install:
+        name: make install*
+        runs-on: ubuntu-latest-16-cores
+        env:
+          GOVER: 1.22.0
+    
+        steps:
+          - uses: actions/checkout@v4
+    
+          - name: Set up Go
+            uses: actions/setup-go@v5
+            with:
+              go-version: ${{ env.GOVER }}
+              cache: false
+    
+          - name: Set up Rust
+            uses: ./.github/actions/setup-rust
+            with:
+              os: 'linux'
+          
+          - name: Install Protoc
+            uses: arduino/setup-protoc@v3
+            with:
+              repo-token: ${{ secrets.GITHUB_TOKEN }}
+    
+          - name: make install
+            run: |
+              make install
+    
+          - name: make install-with-models
+            run: |
+              make install-with-models
+    
+          - name: make install-with-odbc
+            run: |
+              make install-with-odbc
+    
+          - name: make install-cli
+            run: |
+              make install-cli
+    
+          - name: make install-runtime
+            run: |
+              make install-runtime
+    

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -13,10 +13,10 @@
     jobs:
       make_install:
         name: make install*
-        runs-on: ubuntu-latest-64-cores
+        runs-on: ubuntu-latest-32-cores
         env:
           GOVER: 1.22.0
-    
+
         steps:
           - uses: actions/checkout@v4
     

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -1,58 +1,61 @@
----
-    name: Makefile Targets
-    
-    on:
-      pull_request:
-        branches:
-          - trunk
-          - release-*
-          - feature-*
-    
-      workflow_dispatch:
-    
-    jobs:
-      make_install:
-        name: make install*
-        runs-on: ubuntu-latest-32-cores
-        env:
-          GOVER: 1.22.0
+name: Makefile Targets
 
-        steps:
-          - uses: actions/checkout@v4
-    
-          - name: Set up Go
-            uses: actions/setup-go@v5
-            with:
-              go-version: ${{ env.GOVER }}
-              cache: false
-    
-          - name: Set up Rust
-            uses: ./.github/actions/setup-rust
-            with:
-              os: 'linux'
-          
-          - name: Install Protoc
-            uses: arduino/setup-protoc@v3
-            with:
-              repo-token: ${{ secrets.GITHUB_TOKEN }}
-    
-          - name: make install
-            run: |
-              make install
-    
-          - name: make install-with-models
-            run: |
-              make install-with-models
-    
-          - name: make install-with-odbc
-            run: |
-              make install-with-odbc
-    
-          - name: make install-cli
-            run: |
-              make install-cli
-    
-          - name: make install-runtime
-            run: |
-              make install-runtime
-    
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - feature-*
+
+  workflow_dispatch:
+
+concurrency:
+  # Allow only one workflow per any non-trunk branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+  cancel-in-progress: true
+
+jobs:
+  make_install:
+    name: make install*
+    runs-on: ubuntu-latest-32-cores
+    env:
+      GOVER: 1.22.0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOVER }}
+          cache: false
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: 'linux'
+      
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: make install
+        run: |
+          make install
+
+      - name: make install-with-models
+        run: |
+          make install-with-models
+
+      - name: make install-with-odbc
+        run: |
+          make install-with-odbc
+
+      - name: make install-cli
+        run: |
+          make install-cli
+
+      - name: make install-runtime
+        run: |
+          make install-runtime

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -13,7 +13,7 @@
     jobs:
       make_install:
         name: make install*
-        runs-on: ubuntu-latest-16-cores
+        runs-on: ubuntu-latest-32-cores
         env:
           GOVER: 1.22.0
     

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,11 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  # Allow only one workflow per any non-trunk branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Run Go & Rust Linters

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,4 +100,6 @@ datafusion-federation = { git = "https://github.com/spiceai/datafusion-federatio
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "85935dbbc64d2af1ca132ad7e2309a9d87bf3115" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdfc2c482f1ce84c595ab1202530a37815d6" }
+
+# Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }


### PR DESCRIPTION
## 🗣 Description

Adds a CI step to build the `make install*` targets.

Also tweaks the other workflows run on PR to cancel in-progress jobs when new commits are pushed.

## 🔨 Related Issues

Closes #2053 