### PR TITLE
Improve Github Data Connector tables schema

### DIFF
--- a/crates/data_components/src/github.rs
+++ b/crates/data_components/src/github.rs
@@ -20,7 +20,7 @@ use snafu::{ResultExt, Snafu};
 
 use crate::arrow::write::MemTable;
 use arrow::{
-    array::{ArrayRef, RecordBatch, StringBuilder, UInt64Builder},
+    array::{ArrayRef, Int64Builder, RecordBatch, StringBuilder},
     datatypes::{DataType, Field, Schema, SchemaRef},
 };
 use datafusion::{
@@ -70,7 +70,7 @@ impl GithubFilesTableProvider {
         let mut fields = vec![
             Field::new("name", DataType::Utf8, true),
             Field::new("path", DataType::Utf8, true),
-            Field::new("size", DataType::UInt64, true),
+            Field::new("size", DataType::Int64, true),
             Field::new("sha", DataType::Utf8, true),
             Field::new("mode", DataType::Utf8, true),
             Field::new("url", DataType::Utf8, true),
@@ -208,7 +208,7 @@ impl GithubRestClient {
 
         let mut name_builder = StringBuilder::new();
         let mut path_builder = StringBuilder::new();
-        let mut size_builder = UInt64Builder::new();
+        let mut size_builder = Int64Builder::new();
         let mut sha_builder = StringBuilder::new();
         let mut mode_builder = StringBuilder::new();
         let mut url_builder = StringBuilder::new();
@@ -371,6 +371,6 @@ struct GitTreeNode {
     #[serde(rename = "type")]
     node_type: String,
     sha: String,
-    size: Option<u64>,
+    size: Option<i64>,
     url: String,
 }

--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -67,22 +67,23 @@ impl GithubTableArgs for PullRequestTableArgs {
                         }}
                         nodes {{
                             title
+                            number
+                            id
                             url
                             body
                             state
-                            createdAt
-                            mergedAt
-                            closedAt
+                            created_at: createdAt
+                            merged_at: mergedAt
+                            closed_at: closedAt
                             number
-                            num_of_reviews: reviews {{totalCount}}
-                            ref: headRef {{ id }}
+                            reviews {{num_of_reviews: totalCount}}
                             
                             author {{
                                 login
                             }}
                             additions
                             deletions
-                            changedFiles
+                            changed_files: changedFiles
                             comments(first: 100) {{num_of_comments: totalCount}}
                             commits(first: 100) {{num_of_commits: totalCount, hashes: nodes{{ id }} }}
                         }}
@@ -131,18 +132,18 @@ impl GithubTableArgs for CommitTableArgs {
                                     }}
                                     nodes {{
                                         message
-                                        messageHeadline
-                                        messageBody
-                                        oid
+                                        message_head_line: messageHeadline
+                                        message_body: messageBody
+                                        sha: oid
                                         additions
                                         deletions
                                         id
-                                        committedDate
+                                        committed_date: committedDate
                                         authorName: author {{
-                                            name
+                                            author_name: name
                                         }}
                                         authorEmail: author {{
-                                            email
+                                            author_email: email
                                         }}
                                     }}
                                 }}
@@ -180,16 +181,18 @@ impl GithubTableArgs for IssueTableArgs {
                         }}
                         nodes {{
                             id
+                            number
                             title
                             url
                             author: author {{ login }}
                             body
                             number
-                            createdAt
-                            updatedAt
-                            closedAt
+                            created_at: createdAt
+                            updated_at: updatedAt
+                            closed_at: closedAt
                             state
-                            milestone {{ milestone_id: id, milestone_title: title }}
+                            milestoneId: milestone {{ milestone_id: id}}
+                            milestoneTitle: milestone {{ milestone_title: title }}
                             labels(first: 100) {{ labels: nodes {{ name }} }}
                             comments(first:100) {{ num_of_comments: totalCount, comments: nodes {{ body, author {{ login }} }} }}
                         }}


### PR DESCRIPTION
## 🗣 Description

Improve Github Data Connector tables schema:
1. `snake_case` for column names
2. rename `oid` to `sha` for `commits` table
3. add `number` column to `issues` table
4. Change UInt64 to Int64 for `size` column (`files` table) to simplify usage (Int64 is datafusion default type for integers) 

Note: there is also WI to flatten `hashes` and `labels` columns which will be addressed separately: https://github.com/spiceai/spiceai/issues/2447

## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/2445
Closes https://github.com/spiceai/spiceai/issues/2446

