### PR TITLE
docs: Clarify the global requirement for local_infile when loading TPCH

### DIFF
--- a/test/tpch/Readme.md
+++ b/test/tpch/Readme.md
@@ -44,6 +44,8 @@ PGPORT=5432 PGUSER=postgres make tpch-run-pq
 
 ## Load test dataset to MySQL
 
+Ensure `local_infile` is enabled on the MySQL database by first connecting using your `mysql` client and running `SET GLOBAL local_infile=ON;`. This security setting permits the loading on data from files on the client-side, and is disabled by default. The option will disable again at server reboot.
+
 Run commands below to create `tpch` dataset and load test data:
 
 ```bash


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* MySQL requires setting `local_infile=ON` to load data from the TPCH data loading script.

## 🔨 Related Issues

* Part of #2204 for Scale Factor 100 TPCH data loading into MySQL to use for testing