### PR TITLE
Add OTel multiplexer to enable zipkin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9180,6 +9180,7 @@ dependencies = [
  "app",
  "clap",
  "flightrepl",
+ "futures",
  "opentelemetry 0.24.0",
  "opentelemetry-http",
  "opentelemetry-prometheus",

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 app = { path = "../../crates/app" }
 clap = { workspace = true, features = ["derive"] }
 flightrepl = { path = "../../crates/flightrepl" }
+futures.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-prometheus.workspace = true


### PR DESCRIPTION
## 🗣 Description

Adds a simple multiplexer to enable sending traces to multiple OTel exporters. This enables the Zipkin exporter and the internal task history table.
