### PR TITLE
use file as db_path_param as the param prefix is trimmed

### DIFF
--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -50,7 +50,7 @@ impl DuckDBAccelerator {
         Self {
             // DuckDB accelerator uses params.duckdb_file for file connection
             duckdb_factory: DuckDBTableProviderFactory::new()
-                .db_path_param("duckdb_file")
+                .db_path_param("file")
                 .access_mode(AccessMode::ReadWrite),
         }
     }


### PR DESCRIPTION
## 🗣 Description

The bug is introduced when using `Parameters` for dataset accelerator #2177 

Added a test case to cover duckdb file mode creation.

Sqlite is broken too, will fix it in another PR as datafusion-table-providers change is needed.