### PR TITLE
fix: Re-attach DuckDB attachments on each query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=701f54ffe26210759134e7c033c53fd39bf3eee7#701f54ffe26210759134e7c033c53fd39bf3eee7"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=01bef67c63b91365e86a1c0895cb151cf1df77c1#01bef67c63b91365e86a1c0895cb151cf1df77c1"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ datafusion-execution = "41"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }
 datafusion-functions-json = "0.41"
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "701f54ffe26210759134e7c033c53fd39bf3eee7" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "01bef67c63b91365e86a1c0895cb151cf1df77c1" }
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.0"


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates `datafusion-table-providers` to bring in latest DuckDB fixes
* Re-attaches DuckDB attachments on each new query/connection
* Ensures inner thread errors aren't silenced during DuckDB writes/reads

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #2518