### PR TITLE
Fix refresh API using `refresh_mode: append`

### DIFF
--- a/crates/runtime/tests/refresh_sql/mod.rs
+++ b/crates/runtime/tests/refresh_sql/mod.rs
@@ -14,13 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use arrow::array::RecordBatch;
+use futures::TryStreamExt;
+use std::{sync::Arc, time::Duration};
 
 use app::AppBuilder;
-use runtime::{accelerated_table::AcceleratedTable, Runtime};
+use runtime::{
+    accelerated_table::{refresh::RefreshOverrides, AcceleratedTable},
+    component::dataset::acceleration::RefreshMode,
+    datafusion::query::Protocol,
+    Runtime,
+};
 use spicepod::component::dataset::{acceleration::Acceleration, Dataset};
 
-use crate::init_tracing;
+use crate::{init_tracing, wait_until_true};
 
 fn make_spiceai_dataset(path: &str, name: &str, refresh_sql: String) -> Dataset {
     let mut ds = Dataset::new(format!("spiceai:{path}"), name.to_string());
@@ -33,7 +40,6 @@ fn make_spiceai_dataset(path: &str, name: &str, refresh_sql: String) -> Dataset 
 }
 
 #[tokio::test]
-#[allow(clippy::too_many_lines)]
 async fn spiceai_integration_test_refresh_sql_pushdown() -> Result<(), String> {
     use runtime::accelerated_table::refresh_task::RefreshTask;
 
@@ -90,6 +96,90 @@ async fn spiceai_integration_test_refresh_sql_pushdown() -> Result<(), String> {
 
     assert_eq!(data_update.data.len(), 1);
     assert_eq!(data_update.data[0].num_rows(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn spiceai_integration_test_refresh_sql_override_append() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(None);
+    let app = AppBuilder::new("refresh_sql_override_append")
+        .with_dataset(make_spiceai_dataset(
+            "tpch.nation",
+            "nation",
+            "SELECT * FROM nation WHERE n_regionkey != 0".to_string(),
+        ))
+        .build();
+
+    let rt = Runtime::builder().with_app(app).build().await;
+
+    rt.load_components().await;
+
+    let query = rt
+        .datafusion()
+        .query_builder(
+            "SELECT * FROM nation WHERE n_regionkey = 0",
+            Protocol::Internal,
+        )
+        .build()
+        .run()
+        .await?;
+
+    let results: Vec<RecordBatch> = query.data.try_collect::<Vec<RecordBatch>>().await?;
+    assert_eq!(
+        results.len(),
+        0,
+        "Expected refresh SQL to filter out all rows for n_regionkey = 0"
+    );
+
+    rt.datafusion()
+        .refresh_table(
+            "nation",
+            Some(RefreshOverrides {
+                sql: Some("SELECT * FROM nation WHERE n_regionkey = 0".to_string()),
+                mode: Some(RefreshMode::Append),
+            }),
+        )
+        .await?;
+
+    assert!(
+        wait_until_true(Duration::from_secs(10), || async {
+            let Ok(query) = rt
+                .datafusion()
+                .query_builder(
+                    "SELECT * FROM nation WHERE n_regionkey = 0",
+                    Protocol::Internal,
+                )
+                .build()
+                .run()
+                .await
+            else {
+                return false;
+            };
+
+            let results: Vec<RecordBatch> = match query.data.try_collect::<Vec<RecordBatch>>().await
+            {
+                Ok(results) => results,
+                Err(_) => return false,
+            };
+            !results.is_empty()
+        })
+        .await
+    );
+
+    let query = rt
+        .datafusion()
+        .query_builder(
+            "SELECT * FROM nation WHERE n_regionkey = 0 ORDER BY n_nationkey DESC",
+            Protocol::Internal,
+        )
+        .build()
+        .run()
+        .await?;
+
+    let results: Vec<RecordBatch> = query.data.try_collect::<Vec<RecordBatch>>().await?;
+    let results_str = arrow::util::pretty::pretty_format_batches(&results).expect("pretty batches");
+    insta::assert_snapshot!(results_str);
 
     Ok(())
 }

--- a/crates/runtime/tests/refresh_sql/snapshots/integration__refresh_sql__spiceai_integration_test_refresh_sql_override_append.snap
+++ b/crates/runtime/tests/refresh_sql/snapshots/integration__refresh_sql__spiceai_integration_test_refresh_sql_override_append.snap
@@ -1,0 +1,13 @@
+---
+source: crates/runtime/tests/refresh_sql/mod.rs
+expression: results_str
+---
++-------------+------------+-------------+-----------------------------------------------------------------------------------------------+
+| n_nationkey | n_name     | n_regionkey | n_comment                                                                                     |
++-------------+------------+-------------+-----------------------------------------------------------------------------------------------+
+| 16          | MOZAMBIQUE | 0           |  beans after the carefully regular accounts r                                                 |
+| 15          | MOROCCO    | 0           | ct blithely: blithely express accounts nag carefully. silent packages haggle carefully abo    |
+| 14          | KENYA      | 0           | lyly special foxes. slyly regular deposits sleep carefully. carefully permanent accounts slee |
+| 5           | ETHIOPIA   | 0           | regular requests sleep carefull                                                               |
+| 0           | ALGERIA    | 0           | furiously regular requests. platelets affix furious                                           |
++-------------+------------+-------------+-----------------------------------------------------------------------------------------------+


### PR DESCRIPTION
## 🗣 Description

Fixes a bug using the `POST /v1/datasets/<name>/acceleration/refresh` API with the `refresh_sql: <SQL>` and `refresh_mode: append` parameters set on an accelerated dataset configured for full refresh without a `time_column` being set.

## 🔨 Related Issues

Closes #2606
