### PR TITLE
Fix issue with use of `EmbeddingConnector`

### DIFF
--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -46,7 +46,7 @@ impl EmbeddingConnector {
 
     /// Wrap an existing [`TableProvider`] with a [`EmbeddingTable`] provider. If no embeddings
     /// are needed for the [`Dataset`], it is not unnecessarily nested.
-    async fn wrap(
+    pub(crate) async fn wrap(
         &self,
         inner_table_provider: Arc<dyn TableProvider>,
         dataset: &Dataset,

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -46,7 +46,7 @@ impl EmbeddingConnector {
 
     /// Wrap an existing [`TableProvider`] with a [`EmbeddingTable`] provider. If no embeddings
     /// are needed for the [`Dataset`], it is not unnecessarily nested.
-    pub(crate) async fn wrap(
+    pub(crate) async fn wrap_table(
         &self,
         inner_table_provider: Arc<dyn TableProvider>,
         dataset: &Dataset,
@@ -82,7 +82,7 @@ impl DataConnector for EmbeddingConnector {
         &self,
         dataset: &Dataset,
     ) -> DataConnectorResult<Arc<dyn TableProvider>> {
-        self.wrap(self.inner_connector.read_provider(dataset).await?, dataset)
+        self.wrap_table(self.inner_connector.read_provider(dataset).await?, dataset)
             .await
     }
 
@@ -91,7 +91,7 @@ impl DataConnector for EmbeddingConnector {
         dataset: &Dataset,
     ) -> Option<DataConnectorResult<Arc<dyn TableProvider>>> {
         match self.inner_connector.read_write_provider(dataset).await {
-            Some(Ok(inner)) => Some(self.wrap(inner, dataset).await),
+            Some(Ok(inner)) => Some(self.wrap_table(inner, dataset).await),
             Some(Err(e)) => Some(Err(e)),
             None => None,
         }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1057,11 +1057,12 @@ impl Runtime {
         let connector = if ds.embeddings.is_empty() {
             data_connector
         } else {
-            let connector = EmbeddingConnector::new(
-                data_connector,
-                Arc::clone(&self.embeds),
-            );
-            federated_read_table = connector.wrap(federated_read_table, ds).await.boxed().context(UnableToInitializeDataConnectorSnafu)?;
+            let connector = EmbeddingConnector::new(data_connector, Arc::clone(&self.embeds));
+            federated_read_table = connector
+                .wrap(federated_read_table, ds)
+                .await
+                .boxed()
+                .context(UnableToInitializeDataConnectorSnafu)?;
             Arc::new(connector) as Arc<dyn DataConnector>
         };
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1059,7 +1059,7 @@ impl Runtime {
         } else {
             let connector = EmbeddingConnector::new(data_connector, Arc::clone(&self.embeds));
             federated_read_table = connector
-                .wrap(federated_read_table, ds)
+                .wrap_table(federated_read_table, ds)
                 .await
                 .boxed()
                 .context(UnableToInitializeDataConnectorSnafu)?;


### PR DESCRIPTION
## 🗣 Description
- Regression in how the `EmbeddingConnector` is used when registering tables with embedding columns.  The issue occured with the introduction of `federated_read_table` within `RegisterDatasetContext` being a preconstructed table provider. 