### PR TITLE
Disable dataset checkpoint for DuckDB acceleration

### DIFF
--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -84,7 +84,9 @@ mod tests {
         }
     }
 
+    // Disabled until https://github.com/spiceai/spiceai/pull/2669 is merged
     #[tokio::test]
+    #[ignore]
     async fn test_duckdb_checkpoint_exists() {
         let checkpoint = create_in_memory_duckdb_checkpoint();
 
@@ -101,7 +103,9 @@ mod tests {
         assert!(checkpoint.exists().await);
     }
 
+    // Disabled until https://github.com/spiceai/spiceai/pull/2669 is merged
     #[tokio::test]
+    #[ignore]
     async fn test_duckdb_checkpoint_update() {
         let checkpoint = create_in_memory_duckdb_checkpoint();
 

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -20,6 +20,7 @@ use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME};
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 
 impl DatasetCheckpoint {
+    #[expect(dead_code)]
     pub(super) fn exists_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<bool> {
         let mut db_conn = Arc::clone(pool).connect_sync().map_err(|e| e.to_string())?;
         let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
@@ -35,6 +36,7 @@ impl DatasetCheckpoint {
         Ok(rows.next().map_err(|e| e.to_string())?.is_some())
     }
 
+    #[expect(dead_code)]
     pub(super) fn checkpoint_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
         let mut db_conn = Arc::clone(pool).connect_sync().map_err(|e| e.to_string())?;
         let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
@@ -54,8 +54,10 @@ impl DatasetCheckpoint {
 
     pub async fn exists(&self) -> bool {
         match &self.acceleration_connection {
+            // Disabled until https://github.com/spiceai/spiceai/pull/2669 is merged
+            // AccelerationConnection::DuckDB(pool) => self.exists_duckdb(pool).ok().unwrap_or(false),
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.exists_duckdb(pool).ok().unwrap_or(false),
+            AccelerationConnection::DuckDB(_) => false,
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => {
                 self.exists_postgres(pool).await.ok().unwrap_or(false)
@@ -71,8 +73,10 @@ impl DatasetCheckpoint {
 
     pub async fn checkpoint(&self) -> Result<()> {
         match &self.acceleration_connection {
+            // Disabled until https://github.com/spiceai/spiceai/pull/2669 is merged
+            // AccelerationConnection::DuckDB(pool) => self.checkpoint_duckdb(pool),
             #[cfg(feature = "duckdb")]
-            AccelerationConnection::DuckDB(pool) => self.checkpoint_duckdb(pool),
+            AccelerationConnection::DuckDB(_) => Ok(()),
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => self.checkpoint_postgres(pool).await,
             #[cfg(feature = "sqlite")]

--- a/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
@@ -29,7 +29,9 @@ use crate::{
     s3::get_s3_dataset,
 };
 
+// Disabled until https://github.com/spiceai/spiceai/pull/2669 is merged
 #[tokio::test]
+#[ignore]
 async fn test_acceleration_duckdb_checkpoint() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
@@ -28,7 +28,9 @@ use std::sync::Arc;
 use crate::acceleration::get_params;
 use crate::{get_test_datafusion, init_tracing, runtime_ready_check, s3::get_s3_dataset};
 
+// Disabled until https://github.com/spiceai/spiceai/pull/2669 is merged
 #[tokio::test]
+#[ignore]
 async fn test_acceleration_sqlite_checkpoint() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 


### PR DESCRIPTION
## 🗣 Description

Disables the dataset checkpoint functionality (which powers the `/ready` endpoint optimization which doesn't require the runtime to wait for a full refresh on every startup if it can know a previous run completed a full refresh) for DuckDB accelerations. This caused a regression where data wasn't being saved properly to the DuckDB file due to multiple connections competing for the same file.

This was going to be fixed in https://github.com/spiceai/spiceai/pull/2669 but there are other test failures I want to get to the bottom of before merging that.