### PR TITLE
Localhost -> Sink; Fix Sink connector to not require schema via `CREATE TABLE...` and infer on first write

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -226,6 +226,7 @@ impl Builder {
         let (ready_sender, is_ready) = oneshot::channel::<()>();
 
         let (acceleration_refresh_mode, refresh_trigger) = match self.refresh.mode {
+            RefreshMode::Disabled => (refresh::AccelerationRefreshMode::Disabled, None),
             RefreshMode::Append => {
                 if self.refresh.time_column.is_none() {
                     (refresh::AccelerationRefreshMode::Append(None), None)
@@ -271,7 +272,9 @@ impl Builder {
         let refresher = Arc::new(refresher);
 
         let mut handlers = vec![];
-        handlers.push(refresh_handle);
+        if let Some(refresh_handle) = refresh_handle {
+            handlers.push(refresh_handle);
+        }
 
         if let Some(retention) = self.retention {
             let retention_check_handle = tokio::spawn(AcceleratedTable::start_retention_check(

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -493,7 +493,7 @@ impl RefreshTask {
                 refresh.sql.clone(),
                 match refresh.mode {
                     RefreshMode::Disabled => {
-                        unreachable!("refresh is not be called for disabled acceleration")
+                        unreachable!("Refresh cannot be called when acceleration is disabled")
                     }
                     RefreshMode::Full => UpdateType::Overwrite,
                     RefreshMode::Append => UpdateType::Append,

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -203,7 +203,7 @@ impl RefreshTask {
 
         let get_data_update_result = match mode {
             RefreshMode::Disabled => {
-                unreachable!("refresh is not be called for disabled acceleration")
+                unreachable!("Refresh cannot be called when acceleration is disabled")
             }
             RefreshMode::Full => self.get_full_update().await,
             RefreshMode::Append => self.get_incremental_append_update().await,

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -190,7 +190,7 @@ impl RefreshTask {
         let _timer = TimeMeasurement::new(
             match mode {
                 RefreshMode::Disabled => {
-                    unreachable!("refresh is not be called for disabled acceleration")
+                    unreachable!("Refresh cannot be called when acceleration is disabled")
                 }
                 RefreshMode::Full => "load_dataset_duration_ms",
                 RefreshMode::Append => "append_dataset_duration_ms",

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -189,6 +189,9 @@ impl RefreshTask {
 
         let _timer = TimeMeasurement::new(
             match mode {
+                RefreshMode::Disabled => {
+                    unreachable!("refresh is not be called for disabled acceleration")
+                }
                 RefreshMode::Full => "load_dataset_duration_ms",
                 RefreshMode::Append => "append_dataset_duration_ms",
                 RefreshMode::Changes => unreachable!("changes are handled upstream"),
@@ -199,6 +202,9 @@ impl RefreshTask {
         let start_time = SystemTime::now();
 
         let get_data_update_result = match mode {
+            RefreshMode::Disabled => {
+                unreachable!("refresh is not be called for disabled acceleration")
+            }
             RefreshMode::Full => self.get_full_update().await,
             RefreshMode::Append => self.get_incremental_append_update().await,
             RefreshMode::Changes => unreachable!("changes are handled upstream"),
@@ -450,7 +456,7 @@ impl RefreshTask {
     }
 
     fn trace_dataset_loaded(&self, start_time: SystemTime, num_rows: usize, memory_size: usize) {
-        if let Ok(elapse) = util::humantime_elapsed(start_time) {
+        if let Ok(elapsed) = util::humantime_elapsed(start_time) {
             let dataset_name = &self.dataset_name;
             let num_rows = util::pretty_print_number(num_rows);
             let memory_size = if memory_size > 0 {
@@ -461,11 +467,11 @@ impl RefreshTask {
 
             if self.dataset_name.schema() == Some(SPICE_RUNTIME_SCHEMA) {
                 tracing::debug!(
-                    "Loaded {num_rows} rows{memory_size} for dataset {dataset_name} in {elapse}.",
+                    "Loaded {num_rows} rows{memory_size} for dataset {dataset_name} in {elapsed}.",
                 );
             } else {
                 tracing::info!(
-                    "Loaded {num_rows} rows{memory_size} for dataset {dataset_name} in {elapse}."
+                    "Loaded {num_rows} rows{memory_size} for dataset {dataset_name} in {elapsed}."
                 );
             }
         }
@@ -486,6 +492,9 @@ impl RefreshTask {
             (
                 refresh.sql.clone(),
                 match refresh.mode {
+                    RefreshMode::Disabled => {
+                        unreachable!("refresh is not be called for disabled acceleration")
+                    }
                     RefreshMode::Full => UpdateType::Overwrite,
                     RefreshMode::Append => UpdateType::Append,
                     RefreshMode::Changes => unreachable!("changes are handled upstream"),

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -228,8 +228,8 @@ impl Dataset {
         if parts.len() > 1 {
             parts[0].to_string()
         } else {
-            if self.from == "localhost" || self.from.is_empty() {
-                return "localhost".to_string();
+            if self.from == "sink" || self.from.is_empty() {
+                return "sink".to_string();
             }
             "spiceai".to_string()
         }

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -23,6 +23,7 @@ pub mod on_conflict;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum RefreshMode {
+    Disabled,
     Full,
     Append,
     Changes,

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -75,7 +75,6 @@ pub mod flightsql;
 pub mod ftp;
 pub mod graphql;
 pub mod https;
-pub mod localhost;
 #[cfg(feature = "mysql")]
 pub mod mysql;
 #[cfg(feature = "odbc")]
@@ -85,6 +84,7 @@ pub mod postgres;
 pub mod s3;
 #[cfg(feature = "ftp")]
 pub mod sftp;
+pub mod sink;
 #[cfg(feature = "snowflake")]
 pub mod snowflake;
 #[cfg(feature = "spark")]
@@ -272,7 +272,7 @@ pub async fn create_new_connector(
 }
 
 pub async fn register_all() {
-    register_connector_factory("localhost", localhost::LocalhostConnectorFactory::new_arc()).await;
+    register_connector_factory("sink", sink::SinkConnectorFactory::new_arc()).await;
     #[cfg(feature = "databricks")]
     register_connector_factory("databricks", databricks::DatabricksFactory::new_arc()).await;
     #[cfg(feature = "delta_lake")]

--- a/crates/runtime/src/dataconnector/sink.rs
+++ b/crates/runtime/src/dataconnector/sink.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 
 use std::{any::Any, pin::Pin, sync::Arc};
 
-use crate::component::dataset::Dataset;
+use crate::component::dataset::{acceleration::RefreshMode, Dataset};
 use datafusion::{
     config::ConfigOptions,
     datasource::{TableProvider, TableType},
@@ -90,6 +90,10 @@ impl DataConnector for SinkConnector {
         self
     }
 
+    fn resolve_refresh_mode(&self, refresh_mode: Option<RefreshMode>) -> RefreshMode {
+        refresh_mode.unwrap_or(RefreshMode::Disabled)
+    }
+
     async fn read_provider(
         &self,
         _dataset: &Dataset,
@@ -120,7 +124,7 @@ impl SinkContextProvider {
 impl ContextProvider for SinkContextProvider {
     fn get_table_source(&self, _name: TableReference) -> DataFusionResult<Arc<dyn TableSource>> {
         Err(DataFusionError::NotImplemented(
-            "LocalhostContextProvider::get_table_source".to_string(),
+            "SinkContextProvider::get_table_source".to_string(),
         ))
     }
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -23,6 +23,7 @@ use crate::accelerated_table::{refresh::Refresh, AcceleratedTable, Retention};
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::{Dataset, Mode};
 use crate::dataaccelerator::{self, create_accelerator_table};
+use crate::dataconnector::sink::SinkConnector;
 use crate::dataconnector::{DataConnector, DataConnectorError};
 use crate::dataupdate::{
     DataUpdate, StreamingDataUpdate, StreamingDataUpdateExecutionPlan, UpdateType,
@@ -31,7 +32,7 @@ use crate::object_store_registry::default_runtime_env;
 use crate::secrets::Secrets;
 use crate::{embeddings, get_dependent_table_names};
 
-use arrow::datatypes::Schema;
+use arrow::datatypes::{Schema, SchemaRef};
 use arrow::error::ArrowError;
 use arrow_tools::schema::verify_schema;
 use cache::QueryResultsCacheProvider;
@@ -202,10 +203,17 @@ pub enum Table {
     View(String),
 }
 
+struct PendingSinkRegistration {
+    dataset: Arc<Dataset>,
+    secrets: Arc<TokioRwLock<Secrets>>,
+}
+
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     data_writers: RwLock<HashSet<TableReference>>,
     cache_provider: RwLock<Option<Arc<QueryResultsCacheProvider>>>,
+
+    pending_sink_tables: TokioRwLock<Vec<PendingSinkRegistration>>,
 
     /// Has the initial load of the data been completed? It is the responsibility of the caller to call `mark_initial_load_complete` when the initial load is complete.
     initial_load_complete: Mutex<bool>,
@@ -277,6 +285,7 @@ impl DataFusion {
             data_writers: RwLock::new(HashSet::new()),
             cache_provider: RwLock::new(cache_provider),
             initial_load_complete: Mutex::new(false),
+            pending_sink_tables: TokioRwLock::new(Vec::new()),
         }
     }
 
@@ -372,11 +381,19 @@ impl DataFusion {
                     self.ctx
                         .register_table(dataset_table_ref.clone(), Arc::new(accelerated_table))
                         .context(UnableToRegisterTableToDataFusionSnafu)?;
-
-                    return Ok(());
+                } else if source.as_any().downcast_ref::<SinkConnector>().is_some() {
+                    // Sink connectors don't know their schema until the first data is received. Park this registration until the schema is known via the first write.
+                    self.pending_sink_tables
+                        .write()
+                        .await
+                        .push(PendingSinkRegistration {
+                            dataset: Arc::clone(&dataset),
+                            secrets: Arc::clone(&secrets),
+                        });
+                } else {
+                    self.register_accelerated_table(dataset, source, federated_read_table, secrets)
+                        .await?;
                 }
-                self.register_accelerated_table(dataset, source, federated_read_table, secrets)
-                    .await?;
             }
             Table::Federated {
                 data_connector,
@@ -442,6 +459,55 @@ impl DataFusion {
         Ok(table_provider)
     }
 
+    async fn ensure_sink_dataset(
+        &self,
+        table_reference: TableReference,
+        schema: SchemaRef,
+    ) -> Result<()> {
+        let pending_sink_registrations = self.pending_sink_tables.read().await;
+
+        let mut pending_registration = None;
+        let mut pending_registration_idx = 0;
+        for (pending_sink_registration_idx, pending_sink_registration) in
+            pending_sink_registrations.iter().enumerate()
+        {
+            if pending_sink_registration.dataset.name == table_reference {
+                pending_registration = Some(pending_sink_registration);
+                pending_registration_idx = pending_sink_registration_idx;
+                break;
+            }
+        }
+
+        let Some(pending_registration) = pending_registration else {
+            return Ok(());
+        };
+
+        let sink_connector = Arc::new(SinkConnector::new(schema)) as Arc<dyn DataConnector>;
+        let read_provider = sink_connector
+            .read_provider(&pending_registration.dataset)
+            .await
+            .context(UnableToResolveTableProviderSnafu)?;
+
+        tracing::info!(
+            "Loading data for dataset {}",
+            pending_registration.dataset.name
+        );
+        self.register_accelerated_table(
+            Arc::clone(&pending_registration.dataset),
+            sink_connector,
+            read_provider,
+            Arc::clone(&pending_registration.secrets),
+        )
+        .await?;
+
+        drop(pending_sink_registrations);
+
+        let mut pending_sink_registrations = self.pending_sink_tables.write().await;
+        pending_sink_registrations.remove(pending_registration_idx);
+
+        Ok(())
+    }
+
     pub async fn write_data(
         &self,
         table_reference: TableReference,
@@ -453,6 +519,9 @@ impl DataFusion {
             }
             .fail()?;
         }
+
+        self.ensure_sink_dataset(table_reference.clone(), Arc::clone(&data_update.schema))
+            .await?;
 
         let table_provider = self.get_table_provider(&table_reference).await?;
 

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -75,7 +75,7 @@ pub(crate) async fn get(
     };
 
     let valid_datasets = Runtime::get_valid_datasets(readable_app, LogErrors(false));
-    let datasets: Vec<Dataset> = match filter.source {
+    let datasets: Vec<Arc<Dataset>> = match filter.source {
         Some(source) => valid_datasets
             .into_iter()
             .filter(|d| d.source() == source)

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -29,7 +29,7 @@ use crate::secrets::Secrets;
 use crate::{
     accelerated_table::{refresh::Refresh, AcceleratedTable},
     dataaccelerator::{self, create_accelerator_table},
-    dataconnector::{localhost::LocalhostConnector, DataConnector, DataConnectorError},
+    dataconnector::{sink::SinkConnector, DataConnector, DataConnectorError},
 };
 
 #[derive(Debug, Snafu)]
@@ -62,15 +62,14 @@ async fn get_local_table_provider(
     schema: &Arc<Schema>,
 ) -> Result<Arc<dyn TableProvider>, Error> {
     // This shouldn't error because we control the name passed in, and it shouldn't contain a catalog.
-    let mut dataset = Dataset::try_new("localhost://internal".to_string(), &name.to_string())
+    let mut dataset = Dataset::try_new("sink".to_string(), &name.to_string())
         .boxed()
         .context(InternalSnafu {
             code: "IT-GLTP-DTN".to_string(), // InternalTable - GetLocalTableProvider - DatasetTryNew
         })?;
     dataset.mode = Mode::ReadWrite;
 
-    let data_connector =
-        Arc::new(LocalhostConnector::new(Arc::clone(schema))) as Arc<dyn DataConnector>;
+    let data_connector = Arc::new(SinkConnector::new(Arc::clone(schema))) as Arc<dyn DataConnector>;
 
     let source_table_provider = data_connector
         .read_write_provider(&dataset)

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1062,7 +1062,7 @@ impl Runtime {
         } else {
             let connector = EmbeddingConnector::new(data_connector, Arc::clone(&self.embeds));
             federated_read_table = connector
-                .wrap_table(federated_read_table, ds)
+                .wrap_table(federated_read_table, &ds)
                 .await
                 .boxed()
                 .context(UnableToInitializeDataConnectorSnafu)?;

--- a/crates/runtime/src/tracing_util.rs
+++ b/crates/runtime/src/tracing_util.rs
@@ -59,7 +59,7 @@ fn dataset_acceleration_info(
     }
 
     match data_connector.resolve_refresh_mode(acceleration.refresh_mode) {
-        RefreshMode::Full => {}
+        RefreshMode::Full | RefreshMode::Disabled => {}
         RefreshMode::Append => {
             info.push_str(", append");
         }


### PR DESCRIPTION
## 🗣 Description

Renames the undocumented `localhost` data connector to `sink` to more accurately reflect its job. Change the behavior of the `sink` connector to not require a schema to be created via `CREATE TABLE...` and instead infer the schema on the first write. This requires keeping a list of the sink datasets that have been registered but are still waiting for the first write to infer the schema.

Once we get a write for that dataset, then register the table with the schema. This change also adds a `RefreshMode::Disabled` to the sink connector and sets it as the default refresh mode.

This significantly improves the UX of the sink connector and fixes it to its previous behavior before the major rewrite about 3 months ago.

This is the main issue blocking #1960, as that functionality depends on this connector working correctly - and setting the schema via CREATE TABLE statements was a hack.

## 🔨 Related Issues

Part of #1960

## 🤔 Concerns

The sink datasets will not be queryable via the SQL interface until the first write. We could register it with the placeholder schema, but that feels worse than just waiting to register it.