### PR TITLE
Keep `has_metadata_table: boolean` dataset field without rename

### DIFF
--- a/.schema/spicepod.schema.json
+++ b/.schema/spicepod.schema.json
@@ -411,11 +411,15 @@
         "from": {
           "type": "string"
         },
-        "metadata": {
+        "has_metadata_table": {
           "type": [
             "boolean",
             "null"
           ]
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
         },
         "mode": {
           "default": "read",

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -71,7 +71,7 @@ pub struct Dataset {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<Params>,
 
-    #[serde(rename = "metadata", default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub has_metadata_table: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## 🗣 Description

Remove `has_metadata_table` rename, to avoid conflicts with the `metadata` field in the `Dataset` struct.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->