### PR TITLE
Load components metadata into models scope

### DIFF
--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -263,6 +263,10 @@
             "type": "string"
           }
         },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        },
         "name": {
           "type": "string"
         },
@@ -571,6 +575,10 @@
         "from": {
           "type": "string"
         },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        },
         "name": {
           "type": "string"
         },
@@ -868,6 +876,10 @@
             "string",
             "null"
           ]
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
         },
         "name": {
           "type": "string"

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -350,6 +350,7 @@ impl SpiceModelTool for ListDatasetsTool {
                     json!({
                         "name": TableReference::parse_str(&d.name).resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA).to_string(),
                         "description": d.description,
+                        "metadata": d.metadata,
                     })
                 })
                 .collect_vec(),

--- a/crates/spicepod/src/component/catalog.rs
+++ b/crates/spicepod/src/component/catalog.rs
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
+
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use super::{params::Params, WithDependsOn};
 
@@ -28,6 +31,10 @@ pub struct Catalog {
     pub name: String,
 
     pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    pub metadata: HashMap<String, Value>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub include: Vec<String>,
@@ -50,6 +57,7 @@ impl Catalog {
             from,
             name,
             description: None,
+            metadata: HashMap::default(),
             include: Vec::default(),
             params: None,
             dataset_params: None,
@@ -64,6 +72,7 @@ impl WithDependsOn<Catalog> for Catalog {
             from: self.from.clone(),
             name: self.name.clone(),
             description: self.description.clone(),
+            metadata: self.metadata.clone(),
             include: self.include.clone(),
             params: self.params.clone(),
             dataset_params: self.dataset_params.clone(),

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
+
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use super::{embeddings::ColumnEmbeddingConfig, params::Params, Nameable, WithDependsOn};
 
@@ -57,6 +60,10 @@ pub struct Dataset {
     pub name: String,
 
     pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    pub metadata: HashMap<String, Value>,
 
     #[serde(default)]
     pub mode: Mode,
@@ -101,6 +108,7 @@ impl Dataset {
             from,
             name,
             description: None,
+            metadata: HashMap::default(),
             mode: Mode::default(),
             params: None,
             has_metadata_table: None,
@@ -120,6 +128,7 @@ impl WithDependsOn<Dataset> for Dataset {
             from: self.from.clone(),
             name: self.name.clone(),
             description: self.description.clone(),
+            metadata: self.metadata.clone(),
             mode: self.mode.clone(),
             params: self.params.clone(),
             has_metadata_table: self.has_metadata_table,

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -20,6 +20,7 @@ use super::{Nameable, WithDependsOn};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
@@ -28,6 +29,10 @@ pub struct Model {
     pub name: String,
 
     pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    pub metadata: HashMap<String, Value>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "files", default)]
@@ -56,6 +61,7 @@ impl WithDependsOn<Model> for Model {
             from: self.from.clone(),
             name: self.name.clone(),
             description: self.description.clone(),
+            metadata: self.metadata.clone(),
             files: self.files.clone(),
             params: self.params.clone(),
             datasets: self.datasets.clone(),

--- a/crates/spicepod/src/component/view.rs
+++ b/crates/spicepod/src/component/view.rs
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
+
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use super::{Nameable, WithDependsOn};
 
@@ -26,6 +29,10 @@ pub struct View {
     pub name: String,
 
     pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    pub metadata: HashMap<String, Value>,
 
     /// Inline SQL that describes a view.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -52,6 +59,7 @@ impl View {
         Self {
             name,
             description: None,
+            metadata: HashMap::default(),
             sql: None,
             sql_ref: None,
             depends_on: Vec::default(),
@@ -64,6 +72,7 @@ impl WithDependsOn<View> for View {
         Self {
             name: self.name.clone(),
             description: self.description.clone(),
+            metadata: self.metadata.clone(),
             sql: self.sql.clone(),
             sql_ref: self.sql_ref.clone(),
             depends_on: depends_on.to_vec(),


### PR DESCRIPTION
## 🗣 Description

Added `metadata` dictionary to all components, and loads it into datasets tool context

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->