### PR TITLE
Return full vector search response

### DIFF
--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -85,6 +85,7 @@ impl Display for RetrievalLimit {
 
 pub type ModelKey = String;
 
+#[derive(Debug)]
 pub struct VectorSearchResult {
     pub retrieved_entries: HashMap<TableReference, Vec<String>>,
     pub retrieved_primary_keys: HashMap<TableReference, Vec<RecordBatch>>,

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -285,7 +285,7 @@ impl VectorSearch {
             response.retrieved_entries,
         );
         span.in_scope(|| {
-            tracing::info!(target: "task_history", truncated_output = ?response.retrieved_entries);
+            tracing::info!(target: "task_history", truncated_output = ?response);
         });
         Ok(response)
     }


### PR DESCRIPTION
## 🗣 Description

Return the full vector search response, including the primary keys.