### PR TITLE
Better spicepod parsing error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9675,6 +9675,7 @@ dependencies = [
 name = "spicepod"
 version = "0.18.0-beta"
 dependencies = [
+ "regex",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -14,6 +14,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 snafu.workspace = true
 tracing.workspace = true
+regex.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
## 🗣 Description

A more user-friendly error message when the user configure spicepod.yaml that's not conforming to json schema.
* Add custom handling for the errors that specify `line` and `column` message
* For other errors, pass the original error

Note: `serde::Error` variations are private implementation, so the string pattern matching method with regex is adopted here.

Before:
![image](https://github.com/user-attachments/assets/154f244d-3182-41a9-84d6-676b2cca2d27)

After:
![image](https://github.com/user-attachments/assets/3133f45e-7334-45b4-907d-2d04d8bfee3f)


## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->