### PR TITLE
Improve trace when dataset refresh_sql has changed

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -381,15 +381,17 @@ impl AcceleratedTable {
     pub async fn update_refresh_sql(&self, refresh_sql: Option<String>) -> Result<()> {
         let dataset_name = &self.dataset_name;
 
+        let mut refresh = self.refresh_params.write().await;
+        refresh.sql = refresh_sql.clone();
+
         if self.dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
             if let Some(sql_str) = &refresh_sql {
-                tracing::info!("[refresh] Updating refresh SQL for {dataset_name} to {sql_str}");
+                tracing::info!("[refresh] Updated refresh SQL for {dataset_name} to {sql_str}");
             } else {
-                tracing::info!("[refresh] Removing refresh SQL for {dataset_name}");
+                tracing::info!("[refresh] Removed refresh SQL for {dataset_name}");
             }
         }
-        let mut refresh = self.refresh_params.write().await;
-        refresh.sql = refresh_sql;
+
         Ok(())
     }
 

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -382,7 +382,7 @@ impl AcceleratedTable {
         let dataset_name = &self.dataset_name;
 
         let mut refresh = self.refresh_params.write().await;
-        refresh.sql = refresh_sql.clone();
+        refresh.sql.clone_from(&refresh_sql);
 
         if self.dataset_name.schema() != Some(SPICE_RUNTIME_SCHEMA) {
             if let Some(sql_str) = &refresh_sql {


### PR DESCRIPTION
## 🗣 Description

Improve trace when dataset refresh_sql has changed. Also ensures that refresh sql has been updated before logging the trace.


>2024-08-26T18:33:06.965628Z  INFO runtime::accelerated_table: [refresh] Updated refresh SQL for taxi_trips to SELECT * FROM taxi_trips WHERE passenger_count = 3
