### PR TITLE
fix: Run CHECKPOINT in the DuckDB checkpointer

### DIFF
--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -61,7 +61,9 @@ impl DatasetCheckpoint {
             .execute(&upsert, [&self.dataset_name])
             .map_err(|e| e.to_string())?;
 
-        duckdb_conn.execute("CHECKPOINT", []).map_err(|e| e.to_string())?;
+        duckdb_conn
+            .execute("CHECKPOINT", [])
+            .map_err(|e| e.to_string())?;
 
         Ok(())
     }

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -61,6 +61,8 @@ impl DatasetCheckpoint {
             .execute(&upsert, [&self.dataset_name])
             .map_err(|e| e.to_string())?;
 
+        duckdb_conn.execute("CHECKPOINT", []).map_err(|e| e.to_string())?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Runs `CHECKPOINT` inside the DuckDB checkpointer after performing some writes, to ensure the WAL is flushed to disk. We need to manually run `CHECKPOINT` here, because we're not using the write-wrapper provided from `datafusion-table-providers`.

Resolves the following errors:

```
2024-09-16T00:51:35.380511Z  WARN runtime: region The accelerator engine duckdb failed to initialize: Acceleration initialization failed: DuckDBError: Serialization Error: Failed to deserialize: field id mismatch, expected: 100, got: 0
```

and

```
spiced: /home/william/spiceai/target/debug/build/libduckdb-sys-6ce7e38f6204b21a/out/duckdb/src/storage/storage_manager.cpp:66: int64_t duckdb::StorageManager::GetWALSize(): Assertion `!FileSystem::Get(db).FileExists(GetWALPath())' failed.
```