### PR TITLE
Remove unneeded `RwLock` from `EmbeddingModelStore`

### DIFF
--- a/crates/llms/src/embeddings/candle/mod.rs
+++ b/crates/llms/src/embeddings/candle/mod.rs
@@ -113,7 +113,7 @@ impl CandleEmbedding {
 
 #[async_trait]
 impl Embed for CandleEmbedding {
-    async fn embed(&mut self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>> {
+    async fn embed(&self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>> {
         let add_special_tokens = true;
 
         let encodings: Vec<Encoding> = match input {

--- a/crates/llms/src/embeddings/mod.rs
+++ b/crates/llms/src/embeddings/mod.rs
@@ -56,11 +56,11 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[async_trait]
 pub trait Embed: Sync + Send {
-    async fn embed(&mut self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>>;
+    async fn embed(&self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>>;
 
     /// A basic health check to ensure the model can process future [`Self::embed`] requests.
     /// Default implementation is a basic call to [`embed()`].
-    async fn health(&mut self) -> Result<()> {
+    async fn health(&self) -> Result<()> {
         self.embed(EmbeddingInput::String("health".to_string()))
             .await
             .boxed()
@@ -75,7 +75,7 @@ pub trait Embed: Sync + Send {
     /// implementation will be constructed based on the trait's [`embed`] method.
     #[allow(clippy::cast_possible_truncation)]
     async fn embed_request(
-        &mut self,
+        &self,
         req: CreateEmbeddingRequest,
     ) -> Result<CreateEmbeddingResponse, OpenAIError> {
         let result = self.embed(req.input).await.map_err(|e| {

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -180,7 +180,7 @@ impl Chat for Openai {
 #[async_trait]
 impl Embed for Openai {
     async fn embed_request(
-        &mut self,
+        &self,
         req: CreateEmbeddingRequest,
     ) -> Result<CreateEmbeddingResponse, OpenAIError> {
         let mut inner_req = req.clone();
@@ -188,7 +188,7 @@ impl Embed for Openai {
         self.client.embeddings().create(inner_req).await
     }
 
-    async fn embed(&mut self, input: EmbeddingInput) -> EmbedResult<Vec<Vec<f32>>> {
+    async fn embed(&self, input: EmbeddingInput) -> EmbedResult<Vec<Vec<f32>>> {
         // Batch requests to OpenAI endpoint because "any array must be 2048 dimensions or less".
         // https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-input
         let embed_batches = match input {

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -215,11 +215,9 @@ async fn get_embeddings(
         let read_guard = embedding_models.read().await;
         let model_lock_opt = read_guard.get(model_name);
 
-        let Some(model_lock) = model_lock_opt else {
+        let Some(model) = model_lock_opt else {
             continue;
         };
-
-        let mut model = model_lock.write().await;
 
         let raw_data = match rb.column_by_name(col) {
             None => {

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -92,13 +92,9 @@ impl EmbeddingTable {
         embedding_models: &Arc<RwLock<EmbeddingModelStore>>,
     ) -> HashMap<String, i32> {
         let mut model_sizes: HashMap<String, i32> = HashMap::new();
-        for (col, model) in embedded_columns {
-            if let Some(model_lock) = embedding_models.read().await.get(model) {
-                let z = model_lock.read().await.size();
-                model_sizes.insert(col.clone(), z);
-                tracing::debug!("Model {model} has size {z}");
-            } else {
-                tracing::debug!("Model {model} not found for column {col}");
+        for (col, model_name) in embedded_columns {
+            if let Some(model) = embedding_models.read().await.get(model_name) {
+                model_sizes.insert(col.clone(), model.size());
             }
         }
         model_sizes

--- a/crates/runtime/src/embeddings/task.rs
+++ b/crates/runtime/src/embeddings/task.rs
@@ -35,7 +35,7 @@ impl TaskEmbed {
 
 #[async_trait]
 impl Embed for TaskEmbed {
-    async fn embed<'b>(&'b mut self, input: EmbeddingInput) -> EmbedResult<Vec<Vec<f32>>> {
+    async fn embed<'b>(&'b self, input: EmbeddingInput) -> EmbedResult<Vec<Vec<f32>>> {
         let span = tracing::span!(target: "task_history", tracing::Level::INFO, "text_embed", input = %serde_json::to_string(&input).unwrap_or_default());
 
         match self.inner.embed(input).instrument(span.clone()).await {
@@ -50,7 +50,7 @@ impl Embed for TaskEmbed {
         }
     }
 
-    async fn health<'b>(&'b mut self) -> EmbedResult<()> {
+    async fn health<'b>(&'b self) -> EmbedResult<()> {
         self.inner.health().await
     }
 
@@ -60,7 +60,7 @@ impl Embed for TaskEmbed {
 
     #[allow(clippy::cast_possible_truncation)]
     async fn embed_request<'b>(
-        &'b mut self,
+        &'b self,
         req: CreateEmbeddingRequest,
     ) -> Result<CreateEmbeddingResponse, OpenAIError> {
         let span = tracing::span!(target: "task_history", tracing::Level::INFO, "text_embed", input = %serde_json::to_string(&req.input).unwrap_or_default());

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -500,8 +500,6 @@ impl VectorSearch {
             .ok_or(Error::EmbeddingModelNotFound {
                 model_name: embedding_model.to_string(),
             })?
-            .write()
-            .await
             .embed(EmbeddingInput::String(input.to_string()))
             .await
             .boxed()

--- a/crates/runtime/src/http/v1/embeddings.rs
+++ b/crates/runtime/src/http/v1/embeddings.rs
@@ -31,15 +31,10 @@ pub(crate) async fn post(
 ) -> Response {
     let model_id = req.model.clone().to_string();
     match embeddings.read().await.get(&model_id) {
-        Some(model_lock) => {
-            let mut model = model_lock.write().await;
-
+        Some(model) => {
             let resp: Response = match model.embed_request(req).await {
                 Ok(response) => Json(response).into_response(),
-                Err(e) => {
-                    let err_msg = e.to_string();
-                    (StatusCode::INTERNAL_SERVER_ERROR, err_msg).into_response()
-                }
+                Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
             };
 
             resp

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1232,7 +1232,7 @@ impl Runtime {
     async fn load_embedding(&self, in_embed: &Embeddings) -> Result<Box<dyn Embed>> {
         let params_with_secrets = self.get_params_with_secrets(&in_embed.params).await;
 
-        let mut l = try_to_embedding(in_embed, &params_with_secrets)
+        let l = try_to_embedding(in_embed, &params_with_secrets)
             .boxed()
             .context(UnableToInitializeEmbeddingModelSnafu)?;
         l.health()
@@ -1253,7 +1253,7 @@ impl Runtime {
                         let mut embeds_map = self.embeds.write().await;
 
                         let m = Box::new(TaskEmbed::new(e)) as Box<dyn Embed>;
-                        embeds_map.insert(in_embed.name.clone(), m.into());
+                        embeds_map.insert(in_embed.name.clone(), m);
 
                         tracing::info!("Embedding [{}] ready to embed", in_embed.name);
                         metrics::embeddings::COUNT.add(

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -20,9 +20,8 @@ use spicepod::component::{embeddings::EmbeddingPrefix, model::ModelFileType};
 use std::collections::HashMap;
 use std::path::Path;
 use std::result::Result;
-use tokio::sync::RwLock;
 
-pub type EmbeddingModelStore = HashMap<String, RwLock<Box<dyn Embed>>>;
+pub type EmbeddingModelStore = HashMap<String, Box<dyn Embed>>;
 
 pub fn try_to_embedding<S: ::std::hash::BuildHasher>(
     component: &spicepod::component::embeddings::Embeddings,


### PR DESCRIPTION
## 🗣 Description
 - Inspired by #2537 , do the equivalent for `pub trait Embed` and `EmbeddingModelStore`.
 - Remove unnecessary RwLock from `EmbeddingModelStore`.