### PR TITLE
Add a `--force` flag to `spice install` to force it to install the latest released version

### DIFF
--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -33,8 +33,6 @@ const (
 )
 
 func GetLatestRuntimeRelease() (*RepoRelease, error) {
-	fmt.Println("Checking for latest Spice runtime release...")
-
 	release, err := GetLatestRelease(githubClient, GetAssetName(constants.SpiceRuntimeFilename))
 	if err != nil {
 		return nil, err

--- a/bin/spice/pkg/runtime/runtime.go
+++ b/bin/spice/pkg/runtime/runtime.go
@@ -67,8 +67,7 @@ func EnsureInstalled(flavor string) (bool, error) {
 }
 
 func Run(args []string) error {
-	fmt.Println("Spice.ai runtime starting...")
-
+	fmt.Println("Checking for latest Spice runtime release...")
 	rtcontext := context.NewContext()
 
 	err := rtcontext.Init()
@@ -90,6 +89,7 @@ func Run(args []string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 
+	fmt.Println("Spice.ai runtime starting...")
 	err = util.RunCommand(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
## 🗣 Description

Adds a `--force` flag to `spice install` and `spice install ai` to force the CLI to download the latest released runtime version, even if it wouldn't normally.
