### PR TITLE
refactor: Use matrix for benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,12 +10,36 @@ on:
         default: "postgres,spark,mysql,odbc,delta_lake,databricks,duckdb"
 
 jobs:
+  setup-matrix:
+    name: Setup strategy matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.result }}
+
+    steps:
+      - name: Set up matrix
+        uses: actions/github-script@v7
+        id: setup-matrix
+        with:
+          script: |
+            const matrix = "${{ inputs.features }}".split(',').map(f=>{
+              return {
+                feature: f
+              }
+            });
+
+            return matrix;
+
   run-database-bench:
     name: Benchmark Tests
     runs-on: ubuntu-latest
+    needs: setup-matrix
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     services:
       mysql:
-        image: ${{ contains(inputs.features, 'mysql') && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
+        image: ${{ contains(matrix.target.feature, 'mysql') && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
         options: >-
           --health-cmd="mysqladmin ping -uroot -proot --silent"
           --health-interval 10s
@@ -26,7 +50,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
       postgres:
-        image: ${{ contains(inputs.features, 'postgres') && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
+        image: ${{ contains(matrix.target.feature, 'postgres') && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
         options: >-
           --health-cmd="pg_isready -U postgres"
           --health-interval 10s
@@ -49,11 +73,11 @@ jobs:
           echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
 
       - name: Install Protoc
-        if: contains(inputs.features, 'spark')
+        if: contains(matrix.target.feature, 'spark')
         uses: arduino/setup-protoc@v3
       
       - name: Install Databricks ODBC driver
-        if: contains(inputs.features, 'odbc')
+        if: contains(matrix.target.feature, 'odbc')
         run: |
           sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
           wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
@@ -61,13 +85,13 @@ jobs:
           sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
         
       - name: Install Athena ODBC driver
-        if: contains(inputs.features, 'odbc')
+        if: contains(matrix.target.feature, 'odbc')
         run: |
           sudo apt-get install alien -y
           wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
           sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
 
-      - run: cargo bench -p runtime --features ${{ inputs.features }}
+      - run: cargo bench -p runtime --features ${{ matrix.target.feature }}
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
           PG_BENCHMARK_PG_HOST: localhost

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-matrix
     strategy:
+      fail-fast: false
       matrix:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     services:
@@ -73,7 +74,7 @@ jobs:
           echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
 
       - name: Install Protoc
-        if: contains(matrix.target.feature, 'spark')
+        if: contains(matrix.target.feature, 'spark') || contains(matrix.target.feature, 'databricks')
         uses: arduino/setup-protoc@v3
       
       - name: Install Databricks ODBC driver


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Uses a matrix strategy for the benchmark workflow

This allows each individual benchmark to run on their own, making it easier to identify at a glance what benchmark failed and to reduce the total workflow time to benchmark.

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->

* The `s3` and `spice.ai` benchmarks run on every matrix job, because we haven't yet setup a non-feature linked method to determine what to run.