### PR TITLE
Trim trailing `/` for S3 data connector

### DIFF
--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -159,6 +159,14 @@ impl Parameters {
             UserParam(format!("{}_{}", self.prefix, spec.name))
         }
     }
+
+    pub fn insert(&mut self, key: String, value: SecretString) {
+        if let Some(param) = self.params.iter_mut().find(|p| p.0 == key) {
+            param.1 = value;
+        } else {
+            self.params.push((key, value));
+        }
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## 🗣 Description

Improves the experience of using the S3 data connector by automatically trimming the trailing `/` from the endpoint if it exists.

Example spicepod.yaml that previously failed:

```yaml
version: v1beta1
kind: Spicepod
name: cloudflare_r2

datasets:
- from: s3://test-data-private/eth.recent_logs.parquet
  name: logs
  params:
    s3_endpoint: https://{cloudflare_account}.r2.cloudflarestorage.com/
    s3_key: ${env:S3_KEY}
    s3_secret: ${env:S3_SECRET}
  acceleration:
    enabled: true
```

Now:
```console
❯ spice run
Checking for latest Spice runtime release...
Spice.ai runtime starting...
2024-09-02T06:38:14.672466Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
2024-09-02T06:38:14.672621Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
2024-09-02T06:38:14.673085Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
2024-09-02T06:38:14.677333Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
2024-09-02T06:38:14.872726Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
2024-09-02T06:38:14.872850Z  WARN runtime::dataconnector::s3: Trimming trailing '/' from S3 endpoint https://{cloudflare_account}.r2.cloudflarestorage.com/
```

## 🔨 Related Issues

Closes #1852 