### PR TITLE
Fix system prompt in ToolUsingChat, fix builtin registration

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -58,10 +58,12 @@ use snafu::prelude::*;
 use spice_metrics::get_metrics_table_reference;
 use spicepod::component::embeddings::Embeddings;
 use spicepod::component::model::{Model as SpicepodModel, ModelType};
+use spicepod::component::tool::Tool;
 use timing::TimeMeasurement;
 use tls::TlsConfig;
 use tokio::sync::oneshot::error::RecvError;
 use tokio::sync::RwLock;
+use tools::builtin::get_builtin_tool_spec;
 use tools::factory as tool_factory;
 use tools::SpiceModelTool;
 use tracing_util::dataset_registered_trace;
@@ -1289,32 +1291,41 @@ impl Runtime {
         let app_lock = self.app.read().await;
         if let Some(app) = app_lock.as_ref() {
             for tool in &app.tools {
-                status::update_tool(&tool.name, status::ComponentStatus::Initializing);
-                let params_with_secrets: HashMap<String, SecretString> =
-                    self.get_params_with_secrets(&tool.params).await;
+                self.load_tool(tool).await;
+            }
+        }
 
-                match tool_factory::forge(tool, params_with_secrets)
-                    .await
-                    .context(UnableToInitializeLlmToolSnafu)
-                {
-                    Ok(t) => {
-                        let mut tools_map = self.tools.write().await;
-                        tools_map.insert(tool.name.clone(), t);
-                        tracing::info!("Tool [{}] ready to use", tool.name);
-                        metrics::tools::COUNT
-                            .add(1, &[Key::from_static_str("tool").string(tool.name.clone())]);
-                        status::update_tool(&tool.name, status::ComponentStatus::Ready);
-                    }
-                    Err(e) => {
-                        metrics::tools::LOAD_ERROR.add(1, &[]);
-                        status::update_tool(&tool.name, status::ComponentStatus::Error);
-                        tracing::warn!(
-                            "Unable to load tool from spicepod {}, error: {}",
-                            tool.name,
-                            e,
-                        );
-                    }
-                }
+        // Load all built-in tools, regardless if they are in the spicepod
+        for tool in get_builtin_tool_spec() {
+            self.load_tool(&tool).await;
+        }
+    }
+
+    async fn load_tool(&self, tool: &Tool) {
+        status::update_tool(&tool.name, status::ComponentStatus::Initializing);
+        let params_with_secrets: HashMap<String, SecretString> =
+            self.get_params_with_secrets(&tool.params).await;
+
+        match tool_factory::forge(tool, params_with_secrets)
+            .await
+            .context(UnableToInitializeLlmToolSnafu)
+        {
+            Ok(t) => {
+                let mut tools_map = self.tools.write().await;
+                tools_map.insert(tool.name.clone(), t);
+                tracing::info!("Tool [{}] ready to use", tool.name);
+                metrics::tools::COUNT
+                    .add(1, &[Key::from_static_str("tool").string(tool.name.clone())]);
+                status::update_tool(&tool.name, status::ComponentStatus::Ready);
+            }
+            Err(e) => {
+                metrics::tools::LOAD_ERROR.add(1, &[]);
+                status::update_tool(&tool.name, status::ComponentStatus::Error);
+                tracing::warn!(
+                    "Unable to load tool from spicepod {}, error: {}",
+                    tool.name,
+                    e,
+                );
             }
         }
     }

--- a/crates/runtime/src/tools/builtin/document_similarity.rs
+++ b/crates/runtime/src/tools/builtin/document_similarity.rs
@@ -56,7 +56,7 @@ impl From<DocumentSimilarityTool> for spicepod::component::tool::Tool {
             name: val.name().to_string(),
             description: val.description().map(ToString::to_string),
             params: HashMap::default(),
-            depends_on: Vec::default()
+            depends_on: Vec::default(),
         }
     }
 }

--- a/crates/runtime/src/tools/builtin/document_similarity.rs
+++ b/crates/runtime/src/tools/builtin/document_similarity.rs
@@ -16,7 +16,7 @@ limitations under the License.
 use async_trait::async_trait;
 use serde_json::Value;
 use snafu::ResultExt;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tracing_futures::Instrument;
 
 use crate::{
@@ -46,6 +46,18 @@ impl Default for DocumentSimilarityTool {
             "document_similarity",
             Some("Search and retrieve documents from available datasets".to_string()),
         )
+    }
+}
+
+impl From<DocumentSimilarityTool> for spicepod::component::tool::Tool {
+    fn from(val: DocumentSimilarityTool) -> Self {
+        spicepod::component::tool::Tool {
+            from: format!("builtin:{}", val.name()),
+            name: val.name().to_string(),
+            description: val.description().map(ToString::to_string),
+            params: HashMap::default(),
+            depends_on: Vec::default()
+        }
     }
 }
 

--- a/crates/runtime/src/tools/builtin/list_datasets.rs
+++ b/crates/runtime/src/tools/builtin/list_datasets.rs
@@ -65,7 +65,7 @@ impl From<ListDatasetsTool> for spicepod::component::tool::Tool {
             name: val.name().to_string(),
             description: val.description().map(ToString::to_string),
             params: HashMap::default(),
-            depends_on: Vec::default()
+            depends_on: Vec::default(),
         }
     }
 }

--- a/crates/runtime/src/tools/builtin/list_datasets.rs
+++ b/crates/runtime/src/tools/builtin/list_datasets.rs
@@ -58,6 +58,18 @@ impl Default for ListDatasetsTool {
     }
 }
 
+impl From<ListDatasetsTool> for spicepod::component::tool::Tool {
+    fn from(val: ListDatasetsTool) -> Self {
+        spicepod::component::tool::Tool {
+            from: format!("builtin:{}", val.name()),
+            name: val.name().to_string(),
+            description: val.description().map(ToString::to_string),
+            params: HashMap::default(),
+            depends_on: Vec::default()
+        }
+    }
+}
+
 #[async_trait]
 impl SpiceModelTool for ListDatasetsTool {
     fn name(&self) -> &str {

--- a/crates/runtime/src/tools/builtin/mod.rs
+++ b/crates/runtime/src/tools/builtin/mod.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use document_similarity::DocumentSimilarityTool;
 use list_datasets::ListDatasetsTool;
+use spicepod::component::tool::Tool;
 use sql::SqlTool;
 use table_schema::TableSchemaTool;
 
@@ -34,5 +35,15 @@ pub(crate) fn get_builtin_tools() -> Vec<Arc<dyn SpiceModelTool>> {
         Arc::new(TableSchemaTool::default()),
         Arc::new(SqlTool::default()),
         Arc::new(ListDatasetsTool::default()),
+    ]
+}
+
+#[must_use]
+pub fn get_builtin_tool_spec() -> Vec<Tool> {
+    vec![
+        DocumentSimilarityTool::default().into(),
+        TableSchemaTool::default().into(),
+        SqlTool::default().into(),
+        ListDatasetsTool::default().into(),
     ]
 }

--- a/crates/runtime/src/tools/builtin/sql.rs
+++ b/crates/runtime/src/tools/builtin/sql.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     datafusion::query::Protocol,
@@ -56,6 +56,18 @@ impl Default for SqlTool {
             "sql",
             Some("Run an SQL query on the data source".to_string()),
         )
+    }
+}
+
+impl From<SqlTool> for spicepod::component::tool::Tool {
+    fn from(val: SqlTool) -> Self {
+        spicepod::component::tool::Tool {
+            from: format!("builtin:{}", val.name()),
+            name: val.name().to_string(),
+            description: val.description().map(ToString::to_string),
+            params: HashMap::default(),
+            depends_on: Vec::default()
+        }
     }
 }
 

--- a/crates/runtime/src/tools/builtin/sql.rs
+++ b/crates/runtime/src/tools/builtin/sql.rs
@@ -66,7 +66,7 @@ impl From<SqlTool> for spicepod::component::tool::Tool {
             name: val.name().to_string(),
             description: val.description().map(ToString::to_string),
             params: HashMap::default(),
-            depends_on: Vec::default()
+            depends_on: Vec::default(),
         }
     }
 }

--- a/crates/runtime/src/tools/builtin/table_schema.rs
+++ b/crates/runtime/src/tools/builtin/table_schema.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     tools::{parameters, SpiceModelTool},
@@ -53,6 +53,19 @@ impl Default for TableSchemaTool {
         )
     }
 }
+
+impl From<TableSchemaTool> for spicepod::component::tool::Tool {
+    fn from(val: TableSchemaTool) -> Self {
+        spicepod::component::tool::Tool {
+            from: format!("builtin:{}", val.name()),
+            name: val.name().to_string(),
+            description: val.description().map(ToString::to_string),
+            params: HashMap::default(),
+            depends_on: Vec::default()
+        }
+    }
+}
+
 #[async_trait]
 impl SpiceModelTool for TableSchemaTool {
     fn name(&self) -> &str {

--- a/crates/runtime/src/tools/builtin/table_schema.rs
+++ b/crates/runtime/src/tools/builtin/table_schema.rs
@@ -61,7 +61,7 @@ impl From<TableSchemaTool> for spicepod::component::tool::Tool {
             name: val.name().to_string(),
             description: val.description().map(ToString::to_string),
             params: HashMap::default(),
-            depends_on: Vec::default()
+            depends_on: Vec::default(),
         }
     }
 }


### PR DESCRIPTION
## 🗣 Description
Accidentally fixed two bugs in one PR:
 1. Fix the construction of `CreateChatCompletionRequest ` in `ToolUsingChat`. Prior, we were adding the `ToolUsingChat` system message, to the request we would pass to the recursive `ToolUsingChat` call. This would result in the system message being repeated N times for the N'th `ai_completion`. This fix is isolated to `crates/runtime/src/model/tool_use.rs`.
 2. Fix the registration of builtin tools. Since #2344 ,  we were only registering tools that were in the spicepod's `tool` section. This broke the ability to specify a subset of builtin tools for `models.params.spice_tools`. E.g. 
```yaml
  - name: openai-with-spice
    from: openai/gpt-4o
    params:
      spice_tools: sql, list_datasets, table_schema
```