### PR TITLE
Fix run query script to correctly record all errors

### DIFF
--- a/test/scripts/run-queries.bash
+++ b/test/scripts/run-queries.bash
@@ -30,7 +30,7 @@ for i in `ls -d $query_folder/**`; do
   result=`cat runqueries.tmp.txt`
   echo "$result"
   # if result contains error string, then it failed
-  if [[ $result == *"Query Error"* ]] || [[ $result == *"ERROR"* ]]; then
+  if [[ $result == *"Query Error"* ]] || [[ $result == *"Error"* ]]; then
     failed_queries+=($i)
   fi
 done


### PR DESCRIPTION
## 🗣 Description

Fix the error capture logic in run-queries script so that the following error can be recorded:
![image](https://github.com/user-attachments/assets/910f60db-f058-4fce-885a-91640e7a79a3)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->