### PR TITLE
update duckdb rs version to support more types: interval/duration/etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,7 +3477,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "duckdb"
 version = "1.0.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=85935dbbc64d2af1ca132ad7e2309a9d87bf3115#85935dbbc64d2af1ca132ad7e2309a9d87bf3115"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=f2ca47d094a5636df8b9f3792b2f474a7b210dc1#f2ca47d094a5636df8b9f3792b2f474a7b210dc1"
 dependencies = [
  "arrow",
  "cast",
@@ -5415,7 +5415,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 [[package]]
 name = "libduckdb-sys"
 version = "1.0.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=85935dbbc64d2af1ca132ad7e2309a9d87bf3115#85935dbbc64d2af1ca132ad7e2309a9d87bf3115"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=f2ca47d094a5636df8b9f3792b2f474a7b210dc1#f2ca47d094a5636df8b9f3792b2f474a7b210dc1"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ x509-certificate = "0.23.1"
 [patch.crates-io]
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "7c6c88b637db8109a2e899849fe6b023f55cf8c1" }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "ae9da45f8b90451119f3ca032b75ad82a28d7547" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "85935dbbc64d2af1ca132ad7e2309a9d87bf3115" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "f2ca47d094a5636df8b9f3792b2f474a7b210dc1" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdfc2c482f1ce84c595ab1202530a37815d6" }
 


### PR DESCRIPTION
Upgrade vesion of spiceai/duckdb-rs to get the latest support on arrow type: interval/duration/fixed size binary
