### PR TITLE
Microsoft SQL Server data connector initial support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,6 +981,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "connection-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +2797,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.22.1",
+ "bb8",
  "bytes",
  "chrono",
  "clickhouse-rs",
@@ -2805,8 +2825,10 @@ dependencies = [
  "snafu 0.8.4",
  "snowflake-api",
  "spark-connect-rs",
+ "tiberius",
  "tokio",
  "tokio-postgres",
+ "tokio-util",
  "tonic",
  "tracing",
  "tracing-subscriber",
@@ -7756,6 +7778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8693,9 +8721,11 @@ dependencies = [
  "ssh2",
  "suppaftp",
  "telemetry",
+ "tiberius",
  "tokio",
  "tokio-rusqlite",
  "tokio-rustls 0.26.0",
+ "tokio-util",
  "tonic",
  "tonic-health",
  "tracing",
@@ -10171,6 +10201,34 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float 2.10.1",
+]
+
+[[package]]
+name = "tiberius"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "connection-string",
+ "encoding_rs",
+ "enumflags2",
+ "futures-util",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "pretty-hex",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
+ "thiserror",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
+ "tracing",
+ "uuid 1.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ snafu = "0.8.0"
 snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", rev = "2991d97548b0cd7a721704165ed07f7b2818cf7b" }
 ssh2 = { version = "0.9.4" }
 suppaftp = { version = "5.3.1", features = ["async"] }
+tiberius = { version = "0.12.3", default-features = false, features = ["tds73", "rustls"] }
 tokio = { version = "1.39.3", features = [
   "rt-multi-thread",
   "signal",
@@ -104,6 +105,7 @@ tokio-postgres = { version = "0.7.12", features = [
   "with-uuid-1",
 ] }
 tokio-rusqlite = "0.5.1"
+tokio-util = { version = "0.7.11", features = ["compat"] }
 tonic = { version = "0.11", features = ["gzip", "tls"] }
 tonic-health = { version = "0.11" }
 tracing = "0.1.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ snafu = "0.8.0"
 snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", rev = "2991d97548b0cd7a721704165ed07f7b2818cf7b" }
 ssh2 = { version = "0.9.4" }
 suppaftp = { version = "5.3.1", features = ["async"] }
-tiberius = { version = "0.12.3", default-features = false, features = ["tds73", "rustls"] }
+tiberius = { version = "0.12.3", default-features = false, features = ["tds73", "rustls", "chrono"] }
 tokio = { version = "1.39.3", features = [
   "rt-multi-thread",
   "signal",

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -55,6 +55,7 @@ default = [
   "ftp",
   "debezium",
   "anonymous_telemetry",
+  "mssql",
 ]
 delta_lake = ["runtime/delta_lake"]
 dev = ["runtime/dev"]
@@ -64,6 +65,7 @@ flightsql = ["runtime/flightsql"]
 ftp = ["runtime/ftp"]
 keyring-secret-store = ["runtime/keyring-secret-store"]
 models = ["runtime/models"]
+mssql = ["runtime/mssql"]
 mysql = ["runtime/mysql"]
 odbc = ["runtime/odbc"]
 postgres = ["runtime/postgres"]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -17,6 +17,7 @@ arrow.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+bb8 = {workspace = true, optional = true }
 bytes = "1.6.0"
 chrono.workspace = true
 clickhouse-rs = { workspace = true, optional = true }
@@ -77,7 +78,7 @@ duckdb = [
   "datafusion-table-providers/duckdb"
 ]
 flightsql = ["dep:tonic"]
-mssql = ["dep:tiberius", "dep:tokio-util"]
+mssql = ["dep:tiberius", "dep:tokio-util", "dep:bb8"]
 mysql = ["datafusion-table-providers/mysql"]
 odbc = []
 postgres = ["dep:tokio-postgres", "datafusion-table-providers/postgres"]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -52,10 +52,12 @@ snowflake-api = { workspace = true, optional = true }
 spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "d937df525d7c237c717b42e6146494c524dbf267", features = [
   "tls",
 ], optional = true }
+tiberius = { workspace = true, optional = true }
 tokio-postgres = { workspace = true, features = [
   "with-chrono-0_4",
 ], optional = true }
 tokio.workspace = true
+tokio-util = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
 tracing.workspace = true
 url = "2.5.0"
@@ -75,6 +77,7 @@ duckdb = [
   "datafusion-table-providers/duckdb"
 ]
 flightsql = ["dep:tonic"]
+mssql = ["dep:tiberius", "dep:tokio-util"]
 mysql = ["datafusion-table-providers/mysql"]
 odbc = []
 postgres = ["dep:tokio-postgres", "datafusion-table-providers/postgres"]

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -41,6 +41,8 @@ pub mod flight;
 pub mod flightsql;
 #[cfg(feature = "debezium")]
 pub mod kafka;
+#[cfg(feature = "mssql")]
+pub mod mssql;
 #[cfg(feature = "mysql")]
 pub mod mysql;
 #[cfg(feature = "odbc")]

--- a/crates/data_components/src/mssql.rs
+++ b/crates/data_components/src/mssql.rs
@@ -1,4 +1,3 @@
-use arrow::datatypes::{Schema, SchemaRef};
 /*
 Copyright 2024 The Spice.ai OSS Authors
 
@@ -15,49 +14,136 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use async_trait::async_trait;
-use snafu::Snafu;
-use tiberius::Client;
+use bb8::Pool;
+use futures::StreamExt;
+use snafu::{OptionExt, ResultExt, Snafu};
+use tiberius::{Client, Config};
 use tokio::net::TcpStream;
 
 use crate::arrow::write::MemTable;
 
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::{
     catalog::Session,
     datasource::{TableProvider, TableType},
     error::DataFusionError,
     logical_expr::{Expr, TableProviderFilterPushDown},
-    physical_plan::ExecutionPlan, sql::TableReference,
+    physical_plan::ExecutionPlan,
+    sql::TableReference,
 };
 use std::{any::Any, sync::Arc};
-
-use tokio_util::compat::Compat;
+use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Error executing query: {source}"))]
     QueryError { source: tiberius::error::Error },
+
+    #[snafu(display("Unable to parse connection string: {source}"))]
+    InvalidConnectionStringError { source: tiberius::error::Error },
+
+    #[snafu(display("Unable to connect: {source}"))]
+    SqlServerAccessError { source: tiberius::error::Error },
+
+    #[snafu(display("Failed to retrieve the schema"))]
+    SchemaRetrieval,
+
+    #[snafu(display("Unsupported MS SQL data type: {data_type}"))]
+    UnsupportedType { data_type: String },
 }
 
-pub type SqlServerTcpClient = Client<Compat<TcpStream>>;
+pub type SqlServerConnectionPool = Pool<TiberiusConnectionManager>;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct SqlServerTableProvider {
-    client: Arc<SqlServerTcpClient>,
+    #[allow(dead_code)]
+    conn: Arc<SqlServerConnectionPool>,
     schema: SchemaRef,
 }
 
 impl SqlServerTableProvider {
-    pub async fn new(client: Arc<SqlServerTcpClient>, table: &TableReference) -> Result<Self> {
+    pub async fn new(conn: Arc<SqlServerConnectionPool>, table: &TableReference) -> Result<Self> {
+        let schema = Self::get_schema(Arc::clone(&conn), table).await?;
 
-        let schema = Self::get_schema(Arc::clone(&client), table).await?;
-
-        Ok(Self { client, schema })
+        Ok(Self { conn, schema })
     }
 
-    pub async fn get_schema(client: Arc<SqlServerTcpClient>, _table: &TableReference) -> Result<SchemaRef> {
-        Ok(Arc::new(Schema::empty()))
+    pub async fn get_schema(
+        conn: Arc<SqlServerConnectionPool>,
+        table: &TableReference,
+    ) -> Result<SchemaRef> {
+        let table_name = table.to_string();
+        let query: String = format!("SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{table_name}'");
+
+        tracing::debug!("Executing schema query for dataset {table_name}: {query}");
+
+        let mut conn = conn.get().await.unwrap();
+
+        let mut query_res = conn
+            .simple_query(query)
+            .await
+            .context(QuerySnafu)?
+            .into_row_stream();
+
+        let mut fields = Vec::new();
+
+        while let Some(row_result) = query_res.next().await {
+            let row = row_result.context(QuerySnafu)?;
+
+            let column_name: &str = row.get(0).context(SchemaRetrievalSnafu)?;
+            let data_type: &str = row.get(1).context(SchemaRetrievalSnafu)?;
+            let numeric_precision: Option<u8> = row.get(2);
+            let numeric_scale: Option<i32> = row.get(3);
+            let arrow_data_type =
+                map_mssql_type_to_arrow(data_type, numeric_precision, numeric_scale)?;
+
+            fields.push(Field::new(column_name, arrow_data_type, true));
+        }
+        tracing::trace!("Retrieved schema for dataset {table_name}: {fields:?}");
+
+        Ok(Arc::new(Schema::new(fields)))
     }
+}
+
+fn map_mssql_type_to_arrow(
+    data_type: &str,
+    numeric_precision: Option<u8>,
+    numeric_scale: Option<i32>,
+) -> Result<DataType> {
+    // https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql
+    let arrow_type = match data_type.to_lowercase().as_str() {
+        "int" => DataType::Int32,
+        "bigint" => DataType::Int64,
+        "smallint" => DataType::Int16,
+        "tinyint" => DataType::Int8,
+        "float" => DataType::Float64,
+        "real" => DataType::Float32,
+        "decimal" | "numeric" => {
+            let precision = numeric_precision.unwrap_or(38) as u8;
+            let scale = numeric_scale.unwrap_or(0) as i8;
+            DataType::Decimal128(precision, scale)
+        }
+        "char" | "varchar" | "text" | "uniqueidentifier" | "xml" => DataType::Utf8,
+        "nchar" | "nvarchar" | "ntext" => DataType::LargeUtf8,
+        "binary" => DataType::FixedSizeBinary(numeric_precision.unwrap_or(1) as i32),
+        "varbinary" | "image" => DataType::Binary,
+        "date" => DataType::Date32,
+        "time" => DataType::Time64(TimeUnit::Microsecond),
+        "datetime" | "smalldatetime" | "datetime2" => {
+            DataType::Timestamp(TimeUnit::Microsecond, None)
+        }
+        // TODO: correct support for time zones
+        "datetimeoffset" => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+        "bit" => DataType::Boolean,
+        other => {
+            return Err(Error::UnsupportedType {
+                data_type: other.to_string(),
+            })
+        }
+    };
+
+    Ok(arrow_type)
 }
 
 #[async_trait]
@@ -93,5 +179,50 @@ impl TableProvider for SqlServerTableProvider {
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         let table = MemTable::try_new(Arc::clone(&self.schema), vec![])?;
         table.scan(state, projection, filters, limit).await
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TiberiusConnectionManager {
+    config: Config,
+}
+
+impl TiberiusConnectionManager {
+    fn new(config: Config) -> tiberius::Result<TiberiusConnectionManager> {
+        Ok(TiberiusConnectionManager { config })
+    }
+
+    pub async fn create_connection_pool(
+        connection_string: &str,
+    ) -> Result<SqlServerConnectionPool> {
+        let config =
+            Config::from_ado_string(connection_string).context(InvalidConnectionStringSnafu)?;
+        let manager = TiberiusConnectionManager::new(config).unwrap();
+        let pool = bb8::Pool::builder()
+            .build(manager)
+            .await
+            .context(SqlServerAccessSnafu)?;
+        Ok(pool)
+    }
+}
+
+#[async_trait]
+impl bb8::ManageConnection for TiberiusConnectionManager {
+    type Connection = Client<Compat<TcpStream>>;
+    type Error = tiberius::error::Error;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let tcp = TcpStream::connect(&self.config.get_addr()).await?;
+        tcp.set_nodelay(true)?;
+        Client::connect(self.config.clone(), tcp.compat_write()).await
+    }
+
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        conn.simple_query("SELECT 1").await?.into_row().await?;
+        Ok(())
+    }
+
+    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+        false
     }
 }

--- a/crates/data_components/src/mssql.rs
+++ b/crates/data_components/src/mssql.rs
@@ -1,0 +1,97 @@
+use arrow::datatypes::{Schema, SchemaRef};
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use async_trait::async_trait;
+use snafu::Snafu;
+use tiberius::Client;
+use tokio::net::TcpStream;
+
+use crate::arrow::write::MemTable;
+
+use datafusion::{
+    catalog::Session,
+    datasource::{TableProvider, TableType},
+    error::DataFusionError,
+    logical_expr::{Expr, TableProviderFilterPushDown},
+    physical_plan::ExecutionPlan, sql::TableReference,
+};
+use std::{any::Any, sync::Arc};
+
+use tokio_util::compat::Compat;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Error executing query: {source}"))]
+    QueryError { source: tiberius::error::Error },
+}
+
+pub type SqlServerTcpClient = Client<Compat<TcpStream>>;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct SqlServerTableProvider {
+    client: Arc<SqlServerTcpClient>,
+    schema: SchemaRef,
+}
+
+impl SqlServerTableProvider {
+    pub async fn new(client: Arc<SqlServerTcpClient>, table: &TableReference) -> Result<Self> {
+
+        let schema = Self::get_schema(Arc::clone(&client), table).await?;
+
+        Ok(Self { client, schema })
+    }
+
+    pub async fn get_schema(client: Arc<SqlServerTcpClient>, _table: &TableReference) -> Result<SchemaRef> {
+        Ok(Arc::new(Schema::empty()))
+    }
+}
+
+#[async_trait]
+impl TableProvider for SqlServerTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> std::result::Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        Ok(vec![
+            TableProviderFilterPushDown::Unsupported;
+            filters.len()
+        ])
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        let table = MemTable::try_new(Arc::clone(&self.schema), vec![])?;
+        table.scan(state, projection, filters, limit).await
+    }
+}

--- a/crates/data_components/src/mssql.rs
+++ b/crates/data_components/src/mssql.rs
@@ -233,7 +233,6 @@ fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> Result<RecordBatch> {
             let data_type =
                 map_column_type_to_arrow_type(column_type, decimal_precision, decimal_scale);
 
-            // arrow_fields.push(Field::new(column_name.clone(), data_type.clone(), true));
             arrow_columns_builders.push(map_data_type_to_array_builder_optional(Some(&data_type)));
             mssql_types.push(column_type);
             column_names.push(column_name.to_string());

--- a/crates/data_components/src/mssql.rs
+++ b/crates/data_components/src/mssql.rs
@@ -103,7 +103,7 @@ impl SqlServerTableProvider {
         let table_name = table.to_string();
         let columns_meta_query: String = format!("SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{table_name}'");
 
-        tracing::debug!("Executing schema query for dataset {table_name}: {columns_meta_query}");
+        tracing::info!("Executing schema query for dataset {table_name}: {columns_meta_query}");
 
         let mut conn = conn.get().await.unwrap();
 
@@ -139,7 +139,7 @@ impl SqlServerTableProvider {
         sql: &str,
         projected_schema: SchemaRef,
     ) -> Result<Vec<RecordBatch>, Box<dyn std::error::Error + Send + Sync>> {
-        tracing::trace!("Executing sql: {sql}");
+        tracing::info!("Executing sql: {sql}");
 
         let conn_pool = Arc::clone(&self.conn);
         let schema = Arc::clone(&projected_schema);

--- a/crates/data_components/src/mssql.rs
+++ b/crates/data_components/src/mssql.rs
@@ -101,8 +101,10 @@ impl SqlServerTableProvider {
         conn: Arc<SqlServerConnectionPool>,
         table: &TableReference,
     ) -> Result<SchemaRef> {
-        let table_name = table.to_string();
-        let columns_meta_query: String = format!("SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{table_name}'");
+        let table_name = table.table();
+        let table_schema = table.schema().unwrap_or("dbo");
+
+        let columns_meta_query: String = format!("SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{table_name}' AND TABLE_SCHEMA = '{table_schema}'");
 
         tracing::info!("Executing schema query for dataset {table_name}: {columns_meta_query}");
 

--- a/crates/data_components/src/mssql.rs
+++ b/crates/data_components/src/mssql.rs
@@ -15,17 +15,35 @@ limitations under the License.
 */
 use async_trait::async_trait;
 use bb8::Pool;
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use clickhouse_rs::types::Column;
+use datafusion_table_providers::sql::arrow_sql_gen::arrow::map_data_type_to_array_builder_optional;
 use futures::{StreamExt, TryStreamExt};
+use graphql_parser::schema;
 use snafu::{OptionExt, ResultExt, Snafu};
-use tiberius::{Client, Config};
+use tiberius::{numeric::Numeric, Client, ColumnType, Config, Row};
 use tokio::net::TcpStream;
 
 use crate::arrow::write::MemTable;
 
-use arrow::{array::RecordBatch, datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit}};
-use datafusion::{
-    catalog::Session, datasource::{TableProvider, TableType}, error::DataFusionError, execution::SendableRecordBatchStream, logical_expr::{Expr, TableProviderFilterPushDown}, physical_plan::{EmptyRecordBatchStream, ExecutionPlan}, sql::{sqlparser::ast::Table, TableReference}
+use arrow::{
+    array::{
+        ArrayBuilder, ArrayRef, BooleanBuilder, Date32Builder, Decimal128Builder, Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder, Int8Builder, NullBuilder, RecordBatch, RecordBatchOptions, StringBuilder, Time64NanosecondBuilder, TimestampMillisecondBuilder, TimestampNanosecondBuilder, UInt8Builder
+    },
+    datatypes::{DataType, Date32Type, Field, Schema, SchemaRef, TimeUnit},
 };
+use datafusion::{
+    catalog::Session,
+    datasource::{TableProvider, TableType},
+    error::DataFusionError,
+    execution::SendableRecordBatchStream,
+    logical_expr::{Expr, TableProviderFilterPushDown},
+    physical_plan::{stream::RecordBatchStreamAdapter, EmptyRecordBatchStream, ExecutionPlan},
+    sql::{sqlparser::ast::Table, TableReference},
+};
+
+use chrono::{DateTime, Offset, Timelike, Utc};
+
 use std::{any::Any, sync::Arc};
 use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
 
@@ -45,6 +63,15 @@ pub enum Error {
 
     #[snafu(display("Unsupported MS SQL data type: {data_type}"))]
     UnsupportedType { data_type: String },
+
+    #[snafu(display("Failed to build record batch: {source}"))]
+    FailedToBuildRecordBatch { source: arrow::error::ArrowError },
+
+    #[snafu(display("No builder found for index {index}"))]
+    NoBuilderForIndex { index: usize },
+
+    #[snafu(display("Failed to downcast builder for {mssql_type}"))]
+    FailedToDowncastBuilder { mssql_type: String },
 }
 
 pub type SqlServerConnectionPool = Pool<TiberiusConnectionManager>;
@@ -62,7 +89,11 @@ impl SqlServerTableProvider {
     pub async fn new(conn: Arc<SqlServerConnectionPool>, table: &TableReference) -> Result<Self> {
         let schema = Self::get_schema(Arc::clone(&conn), table).await?;
 
-        Ok(Self { conn, schema, table: table.clone() })
+        Ok(Self {
+            conn,
+            schema,
+            table: table.clone(),
+        })
     }
 
     pub async fn get_schema(
@@ -70,14 +101,14 @@ impl SqlServerTableProvider {
         table: &TableReference,
     ) -> Result<SchemaRef> {
         let table_name = table.to_string();
-        let query: String = format!("SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{table_name}'");
+        let columns_meta_query: String = format!("SELECT COLUMN_NAME, DATA_TYPE, NUMERIC_PRECISION, NUMERIC_SCALE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{table_name}'");
 
-        tracing::debug!("Executing schema query for dataset {table_name}: {query}");
+        tracing::debug!("Executing schema query for dataset {table_name}: {columns_meta_query}");
 
         let mut conn = conn.get().await.unwrap();
 
         let mut query_res = conn
-            .simple_query(query)
+            .simple_query(columns_meta_query)
             .await
             .context(QuerySnafu)?
             .into_row_stream();
@@ -91,56 +122,390 @@ impl SqlServerTableProvider {
             let data_type: &str = row.get(1).context(SchemaRetrievalSnafu)?;
             let numeric_precision: Option<u8> = row.get(2);
             let numeric_scale: Option<i32> = row.get(3);
+
+            let column_type = map_type_name_to_column_type(data_type)?;
             let arrow_data_type =
-                map_mssql_type_to_arrow(data_type, numeric_precision, numeric_scale)?;
+                map_column_type_to_arrow_type(column_type, numeric_precision, numeric_scale.map(|v| v as i8));
 
             fields.push(Field::new(column_name, arrow_data_type, true));
         }
-        tracing::trace!("Retrieved schema for dataset {table_name}: {fields:?}");
+        tracing::trace!("Retrieved dataset {table_name}: {fields:?}");
 
         Ok(Arc::new(Schema::new(fields)))
     }
 
     async fn query_arrow(
         &self,
-        _sql: &str,
+        sql: &str,
         projected_schema: SchemaRef,
-    ) -> Result<SendableRecordBatchStream, Box<dyn std::error::Error + Send + Sync>> {
-        let empty_stream = EmptyRecordBatchStream::new(Arc::clone(&projected_schema));
-        Ok(Box::pin(empty_stream))
+    ) -> Result<Vec<RecordBatch>, Box<dyn std::error::Error + Send + Sync>> {
+        tracing::trace!("Executing sql: {sql}");
+
+        let conn_pool = Arc::clone(&self.conn);
+        let schema = Arc::clone(&projected_schema);
+
+        let mut conn = conn_pool.get().await.unwrap();
+
+        let query_res = conn
+            .simple_query(sql)
+            .await
+            .context(QuerySnafu)?
+            .into_row_stream();
+
+        let mut chunked_stream = query_res.chunks(4_000).boxed();
+
+        let mut records: Vec<RecordBatch> = Vec::new();
+
+        while let Some(chunk) = chunked_stream.next().await {
+            let rows = chunk
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .context(QuerySnafu)
+                .map_err(to_datafusion_err)?;
+
+            records.push(rows_to_arrow(&rows, &schema)?);
+        }
+
+        Ok(records)
     }
 }
 
-fn map_mssql_type_to_arrow(
-    data_type: &str,
-    numeric_precision: Option<u8>,
-    numeric_scale: Option<i32>,
-) -> Result<DataType> {
-    // https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql
-    let arrow_type = match data_type.to_lowercase().as_str() {
-        "int" => DataType::Int32,
-        "bigint" => DataType::Int64,
-        "smallint" => DataType::Int16,
-        "tinyint" => DataType::Int8,
-        "float" => DataType::Float64,
-        "real" => DataType::Float32,
-        "decimal" | "numeric" => {
-            let precision = numeric_precision.unwrap_or(38) as u8;
-            let scale = numeric_scale.unwrap_or(0) as i8;
+fn to_datafusion_err(e: Error) -> datafusion::error::DataFusionError {
+    datafusion::error::DataFusionError::External(Box::new(e))
+}
+
+macro_rules! handle_primitive_type {
+    ($builder:expr, $type:expr, $builder_ty:ty, $value_ty:ty, $row:expr, $index:expr) => {{
+        let Some(builder) = $builder else {
+            return NoBuilderForIndexSnafu { index: $index }.fail();
+        };
+        let Some(builder) = builder.as_any_mut().downcast_mut::<$builder_ty>() else {
+            return FailedToDowncastBuilderSnafu {
+                mssql_type: format!("{:?}", $type),
+            }
+            .fail();
+        };
+        let v = $row.get::<$value_ty, usize>($index);
+        match v {
+            Some(v) => builder.append_value(v),
+            None => builder.append_null(),
+        }
+    }};
+}
+
+fn get_column_precision_and_scale(column_name: &str, projected_schema: &SchemaRef) -> Option<(u8, i8)> {
+    let field = projected_schema.field_with_name(column_name).ok()?;
+    match field.data_type() {
+        DataType::Decimal128(precision, scale) => Some((*precision, *scale)),
+        _ => None,
+    }
+}
+
+pub fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> Result<RecordBatch> {
+    // let mut arrow_fields: Vec<Field> = Vec::new();
+    let mut arrow_columns_builders: Vec<Option<Box<dyn ArrayBuilder>>> = Vec::new();
+    let mut mssql_types: Vec<ColumnType> = Vec::new();
+    let mut column_names: Vec<String> = Vec::new();
+
+    if !rows.is_empty() {
+        let row = &rows[0];
+        for column in row.columns().iter() {
+            let column_name = column.name();
+            let column_type = column.column_type();
+
+            let (decimal_precision, decimal_scale) = match column_type {
+                ColumnType::Decimaln | ColumnType::Numericn => {
+                    // use 38, 10 as default precision and scale for decimal types
+                    let (precision, scale) = get_column_precision_and_scale(&column_name, schema).unwrap_or((38, 10));
+                    
+                    (Some(precision), Some(scale))
+                }
+                _ => (None, None),
+            };
+            let data_type = map_column_type_to_arrow_type(column_type, decimal_precision, decimal_scale);
+
+            // arrow_fields.push(Field::new(column_name.clone(), data_type.clone(), true));
+            arrow_columns_builders.push(map_data_type_to_array_builder_optional(Some(&data_type)));
+            mssql_types.push(column_type);
+            column_names.push(column_name.to_string());
+        }
+    }
+
+    for row in rows {
+        for (i, mssql_type) in mssql_types.iter().enumerate() {
+            let Some(builder) = arrow_columns_builders.get_mut(i) else {
+                return NoBuilderForIndexSnafu { index: i }.fail();
+            };
+
+            match *mssql_type {
+                ColumnType::Null => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<NullBuilder>() else {
+                        return FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    builder.append_null();
+                }
+                ColumnType::Int4 => {
+                    handle_primitive_type!(builder, ColumnType::Int4, Int32Builder, i32, row, i);
+                }
+                ColumnType::Int1 => {
+                    handle_primitive_type!(builder, ColumnType::Int1, UInt8Builder, u8, row, i);
+                }
+                ColumnType::Int2 => {
+                    handle_primitive_type!(builder, ColumnType::Int2, Int16Builder, i16, row, i);
+                }
+                ColumnType::Int8 => {
+                    handle_primitive_type!(builder, ColumnType::Int8, Int64Builder, i64, row, i);
+                }
+                ColumnType::Float4 => {
+                    handle_primitive_type!(
+                        builder,
+                        ColumnType::Float4,
+                        Float32Builder,
+                        f32,
+                        row,
+                        i
+                    );
+                }
+                ColumnType::Float8 => {
+                    handle_primitive_type!(
+                        builder,
+                        ColumnType::Float8,
+                        Float64Builder,
+                        f64,
+                        row,
+                        i
+                    );
+                }
+                ColumnType::Bit | ColumnType::Bitn => {
+                    handle_primitive_type!(builder, ColumnType::Bit, BooleanBuilder, bool, row, i);
+                }
+                ColumnType::Datetime | ColumnType::Datetimen | ColumnType::Datetime4 => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder
+                        .as_any_mut()
+                        .downcast_mut::<TimestampMillisecondBuilder>()
+                    else {
+                        return FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<NaiveDateTime, usize>(i);
+                    match v {
+                        Some(v) => builder.append_value(v.and_utc().timestamp_millis()),
+                        None => builder.append_null(),
+                    }
+                }
+
+                ColumnType::Datetime2 => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder
+                        .as_any_mut()
+                        .downcast_mut::<TimestampNanosecondBuilder>()
+                    else {
+                        return FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<NaiveDateTime, usize>(i);
+                    match v {
+                        Some(v) => builder.append_value(v.and_utc().timestamp_nanos()),
+                        None => builder.append_null(),
+                    }
+                }
+
+                ColumnType::Daten => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<Date32Builder>() else {
+                        return FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<NaiveDate, usize>(i);
+                    match v {
+                        Some(v) => builder.append_value(Date32Type::from_naive_date(v)),
+                        None => builder.append_null(),
+                    }
+                }
+
+                ColumnType::Timen => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder
+                        .as_any_mut()
+                        .downcast_mut::<Time64NanosecondBuilder>()
+                    else {
+                        return FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<NaiveTime, usize>(i);
+                    match v {
+                        Some(v) => {
+                            let timestamp: i64 = i64::from(v.num_seconds_from_midnight())
+                                * 1_000_000_000
+                                + i64::from(v.nanosecond());
+                            builder.append_value(timestamp);
+                        }
+                        None => builder.append_null(),
+                    }
+                }
+                ColumnType::Money | ColumnType::Money4 => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<Float64Builder>()
+                    else {
+                        return FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<f64, usize>(i);
+                    match v {
+                        Some(v) => builder.append_value(v),
+                        None => builder.append_null(),
+                    }
+                }
+                ColumnType::Decimaln | ColumnType::Numericn => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<Decimal128Builder>() else {
+                        return FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<Numeric, usize>(i);
+                    match v {
+                        Some(v) => builder.append_value(v.value()),
+                        None => builder.append_null(),
+                    }
+                }
+                ColumnType::BigVarChar
+                | ColumnType::BigChar
+                | ColumnType::NVarchar
+                | ColumnType::NChar
+                | ColumnType::Xml
+                | ColumnType::Udt
+                | ColumnType::Text
+                | ColumnType::NText
+                | ColumnType::SSVariant => {
+                    let Some(builder) = builder else {
+                        return NoBuilderForIndexSnafu { index: i }.fail();
+                    };
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<StringBuilder>() else {
+                        return FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<&str, usize>(i);
+                    match v {
+                        Some(v) => builder.append_value(v),
+                        None => builder.append_null(),
+                    }
+                }
+                _ => unimplemented!("Unsupported column type {:?}", mssql_type),
+            }
+        }
+    }
+
+    let columns = arrow_columns_builders
+        .into_iter()
+        .filter_map(|builder| builder.map(|mut b| b.finish()))
+        .collect::<Vec<ArrayRef>>();
+    //let arrow_fields = arrow_fields.into_iter().flatten().collect::<Vec<Field>>();
+    let options = &RecordBatchOptions::new().with_row_count(Some(rows.len()));
+    RecordBatch::try_new_with_options(Arc::clone(schema), columns, options)
+        .map_err(|err| Error::FailedToBuildRecordBatch { source: err })
+}
+
+pub fn map_column_type_to_arrow_type(
+    column_type: ColumnType,
+    decimal_precision: Option<u8>,
+    decimal_scale: Option<i8>,
+) -> DataType {
+    match column_type {
+        ColumnType::Null => DataType::Null,
+        // https://learn.microsoft.com/en-us/sql/t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql
+        ColumnType::Int1 => DataType::UInt8,
+        ColumnType::Int2 => DataType::Int16,
+        ColumnType::Int4 => DataType::Int32,
+        ColumnType::Int8 => DataType::Int64,
+        ColumnType::Intn => DataType::Int64,
+        ColumnType::Float4 => DataType::Float32,
+        ColumnType::Float8 => DataType::Float64,
+        ColumnType::Floatn => DataType::Float64,
+        ColumnType::Money | ColumnType::Money4 => DataType::Float64,
+        // ColumnType::Money => DataType::Decimal128(19, 4),
+        // ColumnType::Money4 => DataType::Decimal128(10, 4),
+        ColumnType::Datetime4 | ColumnType::Datetime | ColumnType::Datetimen => {
+            DataType::Timestamp(TimeUnit::Millisecond, None)
+        }
+        ColumnType::Datetime2 => DataType::Timestamp(TimeUnit::Nanosecond, None),
+        ColumnType::DatetimeOffsetn => DataType::Timestamp(TimeUnit::Nanosecond, None),
+        ColumnType::Guid => DataType::Utf8,
+        ColumnType::Decimaln | ColumnType::Numericn => {
+            let precision = decimal_precision.unwrap_or(38) as u8; // MSSQL max precision
+            let scale = decimal_scale.unwrap_or(10) as i8;
             DataType::Decimal128(precision, scale)
         }
-        "char" | "varchar" | "text" | "uniqueidentifier" | "xml" | "money" => DataType::Utf8,
-        "nchar" | "nvarchar" | "ntext" => DataType::LargeUtf8,
-        "binary" => DataType::FixedSizeBinary(numeric_precision.unwrap_or(1) as i32),
-        "varbinary" | "image" => DataType::Binary,
-        "date" => DataType::Date32,
-        "time" => DataType::Time64(TimeUnit::Microsecond),
-        "datetime" | "smalldatetime" | "datetime2" => {
-            DataType::Timestamp(TimeUnit::Microsecond, None)
-        }
-        // TODO: correct support for time zones
-        "datetimeoffset" => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
-        "bit" => DataType::Boolean,
+        ColumnType::Daten => DataType::Date32,
+        ColumnType::Timen => DataType::Time64(TimeUnit::Nanosecond),
+        ColumnType::BigVarBin | ColumnType::BigBinary => DataType::Binary,
+        ColumnType::Image => DataType::Binary,
+        ColumnType::BigVarChar | ColumnType::BigChar => DataType::Utf8,
+        ColumnType::NVarchar | ColumnType::NChar => DataType::Utf8,
+        ColumnType::Xml => DataType::Utf8,
+        ColumnType::Udt => DataType::Utf8,
+        ColumnType::Text | ColumnType::NText => DataType::Utf8,
+        ColumnType::SSVariant => DataType::Utf8,
+        ColumnType::Bit | ColumnType::Bitn => DataType::Boolean,
+    }
+}
+
+pub fn map_type_name_to_column_type(data_type: &str) -> Result<ColumnType> {
+    // https://github.com/prisma/tiberius/blob/51f0cbb3e430db74ba0ea4830b236e89f1b1e03f/src/tds/codec/token/token_col_metadata.rs#L26
+    let column_type = match data_type.to_lowercase().as_str() {
+        "int" => ColumnType::Int4,
+        "bigint" => ColumnType::Int8,
+        "smallint" => ColumnType::Int2,
+        "tinyint" => ColumnType::Int1,
+        "float" => ColumnType::Float8,
+        "real" => ColumnType::Float4,
+        "decimal" | "numeric" => ColumnType::Decimaln,
+        "char" | "varchar" | "text" => ColumnType::BigVarChar,
+        "nchar" | "nvarchar" | "ntext" => ColumnType::NVarchar,
+        "uniqueidentifier" => ColumnType::Guid,
+        "binary" => ColumnType::BigBinary,
+        "varbinary" | "image" => ColumnType::BigVarBin,
+        "xml" => ColumnType::Xml,
+        "money" => ColumnType::Money,
+        "date" => ColumnType::Daten,
+        "time" => ColumnType::Timen,
+        "datetime" => ColumnType::Datetime,
+        "smalldatetime" => ColumnType::Datetime4,
+        "datetime2" => ColumnType::Datetime2,
+        "datetimeoffset" => ColumnType::DatetimeOffsetn,
+        "bit" => ColumnType::Bit,
         other => {
             return Err(Error::UnsupportedType {
                 data_type: other.to_string(),
@@ -148,7 +513,7 @@ fn map_mssql_type_to_arrow(
         }
     };
 
-    Ok(arrow_type)
+    Ok(column_type)
 }
 
 #[async_trait]
@@ -182,13 +547,11 @@ impl TableProvider for SqlServerTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-
-        let sql = format!("SELECT * from {table_name}", table_name = self.table.to_string());
-
-        let records_batch_stream = self.query_arrow(&sql, Arc::clone(&self.schema)).await?;
-
-        let records: Vec<RecordBatch> = records_batch_stream
-            .try_collect().await.unwrap();
+        let sql = format!(
+            "SELECT * from {table_name}",
+            table_name = self.table.to_string()
+        );
+        let records = self.query_arrow(&sql, Arc::clone(&self.schema)).await?;
 
         let table = MemTable::try_new(Arc::clone(&self.schema), vec![records])?;
         table.scan(state, projection, filters, limit).await

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = { version = "0.10.8", optional = true }
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt"] }
-tokio-util = "0.7.11"
+tokio-util = { workspace = true, optional = true}
 tracing.workspace = true
 util = { path = "../util" }
 

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = { version = "0.10.8", optional = true }
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt"] }
-tokio-util = { workspace = true, optional = true}
+tokio-util = { workspace = true }
 tracing.workspace = true
 util = { path = "../util" }
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -64,6 +64,7 @@ llms = { path = "../llms" }
 logos = "0.14.0"
 mediatype = "0.19.18"
 model_components = { path = "../model_components" }
+tiberius ={ workspace = true, optional = true }
 mysql_async = { workspace = true, optional = true }
 notify = "6.1.1"
 ns_lookup = { path = "../ns_lookup" }
@@ -103,6 +104,7 @@ telemetry = { path = "../telemetry" }
 tokio-rusqlite = { workspace = true, optional = true }
 tokio-rustls = "0.26.0"
 tokio.workspace = true
+tokio-util = { workspace = true, optional = true }
 tonic-health.workspace = true
 tonic.workspace = true
 tracing.workspace = true
@@ -145,6 +147,7 @@ flightsql = ["data_components/flightsql"]
 ftp = ["dep:suppaftp", "dep:ssh2"]
 keyring-secret-store = ["dep:keyring"]
 models = ["model_components/full", "llms/mistralrs"]
+mssql = ["dep:tiberius", "dep:tokio-util", "data_components/mssql"]
 mysql = ["dep:mysql_async", "db_connection_pool/mysql", "data_components/mysql"]
 odbc = ["db_connection_pool/odbc", "data_components/odbc"]
 postgres = [

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -78,6 +78,8 @@ pub mod ftp;
 pub mod github;
 pub mod graphql;
 pub mod https;
+#[cfg(feature = "mssql")]
+pub mod mssql;
 #[cfg(feature = "mysql")]
 pub mod mysql;
 #[cfg(feature = "odbc")]
@@ -302,6 +304,8 @@ pub async fn register_all() {
     #[cfg(feature = "ftp")]
     register_connector_factory("sftp", sftp::SFTPFactory::new_arc()).await;
     register_connector_factory("spiceai", spiceai::SpiceAIFactory::new_arc()).await;
+    #[cfg(feature = "mssql")]
+    register_connector_factory("mssql", mssql::SqlServerFactory::new_arc()).await;
     #[cfg(feature = "mysql")]
     register_connector_factory("mysql", mysql::MySQLFactory::new_arc()).await;
     #[cfg(feature = "postgres")]

--- a/crates/runtime/src/dataconnector/mssql.rs
+++ b/crates/runtime/src/dataconnector/mssql.rs
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::component::dataset::Dataset;
+use async_trait::async_trait;
+use data_components::mssql::{SqlServerTableProvider, SqlServerTcpClient};
+use datafusion::datasource::TableProvider;
+use datafusion::sql::TableReference;
+use snafu::{ResultExt, Snafu};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{any::Any, future::Future};
+use tokio::net::TcpStream;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+
+use tiberius::{Client, Config};
+
+use super::{
+    DataConnector, DataConnectorFactory, DataConnectorResult, ParameterSpec, Parameters,
+    UnableToGetReadProviderSnafu,
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Missing required parameter: {parameter}"))]
+    MissingParameter { parameter: String },
+
+    #[snafu(display("Unable to parse connection string: {source}"))]
+    InvalidConnectionString { source: tiberius::error::Error },
+
+    #[snafu(display("Unable to connect: {source}"))]
+    SqlServerAccessError { source: tiberius::error::Error },
+
+    #[snafu(display("Error executing query: {source}"))]
+    QueryError { source: tiberius::error::Error },
+
+    #[snafu(display("Unable to connect: {source}"))]
+    UnableToEstablishTcpConnection { source: std::io::Error },
+}
+
+const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::connector("connection_string")
+    .secret()
+    .required()];
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct SqlServer {
+    client: Arc<SqlServerTcpClient>,
+}
+
+impl SqlServer {
+    async fn new(params: &Parameters) -> Result<Self> {
+        let conn_string = params
+            .get("connection_string")
+            .expose()
+            .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?;
+
+        let config = Config::from_ado_string(conn_string).context(InvalidConnectionStringSnafu)?;
+
+        let tcp = TcpStream::connect(config.get_addr())
+            .await
+            .context(UnableToEstablishTcpConnectionSnafu)?;
+        tcp.set_nodelay(true)
+            .context(UnableToEstablishTcpConnectionSnafu)?;
+
+        let mut client = Client::connect(config, tcp.compat_write())
+            .await
+            .context(SqlServerAccessSnafu)?;
+
+        // Test connection
+        client
+            .query("SELECT 1", &[])
+            .await
+            .context(QueryFailedSnafu)?;
+
+        return Ok(Self {
+            client: Arc::new(client),
+        });
+    }
+}
+
+#[derive(Default, Copy, Clone)]
+pub struct SqlServerFactory {}
+
+impl SqlServerFactory {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    #[must_use]
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+impl DataConnectorFactory for SqlServerFactory {
+    fn create(
+        &self,
+        params: Parameters,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(
+            async move { Ok(Arc::new(SqlServer::new(&params).await?) as Arc<dyn DataConnector>) },
+        )
+    }
+
+    fn prefix(&self) -> &'static str {
+        "mssql"
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        PARAMETERS
+    }
+}
+
+#[async_trait]
+impl DataConnector for SqlServer {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> DataConnectorResult<Arc<dyn TableProvider>> {
+        let provider = SqlServerTableProvider::new(Arc::clone(&self.client))
+            .await
+            .boxed()
+            .context(UnableToGetReadProviderSnafu {
+                dataconnector: "mssql",
+            });
+
+        Ok(Arc::new(provider.unwrap()))
+    }
+}

--- a/crates/runtime/src/dataconnector/mssql.rs
+++ b/crates/runtime/src/dataconnector/mssql.rs
@@ -60,9 +60,9 @@ impl SqlServer {
             .await
             .context(UnableToCreateConnectionPoolSnafu)?;
 
-        return Ok(Self {
+        Ok(Self {
             conn: Arc::new(conn),
-        });
+        })
     }
 }
 
@@ -115,8 +115,8 @@ impl DataConnector for SqlServer {
             .boxed()
             .context(UnableToGetReadProviderSnafu {
                 dataconnector: "mssql",
-            });
+            })?;
 
-        Ok(Arc::new(provider.unwrap()))
+        Ok(Arc::new(provider))
     }
 }

--- a/crates/runtime/src/dataconnector/mssql.rs
+++ b/crates/runtime/src/dataconnector/mssql.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::mssql::{
-    self, SqlServerConnectionPool, SqlServerTableProvider, TiberiusConnectionManager,
+    self, SqlServerConnectionManager, SqlServerConnectionPool, SqlServerTableProvider,
 };
 use datafusion::datasource::TableProvider;
 use snafu::{ResultExt, Snafu};
@@ -56,7 +56,7 @@ impl SqlServer {
             .expose()
             .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?;
 
-        let conn = TiberiusConnectionManager::create_connection_pool(conn_string)
+        let conn = SqlServerConnectionManager::create_connection_pool(conn_string)
             .await
             .context(UnableToCreateConnectionPoolSnafu)?;
 


### PR DESCRIPTION
## 🗣 Description

Initial support for Microsoft SQL Server Data Connector.:
 - Auth/connection via `connection_string`
 - Schema inference (all data types except Timestampz and Binary types)
 - Query

```yaml
datasets:
  - from: mssql:saleslt.customer
    name: customer
    params: 
      mssql_connection_string: ${ secrets:MSSQL_CONNECTION_STRING }
```

The following will be done next:
 - More testing and improving error messages
 - Correct support for Timestampz and adding binary types support
 - Basic support for predicates pushdown
 - Streaming


## 🔨 Related Issues

Implements https://github.com/spiceai/spiceai/issues/2736
Part of https://github.com/spiceai/spiceai/issues/2688

## 🤔 Concerns

 Does not use `DbConnectionPool`, added minimal implementation as `SqlServerConnectionManager/SqlServerConnectionPool` directly to data component using bb8. This needs to be revised/improved.