### PR TITLE
Enable rehydration tests for DuckDB

### DIFF
--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -218,8 +218,7 @@ impl DataAccelerator for DuckDBAccelerator {
                 .into());
             }
 
-            DuckDbConnectionPool::new_file(path, &AccessMode::ReadWrite)
-                .context(AccelerationInitializationFailedSnafu)?;
+            self.get_shared_pool(dataset).await?;
         }
 
         Ok(())

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -206,9 +206,7 @@ impl DataAccelerator for SqliteAccelerator {
                 .into());
             }
 
-            SqliteConnectionPool::init(path, acceleration.mode.to_string().as_str().into())
-                .await
-                .context(AccelerationInitializationFailedSnafu)?;
+            self.get_shared_pool(dataset).await?;
         }
 
         Ok(())

--- a/crates/runtime/tests/rehydration/duckdb.rs
+++ b/crates/runtime/tests/rehydration/duckdb.rs
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use anyhow::{Error, Result};
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion_table_providers::sql::db_connection_pool::{
+    duckdbpool::DuckDbConnectionPool, DbConnectionPool,
+};
+use duckdb::AccessMode;
+
+pub(crate) async fn query_local_db(
+    db_file_path: &str,
+    query: &str,
+) -> Result<SendableRecordBatchStream> {
+    let pool = DuckDbConnectionPool::new_file(db_file_path, &AccessMode::ReadOnly)
+        .map_err(|e| Error::msg(format!("Failed to create DuckDB connection pool: {e}")))?;
+
+    let conn_dyn = pool
+        .connect()
+        .await
+        .map_err(|e| Error::msg(format!("Failed to connect to the DuckDB: {e}")))?;
+
+    let conn = conn_dyn
+        .as_sync()
+        .ok_or_else(|| Error::msg("Failed to obtain sync connection"))?;
+
+    conn.query_arrow(query, &[], None)
+        .map_err(|e| Error::msg(format!("Failed to execute query: {e}")))
+}

--- a/crates/runtime/tests/rehydration/mod.rs
+++ b/crates/runtime/tests/rehydration/mod.rs
@@ -101,7 +101,7 @@ async fn spill_to_disk_and_rehydration() -> Result<(), anyhow::Error> {
 /// 2. Start Spice, retrieve row count and loaded items after acceleration is completed, and compare with the baseline.
 /// 3. Restart the runtime and ensure the loaded items remain consistent immediately after the runtime is loaded.
 /// 4. Simulate federated dataset access issue after the runtime is restarted, ensure query result remain consistent.
-///
+#[expect(clippy::expect_used)]
 async fn execute_spill_to_disk_and_rehydration(
     federated_dataset_container: Arc<RunningContainer<'static>>,
     engine: &str,

--- a/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-2.snap
+++ b/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-2.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/rehydration/mod.rs
+expression: restart2_items_pretty
+---
++------------+--------------+
+| l_orderkey | l_linenumber |
++------------+--------------+
+| 1          | 2            |
+| 1          | 3            |
+| 1          | 4            |
+| 1          | 5            |
+| 1          | 6            |
+| 2          | 1            |
+| 3          | 1            |
+| 3          | 2            |
+| 3          | 3            |
+| 3          | 4            |
++------------+--------------+

--- a/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-3.snap
+++ b/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-3.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/rehydration/mod.rs
+expression: restart1_items_pretty
+---
++------------+--------------+
+| l_orderkey | l_linenumber |
++------------+--------------+
+| 1          | 2            |
+| 1          | 3            |
+| 1          | 4            |
+| 1          | 5            |
+| 1          | 6            |
+| 2          | 1            |
+| 3          | 1            |
+| 3          | 2            |
+| 3          | 3            |
+| 3          | 4            |
++------------+--------------+

--- a/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-4.snap
+++ b/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-4.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/rehydration/mod.rs
+expression: restart2_items_pretty
+---
++------------+--------------+
+| l_orderkey | l_linenumber |
++------------+--------------+
+| 1          | 2            |
+| 1          | 3            |
+| 1          | 4            |
+| 1          | 5            |
+| 1          | 6            |
+| 2          | 1            |
+| 3          | 1            |
+| 3          | 2            |
+| 3          | 3            |
+| 3          | 4            |
++------------+--------------+

--- a/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-5.snap
+++ b/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-5.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/rehydration/mod.rs
+expression: restart1_items_pretty
+---
++------------+--------------+
+| l_orderkey | l_linenumber |
++------------+--------------+
+| 1          | 2            |
+| 1          | 3            |
+| 1          | 4            |
+| 1          | 5            |
+| 1          | 6            |
+| 2          | 1            |
+| 3          | 1            |
+| 3          | 2            |
+| 3          | 3            |
+| 3          | 4            |
++------------+--------------+

--- a/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-6.snap
+++ b/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-6.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/rehydration/mod.rs
+expression: restart2_items_pretty
+---
++------------+--------------+
+| l_orderkey | l_linenumber |
++------------+--------------+
+| 1          | 2            |
+| 1          | 3            |
+| 1          | 4            |
+| 1          | 5            |
+| 1          | 6            |
+| 2          | 1            |
+| 3          | 1            |
+| 3          | 2            |
+| 3          | 3            |
+| 3          | 4            |
++------------+--------------+

--- a/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-7.snap
+++ b/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-7.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/rehydration/mod.rs
+expression: restart1_items_pretty
+---
++------------+--------------+
+| l_orderkey | l_linenumber |
++------------+--------------+
+| 1          | 2            |
+| 1          | 3            |
+| 1          | 4            |
+| 1          | 5            |
+| 1          | 6            |
+| 2          | 1            |
+| 3          | 1            |
+| 3          | 2            |
+| 3          | 3            |
+| 3          | 4            |
++------------+--------------+

--- a/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-8.snap
+++ b/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration-8.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/rehydration/mod.rs
+expression: restart2_items_pretty
+---
++------------+--------------+
+| l_orderkey | l_linenumber |
++------------+--------------+
+| 1          | 2            |
+| 1          | 3            |
+| 1          | 4            |
+| 1          | 5            |
+| 1          | 6            |
+| 2          | 1            |
+| 3          | 1            |
+| 3          | 2            |
+| 3          | 3            |
+| 3          | 4            |
++------------+--------------+

--- a/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration.snap
+++ b/crates/runtime/tests/rehydration/snapshots/integration__rehydration__execute_spill_to_disk_and_rehydration.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/rehydration/mod.rs
+expression: restart1_items_pretty
+---
++------------+--------------+
+| l_orderkey | l_linenumber |
++------------+--------------+
+| 1          | 2            |
+| 1          | 3            |
+| 1          | 4            |
+| 1          | 5            |
+| 1          | 6            |
+| 2          | 1            |
+| 3          | 1            |
+| 3          | 2            |
+| 3          | 3            |
+| 3          | 4            |
++------------+--------------+

--- a/crates/runtime/tests/rehydration/sqlite.rs
+++ b/crates/runtime/tests/rehydration/sqlite.rs
@@ -1,0 +1,48 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use anyhow::{Error, Result};
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion_table_providers::sql::db_connection_pool::{
+    sqlitepool::SqliteConnectionPool, DbConnectionPool, JoinPushDown,
+};
+
+pub(crate) async fn query_local_db(
+    db_file_path: &str,
+    query: &str,
+) -> Result<SendableRecordBatchStream> {
+    let conn_pool = SqliteConnectionPool::new(
+        db_file_path,
+        datafusion_table_providers::sql::db_connection_pool::Mode::File,
+        JoinPushDown::Disallow,
+        vec![],
+    )
+    .await
+    .map_err(|e| Error::msg(format!("Failed to create SQLite connection pool: {e}")))?;
+
+    let conn_dyn = conn_pool
+        .connect()
+        .await
+        .map_err(|e| Error::msg(format!("Failed to connect to SQLite: {e}")))?;
+
+    let conn = conn_dyn
+        .as_async()
+        .ok_or_else(|| Error::msg("Failed to obtain async connection"))?;
+
+    conn.query_arrow(query, &[], None)
+        .await
+        .map_err(|e| Error::msg(format!("Failed to execute query: {e}")))
+}


### PR DESCRIPTION
## 🗣 Description

Enable duckdb in rehydration tests.

Also add step to verify num of locally stored records after refresh

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/2476
