### PR TITLE
feat: Add a reference to originating App for a Dataset

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use app::{App, AppBuilder};
 use clap::{ArgAction, Parser};
@@ -114,10 +115,10 @@ pub struct Args {
 pub async fn run(args: Args, prometheus_registry: Option<prometheus::Registry>) -> Result<()> {
     let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
     let pods_watcher = PodsWatcher::new(current_dir.clone());
-    let app: Option<App> = match AppBuilder::build_from_filesystem_path(current_dir.clone())
+    let app: Option<Arc<App>> = match AppBuilder::build_from_filesystem_path(current_dir.clone())
         .context(UnableToConstructSpiceAppSnafu)
     {
-        Ok(app) => Some(app),
+        Ok(app) => Some(Arc::new(app)),
         Err(e) => {
             tracing::warn!("{}", e);
             None

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -34,7 +34,7 @@ use spicepod::{
     Spicepod,
 };
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq)]
 pub struct App {
     pub name: String,
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -34,7 +34,7 @@ use spicepod::{
     Spicepod,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct App {
     pub name: String,
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -138,7 +138,7 @@ impl RuntimeBuilder {
             None
         };
 
-        let secrets = Self::load_secrets(self.app.clone()).await;
+        let secrets = Self::load_secrets(&self.app).await;
 
         let mut rt = Runtime {
             instance_name: format!("{name}-{hash}").to_string(),
@@ -172,7 +172,7 @@ impl RuntimeBuilder {
         rt
     }
 
-    async fn load_secrets(app: Option<Arc<App>>) -> Secrets {
+    async fn load_secrets(app: &Option<Arc<App>>) -> Secrets {
         let _guard = TimeMeasurement::new(&metrics::secrets::STORES_LOAD_DURATION_MS, &[]);
         let mut secrets = secrets::Secrets::new();
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 pub struct RuntimeBuilder {
-    app: Option<app::App>,
+    app: Option<Arc<app::App>>,
     autoload_extensions: HashMap<String, Box<dyn ExtensionFactory>>,
     extensions: Vec<Box<dyn ExtensionFactory>>,
     pods_watcher: Option<podswatcher::PodsWatcher>,
@@ -57,11 +57,11 @@ impl RuntimeBuilder {
     }
 
     pub fn with_app(mut self, app: app::App) -> Self {
-        self.app = Some(app);
+        self.app = Some(Arc::new(app));
         self
     }
 
-    pub fn with_app_opt(mut self, app: Option<app::App>) -> Self {
+    pub fn with_app_opt(mut self, app: Option<Arc<app::App>>) -> Self {
         self.app = app;
         self
     }
@@ -138,7 +138,7 @@ impl RuntimeBuilder {
             None
         };
 
-        let secrets = Self::load_secrets(self.app.as_ref()).await;
+        let secrets = Self::load_secrets(self.app.clone()).await;
 
         let mut rt = Runtime {
             instance_name: format!("{name}-{hash}").to_string(),
@@ -172,7 +172,7 @@ impl RuntimeBuilder {
         rt
     }
 
-    async fn load_secrets(app: Option<&App>) -> Secrets {
+    async fn load_secrets(app: Option<Arc<App>>) -> Secrets {
         let _guard = TimeMeasurement::new(&metrics::secrets::STORES_LOAD_DURATION_MS, &[]);
         let mut secrets = secrets::Secrets::new();
 

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use acceleration::Engine;
+use app::App;
 use arrow::datatypes::SchemaRef;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::util::column_reference;
@@ -22,7 +23,7 @@ use snafu::prelude::*;
 use spicepod::component::{
     dataset as spicepod_dataset, embeddings::ColumnEmbeddingConfig, params::Params,
 };
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -119,6 +120,7 @@ pub struct Dataset {
     pub acceleration: Option<acceleration::Acceleration>,
     pub embeddings: Vec<ColumnEmbeddingConfig>,
     schema: Option<SchemaRef>,
+    app: Option<Arc<App>>,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for Dataset {
@@ -150,6 +152,7 @@ impl TryFrom<spicepod_dataset::Dataset> for Dataset {
             embeddings: dataset.embeddings,
             acceleration,
             schema: None,
+            app: None,
         })
     }
 }
@@ -168,7 +171,18 @@ impl Dataset {
             acceleration: None,
             embeddings: Vec::default(),
             schema: None,
+            app: None,
         })
+    }
+
+    #[must_use]
+    pub fn with_app(mut self, app: Arc<App>) -> Self {
+        self.app = Some(app);
+        self
+    }
+
+    pub fn app(&self) -> Option<Arc<App>> {
+        self.app.clone()
     }
 
     #[must_use]

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -181,6 +181,7 @@ impl Dataset {
         self
     }
 
+    #[must_use]
     pub fn app(&self) -> Option<Arc<App>> {
         self.app.clone()
     }

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -441,7 +441,7 @@ fn string_to_boxed_err(s: String) -> Box<dyn std::error::Error + Send + Sync> {
 
 /// Compute the primary keys for each table in the app. Primary Keys can be explicitly defined in the Spicepod.yaml
 pub async fn parse_explicit_primary_keys(
-    app: Arc<RwLock<Option<App>>>,
+    app: Arc<RwLock<Option<Arc<App>>>>,
 ) -> HashMap<TableReference, Vec<String>> {
     app.read().await.as_ref().map_or(HashMap::new(), |app| {
         app.datasets

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -58,7 +58,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn start<A>(
     bind_address: A,
-    app: Arc<RwLock<Option<App>>>,
+    app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,
     models: Arc<RwLock<HashMap<String, Model>>>,
     llms: Arc<RwLock<LLMModelStore>>,

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -40,7 +40,7 @@ use super::{metrics, v1};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn routes(
-    app: Arc<RwLock<Option<App>>>,
+    app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,
     models: Arc<RwLock<HashMap<String, Model>>>,
     llms: Arc<RwLock<LLMModelStore>>,

--- a/crates/runtime/src/http/v1/catalogs.rs
+++ b/crates/runtime/src/http/v1/catalogs.rs
@@ -65,9 +65,7 @@ pub(crate) async fn get(
             .into_response();
     };
 
-    let readable_app = Arc::clone(readable_app);
-
-    let valid_catalogs = Runtime::get_valid_catalogs(&readable_app, LogErrors(false));
+    let valid_catalogs = Runtime::get_valid_catalogs(readable_app, LogErrors(false));
     let catalogs: Vec<Catalog> = match filter.from {
         Some(provider) => valid_catalogs
             .into_iter()

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -60,13 +60,13 @@ pub(crate) struct DatasetResponseItem {
 }
 
 pub(crate) async fn get(
-    Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+    Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
     Extension(df): Extension<Arc<DataFusion>>,
     Query(filter): Query<DatasetFilter>,
     Query(params): Query<DatasetQueryParams>,
 ) -> Response {
     let app_lock = app.read().await;
-    let Some(readable_app) = &*app_lock else {
+    let Some(readable_app) = app_lock.as_ref() else {
         return (
             status::StatusCode::INTERNAL_SERVER_ERROR,
             Json::<Vec<DatasetResponseItem>>(vec![]),

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -122,7 +122,7 @@ pub struct AccelerationRequest {
 }
 
 pub(crate) async fn refresh(
-    Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+    Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
     Extension(df): Extension<Arc<DataFusion>>,
     Path(dataset_name): Path<String>,
 ) -> Response {
@@ -176,7 +176,7 @@ pub(crate) async fn refresh(
 }
 
 pub(crate) async fn acceleration(
-    Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+    Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
     Extension(df): Extension<Arc<DataFusion>>,
     Path(dataset_name): Path<String>,
     Json(payload): Json<AccelerationRequest>,

--- a/crates/runtime/src/http/v1/inference.rs
+++ b/crates/runtime/src/http/v1/inference.rs
@@ -73,7 +73,7 @@ pub enum PredictStatus {
 }
 
 pub(crate) async fn get(
-    Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+    Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
     Extension(df): Extension<Arc<DataFusion>>,
     Path(model_name): Path<String>,
     Extension(models): Extension<Arc<RwLock<HashMap<String, Model>>>>,
@@ -94,7 +94,7 @@ pub(crate) async fn get(
 }
 
 pub(crate) async fn post(
-    Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+    Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
     Extension(df): Extension<Arc<DataFusion>>,
     Extension(models): Extension<Arc<RwLock<HashMap<String, Model>>>>,
     Json(payload): Json<BatchPredictRequest>,
@@ -128,7 +128,7 @@ pub(crate) async fn post(
 }
 
 async fn run_inference(
-    app: Arc<RwLock<Option<App>>>,
+    app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,
     models: Arc<RwLock<HashMap<String, Model>>>,
     model_name: String,

--- a/crates/runtime/src/http/v1/models.rs
+++ b/crates/runtime/src/http/v1/models.rs
@@ -43,7 +43,7 @@ pub(crate) struct ModelResponse {
 }
 
 pub(crate) async fn get(
-    Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+    Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
     Query(params): Query<ModelsQueryParams>,
 ) -> Response {
     let resp = match app.read().await.as_ref() {

--- a/crates/runtime/src/http/v1/spicepods.rs
+++ b/crates/runtime/src/http/v1/spicepods.rs
@@ -57,7 +57,7 @@ pub(crate) struct SpicepodCsvRow {
 }
 
 pub(crate) async fn get(
-    Extension(app): Extension<Arc<RwLock<Option<App>>>>,
+    Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
     Query(params): Query<SpicepodQueryParams>,
 ) -> Response {
     let Some(readable_app) = &*app.read().await else {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -486,7 +486,12 @@ impl Runtime {
     }
 
     fn datasets_iter(app: &App) -> impl Iterator<Item = Result<Dataset>> + '_ {
-        app.datasets.iter().cloned().map(Dataset::try_from)
+        let app_ref = Arc::new(app.clone());
+        app.datasets
+            .iter()
+            .cloned()
+            .map(Dataset::try_from)
+            .map(move |ds| ds.map(|ds| Dataset::with_app(ds, Arc::clone(&app_ref))))
     }
 
     fn catalogs_iter(app: &App) -> impl Iterator<Item = Result<Catalog>> + '_ {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -272,7 +272,7 @@ pub struct LogErrors(pub bool);
 #[derive(Clone)]
 pub struct Runtime {
     instance_name: String,
-    app: Arc<RwLock<Option<App>>>,
+    app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,
     models: Arc<RwLock<HashMap<String, Model>>>,
     llms: Arc<RwLock<LLMModelStore>>,
@@ -485,21 +485,20 @@ impl Runtime {
         }
     }
 
-    fn datasets_iter(app: &App) -> impl Iterator<Item = Result<Dataset>> + '_ {
-        let app_ref = Arc::new(app.clone());
+    fn datasets_iter(app: &Arc<App>) -> impl Iterator<Item = Result<Dataset>> + '_ {
         app.datasets
-            .iter()
-            .cloned()
+            .clone()
+            .into_iter()
             .map(Dataset::try_from)
-            .map(move |ds| ds.map(|ds| Dataset::with_app(ds, Arc::clone(&app_ref))))
+            .map(move |ds| ds.map(|ds| Dataset::with_app(ds, Arc::clone(app))))
     }
 
-    fn catalogs_iter(app: &App) -> impl Iterator<Item = Result<Catalog>> + '_ {
-        app.catalogs.iter().cloned().map(Catalog::try_from)
+    fn catalogs_iter<'a>(app: &Arc<App>) -> impl Iterator<Item = Result<Catalog>> + 'a {
+        app.catalogs.clone().into_iter().map(Catalog::try_from)
     }
 
     /// Returns a list of valid datasets from the given App, skipping any that fail to parse and logging an error for them.
-    fn get_valid_datasets(app: &App, log_errors: LogErrors) -> Vec<Arc<Dataset>> {
+    fn get_valid_datasets(app: &Arc<App>, log_errors: LogErrors) -> Vec<Arc<Dataset>> {
         Self::datasets_iter(app)
             .zip(&app.datasets)
             .filter_map(|(ds, spicepod_ds)| match ds {
@@ -520,7 +519,7 @@ impl Runtime {
     }
 
     /// Returns a list of valid catalogs from the given App, skipping any that fail to parse and logging an error for them.
-    fn get_valid_catalogs(app: &App, log_errors: LogErrors) -> Vec<Catalog> {
+    fn get_valid_catalogs(app: &Arc<App>, log_errors: LogErrors) -> Vec<Catalog> {
         Self::catalogs_iter(app)
             .zip(&app.catalogs)
             .filter_map(|(catalog, spicepod_catalog)| match catalog {
@@ -541,7 +540,7 @@ impl Runtime {
     }
 
     /// Returns a list of valid views from the given App, skipping any that fail to parse and logging an error for them.
-    fn get_valid_views(app: &App, log_errors: LogErrors) -> Vec<View> {
+    fn get_valid_views(app: &Arc<App>, log_errors: LogErrors) -> Vec<View> {
         let datasets = Self::get_valid_datasets(app, log_errors)
             .iter()
             .map(|ds| ds.name.clone())
@@ -620,7 +619,7 @@ impl Runtime {
         self.load_views(app, &valid_datasets);
     }
 
-    fn load_views(&self, app: &App, valid_datasets: &[Arc<Dataset>]) {
+    fn load_views(&self, app: &Arc<App>, valid_datasets: &[Arc<Dataset>]) {
         let views: Vec<View> = Self::get_valid_views(app, LogErrors(true));
 
         for view in &views {
@@ -1330,7 +1329,7 @@ impl Runtime {
                 recorder.set_remote_schema(Arc::new(Some(metrics_table.schema())));
             } else {
                 tracing::debug!("Registering local metrics table");
-                MetricsRecorder::register_metrics_table(&Arc::clone(&self.df))
+                MetricsRecorder::register_metrics_table(&self.df)
                     .await
                     .context(UnableToStartLocalMetricsSnafu)?;
             }
@@ -1351,6 +1350,7 @@ impl Runtime {
         while let Some(new_app) = rx.recv().await {
             let mut app_lock = self.app.write().await;
             if let Some(current_app) = app_lock.as_mut() {
+                let new_app = Arc::new(new_app);
                 if *current_app == new_app {
                     continue;
                 }
@@ -1433,7 +1433,7 @@ impl Runtime {
 
                 *current_app = new_app;
             } else {
-                *app_lock = Some(new_app);
+                *app_lock = Some(Arc::new(new_app));
             }
         }
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds a property for the originating `App` of `Dataset`

This allows datasets to identify where they came from, which is helpful for the SQLite accelerator to find any other SQLite accelerators that are in the same app.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #2273 