### PR TITLE
clear message when invalid params configured for accelerator

### DIFF
--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -114,10 +114,13 @@ pub trait DataAccelerator: Send + Sync {
         cmd: &CreateExternalTable,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
 
+    // The name of the accelerator
     fn name(&self) -> &'static str;
 
+    // The prefix of the table name
     fn prefix(&self) -> &'static str;
 
+    // The parameters of the accelerator
     fn parameters(&self) -> &'static [ParameterSpec];
 }
 
@@ -274,7 +277,6 @@ pub async fn create_accelerator_table(
     };
 
     let cloned_secrets = Arc::clone(&secrets);
-
     let secret_guard = cloned_secrets.read().await;
     let mut params_with_secrets: HashMap<String, SecretString> = HashMap::new();
 

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 use crate::component::dataset::acceleration::{self, Acceleration, Engine, IndexType, Mode};
-use crate::dataconnector::ParameterSpec;
+use crate::parameters::ParameterSpec;
+use crate::parameters::Parameters;
 use crate::secrets::{ExposeSecret, ParamStr, Secrets};
 use ::arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
@@ -42,8 +43,6 @@ use self::duckdb::DuckDBAccelerator;
 use self::postgres::PostgresAccelerator;
 #[cfg(feature = "sqlite")]
 use self::sqlite::SqliteAccelerator;
-
-pub type Parameters = crate::dataconnector::Parameters;
 
 pub mod arrow;
 #[cfg(feature = "duckdb")]
@@ -287,7 +286,7 @@ pub async fn create_accelerator_table(
     }
 
     let params = Parameters::try_new(
-        accelerator.name(),
+        &format!("accelerator {}", accelerator.name()),
         params_with_secrets.into_iter().collect::<Vec<_>>(),
         accelerator.prefix(),
         secrets,

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -24,7 +24,7 @@ use datafusion::{
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
-use crate::dataconnector::ParameterSpec;
+use crate::parameters::ParameterSpec;
 
 use super::DataAccelerator;
 

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -24,6 +24,8 @@ use datafusion::{
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
+use crate::dataconnector::ParameterSpec;
+
 use super::DataAccelerator;
 
 pub struct ArrowAccelerator {
@@ -51,6 +53,10 @@ impl DataAccelerator for ArrowAccelerator {
         self
     }
 
+    fn name(&self) -> &'static str {
+        "arrow"
+    }
+
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
     async fn create_external_table(
         &self,
@@ -60,5 +66,13 @@ impl DataAccelerator for ArrowAccelerator {
         TableProviderFactory::create(&self.arrow_factory, &ctx.state(), cmd)
             .await
             .boxed()
+    }
+
+    fn prefix(&self) -> &'static str {
+        "arrow"
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        &[]
     }
 }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -26,7 +26,7 @@ use duckdb::AccessMode;
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
-use crate::component::dataset::Dataset;
+use crate::{component::dataset::Dataset, dataconnector::ParameterSpec};
 
 use super::DataAccelerator;
 
@@ -78,10 +78,16 @@ impl Default for DuckDBAccelerator {
     }
 }
 
+const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::connector("file")];
+
 #[async_trait]
 impl DataAccelerator for DuckDBAccelerator {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn name(&self) -> &'static str {
+        "duckdb"
     }
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
@@ -104,6 +110,14 @@ impl DataAccelerator for DuckDBAccelerator {
 
         let deletion_adapter = DeletionTableProviderAdapter::new(duckdb_writer);
         Ok(Arc::new(deletion_adapter))
+    }
+
+    fn prefix(&self) -> &'static str {
+        "duckdb"
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -26,7 +26,7 @@ use duckdb::AccessMode;
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
-use crate::{component::dataset::Dataset, dataconnector::ParameterSpec};
+use crate::{component::dataset::Dataset, parameters::ParameterSpec};
 
 use super::DataAccelerator;
 
@@ -78,7 +78,7 @@ impl Default for DuckDBAccelerator {
     }
 }
 
-const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::connector("file")];
+const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::accelerator("file")];
 
 #[async_trait]
 impl DataAccelerator for DuckDBAccelerator {

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -27,7 +27,7 @@ use datafusion_table_providers::postgres::{
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
-use crate::dataconnector::ParameterSpec;
+use crate::parameters::ParameterSpec;
 
 use super::DataAccelerator;
 
@@ -61,13 +61,13 @@ impl Default for PostgresAccelerator {
 }
 
 const PARAMETERS: &[ParameterSpec] = &[
-    ParameterSpec::connector("host"),
-    ParameterSpec::connector("port"),
-    ParameterSpec::connector("db"),
-    ParameterSpec::connector("user").secret(),
-    ParameterSpec::connector("pass").secret(),
-    ParameterSpec::connector("sslmode"),
-    ParameterSpec::connector("sslrootcert"),
+    ParameterSpec::accelerator("host"),
+    ParameterSpec::accelerator("port"),
+    ParameterSpec::accelerator("db"),
+    ParameterSpec::accelerator("user").secret(),
+    ParameterSpec::accelerator("pass").secret(),
+    ParameterSpec::accelerator("sslmode"),
+    ParameterSpec::accelerator("sslrootcert"),
 ];
 
 #[async_trait]

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -27,6 +27,8 @@ use datafusion_table_providers::postgres::{
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
+use crate::dataconnector::ParameterSpec;
+
 use super::DataAccelerator;
 
 #[derive(Debug, Snafu)]
@@ -58,10 +60,24 @@ impl Default for PostgresAccelerator {
     }
 }
 
+const PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::connector("host"),
+    ParameterSpec::connector("port"),
+    ParameterSpec::connector("db"),
+    ParameterSpec::connector("user").secret(),
+    ParameterSpec::connector("pass").secret(),
+    ParameterSpec::connector("sslmode"),
+    ParameterSpec::connector("sslrootcert"),
+];
+
 #[async_trait]
 impl DataAccelerator for PostgresAccelerator {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn name(&self) -> &'static str {
+        "postgres"
     }
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
@@ -87,5 +103,13 @@ impl DataAccelerator for PostgresAccelerator {
 
         let deletion_adapter = DeletionTableProviderAdapter::new(postgres_writer);
         Ok(Arc::new(deletion_adapter))
+    }
+
+    fn prefix(&self) -> &'static str {
+        "pg"
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        PARAMETERS
     }
 }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -106,12 +106,10 @@ impl DataAccelerator for SqliteAccelerator {
         Ok(Arc::new(deletion_adapter))
     }
 
-    /// .
     fn prefix(&self) -> &'static str {
         "sqlite"
     }
 
-    /// .
     fn parameters(&self) -> &'static [ParameterSpec] {
         PARAMETERS
     }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -25,7 +25,7 @@ use datafusion_table_providers::sqlite::{write::SqliteTableWriter, SqliteTablePr
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
-use crate::{component::dataset::Dataset, dataconnector::ParameterSpec};
+use crate::{component::dataset::Dataset, parameters::ParameterSpec};
 
 use super::DataAccelerator;
 
@@ -72,7 +72,7 @@ impl Default for SqliteAccelerator {
     }
 }
 
-const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::connector("file")];
+const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::accelerator("file")];
 
 #[async_trait]
 impl DataAccelerator for SqliteAccelerator {

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -25,7 +25,7 @@ use datafusion_table_providers::sqlite::{write::SqliteTableWriter, SqliteTablePr
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
-use crate::component::dataset::Dataset;
+use crate::{component::dataset::Dataset, dataconnector::ParameterSpec};
 
 use super::DataAccelerator;
 
@@ -72,10 +72,16 @@ impl Default for SqliteAccelerator {
     }
 }
 
+const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::connector("file")];
+
 #[async_trait]
 impl DataAccelerator for SqliteAccelerator {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn name(&self) -> &'static str {
+        "sqlite"
     }
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
@@ -98,6 +104,16 @@ impl DataAccelerator for SqliteAccelerator {
 
         let deletion_adapter = DeletionTableProviderAdapter::new(sqlite_writer);
         Ok(Arc::new(deletion_adapter))
+    }
+
+    /// .
+    fn prefix(&self) -> &'static str {
+        "sqlite"
+    }
+
+    /// .
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -17,6 +17,8 @@ limitations under the License.
 use crate::component::catalog::Catalog;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
+use crate::parameters::ParameterSpec;
+use crate::parameters::Parameters;
 use crate::secrets::Secrets;
 use crate::Runtime;
 use arrow::datatypes::SchemaRef;
@@ -41,7 +43,7 @@ use datafusion::execution::SendableRecordBatchStream;
 use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::TableReference;
 use object_store::ObjectStore;
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::SecretString;
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;
@@ -178,12 +180,6 @@ pub enum DataConnectorError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Invalid configuration for {dataconnector}. {message}"))]
-    InvalidConfigurationNoSource {
-        dataconnector: String,
-        message: String,
-    },
-
     #[snafu(display(
         "Failed to get {dataconnector} data connector for dataset {dataset_name}. Table {table_name} not found. Ensure the table name is correctly spelled in the spicepod."
     ))]
@@ -215,6 +211,12 @@ pub enum DataConnectorError {
         dataconnector: String,
         code: String,
         source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Invalid configuration for {dataconnector}. {message}"))]
+    InvalidConfigurationNoSource {
+        dataconnector: String,
+        message: String,
     },
 }
 
@@ -255,7 +257,7 @@ pub async fn create_new_connector(
     let factory = connector_factory?;
 
     let params = match Parameters::try_new(
-        name,
+        &format!("connector {name}"),
         params.into_iter().collect(),
         factory.prefix(),
         secrets,
@@ -313,330 +315,6 @@ pub async fn register_all() {
         unity_catalog::UnityCatalogFactory::new_arc(),
     )
     .await;
-}
-
-#[derive(Clone)]
-pub struct Parameters {
-    params: Vec<(String, SecretString)>,
-    prefix: &'static str,
-    all_params: &'static [ParameterSpec],
-}
-
-#[derive(Debug, Clone)]
-pub struct UserParam(String);
-
-impl Display for UserParam {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-pub enum ParamLookup<'a> {
-    Present(&'a SecretString),
-    Absent(UserParam),
-}
-
-impl<'a> ParamLookup<'a> {
-    #[must_use]
-    pub fn ok(&self) -> Option<&'a SecretString> {
-        match self {
-            ParamLookup::Present(s) => Some(*s),
-            ParamLookup::Absent(_) => None,
-        }
-    }
-
-    #[must_use]
-    pub fn expose(self) -> ExposedParamLookup<'a> {
-        match self {
-            ParamLookup::Present(s) => ExposedParamLookup::Present(s.expose_secret()),
-            ParamLookup::Absent(s) => ExposedParamLookup::Absent(s),
-        }
-    }
-
-    pub fn ok_or_else<E>(self, f: impl FnOnce(UserParam) -> E) -> Result<&'a SecretString, E> {
-        match self {
-            ParamLookup::Present(s) => Ok(s),
-            ParamLookup::Absent(s) => Err(f(s)),
-        }
-    }
-}
-
-pub enum ExposedParamLookup<'a> {
-    Present(&'a str),
-    Absent(UserParam),
-}
-
-impl<'a> ExposedParamLookup<'a> {
-    #[must_use]
-    pub fn ok(self) -> Option<&'a str> {
-        match self {
-            ExposedParamLookup::Present(s) => Some(s),
-            ExposedParamLookup::Absent(_) => None,
-        }
-    }
-
-    pub fn ok_or_else<E>(self, f: impl FnOnce(UserParam) -> E) -> Result<&'a str, E> {
-        match self {
-            ExposedParamLookup::Present(s) => Ok(s),
-            ExposedParamLookup::Absent(s) => Err(f(s)),
-        }
-    }
-}
-
-impl Parameters {
-    pub async fn try_new(
-        connector_name: &str,
-        params: Vec<(String, SecretString)>,
-        prefix: &'static str,
-        secrets: Arc<RwLock<Secrets>>,
-        all_params: &'static [ParameterSpec],
-    ) -> AnyErrorResult<Self> {
-        let full_prefix = format!("{prefix}_");
-
-        // Convert the user-provided parameters into the format expected by the data connector
-        let mut params: Vec<(String, SecretString)> = params
-            .into_iter()
-            .filter_map(|(key, value)| {
-                let mut unprefixed_key = key.as_str();
-                let mut has_prefix = false;
-                if key.starts_with(&full_prefix) {
-                    has_prefix = true;
-                    unprefixed_key = &key[full_prefix.len()..];
-                }
-
-                let spec = all_params.iter().find(|p| p.name == unprefixed_key);
-
-                let Some(spec) = spec else {
-                    tracing::warn!("Ignoring parameter {key}: not supported for {connector_name}.");
-                    return None;
-                };
-
-                if !has_prefix && spec.r#type.is_prefixed() {
-                    tracing::warn!(
-                    "Ignoring parameter {key}: must be prefixed with `{full_prefix}` for {connector_name}."
-                );
-                    return None;
-                }
-
-                if has_prefix && !spec.r#type.is_prefixed() {
-                    tracing::warn!(
-                    "Ignoring parameter {key}: must not be prefixed with `{full_prefix}` for {connector_name}."
-                );
-                    return None;
-                }
-
-                Some((unprefixed_key.to_string(), value))
-            })
-            .collect();
-        let secret_guard = secrets.read().await;
-
-        // Try to autoload secrets that might be missing from params.
-        for secret_key in all_params.iter().filter(|p| p.secret) {
-            let secret_key_with_prefix = format!("{prefix}_{}", secret_key.name);
-            tracing::debug!(
-                "Attempting to autoload secret for {connector_name}: {secret_key_with_prefix}",
-            );
-            if params.iter().any(|p| p.0 == secret_key.name) {
-                continue;
-            }
-            let secret = secret_guard.get_secret(&secret_key_with_prefix).await;
-            if let Ok(Some(secret)) = secret {
-                tracing::debug!(
-                    "Autoloading secret for {connector_name}: {secret_key_with_prefix}",
-                );
-                // Insert without the prefix into the params
-                params.push((secret_key.name.to_string(), secret));
-            }
-        }
-
-        // Check if all required parameters are present
-        for parameter in all_params {
-            // If the parameter is missing and has a default value, add it to the params
-            let missing = !params.iter().any(|p| p.0 == parameter.name);
-            if missing {
-                if let Some(default_value) = parameter.default {
-                    params.push((parameter.name.to_string(), default_value.to_string().into()));
-                    continue;
-                }
-            }
-
-            if parameter.required && missing {
-                let param = if parameter.r#type.is_prefixed() {
-                    format!("{full_prefix}{}", parameter.name)
-                } else {
-                    parameter.name.to_string()
-                };
-
-                return Err(Box::new(DataConnectorError::InvalidConfigurationNoSource {
-                    dataconnector: connector_name.to_string(),
-                    message: format!("Missing required parameter: {param}"),
-                }));
-            }
-        }
-
-        Ok(Parameters::new(params, prefix, all_params))
-    }
-
-    #[must_use]
-    pub fn new(
-        params: Vec<(String, SecretString)>,
-        prefix: &'static str,
-        all_params: &'static [ParameterSpec],
-    ) -> Self {
-        Self {
-            params,
-            prefix,
-            all_params,
-        }
-    }
-
-    #[must_use]
-    pub fn to_secret_map(&self) -> HashMap<String, SecretString> {
-        self.params.iter().cloned().collect()
-    }
-
-    /// Returns the `SecretString` for the given parameter, or the user-facing parameter name of the missing parameter.
-    #[must_use]
-    pub fn get<'a>(&'a self, name: &str) -> ParamLookup<'a> {
-        if let Some(param_value) = self.params.iter().find(|p| p.0 == name) {
-            ParamLookup::Present(&param_value.1)
-        } else {
-            ParamLookup::Absent(self.user_param(name))
-        }
-    }
-
-    /// Gets the `ParameterSpec` for the given parameter name.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the parameter is not found in the `all_params` list, as this is a programming error.
-    #[must_use]
-    pub fn describe(&self, name: &str) -> &ParameterSpec {
-        if let Some(spec) = self.all_params.iter().find(|p| p.name == name) {
-            spec
-        } else {
-            panic!("Parameter `{name}` not found in parameters list. Add it to the parameters() list on the DataConnectorFactory.");
-        }
-    }
-
-    /// Retrieves the user-facing parameter name for the given parameter.
-    #[must_use]
-    pub fn user_param(&self, name: &str) -> UserParam {
-        let spec = self.describe(name);
-
-        if self.prefix.is_empty() || !spec.r#type.is_prefixed() {
-            UserParam(spec.name.to_string())
-        } else {
-            UserParam(format!("{}_{}", self.prefix, spec.name))
-        }
-    }
-}
-
-pub struct ParameterSpec {
-    pub name: &'static str,
-    pub required: bool,
-    pub default: Option<&'static str>,
-    pub secret: bool,
-    pub description: &'static str,
-    pub help_link: &'static str,
-    pub examples: &'static [&'static str],
-    pub r#type: ParameterType,
-}
-
-impl ParameterSpec {
-    #[must_use]
-    pub const fn connector(name: &'static str) -> Self {
-        Self {
-            name,
-            required: false,
-            default: None,
-            secret: false,
-            description: "",
-            help_link: "",
-            examples: &[],
-            r#type: ParameterType::Connector,
-        }
-    }
-
-    #[must_use]
-    pub const fn runtime(name: &'static str) -> Self {
-        Self {
-            name,
-            required: false,
-            default: None,
-            secret: false,
-            description: "",
-            help_link: "",
-            examples: &[],
-            r#type: ParameterType::Runtime,
-        }
-    }
-
-    #[must_use]
-    pub const fn required(mut self) -> Self {
-        self.required = true;
-        self
-    }
-
-    #[must_use]
-    pub const fn default(mut self, default: &'static str) -> Self {
-        self.default = Some(default);
-        self
-    }
-
-    #[must_use]
-    pub const fn secret(mut self) -> Self {
-        self.secret = true;
-        self
-    }
-
-    #[must_use]
-    pub const fn description(mut self, description: &'static str) -> Self {
-        self.description = description;
-        self
-    }
-
-    #[must_use]
-    pub const fn help_link(mut self, help_link: &'static str) -> Self {
-        self.help_link = help_link;
-        self
-    }
-
-    #[must_use]
-    pub const fn examples(mut self, examples: &'static [&'static str]) -> Self {
-        self.examples = examples;
-        self
-    }
-}
-
-#[derive(Default, Clone, Copy, PartialEq)]
-pub enum ParameterType {
-    /// A parameter which tells Spice how to connect to the underlying data source.
-    ///
-    /// These parameters are automatically prefixed with the data connector's prefix.
-    ///
-    /// # Examples
-    ///
-    /// In Postgres, the `host` is a Connector parameter and would be auto-prefixed with `pg_`.
-    #[default]
-    Connector,
-    /// Other parameters which control how the runtime interacts with the data source, but does
-    /// not affect the actual connection.
-    ///
-    /// These parameters are not prefixed with the data connector's prefix.
-    ///
-    /// # Examples
-    ///
-    /// In Databricks, the `mode` parameter is used to select which connection to use, and thus is
-    /// not a Connector parameter.
-    Runtime,
-}
-
-impl ParameterType {
-    #[must_use]
-    pub const fn is_prefixed(&self) -> bool {
-        matches!(self, Self::Connector)
-    }
 }
 
 pub trait DataConnectorFactory: Send + Sync {

--- a/crates/runtime/src/dataconnector/clickhouse.rs
+++ b/crates/runtime/src/dataconnector/clickhouse.rs
@@ -34,9 +34,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
-use super::{
-    DataConnector, DataConnectorError, DataConnectorFactory, ParamLookup, ParameterSpec, Parameters,
-};
+use super::{DataConnector, DataConnectorError, DataConnectorFactory, Parameters};
+use crate::parameters::{ParamLookup, ParameterSpec};
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -159,7 +159,7 @@ impl Databricks {
         let factory = DatabricksFactory::new();
 
         let params = Parameters::try_new(
-            "databricks",
+            "connector databricks",
             dataset_params.into_iter().collect(),
             factory.prefix(),
             runtime.secrets(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -88,6 +88,7 @@ pub mod model;
 pub mod object_store_registry;
 pub mod objectstore;
 mod opentelemetry;
+mod parameters;
 pub mod podswatcher;
 pub mod secrets;
 pub mod spice_metrics;

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -22,7 +22,7 @@ impl Parameters {
     ) -> AnyErrorResult<Self> {
         let full_prefix = format!("{prefix}_");
 
-        // Convert the user-provided parameters into the format expected by the data connector
+        // Convert the user-provided parameters into the format expected by the component
         let mut params: Vec<(String, SecretString)> = params
             .into_iter()
             .filter_map(|(key, value)| {

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -1,0 +1,372 @@
+use std::{collections::HashMap, fmt::Display, sync::Arc};
+
+use secrecy::{ExposeSecret, SecretString};
+use snafu::prelude::*;
+use tokio::sync::RwLock;
+
+pub type AnyErrorResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+use crate::secrets::Secrets;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Invalid configuration for {component}. {message}"))]
+    InvalidConfigurationNoSource { component: String, message: String },
+}
+impl Parameters {
+    pub async fn try_new(
+        component_name: &str,
+        params: Vec<(String, SecretString)>,
+        prefix: &'static str,
+        secrets: Arc<RwLock<Secrets>>,
+        all_params: &'static [ParameterSpec],
+    ) -> AnyErrorResult<Self> {
+        let full_prefix = format!("{prefix}_");
+
+        // Convert the user-provided parameters into the format expected by the data connector
+        let mut params: Vec<(String, SecretString)> = params
+            .into_iter()
+            .filter_map(|(key, value)| {
+                let mut unprefixed_key = key.as_str();
+                let mut has_prefix = false;
+                if key.starts_with(&full_prefix) {
+                    has_prefix = true;
+                    unprefixed_key = &key[full_prefix.len()..];
+                }
+
+                let spec = all_params.iter().find(|p| p.name == unprefixed_key);
+
+                let Some(spec) = spec else {
+                    tracing::warn!("Ignoring parameter {key}: not supported for {component_name}.");
+                    return None;
+                };
+
+                if !has_prefix && spec.r#type.is_prefixed() {
+                    tracing::warn!(
+                    "Ignoring parameter {key}: must be prefixed with `{full_prefix}` for {component_name}."
+                );
+                    return None;
+                }
+
+                if has_prefix && !spec.r#type.is_prefixed() {
+                    tracing::warn!(
+                    "Ignoring parameter {key}: must not be prefixed with `{full_prefix}` for {component_name}."
+                );
+                    return None;
+                }
+
+                Some((unprefixed_key.to_string(), value))
+            })
+            .collect();
+        let secret_guard = secrets.read().await;
+
+        // Try to autoload secrets that might be missing from params.
+        for secret_key in all_params.iter().filter(|p| p.secret) {
+            let secret_key_with_prefix = format!("{prefix}_{}", secret_key.name);
+            tracing::debug!(
+                "Attempting to autoload secret for {component_name}: {secret_key_with_prefix}",
+            );
+            if params.iter().any(|p| p.0 == secret_key.name) {
+                continue;
+            }
+            let secret = secret_guard.get_secret(&secret_key_with_prefix).await;
+            if let Ok(Some(secret)) = secret {
+                tracing::debug!(
+                    "Autoloading secret for {component_name}: {secret_key_with_prefix}",
+                );
+                // Insert without the prefix into the params
+                params.push((secret_key.name.to_string(), secret));
+            }
+        }
+
+        // Check if all required parameters are present
+        for parameter in all_params {
+            // If the parameter is missing and has a default value, add it to the params
+            let missing = !params.iter().any(|p| p.0 == parameter.name);
+            if missing {
+                if let Some(default_value) = parameter.default {
+                    params.push((parameter.name.to_string(), default_value.to_string().into()));
+                    continue;
+                }
+            }
+
+            if parameter.required && missing {
+                let param = if parameter.r#type.is_prefixed() {
+                    format!("{full_prefix}{}", parameter.name)
+                } else {
+                    parameter.name.to_string()
+                };
+
+                return Err(Box::new(Error::InvalidConfigurationNoSource {
+                    component: component_name.to_string(),
+                    message: format!("Missing required parameter: {param}"),
+                }));
+            }
+        }
+
+        Ok(Parameters::new(params, prefix, all_params))
+    }
+
+    #[must_use]
+    pub fn new(
+        params: Vec<(String, SecretString)>,
+        prefix: &'static str,
+        all_params: &'static [ParameterSpec],
+    ) -> Self {
+        Self {
+            params,
+            prefix,
+            all_params,
+        }
+    }
+
+    #[must_use]
+    pub fn to_secret_map(&self) -> HashMap<String, SecretString> {
+        self.params.iter().cloned().collect()
+    }
+
+    /// Returns the `SecretString` for the given parameter, or the user-facing parameter name of the missing parameter.
+    #[must_use]
+    pub fn get<'a>(&'a self, name: &str) -> ParamLookup<'a> {
+        if let Some(param_value) = self.params.iter().find(|p| p.0 == name) {
+            ParamLookup::Present(&param_value.1)
+        } else {
+            ParamLookup::Absent(self.user_param(name))
+        }
+    }
+
+    /// Gets the `ParameterSpec` for the given parameter name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the parameter is not found in the `all_params` list, as this is a programming error.
+    #[must_use]
+    pub fn describe(&self, name: &str) -> &ParameterSpec {
+        if let Some(spec) = self.all_params.iter().find(|p| p.name == name) {
+            spec
+        } else {
+            panic!("Parameter `{name}` not found in parameters list. Add it to the parameters() list on the DataConnectorFactory or DataAccelerator.");
+        }
+    }
+
+    /// Retrieves the user-facing parameter name for the given parameter.
+    #[must_use]
+    pub fn user_param(&self, name: &str) -> UserParam {
+        let spec = self.describe(name);
+
+        if self.prefix.is_empty() || !spec.r#type.is_prefixed() {
+            UserParam(spec.name.to_string())
+        } else {
+            UserParam(format!("{}_{}", self.prefix, spec.name))
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Parameters {
+    params: Vec<(String, SecretString)>,
+    prefix: &'static str,
+    all_params: &'static [ParameterSpec],
+}
+
+#[derive(Debug, Clone)]
+pub struct UserParam(pub String);
+
+impl Display for UserParam {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub enum ParamLookup<'a> {
+    Present(&'a SecretString),
+    Absent(UserParam),
+}
+
+impl<'a> ParamLookup<'a> {
+    #[must_use]
+    pub fn ok(&self) -> Option<&'a SecretString> {
+        match self {
+            ParamLookup::Present(s) => Some(*s),
+            ParamLookup::Absent(_) => None,
+        }
+    }
+
+    #[must_use]
+    pub fn expose(self) -> ExposedParamLookup<'a> {
+        match self {
+            ParamLookup::Present(s) => ExposedParamLookup::Present(s.expose_secret()),
+            ParamLookup::Absent(s) => ExposedParamLookup::Absent(s),
+        }
+    }
+
+    pub fn ok_or_else<E>(self, f: impl FnOnce(UserParam) -> E) -> Result<&'a SecretString, E> {
+        match self {
+            ParamLookup::Present(s) => Ok(s),
+            ParamLookup::Absent(s) => Err(f(s)),
+        }
+    }
+}
+
+pub enum ExposedParamLookup<'a> {
+    Present(&'a str),
+    Absent(UserParam),
+}
+
+impl<'a> ExposedParamLookup<'a> {
+    #[must_use]
+    pub fn ok(self) -> Option<&'a str> {
+        match self {
+            ExposedParamLookup::Present(s) => Some(s),
+            ExposedParamLookup::Absent(_) => None,
+        }
+    }
+
+    pub fn ok_or_else<E>(self, f: impl FnOnce(UserParam) -> E) -> Result<&'a str, E> {
+        match self {
+            ExposedParamLookup::Present(s) => Ok(s),
+            ExposedParamLookup::Absent(s) => Err(f(s)),
+        }
+    }
+}
+
+pub struct ParameterSpec {
+    pub name: &'static str,
+    pub required: bool,
+    pub default: Option<&'static str>,
+    pub secret: bool,
+    pub description: &'static str,
+    pub help_link: &'static str,
+    pub examples: &'static [&'static str],
+    pub r#type: ParameterType,
+}
+
+impl ParameterSpec {
+    #[must_use]
+    pub const fn connector(name: &'static str) -> Self {
+        Self {
+            name,
+            required: false,
+            default: None,
+            secret: false,
+            description: "",
+            help_link: "",
+            examples: &[],
+            r#type: ParameterType::Connector,
+        }
+    }
+
+    #[must_use]
+    pub const fn runtime(name: &'static str) -> Self {
+        Self {
+            name,
+            required: false,
+            default: None,
+            secret: false,
+            description: "",
+            help_link: "",
+            examples: &[],
+            r#type: ParameterType::Runtime,
+        }
+    }
+
+    #[must_use]
+    pub const fn accelerator(name: &'static str) -> Self {
+        Self {
+            name,
+            required: false,
+            default: None,
+            secret: false,
+            description: "",
+            help_link: "",
+            examples: &[],
+            r#type: ParameterType::Accelerator,
+        }
+    }
+
+    #[must_use]
+    pub const fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+
+    #[must_use]
+    pub const fn default(mut self, default: &'static str) -> Self {
+        self.default = Some(default);
+        self
+    }
+
+    #[must_use]
+    pub const fn secret(mut self) -> Self {
+        self.secret = true;
+        self
+    }
+
+    #[must_use]
+    pub const fn description(mut self, description: &'static str) -> Self {
+        self.description = description;
+        self
+    }
+
+    #[must_use]
+    pub const fn help_link(mut self, help_link: &'static str) -> Self {
+        self.help_link = help_link;
+        self
+    }
+
+    #[must_use]
+    pub const fn examples(mut self, examples: &'static [&'static str]) -> Self {
+        self.examples = examples;
+        self
+    }
+}
+
+#[derive(Default, Clone, Copy, PartialEq)]
+pub enum ParameterType {
+    /// A parameter which tells Spice how to connect to the underlying data source.
+    ///
+    /// These parameters are automatically prefixed with the data connector's prefix.
+    ///
+    /// # Examples
+    ///
+    /// In Postgres, the `host` is a Connector parameter and would be auto-prefixed with `pg_`.
+    #[default]
+    Connector,
+
+    /// A parameter which tells Spice how to connect to the underlying data accelerator.
+    ///
+    /// These parameters are automatically prefixed with the data accelerator's prefix.
+    ///
+    /// # Examples
+    ///
+    /// In Postgres, the `host` is an Accelerator parameter and would be auto-prefixed with `pg_`.
+    Accelerator,
+
+    /// Other parameters which control how the runtime interacts with the data source, but does
+    /// not affect the actual connection.
+    ///
+    /// These parameters are not prefixed with the data connector's prefix.
+    ///
+    /// # Examples
+    ///
+    /// In Databricks, the `mode` parameter is used to select which connection to use, and thus is
+    /// not a Connector parameter.
+    Runtime,
+}
+
+// Display implementation for ParameterType
+impl Display for ParameterType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParameterType::Connector => write!(f, "Connector"),
+            ParameterType::Accelerator => write!(f, "Accelerator"),
+            ParameterType::Runtime => write!(f, "Runtime"),
+        }
+    }
+}
+
+impl ParameterType {
+    #[must_use]
+    pub const fn is_prefixed(self) -> bool {
+        matches!(self, Self::Connector | Self::Accelerator)
+    }
+}


### PR DESCRIPTION
This extends parameters support onto accelerator, so it gives same experience when configuring params in data connector.

Fix #1255 