### PR TITLE
File Format parsing for Document tables, support for docx + pdf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
  "safetensors",
  "thiserror",
  "yoke",
- "zip",
+ "zip 1.1.4",
 ]
 
 [[package]]
@@ -2059,7 +2059,7 @@ dependencies = [
  "safetensors",
  "thiserror",
  "yoke",
- "zip",
+ "zip 1.1.4",
 ]
 
 [[package]]
@@ -2787,6 +2787,7 @@ dependencies = [
  "datafusion-table-providers",
  "db_connection_pool",
  "delta_kernel",
+ "document_parse",
  "duckdb",
  "flight_client",
  "futures",
@@ -3498,6 +3499,32 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "document_parse"
+version = "0.18.1-beta"
+dependencies = [
+ "bytes",
+ "docx-rs",
+ "lopdf",
+ "snafu 0.8.4",
+ "tokio",
+]
+
+[[package]]
+name = "docx-rs"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e593b51d4fe95d69d70fd40da4b314b029736302c986c3c760826e842fd27dc3"
+dependencies = [
+ "base64 0.13.1",
+ "image 0.24.9",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "xml-rs",
+ "zip 0.6.6",
+]
 
 [[package]]
 name = "dotenvy"
@@ -5184,6 +5211,22 @@ dependencies = [
 
 [[package]]
 name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif",
+ "jpeg-decoder",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
+name = "image"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
@@ -5902,6 +5945,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lopdf"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+dependencies = [
+ "chrono",
+ "encoding_rs",
+ "flate2",
+ "indexmap 2.5.0",
+ "itoa",
+ "log",
+ "md-5",
+ "nom",
+ "rangemap",
+ "rayon",
+ "time",
+ "weezl",
+]
+
+[[package]]
 name = "lrtable"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6174,7 +6237,7 @@ dependencies = [
  "candle-core 0.6.0 (git+https://github.com/EricLBuehler/candle.git?rev=f706ef2)",
  "either",
  "futures",
- "image",
+ "image 0.25.2",
  "indexmap 2.5.0",
  "mistralrs-core",
  "rand",
@@ -6210,7 +6273,7 @@ dependencies = [
  "galil-seiferas",
  "half",
  "hf-hub",
- "image",
+ "image 0.25.2",
  "indexmap 2.5.0",
  "indicatif",
  "itertools 0.13.0",
@@ -6268,7 +6331,7 @@ version = "0.2.5"
 source = "git+https://github.com/spiceai/mistral.rs?rev=cfc0fa7ffaed0ca71cf86caff4dbd950d08626d8#cfc0fa7ffaed0ca71cf86caff4dbd950d08626d8"
 dependencies = [
  "candle-core 0.6.0 (git+https://github.com/EricLBuehler/candle.git?rev=f706ef2)",
- "image",
+ "image 0.25.2",
 ]
 
 [[package]]
@@ -8147,6 +8210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rangemap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8642,6 +8711,7 @@ dependencies = [
  "datafusion-functions-json",
  "datafusion-table-providers",
  "db_connection_pool",
+ "document_parse",
  "dotenvy",
  "duckdb",
  "flight_client",
@@ -11869,6 +11939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
+name = "xml-rs"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12039,6 +12115,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,8 +3514,7 @@ dependencies = [
 [[package]]
 name = "docx-rs"
 version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e593b51d4fe95d69d70fd40da4b314b029736302c986c3c760826e842fd27dc3"
+source = "git+https://github.com/spiceai/docx-rs?rev=ccea202918e005b805c874149c2e6d3a00784007#ccea202918e005b805c874149c2e6d3a00784007"
 dependencies = [
  "base64 0.13.1",
  "image 0.24.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3532,7 +3532,7 @@ dependencies = [
  "bytes",
  "docx-rs",
  "lopdf",
- "snafu 0.8.4",
+ "snafu",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "docx-rs"
 version = "0.4.17"
-source = "git+https://github.com/spiceai/docx-rs?rev=ccea202918e005b805c874149c2e6d3a00784007#ccea202918e005b805c874149c2e6d3a00784007"
+source = "git+https://github.com/spiceai/docx-rs?rev=2d86a60b58afb02b157f96b42a92626417e47f71#2d86a60b58afb02b157f96b42a92626417e47f71"
 dependencies = [
  "base64 0.13.1",
  "image 0.24.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,24 +2,24 @@
 default-members = ["bin/spiced"]
 members = [
   "bin/spiced/",
-  "crates/data_components",
-  "crates/flight_client",
-  "crates/spicepod",
   "crates/app",
   "crates/arrow_sql_gen",
   "crates/arrow_tools",
+  "crates/data_components",
+  "crates/document_parse",
   "crates/flightrepl",
+  "crates/flight_client",
   "crates/llms",
   "crates/model_components",
   "crates/ns_lookup",
-  "crates/util",
-  "crates/spice_cloud",
   "crates/otel-arrow",
+  "crates/spicepod",
+  "crates/spice_cloud",
   "crates/telemetry",
+  "crates/util",
   "tools/flightpublisher/",
   "tools/flightsubscriber/",
   "tools/spicepodschema/", 
-  "crates/document_parse",
 ]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ members = [
   "crates/telemetry",
   "tools/flightpublisher/",
   "tools/flightsubscriber/",
-  "tools/spicepodschema/",
+  "tools/spicepodschema/", 
+  "crates/document_parse",
 ]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -26,6 +26,7 @@ datafusion-table-providers = { workspace = true }
 datafusion.workspace = true
 db_connection_pool = { path = "../db_connection_pool" }
 delta_kernel = { version = "=0.3.0", features = ["default-engine", "cloud"], optional = true }
+document_parse = { path = "../document_parse" }
 duckdb = { workspace = true, features = [
   "bundled",
   "r2d2",

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -35,16 +35,21 @@ use datafusion::{
         ExecutionPlan, Partitioning, PlanProperties,
     },
 };
+use document_parse::DocumentParser;
 use futures::Stream;
 use futures::StreamExt;
 use object_store::{path::Path, GetResult, ObjectMeta, ObjectStore};
-use std::{any::Any, fmt, str::Utf8Error, sync::Arc};
+use snafu::ResultExt;
+use std::{any::Any, fmt, sync::Arc};
 
 use super::ObjectStoreContext;
 use url::Url;
 
 pub struct ObjectStoreTextTable {
     ctx: ObjectStoreContext,
+
+    /// For document tables, provide an optional formatter
+    document_formatter: Option<Arc<dyn DocumentParser>>,
 }
 
 impl ObjectStoreTextTable {
@@ -52,9 +57,11 @@ impl ObjectStoreTextTable {
         store: Arc<dyn ObjectStore>,
         url: &Url,
         extension: Option<String>,
+        formatter: Option<Arc<dyn DocumentParser>>,
     ) -> Result<Arc<Self>, Box<dyn std::error::Error + Send + Sync>> {
         Ok(Arc::new(Self {
             ctx: ObjectStoreContext::try_new(store, url, extension)?,
+            document_formatter: formatter,
         }))
     }
 
@@ -65,7 +72,11 @@ impl ObjectStoreTextTable {
         ])
     }
 
-    fn to_record_batch(meta_list: &[ObjectMeta], raw: &[Bytes]) -> Result<RecordBatch, ArrowError> {
+    fn to_record_batch(
+        meta_list: &[ObjectMeta],
+        raw: &[Bytes],
+        formatter: &Option<Arc<dyn DocumentParser>>,
+    ) -> Result<RecordBatch, ArrowError> {
         if meta_list.len() != raw.len() {
             return Err(ArrowError::ParseError("Length mismatch".to_string()));
         }
@@ -79,14 +90,19 @@ impl ObjectStoreTextTable {
                 .collect::<Vec<_>>(),
         ));
 
-        let utf8_strings: Result<Vec<_>, Utf8Error> =
-            raw.iter().map(|bytes| std::str::from_utf8(bytes)).collect();
+        let utf8_strings: Result<Vec<_>, ArrowError> = raw
+            .iter()
+            .map(|bytes| {
+                let utf8 = match formatter {
+                    Some(ref f) => f.parse(bytes).boxed().map(|p| p.as_flat_utf8()),
+                    None => std::str::from_utf8(bytes).boxed().map(ToString::to_string),
+                };
+                utf8.map_err(ArrowError::from_external_error)
+            })
+            .collect();
 
         let content_array: ArrayRef = Arc::new(StringArray::from(
-            utf8_strings?
-                .into_iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>(),
+            utf8_strings?.into_iter().collect::<Vec<_>>(),
         ));
 
         RecordBatch::try_new(Arc::new(schema), vec![location_array, content_array])
@@ -124,6 +140,7 @@ impl TableProvider for ObjectStoreTextTable {
             filters,
             limit,
             self.ctx.clone(),
+            self.document_formatter.clone(),
         )))
     }
 
@@ -145,6 +162,7 @@ pub struct ObjectStoreTextExec {
     properties: PlanProperties,
 
     ctx: ObjectStoreContext,
+    formatter: Option<Arc<dyn DocumentParser>>,
 }
 
 impl std::fmt::Debug for ObjectStoreTextExec {
@@ -199,7 +217,7 @@ impl ExecutionPlan for ObjectStoreTextExec {
     ) -> DataFusionResult<SendableRecordBatchStream> {
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
-            to_sendable_stream(self.ctx.clone(), self.limit), // TODO get prefix from filters
+            to_sendable_stream(self.ctx.clone(), self.formatter.clone(), self.limit), // TODO get prefix from filters
         )))
     }
 }
@@ -210,6 +228,7 @@ impl ObjectStoreTextExec {
         filters: &[Expr],
         limit: Option<usize>,
         ctx: ObjectStoreContext,
+        formatter: Option<Arc<dyn DocumentParser>>,
     ) -> Self {
         Self {
             projected_schema: Arc::clone(&projected_schema),
@@ -221,12 +240,14 @@ impl ObjectStoreTextExec {
                 ExecutionMode::Bounded,
             ),
             ctx,
+            formatter,
         }
     }
 }
 
 pub(crate) fn to_sendable_stream(
     ctx: ObjectStoreContext,
+    formatter: Option<Arc<dyn DocumentParser>>,
     limit: Option<usize>,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> + 'static {
     stream! {
@@ -244,7 +265,7 @@ pub(crate) fn to_sendable_stream(
                     let result: GetResult = ctx.store.get(&object_meta.location).await?;
                     let bytz = result.bytes().await?;
 
-                    match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz]) {
+                    match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz], &formatter) {
                         Ok(batch) => {
                             let n = batch.num_rows();
                             yield Ok(batch);

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -94,7 +94,10 @@ impl ObjectStoreTextTable {
             .iter()
             .map(|bytes| {
                 let utf8 = match formatter {
-                    Some(ref f) => f.parse(bytes).boxed().map(|p| p.as_flat_utf8()),
+                    Some(ref f) => f
+                        .parse(bytes)
+                        .boxed()
+                        .and_then(|doc| doc.as_flat_utf8().boxed()),
                     None => std::str::from_utf8(bytes).boxed().map(ToString::to_string),
                 };
                 utf8.map_err(ArrowError::from_external_error)

--- a/crates/document_parse/Cargo.toml
+++ b/crates/document_parse/Cargo.toml
@@ -9,8 +9,8 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-docx-rs = "0.4.17"
+docx-rs = { git = "https://github.com/spiceai/docx-rs", rev="ccea202918e005b805c874149c2e6d3a00784007"}
 lopdf = "0.34.0"
 snafu.workspace = true
 bytes = "1.6.0"
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }

--- a/crates/document_parse/Cargo.toml
+++ b/crates/document_parse/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-docx-rs = { git = "https://github.com/spiceai/docx-rs", rev="ccea202918e005b805c874149c2e6d3a00784007"}
+docx-rs = { git = "https://github.com/spiceai/docx-rs", rev="2d86a60b58afb02b157f96b42a92626417e47f71"}
 lopdf = "0.34.0"
 snafu.workspace = true
 bytes = "1.6.0"

--- a/crates/document_parse/Cargo.toml
+++ b/crates/document_parse/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "document_parse"
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+docx-rs = "0.4.17"
+# docx = { git = "https://github.com/Jeadie/docx-rs", rev = "532f6b6ca5543eaf453976ec5bc683ebf38878d8"}
+lopdf = "0.34.0"
+snafu.workspace = true
+bytes = "1.6.0"
+tokio = { workspace = true }

--- a/crates/document_parse/Cargo.toml
+++ b/crates/document_parse/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 
 [dependencies]
 docx-rs = "0.4.17"
-# docx = { git = "https://github.com/Jeadie/docx-rs", rev = "532f6b6ca5543eaf453976ec5bc683ebf38878d8"}
 lopdf = "0.34.0"
 snafu.workspace = true
 bytes = "1.6.0"

--- a/crates/document_parse/src/docx.rs
+++ b/crates/document_parse/src/docx.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use bytes::Bytes;
 use snafu::ResultExt;
 use std::{any::Any, collections::HashMap, sync::Arc};
-
+use docx_rs::Render;
 use docx_rs::{read_docx, Docx};
 
 use crate::{
@@ -63,7 +63,8 @@ struct DocxDocument {
 
 impl Document for DocxDocument {
     fn as_flat_utf8(&self) -> String {
-        self.doc.json()
+        let ascii = self.doc.document.render_ascii();
+        String::from_utf8_lossy(&ascii).to_string()
     }
 
     fn type_(&self) -> DocumentType {

--- a/crates/document_parse/src/docx.rs
+++ b/crates/document_parse/src/docx.rs
@@ -63,8 +63,7 @@ struct DocxDocument {
 
 impl Document for DocxDocument {
     fn as_flat_utf8(&self) -> String {
-        let ascii = self.doc.document.render_ascii();
-        String::from_utf8_lossy(&ascii).to_string()
+        self.doc.document.render_ascii()
     }
 
     fn type_(&self) -> DocumentType {

--- a/crates/document_parse/src/docx.rs
+++ b/crates/document_parse/src/docx.rs
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use bytes::Bytes;
+use snafu::ResultExt;
+use std::{any::Any, collections::HashMap, sync::Arc};
+
+use docx_rs::{read_docx, Docx};
+
+use crate::{Document, DocumentParser, DocumentParserFactory, DocumentType, InternalParsingSnafu, Result};
+
+pub struct DocxParserFactory {}
+
+impl DocumentParserFactory for DocxParserFactory {
+    fn create(&self, parser_options: &HashMap<String, String>) -> Result<Arc<dyn DocumentParser>> {
+        Ok(Arc::new(DocxParser::new(parser_options)))
+    }
+
+    fn default(&self) -> Arc<dyn DocumentParser> {
+        Arc::new(DocxParser::default())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[derive(Default)]
+pub struct DocxParser {}
+impl DocxParser {
+    pub fn new(_parser_options: &HashMap<String, String>) -> Self {
+        DocxParser::default()
+    }    
+}
+
+impl DocumentParser for DocxParser {
+    fn parse(&self, raw: &Bytes) -> Result<Arc<dyn Document>> {
+        let doc = read_docx(raw).boxed().context(InternalParsingSnafu {
+            format: DocumentType::Docx,
+        })?;
+        Ok(Arc::new(DocxDocument { doc }))
+    }
+}
+
+struct DocxDocument {
+    pub doc: Docx,
+}
+
+impl Document for DocxDocument {
+    fn as_flat_utf8(&self) -> String {
+        self.doc.json()
+    }
+
+    fn type_(&self) -> DocumentType {
+        DocumentType::Docx
+    }
+}

--- a/crates/document_parse/src/docx.rs
+++ b/crates/document_parse/src/docx.rs
@@ -20,7 +20,9 @@ use std::{any::Any, collections::HashMap, sync::Arc};
 
 use docx_rs::{read_docx, Docx};
 
-use crate::{Document, DocumentParser, DocumentParserFactory, DocumentType, InternalParsingSnafu, Result};
+use crate::{
+    Document, DocumentParser, DocumentParserFactory, DocumentType, InternalParsingSnafu, Result,
+};
 
 pub struct DocxParserFactory {}
 
@@ -43,7 +45,7 @@ pub struct DocxParser {}
 impl DocxParser {
     pub fn new(_parser_options: &HashMap<String, String>) -> Self {
         DocxParser::default()
-    }    
+    }
 }
 
 impl DocumentParser for DocxParser {

--- a/crates/document_parse/src/docx.rs
+++ b/crates/document_parse/src/docx.rs
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 use bytes::Bytes;
-use snafu::ResultExt;
-use std::{any::Any, collections::HashMap, sync::Arc};
 use docx_rs::Render;
 use docx_rs::{read_docx, Docx};
+use snafu::ResultExt;
+use std::{any::Any, collections::HashMap, sync::Arc};
 
 use crate::{
     Document, DocumentParser, DocumentParserFactory, DocumentType, InternalParsingSnafu, Result,

--- a/crates/document_parse/src/lib.rs
+++ b/crates/document_parse/src/lib.rs
@@ -25,7 +25,9 @@ use std::{
     sync::{Arc, LazyLock},
 };
 use tokio::sync::Mutex;
+
 mod docx;
+mod pdf;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -44,6 +46,7 @@ static DOCUMENT_PARSER_FACTORY_REGISTRY: LazyLock<
 
 pub async fn register_all() {
     register_parser_factory("docx", Arc::new(docx::DocxParserFactory {})).await;
+    register_parser_factory("pdf", Arc::new(pdf::PdfParserFactory {})).await;
 }
 
 pub async fn get_parser_factory(ext: &str) -> Option<Arc<dyn DocumentParserFactory>> {
@@ -75,7 +78,7 @@ pub trait DocumentParser: Send + Sync {
 }
 
 pub trait Document {
-    fn as_flat_utf8(&self) -> String;
+    fn as_flat_utf8(&self) -> Result<String>;
     fn type_(&self) -> DocumentType;
 }
 

--- a/crates/document_parse/src/lib.rs
+++ b/crates/document_parse/src/lib.rs
@@ -1,0 +1,95 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::missing_errors_doc)]
+
+use bytes::Bytes;
+use snafu::prelude::*;
+use std::{
+    any::Any,
+    collections::HashMap,
+    fmt::Display,
+    sync::{Arc, LazyLock},
+};
+use tokio::sync::Mutex;
+mod docx;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Internal parsing {format} document. Error: {source:?}"))]
+    InternalParsingError {
+        format: DocumentType,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+static DOCUMENT_PARSER_FACTORY_REGISTRY: LazyLock<
+    Mutex<HashMap<String, Arc<dyn DocumentParserFactory>>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub async fn register_all() {
+    register_parser_factory("docx", Arc::new(docx::DocxParserFactory {})).await;
+}
+
+pub async fn get_parser_factory(ext: &str) -> Option<Arc<dyn DocumentParserFactory>> {
+    let registry = DOCUMENT_PARSER_FACTORY_REGISTRY.lock().await;
+    registry.get(ext.strip_prefix('.').unwrap_or(ext)).cloned()
+}
+
+pub async fn register_parser_factory(
+    name: &str,
+    connector_factory: Arc<dyn DocumentParserFactory>,
+) {
+    let mut registry = DOCUMENT_PARSER_FACTORY_REGISTRY.lock().await;
+    registry.insert(name.to_string(), connector_factory);
+}
+
+pub trait DocumentParserFactory: Send + Sync {
+    fn create(&self, parser_options: &HashMap<String, String>) -> Result<Arc<dyn DocumentParser>>;
+
+    /// Initialize a [`DocumentParser`] with all options set to default values
+    fn default(&self) -> Arc<dyn DocumentParser>;
+
+    /// Returns the table source as [`Any`] so that it can be
+    /// downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+}
+
+pub trait DocumentParser: Send + Sync {
+    fn parse(&self, raw: &Bytes) -> Result<Arc<dyn Document>>;
+}
+
+pub trait Document {
+    fn as_flat_utf8(&self) -> String;
+    fn type_(&self) -> DocumentType;
+}
+
+#[derive(Debug)]
+pub enum DocumentType {
+    Pdf,
+    Docx,
+}
+
+impl Display for DocumentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DocumentType::Pdf => write!(f, "PDF"),
+            DocumentType::Docx => write!(f, "DOCX"),
+        }
+    }
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -40,6 +40,7 @@ datafusion-functions-json = { workspace = true }
 datafusion-table-providers = { workspace = true }
 datafusion.workspace = true
 db_connection_pool = { path = "../db_connection_pool" }
+document_parse = { path = "../document_parse" }
 dotenvy.workspace = true
 duckdb = { workspace = true, features = [
   "bundled",

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -126,6 +126,7 @@ impl RuntimeBuilder {
         dataconnector::register_all().await;
         dataaccelerator::register_all().await;
         tools::factory::register_all().await;
+        document_parse::register_all().await;
 
         let status = match self.runtime_status {
             Some(status) => status,

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -649,11 +649,20 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
         let (file_format_opt, extension) = self.get_file_format_and_extension(dataset)?;
         match file_format_opt {
             None => {
+                let content_formatter = document_parse::get_parser_factory(extension.as_str())
+                    .await
+                    .map(|factory| {
+                        // TODO: add opts.
+                        factory.default()
+                    });
+
                 // Assume its unstructured text data. Use a [`ObjectStoreTextTable`].
+                // TODO pass in [`DocumentParser`]
                 Ok(ObjectStoreTextTable::try_new(
                     self.get_object_store(dataset)?,
                     &url.clone(),
                     Some(extension.clone()),
+                    content_formatter,
                 )
                 .context(InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),


### PR DESCRIPTION
## 🗣 Description
- New crates `document_parse`. All logic for defining how to parse and extract content from various document formats, e.g: docx, pdf. 
- For `ObjectStoreTextTable`, use a `document_parse::DocumentParser` dependent on file format. 

## 🔨 Related Issues
 - #2718 