### PR TITLE
Improve MySql schema extraction and add InList and ScalarFunction expr support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d7a805c382030aeb3797a4ae0e1d9aeb4b39283e#d7a805c382030aeb3797a4ae0e1d9aeb4b39283e"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b0ee4d0c06cb7d4d9a23344cbc64cafb97c7f0fa#b0ee4d0c06cb7d4d9a23344cbc64cafb97c7f0fa"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=16d871e159be2360aab67a6f07faeb5e9b9bdaf7#16d871e159be2360aab67a6f07faeb5e9b9bdaf7"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d7a805c382030aeb3797a4ae0e1d9aeb4b39283e#d7a805c382030aeb3797a4ae0e1d9aeb4b39283e"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "40.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d7a805c382030aeb3797a4ae0e1d9aeb4b39283e" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b0ee4d0c06cb7d4d9a23344cbc64cafb97c7f0fa" }
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "40.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "eeb9b9c0ed41650db282ba27bc663feb64e62147" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "16d871e159be2360aab67a6f07faeb5e9b9bdaf7" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d7a805c382030aeb3797a4ae0e1d9aeb4b39283e" }
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.0"


### PR DESCRIPTION
## 🗣 Description

Upgrade `datafusion-table-providers` to include 
- [Fix schema extraction for MySql tables](https://github.com/datafusion-contrib/datafusion-table-providers/pull/21)
- [Add InList and ScalarFunction expr support ](https://github.com/datafusion-contrib/datafusion-table-providers/pull/23)
## 🔨 Related Issues

Fixes 
https://github.com/spiceai/spiceai/issues/2061
https://github.com/spiceai/spiceai/issues/2164
https://github.com/spiceai/spiceai/issues/2163