### PR TITLE
Add `include` param support to GitHub Data Connector

### DIFF
--- a/crates/data_components/src/github.rs
+++ b/crates/data_components/src/github.rs
@@ -161,7 +161,7 @@ impl GithubRestClient {
         repo: &str,
         tree_sha: &str,
         limit: Option<usize>,
-        include_patern: Option<Arc<GlobSet>>,
+        include_pattern: Option<Arc<GlobSet>>,
         schema: SchemaRef,
     ) -> Result<Vec<RecordBatch>> {
         let git_tree = self
@@ -175,7 +175,7 @@ impl GithubRestClient {
             .filter(|node| node.node_type == "blob")
             .collect();
 
-        if let Some(pattern) = include_patern.as_ref() {
+        if let Some(pattern) = include_pattern.as_ref() {
             tree.retain(|node| pattern.is_match(&node.path));
         }
 

--- a/crates/data_components/src/github.rs
+++ b/crates/data_components/src/github.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use async_trait::async_trait;
+use globset::GlobSet;
 use snafu::{ResultExt, Snafu};
 
 use crate::arrow::write::MemTable;
@@ -52,6 +53,7 @@ pub struct GithubFilesTableProvider {
     repo: Arc<str>,
     tree_sha: Arc<str>,
     schema: SchemaRef,
+    include: Option<Arc<GlobSet>>,
 }
 
 impl GithubFilesTableProvider {
@@ -60,6 +62,7 @@ impl GithubFilesTableProvider {
         owner: &str,
         repo: &str,
         tree_sha: &str,
+        include: Option<Arc<GlobSet>>,
     ) -> Result<Self> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("name", DataType::Utf8, true),
@@ -72,7 +75,7 @@ impl GithubFilesTableProvider {
 
         // ensure configuration is correct
         client
-            .fetch_files(owner, repo, tree_sha, Some(1), Arc::clone(&schema))
+            .fetch_files(owner, repo, tree_sha, Some(1), None, Arc::clone(&schema))
             .await?;
 
         Ok(Self {
@@ -81,6 +84,7 @@ impl GithubFilesTableProvider {
             repo: repo.into(),
             tree_sha: tree_sha.into(),
             schema,
+            include,
         })
     }
 }
@@ -122,7 +126,8 @@ impl TableProvider for GithubFilesTableProvider {
                 &self.owner,
                 &self.repo,
                 &self.tree_sha,
-                limit,
+                None,
+                self.include.clone(),
                 Arc::clone(&self.schema),
             )
             .await
@@ -156,17 +161,23 @@ impl GithubRestClient {
         repo: &str,
         tree_sha: &str,
         limit: Option<usize>,
+        include_patern: Option<Arc<GlobSet>>,
         schema: SchemaRef,
     ) -> Result<Vec<RecordBatch>> {
         let git_tree = self
             .fetch_git_tree(owner, repo, tree_sha)
             .await
             .context(GithubApiSnafu)?;
+
         let mut tree: Vec<GitTreeNode> = git_tree
             .tree
             .into_iter()
             .filter(|node| node.node_type == "blob")
             .collect();
+
+        if let Some(pattern) = include_patern.as_ref() {
+            tree.retain(|node| pattern.is_match(&node.path));
+        }
 
         if let Some(limit) = limit {
             tree.truncate(limit);

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -219,6 +219,12 @@ pub enum DataConnectorError {
         dataconnector: String,
         message: String,
     },
+
+    #[snafu(display("Invalid glob pattern {pattern}: {source}"))]
+    InvalidGlobPattern {
+        pattern: String,
+        source: globset::Error,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -317,7 +317,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("endpoint")
         .description("The Github API endpoint.")
         .default("https://api.github.com"),
-    ParameterSpec::connector("include")
+    ParameterSpec::runtime("include")
         .description("Include only files matching the pattern.")
         .examples(&["*.json", "**/*.yaml;src/**/*.json"]),
 ];

--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -21,6 +21,7 @@ use data_components::{
     graphql::{client::GraphQLClient, provider::GraphQLTableProvider},
 };
 use datafusion::datasource::TableProvider;
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::{any::Any, future::Future, pin::Pin, sync::Arc};
@@ -278,8 +279,13 @@ impl Github {
                 dataconnector: "github".to_string(),
             })?;
 
+        let include = match self.params.get("include").expose().ok() {
+            Some(pattern) => Some(parse_globs(pattern)?),
+            None => None,
+        };
+
         Ok(Arc::new(
-            GithubFilesTableProvider::new(client, owner, repo, tree_sha)
+            GithubFilesTableProvider::new(client, owner, repo, tree_sha, include)
                 .await
                 .boxed()
                 .context(super::UnableToGetReadProviderSnafu {
@@ -311,6 +317,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("endpoint")
         .description("The Github API endpoint.")
         .default("https://api.github.com"),
+    ParameterSpec::connector("include")
+        .description("Include only files matching the pattern.")
+        .examples(&["*.json", "**/*.yaml;src/**/*.json"]),
 ];
 
 impl DataConnectorFactory for GithubFactory {
@@ -385,4 +394,23 @@ impl DataConnector for Github {
             }),
         }
     }
+}
+
+pub fn parse_globs(input: &str) -> super::DataConnectorResult<Arc<GlobSet>> {
+    let patterns: Vec<&str> = input.split(&[',', ';'][..]).collect();
+    let mut builder = GlobSetBuilder::new();
+
+    for pattern in patterns {
+        let trimmed_pattern = pattern.trim();
+        if !trimmed_pattern.is_empty() {
+            builder.add(
+                Glob::new(trimmed_pattern).context(super::InvalidGlobPatternSnafu { pattern })?,
+            );
+        }
+    }
+
+    let glob_set = builder
+        .build()
+        .context(super::InvalidGlobPatternSnafu { pattern: input })?;
+    Ok(Arc::new(glob_set))
 }


### PR DESCRIPTION
## 🗣 Description

Add param to specify which files to include for the GitHub Data Connector.

```
- from: github:github.com/spiceai/spiceai/files/trunk
  name: spiceai.files
  params:
    github_access_token: ${secrets:github_token}
    include: "*.json;*/ISSUE_TEMPLATE/*"
```

```shell
sql> select path from spiceai.files
+----------------------------------------------------------+
| path                                                     |
+----------------------------------------------------------+
| .github/ISSUE_TEMPLATE/bug_report.md                     |
| .github/ISSUE_TEMPLATE/end_game.md                       |
| .github/ISSUE_TEMPLATE/enhancement.md                    |
| .github/ISSUE_TEMPLATE/feature_request.md                |
| .schema/spicepod.schema.json                             |
| .vscode/launch.json                                      |
| crates/data_components/src/debezium/tests/all_types.json |
| crates/llms/src/chat/template.json                       |
| monitoring/datadog-dashboard.json                        |
| monitoring/grafana-dashboard.json                        |
+----------------------------------------------------------+
```

## 🔨 Related Issues

https://github.com/spiceai/spiceai/issues/2384

## 🤔 Concerns

~Ideally we would like to have param as `include` instead of `github_include`, but it seems all params must be prefixed with data connector name.~