### PR TITLE
add client timeout for all object store providers

### DIFF
--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -20,7 +20,7 @@ use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use url::Url;
+use url::{form_urlencoded, Url};
 
 use super::{
     DataConnector, DataConnectorError, DataConnectorFactory, DataConnectorResult,
@@ -56,6 +56,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("username").secret(),
     ParameterSpec::connector("password").secret(),
     ParameterSpec::connector("port").description("The port to connect to."),
+    ParameterSpec::runtime("client_timeout")
+        .description("The timeout setting for HTTP(S) client."),
 
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),
@@ -143,6 +145,12 @@ impl ListingTableConnector for Https {
                 );
             };
         }
+
+        u.set_fragment(Some(&super::build_fragments(
+            &self.params,
+            vec!["client_timeout"],
+        )));
+
         Ok(u)
     }
 }

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -20,7 +20,7 @@ use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use url::{form_urlencoded, Url};
+use url::Url;
 
 use super::{
     DataConnector, DataConnectorError, DataConnectorFactory, DataConnectorResult,

--- a/crates/runtime/src/object_store_registry.rs
+++ b/crates/runtime/src/object_store_registry.rs
@@ -127,12 +127,16 @@ impl SpiceObjectStoreRegistry {
             DataFusionError::Configuration("No password provided for FTP".to_string())
         })?;
 
-        let mut client_timeout = None;
-        if let Some(timeout) = params.get("client_timeout") {
-            client_timeout = Some(fundu::parse_duration(timeout).map_err(|_| {
-                DataFusionError::Configuration(format!("Unable to parse timeout: {timeout}",))
-            })?);
-        }
+        let client_timeout = params
+            .get("client_timeout")
+            .map(|timeout| fundu::parse_duration(timeout))
+            .transpose()
+            .map_err(|_| {
+                DataFusionError::Configuration(format!(
+                    "Unable to parse timeout: {}",
+                    params["client_timeout"]
+                ))
+            })?;
 
         Ok(Arc::new(FTPObjectStore::new(
             user,
@@ -163,12 +167,16 @@ impl SpiceObjectStoreRegistry {
         let password = params.get("pass").map(ToOwned::to_owned).ok_or_else(|| {
             DataFusionError::Configuration("No password provided for SFTP".to_string())
         })?;
-        let mut client_timeout = None;
-        if let Some(timeout) = params.get("client_timeout") {
-            client_timeout = Some(fundu::parse_duration(timeout).map_err(|_| {
-                DataFusionError::Configuration(format!("Unable to parse timeout: {timeout}",))
-            })?);
-        }
+        let client_timeout = params
+            .get("client_timeout")
+            .map(|timeout| fundu::parse_duration(timeout))
+            .transpose()
+            .map_err(|_| {
+                DataFusionError::Configuration(format!(
+                    "Unable to parse timeout: {}",
+                    params["client_timeout"]
+                ))
+            })?;
 
         Ok(Arc::new(SFTPObjectStore::new(
             user,

--- a/crates/runtime/src/object_store_registry.rs
+++ b/crates/runtime/src/object_store_registry.rs
@@ -64,7 +64,7 @@ impl SpiceObjectStoreRegistry {
         if let Some(endpoint) = params.get("endpoint") {
             s3_builder = s3_builder.with_endpoint(endpoint);
         }
-        if let Some(timeout) = params.get("timeout") {
+        if let Some(timeout) = params.get("client_timeout") {
             client_options =
                 client_options.with_timeout(fundu::parse_duration(timeout).map_err(|_| {
                     DataFusionError::Configuration(format!("Unable to parse timeout: {timeout}",))
@@ -88,12 +88,22 @@ impl SpiceObjectStoreRegistry {
             format!("http://{}/", url.authority())
         };
 
-        Ok(Arc::new(
-            HttpBuilder::new()
-                .with_url(base_url)
-                .with_client_options(ClientOptions::new().with_allow_http(true))
-                .build()?,
-        ))
+        let mut client_options = ClientOptions::new().with_allow_http(true);
+        let params: HashMap<String, String> = parse(url.fragment().unwrap_or_default().as_bytes())
+            .into_owned()
+            .collect();
+        if let Some(timeout) = params.get("client_timeout") {
+            client_options =
+                client_options.with_timeout(fundu::parse_duration(timeout).map_err(|_| {
+                    DataFusionError::Configuration(format!("Unable to parse timeout: {timeout}",))
+                })?);
+        }
+
+        let builder = HttpBuilder::new()
+            .with_url(base_url)
+            .with_client_options(client_options);
+
+        Ok(Arc::new(builder.build()?))
     }
 
     #[cfg(feature = "ftp")]
@@ -113,17 +123,24 @@ impl SpiceObjectStoreRegistry {
         let user = params.get("user").map(ToOwned::to_owned).ok_or_else(|| {
             DataFusionError::Configuration("No user provided for FTP".to_string())
         })?;
-        let password = params
-            .get("password")
-            .map(ToOwned::to_owned)
-            .ok_or_else(|| {
-                DataFusionError::Configuration("No password provided for FTP".to_string())
-            })?;
+        let password = params.get("pass").map(ToOwned::to_owned).ok_or_else(|| {
+            DataFusionError::Configuration("No password provided for FTP".to_string())
+        })?;
 
-        Ok(
-            Arc::new(FTPObjectStore::new(user, password, host.to_string(), port))
-                as Arc<dyn ObjectStore>,
-        )
+        let mut client_timeout = None;
+        if let Some(timeout) = params.get("client_timeout") {
+            client_timeout = Some(fundu::parse_duration(timeout).map_err(|_| {
+                DataFusionError::Configuration(format!("Unable to parse timeout: {timeout}",))
+            })?);
+        }
+
+        Ok(Arc::new(FTPObjectStore::new(
+            user,
+            password,
+            host.to_string(),
+            port,
+            client_timeout,
+        )) as Arc<dyn ObjectStore>)
     }
 
     #[cfg(feature = "ftp")]
@@ -143,17 +160,23 @@ impl SpiceObjectStoreRegistry {
         let user = params.get("user").map(ToOwned::to_owned).ok_or_else(|| {
             DataFusionError::Configuration("No user provided for SFTP".to_string())
         })?;
-        let password = params
-            .get("password")
-            .map(ToOwned::to_owned)
-            .ok_or_else(|| {
-                DataFusionError::Configuration("No password provided for SFTP".to_string())
-            })?;
+        let password = params.get("pass").map(ToOwned::to_owned).ok_or_else(|| {
+            DataFusionError::Configuration("No password provided for SFTP".to_string())
+        })?;
+        let mut client_timeout = None;
+        if let Some(timeout) = params.get("client_timeout") {
+            client_timeout = Some(fundu::parse_duration(timeout).map_err(|_| {
+                DataFusionError::Configuration(format!("Unable to parse timeout: {timeout}",))
+            })?);
+        }
 
-        Ok(
-            Arc::new(SFTPObjectStore::new(user, password, host.to_string(), port))
-                as Arc<dyn ObjectStore>,
-        )
+        Ok(Arc::new(SFTPObjectStore::new(
+            user,
+            password,
+            host.to_string(),
+            port,
+            client_timeout,
+        )) as Arc<dyn ObjectStore>)
     }
 
     fn get_feature_store(url: &Url) -> datafusion::error::Result<Arc<dyn ObjectStore>> {

--- a/crates/runtime/src/objectstore/ftp.rs
+++ b/crates/runtime/src/objectstore/ftp.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::net::{SocketAddr, ToSocketAddrs};
 use std::ops::Range;
 use std::time::Duration;
 


### PR DESCRIPTION
## 🗣 Description

This adds `client_timeout` to all object stores

## 🔨 Related Issues

Fixes #2115 

## 🤔 Concerns

The original plan was to add a function in ObjectStoreRegistry trait `get_object_store_with_options` to allow object store creation with options. However, this approach has flaw that as object_store will be cached in registry which should include all possible options as cache key to differentiate object stores. If go with this approach, get_store and get_store_with_options could create potential conflicts.

