### PR TITLE
Replace `metrics-rs` with OpenTelemetry Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5764,33 +5764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.23.0"
-source = "git+https://github.com/spiceai/metrics.git?rev=b7aa6388e08f395fc6e361a5ff13174ebd4562fe#b7aa6388e08f395fc6e361a5ff13174ebd4562fe"
-dependencies = [
- "ahash 0.8.11",
- "portable-atomic",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.17.0"
-source = "git+https://github.com/spiceai/metrics.git?rev=b7aa6388e08f395fc6e361a5ff13174ebd4562fe#b7aa6388e08f395fc6e361a5ff13174ebd4562fe"
-dependencies = [
- "aho-corasick",
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
- "metrics",
- "num_cpus",
- "ordered-float 4.2.1",
- "quanta",
- "radix_trie",
- "sketches-ddsketch",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8224,7 +8197,6 @@ dependencies = [
  "llms",
  "logos",
  "mediatype",
- "metrics-util",
  "model_components",
  "mysql_async",
  "notify",
@@ -8945,12 +8917,6 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "sketches-ddsketch"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,8 +1929,8 @@ dependencies = [
  "datafusion",
  "fundu",
  "futures",
- "metrics",
  "moka",
+ "opentelemetry 0.24.0",
  "snafu 0.8.4",
  "spicepod",
  "tokio",
@@ -6790,12 +6790,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.23.0",
  "opentelemetry_sdk",
  "prost 0.12.6",
  "tonic",
@@ -6814,7 +6827,7 @@ dependencies = [
  "glob",
  "lazy_static",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.23.0",
  "ordered-float 4.2.1",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4763,7 +4763,6 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "log",
  "rustls 0.23.11",
  "rustls-native-certs 0.7.1",
  "rustls-pki-types",
@@ -5771,26 +5770,6 @@ source = "git+https://github.com/spiceai/metrics.git?rev=b7aa6388e08f395fc6e361a
 dependencies = [
  "ahash 0.8.11",
  "portable-atomic",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
-version = "0.15.1"
-source = "git+https://github.com/spiceai/metrics.git?rev=b7aa6388e08f395fc6e361a5ff13174ebd4562fe#b7aa6388e08f395fc6e361a5ff13174ebd4562fe"
-dependencies = [
- "base64 0.22.1",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-rustls 0.27.2",
- "hyper-util",
- "indexmap 2.2.6",
- "ipnet",
- "metrics",
- "metrics-util",
- "quanta",
- "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -8194,8 +8173,6 @@ dependencies = [
  "llms",
  "logos",
  "mediatype",
- "metrics",
- "metrics-exporter-prometheus",
  "metrics-util",
  "model_components",
  "mysql_async",
@@ -8203,6 +8180,7 @@ dependencies = [
  "ns_lookup",
  "object_store",
  "once_cell",
+ "opentelemetry 0.24.0",
  "opentelemetry-proto",
  "pin-project",
  "prometheus-parse",
@@ -9137,7 +9115,6 @@ dependencies = [
  "app",
  "clap",
  "flightrepl",
- "metrics-exporter-prometheus",
  "runtime",
  "rustls 0.23.11",
  "rustls-pemfile 2.1.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6778,7 +6778,21 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "once_cell",
+ "pin-project-lite",
  "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4191ce34aa274621861a7a9d68dbcf618d5b6c66b10081631b61fd81fbc015"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.24.0",
+ "opentelemetry_sdk 0.24.1",
+ "prometheus",
+ "protobuf",
 ]
 
 [[package]]
@@ -6788,7 +6802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
  "opentelemetry 0.23.0",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.23.0",
  "prost 0.12.6",
  "tonic",
 ]
@@ -6808,6 +6822,22 @@ dependencies = [
  "once_cell",
  "opentelemetry 0.23.0",
  "ordered-float 4.2.1",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry 0.24.0",
  "thiserror",
 ]
 
@@ -7375,6 +7405,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.3",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prometheus-parse"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7461,6 +7506,12 @@ checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
@@ -8181,8 +8232,11 @@ dependencies = [
  "object_store",
  "once_cell",
  "opentelemetry 0.24.0",
+ "opentelemetry-prometheus",
  "opentelemetry-proto",
+ "opentelemetry_sdk 0.24.1",
  "pin-project",
+ "prometheus",
  "prometheus-parse",
  "prost 0.12.6",
  "rand",
@@ -9115,6 +9169,10 @@ dependencies = [
  "app",
  "clap",
  "flightrepl",
+ "opentelemetry 0.24.0",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk 0.24.1",
+ "prometheus",
  "runtime",
  "rustls 0.23.11",
  "rustls-pemfile 2.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ metrics-exporter-prometheus = { git = "https://github.com/spiceai/metrics.git", 
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
 object_store = { version = "0.10.2" }
 odbc-api = { version = "8.1.2" }
+opentelemetry = { version = "0.24.0", default-features = false, features = ["metrics"] }
 pem = "3.0.4"
 r2d2 = "0.8.10"
 regex = "1.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,11 @@ itertools = "0.12"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
 object_store = { version = "0.10.2" }
 odbc-api = { version = "8.1.2" }
-opentelemetry = { version = "0.24.0", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.24", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.24", default-features = false, features = ["metrics"] }
+opentelemetry-prometheus = "0.17"
 pem = "3.0.4"
+prometheus = "0.13"
 r2d2 = "0.8.10"
 regex = "1.10.3"
 rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,6 @@ fundu = "2.0.0"
 futures = "0.3.30"
 globset = "0.4.14"
 itertools = "0.12"
-metrics = { git = "https://github.com/spiceai/metrics.git", rev = "b7aa6388e08f395fc6e361a5ff13174ebd4562fe" }
-metrics-exporter-prometheus = { git = "https://github.com/spiceai/metrics.git", rev = "b7aa6388e08f395fc6e361a5ff13174ebd4562fe" }
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
 object_store = { version = "0.10.2" }
 odbc-api = { version = "8.1.2" }

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -12,6 +12,10 @@ version.workspace = true
 app = { path = "../../crates/app" }
 clap = { workspace = true, features = ["derive"] }
 flightrepl = { path = "../../crates/flightrepl" }
+opentelemetry.workspace = true
+opentelemetry_sdk.workspace = true
+opentelemetry-prometheus.workspace = true
+prometheus.workspace = true
 runtime = { path = "../../crates/runtime" }
 rustls.workspace = true
 rustls-pemfile.workspace = true

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -12,7 +12,6 @@ version.workspace = true
 app = { path = "../../crates/app" }
 clap = { workspace = true, features = ["derive"] }
 flightrepl = { path = "../../crates/flightrepl" }
-metrics-exporter-prometheus = { workspace = true }
 runtime = { path = "../../crates/runtime" }
 rustls.workspace = true
 rustls-pemfile.workspace = true

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 use app::{App, AppBuilder};
 use clap::{ArgAction, Parser};
 use flightrepl::ReplConfig;
-use metrics_exporter_prometheus::PrometheusHandle;
 use runtime::config::Config as RuntimeConfig;
 
 use runtime::podswatcher::PodsWatcher;
@@ -112,7 +111,7 @@ pub struct Args {
     pub tls_key_file: Option<String>,
 }
 
-pub async fn run(args: Args, metrics_handle: Option<PrometheusHandle>) -> Result<()> {
+pub async fn run(args: Args, prometheus_registry: Option<prometheus::Registry>) -> Result<()> {
     let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
     let pods_watcher = PodsWatcher::new(current_dir.clone());
     let app: Option<App> = match AppBuilder::build_from_filesystem_path(current_dir.clone())
@@ -147,7 +146,7 @@ pub async fn run(args: Args, metrics_handle: Option<PrometheusHandle>) -> Result
         )]))
         .with_pods_watcher(pods_watcher)
         .with_datasets_health_monitor()
-        .with_metrics_server_opt(args.metrics, metrics_handle)
+        .with_metrics_server_opt(args.metrics, prometheus_registry)
         .build()
         .await;
 

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -121,7 +121,6 @@ fn init_metrics() -> Result<prometheus::Registry, Box<dyn std::error::Error>> {
     let provider = SdkMeterProvider::builder()
         .with_resource(resource)
         .with_reader(prometheus_exporter)
-        .with_view(view_percentiles)
         .build();
     global::set_meter_provider(provider);
 

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -16,7 +16,10 @@ limitations under the License.
 
 use clap::Parser;
 use opentelemetry::global;
-use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
+use opentelemetry_sdk::{
+    metrics::{Instrument, SdkMeterProvider, Stream},
+    Resource,
+};
 use rustls::crypto::{self, CryptoProvider};
 use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
@@ -118,6 +121,7 @@ fn init_metrics() -> Result<prometheus::Registry, Box<dyn std::error::Error>> {
     let provider = SdkMeterProvider::builder()
         .with_resource(resource)
         .with_reader(prometheus_exporter)
+        .with_view(view_percentiles)
         .build();
     global::set_meter_provider(provider);
 

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 use clap::Parser;
-use metrics_exporter_prometheus::PrometheusBuilder;
+use opentelemetry::global;
+use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
 use rustls::crypto::{self, CryptoProvider};
 use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
@@ -77,12 +78,12 @@ fn main() {
 }
 
 async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Error>> {
-    let metrics_handle = match args.metrics {
-        Some(_) => Some(PrometheusBuilder::new().install_recorder()?),
+    let prometheus_registry = match args.metrics {
+        Some(_) => Some(init_metrics()?),
         None => None,
     };
 
-    spiced::run(args, metrics_handle).await?;
+    spiced::run(args, prometheus_registry).await?;
     Ok(())
 }
 
@@ -100,4 +101,25 @@ fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
     tracing::subscriber::set_global_default(subscriber)?;
 
     Ok(())
+}
+
+fn init_metrics() -> Result<prometheus::Registry, Box<dyn std::error::Error>> {
+    let registry = prometheus::Registry::new();
+
+    let resource = Resource::default();
+
+    let prometheus_exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .without_scope_info()
+        .without_units()
+        .without_counter_suffixes()
+        .build()?;
+
+    let provider = SdkMeterProvider::builder()
+        .with_resource(resource)
+        .with_reader(prometheus_exporter)
+        .build();
+    global::set_meter_provider(provider);
+
+    Ok(registry)
 }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -16,10 +16,7 @@ limitations under the License.
 
 use clap::Parser;
 use opentelemetry::global;
-use opentelemetry_sdk::{
-    metrics::{Instrument, SdkMeterProvider, Stream},
-    Resource,
-};
+use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
 use rustls::crypto::{self, CryptoProvider};
 use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
@@ -116,6 +113,7 @@ fn init_metrics() -> Result<prometheus::Registry, Box<dyn std::error::Error>> {
         .without_scope_info()
         .without_units()
         .without_counter_suffixes()
+        .without_target_info()
         .build()?;
 
     let provider = SdkMeterProvider::builder()

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -16,8 +16,8 @@ byte-unit = "5.1.4"
 datafusion.workspace = true
 fundu = { workspace = true }
 futures.workspace = true
-metrics.workspace = true
 moka = { version = "0.12.7", features = ["future"] }
+opentelemetry.workspace = true
 snafu.workspace = true
 spicepod = { path = "../spicepod" }
 tokio.workspace = true

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -25,7 +25,7 @@ static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("results_cache"))
 
 pub(crate) static SIZE: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("size")
+        .u64_gauge("results_cache_size")
         .with_description("Size of the cache in bytes.")
         .with_unit("b")
         .init()
@@ -33,7 +33,7 @@ pub(crate) static SIZE: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub(crate) static MAX_SIZE: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("max_size")
+        .u64_gauge("results_cache_max_size")
         .with_description("Maximum allowed size of the cache in bytes.")
         .with_unit("b")
         .init()
@@ -41,21 +41,21 @@ pub(crate) static MAX_SIZE: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub(crate) static REQUEST_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("request_count")
+        .u64_counter("results_cache_request_count")
         .with_description("Number of requests to get a key from the cache.")
         .init()
 });
 
 pub(crate) static HIT_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("hit_count")
+        .u64_counter("results_cache_hit_count")
         .with_description("Cache hit count")
         .init()
 });
 
 pub(crate) static ITEM_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("item_count")
+        .u64_counter("results_cache_item_count")
         .with_description("Number of items currently in the cache.")
         .init()
 });

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::LazyLock;
+
+use opentelemetry::{
+    global,
+    metrics::{Counter, Gauge, Meter},
+};
+
+static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("results_cache"));
+
+pub(crate) static SIZE: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    METER
+        .u64_gauge("size")
+        .with_description("Size of the cache in bytes.")
+        .with_unit("b")
+        .init()
+});
+
+pub(crate) static MAX_SIZE: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    METER
+        .u64_gauge("max_size")
+        .with_description("Maximum allowed size of the cache in bytes.")
+        .with_unit("b")
+        .init()
+});
+
+pub(crate) static REQUEST_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("request_count")
+        .with_description("Number of requests to get a key from the cache.")
+        .init()
+});
+
+pub(crate) static HIT_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("hit_count")
+        .with_description("Cache hit count")
+        .init()
+});
+
+pub(crate) static ITEM_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("item_count")
+        .with_description("Number of items currently in the cache.")
+        .init()
+});

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -52,7 +52,7 @@ headers-accept = "0.1.3"
 http = "1.1.0"
 http-body-util = "0.1.2"
 hyper = "1.4.1"
-hyper-util = "0.1.6"
+hyper-util = { version = "0.1.6", features = ["service"] }
 indexmap = "2"
 itertools.workspace = true
 keyring = { version = "2.3.2", optional = true }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -59,14 +59,13 @@ keyring = { version = "2.3.2", optional = true }
 llms = { path = "../llms" }
 logos = "0.14.0"
 mediatype = "0.19.18"
-metrics.workspace = true
-metrics-exporter-prometheus = { workspace = true }
 model_components = { path = "../model_components" }
 mysql_async = { workspace = true, optional = true }
 notify = "6.1.1"
 ns_lookup = { path = "../ns_lookup" }
 object_store = { workspace = true, features = ["aws", "http"] }
 once_cell = "1.19.0"
+opentelemetry.workspace = true
 opentelemetry-proto = { version = "0.6.0", features = [
   "gen-tonic-messages",
   "gen-tonic",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -108,7 +108,6 @@ anyhow = "1.0.86"
 async-graphql = "7.0.5"
 async-graphql-axum = "7.0.5"
 bollard = "0.16.1"
-metrics-util = { git = "https://github.com/spiceai/metrics.git", rev = "b7aa6388e08f395fc6e361a5ff13174ebd4562fe" }
 rand = "0.8.5"
 spice-cloud = { path = "../spice_cloud" }
 tracing-subscriber.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -66,12 +66,15 @@ ns_lookup = { path = "../ns_lookup" }
 object_store = { workspace = true, features = ["aws", "http"] }
 once_cell = "1.19.0"
 opentelemetry.workspace = true
+opentelemetry_sdk.workspace = true
 opentelemetry-proto = { version = "0.6.0", features = [
   "gen-tonic-messages",
   "gen-tonic",
   "metrics",
 ] }
+opentelemetry-prometheus.workspace = true
 pin-project = "1.0"
+prometheus.workspace = true
 prometheus-parse = "0.2.5"
 prost = { version = "0.12.1", default-features = false, features = [
   "prost-derive",

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -50,6 +50,7 @@ use crate::execution_plan::slice::SliceExec;
 use crate::execution_plan::tee::TeeExec;
 use crate::execution_plan::TableScanParams;
 
+mod metrics;
 pub mod refresh;
 pub mod refresh_task;
 mod refresh_task_runner;

--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -33,7 +33,7 @@ pub(crate) static REFRESH_ERRORS: LazyLock<Counter<u64>> = LazyLock::new(|| {
 pub(crate) static LAST_REFRESH_TIME: LazyLock<Gauge<f64>> = LazyLock::new(|| {
     METER
         .f64_gauge("datasets_acceleration_last_refresh_time")
-        .with_description("Seconds elapsed since the last successful refresh.")
+        .with_description("Unix timestamp in seconds when the last refresh completed.")
         .with_unit("s")
         .init()
 });

--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::LazyLock;
+
+use opentelemetry::{
+    global,
+    metrics::{Counter, Gauge, Histogram, Meter},
+};
+
+static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("datasets_acceleration"));
+
+pub(crate) static REFRESH_ERRORS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("refresh_errors")
+        .with_description("Number of errors refreshing the dataset.")
+        .init()
+});
+
+pub(crate) static LAST_REFRESH_TIME: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    METER
+        .f64_gauge("last_refresh_time")
+        .with_description("Seconds elapsed since the last successful refresh.")
+        .with_unit("s")
+        .init()
+});
+
+pub(crate) static LOAD_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("load_duration_ms")
+        .with_description("Duration in milliseconds to load a full refresh acceleration.")
+        .with_unit("ms")
+        .init()
+});
+
+pub(crate) static APPEND_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("append_duration_ms")
+        .with_description("Duration in milliseconds to append to an acceleration.")
+        .with_unit("ms")
+        .init()
+});

--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -25,14 +25,14 @@ static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("datasets_acceler
 
 pub(crate) static REFRESH_ERRORS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("refresh_errors")
+        .u64_counter("datasets_acceleration_refresh_errors")
         .with_description("Number of errors refreshing the dataset.")
         .init()
 });
 
 pub(crate) static LAST_REFRESH_TIME: LazyLock<Gauge<f64>> = LazyLock::new(|| {
     METER
-        .f64_gauge("last_refresh_time")
+        .f64_gauge("datasets_acceleration_last_refresh_time")
         .with_description("Seconds elapsed since the last successful refresh.")
         .with_unit("s")
         .init()
@@ -40,7 +40,7 @@ pub(crate) static LAST_REFRESH_TIME: LazyLock<Gauge<f64>> = LazyLock::new(|| {
 
 pub(crate) static LOAD_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
     METER
-        .f64_histogram("load_duration_ms")
+        .f64_histogram("datasets_acceleration_load_duration_ms")
         .with_description("Duration in milliseconds to load a full refresh acceleration.")
         .with_unit("ms")
         .init()
@@ -48,7 +48,7 @@ pub(crate) static LOAD_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| 
 
 pub(crate) static APPEND_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
     METER
-        .f64_histogram("append_duration_ms")
+        .f64_histogram("datasets_acceleration_append_duration_ms")
         .with_description("Duration in milliseconds to append to an acceleration.")
         .with_unit("ms")
         .init()

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -25,6 +25,7 @@ use datafusion_table_providers::util::retriable_error::{
     check_and_mark_retriable_error, is_retriable_error,
 };
 use futures::{stream, Stream, StreamExt};
+use opentelemetry::Key;
 use snafu::{OptionExt, ResultExt};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{retry, RetryError};
@@ -42,7 +43,7 @@ use crate::{
 };
 
 use super::refresh::get_timestamp;
-use super::UnableToCreateMemTableFromUpdateSnafu;
+use super::{metrics, UnableToCreateMemTableFromUpdateSnafu};
 
 use crate::component::dataset::TimeFormat;
 use std::time::UNIX_EPOCH;
@@ -167,8 +168,8 @@ impl RefreshTask {
 
         retry(retry_strategy, || async {
             self.run_once().await.map_err(|err| {
-                let labels = [("dataset", dataset_name.to_string())];
-                metrics::counter!("datasets_acceleration_refresh_errors", &labels).increment(1);
+                let labels = [Key::from_static_str("dataset").string(dataset_name.to_string())];
+                metrics::REFRESH_ERRORS.add(1, &labels);
                 err
             })
         })
@@ -192,11 +193,11 @@ impl RefreshTask {
                 RefreshMode::Disabled => {
                     unreachable!("Refresh cannot be called when acceleration is disabled")
                 }
-                RefreshMode::Full => "load_dataset_duration_ms",
-                RefreshMode::Append => "append_dataset_duration_ms",
+                RefreshMode::Full => &metrics::LOAD_DURATION_MS,
+                RefreshMode::Append => &metrics::APPEND_DURATION_MS,
                 RefreshMode::Changes => unreachable!("changes are handled upstream"),
             },
-            vec![("dataset", dataset_name.to_string())],
+            vec![Key::from_static_str("dataset").string(dataset_name.to_string())],
         );
 
         let start_time = SystemTime::now();
@@ -727,8 +728,8 @@ impl RefreshTask {
         status::update_dataset(&self.dataset_name, status);
 
         if status == status::ComponentStatus::Error {
-            let labels = [("dataset", self.dataset_name.to_string())];
-            metrics::counter!("datasets_acceleration_refresh_errors", &labels).increment(1);
+            let labels = [Key::from_static_str("dataset").string(self.dataset_name.to_string())];
+            metrics::REFRESH_ERRORS.add(1, &labels);
         }
 
         if status == status::ComponentStatus::Ready {
@@ -736,13 +737,13 @@ impl RefreshTask {
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default();
 
-            let mut labels = vec![("dataset", self.dataset_name.to_string())];
+            let mut labels =
+                vec![Key::from_static_str("dataset").string(self.dataset_name.to_string())];
             if let Some(sql) = &self.refresh.read().await.sql {
-                labels.push(("sql", sql.to_string()));
+                labels.push(Key::from_static_str("sql").string(sql.to_string()));
             };
 
-            metrics::gauge!("datasets_acceleration_last_refresh_time", &labels)
-                .set(now.as_secs_f64());
+            metrics::LAST_REFRESH_TIME.record(now.as_secs_f64(), &labels);
         }
     }
 }

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -90,8 +90,13 @@ impl RuntimeBuilder {
         self
     }
 
-    pub fn with_metrics_server(mut self, metrics_endpoint: SocketAddr) -> Self {
+    pub fn with_metrics_server(
+        mut self,
+        metrics_endpoint: SocketAddr,
+        prometheus_registry: prometheus::Registry,
+    ) -> Self {
         self.metrics_endpoint = Some(metrics_endpoint);
+        self.prometheus_registry = Some(prometheus_registry);
         self
     }
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -26,7 +26,7 @@ use crate::{
     datafusion::DataFusion,
     datasets_health_monitor::DatasetsHealthMonitor,
     extension::{Extension, ExtensionFactory},
-    podswatcher,
+    metrics, podswatcher,
     secrets::{self, Secrets},
     timing::TimeMeasurement,
     tracers, Runtime,
@@ -175,7 +175,7 @@ impl RuntimeBuilder {
 
     async fn load_secrets(app: Option<&App>) -> Secrets {
         // load_secret_stores
-        let _guard = TimeMeasurement::new(todo!(), &[]);
+        let _guard = TimeMeasurement::new(&metrics::secrets::STORES_LOAD_DURATION_MS, &[]);
         let mut secrets = secrets::Secrets::new();
 
         if let Some(app) = app {

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -26,8 +26,9 @@ use crate::{
     datafusion::DataFusion,
     datasets_health_monitor::DatasetsHealthMonitor,
     extension::{Extension, ExtensionFactory},
-    measure_scope_ms, podswatcher,
+    podswatcher,
     secrets::{self, Secrets},
+    timing::TimeMeasurement,
     tracers, Runtime,
 };
 
@@ -173,7 +174,8 @@ impl RuntimeBuilder {
     }
 
     async fn load_secrets(app: Option<&App>) -> Secrets {
-        measure_scope_ms!("load_secret_stores");
+        // load_secret_stores
+        let _guard = TimeMeasurement::new(todo!(), &[]);
         let mut secrets = secrets::Secrets::new();
 
         if let Some(app) = app {

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -32,6 +32,7 @@ pub mod builder;
 pub mod query_history;
 pub use builder::QueryBuilder;
 pub mod error_code;
+mod metrics;
 mod tracker;
 
 use async_stream::stream;

--- a/crates/runtime/src/datafusion/query/metrics.rs
+++ b/crates/runtime/src/datafusion/query/metrics.rs
@@ -25,14 +25,15 @@ static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("query"));
 
 pub(crate) static DURATION_SECONDS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
     METER
-        .f64_histogram("duration_seconds")
+        .f64_histogram("query_duration_seconds")
         .with_description("Duration in seconds to execute a query.")
+        .with_unit("s")
         .init()
 });
 
 pub(crate) static FAILURES: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("failures")
+        .u64_counter("query_failures")
         .with_description("Number of query failures.")
         .init()
 });

--- a/crates/runtime/src/datafusion/query/metrics.rs
+++ b/crates/runtime/src/datafusion/query/metrics.rs
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::LazyLock;
+
+use opentelemetry::{
+    global,
+    metrics::{Counter, Histogram, Meter},
+};
+
+static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("query"));
+
+pub(crate) static DURATION_SECONDS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("duration_seconds")
+        .with_description("Duration in seconds to execute a query.")
+        .init()
+});
+
+pub(crate) static FAILURES: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("failures")
+        .with_description("Number of query failures.")
+        .init()
+});

--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -18,10 +18,11 @@ use std::{collections::HashSet, sync::Arc, time::SystemTime};
 
 use arrow::datatypes::SchemaRef;
 use datafusion::sql::TableReference;
+use opentelemetry::Key;
 use tokio::time::Instant;
 use uuid::Uuid;
 
-use super::{error_code::ErrorCode, Protocol};
+use super::{error_code::ErrorCode, metrics, Protocol};
 
 pub(crate) struct QueryTracker {
     pub(crate) df: Arc<crate::datafusion::DataFusion>,
@@ -76,23 +77,22 @@ impl QueryTracker {
         }
 
         let mut labels = vec![
-            ("tags", tags.join(",")),
-            (
-                "datasets",
+            Key::from_static_str("tags").string(tags.join(",")),
+            Key::from_static_str("datasets").string(
                 self.datasets
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<String>>()
                     .join(","),
             ),
-            ("protocol", self.protocol.to_string()),
+            Key::from_static_str("protocol").string(self.protocol.to_string()),
         ];
 
-        metrics::histogram!("query_duration_seconds", &labels).record(duration.as_secs_f32());
+        metrics::DURATION_SECONDS.record(duration.as_secs_f64(), &labels);
 
         if let Some(err) = &self.error_code {
-            labels.push(("err_code", err.to_string()));
-            metrics::counter!("query_failures", &labels).increment(1);
+            labels.push(Key::from_static_str("err_code").string(err.to_string()));
+            metrics::FAILURES.add(1, &labels);
         }
 
         if let Err(err) = self.write_query_history().await {

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -26,10 +26,11 @@ use datafusion::{
     sql::TableReference,
 };
 use futures::{future::join_all, stream::TryStreamExt};
+use opentelemetry::Key;
 use snafu::{ResultExt, Snafu};
 use tokio::sync::Mutex;
 
-use crate::component::dataset::Dataset;
+use crate::{component::dataset::Dataset, metrics};
 
 const DATASETS_AVAILABILITY_CHECK_INTERVAL_SECONDS: u64 = 60; // every minute
 const DATASET_UNAVAILABLE_THRESHOLD_SECONDS: u64 = 10 * 60; // 10 minutes
@@ -196,20 +197,19 @@ async fn update_dataset_availability_info(
 }
 
 fn report_dataset_unavailable_time(dataset_name: &String, last_available_time: Option<SystemTime>) {
-    let labels = [("dataset", dataset_name.to_string())];
+    let labels = [Key::from_static_str("dataset").string(dataset_name.to_string())];
 
     match last_available_time {
-        Some(last_available_time) => {
-            metrics::gauge!("datasets_unavailable_time", &labels).set(
-                last_available_time
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs_f64(),
-            );
-        }
+        Some(last_available_time) => metrics::datasets::UNAVAILABLE_TIME.record(
+            last_available_time
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs_f64(),
+            &labels,
+        ),
         None => {
             // use 0 to indicate that the dataset is available; otherwise, the dataset will be shown as unavailable indefinitely
-            metrics::gauge!("datasets_unavailable_time", &labels).set(0);
+            metrics::datasets::UNAVAILABLE_TIME.record(0.0, &labels);
         }
     }
 }

--- a/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
+++ b/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
@@ -27,6 +27,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::sql::TableReference;
 use futures::{stream, StreamExt};
+use opentelemetry::Key;
 use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
@@ -191,7 +192,7 @@ impl ExecutionPlan for FallbackOnZeroResultsScanExec {
             } else {
                 tracing::trace!("FallbackOnZeroResultsScanExec input_stream.next() returned None");
                 tracing::info!("{fallback_msg}");
-                metrics::counter!("accelerated_zero_results_federated_fallback", "dataset_name" => table_name.to_string()).increment(1);
+                metrics::FEDERATED_FALLBACK.add(1, &[Key::from_static_str("dataset_name").string(table_name.to_string())]);
                 let fallback_plan = match fallback_provider
                     .scan(
                         &scan_params.state,
@@ -232,6 +233,24 @@ impl ExecutionPlan for FallbackOnZeroResultsScanExec {
 
         Ok(Box::pin(stream_adapter))
     }
+}
+
+mod metrics {
+    use std::sync::LazyLock;
+
+    use opentelemetry::{
+        global,
+        metrics::{Counter, Meter},
+    };
+
+    static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("accelerated_zero_results"));
+
+    pub(super) static FEDERATED_FALLBACK: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        METER
+            .u64_counter("federated_fallback")
+            .with_description("Number of times the federated table was queried due to the accelerated table returning zero results.")
+            .init()
+    });
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
+++ b/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
@@ -247,7 +247,7 @@ mod metrics {
 
     pub(super) static FEDERATED_FALLBACK: LazyLock<Counter<u64>> = LazyLock::new(|| {
         METER
-            .u64_counter("federated_fallback")
+            .u64_counter("accelerated_zero_results_federated_fallback")
             .with_description("Number of times the federated table was queried due to the accelerated table returning zero results.")
             .init()
     });

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -19,6 +19,7 @@ use crate::datafusion::query::{Protocol, QueryBuilder};
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
 use crate::metrics as runtime_metrics;
+use crate::timing::TimeMeasurement;
 use crate::tls::TlsConfig;
 use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
@@ -94,7 +95,7 @@ impl FlightService for Service {
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
-        measure_scope_ms!("flight_get_flight_info_request_duration_ms");
+        let _guard = TimeMeasurement::new(&metrics::GET_FLIGHT_INFO_REQUEST_DURATION_MS, vec![]);
         metrics::GET_FLIGHT_INFO_REQUESTS.add(1, &[]);
         Box::pin(get_flight_info::handle(self, request)).await
     }

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -49,6 +49,7 @@ mod flightsql;
 mod get_flight_info;
 mod get_schema;
 mod handshake;
+mod metrics;
 mod util;
 
 use arrow_flight::{
@@ -76,7 +77,7 @@ impl FlightService for Service {
         &self,
         _request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
-        metrics::counter!("flight_handshake_requests").increment(1);
+        metrics::HANDSHAKE_REQUESTS.add(1, &[]);
         handshake::handle()
     }
 
@@ -84,7 +85,7 @@ impl FlightService for Service {
         &self,
         _request: Request<Criteria>,
     ) -> Result<Response<Self::ListFlightsStream>, Status> {
-        metrics::counter!("flight_list_flights_requests").increment(1);
+        metrics::LIST_FLIGHTS_REQUESTS.add(1, &[]);
         tracing::trace!("list_flights - unimplemented");
         Err(Status::unimplemented("Not yet implemented"))
     }
@@ -94,7 +95,7 @@ impl FlightService for Service {
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
         measure_scope_ms!("flight_get_flight_info_request_duration_ms");
-        metrics::counter!("flight_get_flight_info_requests").increment(1);
+        metrics::GET_FLIGHT_INFO_REQUESTS.add(1, &[]);
         Box::pin(get_flight_info::handle(self, request)).await
     }
 
@@ -109,7 +110,7 @@ impl FlightService for Service {
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<SchemaResult>, Status> {
-        metrics::counter!("flight_get_schema_requests").increment(1);
+        metrics::GET_SCHEMA_REQUESTS.add(1, &[]);
         get_schema::handle(self, request).await
     }
 
@@ -117,7 +118,7 @@ impl FlightService for Service {
         &self,
         request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
-        metrics::counter!("flight_do_get_requests").increment(1);
+        metrics::DO_GET_REQUESTS.add(1, &[]);
         Box::pin(do_get::handle(self, request)).await
     }
 
@@ -125,7 +126,7 @@ impl FlightService for Service {
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
-        metrics::counter!("flight_do_put_requests").increment(1);
+        metrics::DO_PUT_REQUESTS.add(1, &[]);
         do_put::handle(self, request).await
     }
 
@@ -133,7 +134,7 @@ impl FlightService for Service {
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
-        metrics::counter!("flight_do_exchange_requests").increment(1);
+        metrics::DO_EXCHANGE_REQUESTS.add(1, &[]);
         do_exchange::handle(self, request).await
     }
 
@@ -141,7 +142,7 @@ impl FlightService for Service {
         &self,
         request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
-        metrics::counter!("flight_do_action_requests").increment(1);
+        metrics::DO_ACTION_REQUESTS.add(1, &[]);
         Box::pin(actions::do_action(self, request)).await
     }
 
@@ -149,7 +150,7 @@ impl FlightService for Service {
         &self,
         _request: Request<arrow_flight::Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
-        metrics::counter!("flight_list_actions_requests").increment(1);
+        metrics::LIST_ACTIONS_REQUESTS.add(1, &[]);
         Ok(actions::list())
     }
 }

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -18,7 +18,7 @@ use crate::datafusion::query::error_code::ErrorCode;
 use crate::datafusion::query::{Protocol, QueryBuilder};
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
-use crate::measure_scope_ms;
+use crate::metrics as runtime_metrics;
 use crate::tls::TlsConfig;
 use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
@@ -317,7 +317,7 @@ pub async fn start(
     let svc = FlightServiceServer::new(service);
 
     tracing::info!("Spice Runtime Flight listening on {bind_address}");
-    metrics::counter!("spiced_runtime_flight_server_start").increment(1);
+    runtime_metrics::spiced_runtime::FLIGHT_SERVER_START.add(1, &[]);
 
     let mut server = Server::builder();
 

--- a/crates/runtime/src/flight/do_exchange.rs
+++ b/crates/runtime/src/flight/do_exchange.rs
@@ -30,7 +30,7 @@ use tonic::{Request, Response, Status, Streaming};
 
 use crate::dataupdate::{DataUpdate, UpdateType};
 
-use super::Service;
+use super::{metrics, Service};
 
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn handle(
@@ -154,8 +154,7 @@ pub(crate) async fn handle(
                         flights.push(flight_batch.into());
                     }
 
-                    metrics::counter!("flight_do_exchange_data_updates_sent")
-                        .increment(flights.len() as u64);
+                    metrics::DO_EXCHANGE_DATA_UPDATES_SENT.add(flights.len() as u64, &[]);
                     let output = futures::stream::iter(flights.into_iter().map(Ok));
 
                     Some((output, rx))

--- a/crates/runtime/src/flight/do_get.rs
+++ b/crates/runtime/src/flight/do_get.rs
@@ -25,7 +25,7 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::util::attach_cache_metadata,
+    flight::{metrics, util::attach_cache_metadata},
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -77,7 +77,7 @@ async fn do_get_simple(
     tracing::trace!("do_get_simple: {ticket:?}");
     match std::str::from_utf8(&ticket.ticket) {
         Ok(sql) => {
-            let start = TimeMeasurement::new("flight_do_get_simple_duration_ms", vec![]);
+            let start = TimeMeasurement::new(&metrics::DO_GET_SIMPLE_DURATION_MS, vec![]);
             let (output, from_cache) =
                 Box::pin(Service::sql_to_flight_stream(datafusion, sql)).await?;
 

--- a/crates/runtime/src/flight/flightsql/get_catalogs.rs
+++ b/crates/runtime/src/flight/flightsql/get_catalogs.rs
@@ -23,7 +23,7 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::{record_batches_to_flight_stream, to_tonic_err, Service},
+    flight::{metrics, record_batches_to_flight_stream, to_tonic_err, Service},
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -50,7 +50,7 @@ pub(crate) fn do_get(
     flight_svc: &Service,
     query: sql::CommandGetCatalogs,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
-    let start = TimeMeasurement::new("flight_do_get_get_catalogs_duration_ms", vec![]);
+    let start = TimeMeasurement::new(&metrics::flightsql::DO_GET_GET_CATALOGS_DURATION_MS, vec![]);
     tracing::trace!("do_get_catalogs: {query:?}");
     let mut builder = query.into_builder();
 

--- a/crates/runtime/src/flight/flightsql/get_primary_keys.rs
+++ b/crates/runtime/src/flight/flightsql/get_primary_keys.rs
@@ -26,7 +26,7 @@ use arrow_flight::{
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::{record_batches_to_flight_stream, Service},
+    flight::{metrics, record_batches_to_flight_stream, Service},
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -59,7 +59,10 @@ pub(crate) fn do_get(
     _flight_svc: &Service,
     query: &sql::CommandGetPrimaryKeys,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
-    let start = TimeMeasurement::new("flight_do_get_get_primary_keys_duration_ms", vec![]);
+    let start = TimeMeasurement::new(
+        &metrics::flightsql::DO_GET_GET_PRIMARY_KEYS_DURATION_MS,
+        vec![],
+    );
     tracing::trace!("do_get_get_primary_keys: {query:?}");
 
     let schema = Arc::new(Schema::new(vec![

--- a/crates/runtime/src/flight/flightsql/get_schemas.rs
+++ b/crates/runtime/src/flight/flightsql/get_schemas.rs
@@ -23,7 +23,7 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::{record_batches_to_flight_stream, to_tonic_err, Service},
+    flight::{metrics, record_batches_to_flight_stream, to_tonic_err, Service},
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -50,7 +50,7 @@ pub(crate) fn do_get(
     flight_svc: &Service,
     query: sql::CommandGetDbSchemas,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
-    let start = TimeMeasurement::new("flight_do_get_get_schemas_duration_ms", vec![]);
+    let start = TimeMeasurement::new(&metrics::flightsql::DO_GET_GET_SCHEMAS_DURATION_MS, vec![]);
     let catalog = &query.catalog;
     tracing::trace!("do_get: {query:?}");
     let filtered_catalogs = match catalog {

--- a/crates/runtime/src/flight/flightsql/get_sql_info.rs
+++ b/crates/runtime/src/flight/flightsql/get_sql_info.rs
@@ -37,7 +37,7 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::{to_tonic_err, Service},
+    flight::{metrics, to_tonic_err, Service},
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -72,7 +72,7 @@ pub(crate) fn do_get(
     query: sql::CommandGetSqlInfo,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     tracing::trace!("do_get_sql_info: {query:?}");
-    let start = TimeMeasurement::new("flight_do_get_get_sql_info_duration_ms", vec![]);
+    let start = TimeMeasurement::new(&metrics::flightsql::DO_GET_GET_SQL_INFO_DURATION_MS, vec![]);
     let builder = query.into_builder(get_sql_info_data());
     let record_batch = builder.build().map_err(to_tonic_err)?;
 

--- a/crates/runtime/src/flight/flightsql/get_table_types.rs
+++ b/crates/runtime/src/flight/flightsql/get_table_types.rs
@@ -26,7 +26,9 @@ use datafusion::datasource::TableType;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::{flightsql::get_tables, record_batches_to_flight_stream, to_tonic_err, Service},
+    flight::{
+        flightsql::get_tables, metrics, record_batches_to_flight_stream, to_tonic_err, Service,
+    },
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -49,7 +51,7 @@ pub(crate) fn get_flight_info(
 pub(crate) fn do_get(
     query: &sql::CommandGetTableTypes,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
-    let start = TimeMeasurement::new("flight_do_get_table_types_duration_ms", vec![]);
+    let start = TimeMeasurement::new(&metrics::flightsql::DO_GET_TABLE_TYPES_DURATION_MS, vec![]);
     tracing::trace!("do_get_table_types: {query:?}");
 
     let schema = Schema::new(vec![Field::new("table_type", DataType::Utf8, false)]);

--- a/crates/runtime/src/flight/flightsql/get_tables.rs
+++ b/crates/runtime/src/flight/flightsql/get_tables.rs
@@ -45,8 +45,7 @@ pub(crate) async fn do_get(
     flight_svc: &Service,
     query: sql::CommandGetTables,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
-    let metric = &metrics::flightsql::DO_GET_GET_TABLES_DURATION_MS;
-    let start = TimeMeasurement::new(metric, vec![]);
+    let start = TimeMeasurement::new(&metrics::flightsql::DO_GET_GET_TABLES_DURATION_MS, vec![]);
     let catalog = &query.catalog;
     tracing::trace!("do_get_tables: {query:?}");
     let filtered_catalogs = match catalog {

--- a/crates/runtime/src/flight/flightsql/get_tables.rs
+++ b/crates/runtime/src/flight/flightsql/get_tables.rs
@@ -21,7 +21,7 @@ use datafusion::datasource::TableType;
 use tonic::{Request, Response, Status};
 
 use crate::{
-    flight::{record_batches_to_flight_stream, to_tonic_err, Service},
+    flight::{metrics, record_batches_to_flight_stream, to_tonic_err, Service},
     timing::{TimeMeasurement, TimedStream},
 };
 
@@ -45,7 +45,8 @@ pub(crate) async fn do_get(
     flight_svc: &Service,
     query: sql::CommandGetTables,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
-    let start = TimeMeasurement::new("flight_do_get_get_tables_duration_ms", vec![]);
+    let metric = &metrics::flightsql::DO_GET_GET_TABLES_DURATION_MS;
+    let start = TimeMeasurement::new(metric, vec![]);
     let catalog = &query.catalog;
     tracing::trace!("do_get_tables: {query:?}");
     let filtered_catalogs = match catalog {

--- a/crates/runtime/src/flight/handshake.rs
+++ b/crates/runtime/src/flight/handshake.rs
@@ -23,6 +23,8 @@ use uuid::Uuid;
 
 use crate::timing::{TimeMeasurement, TimedStream};
 
+use super::metrics;
+
 type HandshakeResponseStream =
     Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>;
 
@@ -36,7 +38,7 @@ pub(crate) fn handle() -> Result<Response<HandshakeResponseStream>, Status> {
     };
     let result = Ok(result);
     let output = TimedStream::new(futures::stream::iter(vec![result]), || {
-        TimeMeasurement::new("flight_handshake_request_duration_ms", vec![])
+        TimeMeasurement::new(&metrics::HANDSHAKE_REQUEST_DURATION_MS, vec![])
     });
     let str = format!("Bearer {token}");
     let mut resp: Response<HandshakeResponseStream> = Response::new(Box::pin(output));

--- a/crates/runtime/src/flight/metrics.rs
+++ b/crates/runtime/src/flight/metrics.rs
@@ -76,7 +76,7 @@ pub(crate) static DO_ACTION_DURATION_MS: LazyLock<Histogram<f64>> =
     LazyLock::new(|| METER.f64_histogram("do_action_duration_ms").init());
 
 pub(crate) mod flightsql {
-    use super::*;
+    use super::{Histogram, LazyLock, METER};
 
     pub(crate) static DO_GET_GET_CATALOGS_DURATION_MS: LazyLock<Histogram<f64>> =
         LazyLock::new(|| {

--- a/crates/runtime/src/flight/metrics.rs
+++ b/crates/runtime/src/flight/metrics.rs
@@ -18,13 +18,16 @@ use std::sync::LazyLock;
 
 use opentelemetry::{
     global,
-    metrics::{Counter, Meter},
+    metrics::{Counter, Histogram, Meter},
 };
 
 static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("flight"));
 
 pub(crate) static HANDSHAKE_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("handshake_requests").init());
+
+pub(crate) static HANDSHAKE_REQUEST_DURATION_MS: LazyLock<Histogram<f64>> =
+    LazyLock::new(|| METER.f64_histogram("handshake_request_duration_ms").init());
 
 pub(crate) static LIST_FLIGHTS_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("list_flights_requests").init());
@@ -38,8 +41,14 @@ pub(crate) static GET_SCHEMA_REQUESTS: LazyLock<Counter<u64>> =
 pub(crate) static DO_GET_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("do_get_requests").init());
 
+pub(crate) static DO_GET_SIMPLE_DURATION_MS: LazyLock<Histogram<f64>> =
+    LazyLock::new(|| METER.f64_histogram("do_get_simple_duration_ms").init());
+
 pub(crate) static DO_PUT_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("do_put_requests").init());
+
+pub(crate) static DO_PUT_DURATION_MS: LazyLock<Histogram<f64>> =
+    LazyLock::new(|| METER.f64_histogram("do_put_duration_ms").init());
 
 pub(crate) static DO_EXCHANGE_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("do_exchange_requests").init());
@@ -52,3 +61,43 @@ pub(crate) static DO_ACTION_REQUESTS: LazyLock<Counter<u64>> =
 
 pub(crate) static LIST_ACTIONS_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("list_actions_requests").init());
+
+pub(crate) static LIST_ACTIONS_DURATION_MS: LazyLock<Histogram<f64>> =
+    LazyLock::new(|| METER.f64_histogram("list_actions_duration_ms").init());
+
+pub(crate) static DO_ACTION_DURATION_MS: LazyLock<Histogram<f64>> =
+    LazyLock::new(|| METER.f64_histogram("do_action_duration_ms").init());
+
+pub(crate) mod flightsql {
+    use super::*;
+
+    pub(crate) static DO_GET_GET_CATALOGS_DURATION_MS: LazyLock<Histogram<f64>> =
+        LazyLock::new(|| {
+            METER
+                .f64_histogram("do_get_get_catalogs_duration_ms")
+                .init()
+        });
+
+    pub(crate) static DO_GET_GET_PRIMARY_KEYS_DURATION_MS: LazyLock<Histogram<f64>> =
+        LazyLock::new(|| {
+            METER
+                .f64_histogram("do_get_get_primary_keys_duration_ms")
+                .init()
+        });
+
+    pub(crate) static DO_GET_GET_SCHEMAS_DURATION_MS: LazyLock<Histogram<f64>> =
+        LazyLock::new(|| METER.f64_histogram("do_get_get_schemas_duration_ms").init());
+
+    pub(crate) static DO_GET_GET_SQL_INFO_DURATION_MS: LazyLock<Histogram<f64>> =
+        LazyLock::new(|| {
+            METER
+                .f64_histogram("do_get_get_sql_info_duration_ms")
+                .init()
+        });
+
+    pub(crate) static DO_GET_TABLE_TYPES_DURATION_MS: LazyLock<Histogram<f64>> =
+        LazyLock::new(|| METER.f64_histogram("do_get_table_types_duration_ms").init());
+
+    pub(crate) static DO_GET_GET_TABLES_DURATION_MS: LazyLock<Histogram<f64>> =
+        LazyLock::new(|| METER.f64_histogram("do_get_get_tables_duration_ms").init());
+}

--- a/crates/runtime/src/flight/metrics.rs
+++ b/crates/runtime/src/flight/metrics.rs
@@ -35,6 +35,13 @@ pub(crate) static LIST_FLIGHTS_REQUESTS: LazyLock<Counter<u64>> =
 pub(crate) static GET_FLIGHT_INFO_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("get_flight_info_requests").init());
 
+pub(crate) static GET_FLIGHT_INFO_REQUEST_DURATION_MS: LazyLock<Histogram<f64>> =
+    LazyLock::new(|| {
+        METER
+            .f64_histogram("get_flight_info_request_duration_ms")
+            .init()
+    });
+
 pub(crate) static GET_SCHEMA_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("get_schema_requests").init());
 

--- a/crates/runtime/src/flight/metrics.rs
+++ b/crates/runtime/src/flight/metrics.rs
@@ -44,6 +44,9 @@ pub(crate) static DO_PUT_REQUESTS: LazyLock<Counter<u64>> =
 pub(crate) static DO_EXCHANGE_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("do_exchange_requests").init());
 
+pub(crate) static DO_EXCHANGE_DATA_UPDATES_SENT: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("do_exchange_data_updates_sent").init());
+
 pub(crate) static DO_ACTION_REQUESTS: LazyLock<Counter<u64>> =
     LazyLock::new(|| METER.u64_counter("do_action_requests").init());
 

--- a/crates/runtime/src/flight/metrics.rs
+++ b/crates/runtime/src/flight/metrics.rs
@@ -100,4 +100,18 @@ pub(crate) mod flightsql {
 
     pub(crate) static DO_GET_GET_TABLES_DURATION_MS: LazyLock<Histogram<f64>> =
         LazyLock::new(|| METER.f64_histogram("do_get_get_tables_duration_ms").init());
+
+    pub(crate) static DO_GET_PREPARED_STATEMENT_QUERY_DURATION_MS: LazyLock<Histogram<f64>> =
+        LazyLock::new(|| {
+            METER
+                .f64_histogram("do_get_prepared_statement_query_duration_ms")
+                .init()
+        });
+
+    pub(crate) static DO_GET_STATEMENT_QUERY_DURATION_MS: LazyLock<Histogram<f64>> =
+        LazyLock::new(|| {
+            METER
+                .f64_histogram("do_get_statement_query_duration_ms")
+                .init()
+        });
 }

--- a/crates/runtime/src/flight/metrics.rs
+++ b/crates/runtime/src/flight/metrics.rs
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::LazyLock;
+
+use opentelemetry::{
+    global,
+    metrics::{Counter, Meter},
+};
+
+static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("flight"));
+
+pub(crate) static HANDSHAKE_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("handshake_requests").init());
+
+pub(crate) static LIST_FLIGHTS_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("list_flights_requests").init());
+
+pub(crate) static GET_FLIGHT_INFO_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("get_flight_info_requests").init());
+
+pub(crate) static GET_SCHEMA_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("get_schema_requests").init());
+
+pub(crate) static DO_GET_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("do_get_requests").init());
+
+pub(crate) static DO_PUT_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("do_put_requests").init());
+
+pub(crate) static DO_EXCHANGE_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("do_exchange_requests").init());
+
+pub(crate) static DO_ACTION_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("do_action_requests").init());
+
+pub(crate) static LIST_ACTIONS_REQUESTS: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("list_actions_requests").init());

--- a/crates/runtime/src/flight/metrics.rs
+++ b/crates/runtime/src/flight/metrics.rs
@@ -24,56 +24,80 @@ use opentelemetry::{
 static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("flight"));
 
 pub(crate) static HANDSHAKE_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("handshake_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_handshake_requests").init());
 
-pub(crate) static HANDSHAKE_REQUEST_DURATION_MS: LazyLock<Histogram<f64>> =
-    LazyLock::new(|| METER.f64_histogram("handshake_request_duration_ms").init());
+pub(crate) static HANDSHAKE_REQUEST_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("flight_handshake_request_duration_ms")
+        .with_unit("ms")
+        .init()
+});
 
 pub(crate) static LIST_FLIGHTS_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("list_flights_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_list_flights_requests").init());
 
 pub(crate) static GET_FLIGHT_INFO_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("get_flight_info_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_get_flight_info_requests").init());
 
 pub(crate) static GET_FLIGHT_INFO_REQUEST_DURATION_MS: LazyLock<Histogram<f64>> =
     LazyLock::new(|| {
         METER
-            .f64_histogram("get_flight_info_request_duration_ms")
+            .f64_histogram("flight_get_flight_info_request_duration_ms")
+            .with_unit("ms")
             .init()
     });
 
 pub(crate) static GET_SCHEMA_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("get_schema_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_get_schema_requests").init());
 
 pub(crate) static DO_GET_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("do_get_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_do_get_requests").init());
 
-pub(crate) static DO_GET_SIMPLE_DURATION_MS: LazyLock<Histogram<f64>> =
-    LazyLock::new(|| METER.f64_histogram("do_get_simple_duration_ms").init());
+pub(crate) static DO_GET_SIMPLE_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("flight_do_get_simple_duration_ms")
+        .with_unit("ms")
+        .init()
+});
 
 pub(crate) static DO_PUT_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("do_put_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_do_put_requests").init());
 
-pub(crate) static DO_PUT_DURATION_MS: LazyLock<Histogram<f64>> =
-    LazyLock::new(|| METER.f64_histogram("do_put_duration_ms").init());
+pub(crate) static DO_PUT_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("flight_do_put_duration_ms")
+        .with_unit("ms")
+        .init()
+});
 
 pub(crate) static DO_EXCHANGE_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("do_exchange_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_do_exchange_requests").init());
 
-pub(crate) static DO_EXCHANGE_DATA_UPDATES_SENT: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("do_exchange_data_updates_sent").init());
+pub(crate) static DO_EXCHANGE_DATA_UPDATES_SENT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("flight_do_exchange_data_updates_sent")
+        .init()
+});
 
 pub(crate) static DO_ACTION_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("do_action_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_do_action_requests").init());
 
 pub(crate) static LIST_ACTIONS_REQUESTS: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("list_actions_requests").init());
+    LazyLock::new(|| METER.u64_counter("flight_list_actions_requests").init());
 
-pub(crate) static LIST_ACTIONS_DURATION_MS: LazyLock<Histogram<f64>> =
-    LazyLock::new(|| METER.f64_histogram("list_actions_duration_ms").init());
+pub(crate) static LIST_ACTIONS_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("flight_list_actions_duration_ms")
+        .with_unit("ms")
+        .init()
+});
 
-pub(crate) static DO_ACTION_DURATION_MS: LazyLock<Histogram<f64>> =
-    LazyLock::new(|| METER.f64_histogram("do_action_duration_ms").init());
+pub(crate) static DO_ACTION_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("flight_do_action_duration_ms")
+        .with_unit("ms")
+        .init()
+});
 
 pub(crate) mod flightsql {
     use super::{Histogram, LazyLock, METER};
@@ -81,44 +105,64 @@ pub(crate) mod flightsql {
     pub(crate) static DO_GET_GET_CATALOGS_DURATION_MS: LazyLock<Histogram<f64>> =
         LazyLock::new(|| {
             METER
-                .f64_histogram("do_get_get_catalogs_duration_ms")
+                .f64_histogram("flight_do_get_get_catalogs_duration_ms")
+                .with_unit("ms")
                 .init()
         });
 
     pub(crate) static DO_GET_GET_PRIMARY_KEYS_DURATION_MS: LazyLock<Histogram<f64>> =
         LazyLock::new(|| {
             METER
-                .f64_histogram("do_get_get_primary_keys_duration_ms")
+                .f64_histogram("flight_do_get_get_primary_keys_duration_ms")
+                .with_unit("ms")
                 .init()
         });
 
     pub(crate) static DO_GET_GET_SCHEMAS_DURATION_MS: LazyLock<Histogram<f64>> =
-        LazyLock::new(|| METER.f64_histogram("do_get_get_schemas_duration_ms").init());
+        LazyLock::new(|| {
+            METER
+                .f64_histogram("flight_do_get_get_schemas_duration_ms")
+                .with_unit("ms")
+                .init()
+        });
 
     pub(crate) static DO_GET_GET_SQL_INFO_DURATION_MS: LazyLock<Histogram<f64>> =
         LazyLock::new(|| {
             METER
-                .f64_histogram("do_get_get_sql_info_duration_ms")
+                .f64_histogram("flight_do_get_get_sql_info_duration_ms")
+                .with_unit("ms")
                 .init()
         });
 
     pub(crate) static DO_GET_TABLE_TYPES_DURATION_MS: LazyLock<Histogram<f64>> =
-        LazyLock::new(|| METER.f64_histogram("do_get_table_types_duration_ms").init());
+        LazyLock::new(|| {
+            METER
+                .f64_histogram("flight_do_get_table_types_duration_ms")
+                .with_unit("ms")
+                .init()
+        });
 
     pub(crate) static DO_GET_GET_TABLES_DURATION_MS: LazyLock<Histogram<f64>> =
-        LazyLock::new(|| METER.f64_histogram("do_get_get_tables_duration_ms").init());
+        LazyLock::new(|| {
+            METER
+                .f64_histogram("flight_do_get_get_tables_duration_ms")
+                .with_unit("ms")
+                .init()
+        });
 
     pub(crate) static DO_GET_PREPARED_STATEMENT_QUERY_DURATION_MS: LazyLock<Histogram<f64>> =
         LazyLock::new(|| {
             METER
-                .f64_histogram("do_get_prepared_statement_query_duration_ms")
+                .f64_histogram("flight_do_get_prepared_statement_query_duration_ms")
+                .with_unit("ms")
                 .init()
         });
 
     pub(crate) static DO_GET_STATEMENT_QUERY_DURATION_MS: LazyLock<Histogram<f64>> =
         LazyLock::new(|| {
             METER
-                .f64_histogram("do_get_statement_query_duration_ms")
+                .f64_histogram("flight_do_get_statement_query_duration_ms")
+                .with_unit("ms")
                 .init()
         });
 }

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -41,6 +41,7 @@ use crate::{
     EmbeddingModelStore,
 };
 
+mod metrics;
 mod routes;
 mod v1;
 

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -35,6 +35,7 @@ use crate::{
     config,
     datafusion::DataFusion,
     embeddings::vector_search::{self, compute_primary_keys},
+    metrics as runtime_metrics,
     model::LLMModelStore,
     tls::TlsConfig,
     EmbeddingModelStore,
@@ -90,7 +91,7 @@ where
         .context(UnableToBindServerToPortSnafu)?;
     tracing::info!("Spice Runtime HTTP listening on {bind_address:?}");
 
-    metrics::counter!("spiced_runtime_http_server_start").increment(1);
+    runtime_metrics::spiced_runtime::HTTP_SERVER_START.add(1, &[]);
 
     loop {
         let stream = match listener.accept().await {

--- a/crates/runtime/src/http/metrics.rs
+++ b/crates/runtime/src/http/metrics.rs
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::LazyLock;
+
+use opentelemetry::{
+    global,
+    metrics::{Counter, Histogram, Meter},
+};
+
+static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("http"));
+
+pub(crate) static REQUESTS_TOTAL: LazyLock<Counter<u64>> =
+    LazyLock::new(|| METER.u64_counter("requests_total").init());
+
+pub(crate) static REQUESTS_DURATION_SECONDS: LazyLock<Histogram<f64>> =
+    LazyLock::new(|| METER.f64_histogram("requests_duration_seconds").init());

--- a/crates/runtime/src/http/metrics.rs
+++ b/crates/runtime/src/http/metrics.rs
@@ -24,7 +24,11 @@ use opentelemetry::{
 static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("http"));
 
 pub(crate) static REQUESTS_TOTAL: LazyLock<Counter<u64>> =
-    LazyLock::new(|| METER.u64_counter("requests_total").init());
+    LazyLock::new(|| METER.u64_counter("http_requests_total").init());
 
-pub(crate) static REQUESTS_DURATION_SECONDS: LazyLock<Histogram<f64>> =
-    LazyLock::new(|| METER.f64_histogram("requests_duration_seconds").init());
+pub(crate) static REQUESTS_DURATION_SECONDS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("http_requests_duration_seconds")
+        .with_unit("s")
+        .init()
+});

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1146,6 +1146,7 @@ impl Runtime {
         Ok(l)
     }
 
+    #[allow(dead_code)]
     /// Loads a specific Embedding model from the spicepod. If an error occurs, no retry attempt is made.
     async fn load_embedding(&self, in_embed: &Embeddings) -> Result<Box<dyn Embed>> {
         let params_with_secrets = self.get_params_with_secrets(&in_embed.params).await;
@@ -1160,6 +1161,7 @@ impl Runtime {
         Ok(l)
     }
 
+    #[allow(dead_code)]
     async fn load_embeddings(&self) {
         let app_lock = self.app.read().await;
         if let Some(app) = app_lock.as_ref() {

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -124,6 +124,7 @@ pub(crate) mod views {
     });
 }
 
+#[allow(dead_code)]
 pub(crate) mod embeddings {
     use super::{global, Counter, Gauge, LazyLock, Meter, UpDownCounter};
 

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -22,7 +22,7 @@ use opentelemetry::{
 };
 
 pub(crate) mod spiced_runtime {
-    use super::*;
+    use super::{global, Counter, LazyLock, Meter};
 
     pub(crate) static RUNTIME_METER: LazyLock<Meter> =
         LazyLock::new(|| global::meter("spiced_runtime"));
@@ -43,7 +43,7 @@ pub(crate) mod spiced_runtime {
 }
 
 pub(crate) mod secrets {
-    use super::*;
+    use super::{global, Histogram, LazyLock, Meter};
 
     pub(crate) static SECRETS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("secrets"));
 
@@ -57,7 +57,7 @@ pub(crate) mod secrets {
 }
 
 pub(crate) mod datasets {
-    use super::*;
+    use super::{global, Counter, Gauge, LazyLock, Meter, UpDownCounter};
 
     pub(crate) static DATASETS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("datasets"));
 
@@ -92,7 +92,7 @@ pub(crate) mod datasets {
 }
 
 pub(crate) mod catalogs {
-    use super::*;
+    use super::{global, Counter, Gauge, LazyLock, Meter};
 
     pub(crate) static CATALOGS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("catalogs"));
 
@@ -112,7 +112,7 @@ pub(crate) mod catalogs {
 }
 
 pub(crate) mod views {
-    use super::*;
+    use super::{global, Counter, LazyLock, Meter};
 
     pub(crate) static VIEWS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("views"));
 
@@ -125,7 +125,7 @@ pub(crate) mod views {
 }
 
 pub(crate) mod embeddings {
-    use super::*;
+    use super::{global, Counter, Gauge, LazyLock, Meter, UpDownCounter};
 
     pub(crate) static EMBEDDINGS_METER: LazyLock<Meter> =
         LazyLock::new(|| global::meter("embeddings"));
@@ -153,7 +153,7 @@ pub(crate) mod embeddings {
 }
 
 pub(crate) mod models {
-    use super::*;
+    use super::{global, Counter, Gauge, Histogram, LazyLock, Meter, UpDownCounter};
 
     pub(crate) static MODELS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("models"));
 
@@ -190,7 +190,7 @@ pub(crate) mod models {
 }
 
 pub(crate) mod llms {
-    use super::*;
+    use super::{global, Gauge, LazyLock, Meter};
 
     pub(crate) static LLMS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("llms"));
 

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -18,7 +18,7 @@ use std::sync::LazyLock;
 
 use opentelemetry::{
     global,
-    metrics::{Counter, Gauge, Meter, UpDownCounter},
+    metrics::{Counter, Gauge, Histogram, Meter, UpDownCounter},
 };
 
 pub(crate) mod spiced_runtime {
@@ -38,6 +38,20 @@ pub(crate) mod spiced_runtime {
         RUNTIME_METER
             .u64_counter("http_server_start")
             .with_description("Indicates the runtime HTTP server has started.")
+            .init()
+    });
+}
+
+pub(crate) mod secrets {
+    use super::*;
+
+    pub(crate) static SECRETS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("secrets"));
+
+    pub(crate) static STORES_LOAD_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+        SECRETS_METER
+            .f64_histogram("stores_load_duration_ms")
+            .with_description("Duration in milliseconds to load the secret stores.")
+            .with_unit("ms")
             .init()
     });
 }

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -164,6 +164,14 @@ pub(crate) mod models {
             .init()
     });
 
+    pub(crate) static LOAD_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+        MODELS_METER
+            .f64_histogram("load_duration_ms")
+            .with_description("Duration in milliseconds to load the model.")
+            .with_unit("ms")
+            .init()
+    });
+
     pub(crate) static COUNT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
         MODELS_METER
             .i64_up_down_counter("count")

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -29,14 +29,14 @@ pub(crate) mod spiced_runtime {
 
     pub(crate) static FLIGHT_SERVER_START: LazyLock<Counter<u64>> = LazyLock::new(|| {
         RUNTIME_METER
-            .u64_counter("flight_server_start")
+            .u64_counter("spiced_runtime_flight_server_start")
             .with_description("Indicates the runtime Flight server has started.")
             .init()
     });
 
     pub(crate) static HTTP_SERVER_START: LazyLock<Counter<u64>> = LazyLock::new(|| {
         RUNTIME_METER
-            .u64_counter("http_server_start")
+            .u64_counter("spiced_runtime_http_server_start")
             .with_description("Indicates the runtime HTTP server has started.")
             .init()
     });
@@ -49,7 +49,7 @@ pub(crate) mod secrets {
 
     pub(crate) static STORES_LOAD_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
         SECRETS_METER
-            .f64_histogram("stores_load_duration_ms")
+            .f64_histogram("secrets_stores_load_duration_ms")
             .with_description("Duration in milliseconds to load the secret stores.")
             .with_unit("ms")
             .init()
@@ -63,7 +63,7 @@ pub(crate) mod datasets {
 
     pub(crate) static UNAVAILABLE_TIME: LazyLock<Gauge<f64>> = LazyLock::new(|| {
         DATASETS_METER
-            .f64_gauge("unavailable_time")
+            .f64_gauge("datasets_unavailable_time")
             .with_description("Time since the dataset went offline in seconds.")
             .with_unit("s")
             .init()
@@ -71,21 +71,21 @@ pub(crate) mod datasets {
 
     pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
         DATASETS_METER
-            .u64_counter("load_error")
+            .u64_counter("datasets_load_error")
             .with_description("Number of errors loading the dataset.")
             .init()
     });
 
     pub(crate) static COUNT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
         DATASETS_METER
-            .i64_up_down_counter("count")
+            .i64_up_down_counter("datasets_count")
             .with_description("Number of currently loaded datasets.")
             .init()
     });
 
     pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         DATASETS_METER
-            .u64_gauge("status")
+            .u64_gauge("datasets_status")
             .with_description("Status of the dataset. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.")
             .init()
     });
@@ -98,14 +98,14 @@ pub(crate) mod catalogs {
 
     pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
         CATALOGS_METER
-            .u64_counter("load_error")
+            .u64_counter("catalogs_load_error")
             .with_description("Number of errors loading the catalog provider.")
             .init()
     });
 
     pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         CATALOGS_METER
-            .u64_gauge("status")
+            .u64_gauge("catalogs_status")
             .with_description("Status of the catalog provider. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.")
             .init()
     });
@@ -118,7 +118,7 @@ pub(crate) mod views {
 
     pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
         VIEWS_METER
-            .u64_counter("load_error")
+            .u64_counter("views_load_error")
             .with_description("Number of errors loading the view.")
             .init()
     });
@@ -132,21 +132,21 @@ pub(crate) mod embeddings {
 
     pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
         EMBEDDINGS_METER
-            .u64_counter("load_error")
+            .u64_counter("embeddings_load_error")
             .with_description("Number of errors loading the embedding.")
             .init()
     });
 
     pub(crate) static COUNT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
         EMBEDDINGS_METER
-            .i64_up_down_counter("count")
+            .i64_up_down_counter("embeddings_count")
             .with_description("Number of currently loaded embeddings.")
             .init()
     });
 
     pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         EMBEDDINGS_METER
-            .u64_gauge("status")
+            .u64_gauge("embeddings_status")
             .with_description("Status of the embedding. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.")
             .init()
     });
@@ -159,14 +159,14 @@ pub(crate) mod models {
 
     pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
         MODELS_METER
-            .u64_counter("load_error")
+            .u64_counter("models_load_error")
             .with_description("Number of errors loading the model.")
             .init()
     });
 
     pub(crate) static LOAD_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
         MODELS_METER
-            .f64_histogram("load_duration_ms")
+            .f64_histogram("models_load_duration_ms")
             .with_description("Duration in milliseconds to load the model.")
             .with_unit("ms")
             .init()
@@ -174,14 +174,14 @@ pub(crate) mod models {
 
     pub(crate) static COUNT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
         MODELS_METER
-            .i64_up_down_counter("count")
+            .i64_up_down_counter("models_count")
             .with_description("Number of currently loaded models.")
             .init()
     });
 
     pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         MODELS_METER
-            .u64_gauge("status")
+            .u64_gauge("models_status")
             .with_description(
                 "Status of the model. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
             )
@@ -196,7 +196,7 @@ pub(crate) mod llms {
 
     pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         LLMS_METER
-            .u64_gauge("status")
+            .u64_gauge("llms_status")
             .with_description(
                 "Status of the LLM model. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
             )

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -1,0 +1,183 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::LazyLock;
+
+use opentelemetry::{
+    global,
+    metrics::{Counter, Gauge, Meter, UpDownCounter},
+};
+
+pub(crate) mod spiced_runtime {
+    use super::*;
+
+    pub(crate) static RUNTIME_METER: LazyLock<Meter> =
+        LazyLock::new(|| global::meter("spiced_runtime"));
+
+    pub(crate) static FLIGHT_SERVER_START: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        RUNTIME_METER
+            .u64_counter("flight_server_start")
+            .with_description("Indicates the runtime Flight server has started.")
+            .init()
+    });
+
+    pub(crate) static HTTP_SERVER_START: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        RUNTIME_METER
+            .u64_counter("http_server_start")
+            .with_description("Indicates the runtime HTTP server has started.")
+            .init()
+    });
+}
+
+pub(crate) mod datasets {
+    use super::*;
+
+    pub(crate) static DATASETS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("datasets"));
+
+    pub(crate) static UNAVAILABLE_TIME: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+        DATASETS_METER
+            .f64_gauge("unavailable_time")
+            .with_description("Time since the dataset went offline in seconds.")
+            .with_unit("s")
+            .init()
+    });
+
+    pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        DATASETS_METER
+            .u64_counter("load_error")
+            .with_description("Number of errors loading the dataset.")
+            .init()
+    });
+
+    pub(crate) static COUNT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
+        DATASETS_METER
+            .i64_up_down_counter("count")
+            .with_description("Number of currently loaded datasets.")
+            .init()
+    });
+
+    pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+        DATASETS_METER
+            .u64_gauge("status")
+            .with_description("Status of the dataset. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.")
+            .init()
+    });
+}
+
+pub(crate) mod catalogs {
+    use super::*;
+
+    pub(crate) static CATALOGS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("catalogs"));
+
+    pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        CATALOGS_METER
+            .u64_counter("load_error")
+            .with_description("Number of errors loading the catalog provider.")
+            .init()
+    });
+
+    pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+        CATALOGS_METER
+            .u64_gauge("status")
+            .with_description("Status of the catalog provider. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.")
+            .init()
+    });
+}
+
+pub(crate) mod views {
+    use super::*;
+
+    pub(crate) static VIEWS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("views"));
+
+    pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        VIEWS_METER
+            .u64_counter("load_error")
+            .with_description("Number of errors loading the view.")
+            .init()
+    });
+}
+
+pub(crate) mod embeddings {
+    use super::*;
+
+    pub(crate) static EMBEDDINGS_METER: LazyLock<Meter> =
+        LazyLock::new(|| global::meter("embeddings"));
+
+    pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        EMBEDDINGS_METER
+            .u64_counter("load_error")
+            .with_description("Number of errors loading the embedding.")
+            .init()
+    });
+
+    pub(crate) static COUNT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
+        EMBEDDINGS_METER
+            .i64_up_down_counter("count")
+            .with_description("Number of currently loaded embeddings.")
+            .init()
+    });
+
+    pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+        EMBEDDINGS_METER
+            .u64_gauge("status")
+            .with_description("Status of the embedding. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.")
+            .init()
+    });
+}
+
+pub(crate) mod models {
+    use super::*;
+
+    pub(crate) static MODELS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("models"));
+
+    pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
+        MODELS_METER
+            .u64_counter("load_error")
+            .with_description("Number of errors loading the model.")
+            .init()
+    });
+
+    pub(crate) static COUNT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
+        MODELS_METER
+            .i64_up_down_counter("count")
+            .with_description("Number of currently loaded models.")
+            .init()
+    });
+
+    pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+        MODELS_METER
+            .u64_gauge("status")
+            .with_description(
+                "Status of the model. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            )
+            .init()
+    });
+}
+
+pub(crate) mod llms {
+    use super::*;
+
+    pub(crate) static LLMS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("llms"));
+
+    pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+        LLMS_METER
+            .u64_gauge("status")
+            .with_description(
+                "Status of the LLM model. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            )
+            .init()
+    });
+}

--- a/crates/runtime/src/metrics_server/mod.rs
+++ b/crates/runtime/src/metrics_server/mod.rs
@@ -138,7 +138,7 @@ fn handle_http_request(
         let metric_families = prometheus_registry.gather();
         let mut result = Vec::new();
         match encoder.encode(&metric_families, &mut result) {
-            Ok(_) => result.into(),
+            Ok(()) => result.into(),
             Err(e) => {
                 tracing::error!("Error encoding Prometheus metrics: {e}");
                 "Error encoding Prometheus metrics".into()

--- a/crates/runtime/src/metrics_server/mod.rs
+++ b/crates/runtime/src/metrics_server/mod.rs
@@ -24,7 +24,7 @@ use hyper::{
     server::conn::http1::Builder,
 };
 use hyper_util::rt::TokioIo;
-use metrics_exporter_prometheus::PrometheusHandle;
+use prometheus::{Encoder, TextEncoder};
 use snafu::prelude::*;
 use std::net::ToSocketAddrs;
 use std::{fmt::Debug, sync::Arc};
@@ -45,13 +45,14 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub(crate) async fn start<A>(
     bind_address: Option<A>,
-    handle: Option<PrometheusHandle>,
+    prometheus_registry: Option<prometheus::Registry>,
     tls_config: Option<Arc<TlsConfig>>,
 ) -> Result<()>
 where
     A: ToSocketAddrs + Debug + Clone + Copy,
 {
-    let (Some(bind_address), Some(handle)) = (bind_address, handle) else {
+    let (Some(bind_address), Some(prometheus_registry)) = (bind_address, prometheus_registry)
+    else {
         return Ok(());
     };
 
@@ -78,21 +79,25 @@ where
         match tls_config {
             Some(ref config) => {
                 let acceptor = TlsAcceptor::from(Arc::clone(&config.server_config));
-                process_tls_tcp_stream(stream, acceptor.clone(), handle.clone());
+                process_tls_tcp_stream(stream, acceptor.clone(), prometheus_registry.clone());
             }
             None => {
-                process_tcp_stream(stream, handle.clone());
+                process_tcp_stream(stream, prometheus_registry.clone());
             }
         }
     }
 }
 
-fn process_tls_tcp_stream(stream: TcpStream, acceptor: TlsAcceptor, handle: PrometheusHandle) {
+fn process_tls_tcp_stream(
+    stream: TcpStream,
+    acceptor: TlsAcceptor,
+    prometheus_registry: prometheus::Registry,
+) {
     tokio::spawn(async move {
         let stream = acceptor.accept(stream).await;
         match stream {
             Ok(stream) => {
-                serve_connection(stream, handle).await;
+                serve_connection(stream, prometheus_registry).await;
             }
             Err(e) => {
                 tracing::debug!("Error accepting TLS connection: {e}");
@@ -101,17 +106,17 @@ fn process_tls_tcp_stream(stream: TcpStream, acceptor: TlsAcceptor, handle: Prom
     });
 }
 
-fn process_tcp_stream(stream: TcpStream, handle: PrometheusHandle) {
-    tokio::spawn(serve_connection(stream, handle));
+fn process_tcp_stream(stream: TcpStream, prometheus_registry: prometheus::Registry) {
+    tokio::spawn(serve_connection(stream, prometheus_registry));
 }
 
-async fn serve_connection<S>(stream: S, handle: PrometheusHandle)
+async fn serve_connection<S>(stream: S, prometheus_registry: prometheus::Registry)
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     let service = hyper::service::service_fn(move |req: Request<body::Incoming>| {
-        let handle = handle.clone();
-        async move { Ok::<_, hyper::Error>(handle_http_request(&handle, &req)) }
+        let prometheus_registry = prometheus_registry.clone();
+        async move { Ok::<_, hyper::Error>(handle_http_request(&prometheus_registry, &req)) }
     });
 
     if let Err(err) = Builder::new()
@@ -123,12 +128,22 @@ where
 }
 
 fn handle_http_request(
-    handle: &PrometheusHandle,
+    prometheus_registry: &prometheus::Registry,
     req: &Request<Incoming>,
 ) -> Response<Full<Bytes>> {
-    let mut response = Response::new(match req.uri().path() {
-        "/health" => "OK".into(),
-        _ => handle.render().into(),
+    let mut response = Response::new(if req.uri().path() == "/health" {
+        "OK".into()
+    } else {
+        let encoder = TextEncoder::new();
+        let metric_families = prometheus_registry.gather();
+        let mut result = Vec::new();
+        match encoder.encode(&metric_families, &mut result) {
+            Ok(_) => result.into(),
+            Err(e) => {
+                tracing::error!("Error encoding Prometheus metrics: {e}");
+                "Error encoding Prometheus metrics".into()
+            }
+        }
     });
     response
         .headers_mut()

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -17,8 +17,10 @@ limitations under the License.
 use std::fmt::Display;
 
 use datafusion::sql::TableReference;
-use metrics::gauge;
+use opentelemetry::Key;
 use serde::{Deserialize, Serialize};
+
+use crate::metrics;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 pub enum ComponentStatus {
@@ -42,25 +44,40 @@ impl Display for ComponentStatus {
 }
 
 pub fn update_catalog(catalog_name: impl Into<String>, status: ComponentStatus) {
-    gauge!("catalog/status", "catalog" => catalog_name.into()).set(f64::from(status as u32));
+    metrics::catalogs::STATUS.record(
+        status as u64,
+        &[Key::from_static_str("catalog").string(catalog_name.into())],
+    );
 }
 
 pub fn update_dataset(dataset: &TableReference, status: ComponentStatus) {
     let ds_name = dataset.to_string();
-    gauge!("dataset/status", "dataset" => ds_name).set(f64::from(status as u32));
+    metrics::datasets::STATUS.record(
+        status as u64,
+        &[Key::from_static_str("dataset").string(ds_name)],
+    );
 }
 
 pub fn update_model(model_name: &str, status: ComponentStatus) {
     let model_name = model_name.to_string();
-    gauge!("model/status", "model" => model_name).set(f64::from(status as u32));
+    metrics::models::STATUS.record(
+        status as u64,
+        &[Key::from_static_str("model").string(model_name)],
+    );
 }
 
 pub fn update_llm(model_name: &str, status: ComponentStatus) {
     let model_name = model_name.to_string();
-    gauge!("llm/status", "model" => model_name).set(f64::from(status as u32));
+    metrics::llms::STATUS.record(
+        status as u64,
+        &[Key::from_static_str("model").string(model_name)],
+    );
 }
 
 pub fn update_embedding(model_name: &str, status: ComponentStatus) {
     let model_name = model_name.to_string();
-    gauge!("embedding/status", "model" => model_name).set(f64::from(status as u32));
+    metrics::embeddings::STATUS.record(
+        status as u64,
+        &[Key::from_static_str("model").string(model_name)],
+    );
 }

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -25,7 +25,6 @@ use arrow_flight::{
     sql::{CommandStatementQuery, ProstMessageExt},
     FlightDescriptor,
 };
-use metrics_exporter_prometheus::PrometheusBuilder;
 use prost::Message;
 use rand::Rng;
 use runtime::{config::Config, tls::TlsConfig, Runtime};

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -57,17 +57,16 @@ async fn test_tls_endpoints() -> Result<(), anyhow::Error> {
     let cert_bytes = include_bytes!("../../../../test/tls/spiced_cert.pem").to_vec();
     let key_bytes = include_bytes!("../../../../test/tls/spiced_key.pem").to_vec();
 
-    let metrics_recorder = PrometheusBuilder::new().build_recorder();
-    let metrics_handle = metrics_recorder.handle();
-
     let api_config = Config::new()
         .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
         .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
         .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
     let tls_config = TlsConfig::try_new(cert_bytes.clone(), key_bytes).expect("valid TlsConfig");
 
+    let registry = prometheus::Registry::new();
+
     let rt = Runtime::builder()
-        .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), metrics_handle)
+        .with_metrics_server(SocketAddr::new(LOCALHOST, metrics_port), registry)
         .build()
         .await;
 

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1654,7 +1654,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "load_dataset_duration_ms{quantile=~\"${percentile}\", pod=~\"${pods}\"} unless load_dataset == 0",
+          "expr": "datasets_acceleration_load_duration_ms{quantile=~\"${percentile}\", pod=~\"${pods}\"} unless load_dataset == 0",
           "instant": false,
           "legendFormat": "{{dataset}} (P{{quantile}})",
           "range": true,
@@ -1748,7 +1748,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "1000*load_model{quantile=~\"${percentile}\", pod=~\"${pods}\"} unless load_model == 0",
+          "expr": "1000*models_load_duration{quantile=~\"${percentile}\", pod=~\"${pods}\"} unless models_load_duration == 0",
           "instant": false,
           "legendFormat": "{{model}} (P{{quantile}})",
           "range": true,

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1748,7 +1748,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "1000*models_load_duration{quantile=~\"${percentile}\", pod=~\"${pods}\"} unless models_load_duration == 0",
+          "expr": "1000*models_load_duration_ms{quantile=~\"${percentile}\", pod=~\"${pods}\"} unless models_load_duration_ms == 0",
           "instant": false,
           "legendFormat": "{{model}} (P{{quantile}})",
           "range": true,


### PR DESCRIPTION
## 🗣 Description

Replaces `metrics-rs` with the OpenTelemetry Metrics SDK, retaining the Prometheus API but switching to the OpenTelemetry exporter for Prometheus to export into a `prometheus::Registry`.

OpenTelemetry doesn't support the `summary` Prometheus metric type based on histogram data and exposes histogram buckets directly. This approach is correct as combining percentile summaries from multiple sources is not meaningful, whereas combining histograms is.

Current dashboards need reworking to use histogram data directly or to calculate and create the summary metric in Spice. The latter will be implemented in a follow-up PR to make migration easier.

Some metric names have been updated for consistency with the meter name, and these changes are reflected in the linked Grafana dashboard.

## 🔨 Related Issues

Closes #2209

## 🤔 Concerns

I did change the names of some metrics to make them more consistent, but that will be a breaking change for any existing dashboard users. I think that its fine to do now, but I can change it such that we don't make any breaking changes if that is a concern.


## Old Metrics

```bash
# TYPE spiced_runtime_http_server_start counter
spiced_runtime_http_server_start 1

# TYPE spiced_runtime_flight_server_start counter
spiced_runtime_flight_server_start 1

# TYPE dataset_status gauge
dataset_status{dataset="runtime.query_history"} 2
dataset_status{dataset="runtime.metrics"} 2

# TYPE datasets_acceleration_last_refresh_time gauge
datasets_acceleration_last_refresh_time{dataset="runtime.metrics"} 1723101217.5403
datasets_acceleration_last_refresh_time{dataset="runtime.query_history"} 1723101217.540302

# TYPE results_cache_max_size gauge
results_cache_max_size 134217728

# TYPE load_dataset_duration_ms summary
load_dataset_duration_ms{dataset="runtime.query_history",quantile="0"} 10.505125000000001
load_dataset_duration_ms{dataset="runtime.query_history",quantile="0.5"} 10.50551127548251
load_dataset_duration_ms{dataset="runtime.query_history",quantile="0.9"} 10.50551127548251
load_dataset_duration_ms{dataset="runtime.query_history",quantile="0.95"} 10.50551127548251
load_dataset_duration_ms{dataset="runtime.query_history",quantile="0.99"} 10.50551127548251
load_dataset_duration_ms{dataset="runtime.query_history",quantile="0.999"} 10.50551127548251
load_dataset_duration_ms{dataset="runtime.query_history",quantile="1"} 10.505125000000001
load_dataset_duration_ms_sum{dataset="runtime.query_history"} 10.505125000000001
load_dataset_duration_ms_count{dataset="runtime.query_history"} 1
load_dataset_duration_ms{dataset="runtime.metrics",quantile="0"} 10.590583
load_dataset_duration_ms{dataset="runtime.metrics",quantile="0.5"} 10.58989244059569
load_dataset_duration_ms{dataset="runtime.metrics",quantile="0.9"} 10.58989244059569
load_dataset_duration_ms{dataset="runtime.metrics",quantile="0.95"} 10.58989244059569
load_dataset_duration_ms{dataset="runtime.metrics",quantile="0.99"} 10.58989244059569
load_dataset_duration_ms{dataset="runtime.metrics",quantile="0.999"} 10.58989244059569
load_dataset_duration_ms{dataset="runtime.metrics",quantile="1"} 10.590583
load_dataset_duration_ms_sum{dataset="runtime.metrics"} 10.590583
load_dataset_duration_ms_count{dataset="runtime.metrics"} 1

# TYPE load_secret_stores summary
load_secret_stores{quantile="0"} 0.040583
load_secret_stores{quantile="0.5"} 0.04057918552304942
load_secret_stores{quantile="0.9"} 0.04057918552304942
load_secret_stores{quantile="0.95"} 0.04057918552304942
load_secret_stores{quantile="0.99"} 0.04057918552304942
load_secret_stores{quantile="0.999"} 0.04057918552304942
load_secret_stores{quantile="1"} 0.040583
load_secret_stores_sum 0.040583
load_secret_stores_count 1
```

## New Metrics

```bash
# HELP datasets_acceleration_last_refresh_time Unix timestamp in seconds when the last refresh completed.
# TYPE datasets_acceleration_last_refresh_time gauge
datasets_acceleration_last_refresh_time{dataset="runtime.metrics"} 1723105479.307973
datasets_acceleration_last_refresh_time{dataset="runtime.query_history"} 1723105479.307978
# HELP datasets_acceleration_load_duration_ms Duration in milliseconds to load a full refresh acceleration.
# TYPE datasets_acceleration_load_duration_ms histogram
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="0"} 0
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="5"} 0
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="10"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="25"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="50"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="75"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="100"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="250"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="500"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="750"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="1000"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="2500"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="5000"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="7500"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="10000"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.metrics",le="+Inf"} 1
datasets_acceleration_load_duration_ms_sum{dataset="runtime.metrics"} 7.524625
datasets_acceleration_load_duration_ms_count{dataset="runtime.metrics"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="0"} 0
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="5"} 0
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="10"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="25"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="50"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="75"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="100"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="250"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="500"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="750"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="1000"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="2500"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="5000"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="7500"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="10000"} 1
datasets_acceleration_load_duration_ms_bucket{dataset="runtime.query_history",le="+Inf"} 1
datasets_acceleration_load_duration_ms_sum{dataset="runtime.query_history"} 7.5450420000000005
datasets_acceleration_load_duration_ms_count{dataset="runtime.query_history"} 1
# HELP datasets_status Status of the dataset. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.
# TYPE datasets_status gauge
datasets_status{dataset="runtime.metrics"} 2
datasets_status{dataset="runtime.query_history"} 2
# HELP results_cache_max_size Maximum allowed size of the cache in bytes.
# TYPE results_cache_max_size gauge
results_cache_max_size 134217728
# HELP secrets_stores_load_duration_ms Duration in milliseconds to load the secret stores.
# TYPE secrets_stores_load_duration_ms histogram
secrets_stores_load_duration_ms_bucket{le="0"} 0
secrets_stores_load_duration_ms_bucket{le="5"} 1
secrets_stores_load_duration_ms_bucket{le="10"} 1
secrets_stores_load_duration_ms_bucket{le="25"} 1
secrets_stores_load_duration_ms_bucket{le="50"} 1
secrets_stores_load_duration_ms_bucket{le="75"} 1
secrets_stores_load_duration_ms_bucket{le="100"} 1
secrets_stores_load_duration_ms_bucket{le="250"} 1
secrets_stores_load_duration_ms_bucket{le="500"} 1
secrets_stores_load_duration_ms_bucket{le="750"} 1
secrets_stores_load_duration_ms_bucket{le="1000"} 1
secrets_stores_load_duration_ms_bucket{le="2500"} 1
secrets_stores_load_duration_ms_bucket{le="5000"} 1
secrets_stores_load_duration_ms_bucket{le="7500"} 1
secrets_stores_load_duration_ms_bucket{le="10000"} 1
secrets_stores_load_duration_ms_bucket{le="+Inf"} 1
secrets_stores_load_duration_ms_sum 0.13691699999999998
secrets_stores_load_duration_ms_count 1
# HELP spiced_runtime_flight_server_start Indicates the runtime Flight server has started.
# TYPE spiced_runtime_flight_server_start counter
spiced_runtime_flight_server_start 1
# HELP spiced_runtime_http_server_start Indicates the runtime HTTP server has started.
# TYPE spiced_runtime_http_server_start counter
spiced_runtime_http_server_start 1
```