### PR TITLE
Update Helm Chart for 0.18.0-beta release

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: spiceai
 description: Spice.ai OSS
-version: 0.1.23
+version: 0.1.24


### PR DESCRIPTION
## 🗣 Description

Note, image already refer to `0.18.0-beta` but chart version needs to be updated. 

https://github.com/spiceai/spiceai/blob/trunk/deploy/chart/values.yaml

```yaml
image:
  repository: spiceai/spiceai
  tag: 0.18.0-beta
replicaCount: 1
```

```
helm search repo spiceai/spiceai --versions

NAME           	CHART VERSION	APP VERSION	DESCRIPTION
spiceai/spiceai	0.1.23       	           	Spice.ai OSS
spiceai/spiceai	0.1.22       	           	Spice.ai OSS
```
## 🔨 Related Issues
