### PR TITLE
add `disable_query_push_down` option to acceleration settings

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -138,6 +138,7 @@ pub struct AcceleratedTable {
     zero_results_action: ZeroResultsAction,
     refresh_params: Arc<RwLock<refresh::Refresh>>,
     refresher: Arc<refresh::Refresher>,
+    disable_federation: bool,
 }
 
 fn validate_refresh_data_window(
@@ -170,6 +171,7 @@ pub struct Builder {
     cache_provider: Option<Arc<QueryResultsCacheProvider>>,
     changes_stream: Option<ChangesStream>,
     append_stream: Option<ChangesStream>,
+    disable_federation: bool,
 }
 
 impl Builder {
@@ -189,6 +191,7 @@ impl Builder {
             cache_provider: None,
             changes_stream: None,
             append_stream: None,
+            disable_federation: false,
         }
     }
 
@@ -207,6 +210,11 @@ impl Builder {
         cache_provider: Option<Arc<QueryResultsCacheProvider>>,
     ) -> &mut Self {
         self.cache_provider = cache_provider;
+        self
+    }
+
+    pub fn disable_federation(&mut self, disable_federation: bool) -> &mut Self {
+        self.disable_federation = disable_federation;
         self
     }
 
@@ -317,6 +325,7 @@ impl Builder {
                 zero_results_action: self.zero_results_action,
                 refresh_params,
                 refresher,
+                disable_federation: self.disable_federation,
             },
             is_ready,
         )

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -138,7 +138,7 @@ pub struct AcceleratedTable {
     zero_results_action: ZeroResultsAction,
     refresh_params: Arc<RwLock<refresh::Refresh>>,
     refresher: Arc<refresh::Refresher>,
-    disable_federation: bool,
+    disable_query_push_down: bool,
 }
 
 fn validate_refresh_data_window(
@@ -171,7 +171,7 @@ pub struct Builder {
     cache_provider: Option<Arc<QueryResultsCacheProvider>>,
     changes_stream: Option<ChangesStream>,
     append_stream: Option<ChangesStream>,
-    disable_federation: bool,
+    disable_query_push_down: bool,
 }
 
 impl Builder {
@@ -191,7 +191,7 @@ impl Builder {
             cache_provider: None,
             changes_stream: None,
             append_stream: None,
-            disable_federation: false,
+            disable_query_push_down: false,
         }
     }
 
@@ -213,8 +213,8 @@ impl Builder {
         self
     }
 
-    pub fn disable_federation(&mut self, disable_federation: bool) -> &mut Self {
-        self.disable_federation = disable_federation;
+    pub fn disable_query_push_down(&mut self) -> &mut Self {
+        self.disable_query_push_down = true;
         self
     }
 
@@ -325,7 +325,7 @@ impl Builder {
                 zero_results_action: self.zero_results_action,
                 refresh_params,
                 refresher,
-                disable_federation: self.disable_federation,
+                disable_query_push_down: self.disable_query_push_down,
             },
             is_ready,
         )

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -25,7 +25,8 @@ impl AcceleratedTable {
         let schema = Arc::clone(&self.schema());
         let inner = self.get_federation_provider_for_accelerator();
 
-        let enabled = self.zero_results_action != ZeroResultsAction::UseSource;
+        let enabled =
+            self.zero_results_action != ZeroResultsAction::UseSource && !self.disable_federation;
 
         let fed_provider = Arc::new(FederationAdaptor::new(
             inner.clone().map(|x| x as Arc<dyn FederationProvider>),

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -25,8 +25,8 @@ impl AcceleratedTable {
         let schema = Arc::clone(&self.schema());
         let inner = self.get_federation_provider_for_accelerator();
 
-        let enabled =
-            self.zero_results_action != ZeroResultsAction::UseSource && !self.disable_federation;
+        let enabled = self.zero_results_action != ZeroResultsAction::UseSource
+            && !self.disable_query_push_down;
 
         let fed_provider = Arc::new(FederationAdaptor::new(
             inner.clone().map(|x| x as Arc<dyn FederationProvider>),

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -244,7 +244,7 @@ pub struct Acceleration {
 
     pub on_conflict: HashMap<ColumnReference, OnConflictBehavior>,
 
-    pub disable_federation: bool,
+    pub disable_query_push_down: bool,
 }
 
 impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
@@ -343,7 +343,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             retention_period: acceleration.retention_period,
             retention_check_interval: acceleration.retention_check_interval,
             retention_check_enabled: acceleration.retention_check_enabled,
-            disable_federation: disable_query_push_down,
+            disable_query_push_down,
             on_zero_results: ZeroResultsAction::from(acceleration.on_zero_results),
             indexes,
             primary_key,
@@ -373,7 +373,7 @@ impl Default for Acceleration {
             indexes: HashMap::default(),
             primary_key: None,
             on_conflict: HashMap::default(),
-            disable_federation: false,
+            disable_query_push_down: false,
         }
     }
 }

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -206,6 +206,7 @@ impl Display for OnConflictBehavior {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Acceleration {
     pub enabled: bool,
 
@@ -242,6 +243,8 @@ pub struct Acceleration {
     pub primary_key: Option<ColumnReference>,
 
     pub on_conflict: HashMap<ColumnReference, OnConflictBehavior>,
+
+    pub disable_federation: bool,
 }
 
 impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
@@ -331,6 +334,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             retention_period: acceleration.retention_period,
             retention_check_interval: acceleration.retention_check_interval,
             retention_check_enabled: acceleration.retention_check_enabled,
+            disable_federation: acceleration.disable_federation,
             on_zero_results: ZeroResultsAction::from(acceleration.on_zero_results),
             indexes,
             primary_key,
@@ -360,6 +364,7 @@ impl Default for Acceleration {
             indexes: HashMap::default(),
             primary_key: None,
             on_conflict: HashMap::default(),
+            disable_federation: false,
         }
     }
 }

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -312,6 +312,16 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             );
         }
 
+        let mut params = acceleration.params.clone();
+
+        let disable_query_push_down = match params
+            .as_mut()
+            .and_then(|x| x.data.remove("disable_query_push_down"))
+        {
+            Some(spicepod::component::params::ParamValue::Bool(value)) => value,
+            _ => false,
+        };
+
         Ok(Acceleration {
             enabled: acceleration.enabled,
             mode: Mode::from(acceleration.mode),
@@ -326,15 +336,14 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             )?,
             refresh_retry_enabled: acceleration.refresh_retry_enabled,
             refresh_retry_max_attempts: acceleration.refresh_retry_max_attempts,
-            params: acceleration
-                .params
+            params: params
                 .as_ref()
                 .map(Params::as_string_map)
                 .unwrap_or_default(),
             retention_period: acceleration.retention_period,
             retention_check_interval: acceleration.retention_check_interval,
             retention_check_enabled: acceleration.retention_check_enabled,
-            disable_federation: acceleration.disable_federation,
+            disable_federation: disable_query_push_down,
             on_zero_results: ZeroResultsAction::from(acceleration.on_zero_results),
             indexes,
             primary_key,

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -206,7 +206,6 @@ impl Display for OnConflictBehavior {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-#[allow(clippy::struct_excessive_bools)]
 pub struct Acceleration {
     pub enabled: bool,
 

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -205,6 +205,7 @@ impl Display for OnConflictBehavior {
     }
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Acceleration {
     pub enabled: bool,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -729,7 +729,9 @@ impl DataFusion {
 
         accelerated_table_builder.cache_provider(self.cache_provider());
 
-        accelerated_table_builder.disable_federation(acceleration_settings.disable_federation);
+        if acceleration_settings.disable_query_push_down {
+            accelerated_table_builder.disable_query_push_down();
+        }
 
         if refresh_mode == RefreshMode::Changes {
             let source = Box::leak(Box::new(Arc::clone(&source)));

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -728,6 +728,8 @@ impl DataFusion {
 
         accelerated_table_builder.cache_provider(self.cache_provider());
 
+        accelerated_table_builder.disable_federation(acceleration_settings.disable_federation);
+
         if refresh_mode == RefreshMode::Changes {
             let source = Box::leak(Box::new(Arc::clone(&source)));
             let changes_stream = source.changes_stream(Arc::clone(&source_table_provider));

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -367,12 +367,13 @@ mod tests {
         let mut secrets = super::Secrets::new();
         secrets.load_from(&[]).await.expect("to load successfully"); // Will automatically load `env` as the default
 
-        std::env::set_var("MY_SECRET_KEY", "super_secret");
+        let key = &format!("MY_SECRET_KEY_{}", rand::random::<u64>());
+        std::env::set_var(key, "super_secret");
 
         let result = secrets
             .inject_secrets(
-                "MY_SECRET_KEY",
-                super::ParamStr("This is a secret: ${ env:MY_SECRET_KEY }! 🫡"),
+                key,
+                super::ParamStr(&format!("This is a secret: ${{ env:{key} }}! 🫡")),
             )
             .await;
         assert_eq!(
@@ -386,13 +387,15 @@ mod tests {
         let mut secrets = super::Secrets::new();
         secrets.load_from(&[]).await.expect("to load successfully"); // Will automatically load `env` as the default
 
+        let key = &format!("MY_SECRET_KEY_{}", rand::random::<u64>());
+
         // Ensure `MY_SECRET_KEY` is not set from other tests.
-        std::env::remove_var("MY_SECRET_KEY");
+        std::env::remove_var(key);
 
         let result = secrets
             .inject_secrets(
-                "MY_SECRET_KEY",
-                super::ParamStr("This is a secret: ${ env:MY_SECRET_KEY }! 🫡"),
+                key,
+                super::ParamStr(&format!("This is a secret: ${{ env:{key} }}! 🫡")),
             )
             .await;
         assert_eq!("This is a secret: ! 🫡", result.expose_secret().as_str());

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -1,0 +1,1 @@
+mod query_push_down;

--- a/crates/runtime/tests/acceleration/query_push_down.rs
+++ b/crates/runtime/tests/acceleration/query_push_down.rs
@@ -1,0 +1,204 @@
+use std::time::Duration;
+
+use app::AppBuilder;
+use datafusion::assert_batches_eq;
+use futures::StreamExt;
+use runtime::{datafusion::query::Protocol, Runtime};
+use spicepod::component::{
+    dataset::{acceleration::Acceleration, Dataset},
+    params::Params,
+};
+
+use crate::{init_tracing, postgres::common, wait_until_true};
+
+#[cfg(feature = "postgres")]
+#[allow(clippy::too_many_lines)]
+#[tokio::test]
+async fn s3_acceleration() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let port: usize = 20962;
+    let running_container = common::start_postgres_docker_container(port).await?;
+
+    let pool = common::get_postgres_connection_pool(port).await?;
+    let db_conn = pool
+        .connect_direct()
+        .await
+        .expect("connection can be established");
+    db_conn
+        .conn
+        .execute(
+            "
+CREATE TABLE test (
+    id UUID PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);",
+            &[],
+        )
+        .await
+        .expect("table is created");
+    db_conn
+        .conn
+        .execute(
+            "INSERT INTO test (id, created_at) VALUES ('5ea5a3ac-07a0-4d4d-b201-faff68d8356c', '2023-05-02 10:30:00-04:00');",
+            &[],
+        )
+        .await.expect("inserted data");
+
+    let mut federated_acc = Dataset::new("postgres:test", "abc");
+    let mut params = Params::from_string_map(
+        vec![
+            ("pg_host".to_string(), "localhost".to_string()),
+            ("pg_port".to_string(), port.to_string()),
+            ("pg_user".to_string(), "postgres".to_string()),
+            ("pg_pass".to_string(), common::PG_PASSWORD.to_string()),
+            ("pg_sslmode".to_string(), "disable".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    federated_acc.params = Some(params.clone());
+    params.data.insert(
+        "disable_query_push_down".to_string(),
+        spicepod::component::params::ParamValue::Bool(false),
+    );
+
+    federated_acc.acceleration = Some(Acceleration {
+        params: Some(params),
+        enabled: true,
+        engine: Some("postgres".to_string()),
+        ..Acceleration::default()
+    });
+
+    let mut non_federated_acc = Dataset::new("postgres:test", "non_federated_abc");
+    let mut non_federated_params = Params::from_string_map(
+        vec![
+            ("pg_host".to_string(), "localhost".to_string()),
+            ("pg_port".to_string(), port.to_string()),
+            ("pg_user".to_string(), "postgres".to_string()),
+            ("pg_pass".to_string(), common::PG_PASSWORD.to_string()),
+            ("pg_sslmode".to_string(), "disable".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    non_federated_acc.params = Some(non_federated_params.clone());
+    non_federated_params.data.insert(
+        "disable_query_push_down".to_string(),
+        spicepod::component::params::ParamValue::Bool(true),
+    );
+
+    non_federated_acc.acceleration = Some(Acceleration {
+        params: Some(non_federated_params),
+        enabled: true,
+        engine: Some("postgres".to_string()),
+        ..Acceleration::default()
+    });
+
+    let app = AppBuilder::new("acceleration_federation")
+        .with_dataset(federated_acc)
+        .with_dataset(non_federated_acc)
+        .build();
+
+    let rt = Runtime::builder().with_app(app).build().await;
+
+    // Set a timeout for the test
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+            return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+        }
+        () = rt.load_components() => {}
+    }
+
+    assert!(
+        wait_until_true(Duration::from_secs(30), || async {
+            let mut query_result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM abc LIMIT 1", Protocol::Flight)
+                .build()
+                .run()
+                .await
+                .expect("result returned");
+            let mut batches = vec![];
+            while let Some(batch) = query_result.data.next().await {
+                batches.push(batch.expect("batch"));
+            }
+            !batches.is_empty() && batches[0].num_rows() == 1
+        })
+        .await,
+        "Expected 1 rows returned"
+    );
+    assert!(
+        wait_until_true(Duration::from_secs(30), || async {
+            let mut query_result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM non_federated_abc LIMIT 1", Protocol::Flight)
+                .build()
+                .run()
+                .await
+                .expect("result returned");
+            let mut batches = vec![];
+            while let Some(batch) = query_result.data.next().await {
+                batches.push(batch.expect("batch"));
+            }
+            !batches.is_empty() && batches[0].num_rows() == 1
+        })
+        .await,
+        "Expected 1 rows returned"
+    );
+
+    let plan_results = rt
+        .datafusion()
+        .ctx
+        .sql("EXPLAIN SELECT COUNT(1) FROM abc")
+        .await
+        .expect("sql working")
+        .collect()
+        .await
+        .expect("collect working");
+
+    let expected_plan = [
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "| plan_type     | plan                                                                                                                                                                       |",
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "| logical_plan  | Federated                                                                                                                                                                  |",
+        "|               |  Projection: count(Int64(1))                                                                                                                                               |",
+        "|               |   Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                                                                                                                        |",
+        "|               |     TableScan: abc                                                                                                                                                         |",
+        "| physical_plan | SchemaCastScanExec                                                                                                                                                         |",
+        "|               |   RepartitionExec: partitioning=RoundRobinBatch(14), input_partitions=1                                                                                                    |",
+        "|               |     VirtualExecutionPlan name=postgres compute_context=host=Tcp(\"localhost\"),port=20962,user=postgres, sql=SELECT count(1) FROM abc rewritten_sql=SELECT count(1) FROM abc |",
+        "|               |                                                                                                                                                                            |",
+        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected_plan, &plan_results);
+
+    let plan_results = rt
+        .datafusion()
+        .ctx
+        .sql("EXPLAIN SELECT COUNT(1) FROM non_federated_abc")
+        .await
+        .expect("sql working")
+        .collect()
+        .await
+        .expect("collect working");
+
+    let expected_plan = [
+    "+---------------+-------------------------------------------------------------------------------+",
+    "| plan_type     | plan                                                                          |",
+    "+---------------+-------------------------------------------------------------------------------+",
+    "| logical_plan  | Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                             |",
+    "|               |   TableScan: non_federated_abc projection=[]                                  |",
+    "| physical_plan | AggregateExec: mode=Final, gby=[], aggr=[count(Int64(1))]                     |",
+    "|               |   CoalescePartitionsExec                                                      |",
+    "|               |     AggregateExec: mode=Partial, gby=[], aggr=[count(Int64(1))]               |",
+    "|               |       SchemaCastScanExec                                                      |",
+    "|               |         RepartitionExec: partitioning=RoundRobinBatch(14), input_partitions=1 |",
+    "|               |           SqlExec sql=SELECT \"id\", \"created_at\" FROM non_federated_abc        |",
+    "|               |                                                                               |",
+    "+---------------+-------------------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected_plan, &plan_results);
+
+    running_container.remove().await?;
+    Ok(())
+}

--- a/crates/runtime/tests/acceleration/query_push_down.rs
+++ b/crates/runtime/tests/acceleration/query_push_down.rs
@@ -165,7 +165,7 @@ CREATE TABLE test (
         "|               |   Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                                                                                                                        |",
         "|               |     TableScan: abc                                                                                                                                                         |",
         "| physical_plan | SchemaCastScanExec                                                                                                                                                         |",
-        "|               |   RepartitionExec: partitioning=RoundRobinBatch(14), input_partitions=1                                                                                                    |",
+        "|               |   RepartitionExec: partitioning=RoundRobinBatch(16), input_partitions=1                                                                                                    |",
         "|               |     VirtualExecutionPlan name=postgres compute_context=host=Tcp(\"localhost\"),port=20962,user=postgres, sql=SELECT count(1) FROM abc rewritten_sql=SELECT count(1) FROM abc |",
         "|               |                                                                                                                                                                            |",
         "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",

--- a/crates/runtime/tests/acceleration/query_push_down.rs
+++ b/crates/runtime/tests/acceleration/query_push_down.rs
@@ -14,7 +14,7 @@ use crate::{init_tracing, postgres::common, wait_until_true};
 #[cfg(feature = "postgres")]
 #[allow(clippy::too_many_lines)]
 #[tokio::test]
-async fn s3_acceleration() -> Result<(), anyhow::Error> {
+async fn acceleration_with_and_without_federation() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     let port: usize = 20962;
     let running_container = common::start_postgres_docker_container(port).await?;

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -26,6 +26,7 @@ use runtime::{datafusion::DataFusion, Runtime};
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::EnvFilter;
 
+mod acceleration;
 mod catalog;
 #[cfg(feature = "delta_lake")]
 mod delta_lake;
@@ -43,7 +44,6 @@ mod refresh_sql;
 mod results_cache;
 mod s3;
 mod tls;
-mod acceleration;
 
 /// Gets a test `DataFusion` to make test results reproducible across all machines.
 ///

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -43,6 +43,7 @@ mod refresh_sql;
 mod results_cache;
 mod s3;
 mod tls;
+mod acceleration;
 
 /// Gets a test `DataFusion` to make test results reproducible across all machines.
 ///

--- a/crates/runtime/tests/postgres/common.rs
+++ b/crates/runtime/tests/postgres/common.rs
@@ -27,10 +27,10 @@ use crate::{
     docker::{ContainerRunnerBuilder, RunningContainer},
 };
 
-const PG_PASSWORD: &str = "runtime-integration-test-pw";
+pub const PG_PASSWORD: &str = "runtime-integration-test-pw";
 const PG_DOCKER_CONTAINER: &str = "runtime-integration-test-postgres";
 
-fn get_pg_params(port: usize) -> HashMap<String, SecretString> {
+pub fn get_pg_params(port: usize) -> HashMap<String, SecretString> {
     let mut params = HashMap::new();
     params.insert(
         "pg_host".to_string(),
@@ -56,12 +56,12 @@ fn get_pg_params(port: usize) -> HashMap<String, SecretString> {
     params
 }
 
-pub(super) fn get_random_port() -> usize {
+pub fn get_random_port() -> usize {
     rand::thread_rng().gen_range(15432..65535)
 }
 
 #[instrument]
-pub(super) async fn start_postgres_docker_container(
+pub async fn start_postgres_docker_container(
     port: usize,
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
     let container_name = format!("{PG_DOCKER_CONTAINER}-{port}");
@@ -96,7 +96,7 @@ pub(super) async fn start_postgres_docker_container(
 }
 
 #[instrument]
-pub(super) async fn get_postgres_connection_pool(
+pub async fn get_postgres_connection_pool(
     port: usize,
 ) -> Result<PostgresConnectionPool, anyhow::Error> {
     let pool = PostgresConnectionPool::new(get_pg_params(port)).await?;

--- a/crates/runtime/tests/postgres/mod.rs
+++ b/crates/runtime/tests/postgres/mod.rs
@@ -27,7 +27,7 @@ use datafusion_table_providers::{
 
 use crate::init_tracing;
 
-mod common;
+pub mod common;
 
 #[tokio::test]
 async fn test_postgres_types() -> Result<(), anyhow::Error> {

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -236,7 +236,6 @@ pub mod acceleration {
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     #[cfg_attr(feature = "schemars", derive(JsonSchema))]
-    #[allow(clippy::struct_excessive_bools)]
     pub struct Acceleration {
         #[serde(default = "default_true")]
         pub enabled: bool,

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -236,6 +236,7 @@ pub mod acceleration {
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+    #[allow(clippy::struct_excessive_bools)]
     pub struct Acceleration {
         #[serde(default = "default_true")]
         pub enabled: bool,
@@ -290,6 +291,9 @@ pub mod acceleration {
 
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         pub on_conflict: HashMap<String, OnConflictBehavior>,
+
+        #[serde(default, skip_serializing_if = "is_false")]
+        pub disable_federation: bool,
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -322,6 +326,7 @@ pub mod acceleration {
                 indexes: HashMap::default(),
                 primary_key: None,
                 on_conflict: HashMap::default(),
+                disable_federation: false,
             }
         }
     }

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -291,9 +291,6 @@ pub mod acceleration {
 
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         pub on_conflict: HashMap<String, OnConflictBehavior>,
-
-        #[serde(default, skip_serializing_if = "is_false")]
-        pub disable_federation: bool,
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -326,7 +323,6 @@ pub mod acceleration {
                 indexes: HashMap::default(),
                 primary_key: None,
                 on_conflict: HashMap::default(),
-                disable_federation: false,
             }
         }
     }


### PR DESCRIPTION
## 🗣 Description

Add a new `disable_query_push_down` option to the acceleration settings which allows users to escape from the default federated query on accelerator.

UI:

```
    acceleration:
      engine: postgres
      enabled: true
      params:
        disable_query_push_down: true
```

## 🔨 Related Issues

part of #2182 

## 🤔 Concerns

This pattern may eventually lead to a group of "support" keys in the acceleration settings. However, we are not implementing that struct yet until we see another use case emerge.