### PR TITLE
fix: Remove comments from SQL files

### DIFF
--- a/test/scripts/run-queries.bash
+++ b/test/scripts/run-queries.bash
@@ -25,8 +25,10 @@ query_folder=$1;
 failed_queries=()
 for i in `ls -d $query_folder/**`; do
   echo "Running query in $i.."
-  tr '\n' ' ' <  $i | spice sql > runqueries.tmp.txt
+  sed '/^--/d' < $i > $i.tmp # remove comments because we compact the query into one line
+  tr '\n' ' ' <  $i.tmp | spice sql > runqueries.tmp.txt
 
+  rm $i.tmp
   result=`cat runqueries.tmp.txt`
   echo "$result"
   # if result contains error string, then it failed


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Uses `sed` to remove lines that start with `--` from SQL files used in `run-queries.bash`.

This helps with running the TPCDS queries from [datafusion-benchmarks](https://github.com/apache/datafusion-benchmarks/tree/main/tpcds/queries) without needing to pre-process the files and remove the comments beforehand.