### PR TITLE
WIP: Add types integration test for accelerator hardening

### DIFF
--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -17,6 +17,10 @@ limitations under the License.
 use std::{sync::Arc, time::Duration};
 
 use arrow::array::RecordBatch;
+use arrow::{
+    array::*,
+    datatypes::{DataType, Field, Schema, TimeUnit},
+};
 use datafusion::{
     assert_batches_eq, execution::context::SessionContext,
     parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder,
@@ -155,3 +159,109 @@ fn container_registry() -> String {
     std::env::var("CONTAINER_REGISTRY")
         .unwrap_or_else(|_| "public.ecr.aws/docker/library/".to_string())
 }
+
+// Helper functions to create arrow record batches of different types
+fn get_arrow_binary_record_batch() -> RecordBatch {
+    // Binary/LargeBinary/FixedSizeBinary Array
+    let values: Vec<&[u8]> = vec![b"one", b"two", b""];
+    let binary_array = BinaryArray::from_vec(values.clone());
+    let large_binary_array = LargeBinaryArray::from_vec(values);
+    let input_arg = vec![vec![1, 2], vec![3, 4], vec![5, 6]];
+    let fixed_size_binary_array =
+        FixedSizeBinaryArray::try_from_iter(input_arg.into_iter()).unwrap();
+
+    let schema = Schema::new(vec![
+        Field::new("binary", DataType::Binary, false),
+        Field::new("large_binary", DataType::LargeBinary, false),
+        Field::new("fixed_size_binary", DataType::FixedSizeBinary(2), false),
+    ]);
+
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(binary_array),
+            Arc::new(large_binary_array),
+            Arc::new(fixed_size_binary_array),
+        ],
+    )
+    .expect("Failed to created arrow binary record batch")
+}
+
+// WIP: Add all arrow types covered in acceleration beta hardening criteria
+// fn get_arrow_int_recordbatch() {
+//     // Arrow Integer Types
+//     let int8_arr = Int8Array::from(vec![1, 2, 3]);
+//     let int16_arr = Int16Array::from(vec![1, 2, 3]);
+//     let int32_arr = Int32Array::from(vec![1, 2, 3]);
+//     let int64_arr = Int64Array::from(vec![1, 2, 3]);
+//     let uint8_arr = UInt8Array::from(vec![1, 2, 3]);
+//     let uint16_arr = UInt16Array::from(vec![1, 2, 3]);
+//     let uint32_arr = UInt32Array::from(vec![1, 2, 3]);
+//     let uint64_arr = UInt64Array::from(vec![1, 2, 3]);
+// }
+
+// fn get_arrow_float_record_batch() {
+//     // Arrow Float Types
+//     let float32_arr = Float32Array::from(vec![1.0, 2.0, 3.0]);
+//     let float64_arr = Float64Array::from(vec![1.0, 2.0, 3.0]);
+// }
+
+// fn get_arrow_utf8_record_batch() {
+//     // Utf8, LargeUtf8 Types
+//     let string_arr = StringArray::from(vec!["foo", "bar", "baz"]);
+//     let large_string_arr = LargeStringArray::from(vec!["foo", "bar", "baz"]);
+//     let bool_arr: BooleanArray = vec![true, true, false].into();
+// }
+
+// fn get_arrow_time_record_batch() {
+//     // Time32, Time64 Types
+//     let time32_milli_array: Time32MillisecondArray = vec![
+//         (10 * 3600 + 30 * 60) * 1_000,
+//         (10 * 3600 + 45 * 60 + 15) * 1_000,
+//         (11 * 3600 + 0 * 60 + 15) * 1_000,
+//     ]
+//     .into();
+//     let time32_sec_array: Time32SecondArray = vec![
+//         (10 * 3600 + 30 * 60),
+//         (10 * 3600 + 45 * 60 + 15),
+//         (11 * 3600 + 00 * 60 + 15),
+//     ]
+//     .into();
+//     let time64_micro_array: Time64MicrosecondArray = vec![
+//         (10 * 3600 + 30 * 60) * 1_000_000,
+//         (10 * 3600 + 45 * 60 + 15) * 1_000_000,
+//         (11 * 3600 + 0 * 60 + 15) * 1_000_000,
+//     ]
+//     .into();
+//     let time64_nano_array: Time64NanosecondArray = vec![
+//         (10 * 3600 + 30 * 60) * 1_000_000_000,
+//         (10 * 3600 + 45 * 60 + 15) * 1_000_000_000,
+//         (11 * 3600 + 00 * 60 + 15) * 1_000_000_000,
+//     ]
+//     .into();
+// }
+
+// fn get_arrow_timestamp_record_batch() {
+//     // Timestamp Types
+//     let timestamp_second_array =
+//         TimestampSecondArray::from(vec![1_680_000_000, 1_680_040_000, 1_680_080_000])
+//             .with_timezone("+10:00".to_string());
+//     let timestamp_milli_array = TimestampMillisecondArray::from(vec![
+//         1_680_000_000_000,
+//         1_680_040_000_000,
+//         1_680_080_000_000,
+//     ])
+//     .with_timezone("+10:00".to_string());
+//     let timestamp_micro_array = TimestampMicrosecondArray::from(vec![
+//         1_680_000_000_000_000,
+//         1_680_040_000_000_000,
+//         1_680_080_000_000_000,
+//     ])
+//     .with_timezone("+10:00".to_string());
+//     let timestamp_nano_array = TimestampMicrosecondArray::from(vec![
+//         1_680_000_000_000_000_000,
+//         1_680_040_000_000_000_000,
+//         1_680_080_000_000_000_000,
+//     ])
+//     .with_timezone("+10:00".to_string());
+// }

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -19,8 +19,9 @@ use std::{sync::Arc, time::Duration};
 use arrow::array::RecordBatch;
 use arrow::{
     array::*,
-    datatypes::{DataType, Field, Schema, TimeUnit},
+    datatypes::{i256, DataType, Date32Type, Date64Type, Field, Fields, Schema, TimeUnit},
 };
+use chrono::NaiveDate;
 use datafusion::{
     assert_batches_eq, execution::context::SessionContext,
     parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder,
@@ -187,81 +188,270 @@ fn get_arrow_binary_record_batch() -> RecordBatch {
     .expect("Failed to created arrow binary record batch")
 }
 
-// WIP: Add all arrow types covered in acceleration beta hardening criteria
-// fn get_arrow_int_recordbatch() {
-//     // Arrow Integer Types
-//     let int8_arr = Int8Array::from(vec![1, 2, 3]);
-//     let int16_arr = Int16Array::from(vec![1, 2, 3]);
-//     let int32_arr = Int32Array::from(vec![1, 2, 3]);
-//     let int64_arr = Int64Array::from(vec![1, 2, 3]);
-//     let uint8_arr = UInt8Array::from(vec![1, 2, 3]);
-//     let uint16_arr = UInt16Array::from(vec![1, 2, 3]);
-//     let uint32_arr = UInt32Array::from(vec![1, 2, 3]);
-//     let uint64_arr = UInt64Array::from(vec![1, 2, 3]);
-// }
+fn get_arrow_int_recordbatch() -> RecordBatch {
+    // Arrow Integer Types
+    let int8_arr = Int8Array::from(vec![1, 2, 3]);
+    let int16_arr = Int16Array::from(vec![1, 2, 3]);
+    let int32_arr = Int32Array::from(vec![1, 2, 3]);
+    let int64_arr = Int64Array::from(vec![1, 2, 3]);
+    let uint8_arr = UInt8Array::from(vec![1, 2, 3]);
+    let uint16_arr = UInt16Array::from(vec![1, 2, 3]);
+    let uint32_arr = UInt32Array::from(vec![1, 2, 3]);
+    let uint64_arr = UInt64Array::from(vec![1, 2, 3]);
 
-// fn get_arrow_float_record_batch() {
-//     // Arrow Float Types
-//     let float32_arr = Float32Array::from(vec![1.0, 2.0, 3.0]);
-//     let float64_arr = Float64Array::from(vec![1.0, 2.0, 3.0]);
-// }
+    let schema = Schema::new(vec![
+        Field::new("int8", DataType::Int8, false),
+        Field::new("int16", DataType::Int16, false),
+        Field::new("int32", DataType::Int32, false),
+        Field::new("int64", DataType::Int64, false),
+        Field::new("uint8", DataType::UInt8, false),
+        Field::new("uint16", DataType::UInt16, false),
+        Field::new("uint32", DataType::UInt32, false),
+        Field::new("uint64", DataType::UInt64, false),
+    ]);
 
-// fn get_arrow_utf8_record_batch() {
-//     // Utf8, LargeUtf8 Types
-//     let string_arr = StringArray::from(vec!["foo", "bar", "baz"]);
-//     let large_string_arr = LargeStringArray::from(vec!["foo", "bar", "baz"]);
-//     let bool_arr: BooleanArray = vec![true, true, false].into();
-// }
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(int8_arr),
+            Arc::new(int16_arr),
+            Arc::new(int32_arr),
+            Arc::new(int64_arr),
+            Arc::new(uint8_arr),
+            Arc::new(uint16_arr),
+            Arc::new(uint32_arr),
+            Arc::new(uint64_arr),
+        ],
+    )
+    .expect("Failed to created arrow int record batch")
+}
 
-// fn get_arrow_time_record_batch() {
-//     // Time32, Time64 Types
-//     let time32_milli_array: Time32MillisecondArray = vec![
-//         (10 * 3600 + 30 * 60) * 1_000,
-//         (10 * 3600 + 45 * 60 + 15) * 1_000,
-//         (11 * 3600 + 0 * 60 + 15) * 1_000,
-//     ]
-//     .into();
-//     let time32_sec_array: Time32SecondArray = vec![
-//         (10 * 3600 + 30 * 60),
-//         (10 * 3600 + 45 * 60 + 15),
-//         (11 * 3600 + 00 * 60 + 15),
-//     ]
-//     .into();
-//     let time64_micro_array: Time64MicrosecondArray = vec![
-//         (10 * 3600 + 30 * 60) * 1_000_000,
-//         (10 * 3600 + 45 * 60 + 15) * 1_000_000,
-//         (11 * 3600 + 0 * 60 + 15) * 1_000_000,
-//     ]
-//     .into();
-//     let time64_nano_array: Time64NanosecondArray = vec![
-//         (10 * 3600 + 30 * 60) * 1_000_000_000,
-//         (10 * 3600 + 45 * 60 + 15) * 1_000_000_000,
-//         (11 * 3600 + 00 * 60 + 15) * 1_000_000_000,
-//     ]
-//     .into();
-// }
+fn get_arrow_float_record_batch() -> RecordBatch {
+    // Arrow Float Types
+    let float32_arr = Float32Array::from(vec![1.0, 2.0, 3.0]);
+    let float64_arr = Float64Array::from(vec![1.0, 2.0, 3.0]);
 
-// fn get_arrow_timestamp_record_batch() {
-//     // Timestamp Types
-//     let timestamp_second_array =
-//         TimestampSecondArray::from(vec![1_680_000_000, 1_680_040_000, 1_680_080_000])
-//             .with_timezone("+10:00".to_string());
-//     let timestamp_milli_array = TimestampMillisecondArray::from(vec![
-//         1_680_000_000_000,
-//         1_680_040_000_000,
-//         1_680_080_000_000,
-//     ])
-//     .with_timezone("+10:00".to_string());
-//     let timestamp_micro_array = TimestampMicrosecondArray::from(vec![
-//         1_680_000_000_000_000,
-//         1_680_040_000_000_000,
-//         1_680_080_000_000_000,
-//     ])
-//     .with_timezone("+10:00".to_string());
-//     let timestamp_nano_array = TimestampMicrosecondArray::from(vec![
-//         1_680_000_000_000_000_000,
-//         1_680_040_000_000_000_000,
-//         1_680_080_000_000_000_000,
-//     ])
-//     .with_timezone("+10:00".to_string());
-// }
+    let schema = Schema::new(vec![
+        Field::new("float32", DataType::Float32, false),
+        Field::new("float64", DataType::Float64, false),
+    ]);
+
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(float32_arr), Arc::new(float64_arr)],
+    )
+    .expect("Failed to created arrow float record batch")
+}
+
+fn get_arrow_utf8_record_batch() -> RecordBatch {
+    // Utf8, LargeUtf8 Types
+    let string_arr = StringArray::from(vec!["foo", "bar", "baz"]);
+    let large_string_arr = LargeStringArray::from(vec!["foo", "bar", "baz"]);
+    let bool_arr: BooleanArray = vec![true, true, false].into();
+
+    let schema = Schema::new(vec![
+        Field::new("utf8", DataType::Utf8, false),
+        Field::new("largeutf8", DataType::LargeUtf8, false),
+        Field::new("boolean", DataType::Boolean, false),
+    ]);
+
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(string_arr),
+            Arc::new(large_string_arr),
+            Arc::new(bool_arr),
+        ],
+    )
+    .expect("Failed to created arrow utf8 record batch")
+}
+
+fn get_arrow_time_record_batch() -> RecordBatch {
+    // Time32, Time64 Types
+    let time32_milli_array: Time32MillisecondArray = vec![
+        (10 * 3600 + 30 * 60) * 1_000,
+        (10 * 3600 + 45 * 60 + 15) * 1_000,
+        (11 * 3600 + 0 * 60 + 15) * 1_000,
+    ]
+    .into();
+    let time32_sec_array: Time32SecondArray = vec![
+        (10 * 3600 + 30 * 60),
+        (10 * 3600 + 45 * 60 + 15),
+        (11 * 3600 + 00 * 60 + 15),
+    ]
+    .into();
+    let time64_micro_array: Time64MicrosecondArray = vec![
+        (10 * 3600 + 30 * 60) * 1_000_000,
+        (10 * 3600 + 45 * 60 + 15) * 1_000_000,
+        (11 * 3600 + 0 * 60 + 15) * 1_000_000,
+    ]
+    .into();
+    let time64_nano_array: Time64NanosecondArray = vec![
+        (10 * 3600 + 30 * 60) * 1_000_000_000,
+        (10 * 3600 + 45 * 60 + 15) * 1_000_000_000,
+        (11 * 3600 + 00 * 60 + 15) * 1_000_000_000,
+    ]
+    .into();
+
+    let schema = Schema::new(vec![
+        Field::new(
+            "time32_milli",
+            DataType::Time32(TimeUnit::Millisecond),
+            false,
+        ),
+        Field::new("time32_sec", DataType::Time32(TimeUnit::Second), false),
+        Field::new(
+            "time64_micro",
+            DataType::Time64(TimeUnit::Microsecond),
+            false,
+        ),
+        Field::new("time64_nano", DataType::Time64(TimeUnit::Nanosecond), false),
+    ]);
+
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(time32_milli_array),
+            Arc::new(time32_sec_array),
+            Arc::new(time64_micro_array),
+            Arc::new(time64_nano_array),
+        ],
+    )
+    .expect("Failed to created arrow time record batch")
+}
+
+fn get_arrow_timestamp_record_batch() -> RecordBatch {
+    // Timestamp Types
+    let timestamp_second_array =
+        TimestampSecondArray::from(vec![1_680_000_000, 1_680_040_000, 1_680_080_000])
+            .with_timezone("+10:00".to_string());
+    let timestamp_milli_array = TimestampMillisecondArray::from(vec![
+        1_680_000_000_000,
+        1_680_040_000_000,
+        1_680_080_000_000,
+    ])
+    .with_timezone("+10:00".to_string());
+    let timestamp_micro_array = TimestampMicrosecondArray::from(vec![
+        1_680_000_000_000_000,
+        1_680_040_000_000_000,
+        1_680_080_000_000_000,
+    ])
+    .with_timezone("+10:00".to_string());
+    let timestamp_nano_array = TimestampNanosecondArray::from(vec![
+        1_680_000_000_000_000_000,
+        1_680_040_000_000_000_000,
+        1_680_080_000_000_000_000,
+    ])
+    .with_timezone("+10:00".to_string());
+
+    let schema = Schema::new(vec![
+        Field::new(
+            "timestamp_second",
+            DataType::Timestamp(TimeUnit::Second, Some(Arc::from("+10:00".to_string()))),
+            false,
+        ),
+        Field::new(
+            "timestamp_milli",
+            DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("+10:00".to_string()))),
+            false,
+        ),
+        Field::new(
+            "timestamp_micro",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::from("+10:00".to_string()))),
+            false,
+        ),
+        Field::new(
+            "timestamp_nano",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some(Arc::from("+10:00".to_string()))),
+            false,
+        ),
+    ]);
+
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(timestamp_second_array),
+            Arc::new(timestamp_milli_array),
+            Arc::new(timestamp_micro_array),
+            Arc::new(timestamp_nano_array),
+        ],
+    )
+    .expect("Failed to created arrow timestamp record batch")
+}
+
+// Date32, Date64
+fn get_arrow_date_record_batch() -> RecordBatch {
+    let date32_array = Date32Array::from(vec![
+        Date32Type::from_naive_date(NaiveDate::from_ymd_opt(2015, 3, 14).unwrap_or_default()),
+        Date32Type::from_naive_date(NaiveDate::from_ymd_opt(2016, 1, 12).unwrap_or_default()),
+        Date32Type::from_naive_date(NaiveDate::from_ymd_opt(2017, 9, 17).unwrap_or_default()),
+    ]);
+    let date64_array = Date64Array::from(vec![
+        Date64Type::from_naive_date(NaiveDate::from_ymd_opt(2015, 3, 14).unwrap_or_default()),
+        Date64Type::from_naive_date(NaiveDate::from_ymd_opt(2016, 1, 12).unwrap_or_default()),
+        Date64Type::from_naive_date(NaiveDate::from_ymd_opt(2017, 9, 17).unwrap_or_default()),
+    ]);
+
+    println!("{:?}", date32_array.value(0));
+
+    let schema = Schema::new(vec![
+        Field::new("date32", DataType::Date32, false),
+        Field::new("date64", DataType::Date64, false),
+    ]);
+
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(date32_array), Arc::new(date64_array)],
+    )
+    .expect("Failed to created arrow date record batch")
+}
+
+fn get_arrow_struct_record_batch() -> RecordBatch {
+    let boolean = Arc::new(BooleanArray::from(vec![false, false, true, true]));
+    let int = Arc::new(Int32Array::from(vec![42, 28, 19, 31]));
+
+    let struct_array = StructArray::from(vec![
+        (
+            Arc::new(Field::new("b", DataType::Boolean, false)),
+            boolean.clone() as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("c", DataType::Int32, false)),
+            int.clone() as ArrayRef,
+        ),
+    ]);
+
+    let schema = Schema::new(vec![Field::new(
+        "struct",
+        DataType::Struct(Fields::from(vec![
+            Field::new("b", DataType::Boolean, false),
+            Field::new("c", DataType::Int32, false),
+        ])),
+        false,
+    )]);
+
+    RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array)])
+        .expect("Failed to created arrow struct record batch")
+}
+
+fn get_arrow_decimal_record_batch() -> RecordBatch {
+    let decimal128_array =
+        Decimal128Array::from(vec![i128::from(123), i128::from(222), i128::from(321)]);
+    let decimal256_array =
+        Decimal256Array::from(vec![i256::from(123), i256::from(222), i256::from(321)]);
+
+    let schema = Schema::new(vec![
+        Field::new("decimal128", DataType::Decimal128(38, 10), false),
+        Field::new("decimal256", DataType::Decimal256(76, 10), false),
+    ]);
+
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(decimal128_array), Arc::new(decimal256_array)],
+    )
+    .expect("Failed to created arrow decimal record batch")
+}
+
+// TODO
+// Duration, Interval
+// List/FixedSizeList/LargeList

--- a/crates/runtime/tests/postgres/mod.rs
+++ b/crates/runtime/tests/postgres/mod.rs
@@ -326,5 +326,26 @@ async fn test_arrow_postgres_types_conversion() -> Result<(), String> {
     //     Err(e) => panic!("{}", e),
     // };
 
+    // // Pending on datafusion-table-providers fix
+    // let interval_record_batch = get_arrow_interval_record_batch();
+    // match arrow_postgres_round_trip(port, interval_record_batch, "interval_types").await {
+    //     Ok(_) => (),
+    //     Err(e) => panic!("{}", e),
+    // };
+
+    // // Pending on datafusion-table-providers fix
+    // let duration_record_batch = get_arrow_duration_record_batch();
+    // match arrow_postgres_round_trip(port, duration_record_batch, "duration_types").await {
+    //     Ok(_) => (),
+    //     Err(e) => panic!("{}", e),
+    // };
+
+    // Pending on datafusion-table-providers fix
+    // let list_record_batch = get_arrow_list_record_batch();
+    // match arrow_postgres_round_trip(port, list_record_batch, "list_types").await {
+    //     Ok(_) => (),
+    //     Err(e) => panic!("{}", e),
+    // };
+
     Ok(())
 }


### PR DESCRIPTION
## 🗣 Description

Add integration test to cover arrow type -> postgres type -> arrow type round trip conversion, in order to make sure every type in accelerator beta hardening is covered.

The arrow record generation methods can be used for integration tests of other accelerator

WIP:
- [x] Initial test framework added
- [ ] Support all arrow types covered in beta hardening 
- [ ] Migrate the test as unit test instead of integration test

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->