### PR TITLE
Improve GitHub Connector error msg when invalid token or permissions

### DIFF
--- a/crates/data_components/src/github.rs
+++ b/crates/data_components/src/github.rs
@@ -291,28 +291,28 @@ impl GithubRestClient {
         match response.status().as_u16() {
             404 => {
                 let err_msg = format!(
-                    "Github API ({endpoint}) failed with status code {}; Is org `{owner}`, repo `{repo}` and git tree `{tree_sha}` correct?",
+                    "The Github API ({endpoint}) failed with status code {}; Please check that org `{owner}`, repo `{repo}` and git tree `{tree_sha}`are correct.",
                     response.status()
                 );
                 Err(err_msg.into())
             }
             401 => {
                 let err_msg = format!(
-                    "Github API ({endpoint}) failed with status code {}; Is the token correct?",
+                    "The Github API ({endpoint}) failed with status code {}; Please check if the token is correct.",
                     response.status()
                 );
                 Err(err_msg.into())
             }
             403 => {
                 let err_msg = format!(
-                    "Github API ({endpoint}) failed with status code {}; Does the token have the right permissions?",
+                    "The Github API ({endpoint}) failed with status code {}; Please check if the token has the necessary permissions.",
                     response.status()
                 );
                 Err(err_msg.into())
             }
             _ => {
                 let err_msg = format!(
-                    "Github API ({endpoint}) failed with status code {}",
+                    "The Github API ({endpoint}) failed with status code {}",
                     response.status()
                 );
                 Err(err_msg.into())

--- a/crates/data_components/src/graphql/mod.rs
+++ b/crates/data_components/src/graphql/mod.rs
@@ -37,6 +37,9 @@ pub enum Error {
     #[snafu(display("Invalid object access. {message}"))]
     InvalidObjectAccess { message: String },
 
+    #[snafu(display("{message}"))]
+    InvalidCredentialsOrPermissions { message: String },
+
     #[snafu(display(
         r#"GraphQL Query Error:
 Details:


### PR DESCRIPTION
## 🗣 Description

Improve GitHub Connector error msg in when invalid token or permissions

### Before

```shell
2024-08-31T21:24:39.766330Z  WARN runtime: Unable to get read provider for github: GraphQL Query Error:
Details:
- Error: Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.
- Location: Line 3, Column 17
- Query:

   2 |             {
   3 |                 repository(owner: "spicehq", name: "ai-platform") {
     |                 ^

Please verify the syntax of your GraphQL query.
```

### After


>2024-08-31T21:22:35.660339Z  WARN runtime: Unable to get read provider for github: The API returned a 'FORBIDDEN' error. Please check if the credentials have the necessary permissions. Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.


## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/2444

## 🤔 Concerns

The internal GraphQL error message that refers to a specific location might be useful for troubleshooting, but it is too technical and verbose so decided to remove it.
