### PR TITLE
Add back Spice DF runtime_env during SessionContext construction

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -28,6 +28,7 @@ use crate::dataconnector::{DataConnector, DataConnectorError};
 use crate::dataupdate::{
     DataUpdate, StreamingDataUpdate, StreamingDataUpdateExecutionPlan, UpdateType,
 };
+use crate::object_store_registry::default_runtime_env;
 use crate::secrets::Secrets;
 use crate::{embeddings, get_dependent_table_names};
 
@@ -252,6 +253,7 @@ impl DataFusion {
             .with_config(df_config)
             .with_default_features()
             .with_query_planner(Arc::new(FederatedQueryPlanner::new()))
+            .with_runtime_env(default_runtime_env())
             .build();
 
         let ctx = SessionContext::new_with_state(state);


### PR DESCRIPTION
## 🗣 Description

Fixes a regression made when upgrading to DataFusion 41.

PENDING: A test that would have caught this earlier.

## 🔨 Related Issues

Closes #2303