### PR TITLE
Benchmark: data connector tests should continue on query error (s3)

### DIFF
--- a/crates/runtime/benches/bench_s3/mod.rs
+++ b/crates/runtime/benches/bench_s3/mod.rs
@@ -40,15 +40,25 @@ pub(crate) async fn run(
         None => "s3".to_string(),
     };
 
+    let mut errors = Vec::new();
+
     for (query_name, query) in test_queries {
-        super::run_query_and_record_result(
+        if let Err(e) = super::run_query_and_record_result(
             rt,
             benchmark_results,
             bench_name.as_str(),
             query_name,
             query,
         )
-        .await?;
+        .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        }
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
+        return Err(errors.join("\n"));
     }
 
     Ok(())

--- a/crates/runtime/benches/results/mod.rs
+++ b/crates/runtime/benches/results/mod.rs
@@ -25,12 +25,14 @@ use runtime::dataupdate::{DataUpdate, UpdateType};
 #[derive(Copy, Clone)]
 pub(crate) enum Status {
     Passed,
+    Failed,
 }
 
 impl std::fmt::Display for Status {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Status::Passed => write!(f, "passed"),
+            Status::Failed => write!(f, "failed"),
         }
     }
 }
@@ -85,6 +87,7 @@ impl BenchmarkResultsBuilder {
         status: Status,
         min_duration_ms: i64,
         max_duration_ms: i64,
+        iterations: i32,
     ) {
         self.run_id.append_value(&self.this_run_id);
         self.started_at.append_value(start_time);
@@ -94,7 +97,7 @@ impl BenchmarkResultsBuilder {
         self.status.append_value(status.to_string());
         self.min_duration_ms.append_value(min_duration_ms);
         self.max_duration_ms.append_value(max_duration_ms);
-        self.iterations.append_value(self.this_iterations);
+        self.iterations.append_value(iterations);
         self.commit_sha.append_value(&self.this_commit_sha);
         self.branch_name.append_value(&self.this_branch_name);
     }


### PR DESCRIPTION
## 🗣 Description

PR updates `run_query_and_record_result` to save failed query result instead of failing and allow data connector to continue and complete all test queries. This is useful to identify all failed queries for a data connector when some of the queries fail.

The change currently applied to S3 data connector and will be extended to other data connectors if current PR is applied.