### PR TITLE
Benchmark: Discard first measurement of sql query, disable result caching

### DIFF
--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -185,6 +185,10 @@ async fn run_query_and_record_result(
     query_name: &str,
     query: &str,
 ) -> Result<(), String> {
+    // Additional round of query run before recording results.
+    // To discard the abnormal results caused by: establishing initial connection / spark cluster startup time
+    let _ = run_query(rt, connector, query_name, query).await;
+
     tracing::info!("Running query `{connector}` `{query_name}`...");
     let start_time = get_current_unix_ms();
 

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -71,13 +71,6 @@ fn build_app(
     connector: &str,
     acceleration: Option<&Acceleration>,
 ) -> App {
-    // Disable result caching in benchmark test
-    let results_cache = ResultsCache {
-        enabled: false,
-        cache_max_size: None,
-        item_ttl: None,
-        eviction_policy: None,
-    };
     let mut app_builder =
         AppBuilder::new("runtime_benchmark_test").with_results_cache(results_cache);
 

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -17,9 +17,8 @@ limitations under the License.
 use crate::results::BenchmarkResultsBuilder;
 use app::{App, AppBuilder};
 use runtime::{dataupdate::DataUpdate, Runtime};
-use spicepod::component::{
-    dataset::{acceleration::Acceleration, replication::Replication, Dataset, Mode},
-    runtime::ResultsCache,
+use spicepod::component::dataset::{
+    acceleration::Acceleration, replication::Replication, Dataset, Mode,
 };
 use std::process::Command;
 use tracing_subscriber::EnvFilter;
@@ -71,8 +70,7 @@ fn build_app(
     connector: &str,
     acceleration: Option<&Acceleration>,
 ) -> App {
-    let mut app_builder =
-        AppBuilder::new("runtime_benchmark_test").with_results_cache(results_cache);
+    let mut app_builder = AppBuilder::new("runtime_benchmark_test");
 
     app_builder = match connector {
         "spice.ai" => app_builder

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -17,8 +17,9 @@ limitations under the License.
 use crate::results::BenchmarkResultsBuilder;
 use app::{App, AppBuilder};
 use runtime::{dataupdate::DataUpdate, Runtime};
-use spicepod::component::dataset::{
-    acceleration::Acceleration, replication::Replication, Dataset, Mode,
+use spicepod::component::{
+    dataset::{acceleration::Acceleration, replication::Replication, Dataset, Mode},
+    runtime::ResultsCache,
 };
 use std::process::Command;
 use tracing_subscriber::EnvFilter;
@@ -70,7 +71,15 @@ fn build_app(
     connector: &str,
     acceleration: Option<&Acceleration>,
 ) -> App {
-    let mut app_builder = AppBuilder::new("runtime_benchmark_test");
+    // Disable result caching in benchmark test
+    let results_cache = ResultsCache {
+        enabled: false,
+        cache_max_size: None,
+        item_ttl: None,
+        eviction_policy: None,
+    };
+    let mut app_builder =
+        AppBuilder::new("runtime_benchmark_test").with_results_cache(results_cache);
 
     app_builder = match connector {
         "spice.ai" => app_builder


### PR DESCRIPTION
## 🗣 Description

Updates to ensure fair sql query results in benchmark tests;
* Discard the first measurement of sql query. This is to discard the abnormal results caused by warm up: e.g. starting up spark cluster, establish new connection
* Disable results caching in benchmark tests. This ensures the later iterations of query don't directly get results from cache.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->