### PR TITLE
Emit `task_history` traces from tracing OTel exporter

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -158,7 +158,7 @@ pub async fn run(args: Args, prometheus_registry: Option<prometheus::Registry>) 
         .build()
         .await;
 
-    spiced_tracing::init_tracing(app_name, tracing_config.as_ref())
+    spiced_tracing::init_tracing(app_name, tracing_config.as_ref(), rt.datafusion())
         .context(UnableToInitializeTracingSnafu)?;
 
     let tls_config = tls::load_tls_config(&args, spicepod_tls_config.as_ref(), rt.secrets())

--- a/crates/runtime/src/http/v1/chat.rs
+++ b/crates/runtime/src/http/v1/chat.rs
@@ -38,6 +38,7 @@ pub(crate) async fn post(
     Json(req): Json<CreateChatCompletionRequest>,
 ) -> Response {
     let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
+    span.in_scope(|| tracing::info!(name: "labels", target: "task_history", model = %req.model));
 
     let span_clone = span.clone();
     async move {

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -558,6 +558,9 @@ impl Chat for ToolUsingChat {
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
         let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
+        span.in_scope(
+            || tracing::info!(name: "labels", target: "task_history", model = %req.model),
+        );
         // Don't use spice runtime tools if users has explicitly chosen to not use any tools.
         if req
             .tool_choice
@@ -599,6 +602,9 @@ impl Chat for ToolUsingChat {
         req: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
         let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_completion", input = %serde_json::to_string(&req).unwrap_or_default());
+        span.in_scope(
+            || tracing::info!(name: "labels", target: "task_history", model = %req.model),
+        );
         // Don't use spice runtime tools if users has explicitly chosen to not use any tools.
         if req
             .tool_choice

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -27,7 +27,6 @@ use datafusion::sql::TableReference;
 use snafu::prelude::*;
 use snafu::{ResultExt, Snafu};
 use std::collections::HashMap;
-use std::fmt::Display;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::RwLock;
@@ -38,67 +37,24 @@ pub mod otel_exporter;
 
 pub const DEFAULT_TASK_HISTORY_TABLE: &str = "task_history";
 
-pub enum TaskType {
-    SqlQuery,
-    NsqlQuery,
-    AiCompletion,
-    TextEmbed,
-    VectorSearch,
-}
+// pub enum TaskType {
+//     SqlQuery,
+//     NsqlQuery,
+//     AiCompletion,
+//     TextEmbed,
+//     VectorSearch,
+// }
 
-impl Display for TaskType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TaskType::SqlQuery => write!(f, "sql_query"),
-            TaskType::NsqlQuery => write!(f, "nsql_query"),
-            TaskType::AiCompletion => write!(f, "ai_completion"),
-            TaskType::TextEmbed => write!(f, "text_embed"),
-            TaskType::VectorSearch => write!(f, "vector_search"),
-        }
-    }
-}
-
-// fn convert_hashmap_to_maparray(labels: &HashMap<String, String>) -> Result<MapArray, ArrowError> {
-//     let keys_field = Arc::new(Field::new("keys", DataType::Utf8, false));
-//     let values_field = Arc::new(Field::new("values", DataType::Utf8, false));
-
-//     let (keys, values): (Vec<&str>, Vec<&str>) =
-//         labels.iter().map(|(k, v)| (k.as_str(), v.as_str())).unzip();
-
-//     let keys_array = StringArray::from(keys);
-//     let values_array = StringArray::from(values);
-
-//     let entry_struct = StructArray::from(vec![
-//         (
-//             Arc::clone(&keys_field),
-//             Arc::new(keys_array) as Arc<dyn arrow::array::Array>,
-//         ),
-//         (
-//             Arc::clone(&values_field),
-//             Arc::new(values_array) as Arc<dyn arrow::array::Array>,
-//         ),
-//     ]);
-
-//     let entry_offsets = Buffer::from_vec(vec![0, labels.len() as u64]);
-//     let map_data_type = DataType::Map(
-//         Arc::new(Field::new_struct(
-//             "entries",
-//             vec![
-//                 Arc::new(Field::new("keys", DataType::Utf8, false)),
-//                 Arc::new(Field::new("values", DataType::Utf8, false)),
-//             ],
-//             false,
-//         )),
-//         false,
-//     );
-
-//     let map_data = ArrayData::builder(map_data_type)
-//         .len(1)
-//         .add_buffer(entry_offsets)
-//         .add_child_data(entry_struct.to_data())
-//         .build()?;
-
-//     Ok(MapArray::from(map_data))
+// impl Display for TaskType {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         match self {
+//             TaskType::SqlQuery => write!(f, "sql_query"),
+//             TaskType::NsqlQuery => write!(f, "nsql_query"),
+//             TaskType::AiCompletion => write!(f, "ai_completion"),
+//             TaskType::TextEmbed => write!(f, "text_embed"),
+//             TaskType::VectorSearch => write!(f, "vector_search"),
+//         }
+//     }
 // }
 
 /// [`TaskSpan`] records information about the execution of a given task. On [`finish`], it will write to the datafusion.

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -28,6 +28,8 @@ use tokio::sync::RwLock;
 
 use crate::accelerated_table::{AcceleratedTable, Retention};
 
+pub mod otel_exporter;
+
 pub const DEFAULT_TASK_HISTORY_TABLE: &str = "task_history";
 
 pub enum TaskType {

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -118,28 +118,13 @@ pub(crate) struct TaskSpan {
     pub(crate) start_time: SystemTime,
     pub(crate) end_time: SystemTime,
     pub(crate) execution_duration_ms: f64,
-    pub(crate) error_message: Option<String>,
-    pub(crate) labels: HashMap<String, String>,
+    pub(crate) error_message: Option<Arc<str>>,
+    pub(crate) labels: HashMap<Arc<str>, Arc<str>>,
     // For top-level HTTP tasks, have a label:
     // - "http_status" (200, 400)
 }
 
 impl TaskSpan {
-    pub fn with_error_message(mut self, error_message: String) -> Self {
-        self.error_message = Some(error_message);
-        self
-    }
-
-    pub fn label(mut self, key: String, value: String) -> Self {
-        self.labels.insert(key, value);
-        self
-    }
-
-    pub fn labels<I: IntoIterator<Item = (String, String)>>(mut self, labels: I) -> Self {
-        self.labels.extend(labels);
-        self
-    }
-
     pub async fn instantiate_table() -> Result<Arc<AcceleratedTable>, Error> {
         let time_column = Some("start_time".to_string());
         let time_format = Some(TimeFormat::UnixSeconds);

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use opentelemetry::trace::TraceError;
+use opentelemetry::trace::{SpanId, TraceError};
 use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
 
 use crate::datafusion::DataFusion;
@@ -45,11 +46,79 @@ impl TaskHistoryExporter {
 
 impl SpanExporter for TaskHistoryExporter {
     fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        let spans = batch.into_iter().map(span_to_task_span).collect();
         let df = Arc::clone(&self.df);
         Box::pin(async move {
-            TaskSpan::write(df, vec![])
+            TaskSpan::write(df, spans)
                 .await
                 .map_err(|e| TraceError::Other(Box::new(e)))
         })
+    }
+}
+
+fn span_to_task_span(span: SpanData) -> TaskSpan {
+    let trace_id: Arc<str> = span.span_context.trace_id().to_string().into();
+    let span_id: Arc<str> = span.span_context.span_id().to_string().into();
+    let parent_span_id: Option<Arc<str>> = if span.parent_span_id == SpanId::INVALID {
+        None
+    } else {
+        Some(span.parent_span_id.to_string().into())
+    };
+    let task: Arc<str> = span.name.into();
+    let input: Arc<str> = span
+        .attributes
+        .iter()
+        .position(|kv| kv.key.as_str() == "input")
+        .map_or_else(
+            || "".into(),
+            |idx| span.attributes[idx].value.as_str().into(),
+        );
+    let truncated_output: Option<Arc<str>> = span.events.iter().find_map(|event| {
+        let event_attr_idx = event
+            .attributes
+            .iter()
+            .position(|kv| kv.key.as_str() == "truncated_output")?;
+        Some(event.attributes[event_attr_idx].value.as_str().into())
+    });
+    let start_time = span.start_time;
+    let end_time = span.end_time;
+    let execution_duration_ms = end_time
+        .duration_since(start_time)
+        .map_or(0.0, |duration| duration.as_secs_f64() * 1000.0);
+    let error_message: Option<Arc<str>> = span
+        .events
+        .iter()
+        .position(|event| {
+            event
+                .attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "level" && kv.value.as_str() == "ERROR")
+        })
+        .map(|idx| {
+            span.events[idx]
+                .attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == "message")
+                .map_or_else(|| "".into(), |kv| kv.value.as_str().into())
+        });
+    let labels: HashMap<Arc<str>, Arc<str>> = span
+        .attributes
+        .iter()
+        .filter(|kv| kv.key.as_str() != "input")
+        .map(|kv| (kv.key.as_str().into(), kv.value.as_str().into()))
+        .collect();
+
+    TaskSpan {
+        trace_id,
+        span_id,
+        parent_span_id,
+        task,
+        input,
+        truncated_output,
+        start_time,
+        end_time,
+        execution_duration_ms,
+        error_message,
+        labels,
     }
 }

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -15,11 +15,8 @@ limitations under the License.
 */
 
 use std::fmt;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-use std::{
-    fmt::{Debug, Formatter},
-    io::Write,
-};
 
 use futures::future::BoxFuture;
 use opentelemetry::trace::TraceError;

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::fs::File;
+use std::io::Write;
+
+use futures::future::BoxFuture;
+use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
+
+#[derive(Debug)]
+pub struct TaskHistoryExporter {
+    file: File,
+}
+
+impl TaskHistoryExporter {
+    pub fn new() -> Self {
+        let Ok(file) = File::create("task_history_exporter.log") else {
+            panic!("Unable to create task history exporter log file");
+        };
+        Self { file }
+    }
+}
+
+impl SpanExporter for TaskHistoryExporter {
+    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        for span in batch {
+            writeln!(self.file, "{span:#?}");
+        }
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn shutdown(&mut self) {}
+
+    fn force_flush(&mut self) -> BoxFuture<'static, ExportResult> {
+        self.file.flush();
+        Box::pin(async { Ok(()) })
+    }
+}
+
+// async fn write(&self) -> Result<(), Error> {
+//     if self.end_time.is_none() {
+//         return Err(Error::MissingColumnsInRow {
+//             columns: "end_time".to_string(),
+//         });
+//     }
+
+//     let data = self
+//         .to_record_batch()
+//         .boxed()
+//         .context(UnableToWriteToTableSnafu)?;
+
+//     let data_update = DataUpdate {
+//         schema: Arc::new(Self::table_schema()),
+//         data: vec![data],
+//         update_type: crate::dataupdate::UpdateType::Append,
+//     };
+
+//     self.df
+//         .write_data(
+//             TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE),
+//             data_update,
+//         )
+//         .await
+//         .boxed()
+//         .context(UnableToWriteToTableSnafu)?;
+
+//     Ok(())
+// }


### PR DESCRIPTION
## 🗣 Description

Emits the `task_history` traces into the `runtime.task_history` table.
