### PR TITLE
Fix benchmark test to keep running when there's failed queries

### DIFF
--- a/crates/runtime/benches/bench_delta/mod.rs
+++ b/crates/runtime/benches/bench_delta/mod.rs
@@ -25,16 +25,24 @@ pub(crate) async fn run(
     benchmark_results: &mut BenchmarkResultsBuilder,
 ) -> Result<(), String> {
     let test_queries = get_test_queries();
+    let mut errors = Vec::new();
 
     for (query_name, query) in test_queries {
-        super::run_query_and_record_result(
+        if let Err(e) = super::run_query_and_record_result(
             rt,
             benchmark_results,
             "databricks_delta",
             query_name,
             query,
         )
-        .await?;
+        .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        };
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
     }
 
     Ok(())

--- a/crates/runtime/benches/bench_mysql/mod.rs
+++ b/crates/runtime/benches/bench_mysql/mod.rs
@@ -25,10 +25,19 @@ pub(crate) async fn run(
     benchmark_results: &mut BenchmarkResultsBuilder,
 ) -> Result<(), String> {
     let test_queries = get_test_queries();
+    let mut errors = Vec::new();
 
     for (query_name, query) in test_queries {
-        super::run_query_and_record_result(rt, benchmark_results, "mysql", query_name, query)
-            .await?;
+        if let Err(e) =
+            super::run_query_and_record_result(rt, benchmark_results, "mysql", query_name, query)
+                .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        };
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
     }
 
     Ok(())

--- a/crates/runtime/benches/bench_odbc_athena/mod.rs
+++ b/crates/runtime/benches/bench_odbc_athena/mod.rs
@@ -25,10 +25,24 @@ pub(crate) async fn run(
     benchmark_results: &mut BenchmarkResultsBuilder,
 ) -> Result<(), String> {
     let test_queries = get_test_queries();
+    let mut errors = Vec::new();
 
     for (query_name, query) in test_queries {
-        super::run_query_and_record_result(rt, benchmark_results, "odbc-athena", query_name, query)
-            .await?;
+        if let Err(e) = super::run_query_and_record_result(
+            rt,
+            benchmark_results,
+            "odbc-athena",
+            query_name,
+            query,
+        )
+        .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        };
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
     }
 
     Ok(())

--- a/crates/runtime/benches/bench_odbc_databricks/mod.rs
+++ b/crates/runtime/benches/bench_odbc_databricks/mod.rs
@@ -25,16 +25,24 @@ pub(crate) async fn run(
     benchmark_results: &mut BenchmarkResultsBuilder,
 ) -> Result<(), String> {
     let test_queries = get_test_queries();
+    let mut errors = Vec::new();
 
     for (query_name, query) in test_queries {
-        super::run_query_and_record_result(
+        if let Err(e) = super::run_query_and_record_result(
             rt,
             benchmark_results,
             "odbc-databricks",
             query_name,
             query,
         )
-        .await?;
+        .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        };
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
     }
 
     Ok(())

--- a/crates/runtime/benches/bench_postgres/mod.rs
+++ b/crates/runtime/benches/bench_postgres/mod.rs
@@ -22,10 +22,19 @@ pub(crate) async fn run(
     benchmark_results: &mut BenchmarkResultsBuilder,
 ) -> Result<(), String> {
     let test_queries = get_test_queries();
+    let mut errors = Vec::new();
 
     for (query_name, query) in test_queries {
-        super::run_query_and_record_result(rt, benchmark_results, "postgres", query_name, query)
-            .await?;
+        if let Err(e) =
+            super::run_query_and_record_result(rt, benchmark_results, "postgres", query_name, query)
+                .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        };
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
     }
 
     Ok(())

--- a/crates/runtime/benches/bench_s3/mod.rs
+++ b/crates/runtime/benches/bench_s3/mod.rs
@@ -58,7 +58,6 @@ pub(crate) async fn run(
 
     if !errors.is_empty() {
         tracing::error!("There are failed queries:\n{}", errors.join("\n"));
-        return Err(errors.join("\n"));
     }
 
     Ok(())

--- a/crates/runtime/benches/bench_spark/mod.rs
+++ b/crates/runtime/benches/bench_spark/mod.rs
@@ -24,9 +24,18 @@ pub(crate) async fn run(
 ) -> Result<(), String> {
     let test_queries = get_test_queries();
 
+    let mut errors = Vec::new();
     for (query_name, query) in test_queries {
-        super::run_query_and_record_result(rt, benchmark_results, "spark", query_name, query)
-            .await?;
+        if let Err(e) =
+            super::run_query_and_record_result(rt, benchmark_results, "spark", query_name, query)
+                .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        };
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
     }
 
     Ok(())

--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -22,10 +22,19 @@ pub(crate) async fn run(
     benchmark_results: &mut BenchmarkResultsBuilder,
 ) -> Result<(), String> {
     let test_queries = get_test_queries();
+    let mut errors = Vec::new();
 
     for (query_name, query) in test_queries {
-        super::run_query_and_record_result(rt, benchmark_results, "spice.ai", query_name, query)
-            .await?;
+        if let Err(e) =
+            super::run_query_and_record_result(rt, benchmark_results, "spice.ai", query_name, query)
+                .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        };
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
     }
 
     Ok(())


### PR DESCRIPTION
## 🗣 Description

* Stop propagating query running errors into tokio main function, which would terminate the program when query error happens
* Collect errors of running benchmark queries, and display errors in the log.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->