### PR TITLE
Update dependencies to support querying postgres enum types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2872,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2906,7 +2906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "tokio",
 ]
@@ -2914,7 +2914,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "arrow",
  "chrono",
@@ -2934,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2977,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3036,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3076,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "datafusion-common",
  "datafusion-execution",
@@ -3129,7 +3129,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0#6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3178,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=01bef67c63b91365e86a1c0895cb151cf1df77c1#01bef67c63b91365e86a1c0895cb151cf1df77c1"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=80af165dcb8c5b51c0ed24e5231d9bf6607bca8c#80af165dcb8c5b51c0ed24e5231d9bf6607bca8c"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ datafusion-execution = "41"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }
 datafusion-functions-json = "0.41"
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "01bef67c63b91365e86a1c0895cb151cf1df77c1" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "80af165dcb8c5b51c0ed24e5231d9bf6607bca8c" }
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.1"
@@ -114,10 +114,10 @@ uuid = "1.9.1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "6a81dc4fade862ec6b8467b0ba1aa7c73d1d57b0" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "89730a72945ca65371eddd54be9324af0cb9a102" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "89730a72945ca65371eddd54be9324af0cb9a102" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "89730a72945ca65371eddd54be9324af0cb9a102" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "89730a72945ca65371eddd54be9324af0cb9a102" }
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "f2ca47d094a5636df8b9f3792b2f474a7b210dc1" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }


### PR DESCRIPTION
## 🗣 Description

Update dependencies to support querying postgres enum types
Datafusion table provider pr: [Postgres enum support](https://github.com/datafusion-contrib/datafusion-table-providers/pull/100)
Spice AI Datafusion pr: [Support dictionary expression in unparser](https://github.com/spiceai/datafusion/pull/30)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->