### PR TITLE
Revert "Use lower case iso8601 for time_column (#2551)"

### DIFF
--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -41,7 +41,7 @@ pub enum TimeFormat {
     Timestamptz,
     UnixSeconds,
     UnixMillis,
-    #[serde(rename = "iso8601")]
+    #[serde(rename = "ISO8601")]
     ISO8601,
 }
 


### PR DESCRIPTION
## 🗣 Description

This reverts commit 954b63d0422e9acaa4f6ff0c033569b5091b08e0.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->