### PR TITLE
Add on-conflict integration test for file based and memory based sqlite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ nextest:
 test-integration:
 	# Test if .env file exists, and login to Spice if not
 	@test -f .env || (`spice login`)
-	@cargo test -p runtime --test integration --features postgres,mysql,delta_lake,duckdb -- --nocapture
+	@cargo test -p runtime --test integration --features postgres,mysql,delta_lake,duckdb,sqlite -- --nocapture
 
 .PHONY: test-integration-without-spiceai-dataset
 test-integration-without-spiceai-dataset:
-	@cargo test -p runtime --test integration --features postgres,mysql,delta_lake,duckdb -- --nocapture --skip spiceai_integration_test
+	@cargo test -p runtime --test integration --features postgres,mysql,delta_lake,duckdb,sqlite -- --nocapture --skip spiceai_integration_test
 
 .PHONY: test-bench
 test-bench:

--- a/crates/runtime/tests/acceleration/on_conflict.rs
+++ b/crates/runtime/tests/acceleration/on_conflict.rs
@@ -422,11 +422,11 @@ fn get_pg_params(port: usize) -> Params {
     )
 }
 
-fn get_params(mode: &Mode, sqlite_file: Option<String>, engine: &str) -> Option<Params> {
+fn get_params(mode: &Mode, file: Option<String>, engine: &str) -> Option<Params> {
     let param_name = format!("{engine}_file",);
     if mode == &Mode::File {
         return Some(Params::from_string_map(
-            vec![(param_name, sqlite_file.unwrap_or_default())]
+            vec![(param_name, file.unwrap_or_default())]
                 .into_iter()
                 .collect(),
         ));

--- a/crates/runtime/tests/acceleration/on_conflict.rs
+++ b/crates/runtime/tests/acceleration/on_conflict.rs
@@ -14,7 +14,7 @@ use spicepod::component::{
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 #[allow(clippy::too_many_lines)]
-#[cfg(all(feature = "postgres", feature = "duckdb"))]
+#[cfg(all(feature = "postgres", feature = "duckdb", feature = "sqlite"))]
 #[tokio::test]
 async fn test_acceleration_on_conflict() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));


### PR DESCRIPTION
## 🗣 Description

Add integration test to test on-conflict behavior for file based and memory based sqlite

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->