### PR TITLE
Make dataset acceleration delay `period +- jitter`

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -287,11 +287,16 @@ impl Refresher {
         self
     }
 
+    /// Compute a specific delay based on `period +- rand(0, max_jitter)`.
     fn compute_delay(period: Duration, max_jitter: Option<Duration>) -> Duration {
         match max_jitter {
             Some(max_jitter) => {
                 let jitter = rand::thread_rng().gen_range(Duration::from_secs(0)..max_jitter);
-                period + jitter
+                if rand::thread_rng().gen_bool(0.5) {
+                    period + jitter
+                } else {
+                    period.saturating_sub(jitter)
+                }
             }
             None => period,
         }


### PR DESCRIPTION
## 🗣 Description
 - For jitter added to accelerated dataset refresh, the delay is now computed as `period +- jitter` instead of `period + jitter` (truncated to 0).

## 🔨 Related Issues
 - Original PR adding jitter to refresh period: https://github.com/spiceai/spiceai/pull/2510
