### PR TITLE
feat: Add DuckDB accelerator init, attach databases for federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,6 +3153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=c042b6011e76c1f5b88573d338e88559e91dece9#c042b6011e76c1f5b88573d338e88559e91dece9"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,7 +3153,6 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=221a42394fb5e17eeb099f3cd8c8cf8cc626be79#221a42394fb5e17eeb099f3cd8c8cf8cc626be79"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,8 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "41.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ae9da45f8b90451119f3ca032b75ad82a28d7547" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "221a42394fb5e17eeb099f3cd8c8cf8cc626be79" }
+#datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "c2f5f709052188956126670542bf5ce24c2d2a4d" }
+datafusion-table-providers = { path = "../datafusion-table-providers" }
 dirs = "5.0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "41.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ae9da45f8b90451119f3ca032b75ad82a28d7547" }
-#datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "c2f5f709052188956126670542bf5ce24c2d2a4d" }
-datafusion-table-providers = { path = "../datafusion-table-providers" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "c042b6011e76c1f5b88573d338e88559e91dece9" }
 dirs = "5.0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -133,6 +133,19 @@ pub trait DataAccelerator: Send + Sync {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    fn valid_file_extensions(&self) -> Vec<&'static str> {
+        vec![]
+    }
+
+    fn is_valid_file(&self, file_path: &String) -> bool {
+        let path = std::path::Path::new(file_path);
+
+        !path.is_dir()
+            && path.extension().map_or(false, |ext| {
+                self.valid_file_extensions().iter().any(|&e| e == ext)
+            })
+    }
 }
 
 pub struct AcceleratorExternalTableBuilder {

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -59,6 +59,9 @@ pub enum Error {
         valid_extensions: String,
         extension: String,
     },
+
+    #[snafu(display("The \"duckdb_file\" acceleration parameter is a directory."))]
+    InvalidFileIsDirectory,
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -136,6 +139,10 @@ impl DataAccelerator for DuckDBAccelerator {
                     Error::AccelerationInitializationFailed { source: err.into() }
                 })?;
             } else if !self.is_valid_file(path) {
+                if std::path::Path::new(path).is_dir() {
+                    return Err(Error::InvalidFileIsDirectory.into());
+                }
+
                 let extension = std::path::Path::new(path)
                     .extension()
                     .and_then(OsStr::to_str)

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -161,8 +161,10 @@ impl DataAccelerator for SqliteAccelerator {
                     .collect::<Vec<String>>()
             })
         }) {
-            cmd.options
-                .insert("attach_databases".to_string(), attach_databases.join(";"));
+            if !attach_databases.is_empty() {
+                cmd.options
+                    .insert("attach_databases".to_string(), attach_databases.join(";"));
+            }
         }
 
         let ctx = SessionContext::new();

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -58,6 +58,9 @@ pub enum Error {
         valid_extensions: String,
         extension: String,
     },
+
+    #[snafu(display("The \"duckdb_file\" acceleration parameter is a directory."))]
+    InvalidFileIsDirectory,
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -130,6 +133,10 @@ impl DataAccelerator for SqliteAccelerator {
                 make_spice_data_directory()
                     .map_err(|err| Error::AccelerationCreationFailed { source: err.into() })?;
             } else if !self.is_valid_file(path) {
+                if std::path::Path::new(path).is_dir() {
+                    return Err(Error::InvalidFileIsDirectory.into());
+                }
+
                 let extension = std::path::Path::new(path)
                     .extension()
                     .and_then(OsStr::to_str)

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -115,7 +115,7 @@ impl DataAccelerator for SqliteAccelerator {
     }
 
     fn valid_file_extensions(&self) -> Vec<&'static str> {
-        vec!["sqlite"]
+        vec!["sqlite", "db"]
     }
 
     /// Initializes an SQLite database for the dataset


### PR DESCRIPTION
## 🗣 Description

* Fixes a bug in SQLite `attach_databases` calculation that was producing an invalid value of `[""]` because `.split()` on an empty string results in a single element array with an empty string.
* Adds DuckDB accelerator initialization, creating an empty DuckDB file in preparation for federation attachments.
* Adds support for attaching databases to DuckDB for federation.
* Changes the default DuckDB accelerator file location to `~/.spice/data`.

## 🔨 Related Issues

* Closes #2325 
* Closes #2324
* Closes #2229 
* Closes #2313