### PR TITLE
Send telemetry on startup

### DIFF
--- a/crates/otel-arrow/src/converter.rs
+++ b/crates/otel-arrow/src/converter.rs
@@ -300,6 +300,7 @@ impl AttributesBuilder {
 }
 
 impl OtelToArrowConverter {
+    #[must_use]
     pub fn new(capacity: usize) -> Self {
         OtelToArrowConverter {
             time_unix_nano_builder: TimestampNanosecondBuilder::with_capacity(capacity),
@@ -320,6 +321,11 @@ impl OtelToArrowConverter {
         }
     }
 
+    /// Converts the given `ResourceMetrics` into an Arrow `RecordBatch`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the conversion fails.
     pub fn convert(
         &mut self,
         resource_metrics: &ResourceMetrics,

--- a/crates/otel-arrow/src/exporter.rs
+++ b/crates/otel-arrow/src/exporter.rs
@@ -44,6 +44,14 @@ pub struct OtelArrowExporter<E: ArrowExporter> {
     exporter: E,
 }
 
+impl<E: ArrowExporter + Clone> Clone for OtelArrowExporter<E> {
+    fn clone(&self) -> Self {
+        OtelArrowExporter {
+            exporter: self.exporter.clone(),
+        }
+    }
+}
+
 impl<E: ArrowExporter> OtelArrowExporter<E> {
     pub fn new(exporter: E) -> Self {
         OtelArrowExporter { exporter }

--- a/crates/otel-arrow/src/lib.rs
+++ b/crates/otel-arrow/src/lib.rs
@@ -18,6 +18,7 @@ mod schema;
 pub use schema::*;
 
 mod converter;
+pub use converter::*;
 pub mod error;
 mod exporter;
 pub use exporter::*;

--- a/crates/runtime/tests/acceleration/query_push_down.rs
+++ b/crates/runtime/tests/acceleration/query_push_down.rs
@@ -9,13 +9,14 @@ use spicepod::component::{
     params::Params,
 };
 
-use crate::{init_tracing, postgres::common, wait_until_true};
+use crate::{init_tracing, wait_until_true};
 
 #[cfg(feature = "postgres")]
 #[allow(clippy::too_many_lines)]
 #[tokio::test]
 async fn acceleration_with_and_without_federation() -> Result<(), anyhow::Error> {
     use crate::get_test_datafusion;
+    use crate::postgres::common;
 
     let _tracing = init_tracing(Some("integration=debug,info"));
     let port: usize = 20962;
@@ -165,18 +166,18 @@ CREATE TABLE test (
         .expect("collect working");
 
     let expected_plan = [
-        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
-        "| plan_type     | plan                                                                                                                                                                       |",
-        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
-        "| logical_plan  | Federated                                                                                                                                                                  |",
-        "|               |  Projection: count(Int64(1))                                                                                                                                               |",
-        "|               |   Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                                                                                                                        |",
-        "|               |     TableScan: abc                                                                                                                                                         |",
-        "| physical_plan | SchemaCastScanExec                                                                                                                                                         |",
-        "|               |   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                     |",
-        "|               |     VirtualExecutionPlan name=postgres compute_context=host=Tcp(\"localhost\"),port=20962,user=postgres, sql=SELECT count(1) FROM abc rewritten_sql=SELECT count(1) FROM abc |",
-        "|               |                                                                                                                                                                            |",
-        "+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "| plan_type     | plan                                                                                                                                                                         |",
+        "+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "| logical_plan  | Federated                                                                                                                                                                    |",
+        "|               |  Projection: count(Int64(1))                                                                                                                                                 |",
+        "|               |   Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                                                                                                                          |",
+        "|               |     TableScan: abc                                                                                                                                                           |",
+        "| physical_plan | SchemaCastScanExec                                                                                                                                                           |",
+        "|               |   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                       |",
+        "|               |     VirtualExecutionPlan name=postgres compute_context=host=Tcp(\"localhost\"),port=20962,user=postgres, sql=SELECT count(1) FROM abc rewritten_sql=SELECT count(1) FROM \"abc\" |",
+        "|               |                                                                                                                                                                              |",
+        "+---------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
     ];
     assert_batches_eq!(expected_plan, &plan_results);
 

--- a/crates/telemetry/src/exporter.rs
+++ b/crates/telemetry/src/exporter.rs
@@ -26,6 +26,7 @@ use opentelemetry_sdk::metrics::{
     Aggregation, InstrumentKind,
 };
 
+#[derive(Debug, Clone)]
 pub struct AnonymousTelemetryExporter {
     aggregation_selector: DefaultAggregationSelector,
     flight_client: Option<FlightClient>,

--- a/crates/telemetry/src/meter.rs
+++ b/crates/telemetry/src/meter.rs
@@ -21,12 +21,13 @@ use opentelemetry::{
     metrics::{noop::NoopMeterProvider, Meter, MeterProvider},
 };
 
-pub(crate) static METER_PROVIDER: OnceLock<GlobalMeterProvider> = OnceLock::new();
+pub(crate) static METER_PROVIDER_ONCE: OnceLock<GlobalMeterProvider> = OnceLock::new();
 
 /// If the meter provider isn't initialized for anonymous telemetry, use a `NoopMeterProvider`.
 ///
 /// This allows the instrumented code to not require any changes when anonymous telemetry is disabled/compiled out.
-pub(crate) static METER: LazyLock<Meter> = LazyLock::new(|| {
-    let meter = METER_PROVIDER.get_or_init(|| GlobalMeterProvider::new(NoopMeterProvider::new()));
-    meter.meter("oss_telemetry")
+static METER_PROVIDER: LazyLock<&'static GlobalMeterProvider> = LazyLock::new(|| {
+    METER_PROVIDER_ONCE.get_or_init(|| GlobalMeterProvider::new(NoopMeterProvider::new()))
 });
+
+pub(crate) static METER: LazyLock<Meter> = LazyLock::new(|| METER_PROVIDER.meter("oss_telemetry"));


### PR DESCRIPTION
## 🗣 Description

Sends initial telemetry on startup, instead of having to wait an hour for the initial telemetry to be sent.

The OpenTelemetry `PeriodicReader` will wait for the interval to elapse before sending the first batch of telemetry data. To get the behavior of having an `alive` metric sent immediately on startup, manually trigger the first batch of telemetry data to be sent.

## 🔨 Related Issues

Part of #1715

## 🤔 Concerns

I wish there was a way to configure the PeriodicReader itself to not skip the initial interval, but this works reasonably well.