### PR TITLE
Revert "Enable federation for accelerated queries (sqlite, duckdb, postgres) (#2598)

### DIFF
--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -75,17 +75,16 @@ delta_lake = ["dep:delta_kernel"]
 duckdb = [
   "dep:duckdb",
   "db_connection_pool/duckdb",
-  "datafusion-table-providers/duckdb",
-  "datafusion-table-providers/duckdb-federation"
+  "datafusion-table-providers/duckdb"
 ]
 flightsql = ["dep:tonic"]
 mysql = ["datafusion-table-providers/mysql"]
 odbc = []
-postgres = ["dep:tokio-postgres", "datafusion-table-providers/postgres", "datafusion-table-providers/postgres-federation"]
+postgres = ["dep:tokio-postgres", "datafusion-table-providers/postgres"]
 snowflake = ["dep:snowflake-api"]
 spark_connect = ["dep:spark-connect-rs"]
 sharepoint = ["dep:graph-rs-sdk", "dep:http"]
-sqlite = ["dep:rusqlite", "datafusion-table-providers/sqlite", "datafusion-table-providers/sqlite-federation"]
+sqlite = ["dep:rusqlite", "datafusion-table-providers/sqlite"]
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -44,7 +44,7 @@ clickhouse = [
   "arrow_sql_gen/clickhouse",
   "dep:async-stream",
 ]
-duckdb = ["datafusion-table-providers/duckdb", "datafusion-table-providers/duckdb-federation"]
+duckdb = ["datafusion-table-providers/duckdb"]
 mysql = ["datafusion-table-providers/mysql"]
 odbc = [
   "dep:odbc-api",
@@ -58,7 +58,6 @@ postgres = [
   "dep:tokio",
   "dep:async-stream",
   "datafusion-table-providers/postgres",
-  "datafusion-table-providers/postgres-federation"
 ]
 snowflake = ["dep:snowflake-api", "dep:pkcs8", "dep:serde_json"]
-sqlite = ["datafusion-table-providers/sqlite", "datafusion-table-providers/sqlite-federation"]
+sqlite = ["datafusion-table-providers/sqlite"]

--- a/crates/runtime/tests/sqlite/mod.rs
+++ b/crates/runtime/tests/sqlite/mod.rs
@@ -54,6 +54,7 @@ type QueryTests<'a> = Vec<(&'a str, CheckFunction, Option<Box<ValidateFn>>)>;
 
 #[derive(Debug, Copy, Clone)]
 enum DecimalQuery {
+    #[allow(dead_code)]
     Federated,
     NonFederated,
 }
@@ -197,7 +198,7 @@ async fn test_sqlite_decimal_file() -> anyhow::Result<()> {
     runtime_ready_check(&rt).await;
 
     for (query, check_function, validate_result) in
-        decimal_queries("test_sqlite_decimal_file", DecimalQuery::Federated)
+        decimal_queries("test_sqlite_decimal_file", DecimalQuery::NonFederated)
     {
         match check_function {
             CheckFunction::ValidateFullPlan(snapshot_name) => {


### PR DESCRIPTION
## 🗣 Description

Disable federation
This reverts commit 330976c4b8ac189525ed95eab69a0f114855ba58.


## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->