### PR TITLE
Run benchmark separately using workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ env:
   FEATURES: ${{ github.event_name == 'schedule' && 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite' || inputs.features }}
 
 jobs:
-  run-database-bench:
+  build-database-bench:
     name: Benchmark Tests
     runs-on: ubuntu-latest
     services:
@@ -73,7 +73,39 @@ jobs:
           wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
           sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
 
-      - run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release
+      - name: Build benchmark binary
+        run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
+
+      - name: Find, move, and rename benchmark binary
+        run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
+
+      - name: Upload benchmark binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: spice_bench
+          path: ./spice_bench
+
+  run-database-bench:
+    name: Run Benchmark Variations
+    runs-on: ubuntu-latest
+    needs: build-binary
+
+    strategy:
+      matrix:
+        variation: ['-c spice.ai', '-c s3', '-a arrow']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download benchmark binary
+        uses: actions/download-artifact@v2
+        with:
+          name: spice_bench
+
+      - name: Run benchmark with ${{ matrix.variation }}
+        run: ./spice_bench --${{ matrix.variation }}
+        continue-on-error: true
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
           PG_BENCHMARK_PG_HOST: localhost

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   build-database-bench-binary:
-    name: Benchmark Tests
+    name: Build Benchmark Test Binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,6 +20,7 @@ on:
         default: ''
         type: choice
         options:
+          - ''
           - 'spice.ai connector'
           - 's3 connector'
           - 'spark connector'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ on:
           - 'true'
           - 'false'
       selected_benchmark:
-        description: 'Individual connector/acelerator benchmarks to run'
+        description: 'Individual connector/accelerator benchmarks to run'
         required: false
         default: ''
         type: choice

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -80,7 +80,7 @@ jobs:
         run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
 
       - name: Upload benchmark binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: spice_bench
           path: ./spice_bench
@@ -96,10 +96,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download benchmark binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: spice_bench
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,14 +5,9 @@ on:
   schedule:
     - cron: '0 10 * * 3,0'
   workflow_dispatch:
-    inputs:
-      features:
-        description: 'included features for bench'
-        required: true
-        default: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
 
 env:
-  FEATURES: ${{ github.event_name == 'schedule' && 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite' || inputs.features }}
+  FEATURES: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
 
 jobs:
   build-database-bench-binary:
@@ -27,7 +22,6 @@ jobs:
           os: 'linux'
 
       - name: Install Protoc
-        if: contains(env.FEATURES, 'spark')
         uses: arduino/setup-protoc@v3
 
       - name: Build benchmark binary
@@ -49,7 +43,7 @@ jobs:
 
     services:
       mysql:
-        image: ${{ matrix.cmd == '-c mysql' && ((contains(inputs.features, 'mysql') || github.event_name == 'schedule')) && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
+        image: ${{ matrix.cmd == '-c mysql' && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
         options: >-
           --health-cmd="mysqladmin ping -uroot -proot --silent"
           --health-interval 10s
@@ -60,7 +54,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
       postgres:
-        image: ${{ matrix.cmd == '-c postgres' && ((contains(inputs.features, 'postgres') || github.event_name == 'schedule')) && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
+        image: ${{ matrix.cmd == '-c postgres' && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
         options: >-
           --shm-size=2gb
           --health-cmd="pg_isready -U postgres"
@@ -116,7 +110,7 @@ jobs:
           name: spice_bench
 
       - name: Install Databricks ODBC driver
-        if: contains(env.FEATURES, 'odbc') && matrix.cmd == '-c odbc-databricks'
+        if: matrix.cmd == '-c odbc-databricks'
         run: |
           sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
           wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
@@ -124,7 +118,7 @@ jobs:
           sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
 
       - name: Install Athena ODBC driver
-        if: contains(env.FEATURES, 'odbc') && matrix.cmd == '-c odbc-athena'
+        if: matrix.cmd == '-c odbc-athena'
         run: |
           sudo apt-get install alien -y
           wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -116,7 +116,7 @@ jobs:
           name: spice_bench
 
       - name: Install Databricks ODBC driver
-        if: contains(env.FEATURES, 'odbc') && matrix.cmd = '-c odbc-databricks'
+        if: contains(env.FEATURES, 'odbc') && matrix.cmd == '-c odbc-databricks'
         run: |
           sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
           wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
@@ -124,7 +124,7 @@ jobs:
           sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
 
       - name: Install Athena ODBC driver
-        if: contains(env.FEATURES, 'odbc') && matrix.cmd = '-c odbc-athena'
+        if: contains(env.FEATURES, 'odbc') && matrix.cmd == '-c odbc-athena'
         run: |
           sudo apt-get install alien -y
           wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ env:
   FEATURES: ${{ github.event_name == 'schedule' && 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite' || inputs.features }}
 
 jobs:
-  build-database-bench:
+  build-database-bench-binary:
     name: Benchmark Tests
     runs-on: ubuntu-latest
     services:
@@ -88,7 +88,7 @@ jobs:
   run-database-bench:
     name: Run Benchmark Variations
     runs-on: ubuntu-latest
-    needs: build-binary
+    needs: build-database-bench-binary
 
     strategy:
       matrix:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,42 +4,15 @@ name: benchmark tests
 on:
   schedule:
     - cron: '0 10 * * 3,0'
-  ## Temporary trigger for testing
-  push:
-    branches:
-      - 'qianqian/update-workflow'
   workflow_dispatch:
     inputs:
-      run_all:
-        description: 'Run all benchmarks'
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
-      selected_benchmark:
-        description: 'Individual connector/acelerator benchmarks to run'
-        required: false
-        default: ''
-        type: choice
-        options:
-          - 'spice.ai connector'
-          - 's3 connector'
-          - 'spark connector'
-          - 'postgres connector'
-          - 'mysql connector'
-          - 'odbc-databricks connector'
-          - 'odbc-athena connector'
-          - 'delta_lake connector'
-          - 'arrow accelerator (memory mode)'
-          - 'duckdb accelerator (memory mode)'
-          - 'duckdb accelerator (file mode)'
-          - 'sqlite accelerator (memory mode)'
-          - 'sqlite accelerator (file mode)'
+      features:
+        description: 'included features for bench'
+        required: true
+        default: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
 
 env:
-  FEATURES: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
+  FEATURES: ${{ github.event_name == 'schedule' && 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite' || inputs.features }}
 
 jobs:
   build-database-bench-binary:
@@ -54,6 +27,7 @@ jobs:
           os: 'linux'
 
       - name: Install Protoc
+        if: contains(env.FEATURES, 'spark')
         uses: arduino/setup-protoc@v3
 
       - name: Build benchmark binary
@@ -75,7 +49,7 @@ jobs:
 
     services:
       mysql:
-        image: ${{ matrix.cmd == '-c mysql' && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
+        image: ${{ matrix.cmd == '-c mysql' && ((contains(inputs.features, 'mysql') || github.event_name == 'schedule')) && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
         options: >-
           --health-cmd="mysqladmin ping -uroot -proot --silent"
           --health-interval 10s
@@ -86,7 +60,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
       postgres:
-        image: ${{ matrix.cmd == '-c postgres' && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
+        image: ${{ matrix.cmd == '-c postgres' && ((contains(inputs.features, 'postgres') || github.event_name == 'schedule')) && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
         options: >-
           --shm-size=2gb
           --health-cmd="pg_isready -U postgres"
@@ -130,22 +104,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         uses: actions/checkout@v4
 
       - name: Set up Spice.ai API Key
-        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: |
           echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
 
       - name: Download benchmark binary
-        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         uses: actions/download-artifact@v4
         with:
           name: spice_bench
 
       - name: Install Databricks ODBC driver
-        if: matrix.cmd == '-c odbc-databricks' && (github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
+        if: contains(env.FEATURES, 'odbc') && matrix.cmd == '-c odbc-databricks'
         run: |
           sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
           wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
@@ -153,18 +124,16 @@ jobs:
           sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
 
       - name: Install Athena ODBC driver
-        if: matrix.cmd == '-c odbc-athena' && (github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
+        if: contains(env.FEATURES, 'odbc') && matrix.cmd == '-c odbc-athena'
         run: |
           sudo apt-get install alien -y
           wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
           sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
 
       - name: Make benchmark binary executable
-        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: chmod +x ./spice_bench
 
       - name: Run benchmark with ${{ matrix.name }}
-        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,15 +4,42 @@ name: benchmark tests
 on:
   schedule:
     - cron: '0 10 * * 3,0'
+  ## Temporary trigger for testing
+  push:
+    branches:
+      - 'qianqian/update-workflow'
   workflow_dispatch:
     inputs:
-      features:
-        description: 'included features for bench'
-        required: true
-        default: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
+      run_all:
+        description: 'Run all benchmarks'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      selected_benchmark:
+        description: 'Individual connector/acelerator benchmarks to run'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - 'spice.ai connector'
+          - 's3 connector'
+          - 'spark connector'
+          - 'postgres connector'
+          - 'mysql connector'
+          - 'odbc-databricks connector'
+          - 'odbc-athena connector'
+          - 'delta_lake connector'
+          - 'arrow accelerator (memory mode)'
+          - 'duckdb accelerator (memory mode)'
+          - 'duckdb accelerator (file mode)'
+          - 'sqlite accelerator (memory mode)'
+          - 'sqlite accelerator (file mode)'
 
 env:
-  FEATURES: ${{ github.event_name == 'schedule' && 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite' || inputs.features }}
+  FEATURES: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
 
 jobs:
   build-database-bench-binary:
@@ -27,7 +54,6 @@ jobs:
           os: 'linux'
 
       - name: Install Protoc
-        if: contains(env.FEATURES, 'spark')
         uses: arduino/setup-protoc@v3
 
       - name: Build benchmark binary
@@ -49,7 +75,7 @@ jobs:
 
     services:
       mysql:
-        image: ${{ matrix.cmd == '-c mysql' && ((contains(inputs.features, 'mysql') || github.event_name == 'schedule')) && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
+        image: ${{ matrix.cmd == '-c mysql' && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
         options: >-
           --health-cmd="mysqladmin ping -uroot -proot --silent"
           --health-interval 10s
@@ -60,7 +86,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
       postgres:
-        image: ${{ matrix.cmd == '-c postgres' && ((contains(inputs.features, 'postgres') || github.event_name == 'schedule')) && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
+        image: ${{ matrix.cmd == '-c postgres' && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
         options: >-
           --shm-size=2gb
           --health-cmd="pg_isready -U postgres"
@@ -104,19 +130,22 @@ jobs:
 
     steps:
       - name: Checkout repository
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         uses: actions/checkout@v4
 
       - name: Set up Spice.ai API Key
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: |
           echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
 
       - name: Download benchmark binary
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         uses: actions/download-artifact@v4
         with:
           name: spice_bench
 
       - name: Install Databricks ODBC driver
-        if: contains(env.FEATURES, 'odbc') && matrix.cmd == '-c odbc-databricks'
+        if: matrix.cmd == '-c odbc-databricks' && (github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
           sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
           wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
@@ -124,16 +153,18 @@ jobs:
           sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
 
       - name: Install Athena ODBC driver
-        if: contains(env.FEATURES, 'odbc') && matrix.cmd == '-c odbc-athena'
+        if: matrix.cmd == '-c odbc-athena' && (github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
           sudo apt-get install alien -y
           wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
           sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
 
       - name: Make benchmark binary executable
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: chmod +x ./spice_bench
 
       - name: Run benchmark with ${{ matrix.name }}
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -92,7 +92,33 @@ jobs:
 
     strategy:
       matrix:
-        variation: ['-c spice.ai', '-c s3', '-a arrow']
+        include:
+          - cmd: '-c spice.ai'
+            name: 'spice.ai connector'
+          - cmd: '-c s3'
+            name: 's3 connector'
+          - cmd: '-c spark'
+            name: 'spark connector'
+          - cmd: '-c postgres'
+            name: 'postgres connector'
+          - cmd: '-c mysql'
+            name: 'mysql connector'
+          - cmd: '-c odbc-databricks'
+            name: 'odbc-databricks connector'
+          - cmd: '-c odbc-athena'
+            name: 'odbc-athena connector'
+          - cmd: '-c delta_lake'
+            name: 'delta_lake connector'
+          - cmd: '-a arrow'
+            name: 'arrow accelerator (memory mode)'
+          - cmd: '-a duckdb -m memory'
+            name: 'duckdb accelerator (memory mode)'
+          - cmd: '-a duckdb -m file'
+            name: 'duckdb accelerator (memfileory mode)'
+          - cmd: '-a sqlite -m memory'
+            name: 'sqlite accelerator (memory mode)'
+          - cmd: '-a sqlite -m file'
+            name: 'sqlite accelerator (memory mode)'
 
     steps:
       - name: Checkout repository
@@ -103,8 +129,11 @@ jobs:
         with:
           name: spice_bench
 
-      - name: Run benchmark with ${{ matrix.variation }}
-        run: ./spice_bench --${{ matrix.variation }}
+      - name: Make benchmark binary executable
+        run: chmod +x ./spice_bench
+
+      - name: Run benchmark with ${{ matrix.name }}
+        run: ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,30 +18,6 @@ jobs:
   build-database-bench-binary:
     name: Benchmark Tests
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: ${{ (contains(inputs.features, 'mysql') || github.event_name == 'schedule') && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
-        options: >-
-          --health-cmd="mysqladmin ping -uroot -proot --silent"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: root
-      postgres:
-        image: ${{ (contains(inputs.features, 'postgres') || github.event_name == 'schedule') && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
-        options: >-
-          --shm-size=2gb
-          --health-cmd="pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_PASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
 
@@ -49,10 +25,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           os: 'linux'
-
-      - name: Set up Spice.ai API Key
-        run: |
-          echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
 
       - name: Install Protoc
         if: contains(env.FEATURES, 'spark')
@@ -90,6 +62,31 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-database-bench-binary
 
+    services:
+      mysql:
+        image: ${{ matrix.cmd == '-c mysql' && ((contains(inputs.features, 'mysql') || github.event_name == 'schedule')) && 'ghcr.io/spiceai/spice-mysql-bench:latest' || '' }}
+        options: >-
+          --health-cmd="mysqladmin ping -uroot -proot --silent"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: root
+      postgres:
+        image: ${{ matrix.cmd == '-c postgres' && ((contains(inputs.features, 'postgres') || github.event_name == 'schedule')) && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
+        options: >-
+          --shm-size=2gb
+          --health-cmd="pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+
     strategy:
       matrix:
         include:
@@ -123,6 +120,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Spice.ai API Key
+        run: |
+          echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
 
       - name: Download benchmark binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,21 +30,6 @@ jobs:
         if: contains(env.FEATURES, 'spark')
         uses: arduino/setup-protoc@v3
 
-      - name: Install Databricks ODBC driver
-        if: contains(env.FEATURES, 'odbc')
-        run: |
-          sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
-          wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
-          unzip SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
-          sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
-
-      - name: Install Athena ODBC driver
-        if: contains(env.FEATURES, 'odbc')
-        run: |
-          sudo apt-get install alien -y
-          wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
-          sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
-
       - name: Build benchmark binary
         run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
 
@@ -58,7 +43,7 @@ jobs:
           path: ./spice_bench
 
   run-database-bench:
-    name: Run Benchmark Variations
+    name: Run Connector/Accelerator Benchmark
     runs-on: ubuntu-latest
     needs: build-database-bench-binary
 
@@ -129,6 +114,21 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: spice_bench
+
+      - name: Install Databricks ODBC driver
+        if: contains(env.FEATURES, 'odbc') && matrix.cmd = '-c odbc-databricks'
+        run: |
+          sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
+          wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
+          unzip SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
+          sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
+
+      - name: Install Athena ODBC driver
+        if: contains(env.FEATURES, 'odbc') && matrix.cmd = '-c odbc-athena'
+        run: |
+          sudo apt-get install alien -y
+          wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
+          sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
 
       - name: Make benchmark binary executable
         run: chmod +x ./spice_bench

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,34 @@ on:
   schedule:
     - cron: '0 10 * * 3,0'
   workflow_dispatch:
+    inputs:
+      run_all:
+        description: 'Run all benchmarks'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      selected_benchmark:
+        description: 'Individual connector/acelerator benchmarks to run'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - 'spice.ai connector'
+          - 's3 connector'
+          - 'spark connector'
+          - 'postgres connector'
+          - 'mysql connector'
+          - 'odbc-databricks connector'
+          - 'odbc-athena connector'
+          - 'delta_lake connector'
+          - 'arrow accelerator (memory mode)'
+          - 'duckdb accelerator (memory mode)'
+          - 'duckdb accelerator (file mode)'
+          - 'sqlite accelerator (memory mode)'
+          - 'sqlite accelerator (file mode)'
 
 env:
   FEATURES: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
@@ -98,19 +126,22 @@ jobs:
 
     steps:
       - name: Checkout repository
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         uses: actions/checkout@v4
 
       - name: Set up Spice.ai API Key
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: |
           echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
 
       - name: Download benchmark binary
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         uses: actions/download-artifact@v4
         with:
           name: spice_bench
 
       - name: Install Databricks ODBC driver
-        if: matrix.cmd == '-c odbc-databricks'
+        if: matrix.cmd == '-c odbc-databricks' && (github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
           sudo apt-get install unixodbc unixodbc-dev unzip libsasl2-modules-gssapi-mit -y
           wget https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.8.2/SimbaSparkODBC-2.8.2.1013-Debian-64bit.zip
@@ -118,16 +149,18 @@ jobs:
           sudo dpkg -i simbaspark_2.8.2.1013-2_amd64.deb
 
       - name: Install Athena ODBC driver
-        if: matrix.cmd == '-c odbc-athena'
+        if: matrix.cmd == '-c odbc-athena' && (github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
           sudo apt-get install alien -y
           wget https://downloads.athena.us-east-1.amazonaws.com/drivers/ODBC/v2.0.3.0/Linux/AmazonAthenaODBC-2.0.3.0.rpm
           sudo alien -i AmazonAthenaODBC-2.0.3.0.rpm
 
       - name: Make benchmark binary executable
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: chmod +x ./spice_bench
 
       - name: Run benchmark with ${{ matrix.name }}
+        if: github.event.inputs.selected_benchmark == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -89,7 +89,7 @@ pub(crate) async fn setup_benchmark(
 
 async fn runtime_ready_check(rt: &Runtime) {
     assert!(
-        wait_until_true(Duration::from_secs(150), || async {
+        wait_until_true(Duration::from_secs(200), || async {
             rt.status().is_ready()
         })
         .await


### PR DESCRIPTION
## 🗣 Description

This PR updates the benchmark workflow to run connector / accelerator bencmarks separately using the matrix. Including the following changes in detail
* Benchmark workflow will have 2 jobs: `build-database-bench-binary` & `run-database-bench`
* The `build-database-bench-binary` builds the benchmark test binary
* The `run-database-bench` runs the connector / accelerator benchmark using the matrix
![image](https://github.com/user-attachments/assets/cd87159b-0090-4282-aa41-3c076d2311f9)
* Refactor the input to run all / individual benchmark
![image](https://github.com/user-attachments/assets/b8da0a68-979c-4f8d-baee-8289d69a5db9)

This PR will greatly save the time for running benchmark test (2h+ -> 40 minutes), it also prevents the whole benchmark test crash on a single failure of one connector / accelerator. The input will gives the flexibility to choose which connector / accelerator benchmark to run, which will be useful in bug fixing scenarios.



## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->