### PR TITLE
GitHub connector: convert `labels` and `hashes` to primitive arrays

### DIFF
--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -84,6 +84,7 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
 
 /// Flattens a list of struct types with a single field into a list of primitive types.
 /// The struct field must be a primitive type.
+/// If the struct has multiple fields, all except the first field will be ignored.
 ///
 /// # Errors
 ///
@@ -205,7 +206,8 @@ mod test {
             {"labels": null}
             {"labels": null}
             {"labels": null}
-            {"labels": [{"id": 3}{"id": null}]}
+            {"labels": [{"id": 3}, {"id": null}]}
+            {"labels": [{"id": 4,"name":"test"}, {"id": null,"name":null}]}
             {"labels": null}
             "#;
 
@@ -228,6 +230,7 @@ mod test {
             {"labels": null}
             {"labels": null}
             {"labels": [3, null]}
+            {"labels": [4, null]}
             {"labels": null}
             "#;
 

--- a/crates/data_components/src/graphql/mod.rs
+++ b/crates/data_components/src/graphql/mod.rs
@@ -37,6 +37,11 @@ pub enum Error {
     #[snafu(display("Invalid object access. {message}"))]
     InvalidObjectAccess { message: String },
 
+    #[snafu(display("Query response transformation failed: {source}"))]
+    ResultTransformError {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     #[snafu(display(
         r#"GraphQL Query Error:
 Details:

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -50,6 +50,7 @@ pub struct GraphQLTableProvider {
 }
 
 impl GraphQLTableProvider {
+    #[must_use]
     pub fn new(client: GraphQLClient) -> Self {
         Self {
             client,
@@ -59,6 +60,7 @@ impl GraphQLTableProvider {
         }
     }
 
+    #[must_use]
     pub fn with_schema_transform(mut self, transform_fn: TransformFnPointer) -> Self {
         self.transform_fn = Some(transform_fn);
         self

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use snafu::ResultExt;
 
 use crate::arrow::write::MemTable;
-use arrow::datatypes::SchemaRef;
+use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use datafusion::{
     catalog::Session,
     datasource::{TableProvider, TableType},
@@ -27,19 +27,39 @@ use datafusion::{
 };
 use std::{any::Any, sync::Arc};
 
-use super::client::GraphQLClient;
 use super::Result;
+use super::{client::GraphQLClient, ResultTransformSnafu};
+
+pub type TransformFn = Arc<
+    dyn Fn(&RecordBatch) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>>
+        + Send
+        + Sync,
+>;
 
 pub struct GraphQLTableProvider {
     client: GraphQLClient,
-    schema: SchemaRef,
+    gql_schema: SchemaRef,
+    table_schema: SchemaRef,
+    transform_fn: Option<TransformFn>,
 }
 
 impl GraphQLTableProvider {
-    pub async fn new(client: GraphQLClient) -> Result<Self> {
-        let (_, schema, _) = client.execute(None, None, None).await?;
+    pub async fn new(client: GraphQLClient, transform_fn: Option<TransformFn>) -> Result<Self> {
+        let (res, gql_schema, _) = client.execute(None, None, None).await?;
 
-        Ok(Self { client, schema })
+        let table_schema = match (&transform_fn, res.first()) {
+            (Some(transform_fn), Some(record_batch)) => transform_fn(record_batch)
+                .context(ResultTransformSnafu)?
+                .schema(),
+            _ => Arc::clone(&gql_schema),
+        };
+
+        Ok(Self {
+            client,
+            gql_schema,
+            table_schema,
+            transform_fn,
+        })
     }
 }
 
@@ -50,7 +70,7 @@ impl TableProvider for GraphQLTableProvider {
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
+        Arc::clone(&self.table_schema)
     }
 
     fn table_type(&self) -> TableType {
@@ -64,14 +84,26 @@ impl TableProvider for GraphQLTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let res = self
+        let mut res = self
             .client
-            .execute_paginated(Arc::clone(&self.schema), limit)
+            .execute_paginated(Arc::clone(&self.gql_schema), limit)
             .await
             .boxed()
             .map_err(DataFusionError::External)?;
 
-        let table = MemTable::try_new(Arc::clone(&self.schema), res)?;
+        if let Some(transform_fn) = &self.transform_fn {
+            res = res
+                .into_iter()
+                .map(|inner_vec| {
+                    inner_vec
+                        .into_iter()
+                        .map(|batch| transform_fn(&batch).map_err(DataFusionError::External))
+                        .collect::<Result<Vec<_>, DataFusionError>>()
+                })
+                .collect::<Result<Vec<Vec<_>>, DataFusionError>>()?;
+        }
+
+        let table = MemTable::try_new(Arc::clone(&self.table_schema), res)?;
 
         table.scan(state, projection, filters, limit).await
     }

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -17,10 +17,7 @@ use async_trait::async_trait;
 use snafu::ResultExt;
 
 use crate::arrow::write::MemTable;
-use arrow::{
-    array::RecordBatch,
-    datatypes::{Schema, SchemaRef},
-};
+use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use datafusion::{
     catalog::Session,
     datasource::{TableProvider, TableType},
@@ -80,18 +77,6 @@ pub struct GraphQLTableProvider {
     gql_schema: SchemaRef,
     table_schema: SchemaRef,
     transform_fn: Option<TransformFn>,
-}
-
-impl GraphQLTableProvider {
-    #[must_use]
-    pub fn new(client: GraphQLClient) -> Self {
-        Self {
-            client,
-            gql_schema: Arc::new(Schema::empty()),
-            table_schema: Arc::new(Schema::empty()),
-            transform_fn: None,
-        }
-    }
 }
 
 #[async_trait]

--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -20,7 +20,7 @@ use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use data_components::{
     github::{GithubFilesTableProvider, GithubRestClient},
-    graphql::{client::GraphQLClient, provider::GraphQLTableProvider},
+    graphql::{client::GraphQLClient, provider::GraphQLTableProviderBuilder},
 };
 use datafusion::datasource::TableProvider;
 use globset::{Glob, GlobSet, GlobSetBuilder};
@@ -247,7 +247,7 @@ impl Github {
         )?;
 
         Ok(Arc::new(
-            GraphQLTableProvider::new(client)
+            GraphQLTableProviderBuilder::new(client)
                 .with_schema_transform(github_gql_raw_schema_cast)
                 .build()
                 .await

--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -247,7 +247,9 @@ impl Github {
         )?;
 
         Ok(Arc::new(
-            GraphQLTableProvider::new(client, Some(Arc::new(github_gql_raw_schema_cast)))
+            GraphQLTableProvider::new(client)
+                .with_schema_transform(github_gql_raw_schema_cast)
+                .build()
                 .await
                 .boxed()
                 .context(super::UnableToGetReadProviderSnafu {

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -191,7 +191,7 @@ impl DataConnector for GraphQL {
         let client = self.get_client(dataset)?;
 
         Ok(Arc::new(
-            GraphQLTableProvider::new(client)
+            GraphQLTableProvider::new(client, None)
                 .await
                 .map_err(Into::into)
                 .context(super::InternalWithSourceSnafu {

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -191,7 +191,8 @@ impl DataConnector for GraphQL {
         let client = self.get_client(dataset)?;
 
         Ok(Arc::new(
-            GraphQLTableProvider::new(client, None)
+            GraphQLTableProvider::new(client)
+                .build()
                 .await
                 .map_err(Into::into)
                 .context(super::InternalWithSourceSnafu {

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use crate::component::dataset::Dataset;
 use async_trait::async_trait;
-use data_components::graphql::{client::GraphQLClient, provider::GraphQLTableProvider};
+use data_components::graphql::{client::GraphQLClient, provider::GraphQLTableProviderBuilder};
 use datafusion::datasource::TableProvider;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use snafu::ResultExt;
@@ -191,7 +191,7 @@ impl DataConnector for GraphQL {
         let client = self.get_client(dataset)?;
 
         Ok(Arc::new(
-            GraphQLTableProvider::new(client)
+            GraphQLTableProviderBuilder::new(client)
                 .build()
                 .await
                 .map_err(Into::into)


### PR DESCRIPTION
## 🗣 Description

`labels` and `hashes` columns are currently list of structs with single field. PR converts them to List of strings to simplify usage. 

PR extends `GraphQLTableProvider` to allow providing custom transformation function for raw graphql result.

Note: `test_to_primitive_type_list` does not copy/duplicate data, it re-uses original array data.

Before:

```shell
| labels          | List(Field { name: "item", data_type: Struct([Field { name: "name", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }]), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })      
```

After

```shell  
| labels          | List(Field { name: "name", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })      

sql> select title, url, labels from issues limit 10
+----------------------------------------------------------------------------+------------------------------------------------+--------------------+
| title                                                                      | url                                            | labels             |
+----------------------------------------------------------------------------+------------------------------------------------+--------------------+
| e2e test for metal context                                                 | https://github.com/spiceai/spiceai/issues/296  | []                 |
| Matrix publish is flaky                                                    | https://github.com/spiceai/spiceai/issues/298  | [kind/bug]         |
| Support inferencing on multiple training runs                              | https://github.com/spiceai/spiceai/issues/297  | [kind/enhancement] |
| SpiceRack registry client is not setting User-Agent                        | https://github.com/spiceai/spiceai/issues/300  | [kind/bug]         |
| Releases should only be created with a combination of release tag + branch | https://github.com/spiceai/spiceai/issues/299  | [kind/bug]         |
| Basic polling data grid in dashboard                                       | https://github.com/spiceai/spiceai/issues/306  | [kind/enhancement] |
| Extend Spicepod definition (spec) with `results_cache` object              | https://github.com/spiceai/spiceai/issues/1422 | []                 |
| Implement LRU cache provider (size-based eviction + TTL)                   | https://github.com/spiceai/spiceai/issues/1423 | []                 |
| Enhancement: Specify Primary Key/Indexes for Acceleration Engines          | https://github.com/spiceai/spiceai/issues/1412 | [kind/enhancement] |
| Implement caching for HTTP sql requests                                    | https://github.com/spiceai/spiceai/issues/1424 | []                 |
+----------------------------------------------------------------------------+------------------------------------------------+--------------------+

Time: 0.023711792 seconds. 10 rows.  
```

## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/2447

## 🤔 Concerns
