### PR TITLE
Fix misspelled acceleration engine name in benchmark tests

### DIFF
--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -132,7 +132,7 @@ async fn main() -> Result<(), String> {
     }
 
     let accelerators: Vec<Acceleration> = vec![
-        create_acceleration("arrrow", acceleration::Mode::Memory),
+        create_acceleration("arrow", acceleration::Mode::Memory),
         #[cfg(feature = "duckdb")]
         create_acceleration("duckdb", acceleration::Mode::Memory),
         #[cfg(feature = "duckdb")]


### PR DESCRIPTION
## 🗣 Description

Fix misspelled acceleration engine name in benchmark tests
