### PR TITLE
Add check for models flavor on spice chat and prompt to install

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -159,6 +159,7 @@ jobs:
       - name: tar binary (Windows)
         if: matrix.target_os == 'windows'
         run: |
+          rm spiced.exe
           mv target/release/spiced.exe spiced.exe
           tar czf spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced.exe
 

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -108,45 +108,22 @@ jobs:
             Copy-Item -Recurse -Force C:/spiceai/build/target/* target/
           }
 
+      ## Default flavor
       - name: Build spiced
         run: make -C bin/spiced
-
-      - name: Update build cache (macOS)
-        if: matrix.target_os == 'darwin'
-        run: |
-          if [ -d /Users/spiceai/build/target ]; then
-            rsync -av target/ /Users/spiceai/build/target/
-          fi
-
-      - name: Update build cache (Linux)
-        if: matrix.target_os == 'linux'
-        run: |
-          if [ -d /home/spiceai/build/target ]; then
-            rsync -av target/ /home/spiceai/build/target/
-          fi
-
-      - name: Update build cache (Windows)
-        if: matrix.target_os == 'windows'
-        run: |
-          if (Test-Path C:/spiceai/build/target) {
-            Copy-Item -Recurse -Force target/* C:/spiceai/build/target
-          }
-
-      - name: Build spice
-        run: make -C bin/spice
 
       - name: tar binary
         if: matrix.target_os != 'windows'
         run: |
           mv target/release/spiced spiced
           chmod +x spiced
-          tar cf spiced_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced
+          tar czf spiced_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced
 
       - name: tar binary (Windows)
         if: matrix.target_os == 'windows'
         run: |
           mv target/release/spiced.exe spiced.exe
-          tar cf spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced.exe
+          tar czf spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced.exe
 
       - name: Print version
         if: matrix.target_os != 'windows'
@@ -168,18 +145,59 @@ jobs:
           name: spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}
           path: spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
 
+      ## Models flavor
+      - name: Build spiced
+        run: make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="models"
+
+      - name: tar binary
+        if: matrix.target_os != 'windows'
+        run: |
+          mv target/release/spiced spiced
+          chmod +x spiced
+          tar czf spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced
+
+      - name: tar binary (Windows)
+        if: matrix.target_os == 'windows'
+        run: |
+          mv target/release/spiced.exe spiced.exe
+          tar czf spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced.exe
+
+      - name: Print version
+        if: matrix.target_os != 'windows'
+        run: ./spiced --version
+      
+      - name: Print version (Windows)
+        if: matrix.target_os == 'windows'
+        run: ./spiced.exe --version
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.target_os != 'windows'
+        with:
+          name: spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.target_os == 'windows'
+        with:
+          name: spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+
+      ## CLI build
+      - name: Build spice
+        run: make -C bin/spice
+
       - name: tar binary
         if: matrix.target_os != 'windows'
         run: |
           mv target/release/spice spice
           chmod +x spice
-          tar cf spice_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spice
+          tar czf spice_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spice
 
       - name: tar binary (Windows)
         if: matrix.target_os == 'windows'
         run: |
           mv target/release/spice.exe spice.exe
-          tar cf spice.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spice.exe
+          tar czf spice.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spice.exe
 
       - name: Print version
         if: matrix.target_os != 'windows'
@@ -200,6 +218,27 @@ jobs:
         with:
           name: spice.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}
           path: spice.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+      
+      - name: Update build cache (macOS)
+        if: matrix.target_os == 'darwin'
+        run: |
+          if [ -d /Users/spiceai/build/target ]; then
+            rsync -av target/ /Users/spiceai/build/target/
+          fi
+
+      - name: Update build cache (Linux)
+        if: matrix.target_os == 'linux'
+        run: |
+          if [ -d /home/spiceai/build/target ]; then
+            rsync -av target/ /home/spiceai/build/target/
+          fi
+
+      - name: Update build cache (Windows)
+        if: matrix.target_os == 'windows'
+        run: |
+          if (Test-Path C:/spiceai/build/target) {
+            Copy-Item -Recurse -Force target/* C:/spiceai/build/target
+          }
 
   publish:
     name: Publish ${{ matrix.target_os }}-${{ matrix.target_arch }} binaries
@@ -255,6 +294,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os != 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os == 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}
           path: ${{ env.ARTIFACT_DIR }}
 
       - name: lists artifacts

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -146,28 +146,28 @@ jobs:
           path: spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
 
       ## Models flavor
-      - name: Build spiced
+      - name: Build spiced (models)
         run: make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="models"
 
-      - name: tar binary
+      - name: tar binary (models)
         if: matrix.target_os != 'windows'
         run: |
           mv target/release/spiced spiced
           chmod +x spiced
           tar czf spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced
 
-      - name: tar binary (Windows)
+      - name: tar binary (models) (Windows)
         if: matrix.target_os == 'windows'
         run: |
           rm spiced.exe
           mv target/release/spiced.exe spiced.exe
           tar czf spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced.exe
 
-      - name: Print version
+      - name: Print version (models)
         if: matrix.target_os != 'windows'
         run: ./spiced --version
       
-      - name: Print version (Windows)
+      - name: Print version (models) (Windows)
         if: matrix.target_os == 'windows'
         run: ./spiced.exe --version
 

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 )
 
 const (
@@ -65,6 +66,25 @@ spice chat --model <model>
 spice chat --model <model> --cloud
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		rtcontext := context.NewContext()
+
+		if !rtcontext.ModelsFlavorInstalled() {
+			cmd.Print("This feature requires a runtime version with models enabled. Install (y/n)? ")
+			var confirm string
+			_, _ = fmt.Scanf("%s", &confirm)
+			if strings.ToLower(strings.TrimSpace(confirm)) != "y" {
+				cmd.Println("Models runtime not installed, exiting...")
+				os.Exit(0)
+				return
+			}
+			cmd.Println("Installing models runtime...")
+			err := rtcontext.InstallOrUpgradeRuntime("models")
+			if err != nil {
+				cmd.Println("Error installing models runtime", err)
+				os.Exit(1)
+			}
+		}
+
 		cloud, _ := cmd.Flags().GetBool(cloudKeyFlag)
 
 		model, err := cmd.Flags().GetString(modelKeyFlag)

--- a/bin/spice/cmd/install.go
+++ b/bin/spice/cmd/install.go
@@ -25,10 +25,12 @@ import (
 )
 
 var installCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install the Spice.ai runtime",
+	Use:     "install [flavor]",
+	Aliases: []string{"i"},
+	Short:   "Install the Spice.ai runtime",
 	Example: `
 spice install
+spice install ai
 
 # See more at: https://docs.spiceai.org/
 `,
@@ -38,7 +40,12 @@ spice install
 			cmd.PrintErrf("failed to check for latest CLI release version: %s\n", err.Error())
 		}
 
-		installed, err := runtime.EnsureInstalled()
+		flavor := ""
+		if len(args) > 0 {
+			flavor = args[0]
+		}
+
+		installed, err := runtime.EnsureInstalled(flavor)
 		if err != nil {
 			cmd.PrintErrln(err.Error())
 			os.Exit(1)

--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -52,8 +52,8 @@ func GetLatestCliRelease() (*RepoRelease, error) {
 	return release, nil
 }
 
-func DownloadRuntimeAsset(release *RepoRelease, downloadPath string) error {
-	assetName := GetRuntimeAssetName()
+func DownloadRuntimeAsset(flavor string, release *RepoRelease, downloadPath string) error {
+	assetName := GetRuntimeAssetName(flavor)
 	fmt.Println("Downloading the Spice runtime...", assetName)
 	return DownloadReleaseAsset(githubClient, release, assetName, downloadPath)
 }
@@ -62,8 +62,12 @@ func DownloadAsset(release *RepoRelease, downloadPath string, assetName string) 
 	return DownloadReleaseAsset(githubClient, release, assetName, downloadPath)
 }
 
-func GetRuntimeAssetName() string {
-	assetName := fmt.Sprintf("%s_%s_%s.tar.gz", constants.SpiceRuntimeFilename, runtime.GOOS, getRustArch())
+func GetRuntimeAssetName(flavor string) string {
+	if flavor != "" {
+		flavor = fmt.Sprintf("_%s", flavor)
+	}
+
+	assetName := fmt.Sprintf("%s%s_%s_%s.tar.gz", constants.SpiceRuntimeFilename, flavor, runtime.GOOS, getRustArch())
 
 	return assetName
 }

--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -63,7 +63,10 @@ func DownloadAsset(release *RepoRelease, downloadPath string, assetName string) 
 }
 
 func GetRuntimeAssetName(flavor string) string {
-	if flavor != "" {
+	switch {
+	case flavor == "ai":
+		flavor = "_models"
+	case flavor != "":
 		flavor = fmt.Sprintf("_%s", flavor)
 	}
 

--- a/bin/spice/pkg/runtime/runtime.go
+++ b/bin/spice/pkg/runtime/runtime.go
@@ -26,7 +26,11 @@ import (
 )
 
 // Ensures the runtime is installed. Returns true if the runtime was installed or upgraded, false if it was already installed.
-func EnsureInstalled() (bool, error) {
+func EnsureInstalled(flavor string) (bool, error) {
+	if flavor != "ai" && flavor != "" {
+		return false, fmt.Errorf("invalid flavor: %s", flavor)
+	}
+
 	rtcontext := context.NewContext()
 	err := rtcontext.Init()
 	if err != nil {
@@ -47,8 +51,12 @@ func EnsureInstalled() (bool, error) {
 		}
 	}
 
+	if flavor == "ai" && !rtcontext.ModelsFlavorInstalled() {
+		shouldInstall = true
+	}
+
 	if shouldInstall {
-		err = rtcontext.InstallOrUpgradeRuntime("")
+		err = rtcontext.InstallOrUpgradeRuntime(flavor)
 		if err != nil {
 			return shouldInstall, err
 		}
@@ -68,7 +76,7 @@ func Run(args []string) error {
 		os.Exit(1)
 	}
 
-	_, err = EnsureInstalled()
+	_, err = EnsureInstalled("")
 	if err != nil {
 		return err
 	}

--- a/bin/spice/pkg/runtime/runtime.go
+++ b/bin/spice/pkg/runtime/runtime.go
@@ -48,7 +48,7 @@ func EnsureInstalled() (bool, error) {
 	}
 
 	if shouldInstall {
-		err = rtcontext.InstallOrUpgradeRuntime()
+		err = rtcontext.InstallOrUpgradeRuntime("")
 		if err != nil {
 			return shouldInstall, err
 		}

--- a/bin/spice/pkg/util/file.go
+++ b/bin/spice/pkg/util/file.go
@@ -125,7 +125,7 @@ func ExtractTarGzInsideZip(body []byte, downloadDir string) error {
 func ExtractTarGz(body []byte, downloadDir string) error {
 	bodyReader := bytes.NewReader(body)
 	err := Untar(bodyReader, downloadDir, true)
-	if err.Error() == "requires gzip-compressed body: gzip: invalid header" {
+	if err != nil && err.Error() == "requires gzip-compressed body: gzip: invalid header" {
 		_, err = bodyReader.Seek(0, io.SeekStart)
 		if err != nil {
 			return err

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
 
     if args.version {
         if cfg!(feature = "release") {
-            println!("v{}", env!("CARGO_PKG_VERSION"));
+            println!("v{}{}", env!("CARGO_PKG_VERSION"), build_metadata());
         } else {
             print!(
                 "v{}-rc.{}",
@@ -38,6 +38,8 @@ fn main() {
             if cfg!(feature = "dev") {
                 print!("-dev");
             }
+
+            print!("{}", build_metadata());
 
             println!();
         };
@@ -73,4 +75,15 @@ fn main() {
 async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Error>> {
     spiced::run(args).await?;
     Ok(())
+}
+
+/// Build metadata conforming to <https://semver.org/#spec-item-10>
+///
+/// Build metadata is always known at compile time, so return a string literal.
+const fn build_metadata() -> &'static str {
+    if cfg!(feature = "models") {
+        "+models"
+    } else {
+        ""
+    }
 }


### PR DESCRIPTION
## 🗣 Description

Checks if the installed version includes build metadata for `models`. If it doesn't, prompt to install the `models` runtime flavor from GitHub releases.

TBD: Requires a new asset added to each release with `_models` added, i.e. `spiced_darwin_aarch64.tar.gz` -> `spiced_models_darwin_aarch64.tar.gz`.

Added a new command for `spice install ai` that will install the AI-enabled models runtime. Also added an alias `spice i` for `spice install` for convenience.

