### PR TITLE
Use a single instance for all SQLite accelerated datasets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=0ad0322aba626bb76ea9f8a8af9ce69f47e64643#0ad0322aba626bb76ea9f8a8af9ce69f47e64643"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d43347c873e0239302acc8614ccbe322ca8094a0#d43347c873e0239302acc8614ccbe322ca8094a0"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ datafusion-execution = "41"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }
 datafusion-functions-json = "0.41"
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "0ad0322aba626bb76ea9f8a8af9ce69f47e64643" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d43347c873e0239302acc8614ccbe322ca8094a0" }
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.1"

--- a/crates/runtime/tests/rehydration/mod.rs
+++ b/crates/runtime/tests/rehydration/mod.rs
@@ -179,10 +179,10 @@ fn resolve_local_db_file_path(
         ));
     }
 
-    match engine {
-        "duckdb" => Ok(format!("{}/lineitem.db", spice_data_base_path())),
-        _ => Ok(format!("{}/lineitem_{engine}.db", spice_data_base_path())),
-    }
+    Ok(format!(
+        "{}/accelerated_{engine}.db",
+        spice_data_base_path()
+    ))
 }
 
 async fn run_query(query: &str, rt: &Runtime) -> Result<Vec<RecordBatch>, anyhow::Error> {


### PR DESCRIPTION
## 🗣 Description

Brings in the following PR from `datafusion-table-providers`: https://github.com/datafusion-contrib/datafusion-table-providers/pull/109

This PR changes the SQLite accelerator to use a single instance for datasets that can be in the same file. This means all in-memory SQLite datasets will be accelerated together, all datasets that specify the same file will be accelerated together, and all datasets that specify file-acceleration but don't specify a `sqlite_file` param will be accelerated into `.spice/data/accelerated_sqlite.db`

## 🔨 Related Issues

Closes #2665
Closes #2666
Closes #2561