### PR TITLE
Bump `datafusion-table-providers` to fix DuckDB acceleration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=e9d9e7adca882101f8a8bef453f973097f9fcdda#e9d9e7adca882101f8a8bef453f973097f9fcdda"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=e75565b74364e9f1da20f80f4c029d18bfaf9812#e75565b74364e9f1da20f80f4c029d18bfaf9812"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ datafusion-execution = "41"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "21f07bec7284bcbff2bf4e570008290b66e3dc6f" }
 datafusion-functions-json = "0.41"
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "e9d9e7adca882101f8a8bef453f973097f9fcdda" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "e75565b74364e9f1da20f80f4c029d18bfaf9812" }
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.0"


### PR DESCRIPTION
## 🗣 Description

Fixes an issue with DuckDB acceleration when the file doesn't exist.