### PR TITLE
Move table creation for spice_sys_dataset_checkpoint to DatasetCheckpoint::try_new

### DIFF
--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -85,6 +85,7 @@ mod tests {
         let pool = Arc::new(
             DuckDbConnectionPool::new_memory().expect("Failed to create in-memory DuckDB database"),
         );
+        DatasetCheckpoint::init_duckdb(&pool).expect("Failed to initialize DuckDB");
         DatasetCheckpoint {
             dataset_name: "test_dataset".to_string(),
             acceleration_connection: AccelerationConnection::DuckDB(pool),

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -20,6 +20,26 @@ use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME};
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 
 impl DatasetCheckpoint {
+    pub(super) fn init_duckdb(pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
+        let mut db_conn = Arc::clone(pool).connect_sync().map_err(|e| e.to_string())?;
+        let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
+            .map_err(|e| e.to_string())?
+            .get_underlying_conn_mut();
+
+        let create_table = format!(
+            "CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE_NAME} (
+                dataset_name TEXT PRIMARY KEY,
+                created_at TIMESTAMP,
+                updated_at TIMESTAMP
+            )"
+        );
+        duckdb_conn
+            .execute(&create_table, [])
+            .map_err(|e| e.to_string())?;
+
+        Ok(())
+    }
+
     pub(super) fn exists_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<bool> {
         let mut db_conn = Arc::clone(pool).connect_sync().map_err(|e| e.to_string())?;
         let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
@@ -40,17 +60,6 @@ impl DatasetCheckpoint {
         let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
             .map_err(|e| e.to_string())?
             .get_underlying_conn_mut();
-
-        let create_table = format!(
-            "CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE_NAME} (
-                dataset_name TEXT PRIMARY KEY,
-                created_at TIMESTAMP,
-                updated_at TIMESTAMP
-            )"
-        );
-        duckdb_conn
-            .execute(&create_table, [])
-            .map_err(|e| e.to_string())?;
 
         let upsert = format!(
             "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, created_at, updated_at)

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
@@ -20,6 +20,28 @@ use datafusion_table_providers::sql::db_connection_pool::{
 };
 
 impl DatasetCheckpoint {
+    pub(super) async fn init_sqlite(pool: &SqliteConnectionPool) -> Result<()> {
+        let conn_sync = pool.connect_sync();
+        let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
+            return Err("Failed to downcast to SqliteConnection".into());
+        };
+        conn.conn
+            .call(move |conn| {
+                let create_table = format!(
+                    "CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE_NAME} (
+                        dataset_name TEXT PRIMARY KEY,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    )"
+                );
+                conn.execute(&create_table, [])?;
+
+                Ok(())
+            })
+            .await
+            .map_err(|e| e.to_string().into())
+    }
+
     pub(super) async fn exists_sqlite(&self, pool: &SqliteConnectionPool) -> Result<bool> {
         let conn_sync = pool.connect_sync();
         let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
@@ -46,15 +68,6 @@ impl DatasetCheckpoint {
         let dataset_name = self.dataset_name.clone();
         conn.conn
             .call(move |conn| {
-                let create_table = format!(
-                    "CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE_NAME} (
-                    dataset_name TEXT PRIMARY KEY,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                )"
-                );
-                conn.execute(&create_table, [])?;
-
                 let upsert = format!(
                     "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, updated_at)
                  VALUES (?1, CURRENT_TIMESTAMP)

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
@@ -93,13 +93,16 @@ mod tests {
     use super::*;
 
     async fn create_in_memory_sqlite_checkpoint() -> DatasetCheckpoint {
-        let conn = SqliteConnectionPoolFactory::new("", Mode::Memory)
+        let pool = SqliteConnectionPoolFactory::new("", Mode::Memory)
             .build()
             .await
             .expect("to build in-memory sqlite connection pool");
+        DatasetCheckpoint::init_sqlite(&pool)
+            .await
+            .expect("Failed to initialize SQLite");
         DatasetCheckpoint {
             dataset_name: "test_dataset".to_string(),
-            acceleration_connection: AccelerationConnection::SQLite(conn),
+            acceleration_connection: AccelerationConnection::SQLite(pool),
         }
     }
 

--- a/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
@@ -74,6 +74,8 @@ async fn test_acceleration_duckdb_checkpoint() -> Result<(), anyhow::Error> {
 
     runtime_ready_check(&rt).await;
 
+    // Wait for the checkpoint to be created
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     drop(rt);
     runtime::dataaccelerator::clear_registry().await;
     runtime::dataaccelerator::register_all().await;

--- a/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
@@ -79,6 +79,7 @@ async fn test_acceleration_duckdb_checkpoint() -> Result<(), anyhow::Error> {
     drop(rt);
     runtime::dataaccelerator::clear_registry().await;
     runtime::dataaccelerator::register_all().await;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let pool =
         DuckDbConnectionPool::new_file("./decimal.db", &AccessMode::ReadWrite).expect("valid path");

--- a/crates/runtime/tests/acceleration/checkpoint_postgres.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_postgres.rs
@@ -80,6 +80,9 @@ async fn test_acceleration_postgres_checkpoint() -> Result<(), anyhow::Error> {
     }
 
     runtime_ready_check(&rt).await;
+
+    // Wait for the checkpoint to be created
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     drop(rt);
     runtime::dataaccelerator::clear_registry().await;
     runtime::dataaccelerator::register_all().await;

--- a/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
@@ -74,6 +74,8 @@ async fn test_acceleration_sqlite_checkpoint() -> Result<(), anyhow::Error> {
 
     runtime_ready_check(&rt).await;
 
+    // Wait for the checkpoint to be created
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     drop(rt);
     runtime::dataaccelerator::clear_registry().await;
     runtime::dataaccelerator::register_all().await;


### PR DESCRIPTION
## 🗣 Description

Prevents a case where the dataset checkpoint may fail for DuckDB if two datasets are trying to checkpoint at the same time, and the table doesn't exist. One of the calls will fail with a `write-write` conflict because they are both attempting to create the same table.

Now the table creation for `spice_sys_dataset_checkpoint` happens once in the constructor of `DatasetCheckpoint` instead of every time the checkpoint is attempted.