### PR TITLE
Fix LLMs health check; Add `updatedAt` field to GitHub connector

### DIFF
--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -245,7 +245,7 @@ pub trait Chat: Sync + Send {
 
         if let Err(e) = self
             .chat_request(CreateChatCompletionRequest {
-                max_tokens: Some(1),
+                max_tokens: None,
                 messages: vec![ChatCompletionRequestMessage::System(
                     ChatCompletionRequestSystemMessage {
                         content: "health".to_string(),

--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -89,6 +89,7 @@ impl GithubTableArgs for PullRequestTableArgs {
                             comments(first: 100) {{num_of_comments: totalCount}}
                             commits(first: 100) {{num_of_commits: totalCount, hashes: nodes{{ id }} }}
                             assignees(first: 100) {{ assignees: nodes {{ login }} }}
+                            updatedAt
                         }}
                     }}
                 }}
@@ -199,6 +200,7 @@ impl GithubTableArgs for IssueTableArgs {
                             labels(first: 100) {{ labels: nodes {{ name }} }}
                             comments(first: 100) {{ num_of_comments: totalCount, comments: nodes {{ body, author {{ login }} }} }}
                             assignees(first: 100) {{ assignees: nodes {{ login }} }}
+                            updatedAt
                         }}
                     }}
                 }}

--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -77,8 +77,9 @@ impl GithubTableArgs for PullRequestTableArgs {
                             created_at: createdAt
                             merged_at: mergedAt
                             closed_at: closedAt
+                            updated_at: updated_at
                             number
-                            reviews {{num_of_reviews: totalCount}}
+                            reviews {{reviews_count: totalCount}}
                             
                             author {{
                                 login
@@ -86,10 +87,9 @@ impl GithubTableArgs for PullRequestTableArgs {
                             additions
                             deletions
                             changed_files: changedFiles
-                            comments(first: 100) {{num_of_comments: totalCount}}
-                            commits(first: 100) {{num_of_commits: totalCount, hashes: nodes{{ id }} }}
+                            comments(first: 100) {{comments_count: totalCount}}
+                            commits(first: 100) {{commits_count: totalCount, hashes: nodes{{ id }} }}
                             assignees(first: 100) {{ assignees: nodes {{ login }} }}
-                            updatedAt
                         }}
                     }}
                 }}
@@ -198,9 +198,8 @@ impl GithubTableArgs for IssueTableArgs {
                             milestoneId: milestone {{ milestone_id: id}}
                             milestoneTitle: milestone {{ milestone_title: title }}
                             labels(first: 100) {{ labels: nodes {{ name }} }}
-                            comments(first: 100) {{ num_of_comments: totalCount, comments: nodes {{ body, author {{ login }} }} }}
+                            comments(first: 100) {{ comments_count: totalCount, comments: nodes {{ body, author {{ login }} }} }}
                             assignees(first: 100) {{ assignees: nodes {{ login }} }}
-                            updatedAt
                         }}
                     }}
                 }}


### PR DESCRIPTION
- Fix llm health check - don't specify max_tokens - completions request was failing

![CleanShot 2024-09-02 at 23 55 40@2x](https://github.com/user-attachments/assets/dff05565-19d5-4d2a-b1b8-350bc419a51e)

- Add `updated_at` field to GitHub pulls datasets
- Renamed count fields:
  - `pulls.num_of_reviews` -> `pulls.reviews_count`
  - `pulls.num_of_commits` -> `pulls.commits_count`
  - `issues.num_of_comments` -> `issues.comments_count`
