### PR TITLE
Add `assignees` and `labels` fields to github issues and github pulls datasets

### DIFF
--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -88,7 +88,7 @@ impl GithubTableArgs for PullRequestTableArgs {
                             changed_files: changedFiles
                             comments(first: 100) {{num_of_comments: totalCount}}
                             commits(first: 100) {{num_of_commits: totalCount, hashes: nodes{{ id }} }}
-                            assignees(first: 100) {{ assignees: edges {{ node {{ login }} }} }}
+                            assignees(first: 100) {{ assignees: nodes {{ login }} }}
                         }}
                     }}
                 }}
@@ -198,7 +198,7 @@ impl GithubTableArgs for IssueTableArgs {
                             milestoneTitle: milestone {{ milestone_title: title }}
                             labels(first: 100) {{ labels: nodes {{ name }} }}
                             comments(first: 100) {{ num_of_comments: totalCount, comments: nodes {{ body, author {{ login }} }} }}
-                            assignees(first: 100) {{ assignees: edges {{ node {{ login }} }} }}
+                            assignees(first: 100) {{ assignees: nodes {{ login }} }}
                         }}
                     }}
                 }}

--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -88,6 +88,7 @@ impl GithubTableArgs for PullRequestTableArgs {
                             changed_files: changedFiles
                             comments(first: 100) {{num_of_comments: totalCount}}
                             commits(first: 100) {{num_of_commits: totalCount, hashes: nodes{{ id }} }}
+                            assignees(first: 100) {{ assignees: edges {{ node {{ login }} }} }}
                         }}
                     }}
                 }}
@@ -196,7 +197,8 @@ impl GithubTableArgs for IssueTableArgs {
                             milestoneId: milestone {{ milestone_id: id}}
                             milestoneTitle: milestone {{ milestone_title: title }}
                             labels(first: 100) {{ labels: nodes {{ name }} }}
-                            comments(first:100) {{ num_of_comments: totalCount, comments: nodes {{ body, author {{ login }} }} }}
+                            comments(first: 100) {{ num_of_comments: totalCount, comments: nodes {{ body, author {{ login }} }} }}
+                            assignees(first: 100) {{ assignees: edges {{ node {{ login }} }} }}
                         }}
                     }}
                 }}


### PR DESCRIPTION
Added `assignees` field to GitHub issues dataset, and `assignees` and `labels` to pulls dataset.

![CleanShot 2024-09-02 at 20 06 24@2x](https://github.com/user-attachments/assets/a4454563-469b-4dd6-a84b-8c4d161b17b5)

![CleanShot 2024-09-02 at 20 10 18@2x](https://github.com/user-attachments/assets/b632076e-fadb-48a5-b83d-d4f4becdf295)


