### PR TITLE
 Benchmark: use SF1 for MySQL TPC-H tests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -79,7 +79,7 @@ jobs:
           MYSQL_BENCHMARK_MYSQL_HOST: localhost
           MYSQL_BENCHMARK_MYSQL_USER: root
           MYSQL_BENCHMARK_MYSQL_PASS: root
-          MYSQL_BENCHMARK_MYSQL_DB: tpch_sf0_01
+          MYSQL_BENCHMARK_MYSQL_DB: tpch_sf1
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_ODBC_PATH: ${{ secrets.DATABRICKS_ODBC_PATH }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}

--- a/.github/workflows/spice_mysql_bench_docker.yml
+++ b/.github/workflows/spice_mysql_bench_docker.yml
@@ -30,10 +30,10 @@ jobs:
       working-directory: ./test/tpch
       run: |
         make tpch-init
-        for sf in 0.01 0.05 1; do
+        for sf in 0.01 1; do
           DB_NAME=tpch_sf${sf//./_}
           DBGEN_SCALE=$sf make tpch-gen
-          DB_HOST=127.0.0.1 DB_PORT=3306 DB_USER=root DB_PASS=root DB_NAME=$DB_NAME make mysql-init
+          DB_HOST=127.0.0.1 DB_PORT=3306 DB_USER=root DB_PASS=root DB_NAME=$DB_NAME ADD_INDEXES=true make mysql-init
           DB_HOST=127.0.0.1 DB_PORT=3306 DB_USER=root DB_PASS=root DB_NAME=$DB_NAME make mysql-load
           echo "CREATE DATABASE IF NOT EXISTS $DB_NAME;" >mysql-bench/backup_$DB_NAME.sql
           echo "USE $DB_NAME;" >> mysql-bench/backup_$DB_NAME.sql

--- a/test/tpch/Makefile
+++ b/test/tpch/Makefile
@@ -60,11 +60,9 @@ pg-init:
 
 # Example: DB_HOST=localhost DB_PORT=5432 DB_USER=postgres DB_NAME=tpch make pg-load
 pg-load:
-	@for i in tpch-kit/dbgen/*.tbl; do \
-		table=$$(basename $$i .tbl); \
+	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' $$i > ./tmp/$$table.tbl; \
-		psql -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USER} $(DB_NAME) -q -c "TRUNCATE $$table"; \
+		sed 's/|$$//' tpch-kit/dbgen/$$table.tbl > ./tmp/$$table.tbl; \
 		psql -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USER} $(DB_NAME) -c "\\copy $$table FROM './tmp/$$table.tbl' CSV DELIMITER '|';"; \
 	done
 	@echo "Benchmark dataset has been successfully loaded to $(DB_NAME) database"
@@ -73,7 +71,7 @@ pg-load:
 tpch-run-pq:
 	psql $(DB_NAME) < ./tpch_queries.sql
 
-# Example: DB_HOST=localhost DB_PORT=3306 DB_USER=root DB_PASS=root DB_NAME=tpch make mysql-init
+# Example: DB_HOST=localhost DB_PORT=3306 DB_USER=root DB_PASS=root DB_NAME=tpch ADD_INDEXES=true make mysql-init
 mysql-init:
 	@echo "Checking if database '$(DB_NAME)' exists..."
 	@if mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) -e "USE $(DB_NAME);" 2>/dev/null; then \
@@ -91,16 +89,20 @@ mysql-init:
 	@echo "Creating tables from dss.ddl..."
 	@mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) $(DB_NAME) < ./tpch-kit/dbgen/dss.ddl
 
+	@if [ "$(ADD_INDEXES)" = "true" ] || [ "$(ADD_INDEXES)" = "1" ]; then \
+		echo "Applying indexes from tpch_index.sql..."; \
+		mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) $(DB_NAME) < tpch_index.sql; \
+		echo "Indexes applied successfully."; \
+	fi
+
 	@echo "Database '$(DB_NAME)' has been successfully created or updated."
 
 # Example: DB_HOST=localhost DB_PORT=3306 DB_USER=root DB_PASS=root DB_NAME=tpch make mysql-load
 mysql-load:
 	@mkdir -p ./tmp
-	@for i in tpch-kit/dbgen/*.tbl; do \
-		table=$$(basename $$i .tbl); \
+	@for table in region nation customer supplier part partsupp orders lineitem; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' $$i > ./tmp/$$table.tbl; \
-		mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) $(DB_NAME) -e "TRUNCATE TABLE $$table;"; \
+		sed 's/|$$//' tpch-kit/dbgen/$$table.tbl > ./tmp/$$table.tbl; \
 		mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) --local-infile=1 $(DB_NAME) -e "LOAD DATA LOCAL INFILE './tmp/$$table.tbl' INTO TABLE $$table FIELDS TERMINATED BY '|' LINES TERMINATED BY '\n';"; \
 	done
 	@echo "Benchmark dataset has been successfully loaded to '$(DB_NAME)' database."

--- a/test/tpch/mysql-bench/Dockerfile
+++ b/test/tpch/mysql-bench/Dockerfile
@@ -4,4 +4,6 @@ ENV MYSQL_ROOT_PASSWORD=root
 
 COPY backup_*.sql /docker-entrypoint-initdb.d/
 
+COPY ./conf.d/my.cnf /etc/mysql/conf.d/my.cnf
+
 EXPOSE 3306

--- a/test/tpch/mysql-bench/conf.d/my.cnf
+++ b/test/tpch/mysql-bench/conf.d/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+innodb_buffer_pool_size=2G

--- a/test/tpch/tpch_index.sql
+++ b/test/tpch/tpch_index.sql
@@ -1,0 +1,32 @@
+-- Indexes for TPC-H queries optimization
+
+-- Primary keys
+ALTER TABLE region ADD PRIMARY KEY (r_regionkey);
+ALTER TABLE nation ADD PRIMARY KEY (n_nationkey);
+ALTER TABLE part ADD PRIMARY KEY (p_partkey);
+ALTER TABLE supplier ADD PRIMARY KEY (s_suppkey);
+ALTER TABLE partsupp ADD PRIMARY KEY (ps_partkey, ps_suppkey);
+ALTER TABLE customer ADD PRIMARY KEY (c_custkey);
+ALTER TABLE lineitem ADD PRIMARY KEY (l_orderkey, l_linenumber);
+ALTER TABLE orders ADD PRIMARY KEY (o_orderkey);
+
+-- Indexes
+CREATE INDEX idx_region_name ON region(r_name);
+
+CREATE INDEX idx_nation_region ON nation(n_regionkey);
+
+CREATE INDEX idx_supplier_nation ON supplier(s_nationkey);
+CREATE INDEX idx_supplier_suppkey ON supplier(s_suppkey);
+
+CREATE INDEX idx_customer_nation ON customer(c_nationkey);
+CREATE INDEX idx_customer_custkey ON customer(c_custkey);
+
+CREATE INDEX idx_orders_custkey_orderdate ON orders(o_custkey, o_orderdate);
+CREATE INDEX idx_orders_orderkey ON orders(o_orderkey);
+
+CREATE INDEX idx_lineitem_suppkey ON lineitem(l_suppkey);
+CREATE INDEX idx_lineitem_partkey ON lineitem(l_partkey);
+CREATE INDEX idx_lineitem_orderkey ON lineitem(l_orderkey);
+
+CREATE INDEX idx_partsupp_supplier ON partsupp(ps_suppkey);
+CREATE INDEX idx_partsupp_part ON partsupp(ps_partkey);


### PR DESCRIPTION
## 🗣 Description

PR adds indexes for MySQL TPC-H test data  and additional server configuration to optimize queries so that can handle SF1.

Example test run: https://github.com/spiceai/spiceai/actions/runs/10234963303 

## 🔨 Related Issues

https://github.com/spiceai/spiceai/issues/2174