### PR TITLE
Pin actions/upload-artifact to v4.3.4

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -156,13 +156,15 @@ jobs:
         if: matrix.target_os == 'windows'
         run: ./spiced.exe --version
 
-      - uses: actions/upload-artifact@v4
+      # Verify https://github.com/actions/upload-artifact/issues/591 is fixed before upgrading.
+      - uses: actions/upload-artifact@v4.3.4
         if: matrix.target_os != 'windows'
         with:
           name: spiced_${{ matrix.target_os }}_${{ matrix.target_arch }}
           path: spiced_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
 
-      - uses: actions/upload-artifact@v4
+      # Verify https://github.com/actions/upload-artifact/issues/591 is fixed before upgrading.
+      - uses: actions/upload-artifact@v4.3.4
         if: matrix.target_os == 'windows'
         with:
           name: spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}


### PR DESCRIPTION
## 🗣 Description

The latest `actions/upload-artifact` version broke our release pipeline by changing the chunk upload timeout from 5 minutes to 30 seconds. I've filed a bug report here: https://github.com/actions/upload-artifact/issues/591

Until that is fixed, pin our release pipeline to the previous version: v4.3.4