### PR TITLE
fix out of order projections in sharepoint scans

### DIFF
--- a/crates/data_components/src/sharepoint/client.rs
+++ b/crates/data_components/src/sharepoint/client.rs
@@ -345,7 +345,7 @@ impl SharepointListExec {
             schema: projected_schema,
             properties,
             limit,
-            projections,
+            projections: projections.cloned(),
         })
     }
 


### PR DESCRIPTION
## 🗣 Description
 - The following SQL would return the wrong result
 ```shell
 sql> select web_url, created_by_id, created_by_name, created_date_time from docs limit 3
+----------------------------------------------+--------------------------------------+-----------------+---------------------+
| web_url                                      | created_by_id                        | created_by_name | created_date_time   |
+----------------------------------------------+--------------------------------------+-----------------+---------------------+
| "c:{BD4D130F-2C95-4E59-9F93-85BD0A9E1B19},1" | cbccd193-f9f1-4603-b01d-ff6f3e6f2108 | Jack Eadie      | 2024-09-09T04:57:00 |
| "c:{B6F79DEE-6FBB-4F58-B2D9-34A905E8290A},1" | cbccd193-f9f1-4603-b01d-ff6f3e6f2108 | Jack Eadie      | 2024-09-09T04:57:01 |
| "c:{39B97D59-281E-49F2-9238-8D40294C7668},1" | cbccd193-f9f1-4603-b01d-ff6f3e6f2108 | Jack Eadie      | 2024-09-09T04:57:00 |
+----------------------------------------------+--------------------------------------+-----------------+---------------------+

Time: 0.824023708 seconds. 3 rows.
 
 ```

 - `RecordBatchStreamAdapter::new` doesn't apply a projection on the `RecordBatch` based on the schema. This causes the `RecordBatch` to have incorrect columns, or invalid conversion failures (in the example above, it just tries to return the first four columns of the full table schema, i.e. `c_tag` not `web_url`).