### PR TITLE
add client timeout for deltalake connector

### DIFF
--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -57,6 +57,8 @@ impl DeltaLakeFactory {
 }
 
 const PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::runtime("client_timeout")
+        .description("The timeout setting for object store client."),
     // S3 storage options
     ParameterSpec::connector("aws_region")
         .description("The AWS region to use for S3 storage.")


### PR DESCRIPTION
## 🗣 Description

`client_timeout` setting for delta lake. This is to avoid when opening large parquet files in deltalake, object store clients time out resulting in errors.

Part of #2198 .