### PR TITLE
fix: Disable DuckDB and SQLite federation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -73,7 +73,7 @@ jobs:
           wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
           sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
 
-      - run: cargo bench -p runtime --features ${{ env.FEATURES }}
+      - run: cargo bench -p runtime --features ${{ env.FEATURES }} --release
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
           PG_BENCHMARK_PG_HOST: localhost

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,9 +3155,9 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b2cac6789de4012a787096ec2c65de1b28502d36#b2cac6789de4012a787096ec2c65de1b28502d36"
 dependencies = [
  "arrow",
+ "arrow-json",
  "async-stream",
  "async-trait",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,9 +3155,9 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b2cac6789de4012a787096ec2c65de1b28502d36#b2cac6789de4012a787096ec2c65de1b28502d36"
 dependencies = [
  "arrow",
- "arrow-json",
  "async-stream",
  "async-trait",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,9 +3155,10 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b2cac6789de4012a787096ec2c65de1b28502d36#b2cac6789de4012a787096ec2c65de1b28502d36"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=55f878c3accba051a1e06c33fd0b4b5937a05d66#55f878c3accba051a1e06c33fd0b4b5937a05d66"
 dependencies = [
  "arrow",
+ "arrow-json",
  "async-stream",
  "async-trait",
  "bb8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2865,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2899,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "tokio",
 ]
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "arrow",
  "chrono",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3034,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3053,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3095,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "datafusion-common",
  "datafusion-execution",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=7c6c88b637db8109a2e899849fe6b023f55cf8c1#7c6c88b637db8109a2e899849fe6b023f55cf8c1"
+source = "git+https://github.com/spiceai/datafusion.git?rev=4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a#4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,8 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "41.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b2cac6789de4012a787096ec2c65de1b28502d36" }
+#datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b2cac6789de4012a787096ec2c65de1b28502d36" }
+datafusion-table-providers = { path = "../datafusion-table-providers" }
 dirs = "5.0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ uuid = "1.9.1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "7c6c88b637db8109a2e899849fe6b023f55cf8c1" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a" }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "f2ca47d094a5636df8b9f3792b2f474a7b210dc1" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,7 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 datafusion = "41.0.0"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }
-#datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b2cac6789de4012a787096ec2c65de1b28502d36" }
-datafusion-table-providers = { path = "../datafusion-table-providers" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "55f878c3accba051a1e06c33fd0b4b5937a05d66" }
 dirs = "5.0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"


### PR DESCRIPTION
## 🗣 Description

* Disables DuckDB and SQLite federation
* Updates `datafusion` to include the fix for SQLite `Strftime` in `SqliteDialect`
* Updates benchmarks to run in `--release` mode to improve runtime performance for benchmarks

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #2351 