### PR TITLE
Enable Warn/Error traces from dependency components

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -35,7 +35,7 @@ pub(crate) fn init_tracing(
     let filter = if let Ok(env_log) = std::env::var("SPICED_LOG") {
         EnvFilter::new(env_log)
     } else {
-        EnvFilter::new("task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO")
+        EnvFilter::new("task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO,WARN")
     };
 
     let subscriber = tracing_subscriber::registry()


### PR DESCRIPTION
## 🗣 Description

We don't currently show trace messages from dependency components, for example, `datafusion-table-providers`. PR enables important (Warnings and Errors) messages to be displayed.

## 🤔 Concerns

It might be better to include traces specifically for `datafusion-table-providers` only?