### PR TITLE
Upgrade tonic and opentelemetry-proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127ea5e585a12ec9f742232442828ebaf264dfa5eefdd71282376c599562b77"
+checksum = "05048a8932648b63f21c37d88b552ccc8a65afb6dfe9fc9f30ce79174c2e7a85"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add7f39210b7d726e2a8efc0083e7bf06e8f2d15bdb4896b564dce4410fbf5d"
+checksum = "1d8a57966e43bfe9a3277984a14c24ec617ad874e4c0e1d2a1b083a39cfbf22c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c16ec702d3898c2f5cfdc148443c6cd7dbe5bac28399859eb0a3d38f072827"
+checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae6970bab043c4fbc10aee1660ceb5b306d0c42c8cc5f6ae564efcd9759b663"
+checksum = "c975484888fc95ec4a632cdc98be39c085b1bb518531b0c80c5d462063e5daa1"
 dependencies = [
  "bytes",
  "half",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7ef44f26ef4f8edc392a048324ed5d757ad09135eff6d5509e6450d39e0398"
+checksum = "da26719e76b81d8bc3faad1d4dbdc1bcc10d14704e63dc17fc9f3e7e1e567c8e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f843490bd258c5182b66e888161bb6f198f49f3792f7c7f98198b924ae0f564"
+checksum = "c13c36dc5ddf8c128df19bab27898eea64bf9da2b555ec1cd17a8ff57fba9ec2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a769666ffac256dd301006faca1ca553d0ae7cffcf4cd07095f73f95eb226514"
+checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403acefc53178d88540631c454b088300ba14ba49dd7e5f05abe3bf226fbccbb"
+checksum = "8e7ffbc96072e466ae5188974725bb46757587eafe427f77a25b828c375ae882"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -384,14 +384,14 @@ dependencies = [
  "prost 0.12.6",
  "prost-types",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf9c3fb57390a1af0b7bb3b5558c1ee1f63905f3eccf49ae7676a8d1e6e5a72"
+checksum = "e786e1cdd952205d9a8afc69397b317cfbb6e0095e445c69cda7e8da5c1eeb0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e7f3724176b66ddfacba31af397c48e106fbe4d281c8144e7d237df5acfd7"
+checksum = "fb22284c5a2a01d73cebfd88a33511a3234ab45d66086b2ca2d1228c3498e445"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8008370e624e8e3c68174faaf793540287106cfda8ad1da862fdc53d8e096b4"
+checksum = "42745f86b1ab99ef96d1c0bcf49180848a64fe2c7a7a0d945bc64fa2b21ba9bc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5e3a6b7fda8d9fe03f3b18a2d946354ea7f3c8e4076dbdb502ad50d9d44824"
+checksum = "4cd09a518c602a55bd406bcc291a967b284cfa7a63edfbf8b897ea4748aad23c"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -461,23 +461,22 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab1c12b40e29d9f3b699e0203c2a73ba558444c05e388a4377208f8f9c97eee"
+checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80159088ffe8c48965cb9b1a7c968b2729f29f37363df7eca177fc3281fe7c3"
+checksum = "600bae05d43483d216fb3494f8c32fdbefd8aa4e1de237e790dbb3d9f44690a3"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -489,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd04a6ea7de183648edbcb7a6dd925bbd04c210895f6384c780e27a9b54afcd"
+checksum = "f0dc1985b67cb45f6606a248ac2b4a288849f196bab8c657ea5589f47cdd55e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2777,7 +2776,7 @@ dependencies = [
  "spark-connect-rs",
  "tokio",
  "tokio-postgres",
- "tonic 0.12.1",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3772,7 +3771,7 @@ dependencies = [
  "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "snafu 0.8.4",
- "tonic 0.12.1",
+ "tonic",
 ]
 
 [[package]]
@@ -3785,7 +3784,7 @@ dependencies = [
  "futures",
  "parquet",
  "tokio",
- "tonic 0.12.1",
+ "tonic",
 ]
 
 [[package]]
@@ -3803,7 +3802,7 @@ dependencies = [
  "reqwest 0.11.27",
  "rustyline",
  "serde_json",
- "tonic 0.12.1",
+ "tonic",
 ]
 
 [[package]]
@@ -3814,7 +3813,7 @@ dependencies = [
  "clap",
  "futures",
  "tokio",
- "tonic 0.12.1",
+ "tonic",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4784,19 +4783,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
-dependencies = [
- "hyper 1.4.1",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -6791,9 +6777,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6805,34 +6791,31 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
- "hex",
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.1",
- "serde",
- "tonic 0.12.1",
+ "prost 0.12.6",
+ "tonic",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.24.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
+ "lazy_static",
  "once_cell",
  "opentelemetry",
- "percent-encoding",
- "rand",
- "serde_json",
+ "ordered-float 4.2.1",
  "thiserror",
 ]
 
@@ -6957,9 +6940,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f22ba0d95db56dde8685e3fadcb915cdaadda31ab8abbe3ff7f0ad1ef333267"
+checksum = "e977b9066b4d3b03555c22bdc442f3fadebd96a39111249113087d0edb2691cd"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -7432,16 +7415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
-dependencies = [
- "bytes",
- "prost-derive 0.13.1",
-]
-
-[[package]]
 name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7483,19 +7456,6 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.71",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
-dependencies = [
- "anyhow",
- "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.71",
@@ -8251,7 +8211,7 @@ dependencies = [
  "tokio",
  "tokio-rusqlite",
  "tokio-rustls 0.26.0",
- "tonic 0.12.1",
+ "tonic",
  "tonic-health",
  "tracing",
  "tracing-subscriber",
@@ -9114,7 +9074,7 @@ dependencies = [
  "rand",
  "serde_json",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
  "tonic-build",
  "url",
  "uuid 1.10.0",
@@ -9942,11 +9902,12 @@ dependencies = [
  "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
+ "flate2",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout 0.4.1",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project",
  "prost 0.12.6",
@@ -9955,39 +9916,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.7.5",
- "base64 0.22.1",
- "bytes",
- "h2 0.4.5",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-timeout 0.5.1",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.1",
- "rustls-native-certs 0.7.1",
- "rustls-pemfile 2.1.2",
- "socket2 0.5.7",
- "tokio",
- "tokio-rustls 0.26.0",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -10010,15 +9938,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e10e6a96ee08b6ce443487d4368442d328d0e746f3681f81127f7dc41b4955"
+checksum = "2cef6e24bc96871001a7e48e820ab240b3de2201e59b517cf52835df2f1d2350"
 dependencies = [
  "async-stream",
- "prost 0.13.1",
+ "prost 0.12.6",
  "tokio",
  "tokio-stream",
- "tonic 0.12.1",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,7 +2777,7 @@ dependencies = [
  "spark-connect-rs",
  "tokio",
  "tokio-postgres",
- "tonic 0.11.0",
+ "tonic 0.12.1",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3772,7 +3772,7 @@ dependencies = [
  "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "snafu 0.8.4",
- "tonic 0.11.0",
+ "tonic 0.12.1",
 ]
 
 [[package]]
@@ -3785,7 +3785,7 @@ dependencies = [
  "futures",
  "parquet",
  "tokio",
- "tonic 0.11.0",
+ "tonic 0.12.1",
 ]
 
 [[package]]
@@ -3803,7 +3803,7 @@ dependencies = [
  "reqwest 0.11.27",
  "rustyline",
  "serde_json",
- "tonic 0.11.0",
+ "tonic 0.12.1",
 ]
 
 [[package]]
@@ -3814,7 +3814,7 @@ dependencies = [
  "clap",
  "futures",
  "tokio",
- "tonic 0.11.0",
+ "tonic 0.12.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4784,6 +4784,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -6778,37 +6791,37 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.2.6",
  "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
+checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
 dependencies = [
+ "hex",
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.11.9",
- "tonic 0.9.2",
+ "prost 0.13.1",
+ "serde",
+ "tonic 0.12.1",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.21.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -6817,7 +6830,9 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float 4.2.1",
+ "percent-encoding",
+ "rand",
+ "serde_json",
  "thiserror",
 ]
 
@@ -7417,6 +7432,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.1",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7458,6 +7483,19 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.71",
@@ -8213,8 +8251,7 @@ dependencies = [
  "tokio",
  "tokio-rusqlite",
  "tokio-rustls 0.26.0",
- "tonic 0.11.0",
- "tonic 0.9.2",
+ "tonic 0.12.1",
  "tonic-health",
  "tracing",
  "tracing-subscriber",
@@ -9896,38 +9933,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "flate2",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "rustls-pemfile 1.0.4",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
@@ -9941,7 +9946,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost 0.12.6",
@@ -9950,6 +9955,39 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.5",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.1",
+ "rustls-native-certs 0.7.1",
+ "rustls-pemfile 2.1.2",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-rustls 0.26.0",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -9972,15 +10010,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.9.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080964d45894b90273d2b1dd755fdd114560db8636bb41cea615213c45043c4d"
+checksum = "e1e10e6a96ee08b6ce443487d4368442d328d0e746f3681f81127f7dc41b4955"
 dependencies = [
  "async-stream",
- "prost 0.11.9",
+ "prost 0.13.1",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,8 @@ tokio-postgres = { version = "0.7.10", features = [
   "with-uuid-1",
 ] }
 tokio-rusqlite = "0.5.1"
-tonic = { version = "0.11.0", features = ["tls"] }
+tonic = { version = "0.12.1", features = ["tls"] }
+tonic-health = { version = "0.12.1" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,12 @@ rust-version = "1.80"
 version = "0.17.2-beta"
 
 [workspace.dependencies]
-arrow = "52.0.0"
-arrow-buffer = "52.0.0"
-arrow-flight = "52.0.0"
+arrow = "52.2.0"
+arrow-buffer = "52.2.0"
+arrow-flight = "52.2.0"
+arrow-json = "52.2.0"
+arrow-ipc = "52.2.0"
+parquet = "52.2.0"
 arrow-odbc = "11.2.0"
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "48173bdee3d3be04dcc579b3211662e359b72734" }
 async-stream = "0.3.5"
@@ -88,8 +91,8 @@ tokio-postgres = { version = "0.7.10", features = [
   "with-uuid-1",
 ] }
 tokio-rusqlite = "0.5.1"
-tonic = { version = "0.12.1", features = ["tls"] }
-tonic-health = { version = "0.12.1" }
+tonic = { version = "0.11", features = ["gzip", "tls"] }
+tonic-health = { version = "0.11" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1.9.1"

--- a/crates/flightrepl/Cargo.toml
+++ b/crates/flightrepl/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 [dependencies]
 ansi_term = "0.12.1"
 arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
-arrow-json = "52.0.0"
+arrow-json.workspace = true
 clap.workspace = true
 datafusion.workspace = true
 futures.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -11,8 +11,8 @@ version.workspace = true
 [dependencies]
 app = { path = "../app" }
 arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
-arrow-ipc = "52.0.0"
-arrow-json = "52.0.0"
+arrow-ipc.workspace = true
+arrow-json.workspace = true
 arrow.workspace = true
 arrow_sql_gen = { path = "../arrow_sql_gen" }
 arrow_tools = { path = "../arrow_tools" }
@@ -67,7 +67,7 @@ notify = "6.1.1"
 ns_lookup = { path = "../ns_lookup" }
 object_store = { workspace = true, features = ["aws", "http"] }
 once_cell = "1.19.0"
-opentelemetry-proto = { version = "0.7.0", features = [
+opentelemetry-proto = { version = "0.6.0", features = [
   "gen-tonic-messages",
   "gen-tonic",
   "metrics",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -67,7 +67,7 @@ notify = "6.1.1"
 ns_lookup = { path = "../ns_lookup" }
 object_store = { workspace = true, features = ["aws", "http"] }
 once_cell = "1.19.0"
-opentelemetry-proto = { version = "0.4.0", features = [
+opentelemetry-proto = { version = "0.7.0", features = [
   "gen-tonic-messages",
   "gen-tonic",
   "metrics",
@@ -92,9 +92,8 @@ suppaftp = { workspace = true, optional = true }
 tokio-rusqlite = { workspace = true, optional = true }
 tokio-rustls = "0.26.0"
 tokio.workspace = true
-tonic_health_0_9_0 = { version = "0.9.0", package = "tonic-health" }
+tonic-health.workspace = true
 tonic.workspace = true
-tonic_0_9_0 = { version = "0.9.0", package = "tonic", features = ["gzip", "tls"] }
 tracing.workspace = true
 tract-core = "0.21.0"
 url = "2.5.0"

--- a/crates/runtime/src/component/dataset/acceleration/constraints.rs
+++ b/crates/runtime/src/component/dataset/acceleration/constraints.rs
@@ -39,7 +39,7 @@ impl Acceleration {
 
     fn valid_columns(schema: &SchemaRef) -> String {
         schema
-            .all_fields()
+            .flattened_fields()
             .into_iter()
             .map(|f| f.name().to_string())
             .collect::<Vec<_>>()

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -192,7 +192,7 @@ fn construct_record_batch(
     embedding_cols: &HashMap<String, ArrayRef>,
 ) -> Result<RecordBatch, ArrowError> {
     let cols: Vec<ArrayRef> = projected_schema
-        .all_fields()
+        .flattened_fields()
         .iter()
         .filter_map(|&f| match embedding_cols.get(f.name()).cloned() {
             Some(embedded_col) => Some(embedded_col),

--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -17,8 +17,8 @@ use csv::Writer;
 use flight_client::FlightClient;
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, sync::Arc};
-use tonic_0_9_0::transport::Channel;
-use tonic_health_0_9_0::{pb::health_client::HealthClient, ServingStatus};
+use tonic::transport::Channel;
+use tonic_health::{pb::health_client::HealthClient, ServingStatus};
 
 use axum::{
     extract::Query,
@@ -162,7 +162,7 @@ async fn get_opentelemetry_status(
     let mut client = HealthClient::new(channel);
 
     let resp = client
-        .check(tonic_health_0_9_0::pb::HealthCheckRequest {
+        .check(tonic_health::pb::HealthCheckRequest {
             service: String::new(),
         })
         .await?;

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -44,14 +44,14 @@ use opentelemetry_proto::tonic::metrics::v1::DataPointFlags;
 use opentelemetry_proto::tonic::metrics::v1::NumberDataPoint;
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
-use tonic_0_9_0::async_trait;
-use tonic_0_9_0::codec::CompressionEncoding;
-use tonic_0_9_0::transport::{Identity, Server, ServerTlsConfig};
-use tonic_0_9_0::Request;
-use tonic_0_9_0::Response;
-use tonic_0_9_0::Status;
-use tonic_health_0_9_0::pb::health_server::Health;
-use tonic_health_0_9_0::pb::health_server::HealthServer;
+use tonic::async_trait;
+use tonic::codec::CompressionEncoding;
+use tonic::transport::{Identity, Server, ServerTlsConfig};
+use tonic::Request;
+use tonic::Response;
+use tonic::Status;
+use tonic_health::pb::health_server::Health;
+use tonic_health::pb::health_server::HealthServer;
 
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
@@ -64,9 +64,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Unable to serve: {source}"))]
-    UnableToServe {
-        source: tonic_0_9_0::transport::Error,
-    },
+    UnableToServe { source: tonic::transport::Error },
 
     #[snafu(display("Failed to build record batch from OpenTelemetry metrics: {source}"))]
     FailedToBuildRecordBatch { source: arrow::error::ArrowError },
@@ -95,9 +93,7 @@ pub enum Error {
     FirstMetricDataPointHasNoValue { metric: String },
 
     #[snafu(display("Unable to configure TLS on the Flight server: {source}"))]
-    UnableToConfigureTls {
-        source: tonic_0_9_0::transport::Error,
-    },
+    UnableToConfigureTls { source: tonic::transport::Error },
 }
 
 const VALUE_COLUMN_NAME: &str = "value";
@@ -206,7 +202,7 @@ impl MetricsService for Service {
 }
 
 async fn create_health_service() -> HealthServer<impl Health> {
-    let (mut health_reporter, health_service) = tonic_health_0_9_0::server::health_reporter();
+    let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter
         .set_serving::<MetricsServiceServer<Service>>()
         .await;

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -31,7 +31,7 @@ use rand::Rng;
 use runtime::{config::Config, tls::TlsConfig, Runtime};
 use rustls::crypto::{self, CryptoProvider};
 use tonic::transport::Channel;
-use tonic_health_0_9_0::pb::health_client::HealthClient;
+use tonic_health::pb::health_client::HealthClient;
 
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
@@ -137,20 +137,17 @@ async fn test_tls_endpoints() -> Result<(), anyhow::Error> {
     tracing::info!("Flight (GRPC) health check passed");
 
     // OpenTelemetry (GRPC)
-    let root_cert_tonic_0_9_0 = tonic_0_9_0::transport::Certificate::from_pem(&root_cert_bytes);
+    let root_cert_tonic = tonic::transport::Certificate::from_pem(&root_cert_bytes);
     let otel_channel =
-        tonic_0_9_0::transport::Channel::from_shared(format!("https://127.0.0.1:{otel_port}"))?
-            .tls_config(
-                tonic_0_9_0::transport::ClientTlsConfig::new()
-                    .ca_certificate(root_cert_tonic_0_9_0),
-            )
+        tonic::transport::Channel::from_shared(format!("https://127.0.0.1:{otel_port}"))?
+            .tls_config(tonic::transport::ClientTlsConfig::new().ca_certificate(root_cert_tonic))
             .expect("valid tls config")
             .connect()
             .await
             .expect("to connect to otel port");
     let mut health_client = HealthClient::new(otel_channel);
     health_client
-        .check(tonic_health_0_9_0::pb::HealthCheckRequest {
+        .check(tonic_health::pb::HealthCheckRequest {
             service: String::new(),
         })
         .await

--- a/tools/flightpublisher/Cargo.toml
+++ b/tools/flightpublisher/Cargo.toml
@@ -13,6 +13,6 @@ arrow.workspace = true
 arrow-flight.workspace = true
 clap = { workspace = true, features = ["derive"] }
 futures.workspace = true
-parquet = "52.0.0"
+parquet.workspace = true
 tokio.workspace = true
 tonic = { workspace = true, features = ["transport", "tls", "tls-roots"] }


### PR DESCRIPTION
## 🗣 Description

Upgrades:
- tonic to v0.11
- opentelemetry-proto to v0.6.0. 
- arrow to v52.2.0
- parquet to v52.0.0

The nice thing about this upgrade is we don't need two versions of tonic anymore.

The latest version of tonic is v0.12 and the latest version of opentelemetry-proto is v0.7.0 - but Arrow is still on tonic v0.11, and we can't upgrade it until Arrow v53.

## 🔨 Related Issues

Part of #2209
