### PR TITLE
Remove unneeded RwLock from LlmModelStore

### DIFF
--- a/crates/runtime/src/http/v1/chat.rs
+++ b/crates/runtime/src/http/v1/chat.rs
@@ -46,7 +46,7 @@ pub(crate) async fn post(
         match llms.read().await.get(&model_id) {
             Some(model) => {
                 if req.stream.unwrap_or_default() {
-                    match model.write().await.chat_stream(req).await {
+                    match model.chat_stream(req).await {
                         Ok(strm) => {
                             create_sse_response(strm, time::Duration::from_secs(30), span_clone)
                         }
@@ -57,7 +57,7 @@ pub(crate) async fn post(
                         }
                     }
                 } else {
-                    match model.write().await.chat_request(req).await {
+                    match model.chat_request(req).await {
                         Ok(response) => {
                             let preview = response
                                 .choices

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -109,7 +109,7 @@ pub(crate) async fn post(
                 )
                     .into_response();
             };
-            match nql_model.write().await.chat_request(req).await {
+            match nql_model.chat_request(req).await {
                 Ok(r) => r,
                 Err(e) => {
                     tracing::error!("Error running NQL model: {e}");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1375,7 +1375,7 @@ impl Runtime {
             Some(ModelType::Llm) => match self.load_llm(m.clone(), params).await {
                 Ok(l) => {
                     let mut llm_map = self.llms.write().await;
-                    llm_map.insert(m.name.clone(), l.into());
+                    llm_map.insert(m.name.clone(), l);
                     Ok(())
                 }
                 Err(e) => Err(format!(

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -31,7 +31,6 @@ use spicepod::component::model::{Model, ModelFileType, ModelSource};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use tracing_futures::Instrument;
 
 use super::tool_use::ToolUsingChat;
@@ -40,7 +39,7 @@ use crate::{
     Runtime,
 };
 
-pub type LLMModelStore = HashMap<String, RwLock<Box<dyn Chat>>>;
+pub type LLMModelStore = HashMap<String, Box<dyn Chat>>;
 
 /// Attempt to derive a runnable Chat model from a given component from the Spicepod definition.
 pub async fn try_to_chat_model<S: ::std::hash::BuildHasher>(


### PR DESCRIPTION
## 🗣 Description
 - `pub trait Chat` has recently had its methods changed from `mut self` to `&self`. 
 - Because of this, the additional RwLock on the `Box<dyn Chat>` in `LLMModelStore` is no longer needed.

## 🔨 Related Issues
 - Remove `mut`: #2255 