### PR TITLE
Add gRPC action to trigger accelerated dataset refresh

### DIFF
--- a/crates/runtime/src/flight/actions.rs
+++ b/crates/runtime/src/flight/actions.rs
@@ -31,9 +31,12 @@ use arrow_flight::{
     Action, ActionType as FlightActionType,
 };
 
+mod datasets;
+
 enum ActionType {
     CreatePreparedStatement,
     ClosePreparedStatement,
+    AcceleratedDatasetRefresh,
     Unknown,
 }
 
@@ -42,6 +45,7 @@ impl ActionType {
         match s {
             "CreatePreparedStatement" => ActionType::CreatePreparedStatement,
             "ClosePreparedStatement" => ActionType::ClosePreparedStatement,
+            "AcceleratedDatasetRefresh" => ActionType::AcceleratedDatasetRefresh,
             _ => ActionType::Unknown,
         }
     }
@@ -50,6 +54,7 @@ impl ActionType {
         match self {
             ActionType::CreatePreparedStatement => "CreatePreparedStatement",
             ActionType::ClosePreparedStatement => "ClosePreparedStatement",
+            ActionType::AcceleratedDatasetRefresh => "AcceleratedDatasetRefresh",
             ActionType::Unknown => "Unknown",
         }
     }
@@ -77,9 +82,17 @@ pub(crate) fn list() -> Response<<Service as FlightService>::ListActionsStream> 
             Response Message: N/A"
             .into(),
     };
+    let accelerated_dataset_refresh_action_type = FlightActionType {
+        r#type: ActionType::AcceleratedDatasetRefresh.to_string(),
+        description: "Refreshes an accelerated dataset.\n
+            Request Message: ActionAcceleratedDatasetRefreshRequest\n
+            Response Message: N/A"
+            .into(),
+    };
     let actions: Vec<Result<FlightActionType, Status>> = vec![
         Ok(create_prepared_statement_action_type),
         Ok(close_prepared_statement_action_type),
+        Ok(accelerated_dataset_refresh_action_type),
     ];
 
     let output = TimedStream::new(futures::stream::iter(actions), || {
@@ -121,6 +134,21 @@ pub(crate) async fn do_action(
         }
         ActionType::ClosePreparedStatement => {
             tracing::trace!("do_action: ClosePreparedStatement");
+            futures::stream::iter(vec![Ok(arrow_flight::Result::default())])
+        }
+        ActionType::AcceleratedDatasetRefresh => {
+            tracing::trace!("do_action: AcceleratedDatasetRefresh");
+            let any = Any::decode(&*request.get_ref().body).map_err(to_tonic_err)?;
+
+            let cmd = datasets::ActionAcceleratedDatasetRefreshRequest::decode(any.value.as_ref())
+                .map_err(|e| {
+                    Status::invalid_argument(format!(
+                        "Unable to decode ActionAcceleratedDatasetRefreshRequest: {e}"
+                    ))
+                })?;
+
+            datasets::do_action_accelerated_dataset_refresh(flight_svc, cmd).await?;
+
             futures::stream::iter(vec![Ok(arrow_flight::Result::default())])
         }
         ActionType::Unknown => return Err(Status::invalid_argument("Unknown action type")),

--- a/crates/runtime/src/flight/actions/datasets.rs
+++ b/crates/runtime/src/flight/actions/datasets.rs
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use tonic::Status;
+
+use crate::{datafusion::Error, flight::Service};
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ActionAcceleratedDatasetRefreshRequest {
+    #[prost(string, tag = "1")]
+    pub dataset_name: ::prost::alloc::string::String,
+}
+
+pub(crate) async fn do_action_accelerated_dataset_refresh(
+    flight_svc: &Service,
+    cmd: ActionAcceleratedDatasetRefreshRequest,
+) -> Result<(), Status> {
+    tracing::trace!("do_action_accelerated_dataset_refresh: {cmd:?}");
+
+    let dataset_name = &cmd.dataset_name;
+
+    match flight_svc.datafusion.refresh_table(&cmd.dataset_name).await {
+        Ok(()) => {
+            tracing::info!("Dataset refresh triggered for {dataset_name}.");
+            Ok(())
+        }
+        Err(e) => {
+            let err_message = format!("Error refreshing dataset {dataset_name}: {e}");
+            tracing::error!(err_message);
+            match e {
+                Error::UnableToGetTable { .. } | Error::NotAcceleratedTable { .. } => {
+                    Err(Status::invalid_argument(err_message))
+                }
+                _ => Err(Status::internal(err_message)),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🗣 Description

Adds support for triggering an accelerated dataset refresh via gRPC. This will be an alternative method for refreshing datasets used by Spice SDKs.

Tests will be added next.

## 🔨 Related Issues

https://github.com/spiceai/spice-java/issues/15

## 🤔 Concerns

1. Considered adding single `SpiceRuntimeCommand` action type (command_type: int, params: json encoded string) to handle all runtime commands in the future (simplify adding new commands). Selected current approach as it is more explicit (params) and easier to use/integrate with.
2. PR does not include .proto file that is usually used to generate gRPC client code. 