### PR TITLE
Intra-table federation query on duckdb accelerated table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a726db96439dc7916b8a2ce21c444074a6590235#a726db96439dc7916b8a2ce21c444074a6590235"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,7 +3144,6 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=fa39588806bb6d859ca6a92ec8ace676607a0090#fa39588806bb6d859ca6a92ec8ace676607a0090"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3144,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a726db96439dc7916b8a2ce21c444074a6590235#a726db96439dc7916b8a2ce21c444074a6590235"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=6a383441d962cf8a0fe027f95a0b1dffb66ee414#6a383441d962cf8a0fe027f95a0b1dffb66ee414"
 dependencies = [
  "arrow",
  "async-stream",
@@ -3161,9 +3170,11 @@ dependencies = [
  "duckdb",
  "fallible-iterator 0.3.0",
  "futures",
+ "geo-types",
  "itertools 0.13.0",
  "mysql_async",
  "native-tls",
+ "num-bigint",
  "pem",
  "postgres-native-tls",
  "r2d2",
@@ -4302,6 +4313,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -7401,6 +7423,7 @@ dependencies = [
  "bytes",
  "chrono",
  "fallible-iterator 0.2.0",
+ "geo-types",
  "postgres-protocol",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=6a383441d962cf8a0fe027f95a0b1dffb66ee414#6a383441d962cf8a0fe027f95a0b1dffb66ee414"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=221a42394fb5e17eeb099f3cd8c8cf8cc626be79#221a42394fb5e17eeb099f3cd8c8cf8cc626be79"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8321,6 +8321,7 @@ dependencies = [
  "data_components",
  "datafusion",
  "datafusion-federation",
+ "datafusion-federation-sql",
  "datafusion-table-providers",
  "db_connection_pool",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "41.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ae9da45f8b90451119f3ca032b75ad82a28d7547" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a726db96439dc7916b8a2ce21c444074a6590235" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "6a383441d962cf8a0fe027f95a0b1dffb66ee414" }
 dirs = "5.0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "41.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ae9da45f8b90451119f3ca032b75ad82a28d7547" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "fa39588806bb6d859ca6a92ec8ace676607a0090" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a726db96439dc7916b8a2ce21c444074a6590235" }
 dirs = "5.0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"
@@ -116,6 +116,3 @@ arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdf
 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
-
-[patch."https://github.com/datafusion-contrib/datafusion-table-providers.git"]
-datafusion-table-providers = { path = "../../datafusion-contrib/datafusion-table-providers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,6 @@ arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdf
 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
+
+[patch."https://github.com/datafusion-contrib/datafusion-table-providers.git"]
+datafusion-table-providers = { path = "../../datafusion-contrib/datafusion-table-providers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "41.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ae9da45f8b90451119f3ca032b75ad82a28d7547" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "6a383441d962cf8a0fe027f95a0b1dffb66ee414" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "221a42394fb5e17eeb099f3cd8c8cf8cc626be79" }
 dirs = "5.0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"

--- a/crates/data_components/src/delete.rs
+++ b/crates/data_components/src/delete.rs
@@ -20,6 +20,8 @@ use datafusion::{
     },
 };
 
+use crate::sandwich::SandwichTableProvider;
+
 #[async_trait]
 pub trait DeletionTableProvider: TableProvider {
     async fn delete_from(
@@ -143,6 +145,9 @@ impl DeletionTableProviderAdapter {
 pub fn get_deletion_provider(
     from: Arc<dyn TableProvider>,
 ) -> Option<Arc<dyn DeletionTableProvider>> {
+    if let Some(p) = from.as_any().downcast_ref::<SandwichTableProvider>() {
+        return Some(Arc::new(p.clone()));
+    }
     if let Some(p) = from.as_any().downcast_ref::<DeletionTableProviderAdapter>() {
         return Some(Arc::clone(&p.source));
     }

--- a/crates/data_components/src/delete.rs
+++ b/crates/data_components/src/delete.rs
@@ -20,7 +20,7 @@ use datafusion::{
     },
 };
 
-use crate::sandwich::SandwichTableProvider;
+use crate::poly::PolyTableProvider;
 
 #[async_trait]
 pub trait DeletionTableProvider: TableProvider {
@@ -145,7 +145,7 @@ impl DeletionTableProviderAdapter {
 pub fn get_deletion_provider(
     from: Arc<dyn TableProvider>,
 ) -> Option<Arc<dyn DeletionTableProvider>> {
-    if let Some(p) = from.as_any().downcast_ref::<SandwichTableProvider>() {
+    if let Some(p) = from.as_any().downcast_ref::<PolyTableProvider>() {
         return Some(Arc::new(p.clone()));
     }
     if let Some(p) = from.as_any().downcast_ref::<DeletionTableProviderAdapter>() {

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -58,6 +58,7 @@ pub mod unity_catalog;
 pub mod cdc;
 pub mod delete;
 pub mod object;
+pub mod sandwich;
 
 #[async_trait]
 pub trait Read: Send + Sync {

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -58,7 +58,7 @@ pub mod unity_catalog;
 pub mod cdc;
 pub mod delete;
 pub mod object;
-pub mod sandwich;
+pub mod poly;
 
 #[async_trait]
 pub trait Read: Send + Sync {

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -11,7 +11,9 @@ use datafusion::{
     physical_plan::ExecutionPlan,
     prelude::Expr,
 };
-use datafusion_federation::{FederatedTableProviderAdaptor, FederationProvider};
+use datafusion_federation::{
+    FederatedTableProviderAdaptor, FederatedTableSource, FederationProvider,
+};
 
 use crate::delete::{get_deletion_provider, DeletionTableProvider};
 
@@ -36,6 +38,16 @@ impl PolyTableProvider {
             .as_any()
             .downcast_ref::<FederatedTableProviderAdaptor>()
             .map(|x| x.source.federation_provider())
+    }
+
+    #[must_use]
+    pub fn get_table_source(&self) -> Option<Arc<dyn FederatedTableSource>> {
+        let adaptor = self
+            .fed
+            .as_any()
+            .downcast_ref::<FederatedTableProviderAdaptor>();
+
+        adaptor.map(|f| Arc::clone(&f.source))
     }
 }
 

--- a/crates/data_components/src/sandwich.rs
+++ b/crates/data_components/src/sandwich.rs
@@ -1,0 +1,109 @@
+use std::{any::Any, sync::Arc};
+
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::{
+    common::Constraints,
+    datasource::{TableProvider, TableType},
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::context::SessionState,
+    logical_expr::LogicalPlan,
+    physical_plan::ExecutionPlan,
+    prelude::Expr,
+};
+use datafusion_federation::{FederatedTableProviderAdaptor, FederationProvider};
+
+use crate::delete::{get_deletion_provider, DeletionTableProvider};
+
+pub struct SandwichTableProvider {
+    write: Arc<dyn TableProvider>,
+    delete: Arc<dyn TableProvider>,
+    fed: Arc<dyn TableProvider>,
+}
+
+impl SandwichTableProvider {
+    pub fn new(
+        write: Arc<dyn TableProvider>,
+        delete: Arc<dyn TableProvider>,
+        fed: Arc<dyn TableProvider>,
+    ) -> Self {
+        SandwichTableProvider { write, delete, fed }
+    }
+
+    fn get_federation_provider(&self) -> Option<Arc<dyn FederationProvider>> {
+        self.fed
+            .as_any()
+            .downcast_ref::<Arc<FederatedTableProviderAdaptor>>()
+            .map(|x| x.source.federation_provider())
+    }
+}
+
+#[async_trait]
+impl DeletionTableProvider for SandwichTableProvider {
+    async fn delete_from(
+        &self,
+        state: &SessionState,
+        filters: &[Expr],
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let delete = get_deletion_provider(Arc::clone(&self.delete))
+            .ok_or(DataFusionError::Plan("Not implemented".to_string()))?;
+
+        delete.delete_from(state, filters).await
+    }
+}
+
+impl FederationProvider for SandwichTableProvider {
+    fn name(&self) -> &str {
+        "SandwichFederationProvider"
+    }
+
+    fn compute_context(&self) -> Option<String> {
+        self.get_federation_provider()
+            .and_then(|f| f.compute_context())
+    }
+
+    fn analyzer(&self) -> Option<Arc<datafusion::optimizer::Analyzer>> {
+        self.get_federation_provider().and_then(|f| f.analyzer())
+    }
+}
+
+#[async_trait]
+impl TableProvider for SandwichTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn schema(&self) -> SchemaRef {
+        self.write.schema()
+    }
+    fn constraints(&self) -> Option<&Constraints> {
+        self.write.constraints()
+    }
+    fn table_type(&self) -> TableType {
+        self.write.table_type()
+    }
+    fn get_logical_plan(&self) -> Option<&LogicalPlan> {
+        self.write.get_logical_plan()
+    }
+    fn get_column_default(&self, column: &str) -> Option<&Expr> {
+        self.write.get_column_default(column)
+    }
+
+    async fn scan(
+        &self,
+        state: &SessionState,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.write.scan(state, projection, filters, limit).await
+    }
+
+    async fn insert_into(
+        &self,
+        state: &SessionState,
+        input: Arc<dyn ExecutionPlan>,
+        overwrite: bool,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.write.insert_into(state, input, overwrite).await
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -34,6 +34,7 @@ csv = "1.3.0"
 dashmap = "5.5.3"
 data_components = { path = "../data_components" }
 datafusion-federation = { workspace = true }
+datafusion-federation-sql = { workspace = true }
 datafusion-table-providers = { workspace = true }
 datafusion.workspace = true
 db_connection_pool = { path = "../db_connection_pool" }

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -50,10 +50,10 @@ use crate::execution_plan::slice::SliceExec;
 use crate::execution_plan::tee::TeeExec;
 use crate::execution_plan::TableScanParams;
 
+pub mod federation;
 mod metrics;
 pub mod refresh;
 pub mod refresh_task;
-pub mod federation;
 mod refresh_task_runner;
 
 #[derive(Debug, Snafu)]
@@ -497,8 +497,6 @@ impl Drop for AcceleratedTable {
         }
     }
 }
-
-
 
 #[async_trait]
 impl TableProvider for AcceleratedTable {

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -53,6 +53,7 @@ use crate::execution_plan::TableScanParams;
 mod metrics;
 pub mod refresh;
 pub mod refresh_task;
+pub mod federation;
 mod refresh_task_runner;
 
 #[derive(Debug, Snafu)]
@@ -496,6 +497,8 @@ impl Drop for AcceleratedTable {
         }
     }
 }
+
+
 
 #[async_trait]
 impl TableProvider for AcceleratedTable {

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -1,5 +1,6 @@
 use std::{any::Any, sync::Arc};
 
+use crate::component::dataset::acceleration::ZeroResultsAction;
 use arrow::datatypes::SchemaRef;
 use data_components::poly::PolyTableProvider;
 use datafusion::datasource::TableType;
@@ -8,9 +9,6 @@ use datafusion::{datasource::TableProvider, logical_expr::TableSource};
 use datafusion_federation::{
     FederatedTableProviderAdaptor, FederatedTableSource, FederationProvider,
 };
-use uuid::Uuid;
-
-use crate::component::dataset::acceleration::ZeroResultsAction;
 
 use super::AcceleratedTable;
 
@@ -67,16 +65,13 @@ impl FederationProvider for FederationProviderAdapter {
     }
 
     fn compute_context(&self) -> Option<String> {
-        if !self.enabled {
-            return None;
-        }
-
-        // To ensure this is unique
-        // This will need to call the inner.compute_context to enable inter-table
-        Some(Uuid::new_v4().to_string())
+        self.inner.compute_context()
     }
 
     fn analyzer(&self) -> Option<Arc<datafusion::optimizer::Analyzer>> {
+        if !self.enabled {
+            return None;
+        }
         self.inner.analyzer()
     }
 }

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -1,0 +1,114 @@
+use std::{any::Any, sync::Arc};
+
+use arrow::datatypes::SchemaRef;
+use datafusion::datasource::TableType;
+use datafusion::error::Result as DataFusionResult;
+use datafusion::{datasource::TableProvider, logical_expr::TableSource};
+use datafusion_federation::{
+    FederatedTableProviderAdaptor, FederatedTableSource, FederationProvider,
+};
+
+use super::AcceleratedTable;
+
+impl AcceleratedTable {
+    fn get_federation_provider_for_accelerator(&self) -> Option<Arc<dyn FederationProvider>> {
+        let provider = self.accelerator.as_any().downcast_ref::<_>()?;
+
+        Some(Arc::clone(provider) as Arc<dyn FederationProvider>)
+    }
+
+    fn create_federated_table_source(&self) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
+        let schema = Arc::clone(&self.schema());
+        let fed_provider = Arc::new(FederationProviderAdapter::new(
+            "test".to_string(),
+            self.get_federation_provider_for_accelerator().unwrap(),
+        ));
+        Ok(Arc::new(SomeTableSource::new_with_schema(
+            fed_provider,
+            schema,
+        )?))
+    }
+
+    pub fn create_federated_table_provider(
+        self: Arc<Self>,
+    ) -> DataFusionResult<FederatedTableProviderAdaptor> {
+        let table_source = self.create_federated_table_source()?;
+        Ok(FederatedTableProviderAdaptor::new_with_provider(
+            table_source,
+            self,
+        ))
+    }
+}
+
+impl FederationProvider for AcceleratedTable {
+    fn name(&self) -> &str {
+        "AcceleratorTableFederatedProvider"
+    }
+
+    fn compute_context(&self) -> Option<String> {
+        // Return uuid for now which doesn't plan to be accelerating
+        Some(uuid::Uuid::new_v4().to_string())
+    }
+
+    fn analyzer(&self) -> Option<Arc<datafusion::optimizer::Analyzer>> {
+        self.get_federation_provider_for_accelerator()
+            .and_then(|x| x.analyzer())
+    }
+}
+
+pub struct FederationProviderAdapter {
+    pub name: String,
+    pub inner: Arc<dyn FederationProvider>,
+}
+
+impl FederationProviderAdapter {
+    fn new(name: String, inner: Arc<dyn FederationProvider>) -> Self {
+        Self { name, inner }
+    }
+}
+
+impl FederationProvider for FederationProviderAdapter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn compute_context(&self) -> Option<String> {
+        self.inner.compute_context()
+    }
+
+    fn analyzer(&self) -> Option<Arc<datafusion::optimizer::Analyzer>> {
+        self.inner.analyzer()
+    }
+}
+
+pub struct SomeTableSource {
+    provider: Arc<FederationProviderAdapter>,
+    schema: SchemaRef,
+}
+
+impl SomeTableSource {
+    pub fn new_with_schema(
+        provider: Arc<FederationProviderAdapter>,
+        schema: SchemaRef,
+    ) -> DataFusionResult<Self> {
+        Ok(Self { provider, schema })
+    }
+}
+
+impl FederatedTableSource for SomeTableSource {
+    fn federation_provider(&self) -> Arc<dyn FederationProvider> {
+        Arc::clone(&self.provider) as Arc<dyn FederationProvider>
+    }
+}
+
+impl TableSource for SomeTableSource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Temporary
+    }
+}

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use async_trait::async_trait;
-use data_components::{delete::DeletionTableProviderAdapter, sandwich::SandwichTableProvider};
+use data_components::{delete::DeletionTableProviderAdapter, poly::PolyTableProvider};
 use datafusion::{
     catalog::TableProviderFactory, datasource::TableProvider, execution::context::SessionContext,
     logical_expr::CreateExternalTable,
@@ -105,16 +105,14 @@ impl DataAccelerator for DuckDBAccelerator {
             unreachable!("DuckDBTableWriter should be returned from DuckDBTableProviderFactory")
         };
 
-        let cloned_reader = Arc::clone(&duckdb_writer.clone().read_provider);
+        let read_provider = Arc::clone(&duckdb_writer.read_provider);
         let duckdb_writer = Arc::new(duckdb_writer.clone());
         let cloned_writer = Arc::clone(&duckdb_writer);
 
-        let deletion_adapter = DeletionTableProviderAdapter::new(duckdb_writer);
-
-        Ok(Arc::new(SandwichTableProvider::new(
+        Ok(Arc::new(PolyTableProvider::new(
             cloned_writer,
-            Arc::new(deletion_adapter),
-            cloned_reader,
+            Arc::new(DeletionTableProviderAdapter::new(duckdb_writer)),
+            read_provider,
         )))
     }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -50,7 +50,6 @@ impl DuckDBAccelerator {
             // DuckDB accelerator uses params.duckdb_file for file connection
             duckdb_factory: DuckDBTableProviderFactory::new()
                 .db_path_param("file")
-                .federated_reader_in_writer(true)
                 .access_mode(AccessMode::ReadWrite),
         }
     }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use async_trait::async_trait;
-use data_components::{delete::DeletionTableProviderAdapter, poly::PolyTableProvider};
+use data_components::poly::PolyTableProvider;
 use datafusion::{
     catalog::TableProviderFactory, datasource::TableProvider, execution::context::SessionContext,
     logical_expr::CreateExternalTable,

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use async_trait::async_trait;
-use data_components::delete::DeletionTableProviderAdapter;
+use data_components::{delete::DeletionTableProviderAdapter, sandwich::SandwichTableProvider};
 use datafusion::{
     catalog::TableProviderFactory, datasource::TableProvider, execution::context::SessionContext,
     logical_expr::CreateExternalTable,
@@ -106,8 +106,13 @@ impl DataAccelerator for DuckDBAccelerator {
         };
 
         let duckdb_writer = Arc::new(duckdb_writer.clone());
+        let cloned_writer = Arc::clone(&duckdb_writer);
 
         let deletion_adapter = DeletionTableProviderAdapter::new(duckdb_writer);
+
+        SandwichTableProvider::new(cloned_writer, Arc::new(deletion_adapter), duckdb_writer);
+
+
         Ok(Arc::new(deletion_adapter))
     }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -111,7 +111,7 @@ impl DataAccelerator for DuckDBAccelerator {
 
         Ok(Arc::new(PolyTableProvider::new(
             cloned_writer,
-            Arc::new(DeletionTableProviderAdapter::new(duckdb_writer)),
+            duckdb_writer,
             read_provider,
         )))
     }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -51,9 +51,7 @@ impl SqliteAccelerator {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            sqlite_factory: SqliteTableProviderFactory::new()
-                .db_path_param("file")
-                .db_base_folder_param("data_directory"),
+            sqlite_factory: SqliteTableProviderFactory::new(),
         }
     }
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -830,7 +830,7 @@ impl DataFusion {
         Ok(())
     }
 
-    async fn get_accelerated_table_provider(
+    pub async fn get_accelerated_table_provider(
         &self,
         dataset_name: &str,
     ) -> Result<Arc<dyn TableProvider>> {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -404,7 +404,14 @@ impl DataFusion {
                     );
 
                     self.ctx
-                        .register_table(dataset_table_ref.clone(), Arc::new(accelerated_table))
+                        .register_table(
+                            dataset_table_ref.clone(),
+                            Arc::new(
+                                Arc::new(accelerated_table)
+                                    .create_federated_table_provider()
+                                    .unwrap(),
+                            ),
+                        )
                         .context(UnableToRegisterTableToDataFusionSnafu)?;
                 } else if source.as_any().downcast_ref::<SinkConnector>().is_some() {
                     // Sink connectors don't know their schema until the first data is received. Park this registration until the schema is known via the first write.
@@ -759,7 +766,14 @@ impl DataFusion {
             .await?;
 
         self.ctx
-            .register_table(dataset.name.clone(), Arc::new(accelerated_table))
+            .register_table(
+                dataset.name.clone(),
+                Arc::new(
+                    Arc::new(accelerated_table)
+                        .create_federated_table_provider()
+                        .unwrap(),
+                ),
+            )
             .context(UnableToRegisterTableToDataFusionSnafu)?;
 
         self.register_metadata_table(&dataset, Arc::clone(&source))

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -409,7 +409,7 @@ impl DataFusion {
                             Arc::new(
                                 Arc::new(accelerated_table)
                                     .create_federated_table_provider()
-                                    .unwrap(),
+                                    .context(UnableToRegisterTableToDataFusionSnafu)?,
                             ),
                         )
                         .context(UnableToRegisterTableToDataFusionSnafu)?;
@@ -771,7 +771,7 @@ impl DataFusion {
                 Arc::new(
                     Arc::new(accelerated_table)
                         .create_federated_table_provider()
-                        .unwrap(),
+                        .context(UnableToRegisterTableToDataFusionSnafu)?,
                 ),
             )
             .context(UnableToRegisterTableToDataFusionSnafu)?;

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -91,8 +91,7 @@ async fn prepare_test_environment() -> Result<RunningContainer<'static>, String>
 async fn create_refresh_task(rt: &Runtime, table_name: &str) -> Result<RefreshTask, String> {
     let table = rt
         .datafusion()
-        .ctx
-        .table_provider(table_name)
+        .get_accelerated_table_provider(table_name)
         .await
         .map_err(|e| e.to_string())?;
 
@@ -112,8 +111,7 @@ async fn create_refresh_task(rt: &Runtime, table_name: &str) -> Result<RefreshTa
 async fn get_accelerator(rt: &Runtime, table_name: &str) -> Result<Arc<dyn TableProvider>, String> {
     let table = rt
         .datafusion()
-        .ctx
-        .table_provider(table_name)
+        .get_accelerated_table_provider(table_name)
         .await
         .map_err(|e| e.to_string())?;
 

--- a/crates/runtime/tests/refresh_sql/mod.rs
+++ b/crates/runtime/tests/refresh_sql/mod.rs
@@ -52,8 +52,7 @@ async fn spiceai_integration_test_refresh_sql_pushdown() -> Result<(), String> {
 
     let traces_table = rt
         .datafusion()
-        .ctx
-        .table_provider("traces")
+        .get_accelerated_table_provider("traces")
         .await
         .map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
## 🗣 Description

Intra table federation for accelerated table.

## 🔨 Related Issues

part of #2182 

<img width="2111" alt="image" src="https://github.com/user-attachments/assets/70fa0556-5944-4920-9dd8-a839bd02d89e">

## Concerns

- when there is a use_source action on zero result, the federation will be disabled to use original logic. This can be enhanced introducing a virtual execution to handle this case.
