### PR TITLE
Fix `secrets.inject_secrets` when secret not found.

### DIFF
--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -138,7 +138,7 @@ impl Secrets {
                 .await
                 .unwrap_or_default();
 
-            // Replace the token with the secret value or keep the original text if secret not found
+            // Replace the token with the desired string
             result.push_str(&secret);
 
             // Update the last end to the end of the current match

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -129,12 +129,14 @@ impl Secrets {
             result.push_str(&param_str.0[last_end..secret_replacement.span.start]);
 
             // Get the secret value from the store
-            let secret = self.get_store_secret(
-                &param_str,
-                &secret_replacement.store_name,
-                &secret_replacement.key,
-            )
-            .await.unwrap_or_default();
+            let secret = self
+                .get_store_secret(
+                    &param_str,
+                    &secret_replacement.store_name,
+                    &secret_replacement.key,
+                )
+                .await
+                .unwrap_or_default();
 
             // Replace the token with the secret value or keep the original text if secret not found
             result.push_str(&secret);
@@ -390,9 +392,6 @@ mod tests {
                 super::ParamStr("This is a secret: ${ env:MY_SECRET_KEY }! 🫡"),
             )
             .await;
-        assert_eq!(
-            "This is a secret: ! 🫡",
-            result.expose_secret().as_str()
-        );
+        assert_eq!("This is a secret: ! 🫡", result.expose_secret().as_str());
     }
 }

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -386,6 +386,9 @@ mod tests {
         let mut secrets = super::Secrets::new();
         secrets.load_from(&[]).await.expect("to load successfully"); // Will automatically load `env` as the default
 
+        // Ensure `MY_SECRET_KEY` is not set from other tests.
+        std::env::remove_var("MY_SECRET_KEY");
+
         let result = secrets
             .inject_secrets(
                 "MY_SECRET_KEY",


### PR DESCRIPTION
## 🗣 Description
 - This pull request fixes the `secrets.inject_secrets`. 
 - If the secret placeholder is not found, populated with empty stting.

#### Currently
```rust
assert_eq!(
    super::Secrets::new().inject_secrets(
        "MY_SECRET_KEY",
        ParamStr("This is a secret: ${ env:MY_SECRET_KEY }! 🫡")
    ).await,
    "This is a secret: This is a secret: ${ env:MY_SECRET_KEY }! 🫡"
)
```

#### This PR
```rust
assert_eq!(
    super::Secrets::new().inject_secrets(
        "MY_SECRET_KEY",
        ParamStr("This is a secret: ${ env:MY_SECRET_KEY }! 🫡")
    ).await,
    "This is a secret: ! 🫡"
)
```