### PR TITLE
Track nested spans into Zipkin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8275,6 +8275,7 @@ dependencies = [
  "tonic",
  "tonic-health",
  "tracing",
+ "tracing-futures",
  "tracing-subscriber",
  "tract-core",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9193,6 +9193,7 @@ dependencies = [
  "spice-cloud",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -10094,6 +10095,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.24.0",
+ "opentelemetry_sdk 0.24.1",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5534,6 +5534,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -10084,6 +10085,18 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6765,6 +6765,7 @@ dependencies = [
  "bytes",
  "http 1.1.0",
  "opentelemetry 0.24.0",
+ "reqwest 0.12.5",
 ]
 
 [[package]]
@@ -7984,6 +7985,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.5",
@@ -9176,6 +9178,7 @@ dependencies = [
  "clap",
  "flightrepl",
  "opentelemetry 0.24.0",
+ "opentelemetry-http",
  "opentelemetry-prometheus",
  "opentelemetry-zipkin",
  "opentelemetry_sdk 0.24.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ dependencies = [
  "object_store",
  "rdkafka",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.5",
  "rusqlite",
  "secrecy",
  "serde",
@@ -3799,7 +3799,7 @@ dependencies = [
  "futures",
  "llms",
  "prost 0.12.6",
- "reqwest 0.11.27",
+ "reqwest 0.12.5",
  "rustyline",
  "serde_json",
  "tonic",
@@ -4769,7 +4769,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.3",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5919,7 +5919,7 @@ dependencies = [
  "dirs",
  "ndarray",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.5",
  "secrecy",
  "serde",
  "serde_json",
@@ -6756,6 +6756,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad31e9de44ee3538fb9d64fe3376c1362f406162434609e79aea2a41a0af78ab"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.1.0",
+ "opentelemetry 0.24.0",
+]
+
+[[package]]
 name = "opentelemetry-prometheus"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6778,6 +6790,33 @@ dependencies = [
  "opentelemetry_sdk 0.23.0",
  "prost 0.12.6",
  "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
+
+[[package]]
+name = "opentelemetry-zipkin"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68336254a44c5c20574989699582175910b933be85a593a13031ee58811d93d"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 1.1.0",
+ "once_cell",
+ "opentelemetry 0.24.0",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk 0.24.1",
+ "reqwest 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "typed-builder",
 ]
 
 [[package]]
@@ -6811,7 +6850,12 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry 0.24.0",
+ "percent-encoding",
+ "rand",
+ "serde_json",
  "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -7905,7 +7949,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -7915,7 +7958,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -7924,13 +7966,11 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -7983,7 +8023,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.3",
+ "webpki-roots",
  "winreg 0.52.0",
 ]
 
@@ -8213,7 +8253,7 @@ dependencies = [
  "prost 0.12.6",
  "rand",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.5",
  "rustls 0.23.11",
  "rustls-pemfile 2.1.2",
  "secrecy",
@@ -9119,7 +9159,7 @@ dependencies = [
  "datafusion",
  "futures",
  "globset",
- "reqwest 0.11.27",
+ "reqwest 0.12.5",
  "runtime",
  "serde",
  "serde_json",
@@ -9137,8 +9177,10 @@ dependencies = [
  "flightrepl",
  "opentelemetry 0.24.0",
  "opentelemetry-prometheus",
+ "opentelemetry-zipkin",
  "opentelemetry_sdk 0.24.1",
  "prometheus",
+ "reqwest 0.12.5",
  "runtime",
  "rustls 0.23.11",
  "rustls-pemfile 2.1.2",
@@ -10318,6 +10360,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10437,7 +10499,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.3",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -10720,12 +10782,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,8 @@ odbc-api = { version = "8.1.2" }
 opentelemetry = { version = "0.24", default-features = false, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.24", default-features = false, features = ["metrics", "rt-tokio"] }
 opentelemetry-prometheus = "0.17"
-opentelemetry-zipkin = { version = "0.22.0", default-features = false, features = ["reqwest"] }
+opentelemetry-zipkin = { version = "0.22.0", default-features = false, features = ["reqwest", "reqwest-rustls"] }
+opentelemetry-http = { version = "0.13.0", features = ["reqwest-rustls"] }
 pem = "3.0.4"
 prometheus = "0.13"
 r2d2 = "0.8.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ tonic = { version = "0.11", features = ["gzip", "tls"] }
 tonic-health = { version = "0.11" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-opentelemetry = "0.25.0"
 uuid = "1.9.1"
 x509-certificate = "0.23.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,12 +66,14 @@ mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
 object_store = { version = "0.10.2" }
 odbc-api = { version = "8.1.2" }
 opentelemetry = { version = "0.24", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.24", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.24", default-features = false, features = ["metrics", "rt-tokio"] }
 opentelemetry-prometheus = "0.17"
+opentelemetry-zipkin = { version = "0.22.0", default-features = false, features = ["reqwest"] }
 pem = "3.0.4"
 prometheus = "0.13"
 r2d2 = "0.8.10"
 regex = "1.10.3"
+reqwest = {version = "0.12.5", features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 rustls = "0.23"
 rustls-pemfile = "2.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ tonic-health = { version = "0.11" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-opentelemetry = "0.25.0"
+tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 uuid = "1.9.1"
 x509-certificate = "0.23.1"
 

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -15,7 +15,9 @@ flightrepl = { path = "../../crates/flightrepl" }
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-prometheus.workspace = true
+opentelemetry-zipkin.workspace = true
 prometheus.workspace = true
+reqwest.workspace = true
 runtime = { path = "../../crates/runtime" }
 rustls.workspace = true
 rustls-pemfile.workspace = true

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -28,6 +28,7 @@ spice-cloud = { path = "../../crates/spice_cloud" }
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-opentelemetry.workspace = true
 
 [features]
 aws-secrets-manager = ["runtime/aws-secrets-manager"]

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -16,6 +16,7 @@ opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-prometheus.workspace = true
 opentelemetry-zipkin.workspace = true
+opentelemetry-http.workspace = true
 prometheus.workspace = true
 reqwest.workspace = true
 runtime = { path = "../../crates/runtime" }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -68,6 +68,8 @@ fn main() {
     if let Err(err) = tokio_runtime.block_on(start_runtime(args)) {
         eprintln!("Spice Runtime error: {err}");
     }
+
+    global::shutdown_tracer_provider();
 }
 
 async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Error>> {
@@ -89,7 +91,7 @@ fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
     let filter = if let Ok(env_log) = std::env::var("SPICED_LOG") {
         EnvFilter::new(env_log)
     } else {
-        EnvFilter::new("spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO")
+        EnvFilter::new("task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO")
     };
 
     let registry = Registry::default();
@@ -105,13 +107,7 @@ fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
                     metadata.target() == "task_history"
                 })),
         )
-        .with(
-            fmt::layer()
-                .with_ansi(true)
-                .with_filter(filter::filter_fn(|metadata| {
-                    metadata.target() != "task_history"
-                })),
-        );
+        .with(fmt::layer().with_ansi(true));
 
     tracing::subscriber::set_global_default(subscriber)?;
 

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -83,6 +83,8 @@ async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Err
         None => None,
     };
 
+    init_otel_tracing()?;
+
     spiced::run(args, prometheus_registry).await?;
     Ok(())
 }
@@ -99,8 +101,6 @@ fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
         .with_ansi(true)
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
-
-    init_otel_tracing()?;
 
     Ok(())
 }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -16,21 +16,16 @@ limitations under the License.
 
 use clap::Parser;
 use opentelemetry::global;
-use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
+use opentelemetry_sdk::{metrics::SdkMeterProvider, trace::Tracer, Resource};
 use rustls::crypto::{self, CryptoProvider};
 use tokio::runtime::Runtime;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{filter, fmt, prelude::*, EnvFilter, Registry};
 
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 fn main() {
     let args = spiced::Args::parse();
-
-    if let Err(err) = init_tracing() {
-        eprintln!("Unable to initialize tracing: {err}");
-        std::process::exit(1);
-    }
 
     if args.version {
         if cfg!(feature = "release") {
@@ -55,25 +50,23 @@ fn main() {
     let tokio_runtime = match Runtime::new() {
         Ok(runtime) => runtime,
         Err(err) => {
-            tracing::error!("Unable to start Tokio runtime: {err}");
+            eprintln!("Unable to start Tokio runtime: {err}");
             std::process::exit(1);
         }
     };
 
     if args.repl {
         if let Err(e) = tokio_runtime.block_on(flightrepl::run(args.repl_config)) {
-            tracing::error!("SQL REPL Error: {e}");
+            eprintln!("SQL REPL Error: {e}");
         };
         return;
     }
-
-    tracing::trace!("Starting Spice Runtime!");
 
     // Install the default AWS LC RS crypto provider for rusttls
     let _ = CryptoProvider::install_default(crypto::aws_lc_rs::default_provider());
 
     if let Err(err) = tokio_runtime.block_on(start_runtime(args)) {
-        tracing::error!("Spice Runtime error: {err}");
+        eprintln!("Spice Runtime error: {err}");
     }
 }
 
@@ -83,7 +76,10 @@ async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Err
         None => None,
     };
 
-    init_otel_tracing()?;
+    if let Err(err) = init_tracing() {
+        eprintln!("Unable to initialize tracing: {err}");
+        std::process::exit(1);
+    }
 
     spiced::run(args, prometheus_registry).await?;
     Ok(())
@@ -96,21 +92,38 @@ fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
         EnvFilter::new("spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO")
     };
 
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(filter)
-        .with_ansi(true)
-        .finish();
+    let registry = Registry::default();
+
+    let otel_tracer = init_otel_tracing()?;
+
+    let subscriber = registry
+        .with(filter)
+        .with(
+            tracing_opentelemetry::layer()
+                .with_tracer(otel_tracer)
+                .with_filter(filter::filter_fn(|metadata| {
+                    metadata.target() == "task_history"
+                })),
+        )
+        .with(
+            fmt::layer()
+                .with_ansi(true)
+                .with_filter(filter::filter_fn(|metadata| {
+                    metadata.target() != "task_history"
+                })),
+        );
+
     tracing::subscriber::set_global_default(subscriber)?;
 
     Ok(())
 }
 
-fn init_otel_tracing() -> Result<(), Box<dyn std::error::Error>> {
-    let _ = opentelemetry_zipkin::new_pipeline()
+fn init_otel_tracing() -> Result<Tracer, Box<dyn std::error::Error>> {
+    let tracer = opentelemetry_zipkin::new_pipeline()
         .with_http_client(reqwest::Client::new())
         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 
-    Ok(())
+    Ok(tracer)
 }
 
 fn init_metrics() -> Result<prometheus::Registry, Box<dyn std::error::Error>> {

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -100,6 +100,16 @@ fn init_tracing() -> Result<(), Box<dyn std::error::Error>> {
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
 
+    init_otel_tracing()?;
+
+    Ok(())
+}
+
+fn init_otel_tracing() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = opentelemetry_zipkin::new_pipeline()
+        .with_http_client(reqwest::Client::new())
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
     Ok(())
 }
 

--- a/bin/spiced/src/tls.rs
+++ b/bin/spiced/src/tls.rs
@@ -28,7 +28,7 @@ use crate::Args;
 
 pub(crate) async fn load_tls_config(
     args: &Args,
-    spicepod_tls_config: Option<SpicepodTlsConfig>,
+    spicepod_tls_config: Option<&SpicepodTlsConfig>,
     secrets: Arc<RwLock<Secrets>>,
 ) -> std::result::Result<Option<Arc<TlsConfig>>, Box<dyn std::error::Error>> {
     let tls_enabled = args.tls_enabled || spicepod_tls_config.as_ref().is_some_and(|c| c.enabled);
@@ -40,7 +40,7 @@ pub(crate) async fn load_tls_config(
 
     let app_cert_bytes = load_spicepod_tls_param(
         &secrets,
-        &spicepod_tls_config,
+        spicepod_tls_config,
         |tls| &tls.certificate_file,
         |tls| &tls.certificate,
         "certificate",
@@ -50,7 +50,7 @@ pub(crate) async fn load_tls_config(
 
     let app_key_bytes = load_spicepod_tls_param(
         &secrets,
-        &spicepod_tls_config,
+        spicepod_tls_config,
         |tls| &tls.key_file,
         |tls| &tls.key,
         "key",
@@ -82,7 +82,7 @@ pub(crate) async fn load_tls_config(
 
 async fn load_spicepod_tls_param(
     secrets: &RwLockReadGuard<'_, Secrets>,
-    spicepod_tls_config: &Option<SpicepodTlsConfig>,
+    spicepod_tls_config: Option<&SpicepodTlsConfig>,
     file_field: impl Fn(&SpicepodTlsConfig) -> &Option<String>,
     secret_field: impl Fn(&SpicepodTlsConfig) -> &Option<String>,
     secret_name: &str,

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::borrow::Cow;
+
+use app::spicepod::component::runtime::TracingConfig;
+use tracing::Subscriber;
+use tracing_subscriber::{filter, fmt, layer::Layer, prelude::*, registry::LookupSpan, EnvFilter};
+
+pub(crate) fn init_tracing(
+    app_name: Option<String>,
+    config: Option<&TracingConfig>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let filter = if let Ok(env_log) = std::env::var("SPICED_LOG") {
+        EnvFilter::new(env_log)
+    } else {
+        EnvFilter::new("task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO")
+    };
+
+    let subscriber = tracing_subscriber::registry()
+        .with(filter)
+        .with(zipkin_task_history_tracing(app_name, config)?)
+        .with(fmt::layer().with_ansi(true));
+
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    Ok(())
+}
+
+fn zipkin_task_history_tracing<S>(
+    app_name: Option<String>,
+    config: Option<&TracingConfig>,
+) -> Result<Option<impl Layer<S>>, Box<dyn std::error::Error>>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    let Some(config) = config else {
+        return Ok(None);
+    };
+    if !config.zipkin_enabled {
+        return Ok(None);
+    }
+
+    let Some(zipkin_endpoint) = config.zipkin_endpoint.as_ref() else {
+        return Err("zipkin_endpoint is required when zipkin_enabled is true".into());
+    };
+
+    let service_name: Cow<'static, str> = match app_name {
+        Some(name) => Cow::Owned(name),
+        None => Cow::Borrowed("Spice.ai"),
+    };
+
+    let tracer = opentelemetry_zipkin::new_pipeline()
+        .with_service_name(service_name)
+        .with_collector_endpoint(zipkin_endpoint)
+        .with_http_client(reqwest::Client::new())
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
+    let layer = tracing_opentelemetry::layer()
+        .with_tracer(tracer)
+        .with_filter(filter::filter_fn(|metadata| {
+            metadata.target() == "task_history"
+        }));
+
+    Ok(Some(layer))
+}

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -33,7 +33,13 @@ pub(crate) fn init_tracing(
     let subscriber = tracing_subscriber::registry()
         .with(filter)
         .with(zipkin_task_history_tracing(app_name, config)?)
-        .with(fmt::layer().with_ansi(true));
+        .with(
+            fmt::layer()
+                .with_ansi(true)
+                .with_filter(filter::filter_fn(|metadata| {
+                    metadata.target() != "task_history"
+                })),
+        );
 
     tracing::subscriber::set_global_default(subscriber)?;
 

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -42,7 +42,7 @@ globset.workspace = true
 object_store = { workspace = true }
 rdkafka = { version = "0.36.2", optional = true }
 regex = "1.10.4"
-reqwest = { version = "0.11.24", features = ["json"] }
+reqwest.workspace = true
 rusqlite = { workspace = true, optional = true }
 secrecy.workspace = true
 serde.workspace = true

--- a/crates/flightrepl/Cargo.toml
+++ b/crates/flightrepl/Cargo.toml
@@ -19,7 +19,7 @@ llms = { path = "../llms" }
 prost = { version = "0.12.1", default-features = false, features = [
   "prost-derive",
 ] }
-reqwest = { version = "0.11.24", features = ["json"] }
+reqwest.workspace = true
 rustyline = "13.0.0"
 serde_json.workspace = true
 tonic = { workspace = true, features = ["transport", "tls", "tls-roots"] }

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -24,6 +24,7 @@ hf-hub = { version = "0.3.0", features = ["tokio"] }
 serde = { workspace = true, features = ["derive"] }
 tokenizers = { version = "0.19.1" }
 tracing.workspace = true
+tracing-futures.workspace = true
 
 ## `candle` feature packages
 candle-core = { version = "0.5.0", optional = true }

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -144,7 +144,7 @@ pub trait Chat: Sync + Send {
     /// A basic health check to ensure the model can process future [`Self::run`] requests.
     /// Default implementation is a basic call to [`Self::run`].
     async fn health(&self) -> Result<()> {
-        let span = tracing::span!(target: "task_history", tracing::Level::DEBUG, "health", input = "health");
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "health", input = "health");
         self.run("health".to_string())
             .instrument(span)
             .await

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -19,6 +19,7 @@ use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::{path::Path, pin::Pin};
+use tracing_futures::Instrument;
 
 use async_openai::{
     error::{ApiError, OpenAIError},
@@ -143,7 +144,9 @@ pub trait Chat: Sync + Send {
     /// A basic health check to ensure the model can process future [`Self::run`] requests.
     /// Default implementation is a basic call to [`Self::run`].
     async fn health(&self) -> Result<()> {
+        let span = tracing::span!(target: "task_history", tracing::Level::DEBUG, "health", input = "health");
         self.run("health".to_string())
+            .instrument(span)
             .await
             .boxed()
             .context(HealthCheckSnafu)?;

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -176,7 +176,7 @@ impl Chat for Openai {
             })
             .last()
             .unwrap_or_default();
-        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "OpenAI::chat_stream", prompt = %prompt, model = %self.model);
+        let span = tracing::span!(target: "task_history", tracing::Level::DEBUG, "OpenAI::chat_stream", prompt = %prompt, model = %self.model);
 
         let mut inner_req = req.clone();
         inner_req.model.clone_from(&self.model);

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -37,7 +37,6 @@ use async_trait::async_trait;
 use futures::future::try_join_all;
 use futures::{Stream, StreamExt};
 use snafu::ResultExt;
-use tracing::Span;
 use tracing_futures::Instrument;
 
 pub const MAX_COMPLETION_TOKENS: u16 = 1024_u16; // Avoid accidentally using infinite tokens. Should think about this more.

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -89,10 +89,7 @@ impl Openai {
 #[async_trait]
 impl Chat for Openai {
     async fn run(&self, prompt: String) -> ChatResult<Option<String>> {
-        let span = tracing::span!(target: "task_history", tracing::Level::DEBUG, "openai::run", input = %prompt);
-        span.in_scope(
-            || tracing::debug!(name: "labels", target: "task_history", model = %self.model),
-        );
+        let span = tracing::Span::current();
 
         async move {
             let req = CreateChatCompletionRequestArgs::default()
@@ -167,14 +164,7 @@ impl Chat for Openai {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
-        let span = match Span::current() {
-            span if matches!(span.metadata(), Some(metadata) if metadata.name() == "ai_completion") => {
-                span
-            }
-            _ => {
-                tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default())
-            }
-        };
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
         span.in_scope(
             || tracing::info!(name: "labels", target: "task_history", model = %self.model),
         );
@@ -197,14 +187,7 @@ impl Chat for Openai {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
-        let span = match Span::current() {
-            span if matches!(span.metadata(), Some(metadata) if metadata.name() == "ai_completion") => {
-                span
-            }
-            _ => {
-                tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default())
-            }
-        };
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
         span.in_scope(
             || tracing::info!(name: "labels", target: "task_history", model = %self.model),
         );

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -164,10 +164,10 @@ impl Chat for Openai {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
-        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
-        span.in_scope(
-            || tracing::info!(name: "labels", target: "task_history", model = %self.model),
-        );
+        // let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
+        // span.in_scope(
+        //     || tracing::info!(name: "labels", target: "task_history", model = %self.model),
+        // );
 
         let mut inner_req = req.clone();
         inner_req.model.clone_from(&self.model);
@@ -175,10 +175,11 @@ impl Chat for Openai {
             .client
             .chat()
             .create_stream(inner_req)
-            .instrument(span.clone())
+            // .instrument(span.clone())
             .await?;
 
-        Ok(Box::pin(stream.instrument(span)))
+        // Ok(Box::pin(stream.instrument(span)))
+        Ok(Box::pin(stream))
     }
 
     /// An OpenAI-compatible interface for the `v1/chat/completion` `Chat` trait. If not implemented, the default
@@ -187,14 +188,15 @@ impl Chat for Openai {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
-        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
-        span.in_scope(
-            || tracing::info!(name: "labels", target: "task_history", model = %self.model),
-        );
+        // let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
+        // span.in_scope(
+        //     || tracing::info!(name: "labels", target: "task_history", model = %self.model),
+        // );
 
         let mut inner_req = req.clone();
         inner_req.model.clone_from(&self.model);
-        self.client.chat().create(inner_req).instrument(span).await
+        // self.client.chat().create(inner_req).instrument(span).await
+        self.client.chat().create(inner_req).await
     }
 }
 

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -21,6 +21,7 @@ use crate::embeddings::{Embed, Error as EmbedError, Result as EmbedResult};
 
 use async_openai::error::OpenAIError;
 use async_openai::types::{
+    ChatCompletionRequestMessage, ChatCompletionRequestUserMessageContent,
     ChatCompletionResponseStream, CreateChatCompletionRequest, CreateChatCompletionResponse,
     CreateEmbeddingRequest, CreateEmbeddingRequestArgs, CreateEmbeddingResponse,
 };
@@ -37,6 +38,7 @@ use async_trait::async_trait;
 use futures::future::try_join_all;
 use futures::{Stream, StreamExt};
 use snafu::ResultExt;
+use tracing_futures::Instrument;
 
 pub const MAX_COMPLETION_TOKENS: u16 = 1024_u16; // Avoid accidentally using infinite tokens. Should think about this more.
 
@@ -87,35 +89,43 @@ impl Openai {
 #[async_trait]
 impl Chat for Openai {
     async fn run(&self, prompt: String) -> ChatResult<Option<String>> {
-        let req = CreateChatCompletionRequestArgs::default()
-            .model(self.model.clone())
-            .messages(vec![ChatCompletionRequestSystemMessageArgs::default()
-                .content(prompt)
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "OpenAI::run", prompt = %prompt, model = %self.model);
+
+        async move {
+            let req = CreateChatCompletionRequestArgs::default()
+                .model(self.model.clone())
+                .messages(vec![ChatCompletionRequestSystemMessageArgs::default()
+                    .content(prompt)
+                    .build()
+                    .boxed()
+                    .map_err(|source| ChatError::FailedToLoadTokenizer { source })?
+                    .into()])
                 .build()
                 .boxed()
-                .map_err(|source| ChatError::FailedToLoadTokenizer { source })?
-                .into()])
-            .build()
-            .boxed()
-            .map_err(|source| ChatError::FailedToLoadModel { source })?;
+                .map_err(|source| ChatError::FailedToLoadModel { source })?;
 
-        let resp = self
-            .chat_request(req)
-            .await
-            .boxed()
-            .map_err(|source| ChatError::FailedToRunModel { source })?;
+            let resp = self
+                .chat_request(req)
+                .await
+                .boxed()
+                .map_err(|source| ChatError::FailedToRunModel { source })?;
 
-        Ok(resp
-            .choices
-            .into_iter()
-            .next()
-            .and_then(|c| c.message.content))
+            Ok(resp
+                .choices
+                .into_iter()
+                .next()
+                .and_then(|c| c.message.content))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn stream<'a>(
         &self,
         prompt: String,
     ) -> ChatResult<Pin<Box<dyn Stream<Item = ChatResult<Option<String>>> + Send>>> {
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "OpenAI::stream", prompt = %prompt, model = %self.model);
+        let guard = span.enter();
         let req = CreateChatCompletionRequestArgs::default()
             .model(self.model.clone())
             .stream(true)
@@ -128,13 +138,15 @@ impl Chat for Openai {
             .build()
             .boxed()
             .map_err(|source| ChatError::FailedToLoadModel { source })?;
+        drop(guard);
         let mut chat_stream = self
             .chat_stream(req)
+            .instrument(span.clone())
             .await
             .boxed()
             .map_err(|source| ChatError::FailedToRunModel { source })?;
         Ok(Box::pin(stream! {
-            while let Some(msg) = chat_stream.next().await {
+            while let Some(msg) = chat_stream.next().instrument(span.clone()).await {
                 match msg {
                     Ok(resp) => {
                         yield Ok(resp.choices.into_iter().next().and_then(|c| c.delta.content));
@@ -151,9 +163,26 @@ impl Chat for Openai {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
+        let prompt = req
+            .messages
+            .last()
+            .iter()
+            .filter_map(|m| match m {
+                ChatCompletionRequestMessage::User(u) => match u.content {
+                    ChatCompletionRequestUserMessageContent::Text(ref t) => Some(t.clone()),
+                    ChatCompletionRequestUserMessageContent::Array(_) => None,
+                },
+                _ => None,
+            })
+            .last()
+            .unwrap_or_default();
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "OpenAI::chat_stream", prompt = %prompt, model = %self.model);
+
         let mut inner_req = req.clone();
         inner_req.model.clone_from(&self.model);
-        self.client.chat().create_stream(inner_req).await
+        let stream = self.client.chat().create_stream(inner_req).await?;
+
+        Ok(Box::pin(stream.instrument(span)))
     }
 
     /// An OpenAI-compatible interface for the `v1/chat/completion` `Chat` trait. If not implemented, the default

--- a/crates/model_components/Cargo.toml
+++ b/crates/model_components/Cargo.toml
@@ -17,7 +17,7 @@ async-trait.workspace = true
 dirs = "5.0.1"
 ndarray = "0.15.3"
 regex = "1.10.3"
-reqwest = { version = "0.11.24", features = ["json"] }
+reqwest.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -98,6 +98,7 @@ tokio.workspace = true
 tonic-health.workspace = true
 tonic.workspace = true
 tracing.workspace = true
+tracing-futures.workspace = true
 tract-core = "0.21.0"
 url = "2.5.0"
 util = { path = "../util" }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -80,7 +80,7 @@ prost = { version = "0.12.1", default-features = false, features = [
   "prost-derive",
 ] }
 regex.workspace = true
-reqwest = { version = "0.11.24", features = ["json", "rustls-tls"] }
+reqwest.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
 secrecy.workspace = true

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -162,7 +162,7 @@ impl RuntimeBuilder {
             let mut extension = factory.create();
             let extension_name = extension.name();
             if let Err(err) = extension.initialize(&rt).await {
-                tracing::warn!("Failed to initialize extension {extension_name}: {err}");
+                eprintln!("Failed to initialize extension {extension_name}: {err}");
             } else {
                 extensions.insert(extension_name.into(), extension.into());
             };
@@ -178,7 +178,7 @@ impl RuntimeBuilder {
 
         if let Some(app) = app {
             if let Err(e) = secrets.load_from(&app.secrets).await {
-                tracing::error!("Error loading secret stores: {e}");
+                eprintln!("Error loading secret stores: {e}");
             };
         }
 

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -29,6 +29,8 @@ use datafusion::{
 };
 use error_code::ErrorCode;
 use snafu::{ResultExt, Snafu};
+use tracing::Span;
+use tracing_futures::Instrument;
 pub(crate) use tracker::QueryTracker;
 
 pub mod builder;
@@ -94,10 +96,11 @@ pub struct Query {
 }
 
 macro_rules! handle_error {
-    ($self:expr, $error_code:expr, $error:expr, $target_error:ident) => {{
+    ($span:expr, $self:expr, $error_code:expr, $error:expr, $target_error:ident) => {{
         let snafu_error = Error::$target_error { source: $error };
         $self
             .finish_with_error(snafu_error.to_string(), $error_code)
+            .instrument($span)
             .await;
         return Err(snafu_error);
     }};
@@ -105,16 +108,26 @@ macro_rules! handle_error {
 
 impl Query {
     pub async fn run(self) -> Result<QueryResult> {
+        let span = match &self.tracker.nsql {
+            Some(nsql) => tracing::span!(tracing::Level::INFO, "nsql_query", input = %nsql),
+            None => {
+                tracing::span!(tracing::Level::INFO, "sql_query", input = %self.sql)
+            }
+        };
         let session = self.df.ctx.state();
 
         let ctx = self;
         let mut tracker = ctx.tracker;
 
-        let plan = match session.create_logical_plan(&ctx.sql).await {
+        let plan = match session
+            .create_logical_plan(&ctx.sql)
+            .instrument(span.clone())
+            .await
+        {
             Ok(plan) => plan,
             Err(e) => {
                 let error_code = ErrorCode::from(&e);
-                handle_error!(tracker, error_code, e, UnableToExecuteQuery)
+                handle_error!(span.clone(), tracker, error_code, e, UnableToExecuteQuery)
             }
         };
 
@@ -122,11 +135,19 @@ impl Query {
         let plan_cache_key = cache::key_for_logical_plan(&plan);
 
         if let Some(cache_provider) = &ctx.df.cache_provider() {
-            if let Some(cached_result) = match cache_provider.get(&plan).await {
-                Ok(Some(v)) => Some(v),
-                Ok(None) => None,
-                Err(e) => handle_error!(tracker, ErrorCode::InternalError, e, FailedToAccessCache),
-            } {
+            if let Some(cached_result) =
+                match cache_provider.get(&plan).instrument(span.clone()).await {
+                    Ok(Some(v)) => Some(v),
+                    Ok(None) => None,
+                    Err(e) => handle_error!(
+                        span.clone(),
+                        tracker,
+                        ErrorCode::InternalError,
+                        e,
+                        FailedToAccessCache
+                    ),
+                }
+            {
                 tracker = tracker
                     .datasets(cached_result.input_tables)
                     .results_cache_hit(true);
@@ -139,6 +160,7 @@ impl Query {
                     Ok(stream) => stream,
                     Err(e) => {
                         handle_error!(
+                            span.clone(),
                             tracker,
                             ErrorCode::InternalError,
                             e,
@@ -148,7 +170,7 @@ impl Query {
                 };
 
                 return Ok(QueryResult::new(
-                    attach_query_tracker_to_stream(tracker, Box::pin(record_batch_stream)),
+                    attach_query_tracker_to_stream(span, tracker, Box::pin(record_batch_stream)),
                     Some(true),
                 ));
             }
@@ -162,6 +184,7 @@ impl Query {
                 RESTRICTED_SQL_OPTIONS.with(|sql_options| sql_options.verify_plan(&plan))
             {
                 handle_error!(
+                    span.clone(),
                     tracker,
                     ErrorCode::QueryPlanningError,
                     e,
@@ -172,28 +195,41 @@ impl Query {
 
         tracker = tracker.datasets(Arc::new(get_logical_plan_input_tables(&plan)));
 
-        let df = match ctx.df.ctx.execute_logical_plan(plan).await {
+        let df = match ctx
+            .df
+            .ctx
+            .execute_logical_plan(plan)
+            .instrument(span.clone())
+            .await
+        {
             Ok(df) => df,
             Err(e) => {
                 let error_code = ErrorCode::from(&e);
-                handle_error!(tracker, error_code, e, UnableToExecuteQuery)
+                handle_error!(span.clone(), tracker, error_code, e, UnableToExecuteQuery)
             }
         };
 
         let df_schema: SchemaRef = Arc::clone(df.schema().inner());
 
-        let res_stream: SendableRecordBatchStream = match df.execute_stream().await {
-            Ok(stream) => stream,
-            Err(e) => {
-                let error_code = ErrorCode::from(&e);
-                handle_error!(tracker, error_code, e, UnableToExecuteQuery)
-            }
-        };
+        let res_stream: SendableRecordBatchStream =
+            match df.execute_stream().instrument(span.clone()).await {
+                Ok(stream) => stream,
+                Err(e) => {
+                    let error_code = ErrorCode::from(&e);
+                    handle_error!(span.clone(), tracker, error_code, e, UnableToExecuteQuery)
+                }
+            };
 
         let res_schema = res_stream.schema();
 
         if let Err(e) = verify_schema(df_schema.fields(), res_schema.fields()) {
-            handle_error!(tracker, ErrorCode::InternalError, e, SchemaMismatch)
+            handle_error!(
+                span.clone(),
+                tracker,
+                ErrorCode::InternalError,
+                e,
+                SchemaMismatch
+            )
         };
 
         if plan_is_cache_enabled {
@@ -206,14 +242,14 @@ impl Query {
                 );
 
                 return Ok(QueryResult::new(
-                    attach_query_tracker_to_stream(tracker, record_batch_stream),
+                    attach_query_tracker_to_stream(span, tracker, record_batch_stream),
                     Some(false),
                 ));
             }
         }
 
         Ok(QueryResult::new(
-            attach_query_tracker_to_stream(tracker, res_stream),
+            attach_query_tracker_to_stream(span, tracker, res_stream),
             None,
         ))
     }
@@ -239,6 +275,7 @@ impl Query {
 /// Note: If an error occurs during stream processing, the query tracker
 /// is finalized with error details, and further streaming is terminated.
 fn attach_query_tracker_to_stream(
+    span: Span,
     ctx: QueryTracker,
     mut stream: SendableRecordBatchStream,
 ) -> SendableRecordBatchStream {
@@ -282,7 +319,7 @@ fn attach_query_tracker_to_stream(
 
     Box::pin(RecordBatchStreamAdapter::new(
         schema,
-        Box::pin(updated_stream),
+        Box::pin(updated_stream.instrument(span)),
     ))
 }
 

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -107,6 +107,7 @@ macro_rules! handle_error {
 }
 
 impl Query {
+    #[allow(clippy::too_many_lines)]
     pub async fn run(self) -> Result<QueryResult> {
         let span = match &self.tracker.nsql {
             Some(nsql) => tracing::span!(tracing::Level::INFO, "nsql_query", input = %nsql),

--- a/crates/runtime/src/datafusion/query/query_history.rs
+++ b/crates/runtime/src/datafusion/query/query_history.rs
@@ -160,7 +160,7 @@ impl QueryTracker {
             .boxed()
             .context(UnableToWriteToTableSnafu)?;
 
-        trace_query(self, truncated_output);
+        trace_query(self, &truncated_output);
 
         Ok(())
     }
@@ -229,8 +229,7 @@ impl QueryTracker {
     }
 }
 
-fn trace_query(query_tracker: &QueryTracker, truncated_output: Arc<str>) {
-    // task_history::TODO: Add top-level span for query, setting the name and input properly
+fn trace_query(query_tracker: &QueryTracker, truncated_output: &str) {
     if let Some(schema) = &query_tracker.schema {
         tracing::info!(name: "labels", target: "task_history", schema = ?schema);
     }

--- a/crates/runtime/src/datafusion/query/query_history.rs
+++ b/crates/runtime/src/datafusion/query/query_history.rs
@@ -165,7 +165,7 @@ impl QueryTracker {
 
         // Whilst both the query history and task history tables exist, don't need a `TaskTracker` for recording queries.
         Into::<TaskSpan>::into(self)
-            .truncated_output_text(truncated_output)
+            .truncated_output(truncated_output)
             .write()
             .await
             .boxed()

--- a/crates/runtime/src/embeddings/task.rs
+++ b/crates/runtime/src/embeddings/task.rs
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
-
-use crate::datafusion::DataFusion;
 use async_openai::{
     error::OpenAIError,
     types::{CreateEmbeddingRequest, CreateEmbeddingResponse, EmbeddingInput},
@@ -27,12 +24,11 @@ use tracing::{Instrument, Span};
 
 pub struct TaskEmbed {
     inner: Box<dyn Embed>,
-    df: Arc<DataFusion>,
 }
 
 impl TaskEmbed {
-    pub fn new(inner: Box<dyn Embed>, df: Arc<DataFusion>) -> Self {
-        Self { inner, df }
+    pub fn new(inner: Box<dyn Embed>) -> Self {
+        Self { inner }
     }
 }
 

--- a/crates/runtime/src/embeddings/task.rs
+++ b/crates/runtime/src/embeddings/task.rs
@@ -27,6 +27,7 @@ pub struct TaskEmbed {
 }
 
 impl TaskEmbed {
+    #[must_use]
     pub fn new(inner: Box<dyn Embed>) -> Self {
         Self { inner }
     }

--- a/crates/runtime/src/http/v1/assist.rs
+++ b/crates/runtime/src/http/v1/assist.rs
@@ -32,7 +32,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
-use tracing::Instrument;
 
 use futures::StreamExt;
 

--- a/crates/runtime/src/http/v1/assist.rs
+++ b/crates/runtime/src/http/v1/assist.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
+use tracing::Instrument;
 
 use futures::StreamExt;
 
@@ -240,8 +241,11 @@ pub(crate) async fn post(
     )
     .label("tables".to_string(), format!("{input_tables:?}"));
 
+    let tspan = tracing::span!(target: "task_history", tracing::Level::INFO, "vector_search", input_text = %payload.text);
+
     let relevant_data = match vs
         .search(payload.text.clone(), input_tables, RetrievalLimit::TopN(3))
+        .instrument(tspan)
         .await
     {
         Ok(relevant_data) => {

--- a/crates/runtime/src/http/v1/assist.rs
+++ b/crates/runtime/src/http/v1/assist.rs
@@ -241,11 +241,8 @@ pub(crate) async fn post(
     )
     .label("tables".to_string(), format!("{input_tables:?}"));
 
-    let tspan = tracing::span!(target: "task_history", tracing::Level::INFO, "vector_search", input_text = %payload.text);
-
     let relevant_data = match vs
         .search(payload.text.clone(), input_tables, RetrievalLimit::TopN(3))
-        .instrument(tspan)
         .await
     {
         Ok(relevant_data) => {

--- a/crates/runtime/src/http/v1/assist.rs
+++ b/crates/runtime/src/http/v1/assist.rs
@@ -32,13 +32,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
+use tracing::Instrument;
 
 use futures::StreamExt;
 
 use crate::{
     embeddings::vector_search::{RetrievalLimit, VectorSearch, VectorSearchResult},
     model::LLMModelStore,
-    task_history::{TaskSpan, TaskType},
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -231,27 +231,19 @@ pub(crate) async fn post(
         .map(TableReference::from)
         .collect();
 
-    let mut span = TaskSpan::new(
-        Arc::clone(&vs.df),
-        uuid::Uuid::new_v4(),
-        TaskType::VectorSearch,
-        Arc::from(payload.text.clone()),
-        None,
-    )
-    .label("tables".to_string(), format!("{input_tables:?}"));
+    let span = tracing::span!(target: "task_history", tracing::Level::INFO, "vector_search", input = %payload.text);
 
     let relevant_data = match vs
         .search(payload.text.clone(), input_tables, RetrievalLimit::TopN(3))
+        .instrument(span.clone())
         .await
     {
         Ok(relevant_data) => {
-            span = span.outputs_produced(relevant_data.retrieved_entries.len() as u64);
-            span.finish();
+            tracing::info!(name: "labels", target: "task_history", parent: &span, outputs_produced = relevant_data.retrieved_entries.len());
             relevant_data
         }
         Err(e) => {
-            span = span.with_error_message(e.to_string());
-            span.finish();
+            tracing::error!(target: "task_history", parent: &span, "{e}");
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
     };

--- a/crates/runtime/src/http/v1/chat.rs
+++ b/crates/runtime/src/http/v1/chat.rs
@@ -51,7 +51,7 @@ pub(crate) async fn post(
     )
     .label("model".to_string(), req.model.clone());
 
-    let tspan = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input_text = %serde_json::to_string(&req).unwrap_or_default());
+    let tspan = tracing::span!(target: "task_history", tracing::Level::DEBUG, "POST /v1/chat", input = %serde_json::to_string(&req).unwrap_or_default(), model = %req.model);
 
     let tspan_clone = tspan.clone();
     async move {

--- a/crates/runtime/src/http/v1/embeddings.rs
+++ b/crates/runtime/src/http/v1/embeddings.rs
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use crate::{datafusion::DataFusion, model::EmbeddingModelStore, task_history};
-use async_openai::types::{CreateEmbeddingRequest, EncodingFormat};
+use crate::model::EmbeddingModelStore;
+use async_openai::types::CreateEmbeddingRequest;
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -26,69 +26,24 @@ use axum::{
 use tokio::sync::RwLock;
 
 pub(crate) async fn post(
-    Extension(df): Extension<Arc<DataFusion>>,
     Extension(embeddings): Extension<Arc<RwLock<EmbeddingModelStore>>>,
     Json(req): Json<CreateEmbeddingRequest>,
 ) -> Response {
-    let context_id = uuid::Uuid::new_v4();
-
-    let Ok(input_text) = serde_json::to_string(&req.input) else {
-        return (StatusCode::BAD_REQUEST, "invalid input").into_response();
-    };
-
     let model_id = req.model.clone().to_string();
     match embeddings.read().await.get(&model_id) {
         Some(model_lock) => {
             let mut model = model_lock.write().await;
-            let mut task_span = task_history::TaskSpan::new(
-                df,
-                context_id,
-                task_history::TaskType::TextEmbed,
-                Arc::from(input_text.clone()),
-                None,
-            );
-
-            task_span = task_span.labels(labels_from_request(&req));
 
             let resp: Response = match model.embed_request(req).await {
-                Ok(response) => {
-                    task_span = task_span.outputs_produced(response.data.len() as u64);
-                    Json(response).into_response()
-                }
+                Ok(response) => Json(response).into_response(),
                 Err(e) => {
                     let err_msg = e.to_string();
-                    task_span = task_span.with_error_message(err_msg.clone());
                     (StatusCode::INTERNAL_SERVER_ERROR, err_msg).into_response()
                 }
             };
 
-            task_span.finish();
             resp
         }
         None => (StatusCode::NOT_FOUND, "model not found").into_response(),
     }
-}
-
-fn labels_from_request(req: &CreateEmbeddingRequest) -> HashMap<String, String> {
-    let mut labels = HashMap::new();
-    labels.insert("model".to_string(), req.model.clone());
-
-    if let Some(encoding_format) = &req.encoding_format {
-        labels.insert(
-            "encoding_format".to_string(),
-            match encoding_format {
-                EncodingFormat::Base64 => "base64".to_string(),
-                EncodingFormat::Float => "float".to_string(),
-            },
-        );
-    }
-    if let Some(user) = &req.user {
-        labels.insert("user".to_string(), user.clone());
-    }
-
-    if let Some(dims) = req.dimensions {
-        labels.insert("dimensions".to_string(), dims.to_string());
-    }
-
-    labels
 }

--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -13,10 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use crate::{
-    embeddings::vector_search::{RetrievalLimit, VectorSearch, VectorSearchResult},
-    task_history::{TaskSpan, TaskType},
-};
+use crate::embeddings::vector_search::{RetrievalLimit, VectorSearch, VectorSearchResult};
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -82,15 +79,6 @@ pub(crate) async fn post(
         .map(TableReference::from)
         .collect();
 
-    let span = TaskSpan::new(
-        Arc::clone(&vs.df),
-        uuid::Uuid::new_v4(),
-        TaskType::VectorSearch,
-        Arc::from(payload.text.clone()),
-        None,
-    )
-    .label("tables".to_string(), format!("{input_tables:?}"));
-
     match vs
         .search(
             payload.text.clone(),
@@ -101,16 +89,19 @@ pub(crate) async fn post(
     {
         Ok(resp) => match SearchResponse::from_vector_search(resp) {
             Ok(r) => {
-                span.outputs_produced(r.entries.len() as u64).finish();
+                // task_history::TODO
+                //span.outputs_produced(r.entries.len() as u64).finish();
                 (StatusCode::OK, Json(r)).into_response()
             }
             Err(e) => {
-                span.with_error_message(e.to_string()).finish();
+                // task_history::TODO
+                //span.with_error_message(e.to_string()).finish();
                 (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
             }
         },
         Err(e) => {
-            span.with_error_message(e.to_string()).finish();
+            // task_history::TODO
+            //span.with_error_message(e.to_string()).finish();
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1173,7 +1173,7 @@ impl Runtime {
                     Ok(e) => {
                         let mut embeds_map = self.embeds.write().await;
 
-                        let m = Box::new(TaskEmbed::new(e, Arc::clone(&self.df))) as Box<dyn Embed>;
+                        let m = Box::new(TaskEmbed::new(e)) as Box<dyn Embed>;
                         embeds_map.insert(in_embed.name.clone(), m.into());
 
                         tracing::info!("Embedding [{}] ready to embed", in_embed.name);

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -15,14 +15,10 @@ limitations under the License.
 */
 
 use crate::accelerated_table::refresh::Refresh;
-use crate::dataupdate::DataUpdate;
 use crate::internal_table::create_internal_accelerated_table;
 use crate::{component::dataset::acceleration::Acceleration, datafusion::SPICE_RUNTIME_SCHEMA};
 use crate::{component::dataset::TimeFormat, secrets::Secrets};
-use arrow::array::{
-    Array, ArrayData, BooleanArray, Float64Array, MapArray, RecordBatch, StringArray, StructArray,
-    TimestampNanosecondArray, UInt64Array,
-};
+use arrow::array::{Array, ArrayData, MapArray, StringArray, StructArray};
 use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::error::ArrowError;

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -151,27 +151,25 @@ fn convert_hashmap_to_maparray(labels: &HashMap<String, String>) -> Result<MapAr
 /// [`TaskSpan`] records information about the execution of a given task. On [`finish`], it will write to the datafusion.
 pub(crate) struct TaskSpan {
     pub(crate) df: Arc<crate::datafusion::DataFusion>,
-    pub(crate) id: Uuid,
+    pub(crate) trace_id: String,
 
     /// An identifier for the top level [`TaskSpan`] that this [`TaskSpan`] occurs in.
-    pub(crate) context_id: Uuid,
+    pub(crate) span_id: String,
 
     /// An identifier to the [`TaskSpan`] that directly started this [`TaskSpan`].
-    pub(crate) parent_id: Option<Uuid>,
+    pub(crate) parent_span_id: Option<String>,
 
-    pub(crate) task_type: TaskType,
-    pub(crate) input_text: Arc<str>,
-    pub(crate) truncated_output_text: Option<Arc<str>>,
+    pub(crate) task: String,
+    pub(crate) input: Arc<str>,
+    pub(crate) truncated_output: Option<Arc<str>>,
 
     pub(crate) start_time: SystemTime,
-    pub(crate) end_time: Option<SystemTime>,
-    pub(crate) execution_duration_ms: Option<f64>,
-    pub(crate) outputs_produced: u64,
-    pub(crate) cache_hit: Option<bool>,
+    pub(crate) end_time: SystemTime,
+    pub(crate) execution_duration_ms: f64,
     pub(crate) error_message: Option<String>,
     pub(crate) labels: HashMap<String, String>,
-
-    pub(crate) timer: Instant,
+    // For top-level HTTP tasks, have a label:
+    // - "http_status" (200, 400)
 }
 
 impl TaskSpan {

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -18,16 +18,12 @@ use crate::accelerated_table::refresh::Refresh;
 use crate::internal_table::create_internal_accelerated_table;
 use crate::{component::dataset::acceleration::Acceleration, datafusion::SPICE_RUNTIME_SCHEMA};
 use crate::{component::dataset::TimeFormat, secrets::Secrets};
-use arrow::array::{Array, ArrayData, MapArray, StringArray, StructArray};
-use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
-use arrow::error::ArrowError;
 use datafusion::sql::TableReference;
 use snafu::{ResultExt, Snafu};
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 use tokio::sync::RwLock;
 
 use crate::accelerated_table::{AcceleratedTable, Retention};
@@ -54,88 +50,88 @@ impl Display for TaskType {
     }
 }
 
-fn convert_hashmap_to_maparray(labels: &HashMap<String, String>) -> Result<MapArray, ArrowError> {
-    let keys_field = Arc::new(Field::new("keys", DataType::Utf8, false));
-    let values_field = Arc::new(Field::new("values", DataType::Utf8, false));
+// fn convert_hashmap_to_maparray(labels: &HashMap<String, String>) -> Result<MapArray, ArrowError> {
+//     let keys_field = Arc::new(Field::new("keys", DataType::Utf8, false));
+//     let values_field = Arc::new(Field::new("values", DataType::Utf8, false));
 
-    let (keys, values): (Vec<&str>, Vec<&str>) =
-        labels.iter().map(|(k, v)| (k.as_str(), v.as_str())).unzip();
+//     let (keys, values): (Vec<&str>, Vec<&str>) =
+//         labels.iter().map(|(k, v)| (k.as_str(), v.as_str())).unzip();
 
-    let keys_array = StringArray::from(keys);
-    let values_array = StringArray::from(values);
+//     let keys_array = StringArray::from(keys);
+//     let values_array = StringArray::from(values);
 
-    let entry_struct = StructArray::from(vec![
-        (
-            Arc::clone(&keys_field),
-            Arc::new(keys_array) as Arc<dyn arrow::array::Array>,
-        ),
-        (
-            Arc::clone(&values_field),
-            Arc::new(values_array) as Arc<dyn arrow::array::Array>,
-        ),
-    ]);
+//     let entry_struct = StructArray::from(vec![
+//         (
+//             Arc::clone(&keys_field),
+//             Arc::new(keys_array) as Arc<dyn arrow::array::Array>,
+//         ),
+//         (
+//             Arc::clone(&values_field),
+//             Arc::new(values_array) as Arc<dyn arrow::array::Array>,
+//         ),
+//     ]);
 
-    let entry_offsets = Buffer::from_vec(vec![0, labels.len() as u64]);
-    let map_data_type = DataType::Map(
-        Arc::new(Field::new_struct(
-            "entries",
-            vec![
-                Arc::new(Field::new("keys", DataType::Utf8, false)),
-                Arc::new(Field::new("values", DataType::Utf8, false)),
-            ],
-            false,
-        )),
-        false,
-    );
+//     let entry_offsets = Buffer::from_vec(vec![0, labels.len() as u64]);
+//     let map_data_type = DataType::Map(
+//         Arc::new(Field::new_struct(
+//             "entries",
+//             vec![
+//                 Arc::new(Field::new("keys", DataType::Utf8, false)),
+//                 Arc::new(Field::new("values", DataType::Utf8, false)),
+//             ],
+//             false,
+//         )),
+//         false,
+//     );
 
-    let map_data = ArrayData::builder(map_data_type)
-        .len(1)
-        .add_buffer(entry_offsets)
-        .add_child_data(entry_struct.to_data())
-        .build()?;
+//     let map_data = ArrayData::builder(map_data_type)
+//         .len(1)
+//         .add_buffer(entry_offsets)
+//         .add_child_data(entry_struct.to_data())
+//         .build()?;
 
-    Ok(MapArray::from(map_data))
-}
+//     Ok(MapArray::from(map_data))
+// }
 
 /// [`TaskSpan`] records information about the execution of a given task. On [`finish`], it will write to the datafusion.
 pub(crate) struct TaskSpan {
-    pub(crate) df: Arc<crate::datafusion::DataFusion>,
-    pub(crate) trace_id: Arc<str>,
+    // pub(crate) df: Arc<crate::datafusion::DataFusion>,
+    // pub(crate) trace_id: Arc<str>,
 
-    /// An identifier for the top level [`TaskSpan`] that this [`TaskSpan`] occurs in.
-    pub(crate) span_id: Arc<str>,
+    // /// An identifier for the top level [`TaskSpan`] that this [`TaskSpan`] occurs in.
+    // pub(crate) span_id: Arc<str>,
 
-    /// An identifier to the [`TaskSpan`] that directly started this [`TaskSpan`].
-    pub(crate) parent_span_id: Option<Arc<str>>,
+    // /// An identifier to the [`TaskSpan`] that directly started this [`TaskSpan`].
+    // pub(crate) parent_span_id: Option<Arc<str>>,
 
-    pub(crate) task: Arc<str>,
-    pub(crate) input: Arc<str>,
-    pub(crate) truncated_output: Option<Arc<str>>,
+    // pub(crate) task: Arc<str>,
+    // pub(crate) input: Arc<str>,
+    // pub(crate) truncated_output: Option<Arc<str>>,
 
-    pub(crate) start_time: SystemTime,
-    pub(crate) end_time: SystemTime,
-    pub(crate) execution_duration_ms: f64,
-    pub(crate) error_message: Option<String>,
-    pub(crate) labels: HashMap<String, String>,
+    // pub(crate) start_time: SystemTime,
+    // pub(crate) end_time: SystemTime,
+    // pub(crate) execution_duration_ms: f64,
+    // pub(crate) error_message: Option<String>,
+    // pub(crate) labels: HashMap<String, String>,
     // For top-level HTTP tasks, have a label:
     // - "http_status" (200, 400)
 }
 
 impl TaskSpan {
-    pub fn with_error_message(mut self, error_message: String) -> Self {
-        self.error_message = Some(error_message);
-        self
-    }
+    // pub fn with_error_message(mut self, error_message: String) -> Self {
+    //     self.error_message = Some(error_message);
+    //     self
+    // }
 
-    pub fn label(mut self, key: String, value: String) -> Self {
-        self.labels.insert(key, value);
-        self
-    }
+    // pub fn label(mut self, key: String, value: String) -> Self {
+    //     self.labels.insert(key, value);
+    //     self
+    // }
 
-    pub fn labels<I: IntoIterator<Item = (String, String)>>(mut self, labels: I) -> Self {
-        self.labels.extend(labels);
-        self
-    }
+    // pub fn labels<I: IntoIterator<Item = (String, String)>>(mut self, labels: I) -> Self {
+    //     self.labels.extend(labels);
+    //     self
+    // }
 
     pub async fn instantiate_table() -> Result<Arc<AcceleratedTable>, Error> {
         let time_column = Some("start_time".to_string());

--- a/crates/spice_cloud/Cargo.toml
+++ b/crates/spice_cloud/Cargo.toml
@@ -13,7 +13,7 @@ async-trait.workspace = true
 datafusion.workspace = true
 futures.workspace = true
 globset.workspace = true
-reqwest = { version = "0.11.24", features = ["json"] }
+reqwest.workspace = true
 runtime = { path = "../runtime" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -27,6 +27,8 @@ pub struct Runtime {
 
     /// If set, the runtime will configure all endpoints to use TLS
     pub tls: Option<TlsConfig>,
+
+    pub tracing: Option<TracingConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -72,4 +74,12 @@ pub struct TlsConfig {
 
     /// A PEM encoded private key
     pub key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct TracingConfig {
+    pub zipkin_enabled: bool,
+    pub zipkin_endpoint: Option<String>,
 }


### PR DESCRIPTION
## 🗣 Description

Instruments the `ai_completion` calls with proper nested span tracking, with optional Zipkin tracing configuration.

The next step will be to configure the OTel traces exporter to go directly into the `task_history` table and remove the existing TaskSpan code.

### Testing

Run zipkin locally:
`docker run -d -p 9411:9411 openzipkin/zipkin`

Add this Spicepod config:

```yaml
runtime:
  tracing:
    zipkin_enabled: true
    zipkin_endpoint: http://localhost:9411/api/v2/spans
```
