### PR TITLE
Fix typo in workflow, fix the postgres connector container readiness check

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -86,7 +86,7 @@ jobs:
         image: ${{ matrix.cmd == '-c postgres' && 'ghcr.io/spiceai/spice-postgres-bench:latest' || '' }}
         options: >-
           --shm-size=2gb
-          --health-cmd="pg_isready -U postgres"
+          --health-cmd="test -f /var/lib/postgresql/data/data_loading_complete"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -119,11 +119,11 @@ jobs:
           - cmd: '-a duckdb -m memory'
             name: 'duckdb accelerator (memory mode)'
           - cmd: '-a duckdb -m file'
-            name: 'duckdb accelerator (memfileory mode)'
+            name: 'duckdb accelerator (file mode)'
           - cmd: '-a sqlite -m memory'
             name: 'sqlite accelerator (memory mode)'
           - cmd: '-a sqlite -m file'
-            name: 'sqlite accelerator (memory mode)'
+            name: 'sqlite accelerator (file mode)'
 
     steps:
       - name: Checkout repository

--- a/test/tpch/postgres-bench/postgres-entrypoint.sh
+++ b/test/tpch/postgres-bench/postgres-entrypoint.sh
@@ -32,5 +32,8 @@ for sf in 0.01 0.05 1; do
     import_sql "$DB_NAME" "backup_${DB_NAME}.sql"
 done
 
+# Create a flag file to indicate data loading is complete
+touch /var/lib/postgresql/data/data_loading_complete
+
 # Wait for the original entrypoint script to finish
 wait


### PR DESCRIPTION
## 🗣 Description

Fix the readiness check in postgres connector benchmark, so that the benchmark only run after the tpch data loading is finished.

Successful run: https://github.com/spiceai/spiceai/actions/runs/10858084957

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->