### PR TITLE
Update to use DuckDB streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=5f9d49ad9e51927f0209f844a0b702c2796ac17f#5f9d49ad9e51927f0209f844a0b702c2796ac17f"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=8a2610d13b5679ced583004207845156abc662e8#8a2610d13b5679ced583004207845156abc662e8"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -3117,6 +3117,7 @@ dependencies = [
  "datafusion-federation",
  "datafusion-federation-sql",
  "duckdb",
+ "dyn-clone",
  "fallible-iterator 0.3.0",
  "futures",
  "geo-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ datafusion-execution = "41"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }
 datafusion-functions-json = "0.41"
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "5f9d49ad9e51927f0209f844a0b702c2796ac17f" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "8a2610d13b5679ced583004207845156abc662e8" }
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.0"


### PR DESCRIPTION
## 🗣 Description

Updates to the latest commit of the `spiceai` branch on `datafusion-table-providers` which includes https://github.com/datafusion-contrib/datafusion-table-providers/pull/41

## 🔨 Related Issues

Closes #1780
Part of #2235
