### PR TITLE
Bump datafusion-federation/datafusion-table-providers dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=e0a4eaef873949c4f4bb3edf64e411821e62dcb2#e0a4eaef873949c4f4bb3edf64e411821e62dcb2"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=21f07bec7284bcbff2bf4e570008290b66e3dc6f#21f07bec7284bcbff2bf4e570008290b66e3dc6f"
 dependencies = [
  "arrow-json",
  "async-stream",
@@ -2957,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation-sql"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=e0a4eaef873949c4f4bb3edf64e411821e62dcb2#e0a4eaef873949c4f4bb3edf64e411821e62dcb2"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=21f07bec7284bcbff2bf4e570008290b66e3dc6f#21f07bec7284bcbff2bf4e570008290b66e3dc6f"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=55f878c3accba051a1e06c33fd0b4b5937a05d66#55f878c3accba051a1e06c33fd0b4b5937a05d66"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=e9d9e7adca882101f8a8bef453f973097f9fcdda#e9d9e7adca882101f8a8bef453f973097f9fcdda"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
 ] }
 datafusion = "41.0.0"
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "55f878c3accba051a1e06c33fd0b4b5937a05d66" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "21f07bec7284bcbff2bf4e570008290b66e3dc6f" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "e9d9e7adca882101f8a8bef453f973097f9fcdda" }
 dirs = "5.0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"
@@ -110,7 +110,7 @@ x509-certificate = "0.23.1"
 
 [patch.crates-io]
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "4fa3dbc3a0f12202b9f700740069cb9e0dc2dc2a" }
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "e0a4eaef873949c4f4bb3edf64e411821e62dcb2" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "21f07bec7284bcbff2bf4e570008290b66e3dc6f" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "f2ca47d094a5636df8b9f3792b2f474a7b210dc1" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdfc2c482f1ce84c595ab1202530a37815d6" }


### PR DESCRIPTION
## 🗣 Description

Bumps the `datafusion-federation` and `datafusion-table-providers` dependencies to their latest versions

This brings  the following improvements:
 - https://github.com/datafusion-contrib/datafusion-table-providers/pull/72
 - https://github.com/spiceai/datafusion-federation/pull/16