### PR TITLE
Remove non existing updated_at from github.pulls dataset

### DIFF
--- a/crates/runtime/src/dataconnector/github.rs
+++ b/crates/runtime/src/dataconnector/github.rs
@@ -77,7 +77,6 @@ impl GithubTableArgs for PullRequestTableArgs {
                             created_at: createdAt
                             merged_at: mergedAt
                             closed_at: closedAt
-                            updated_at: updated_at
                             number
                             reviews {{reviews_count: totalCount}}
                             


### PR DESCRIPTION
GitHub pullRequests doesn't have `updatedAt` field