### PR TITLE
Define the new metrics Arrow schema based on Open Telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6958,6 +6958,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "otel-arrow"
+version = "0.17.2-beta"
+dependencies = [
+ "arrow",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8317,6 +8324,7 @@ dependencies = [
  "opentelemetry-prometheus",
  "opentelemetry-proto",
  "opentelemetry_sdk 0.24.1",
+ "otel-arrow",
  "pin-project",
  "prometheus",
  "prometheus-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/ns_lookup",
   "crates/util",
   "crates/spice_cloud",
+  "crates/otel-arrow",
   "tools/flightpublisher/",
   "tools/flightsubscriber/",
   "tools/spicepodschema/",

--- a/crates/otel-arrow/Cargo.toml
+++ b/crates/otel-arrow/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "otel-arrow"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+arrow.workspace = true

--- a/crates/otel-arrow/src/lib.rs
+++ b/crates/otel-arrow/src/lib.rs
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+mod schema;
+pub use schema::*;

--- a/crates/otel-arrow/src/schema.rs
+++ b/crates/otel-arrow/src/schema.rs
@@ -1,0 +1,260 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Will remove in a follow-up PR
+#![allow(dead_code)]
+
+use std::{cell::LazyCell, sync::Arc};
+
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+#[must_use]
+pub fn schema() -> Arc<Schema> {
+    METRICS_SCHEMA.with(|schema| Arc::clone(schema))
+}
+
+thread_local! {
+    /// This is a flattened schema based on the OpenTelemetry Metrics protobuf.
+    /// https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto
+    ///
+    /// The flattened schema is also loosely based on https://github.com/open-telemetry/otel-arrow.
+    /// The main difference between otel-arrow and this schema, is that this schema combines the attributes and data
+    /// into a single table. otel-arrow separates each metric type and attributes into a separate
+    /// stream of Arrow records for better performance over the wire, at the cost of implementation complexity and a
+    /// combined representation.
+    ///
+    /// This format is suitable for storage in a single table, where each row represents a single metric. It can be losslessly
+    /// converted to the hierarchical OTel Protobuf schema and into the otel-arrow schema.
+    ///
+    /// The hierarchical OTel Protobuf schema this flattened view is based on is:
+    /// ResourceMetrics
+    ///   ├── Resource
+    ///      ├── Attributes
+    ///      └── DroppedAttributesCount
+    ///   ├── SchemaURL
+    ///   └── ScopeMetrics
+    ///      ├── Scope
+    ///        ├── Name
+    ///        ├── Version
+    ///        ├── Attributes
+    ///        └── DroppedAttributesCount
+    ///      ├── SchemaURL
+    ///      └── Metric
+    ///         ├── Name
+    ///         ├── Description
+    ///         ├── Unit
+    ///         └── data
+    ///            ├── Gauge
+    ///              ├── NumberDataPoint
+    ///                ├── StartTimeUnixNano
+    ///                ├── TimeUnixNano
+    ///                ├── Value
+    ///                ├── Flags
+    ///                └── Attributes
+    ///            ├── Sum
+    ///              ├── NumberDataPoint
+    ///                ├── StartTimeUnixNano
+    ///                ├── TimeUnixNano
+    ///                ├── Value
+    ///                ├── Flags
+    ///                └── Attributes
+    ///              ├── IsMonotonic
+    ///              └── AggregationTemporality
+    ///            └── Histogram
+    ///              ├── HistogramDataPoint
+    ///                ├── StartTimeUnixNano
+    ///                ├── TimeUnixNano
+    ///                ├── Count
+    ///                ├── Sum
+    ///                ├── BucketCounts
+    ///                ├── ExplicitBounds
+    ///                ├── Flags
+    ///                ├── Min
+    ///                ├── Max
+    ///                └── Attributes
+    ///              └── AggregationTemporality
+    static METRICS_SCHEMA: LazyCell<Arc<Schema>> = LazyCell::new(|| {
+        let fields = vec![
+            Field::new("time_unix_nano", DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())), false),
+            Field::new(
+                "start_time_unix_nano",
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                true,
+            ),
+            Field::new("resource", DataType::Struct(
+                vec![
+                    Field::new("schema_url", DataType::Utf8, true),
+                    Field::new("attributes", attributes_type(), true),
+                    Field::new("dropped_attributes_count", DataType::UInt32, true),
+                ]
+                .into(),
+            ), true),
+            Field::new("scope", DataType::Struct(
+                vec![
+                    Field::new("name", DataType::Utf8, true),
+                    Field::new("version", DataType::Utf8, true),
+                    Field::new("attributes", attributes_type(), true),
+                    Field::new("dropped_attributes_count", DataType::UInt32, true),
+                ]
+                .into(),
+            ), true),
+            Field::new("schema_url", DataType::Utf8, true),
+            // MetricType is the Rust enum corresponding to the UInt8 `metric_type`.
+            Field::new("metric_type", DataType::UInt8, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("description", DataType::Utf8, true),
+            Field::new("unit", DataType::Utf8, true),
+            Field::new("aggregation_temporality", DataType::Int32, true),
+            Field::new("is_monotonic", DataType::Boolean, true),
+            Field::new("flags", DataType::UInt32, true),
+            Field::new("attributes", attributes_type(), true),
+
+            // Only one of these will be set, based on the metric_type.
+            // Gauge and Sum will use data_number, Histogram will use data_histogram.
+            Field::new("data_number", number_data_type(), true),
+            Field::new("data_histogram", histogram_data_type(), true),
+        ];
+        Arc::new(Schema::new(fields))
+    });
+}
+
+fn attributes_type() -> DataType {
+    DataType::Struct(
+        vec![
+            Field::new("key", DataType::Utf8, false),
+            // AttributeValueType is the Rust enum corresponding to the UInt8 `type`.
+            Field::new("type", DataType::UInt8, false),
+            Field::new("str", DataType::Utf8, false),
+            Field::new("int", DataType::Int64, true),
+            Field::new("double", DataType::Float64, true),
+            Field::new("bool", DataType::Boolean, true),
+            Field::new("bytes", DataType::Binary, true),
+            // cbor encoded map
+            Field::new("ser", DataType::Binary, true),
+        ]
+        .into(),
+    )
+}
+
+fn number_data_type() -> DataType {
+    DataType::Struct(
+        vec![
+            Field::new("int_value", DataType::Int64, true),
+            Field::new("double_value", DataType::Float64, true),
+        ]
+        .into(),
+    )
+}
+
+fn histogram_data_type() -> DataType {
+    DataType::Struct(
+        vec![
+            Field::new("count", DataType::UInt64, true),
+            Field::new("sum", DataType::Float64, true),
+            Field::new(
+                "bucket_counts",
+                DataType::List(Arc::new(Field::new("item", DataType::UInt64, false))),
+                true,
+            ),
+            Field::new(
+                "explicit_bounds",
+                DataType::List(Arc::new(Field::new("item", DataType::Float64, false))),
+                true,
+            ),
+            Field::new("min", DataType::Float64, true),
+            Field::new("max", DataType::Float64, true),
+        ]
+        .into(),
+    )
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum MetricType {
+    Gauge = 1,
+    Sum = 2,
+    Histogram = 3,
+}
+
+impl MetricType {
+    fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    fn from_u8(value: u8) -> Option<MetricType> {
+        match value {
+            0 => Some(MetricType::Gauge),
+            1 => Some(MetricType::Sum),
+            2 => Some(MetricType::Histogram),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for MetricType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            MetricType::Gauge => "Gauge",
+            MetricType::Sum => "Sum",
+            MetricType::Histogram => "Histogram",
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum AttributeValueType {
+    Str = 1,
+    Int = 2,
+    Double = 3,
+    Bool = 4,
+    Map = 5,
+    Slice = 6,
+    Bytes = 7,
+}
+
+impl AttributeValueType {
+    fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    fn from_u8(value: u8) -> Option<AttributeValueType> {
+        match value {
+            1 => Some(AttributeValueType::Str),
+            2 => Some(AttributeValueType::Int),
+            3 => Some(AttributeValueType::Double),
+            4 => Some(AttributeValueType::Bool),
+            5 => Some(AttributeValueType::Map),
+            6 => Some(AttributeValueType::Slice),
+            7 => Some(AttributeValueType::Bytes),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for AttributeValueType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            AttributeValueType::Str => "Str",
+            AttributeValueType::Int => "Int",
+            AttributeValueType::Double => "Double",
+            AttributeValueType::Bool => "Bool",
+            AttributeValueType::Map => "Map",
+            AttributeValueType::Slice => "Slice",
+            AttributeValueType::Bytes => "Bytes",
+        };
+        write!(f, "{s}")
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -74,6 +74,7 @@ opentelemetry-proto = { version = "0.6.0", features = [
   "metrics",
 ] }
 opentelemetry-prometheus.workspace = true
+otel-arrow = { path = "../otel-arrow" }
 pin-project = "1.0"
 prometheus.workspace = true
 prometheus-parse = "0.2.5"

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -18,7 +18,6 @@ use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use app::App;
 use tokio::sync::RwLock;
-use uuid::Uuid;
 
 use crate::{
     dataaccelerator, dataconnector,
@@ -119,12 +118,6 @@ impl RuntimeBuilder {
         dataconnector::register_all().await;
         dataaccelerator::register_all().await;
 
-        let hash = Uuid::new_v4().to_string()[..8].to_string();
-        let name = match &self.app {
-            Some(app) => app.name.clone(),
-            None => "spice".to_string(),
-        };
-
         let df = match self.datafusion {
             Some(df) => df,
             None => Arc::new(DataFusion::new()),
@@ -141,7 +134,6 @@ impl RuntimeBuilder {
         let secrets = Self::load_secrets(&self.app).await;
 
         let mut rt = Runtime {
-            instance_name: format!("{name}-{hash}").to_string(),
             app: Arc::new(RwLock::new(self.app)),
             df,
             models: Arc::new(RwLock::new(HashMap::new())),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -21,7 +21,6 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::{collections::HashMap, sync::Arc};
 
-use crate::spice_metrics::MetricsRecorder;
 use crate::{dataconnector::DataConnector, datafusion::DataFusion};
 use ::datafusion::datasource::TableProvider;
 use ::datafusion::error::DataFusionError;
@@ -271,7 +270,6 @@ pub struct LogErrors(pub bool);
 
 #[derive(Clone)]
 pub struct Runtime {
-    instance_name: String,
     app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,
     models: Arc<RwLock<HashMap<String, Model>>>,
@@ -344,7 +342,7 @@ impl Runtime {
         config: Config,
         tls_config: Option<Arc<TlsConfig>>,
     ) -> Result<()> {
-        self.register_metrics_table(self.prometheus_registry.clone())
+        self.register_metrics_table(self.prometheus_registry.is_some())
             .await?;
 
         let http_server_future = tokio::spawn(http::start(
@@ -1315,26 +1313,17 @@ impl Runtime {
         self.load_model(m).await;
     }
 
-    async fn register_metrics_table(
-        &self,
-        with_metrics: Option<prometheus::Registry>,
-    ) -> Result<()> {
-        if let Some(registry) = with_metrics {
-            let mut recorder = MetricsRecorder::new(registry);
-
+    async fn register_metrics_table(&self, metrics_enabled: bool) -> Result<()> {
+        if metrics_enabled {
             let table_reference = get_metrics_table_reference();
             let metrics_table = self.df.get_table(table_reference).await;
 
-            if let Some(metrics_table) = metrics_table {
-                recorder.set_remote_schema(Arc::new(Some(metrics_table.schema())));
-            } else {
+            if metrics_table.is_none() {
                 tracing::debug!("Registering local metrics table");
-                MetricsRecorder::register_metrics_table(&self.df)
+                spice_metrics::register_metrics_table(&self.df)
                     .await
                     .context(UnableToStartLocalMetricsSnafu)?;
             }
-
-            recorder.start(self.instance_name.clone(), &self.df);
         }
 
         Ok(())

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -17,15 +17,8 @@ limitations under the License.
 use std::sync::Arc;
 use std::time::Duration;
 
-use arrow::array::{Float64Array, StringArray, TimestampNanosecondArray};
-use arrow::datatypes::{DataType, Field, Schema};
-use arrow::record_batch::RecordBatch;
-use arrow_tools::record_batch::{self, try_cast_to};
-use chrono::Utc;
 use datafusion::sql::TableReference;
-use prometheus::TextEncoder;
 use snafu::prelude::*;
-use tokio::spawn;
 use tokio::sync::RwLock;
 
 use crate::accelerated_table::refresh::Refresh;
@@ -34,27 +27,11 @@ use crate::component::dataset::acceleration::Acceleration;
 use crate::component::dataset::TimeFormat;
 use crate::datafusion::Error as DataFusionError;
 use crate::datafusion::{DataFusion, SPICE_RUNTIME_SCHEMA};
-use crate::dataupdate::DataUpdate;
 use crate::internal_table::{create_internal_accelerated_table, Error as InternalTableError};
 use crate::secrets::Secrets;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Error creating record batch: {source}",))]
-    UnableToCreateRecordBatch { source: arrow::error::ArrowError },
-
-    #[snafu(display("Error casting record batch: {source}",))]
-    UnableToCastRecordBatch { source: record_batch::Error },
-
-    #[snafu(display("Error rendering Prometheus metrics: {source}",))]
-    UnableToRenderPrometheusMetrics { source: prometheus::Error },
-
-    #[snafu(display("Error parsing prometheus metrics: {source}"))]
-    UnableToParsePrometheusMetrics { source: std::io::Error },
-
-    #[snafu(display("Error writing to metrics table: {source}"))]
-    UnableToWriteToMetricsTable { source: DataFusionError },
-
     #[snafu(display("Error creating metrics table: {source}"))]
     UnableToCreateMetricsTable { source: InternalTableError },
 
@@ -62,176 +39,33 @@ pub enum Error {
     UnableToRegisterToMetricsTable { source: DataFusionError },
 }
 
-pub struct MetricsRecorder {
-    remote_schema: Arc<Option<Arc<Schema>>>,
-    registry: prometheus::Registry,
-}
+pub async fn register_metrics_table(datafusion: &Arc<DataFusion>) -> Result<(), Error> {
+    let metrics_table_reference = get_metrics_table_reference();
 
-impl MetricsRecorder {
-    #[must_use]
-    pub fn new(registry: prometheus::Registry) -> Self {
-        Self {
-            registry,
-            remote_schema: Arc::new(None),
-        }
-    }
+    let retention = Retention::new(
+        Some("time_unix_nano".to_string()),
+        Some(TimeFormat::Timestamptz),
+        Some(Duration::from_secs(1800)), // delete metrics older then 30 minutes
+        Some(Duration::from_secs(300)),  // run retention every 5 minutes
+        true,
+    );
 
-    pub fn set_remote_schema(&mut self, schema: Arc<Option<Arc<Schema>>>) {
-        self.remote_schema = schema;
-    }
+    let table = create_internal_accelerated_table(
+        metrics_table_reference.clone(),
+        otel_arrow::schema(),
+        Acceleration::default(),
+        Refresh::default(),
+        retention,
+        Arc::new(RwLock::new(Secrets::default())),
+    )
+    .await
+    .context(UnableToCreateMetricsTableSnafu)?;
 
-    pub async fn register_metrics_table(datafusion: &Arc<DataFusion>) -> Result<(), Error> {
-        let metrics_table_reference = get_metrics_table_reference();
+    datafusion
+        .register_runtime_table(metrics_table_reference, table)
+        .context(UnableToRegisterToMetricsTableSnafu)?;
 
-        let retention = Retention::new(
-            Some("timestamp".to_string()),
-            Some(TimeFormat::UnixSeconds),
-            Some(Duration::from_secs(1800)), // delete metrics older then 30 minutes
-            Some(Duration::from_secs(300)),  // run retention every 5 minutes
-            true,
-        );
-
-        let table = create_internal_accelerated_table(
-            metrics_table_reference.clone(),
-            get_metrics_schema(),
-            Acceleration::default(),
-            Refresh::default(),
-            retention,
-            Arc::new(RwLock::new(Secrets::default())),
-        )
-        .await
-        .context(UnableToCreateMetricsTableSnafu)?;
-
-        datafusion
-            .register_runtime_table(metrics_table_reference, table)
-            .context(UnableToRegisterToMetricsTableSnafu)?;
-
-        Ok(())
-    }
-
-    async fn tick(
-        registry: &prometheus::Registry,
-        instance_name: String,
-        datafusion: &Arc<DataFusion>,
-        remote_schema: &Arc<Option<Arc<Schema>>>,
-    ) -> Result<(), Error> {
-        let encoder = TextEncoder::new();
-        let metric_families = registry.gather();
-        let mut body = String::new();
-        encoder
-            .encode_utf8(&metric_families, &mut body)
-            .context(UnableToRenderPrometheusMetricsSnafu)?;
-
-        let lines = body.lines().map(|s| Ok(s.to_owned()));
-        let scrape =
-            prometheus_parse::Scrape::parse(lines).context(UnableToParsePrometheusMetricsSnafu)?;
-
-        let sample_size = scrape.samples.len();
-
-        let mut timestamps: Vec<i64> = Vec::with_capacity(sample_size);
-        let mut instances: Vec<String> = Vec::with_capacity(sample_size);
-        let mut names: Vec<String> = Vec::with_capacity(sample_size);
-        let mut values: Vec<f64> = Vec::with_capacity(sample_size);
-        let mut properties: Vec<Option<String>> = Vec::with_capacity(sample_size);
-
-        for sample in scrape.samples {
-            let value: f64 = match sample.value {
-                prometheus_parse::Value::Counter(v)
-                | prometheus_parse::Value::Gauge(v)
-                | prometheus_parse::Value::Untyped(v) => v,
-                prometheus_parse::Value::Histogram(v) => v.into_iter().map(|v| v.count).sum(),
-                prometheus_parse::Value::Summary(v) => v.into_iter().map(|v| v.count).sum(),
-            };
-
-            let timestamp = sample.timestamp.with_timezone(&Utc);
-            if let Some(timestamp_nano) = timestamp.timestamp_nanos_opt() {
-                timestamps.push(timestamp_nano);
-            } else {
-                timestamps.push(timestamp.timestamp_micros() * 1000);
-            }
-            instances.push(instance_name.clone());
-            names.push(sample.metric);
-            values.push(value);
-
-            properties.push(if sample.labels.is_empty() {
-                None
-            } else {
-                serde_json::to_string(&*sample.labels).ok()
-            });
-        }
-
-        let mut schema = get_metrics_schema();
-        let mut record_batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(
-                    TimestampNanosecondArray::from(timestamps).with_timezone(Arc::from("UTC")),
-                ),
-                Arc::new(StringArray::from(instances)),
-                Arc::new(StringArray::from(names)),
-                Arc::new(Float64Array::from(values)),
-                Arc::new(StringArray::from(properties)),
-            ],
-        )
-        .context(UnableToCreateRecordBatchSnafu)?;
-
-        // If a remote schema is provided, cast the record batch to it
-        if let Some(remote_schema) = remote_schema.as_ref() {
-            schema = Arc::clone(remote_schema);
-            record_batch = try_cast_to(record_batch.clone(), Arc::clone(remote_schema))
-                .context(UnableToCastRecordBatchSnafu)?;
-        }
-
-        let data_update = DataUpdate {
-            schema: Arc::clone(&schema),
-            data: vec![record_batch],
-            update_type: crate::dataupdate::UpdateType::Append,
-        };
-
-        datafusion
-            .write_data(get_metrics_table_reference(), data_update)
-            .await
-            .context(UnableToWriteToMetricsTableSnafu)?;
-
-        Ok(())
-    }
-
-    pub fn start(&self, instance_name: String, datafusion: &Arc<DataFusion>) {
-        let registry = self.registry.clone();
-        let df = Arc::clone(datafusion);
-        let schema = Arc::clone(&self.remote_schema);
-
-        spawn(async move {
-            loop {
-                if let Err(err) =
-                    MetricsRecorder::tick(&registry, instance_name.clone(), &df, &schema).await
-                {
-                    tracing::error!("{err}");
-                }
-                tokio::time::sleep(Duration::from_secs(30)).await;
-            }
-        });
-    }
-}
-
-#[must_use]
-pub fn get_metrics_schema() -> Arc<Schema> {
-    let fields = vec![
-        Field::new(
-            "timestamp",
-            DataType::Timestamp(
-                arrow::datatypes::TimeUnit::Nanosecond,
-                Some(Arc::from("UTC")),
-            ),
-            false,
-        ),
-        Field::new("instance", DataType::Utf8, false),
-        Field::new("name", DataType::Utf8, false),
-        Field::new("value", DataType::Float64, false),
-        Field::new("properties", DataType::Utf8, true),
-    ];
-
-    Arc::new(Schema::new(fields))
+    Ok(())
 }
 
 #[must_use]


### PR DESCRIPTION
## 🗣 Description

Defines a new Arrow schema for metrics that is based on the OpenTelemetry data model. It takes many implementation cues from https://github.com/open-telemetry/otel-arrow, but isn't an exact match to that data model. The Arrow schemas defined in `open-telemetry/otel-arrow` are designed to be sent over a custom gRPC service that can handle schema switching to more efficient encode the different metrics structures over the wire. I've created a combined metrics schema that can be represented in a single table. 

I've put this schema into a new `otel-arrow` crate, with the intention that it could be published as a separate crate for use in other projects. I plan to implement an OTel metrics exporter in that crate in a follow up PR.

The `runtime.metrics` table will no longer be populated, but that is going to be fixed in the next PR with the OTel metrics exporter.

This comment from the code explains more:

```rust
    /// This is a flattened schema based on the OpenTelemetry Metrics protobuf.
    /// https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto
    ///
    /// The flattened schema is also loosely based on https://github.com/open-telemetry/otel-arrow.
    /// The main difference between otel-arrow and this schema, is that this schema combines the attributes and data
    /// into a single table. otel-arrow separates each metric type and attributes into a separate
    /// stream of Arrow records for better performance over the wire, at the cost of implementation complexity and a
    /// combined representation.
    ///
    /// This format is suitable for storage in a single table, where each row represents a single metric. It can be losslessly
    /// converted to the hierarchical OTel Protobuf schema and into the otel-arrow schema.
    ///
    /// The hierarchical OTel Protobuf schema this flattened view is based on is:
    /// ResourceMetrics
    ///   ├── Resource
    ///      ├── Attributes
    ///      └── DroppedAttributesCount
    ///   ├── SchemaURL
    ///   └── ScopeMetrics
    ///      ├── Scope
    ///        ├── Name
    ///        ├── Version
    ///        ├── Attributes
    ///        └── DroppedAttributesCount
    ///      ├── SchemaURL
    ///      └── Metric
    ///         ├── Name
    ///         ├── Description
    ///         ├── Unit
    ///         └── data
    ///            ├── Gauge
    ///              ├── NumberDataPoint
    ///                ├── StartTimeUnixNano
    ///                ├── TimeUnixNano
    ///                ├── Value
    ///                ├── Flags
    ///                └── Attributes
    ///            ├── Sum
    ///              ├── NumberDataPoint
    ///                ├── StartTimeUnixNano
    ///                ├── TimeUnixNano
    ///                ├── Value
    ///                ├── Flags
    ///                └── Attributes
    ///              ├── IsMonotonic
    ///              └── AggregationTemporality
    ///            └── Histogram
    ///              ├── HistogramDataPoint
    ///                ├── StartTimeUnixNano
    ///                ├── TimeUnixNano
    ///                ├── Count
    ///                ├── Sum
    ///                ├── BucketCounts
    ///                ├── ExplicitBounds
    ///                ├── Flags
    ///                ├── Min
    ///                ├── Max
    ///                └── Attributes
    ///              └── AggregationTemporality
```

## 🔨 Related Issues

Closes #2210
