### PR TITLE
Upgrade to Arrow 53, DataFusion 42 and DuckDB 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=69b47e3b371df2c117b059f12da4f1a89b0e6a48#69b47e3b371df2c117b059f12da4f1a89b0e6a48"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b9be339bf79425df265c6b43f81825418cb61d81#b9be339bf79425df265c6b43f81825418cb61d81"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "log",
  "tokio",
@@ -2896,7 +2896,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "arrow",
  "chrono",
@@ -2916,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2998,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3018,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3065,7 +3065,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
@@ -3076,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3095,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3126,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "arrow-schema",
  "datafusion-common",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3186,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "42.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ce18dfa80684d4084b9822e640c3989946b11e15#ce18dfa80684d4084b9822e640c3989946b11e15"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,19 +264,40 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05048a8932648b63f21c37d88b552ccc8a65afb6dfe9fc9f30ce79174c2e7a85"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 52.2.0",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-cast 52.2.0",
+ "arrow-csv 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-ipc 52.2.0",
+ "arrow-json 52.2.0",
+ "arrow-ord 52.2.0",
+ "arrow-row 52.2.0",
+ "arrow-schema 52.2.0",
+ "arrow-select 52.2.0",
+ "arrow-string 52.2.0",
+]
+
+[[package]]
+name = "arrow"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45aef0d9cf9a039bf6cd1acc451b137aca819977b0928dece52bd92811b640ba"
+dependencies = [
+ "arrow-arith 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-cast 53.0.0",
+ "arrow-csv 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-ipc 53.0.0",
+ "arrow-json 53.0.0",
+ "arrow-ord 53.0.0",
+ "arrow-row 53.0.0",
+ "arrow-schema 53.0.0",
+ "arrow-select 53.0.0",
+ "arrow-string 53.0.0",
 ]
 
 [[package]]
@@ -285,10 +306,25 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d8a57966e43bfe9a3277984a14c24ec617ad874e4c0e1d2a1b083a39cfbf22c"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "chrono",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03675e42d1560790f3524800e41403b40d0da1c793fe9528929fde06d8c7649a"
+dependencies = [
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
  "chrono",
  "half",
  "num",
@@ -301,9 +337,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
 dependencies = [
  "ahash 0.8.11",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "chrono",
+ "half",
+ "hashbrown 0.14.5",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2bf348cf9f02a5975c5962c7fa6dee107a2009a7b41ac5fb1a027e12dc033f"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-buffer 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
  "chrono",
  "chrono-tz 0.9.0",
  "half",
@@ -323,16 +375,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3092e37715f168976012ce52273c3989b5793b0db5f06cbaa246be25e5f0924d"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da26719e76b81d8bc3faad1d4dbdc1bcc10d14704e63dc17fc9f3e7e1e567c8e"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "arrow-select 52.2.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce1018bb710d502f9db06af026ed3561552e493e989a79d0d0f5d9cf267a785"
+dependencies = [
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
+ "arrow-select 53.0.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -349,11 +433,30 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13c36dc5ddf8c128df19bab27898eea64bf9da2b555ec1cd17a8ff57fba9ec2"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-cast 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd178575f45624d045e4ebee714e246a05d9652e41363ee3f57ec18cca97f740"
+dependencies = [
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-cast 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
  "chrono",
  "csv",
  "csv-core",
@@ -368,38 +471,50 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 52.2.0",
+ "arrow-schema 52.2.0",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4ac0c4ee79150afe067dc4857154b3ee9c1cd52b5f40d59a77306d0ed18d65"
+dependencies = [
+ "arrow-buffer 53.0.0",
+ "arrow-schema 53.0.0",
  "half",
  "num",
 ]
 
 [[package]]
 name = "arrow-flight"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7ffbc96072e466ae5188974725bb46757587eafe427f77a25b828c375ae882"
+checksum = "b915fb36d935b969894d7909ad417c67ddeadebbbd57c3c168edf64721a37d31"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-cast 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-ipc 53.0.0",
+ "arrow-ord 53.0.0",
+ "arrow-row 53.0.0",
+ "arrow-schema 53.0.0",
+ "arrow-select 53.0.0",
+ "arrow-string 53.0.0",
  "base64 0.22.1",
  "bytes",
  "futures",
  "once_cell",
  "paste",
- "prost 0.12.6",
- "prost-types",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
  "tokio",
- "tonic",
+ "tonic 0.12.2",
 ]
 
 [[package]]
@@ -408,11 +523,25 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e786e1cdd952205d9a8afc69397b317cfbb6e0095e445c69cda7e8da5c1eeb0f"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-cast 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb307482348a1267f91b0912e962cd53440e5de0f7fb24c5f7b10da70b38c94a"
+dependencies = [
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-cast 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
  "flatbuffers",
  "lz4_flex",
 ]
@@ -423,11 +552,31 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb22284c5a2a01d73cebfd88a33511a3234ab45d66086b2ca2d1228c3498e445"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-cast 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "chrono",
+ "half",
+ "indexmap 2.5.0",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-json"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24805ba326758effdd6f2cbdd482fcfab749544f21b134701add25b33f474e6"
+dependencies = [
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-cast 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
  "chrono",
  "half",
  "indexmap 2.5.0",
@@ -442,7 +591,7 @@ name = "arrow-odbc"
 version = "11.2.0"
 source = "git+https://github.com/spiceai/arrow-odbc.git?rev=24ecbdfc2c482f1ce84c595ab1202530a37815d6#24ecbdfc2c482f1ce84c595ab1202530a37815d6"
 dependencies = [
- "arrow",
+ "arrow 52.2.0",
  "chrono",
  "log",
  "odbc-api",
@@ -455,11 +604,26 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42745f86b1ab99ef96d1c0bcf49180848a64fe2c7a7a0d945bc64fa2b21ba9bc"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "arrow-select 52.2.0",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644046c479d80ae8ed02a7f1e1399072ea344ca6a7b0e293ab2d5d9ed924aa3b"
+dependencies = [
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
+ "arrow-select 53.0.0",
  "half",
  "num",
 ]
@@ -471,10 +635,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd09a518c602a55bd406bcc291a967b284cfa7a63edfbf8b897ea4748aad23c"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29791f8eb13b340ce35525b723f5f0df17ecb955599e11f65c2a94ab34e2efb"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
  "half",
 ]
 
@@ -484,8 +662,16 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
 dependencies = [
- "bitflags 2.6.0",
  "serde",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85320a3a2facf2b2822b57aa9d6d9d55edb8aee0b6b5d3b8df158e503d10858"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -495,10 +681,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600bae05d43483d216fb3494f8c32fdbefd8aa4e1de237e790dbb3d9f44690a3"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc7e6b582e23855fd1625ce46e51647aa440c20ea2e71b1d748e0839dd73cba"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
  "num",
 ]
 
@@ -508,11 +708,28 @@ version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc1985b67cb45f6606a248ac2b4a288849f196bab8c657ea5589f47cdd55e6"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 52.2.0",
+ "arrow-buffer 52.2.0",
+ "arrow-data 52.2.0",
+ "arrow-schema 52.2.0",
+ "arrow-select 52.2.0",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "arrow-string"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0775b6567c66e56ded19b87a954b6b1beffbdd784ef95a3a2b03f59570c1d230"
+dependencies = [
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-schema 53.0.0",
+ "arrow-select 53.0.0",
  "memchr",
  "num",
  "regex",
@@ -523,7 +740,7 @@ dependencies = [
 name = "arrow_sql_gen"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "bigdecimal",
  "chrono",
  "chrono-tz 0.8.6",
@@ -537,7 +754,7 @@ dependencies = [
 name = "arrow_tools"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "snafu 0.8.4",
 ]
 
@@ -1992,7 +2209,7 @@ dependencies = [
 name = "cache"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "async-stream",
  "async-trait",
  "byte-unit",
@@ -2772,8 +2989,8 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 name = "data_components"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 53.0.0",
+ "arrow-buffer 53.0.0",
  "arrow-flight",
  "async-stream",
  "async-trait",
@@ -2794,7 +3011,7 @@ dependencies = [
  "graph-rs-sdk",
  "graphql-parser",
  "http 1.1.0",
- "object_store",
+ "object_store 0.11.0",
  "rdkafka",
  "regex",
  "reqwest 0.12.7",
@@ -2807,7 +3024,7 @@ dependencies = [
  "spark-connect-rs",
  "tokio",
  "tokio-postgres",
- "tonic",
+ "tonic 0.12.2",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2816,14 +3033,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
+ "arrow 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-ipc 53.0.0",
+ "arrow-schema 53.0.0",
  "async-compression",
  "async-trait",
  "bytes",
@@ -2838,6 +3055,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-nested",
+ "datafusion-functions-window",
  "datafusion-optimizer",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
@@ -2850,10 +3068,10 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "num_cpus",
- "object_store",
+ "object_store 0.11.0",
  "parking_lot 0.12.3",
  "parquet",
  "paste",
@@ -2871,52 +3089,56 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 53.0.0",
  "async-trait",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-physical-plan",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-schema 53.0.0",
  "chrono",
  "half",
  "hashbrown 0.14.5",
  "instant",
  "libc",
  "num_cpus",
- "object_store",
+ "object_store 0.11.0",
  "parquet",
+ "paste",
  "sqlparser",
+ "tokio",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
+ "log",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-execution"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "chrono",
  "dashmap 6.1.0",
  "datafusion-common",
@@ -2924,7 +3146,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "log",
- "object_store",
+ "object_store 0.11.0",
  "parking_lot 0.12.3",
  "rand",
  "tempfile",
@@ -2933,15 +3155,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-array",
- "arrow-buffer",
+ "arrow 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
  "chrono",
  "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
  "paste",
  "serde_json",
  "sqlparser",
@@ -2950,11 +3175,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-expr-common"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+dependencies = [
+ "arrow 53.0.0",
+ "datafusion-common",
+ "paste",
+]
+
+[[package]]
 name = "datafusion-federation"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=b6682948d07cc3155edb3dfbf03f8b55570fc1d2#b6682948d07cc3155edb3dfbf03f8b55570fc1d2"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=7c69f7bc5d4f67469aaa215650e89000941d6915#7c69f7bc5d4f67469aaa215650e89000941d6915"
 dependencies = [
- "arrow-json",
+ "arrow-json 53.0.0",
  "async-stream",
  "async-trait",
  "datafusion",
@@ -2964,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation-sql"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=b6682948d07cc3155edb3dfbf03f8b55570fc1d2#b6682948d07cc3155edb3dfbf03f8b55570fc1d2"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=7c69f7bc5d4f67469aaa215650e89000941d6915#7c69f7bc5d4f67469aaa215650e89000941d6915"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -2976,11 +3211,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 53.0.0",
+ "arrow-buffer 53.0.0",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -2990,7 +3225,7 @@ dependencies = [
  "datafusion-expr",
  "hashbrown 0.14.5",
  "hex",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "md-5",
  "rand",
@@ -3002,32 +3237,44 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-schema",
+ "arrow 53.0.0",
+ "arrow-schema 53.0.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "half",
  "log",
  "paste",
  "sqlparser",
 ]
 
 [[package]]
-name = "datafusion-functions-json"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00900606bdd73248f0a0bea254379ef06832f4958510581e752fedd17b33b8b4"
+name = "datafusion-functions-aggregate-common"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "ahash 0.8.11",
+ "arrow 53.0.0",
  "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
+ "rand",
+]
+
+[[package]]
+name = "datafusion-functions-json"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532feb5c208fd1708f4d93b1984fb7a7ed678a9f0e6f799af97118d7c4e863a1"
+dependencies = [
+ "datafusion",
  "jiter",
  "log",
  "paste",
@@ -3035,31 +3282,43 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-ord 53.0.0",
+ "arrow-schema 53.0.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
  "datafusion-functions-aggregate",
- "itertools 0.12.1",
+ "datafusion-physical-expr-common",
+ "itertools 0.13.0",
  "log",
  "paste",
  "rand",
 ]
 
 [[package]]
-name = "datafusion-optimizer"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+name = "datafusion-functions-window"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "log",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
+dependencies = [
+ "arrow 53.0.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -3067,7 +3326,7 @@ dependencies = [
  "datafusion-physical-expr",
  "hashbrown 0.14.5",
  "indexmap 2.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "paste",
  "regex-syntax 0.8.4",
@@ -3075,27 +3334,29 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
- "arrow-string",
+ "arrow 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-ord 53.0.0",
+ "arrow-schema 53.0.0",
+ "arrow-string 53.0.0",
  "base64 0.22.1",
  "chrono",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
  "hex",
  "indexmap 2.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "paste",
  "petgraph",
@@ -3104,39 +3365,41 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
+ "arrow 53.0.0",
  "datafusion-common",
- "datafusion-expr",
+ "datafusion-expr-common",
  "hashbrown 0.14.5",
  "rand",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
+ "arrow-schema 53.0.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
+ "itertools 0.13.0",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-ord 53.0.0",
+ "arrow-schema 53.0.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -3144,13 +3407,14 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "once_cell",
  "parking_lot 0.12.3",
@@ -3161,12 +3425,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "41.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=89730a72945ca65371eddd54be9324af0cb9a102#89730a72945ca65371eddd54be9324af0cb9a102"
+version = "42.0.0"
+source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-schema 53.0.0",
  "datafusion-common",
  "datafusion-expr",
  "log",
@@ -3178,10 +3442,10 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d43347c873e0239302acc8614ccbe322ca8094a0#d43347c873e0239302acc8614ccbe322ca8094a0"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=69b47e3b371df2c117b059f12da4f1a89b0e6a48#69b47e3b371df2c117b059f12da4f1a89b0e6a48"
 dependencies = [
- "arrow",
- "arrow-json",
+ "arrow 53.0.0",
+ "arrow-json 53.0.0",
  "async-stream",
  "async-trait",
  "bb8",
@@ -3223,7 +3487,7 @@ dependencies = [
 name = "db_connection_pool"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "arrow-odbc",
  "arrow_sql_gen",
  "async-stream",
@@ -3255,17 +3519,18 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
 name = "delta_kernel"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa08a82239f51e6d3d249c38f0f5bf7c8a78b28587e1b466893c9eac84d252d8"
+checksum = "16155315d01e177d0d2217fbe972f03b1383b1618a07955b2e38e853cdf0e77b"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-cast",
- "arrow-json",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-arith 53.0.0",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-cast 53.0.0",
+ "arrow-json 53.0.0",
+ "arrow-ord 53.0.0",
+ "arrow-schema 53.0.0",
+ "arrow-select 53.0.0",
  "bytes",
  "chrono",
  "delta_kernel_derive",
@@ -3276,7 +3541,7 @@ dependencies = [
  "indexmap 2.5.0",
  "itertools 0.13.0",
  "lazy_static",
- "object_store",
+ "object_store 0.11.0",
  "parquet",
  "reqwest 0.12.7",
  "roaring",
@@ -3518,10 +3783,10 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "duckdb"
-version = "1.0.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=f2ca47d094a5636df8b9f3792b2f474a7b210dc1#f2ca47d094a5636df8b9f3792b2f474a7b210dc1"
+version = "1.1.0"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=5b98603705a381ceeb5cc371e4f606b7332b57ce#5b98603705a381ceeb5cc371e4f606b7332b57ce"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "cast",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
@@ -3859,7 +4124,7 @@ dependencies = [
 name = "flight_client"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "arrow-flight",
  "base64 0.22.1",
  "bytes",
@@ -3867,20 +4132,20 @@ dependencies = [
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.1.3",
  "snafu 0.8.4",
- "tonic",
+ "tonic 0.12.2",
 ]
 
 [[package]]
 name = "flightpublisher"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "arrow-flight",
  "clap",
  "futures",
  "parquet",
  "tokio",
- "tonic",
+ "tonic 0.12.2",
 ]
 
 [[package]]
@@ -3889,7 +4154,7 @@ version = "0.18.1-beta"
 dependencies = [
  "ansi_term",
  "arrow-flight",
- "arrow-json",
+ "arrow-json 53.0.0",
  "clap",
  "datafusion",
  "futures",
@@ -3898,7 +4163,7 @@ dependencies = [
  "reqwest 0.12.7",
  "rustyline",
  "serde_json",
- "tonic",
+ "tonic 0.12.2",
 ]
 
 [[package]]
@@ -3909,7 +4174,7 @@ dependencies = [
  "clap",
  "futures",
  "tokio",
- "tonic",
+ "tonic 0.12.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4715,7 +4980,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
  "rand",
  "regex",
  "roxmltree",
@@ -4729,16 +4994,16 @@ dependencies = [
 
 [[package]]
 name = "hdfs-native-object-store"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54730badbcfe7e9bdef975fd86563c0d98d4f9e0c924e335066a6c51a8a1af2b"
+checksum = "6709e96e8be2d5794b136dc814c9f99d56ef38e39ab909d6098e18f5f3f30d07"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
  "futures",
  "hdfs-native",
- "object_store",
+ "object_store 0.10.2",
  "thiserror",
  "tokio",
 ]
@@ -5067,6 +5332,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -5650,8 +5928,8 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.0.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=f2ca47d094a5636df8b9f3792b2f474a7b210dc1#f2ca47d094a5636df8b9f3792b2f474a7b210dc1"
+version = "1.1.0"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=5b98603705a381ceeb5cc371e4f606b7332b57ce#5b98603705a381ceeb5cc371e4f606b7332b57ce"
 dependencies = [
  "autocfg",
  "cc",
@@ -6276,7 +6554,7 @@ name = "model_components"
 version = "0.18.1-beta"
 dependencies = [
  "anyhow",
- "arrow",
+ "arrow 53.0.0",
  "async-trait",
  "dirs",
  "ndarray",
@@ -6990,6 +7268,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
 dependencies = [
  "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "itertools 0.13.0",
+ "parking_lot 0.12.3",
+ "percent-encoding",
+ "snafu 0.7.5",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "object_store"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
+dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -7007,7 +7306,7 @@ dependencies = [
  "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
- "snafu 0.7.5",
+ "snafu 0.8.4",
  "tokio",
  "tracing",
  "url",
@@ -7177,7 +7476,7 @@ dependencies = [
  "opentelemetry 0.23.0",
  "opentelemetry_sdk 0.23.0",
  "prost 0.12.6",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -7293,8 +7592,8 @@ dependencies = [
 name = "otel-arrow"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 53.0.0",
+ "arrow-buffer 53.0.0",
  "async-trait",
  "opentelemetry 0.24.0",
  "opentelemetry_sdk 0.24.1",
@@ -7378,18 +7677,18 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "52.2.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e977b9066b4d3b03555c22bdc442f3fadebd96a39111249113087d0edb2691cd"
+checksum = "f0fbf928021131daaa57d334ca8e3904fe9ae22f73c56244fc7db9b04eedc3d8"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.0.0",
+ "arrow-buffer 53.0.0",
+ "arrow-cast 53.0.0",
+ "arrow-data 53.0.0",
+ "arrow-ipc 53.0.0",
+ "arrow-schema 53.0.0",
+ "arrow-select 53.0.0",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -7401,7 +7700,7 @@ dependencies = [
  "lz4_flex",
  "num",
  "num-bigint",
- "object_store",
+ "object_store 0.11.0",
  "paste",
  "seq-macro",
  "snap",
@@ -7874,6 +8173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.2",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7888,7 +8197,7 @@ dependencies = [
  "petgraph",
  "prettyplease",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
  "regex",
  "syn 2.0.77",
  "tempfile",
@@ -7921,12 +8230,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
+dependencies = [
+ "prost 0.13.2",
 ]
 
 [[package]]
@@ -8609,11 +8940,11 @@ version = "0.18.1-beta"
 dependencies = [
  "anyhow",
  "app",
- "arrow",
+ "arrow 53.0.0",
  "arrow-flight",
- "arrow-ipc",
- "arrow-json",
- "arrow-schema",
+ "arrow-ipc 53.0.0",
+ "arrow-json 53.0.0",
+ "arrow-schema 52.2.0",
  "arrow_sql_gen",
  "arrow_tools",
  "async-graphql",
@@ -8665,7 +8996,7 @@ dependencies = [
  "mysql_async",
  "notify",
  "ns_lookup",
- "object_store",
+ "object_store 0.11.0",
  "once_cell",
  "opentelemetry 0.24.0",
  "opentelemetry-prometheus",
@@ -8696,7 +9027,7 @@ dependencies = [
  "tokio",
  "tokio-rusqlite",
  "tokio-rustls 0.26.0",
- "tonic",
+ "tonic 0.12.2",
  "tonic-health",
  "tracing",
  "tracing-futures",
@@ -9525,9 +9856,9 @@ dependencies = [
 [[package]]
 name = "snowflake-api"
 version = "0.9.0"
-source = "git+https://github.com/spiceai/snowflake-rs.git?rev=2991d97548b0cd7a721704165ed07f7b2818cf7b#2991d97548b0cd7a721704165ed07f7b2818cf7b"
+source = "git+https://github.com/spiceai/snowflake-rs.git?rev=f95bd4715b9b9e3eaa425d7a775b49e1dcbb1212#f95bd4715b9b9e3eaa425d7a775b49e1dcbb1212"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "async-stream",
  "async-trait",
  "base64 0.22.1",
@@ -9535,7 +9866,7 @@ dependencies = [
  "futures",
  "glob",
  "log",
- "object_store",
+ "object_store 0.11.0",
  "regex",
  "reqwest 0.12.7",
  "reqwest-middleware",
@@ -9589,16 +9920,16 @@ name = "spark-connect-core"
 version = "0.0.1-beta.4"
 source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=d937df525d7c237c717b42e6146494c524dbf267#d937df525d7c237c717b42e6146494c524dbf267"
 dependencies = [
- "arrow",
- "arrow-ipc",
+ "arrow 52.2.0",
+ "arrow-ipc 52.2.0",
  "chrono",
  "parking_lot 0.12.3",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
  "rand",
  "serde_json",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
  "tonic-build",
  "url",
  "uuid 1.10.0",
@@ -9724,9 +10055,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
+checksum = "b2e5b515a2bd5168426033e9efbfd05500114833916f1d5c268f938b4ee130ac"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -10069,7 +10400,7 @@ dependencies = [
 name = "telemetry"
 version = "0.18.1-beta"
 dependencies = [
- "arrow",
+ "arrow 53.0.0",
  "async-trait",
  "flight_client",
  "hostname 0.4.0",
@@ -10495,12 +10826,11 @@ dependencies = [
  "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
- "flate2",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost 0.12.6",
@@ -10509,6 +10839,40 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.5",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.2",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.1.3",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-rustls 0.26.0",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -10531,15 +10895,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cef6e24bc96871001a7e48e820ab240b3de2201e59b517cf52835df2f1d2350"
+checksum = "ec0a34e6f706bae26b2b490e1da5c3f6a6ff87cae442bcbc7c881bab9631b5a7"
 dependencies = [
  "async-stream",
- "prost 0.12.6",
+ "prost 0.13.2",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,59 +260,23 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05048a8932648b63f21c37d88b552ccc8a65afb6dfe9fc9f30ce79174c2e7a85"
-dependencies = [
- "arrow-arith 52.2.0",
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-cast 52.2.0",
- "arrow-csv 52.2.0",
- "arrow-data 52.2.0",
- "arrow-ipc 52.2.0",
- "arrow-json 52.2.0",
- "arrow-ord 52.2.0",
- "arrow-row 52.2.0",
- "arrow-schema 52.2.0",
- "arrow-select 52.2.0",
- "arrow-string 52.2.0",
-]
-
-[[package]]
-name = "arrow"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45aef0d9cf9a039bf6cd1acc451b137aca819977b0928dece52bd92811b640ba"
 dependencies = [
- "arrow-arith 53.0.0",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-cast 53.0.0",
- "arrow-csv 53.0.0",
- "arrow-data 53.0.0",
- "arrow-ipc 53.0.0",
- "arrow-json 53.0.0",
- "arrow-ord 53.0.0",
- "arrow-row 53.0.0",
- "arrow-schema 53.0.0",
- "arrow-select 53.0.0",
- "arrow-string 53.0.0",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a57966e43bfe9a3277984a14c24ec617ad874e4c0e1d2a1b083a39cfbf22c"
-dependencies = [
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "chrono",
- "half",
- "num",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
@@ -321,28 +285,12 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03675e42d1560790f3524800e41403b40d0da1c793fe9528929fde06d8c7649a"
 dependencies = [
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
-dependencies = [
- "ahash 0.8.11",
- "arrow-buffer 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "chrono",
- "half",
- "hashbrown 0.14.5",
  "num",
 ]
 
@@ -353,24 +301,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd2bf348cf9f02a5975c5962c7fa6dee107a2009a7b41ac5fb1a027e12dc033f"
 dependencies = [
  "ahash 0.8.11",
- "arrow-buffer 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz 0.9.0",
  "half",
  "hashbrown 0.14.5",
- "num",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c975484888fc95ec4a632cdc98be39c085b1bb518531b0c80c5d462063e5daa1"
-dependencies = [
- "bytes",
- "half",
  "num",
 ]
 
@@ -387,36 +324,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da26719e76b81d8bc3faad1d4dbdc1bcc10d14704e63dc17fc9f3e7e1e567c8e"
-dependencies = [
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "arrow-select 52.2.0",
- "atoi",
- "base64 0.22.1",
- "chrono",
- "comfy-table",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
-name = "arrow-cast"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce1018bb710d502f9db06af026ed3561552e493e989a79d0d0f5d9cf267a785"
 dependencies = [
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
- "arrow-select 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -425,25 +341,6 @@ dependencies = [
  "lexical-core",
  "num",
  "ryu",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13c36dc5ddf8c128df19bab27898eea64bf9da2b555ec1cd17a8ff57fba9ec2"
-dependencies = [
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-cast 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "lexical-core",
- "regex",
 ]
 
 [[package]]
@@ -452,11 +349,11 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd178575f45624d045e4ebee714e246a05d9652e41363ee3f57ec18cca97f740"
 dependencies = [
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-cast 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
@@ -467,24 +364,12 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
-dependencies = [
- "arrow-buffer 52.2.0",
- "arrow-schema 52.2.0",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-data"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4ac0c4ee79150afe067dc4857154b3ee9c1cd52b5f40d59a77306d0ed18d65"
 dependencies = [
- "arrow-buffer 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow-buffer",
+ "arrow-schema",
  "half",
  "num",
 ]
@@ -495,17 +380,17 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b915fb36d935b969894d7909ad417c67ddeadebbbd57c3c168edf64721a37d31"
 dependencies = [
- "arrow-arith 53.0.0",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-cast 53.0.0",
- "arrow-data 53.0.0",
- "arrow-ipc 53.0.0",
- "arrow-ord 53.0.0",
- "arrow-row 53.0.0",
- "arrow-schema 53.0.0",
- "arrow-select 53.0.0",
- "arrow-string 53.0.0",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
  "base64 0.22.1",
  "bytes",
  "futures",
@@ -514,21 +399,7 @@ dependencies = [
  "prost 0.13.2",
  "prost-types 0.13.2",
  "tokio",
- "tonic 0.12.2",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e786e1cdd952205d9a8afc69397b317cfbb6e0095e445c69cda7e8da5c1eeb0f"
-dependencies = [
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-cast 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "flatbuffers",
+ "tonic",
 ]
 
 [[package]]
@@ -537,33 +408,13 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb307482348a1267f91b0912e962cd53440e5de0f7fb24c5f7b10da70b38c94a"
 dependencies = [
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-cast 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "flatbuffers",
  "lz4_flex",
-]
-
-[[package]]
-name = "arrow-json"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb22284c5a2a01d73cebfd88a33511a3234ab45d66086b2ca2d1228c3498e445"
-dependencies = [
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-cast 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "chrono",
- "half",
- "indexmap 2.5.0",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -572,11 +423,11 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24805ba326758effdd6f2cbdd482fcfab749544f21b134701add25b33f474e6"
 dependencies = [
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-cast 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.5.0",
@@ -589,9 +440,9 @@ dependencies = [
 [[package]]
 name = "arrow-odbc"
 version = "11.2.0"
-source = "git+https://github.com/spiceai/arrow-odbc.git?rev=24ecbdfc2c482f1ce84c595ab1202530a37815d6#24ecbdfc2c482f1ce84c595ab1202530a37815d6"
+source = "git+https://github.com/spiceai/arrow-odbc.git?rev=dfb1e03a5f0702c1a318db5abf40e762d6b2bcc2#dfb1e03a5f0702c1a318db5abf40e762d6b2bcc2"
 dependencies = [
- "arrow 52.2.0",
+ "arrow",
  "chrono",
  "log",
  "odbc-api",
@@ -600,46 +451,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42745f86b1ab99ef96d1c0bcf49180848a64fe2c7a7a0d945bc64fa2b21ba9bc"
-dependencies = [
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "arrow-select 52.2.0",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-ord"
 version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644046c479d80ae8ed02a7f1e1399072ea344ca6a7b0e293ab2d5d9ed924aa3b"
 dependencies = [
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
- "arrow-select 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "half",
  "num",
-]
-
-[[package]]
-name = "arrow-row"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd09a518c602a55bd406bcc291a967b284cfa7a63edfbf8b897ea4748aad23c"
-dependencies = [
- "ahash 0.8.11",
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "half",
 ]
 
 [[package]]
@@ -649,20 +471,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a29791f8eb13b340ce35525b723f5f0df17ecb955599e11f65c2a94ab34e2efb"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "half",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -672,20 +485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85320a3a2facf2b2822b57aa9d6d9d55edb8aee0b6b5d3b8df158e503d10858"
 dependencies = [
  "bitflags 2.6.0",
-]
-
-[[package]]
-name = "arrow-select"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600bae05d43483d216fb3494f8c32fdbefd8aa4e1de237e790dbb3d9f44690a3"
-dependencies = [
- "ahash 0.8.11",
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "num",
+ "serde",
 ]
 
 [[package]]
@@ -695,28 +495,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc7e6b582e23855fd1625ce46e51647aa440c20ea2e71b1d748e0839dd73cba"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "num",
-]
-
-[[package]]
-name = "arrow-string"
-version = "52.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc1985b67cb45f6606a248ac2b4a288849f196bab8c657ea5589f47cdd55e6"
-dependencies = [
- "arrow-array 52.2.0",
- "arrow-buffer 52.2.0",
- "arrow-data 52.2.0",
- "arrow-schema 52.2.0",
- "arrow-select 52.2.0",
- "memchr",
- "num",
- "regex",
- "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -725,11 +508,11 @@ version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0775b6567c66e56ded19b87a954b6b1beffbdd784ef95a3a2b03f59570c1d230"
 dependencies = [
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-data 53.0.0",
- "arrow-schema 53.0.0",
- "arrow-select 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "memchr",
  "num",
  "regex",
@@ -740,7 +523,7 @@ dependencies = [
 name = "arrow_sql_gen"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "bigdecimal",
  "chrono",
  "chrono-tz 0.8.6",
@@ -754,7 +537,7 @@ dependencies = [
 name = "arrow_tools"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "snafu",
 ]
 
@@ -951,7 +734,7 @@ checksum = "329afc4fc7359f112b7593bc930b788544cedbc97c4fbdf1db21e58704b4b5d0"
 dependencies = [
  "async-graphql",
  "async-trait",
- "axum 0.7.5",
+ "axum",
  "bytes",
  "futures-util",
  "serde_json",
@@ -1583,40 +1366,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
- "axum-core 0.4.3",
+ "axum-core",
  "axum-macros",
  "base64 0.21.7",
  "bytes",
@@ -1649,23 +1404,6 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
@@ -1691,8 +1429,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
 dependencies = [
- "axum 0.7.5",
- "axum-core 0.4.3",
+ "axum",
+ "axum-core",
  "bytes",
  "futures-util",
  "headers",
@@ -2222,7 +1960,7 @@ dependencies = [
 name = "cache"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "async-stream",
  "async-trait",
  "byte-unit",
@@ -2230,7 +1968,7 @@ dependencies = [
  "fundu",
  "futures",
  "moka",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "snafu",
  "spicepod",
  "tokio",
@@ -3008,8 +2746,8 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 name = "data_components"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
- "arrow-buffer 53.0.0",
+ "arrow",
+ "arrow-buffer",
  "arrow-flight",
  "async-stream",
  "async-trait",
@@ -3046,7 +2784,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-util",
- "tonic 0.12.2",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3059,10 +2797,10 @@ version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow 53.0.0",
- "arrow-array 53.0.0",
- "arrow-ipc 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -3114,7 +2852,7 @@ name = "datafusion-catalog"
 version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow-schema 53.0.0",
+ "arrow-schema",
  "async-trait",
  "datafusion-common",
  "datafusion-execution",
@@ -3129,10 +2867,10 @@ version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow 53.0.0",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "chrono",
  "half",
  "hashbrown 0.14.5",
@@ -3160,7 +2898,7 @@ name = "datafusion-execution"
 version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "chrono",
  "dashmap 6.1.0",
  "datafusion-common",
@@ -3181,9 +2919,9 @@ version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow 53.0.0",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
@@ -3201,7 +2939,7 @@ name = "datafusion-expr-common"
 version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "datafusion-common",
  "paste",
 ]
@@ -3211,7 +2949,7 @@ name = "datafusion-federation"
 version = "0.1.6"
 source = "git+https://github.com/spiceai/datafusion-federation.git?rev=7c69f7bc5d4f67469aaa215650e89000941d6915#7c69f7bc5d4f67469aaa215650e89000941d6915"
 dependencies = [
- "arrow-json 53.0.0",
+ "arrow-json",
  "async-stream",
  "async-trait",
  "datafusion",
@@ -3236,8 +2974,8 @@ name = "datafusion-functions"
 version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow 53.0.0",
- "arrow-buffer 53.0.0",
+ "arrow",
+ "arrow-buffer",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -3263,8 +3001,8 @@ version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -3283,7 +3021,7 @@ version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow 53.0.0",
+ "arrow",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -3307,11 +3045,11 @@ name = "datafusion-functions-nested"
 version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow 53.0.0",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-ord 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -3340,7 +3078,7 @@ name = "datafusion-optimizer"
 version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -3360,12 +3098,12 @@ version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow 53.0.0",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-ord 53.0.0",
- "arrow-schema 53.0.0",
- "arrow-string 53.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-string",
  "base64 0.22.1",
  "chrono",
  "datafusion-common",
@@ -3391,7 +3129,7 @@ version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow 53.0.0",
+ "arrow",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
@@ -3403,7 +3141,7 @@ name = "datafusion-physical-optimizer"
 version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow-schema 53.0.0",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-physical-expr",
@@ -3417,11 +3155,11 @@ version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
  "ahash 0.8.11",
- "arrow 53.0.0",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-ord 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -3450,9 +3188,9 @@ name = "datafusion-sql"
 version = "42.0.0"
 source = "git+https://github.com/spiceai/datafusion.git?rev=388d6038653458a8b5f56f49b3f8d4402b51a425#388d6038653458a8b5f56f49b3f8d4402b51a425"
 dependencies = [
- "arrow 53.0.0",
- "arrow-array 53.0.0",
- "arrow-schema 53.0.0",
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
  "log",
@@ -3466,8 +3204,8 @@ name = "datafusion-table-providers"
 version = "0.1.0"
 source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=69b47e3b371df2c117b059f12da4f1a89b0e6a48#69b47e3b371df2c117b059f12da4f1a89b0e6a48"
 dependencies = [
- "arrow 53.0.0",
- "arrow-json 53.0.0",
+ "arrow",
+ "arrow-json",
  "async-stream",
  "async-trait",
  "bb8",
@@ -3509,7 +3247,7 @@ dependencies = [
 name = "db_connection_pool"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "arrow-odbc",
  "arrow_sql_gen",
  "async-stream",
@@ -3545,14 +3283,14 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16155315d01e177d0d2217fbe972f03b1383b1618a07955b2e38e853cdf0e77b"
 dependencies = [
- "arrow-arith 53.0.0",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-cast 53.0.0",
- "arrow-json 53.0.0",
- "arrow-ord 53.0.0",
- "arrow-schema 53.0.0",
- "arrow-select 53.0.0",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
  "bytes",
  "chrono",
  "delta_kernel_derive",
@@ -3808,7 +3546,7 @@ name = "duckdb"
 version = "1.1.0"
 source = "git+https://github.com/spiceai/duckdb-rs.git?rev=5b98603705a381ceeb5cc371e4f606b7332b57ce#5b98603705a381ceeb5cc371e4f606b7332b57ce"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "cast",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
@@ -4146,7 +3884,7 @@ dependencies = [
 name = "flight_client"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "arrow-flight",
  "base64 0.22.1",
  "bytes",
@@ -4154,20 +3892,20 @@ dependencies = [
  "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.1.3",
  "snafu",
- "tonic 0.12.2",
+ "tonic",
 ]
 
 [[package]]
 name = "flightpublisher"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "arrow-flight",
  "clap",
  "futures",
  "parquet",
  "tokio",
- "tonic 0.12.2",
+ "tonic",
 ]
 
 [[package]]
@@ -4176,16 +3914,16 @@ version = "0.18.1-beta"
 dependencies = [
  "ansi_term",
  "arrow-flight",
- "arrow-json 53.0.0",
+ "arrow-json",
  "clap",
  "datafusion",
  "futures",
  "llms",
- "prost 0.12.6",
+ "prost 0.13.2",
  "reqwest 0.12.7",
  "rustyline",
  "serde_json",
- "tonic 0.12.2",
+ "tonic",
 ]
 
 [[package]]
@@ -4196,7 +3934,7 @@ dependencies = [
  "clap",
  "futures",
  "tokio",
- "tonic 0.12.2",
+ "tonic",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5342,18 +5080,6 @@ dependencies = [
  "tokio-rustls 0.26.0",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.30",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -6576,7 +6302,7 @@ name = "model_components"
 version = "0.18.1-beta"
 dependencies = [
  "anyhow",
- "arrow 53.0.0",
+ "arrow",
  "async-trait",
  "dirs",
  "ndarray",
@@ -7416,23 +7142,8 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+version = "0.25.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=c3b59ba61055b7ec6916b6b88a9ac94f6656922b#c3b59ba61055b7ec6916b6b88a9ac94f6656922b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -7444,62 +7155,63 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.13.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad31e9de44ee3538fb9d64fe3376c1362f406162434609e79aea2a41a0af78ab"
+checksum = "88d8c2b76e5f7848a289aa9666dbe56b16f8a22a4c5246ef37a14941818d2913"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.1.0",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "reqwest 0.12.7",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4191ce34aa274621861a7a9d68dbcf618d5b6c66b10081631b61fd81fbc015"
+source = "git+https://github.com/spiceai/opentelemetry-rust.git?rev=39584779eff60a71ea6b900daca71fd85730e91a#39584779eff60a71ea6b900daca71fd85730e91a"
 dependencies = [
  "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prometheus",
  "protobuf",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.6.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+checksum = "2c43620e8f93359eb7e627a3b16ee92d8585774986f24f2ab010817426c5ce61"
 dependencies = [
- "opentelemetry 0.23.0",
- "opentelemetry_sdk 0.23.0",
- "prost 0.12.6",
- "tonic 0.11.0",
+ "hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.13.2",
+ "serde",
+ "tonic",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.16.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
+checksum = "9b8e442487022a943e2315740e443dc5ee95fd541c18f509a5a6251b408a9f95"
 
 [[package]]
 name = "opentelemetry-zipkin"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68336254a44c5c20574989699582175910b933be85a593a13031ee58811d93d"
+checksum = "e75b57e1df6d1a6dbb21193f501d3db0c65580d29fa739d902d33aba2323d3ad"
 dependencies = [
  "async-trait",
  "futures-core",
  "http 1.1.0",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry_sdk",
  "reqwest 0.12.7",
  "serde",
  "serde_json",
@@ -7509,27 +7221,8 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "lazy_static",
- "once_cell",
- "opentelemetry 0.23.0",
- "ordered-float 4.2.2",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+version = "0.25.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=c3b59ba61055b7ec6916b6b88a9ac94f6656922b#c3b59ba61055b7ec6916b6b88a9ac94f6656922b"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -7537,7 +7230,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "percent-encoding",
  "rand",
  "serde_json",
@@ -7571,15 +7264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7593,11 +7277,11 @@ dependencies = [
 name = "otel-arrow"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
- "arrow-buffer 53.0.0",
+ "arrow",
+ "arrow-buffer",
  "async-trait",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
 ]
 
 [[package]]
@@ -7683,13 +7367,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0fbf928021131daaa57d334ca8e3904fe9ae22f73c56244fc7db9b04eedc3d8"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array 53.0.0",
- "arrow-buffer 53.0.0",
- "arrow-cast 53.0.0",
- "arrow-data 53.0.0",
- "arrow-ipc 53.0.0",
- "arrow-schema 53.0.0",
- "arrow-select 53.0.0",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -8947,11 +8631,11 @@ version = "0.18.1-beta"
 dependencies = [
  "anyhow",
  "app",
- "arrow 53.0.0",
+ "arrow",
  "arrow-flight",
- "arrow-ipc 53.0.0",
- "arrow-json 53.0.0",
- "arrow-schema 52.2.0",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-schema",
  "arrow_sql_gen",
  "arrow_tools",
  "async-graphql",
@@ -8962,7 +8646,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
  "aws-sdk-sts",
- "axum 0.7.5",
+ "axum",
  "axum-extra",
  "base64 0.22.1",
  "bollard",
@@ -9005,15 +8689,15 @@ dependencies = [
  "ns_lookup",
  "object_store",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-prometheus",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry_sdk",
  "otel-arrow",
  "pin-project",
  "prometheus",
  "prometheus-parse",
- "prost 0.12.6",
+ "prost 0.13.2",
  "rand",
  "regex",
  "reqwest 0.12.7",
@@ -9036,7 +8720,7 @@ dependencies = [
  "tokio-rusqlite",
  "tokio-rustls 0.26.0",
  "tokio-util",
- "tonic 0.12.2",
+ "tonic",
  "tonic-health",
  "tracing",
  "tracing-futures",
@@ -9165,20 +8849,6 @@ dependencies = [
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -9845,7 +9515,7 @@ name = "snowflake-api"
 version = "0.9.0"
 source = "git+https://github.com/spiceai/snowflake-rs.git?rev=f95bd4715b9b9e3eaa425d7a775b49e1dcbb1212#f95bd4715b9b9e3eaa425d7a775b49e1dcbb1212"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "async-stream",
  "async-trait",
  "base64 0.22.1",
@@ -9905,18 +9575,18 @@ dependencies = [
 [[package]]
 name = "spark-connect-core"
 version = "0.0.1-beta.4"
-source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=d937df525d7c237c717b42e6146494c524dbf267#d937df525d7c237c717b42e6146494c524dbf267"
+source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=bf6309f0934c646fafb423ed6114fb739f38ddc3#bf6309f0934c646fafb423ed6114fb739f38ddc3"
 dependencies = [
- "arrow 52.2.0",
- "arrow-ipc 52.2.0",
+ "arrow",
+ "arrow-ipc",
  "chrono",
  "parking_lot 0.12.3",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
  "rand",
  "serde_json",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
  "tonic-build",
  "url",
  "uuid 1.10.0",
@@ -9925,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "spark-connect-rs"
 version = "0.0.1-beta.4"
-source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=d937df525d7c237c717b42e6146494c524dbf267#d937df525d7c237c717b42e6146494c524dbf267"
+source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=bf6309f0934c646fafb423ed6114fb739f38ddc3#bf6309f0934c646fafb423ed6114fb739f38ddc3"
 dependencies = [
  "spark-connect-core",
 ]
@@ -9967,11 +9637,11 @@ dependencies = [
  "clap",
  "flightrepl",
  "futures",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-prometheus",
  "opentelemetry-zipkin",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry_sdk",
  "otel-arrow",
  "prometheus",
  "reqwest 0.12.7",
@@ -10387,12 +10057,12 @@ dependencies = [
 name = "telemetry"
 version = "0.18.1-beta"
 dependencies = [
- "arrow 53.0.0",
+ "arrow",
  "async-trait",
  "flight_client",
  "hostname 0.4.0",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "otel-arrow",
  "sha2",
  "tokio",
@@ -10488,7 +10158,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float 2.10.1",
+ "ordered-float",
 ]
 
 [[package]]
@@ -10639,16 +10309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10723,17 +10383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -10832,44 +10481,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost 0.12.6",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.1.3",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.7.5",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "flate2",
@@ -10878,7 +10496,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-timeout 0.5.1",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
@@ -10918,7 +10536,7 @@ dependencies = [
  "prost 0.13.2",
  "tokio",
  "tokio-stream",
- "tonic 0.12.2",
+ "tonic",
 ]
 
 [[package]]
@@ -11022,14 +10640,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
+version = "0.26.0"
+source = "git+https://github.com/spiceai/tracing-opentelemetry.git?rev=67d70b46ec463e5eae31e655bad9c05ac760d986#67d70b46ec463e5eae31e655bad9c05ac760d986"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ rust-version = "1.81"
 version = "0.18.1-beta"
 
 [workspace.dependencies]
-arrow = "52.2.0"
-arrow-buffer = "52.2.0"
-arrow-flight = "52.2.0"
-arrow-json = "52.2.0"
-arrow-ipc = "52.2.0"
-parquet = "52.2.0"
+arrow = "53"
+arrow-buffer = "53"
+arrow-flight = "53"
+arrow-json = "53"
+arrow-ipc = "53"
+parquet = "53"
 arrow-odbc = "11.2.0"
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "9b0f8caa3be0eb97ec35e0abebb31d016821035d" }
 async-stream = "0.3.5"
@@ -54,14 +54,14 @@ clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0
   "tokio_io",
   "tls",
 ] }
-datafusion = "41.0.0"
-datafusion-common = "41"
-datafusion-expr = "41"
-datafusion-execution = "41"
+datafusion = "42"
+datafusion-common = "42"
+datafusion-expr = "42"
+datafusion-execution = "42"
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }
-datafusion-functions-json = "0.41"
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d43347c873e0239302acc8614ccbe322ca8094a0" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7c69f7bc5d4f67469aaa215650e89000941d6915" }
+datafusion-functions-json = "0.42"
+datafusion-table-providers = "0.1.0"
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.1"
@@ -71,7 +71,7 @@ graph-rs-sdk = { git = "https://github.com/spiceai/graph-rs-sdk", rev = "f8703df
 insta = { version = "1.40.0", features = ["filters"] }
 itertools = "0.13"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
-object_store = { version = "0.10.2" }
+object_store = { version = "0.11" }
 odbc-api = { version = "8.1.2" }
 opentelemetry = { version = "0.24", default-features = false, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.24", default-features = false, features = ["metrics", "rt-tokio", "trace"] }
@@ -91,10 +91,10 @@ serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.30"
 snafu = "0.8.0"
-snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", rev = "2991d97548b0cd7a721704165ed07f7b2818cf7b" }
+snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", rev = "f95bd4715b9b9e3eaa425d7a775b49e1dcbb1212" }
 ssh2 = { version = "0.9.4" }
 suppaftp = { version = "5.3.1", features = ["async"] }
-tokio = { version = "1.39.3", features = [
+tokio = { version = "1", features = [
   "rt-multi-thread",
   "signal",
   "macros",
@@ -104,8 +104,8 @@ tokio-postgres = { version = "0.7.12", features = [
   "with-uuid-1",
 ] }
 tokio-rusqlite = "0.5.1"
-tonic = { version = "0.11", features = ["gzip", "tls"] }
-tonic-health = { version = "0.11" }
+tonic = { version = "0.12", features = ["gzip", "tls"] }
+tonic-health = { version = "0.12" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-opentelemetry = "0.25.0"
@@ -114,12 +114,16 @@ uuid = "1.9.1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "89730a72945ca65371eddd54be9324af0cb9a102" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "89730a72945ca65371eddd54be9324af0cb9a102" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "89730a72945ca65371eddd54be9324af0cb9a102" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "89730a72945ca65371eddd54be9324af0cb9a102" }
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "b6682948d07cc3155edb3dfbf03f8b55570fc1d2" }
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "f2ca47d094a5636df8b9f3792b2f474a7b210dc1" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
+
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7c69f7bc5d4f67469aaa215650e89000941d6915" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "69b47e3b371df2c117b059f12da4f1a89b0e6a48" }
+
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "5b98603705a381ceeb5cc371e4f606b7332b57ce" }
+
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdfc2c482f1ce84c595ab1202530a37815d6" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ datafusion-execution = "42"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7c69f7bc5d4f67469aaa215650e89000941d6915" }
 datafusion-functions-json = "0.42"
-datafusion-table-providers = "0.1.0"
+datafusion-table-providers = "0.1"
 dotenvy = "0.15"
 duckdb = "1.0.0"
 fundu = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "38
 datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7c69f7bc5d4f67469aaa215650e89000941d6915" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "69b47e3b371df2c117b059f12da4f1a89b0e6a48" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b9be339bf79425df265c6b43f81825418cb61d81" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "5b98603705a381ceeb5cc371e4f606b7332b57ce" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ arrow-buffer = "53"
 arrow-flight = "53"
 arrow-json = "53"
 arrow-ipc = "53"
+arrow-schema = "53"
 parquet = "53"
 arrow-odbc = "11.2.0"
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "9b0f8caa3be0eb97ec35e0abebb31d016821035d" }
@@ -73,11 +74,11 @@ itertools = "0.13"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
 object_store = { version = "0.11" }
 odbc-api = { version = "8.1.2" }
-opentelemetry = { version = "0.24", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.24", default-features = false, features = ["metrics", "rt-tokio", "trace"] }
+opentelemetry = { version = "0.25", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.25", default-features = false, features = ["metrics", "rt-tokio", "trace"] }
 opentelemetry-prometheus = "0.17"
-opentelemetry-zipkin = { version = "0.22.0", default-features = false, features = ["reqwest", "reqwest-rustls"] }
-opentelemetry-http = { version = "0.13.0", features = ["reqwest-rustls"] }
+opentelemetry-zipkin = { version = "0.25", default-features = false, features = ["reqwest", "reqwest-rustls"] }
+opentelemetry-http = { version = "0.25", features = ["reqwest-rustls"] }
 pem = "3.0.4"
 prometheus = "0.13"
 r2d2 = "0.8.10"
@@ -110,7 +111,7 @@ tonic = { version = "0.12", features = ["gzip", "tls"] }
 tonic-health = { version = "0.12" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing-opentelemetry = "0.25.0"
+tracing-opentelemetry = "0.26"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 uuid = "1.9.1"
 x509-certificate = "0.23.1"
@@ -127,9 +128,15 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "5b98603705a381ceeb5cc371e4f606b7332b57ce" }
 
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }
-arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "24ecbdfc2c482f1ce84c595ab1202530a37815d6" }
+arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "dfb1e03a5f0702c1a318db5abf40e762d6b2bcc2" }
 
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af725caf5d3e952e349746706e00d0ea5" }
 
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
+
+# Required until next release with https://github.com/open-telemetry/opentelemetry-rust/pull/2095 is included
+opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "c3b59ba61055b7ec6916b6b88a9ac94f6656922b" }
+opentelemetry_sdk = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "c3b59ba61055b7ec6916b6b88a9ac94f6656922b" }
+tracing-opentelemetry = { git = "https://github.com/spiceai/tracing-opentelemetry.git", rev = "67d70b46ec463e5eae31e655bad9c05ac760d986" }
+opentelemetry-prometheus = { git = "https://github.com/spiceai/opentelemetry-rust.git", rev = "39584779eff60a71ea6b900daca71fd85730e91a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,10 +117,10 @@ uuid = "1.9.1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "388d6038653458a8b5f56f49b3f8d4402b51a425" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ce18dfa80684d4084b9822e640c3989946b11e15" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ce18dfa80684d4084b9822e640c3989946b11e15" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ce18dfa80684d4084b9822e640c3989946b11e15" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "ce18dfa80684d4084b9822e640c3989946b11e15" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7c69f7bc5d4f67469aaa215650e89000941d6915" }
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b9be339bf79425df265c6b43f81825418cb61d81" }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -50,7 +50,7 @@ serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
-spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "d937df525d7c237c717b42e6146494c524dbf267", features = [
+spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "bf6309f0934c646fafb423ed6114fb739f38ddc3", features = [
   "tls",
 ], optional = true }
 tiberius = { workspace = true, optional = true }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -25,7 +25,7 @@ datafusion-federation-sql = { workspace = true }
 datafusion-table-providers = { workspace = true }
 datafusion.workspace = true
 db_connection_pool = { path = "../db_connection_pool" }
-delta_kernel = { version = "=0.3.0", features = ["default-engine", "cloud"], optional = true }
+delta_kernel = { version = "0.3.1", features = ["default-engine", "cloud"], optional = true }
 duckdb = { workspace = true, features = [
   "bundled",
   "r2d2",

--- a/crates/data_components/src/delete.rs
+++ b/crates/data_components/src/delete.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::missing_errors_doc)]
-use std::{any::Any, error::Error, sync::Arc};
+use std::{any::Any, borrow::Cow, error::Error, sync::Arc};
 
 use ::arrow::{
     array::{ArrayRef, RecordBatch, UInt64Array},
@@ -169,7 +169,7 @@ impl TableProvider for DeletionTableProviderAdapter {
     fn table_type(&self) -> TableType {
         self.source.table_type()
     }
-    fn get_logical_plan(&self) -> Option<&LogicalPlan> {
+    fn get_logical_plan(&self) -> Option<Cow<LogicalPlan>> {
         self.source.get_logical_plan()
     }
     fn get_column_default(&self, column: &str) -> Option<&Expr> {

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, sync::Arc};
+use std::{any::Any, borrow::Cow, sync::Arc};
 
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
@@ -91,7 +91,7 @@ impl TableProvider for PolyTableProvider {
     fn table_type(&self) -> TableType {
         self.write.table_type()
     }
-    fn get_logical_plan(&self) -> Option<&LogicalPlan> {
+    fn get_logical_plan(&self) -> Option<Cow<LogicalPlan>> {
         self.write.get_logical_plan()
     }
     fn get_column_default(&self, column: &str) -> Option<&Expr> {

--- a/crates/flightrepl/Cargo.toml
+++ b/crates/flightrepl/Cargo.toml
@@ -16,7 +16,7 @@ clap.workspace = true
 datafusion.workspace = true
 futures.workspace = true
 llms = { path = "../llms" }
-prost = { version = "0.12.1", default-features = false, features = [
+prost = { version = "0.13.1", default-features = false, features = [
   "prost-derive",
 ] }
 reqwest.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -14,7 +14,7 @@ arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
 arrow-ipc.workspace = true
 arrow-json.workspace = true
 arrow.workspace = true
-arrow-schema = {version="52.2.0", features= ["serde"] }
+arrow-schema = { workspace = true, features= ["serde"] }
 arrow_sql_gen = { path = "../arrow_sql_gen" }
 arrow_tools = { path = "../arrow_tools" }
 async-openai.workspace = true
@@ -72,7 +72,7 @@ object_store = { workspace = true, features = ["aws", "http"] }
 once_cell = "1.19.0"
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
-opentelemetry-proto = { version = "0.6.0", features = [
+opentelemetry-proto = { version = "0.25", features = [
   "gen-tonic-messages",
   "gen-tonic",
   "metrics",
@@ -82,7 +82,7 @@ otel-arrow = { path = "../otel-arrow" }
 pin-project = "1.0"
 prometheus.workspace = true
 prometheus-parse = "0.2.5"
-prost = { version = "0.12.1", default-features = false, features = [
+prost = { version = "0.13.1", default-features = false, features = [
   "prost-derive",
 ] }
 rand = "0.8.5"

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -29,7 +29,7 @@ use data_components::cdc::ChangesStream;
 use datafusion::common::TableReference;
 use datafusion::datasource::TableProvider;
 use futures::future::BoxFuture;
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
@@ -546,10 +546,10 @@ async fn notify_refresh_done(
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default();
 
-    let mut labels = vec![Key::from_static_str("dataset").string(dataset_name.to_string())];
+    let mut labels = vec![KeyValue::new("dataset", dataset_name.to_string())];
     let refresh_guard = refresh.read().await;
     if let Some(sql) = &refresh_guard.sql {
-        labels.push(Key::from_static_str("sql").string(sql.to_string()));
+        labels.push(KeyValue::new("sql", sql.to_string()));
     };
 
     metrics::LAST_REFRESH_TIME.record(now.as_secs_f64(), &labels);

--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -18,7 +18,7 @@ use std::{collections::HashSet, sync::Arc, time::SystemTime};
 
 use arrow::datatypes::SchemaRef;
 use datafusion::sql::TableReference;
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use tokio::time::Instant;
 use uuid::Uuid;
 
@@ -84,15 +84,16 @@ impl QueryTracker {
         }
 
         let mut labels = vec![
-            Key::from_static_str("tags").string(tags.join(",")),
-            Key::from_static_str("datasets").string(
+            KeyValue::new("tags", tags.join(",")),
+            KeyValue::new(
+                "datasets",
                 self.datasets
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<String>>()
                     .join(","),
             ),
-            Key::from_static_str("protocol").string(self.protocol.as_arc_str()),
+            KeyValue::new("protocol", self.protocol.as_arc_str()),
         ];
 
         metrics::DURATION_SECONDS.record(query_duration.as_secs_f64(), &labels);
@@ -103,7 +104,7 @@ impl QueryTracker {
         );
 
         if let Some(err) = &self.error_code {
-            labels.push(Key::from_static_str("err_code").string(err.to_string()));
+            labels.push(KeyValue::new("err_code", err.to_string()));
             metrics::FAILURES.add(1, &labels);
         }
 

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -26,7 +26,7 @@ use datafusion::{
     sql::TableReference,
 };
 use futures::{future::join_all, stream::TryStreamExt};
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use snafu::{ResultExt, Snafu};
 use tokio::sync::Mutex;
 
@@ -197,7 +197,7 @@ async fn update_dataset_availability_info(
 }
 
 fn report_dataset_unavailable_time(dataset_name: &String, last_available_time: Option<SystemTime>) {
-    let labels = [Key::from_static_str("dataset").string(dataset_name.to_string())];
+    let labels = vec![KeyValue::new("dataset", dataset_name.to_string())];
 
     match last_available_time {
         Some(last_available_time) => metrics::datasets::UNAVAILABLE_TIME.record(

--- a/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
+++ b/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
@@ -27,7 +27,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::sql::TableReference;
 use futures::{stream, StreamExt};
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
@@ -192,7 +192,7 @@ impl ExecutionPlan for FallbackOnZeroResultsScanExec {
             } else {
                 tracing::trace!("FallbackOnZeroResultsScanExec input_stream.next() returned None");
                 tracing::info!("{fallback_msg}");
-                metrics::FEDERATED_FALLBACK.add(1, &[Key::from_static_str("dataset_name").string(table_name.to_string())]);
+                metrics::FEDERATED_FALLBACK.add(1, &[KeyValue::new("dataset_name", table_name.to_string())]);
                 let fallback_plan = match fallback_provider
                     .scan(
                         &scan_params.state,

--- a/crates/runtime/src/flight/actions.rs
+++ b/crates/runtime/src/flight/actions.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::fmt::{self, Display, Formatter};
 
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use prost::Message;
 use tonic::{Request, Response, Status};
 
@@ -98,7 +98,7 @@ pub(crate) async fn do_action(
     let action_type_str = action_type.as_str().to_string();
     let start = TimeMeasurement::new(
         &metrics::DO_ACTION_DURATION_MS,
-        vec![Key::from_static_str("action_type").string(action_type_str)],
+        vec![KeyValue::new("action_type", action_type_str)],
     );
 
     let stream = match action_type {

--- a/crates/runtime/src/flight/do_get.rs
+++ b/crates/runtime/src/flight/do_get.rs
@@ -63,7 +63,7 @@ pub(crate) async fn handle(
         Command::CommandGetPrimaryKeys(command) => {
             flightsql::get_primary_keys::do_get(flight_svc, &command)
         }
-        Command::CommandGetTableTypes(command) => flightsql::get_table_types::do_get(&command),
+        Command::CommandGetTableTypes(command) => flightsql::get_table_types::do_get(command),
         Command::CommandGetSqlInfo(command) => flightsql::get_sql_info::do_get(command),
         _ => Err(Status::unimplemented("Not yet implemented")),
     }

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -20,7 +20,7 @@ use arrow_flight::{flight_service_server::FlightService, FlightData, PutResult};
 use arrow_ipc::convert::try_schema_from_flatbuffer_bytes;
 use datafusion::sql::TableReference;
 use futures::stream;
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use tokio::sync::{broadcast::Sender, RwLock};
 use tonic::{Request, Response, Status, Streaming};
 
@@ -63,7 +63,7 @@ pub(crate) async fn handle(
 
     let path = TableReference::parse_str(&fd.path.join("."));
 
-    duration_metric.with_labels(vec![Key::from_static_str("path").string(path.to_string())]);
+    duration_metric.with_labels(vec![KeyValue::new("path", path.to_string())]);
 
     if !flight_svc.datafusion.is_writable(&path) {
         return Err(Status::invalid_argument(format!(

--- a/crates/runtime/src/flight/flightsql/get_catalogs.rs
+++ b/crates/runtime/src/flight/flightsql/get_catalogs.rs
@@ -29,7 +29,7 @@ use crate::{
 
 /// Get a `FlightInfo` for listing catalogs.
 pub(crate) fn get_flight_info(
-    query: &sql::CommandGetCatalogs,
+    query: sql::CommandGetCatalogs,
     request: Request<FlightDescriptor>,
 ) -> Response<FlightInfo> {
     tracing::trace!("get_flight_info_catalogs");

--- a/crates/runtime/src/flight/flightsql/get_table_types.rs
+++ b/crates/runtime/src/flight/flightsql/get_table_types.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 pub(crate) fn get_flight_info(
-    query: &sql::CommandGetTableTypes,
+    query: sql::CommandGetTableTypes,
     request: Request<FlightDescriptor>,
 ) -> Response<FlightInfo> {
     let fd = request.into_inner();
@@ -49,7 +49,7 @@ pub(crate) fn get_flight_info(
 }
 
 pub(crate) fn do_get(
-    query: &sql::CommandGetTableTypes,
+    query: sql::CommandGetTableTypes,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let start = TimeMeasurement::new(&metrics::flightsql::DO_GET_TABLE_TYPES_DURATION_MS, vec![]);
     tracing::trace!("do_get_table_types: {query:?}");

--- a/crates/runtime/src/flight/get_flight_info.rs
+++ b/crates/runtime/src/flight/get_flight_info.rs
@@ -43,7 +43,7 @@ pub(crate) async fn handle(
             flightsql::prepared_statement_query::get_flight_info(flight_svc, handle, request).await
         }
         Command::CommandGetCatalogs(token) => {
-            Ok(flightsql::get_catalogs::get_flight_info(&token, request))
+            Ok(flightsql::get_catalogs::get_flight_info(token, request))
         }
         Command::CommandGetDbSchemas(token) => {
             Ok(flightsql::get_schemas::get_flight_info(&token, request))
@@ -55,7 +55,7 @@ pub(crate) async fn handle(
             flightsql::get_sql_info::get_flight_info(&token, request)
         }
         Command::CommandGetTableTypes(token) => {
-            Ok(flightsql::get_table_types::get_flight_info(&token, request))
+            Ok(flightsql::get_table_types::get_flight_info(token, request))
         }
         Command::CommandGetPrimaryKeys(token) => Ok(flightsql::get_primary_keys::get_flight_info(
             &token, request,

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -21,7 +21,7 @@ use crate::{config, datafusion::DataFusion};
 use app::App;
 use axum::routing::patch;
 use model_components::model::Model;
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use std::net::SocketAddr;
 use std::{collections::HashMap, sync::Arc};
 
@@ -105,9 +105,9 @@ async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse {
     let status = response.status().as_u16().to_string();
 
     let labels = [
-        Key::from_static_str("method").string(method.to_string()),
-        Key::from_static_str("path").string(path),
-        Key::from_static_str("status").string(status),
+        KeyValue::new("method", method.to_string()),
+        KeyValue::new("path", path),
+        KeyValue::new("status", status),
     ];
 
     metrics::REQUESTS_TOTAL.add(1, &labels);

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -24,7 +24,7 @@ use crate::{dataconnector::DataConnector, datafusion::DataFusion};
 use ::datafusion::datasource::TableProvider;
 use ::datafusion::error::DataFusionError;
 use ::datafusion::sql::{sqlparser, TableReference};
-use ::opentelemetry::Key;
+use ::opentelemetry::KeyValue;
 use accelerated_table::AcceleratedTable;
 use app::App;
 use builder::RuntimeBuilder;
@@ -975,7 +975,7 @@ impl Runtime {
                         }
                     },
                 );
-                metrics::datasets::COUNT.add(1, &[Key::from_static_str("engine").string(engine)]);
+                metrics::datasets::COUNT.add(1, &[KeyValue::new("engine", engine)]);
 
                 Ok(())
             }
@@ -1022,7 +1022,7 @@ impl Runtime {
                 }
             },
         );
-        metrics::datasets::COUNT.add(-1, &[Key::from_static_str("engine").string(engine)]);
+        metrics::datasets::COUNT.add(-1, &[KeyValue::new("engine", engine)]);
     }
 
     async fn update_dataset(&self, ds: Arc<Dataset>) {
@@ -1285,8 +1285,9 @@ impl Runtime {
                         metrics::embeddings::COUNT.add(
                             1,
                             &[
-                                Key::from_static_str("embeddings").string(in_embed.name.clone()),
-                                Key::from_static_str("source").string(
+                                KeyValue::new("embeddings", in_embed.name.clone()),
+                                KeyValue::new(
+                                    "source",
                                     in_embed
                                         .get_prefix()
                                         .map(|x| x.to_string())
@@ -1355,8 +1356,7 @@ impl Runtime {
                 let mut tools_map = self.tools.write().await;
                 tools_map.insert(tool.name.clone(), t);
                 tracing::info!("Tool [{}] ready to use", tool.name);
-                metrics::tools::COUNT
-                    .add(1, &[Key::from_static_str("tool").string(tool.name.clone())]);
+                metrics::tools::COUNT.add(1, &[KeyValue::new("tool", tool.name.clone())]);
                 self.status
                     .update_tool(&tool.name, status::ComponentStatus::Ready);
             }
@@ -1381,8 +1381,8 @@ impl Runtime {
         let _guard = TimeMeasurement::new(
             &metrics::models::LOAD_DURATION_MS,
             &[
-                Key::from_static_str("model").string(m.name.clone()),
-                Key::from_static_str("source").string(source_str.clone()),
+                KeyValue::new("model", m.name.clone()),
+                KeyValue::new("source", source_str.clone()),
             ],
         );
 
@@ -1440,8 +1440,8 @@ impl Runtime {
                 metrics::models::COUNT.add(
                     1,
                     &[
-                        Key::from_static_str("model").string(m.name.clone()),
-                        Key::from_static_str("source").string(source_str),
+                        KeyValue::new("model", m.name.clone()),
+                        KeyValue::new("source", source_str),
                     ],
                 );
                 self.status
@@ -1474,8 +1474,8 @@ impl Runtime {
         metrics::models::COUNT.add(
             -1,
             &[
-                Key::from_static_str("model").string(m.name.clone()),
-                Key::from_static_str("source").string(source_str),
+                KeyValue::new("model", m.name.clone()),
+                KeyValue::new("source", source_str),
             ],
         );
     }

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use datafusion::sql::TableReference;
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 
 use crate::metrics;
@@ -84,55 +84,37 @@ impl RuntimeStatus {
     pub fn update_catalog(&self, catalog_name: impl Into<String>, status: ComponentStatus) {
         let catalog_name = catalog_name.into();
         self.update_component_status(format!("catalog:{catalog_name}"), status);
-        metrics::catalogs::STATUS.record(
-            status as u64,
-            &[Key::from_static_str("catalog").string(catalog_name)],
-        );
+        metrics::catalogs::STATUS.record(status as u64, &[KeyValue::new("catalog", catalog_name)]);
     }
 
     pub fn update_dataset(&self, dataset: &TableReference, status: ComponentStatus) {
         let ds_name = dataset.to_string();
         self.update_component_status(format!("dataset:{ds_name}"), status);
-        metrics::datasets::STATUS.record(
-            status as u64,
-            &[Key::from_static_str("dataset").string(ds_name)],
-        );
+        metrics::datasets::STATUS.record(status as u64, &[KeyValue::new("dataset", ds_name)]);
     }
 
     pub fn update_model(&self, model_name: &str, status: ComponentStatus) {
         let model_name = model_name.to_string();
         self.update_component_status(format!("model:{model_name}"), status);
-        metrics::models::STATUS.record(
-            status as u64,
-            &[Key::from_static_str("model").string(model_name)],
-        );
+        metrics::models::STATUS.record(status as u64, &[KeyValue::new("model", model_name)]);
     }
 
     pub fn update_tool(&self, tool_name: &str, status: ComponentStatus) {
         let tool_name = tool_name.to_string();
         self.update_component_status(format!("tool:{tool_name}"), status);
-        metrics::tools::STATUS.record(
-            status as u64,
-            &[Key::from_static_str("tool").string(tool_name)],
-        );
+        metrics::tools::STATUS.record(status as u64, &[KeyValue::new("tool", tool_name)]);
     }
 
     pub fn update_llm(&self, model_name: &str, status: ComponentStatus) {
         let model_name = model_name.to_string();
         self.update_component_status(format!("llm:{model_name}"), status);
-        metrics::llms::STATUS.record(
-            status as u64,
-            &[Key::from_static_str("model").string(model_name)],
-        );
+        metrics::llms::STATUS.record(status as u64, &[KeyValue::new("model", model_name)]);
     }
 
     pub fn update_embedding(&self, model_name: &str, status: ComponentStatus) {
         let model_name = model_name.to_string();
         self.update_component_status(format!("embedding:{model_name}"), status);
-        metrics::embeddings::STATUS.record(
-            status as u64,
-            &[Key::from_static_str("model").string(model_name)],
-        );
+        metrics::embeddings::STATUS.record(status as u64, &[KeyValue::new("model", model_name)]);
     }
 
     /// Checks if all registered components have been ready at least once.

--- a/crates/runtime/tests/acceleration/query_push_down.rs
+++ b/crates/runtime/tests/acceleration/query_push_down.rs
@@ -179,34 +179,33 @@ CREATE TABLE test (
         "Expected 1 rows returned"
     );
 
-    // Re-enable with https://github.com/spiceai/spiceai/issues/2550
-    // let plan_results = rt
-    //     .datafusion()
-    //     .ctx
-    //     .sql("EXPLAIN SELECT COUNT(1) FROM abc")
-    //     .await
-    //     .expect("sql working")
-    //     .collect()
-    //     .await
-    //     .expect("collect working");
+    let plan_results = rt
+        .datafusion()
+        .ctx
+        .sql("EXPLAIN SELECT COUNT(1) FROM abc")
+        .await
+        .expect("sql working")
+        .collect()
+        .await
+        .expect("collect working");
 
-    // let expected_plan = [
-    //     "+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
-    //     "| plan_type     | plan                                                                                                                                                                           |",
-    //     "+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
-    //     "| logical_plan  | BytesProcessedNode                                                                                                                                                             |",
-    //     "|               |   Federated                                                                                                                                                                    |",
-    //     "|               |  Projection: count(Int64(1))                                                                                                                                                   |",
-    //     "|               |   Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                                                                                                                            |",
-    //     "|               |     TableScan: abc                                                                                                                                                             |",
-    //     "| physical_plan | BytesProcessedExec                                                                                                                                                             |",
-    //     "|               |   SchemaCastScanExec                                                                                                                                                           |",
-    //     "|               |     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                       |",
-    //     "|               |       VirtualExecutionPlan name=postgres compute_context=host=Tcp(\"localhost\"),port=20962,user=postgres, sql=SELECT count(1) FROM abc rewritten_sql=SELECT count(1) FROM \"abc\" |",
-    //     "|               |                                                                                                                                                                                |",
-    //     "+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
-    // ];
-    // assert_batches_eq!(expected_plan, &plan_results);
+    let expected_plan = [
+        "+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "| plan_type     | plan                                                                                                                                                                           |",
+        "+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+        "| logical_plan  | BytesProcessedNode                                                                                                                                                             |",
+        "|               |   Federated                                                                                                                                                                    |",
+        "|               |  Projection: count(Int64(1))                                                                                                                                                   |",
+        "|               |   Aggregate: groupBy=[[]], aggr=[[count(Int64(1))]]                                                                                                                            |",
+        "|               |     TableScan: abc                                                                                                                                                             |",
+        "| physical_plan | BytesProcessedExec                                                                                                                                                             |",
+        "|               |   SchemaCastScanExec                                                                                                                                                           |",
+        "|               |     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                                                                                       |",
+        "|               |       VirtualExecutionPlan name=postgres compute_context=host=Tcp(\"localhost\"),port=20962,user=postgres, sql=SELECT count(1) FROM abc rewritten_sql=SELECT count(1) FROM \"abc\" |",
+        "|               |                                                                                                                                                                                |",
+        "+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+",
+    ];
+    assert_batches_eq!(expected_plan, &plan_results);
 
     let plan_results = rt
         .datafusion()

--- a/crates/runtime/tests/catalog/mod.rs
+++ b/crates/runtime/tests/catalog/mod.rs
@@ -28,6 +28,9 @@ use std::sync::Arc;
 
 #[tokio::test]
 async fn spiceai_integration_test_catalog() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
     let _tracing = init_tracing(None);
     let app = AppBuilder::new("spiceai_catalog_test")
         .with_catalog(Catalog::new("spiceai".to_string(), "spiceai".to_string()))
@@ -77,6 +80,9 @@ async fn spiceai_integration_test_catalog() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn spiceai_integration_test_catalog_include() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
     let _tracing = init_tracing(None);
     let mut catalog = Catalog::new("spiceai".to_string(), "spiceai".to_string());
     catalog.include = vec![

--- a/crates/runtime/tests/snapshots/integration__test_graphql_pagination_select_limit_1_id_4.snap
+++ b/crates/runtime/tests/snapshots/integration__test_graphql_pagination_select_limit_1_id_4.snap
@@ -2,20 +2,19 @@
 source: crates/runtime/tests/integration.rs
 description: "Query: SELECT * FROM test_graphql where id = '4' limit 1"
 ---
-+---------------+------------------------------------------------------------------------------+
-| plan_type     | plan                                                                         |
-+---------------+------------------------------------------------------------------------------+
-| logical_plan  | Limit: skip=0, fetch=1                                                       |
-|               |   BytesProcessedNode                                                         |
-|               |     Filter: test_graphql.id = Utf8("4")                                      |
-|               |       TableScan: test_graphql projection=[id, name, posts]                   |
-| physical_plan | GlobalLimitExec: skip=0, fetch=1                                             |
-|               |   CoalescePartitionsExec                                                     |
-|               |     LocalLimitExec: fetch=1                                                  |
-|               |       BytesProcessedExec                                                     |
-|               |         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2 |
-|               |           CoalesceBatchesExec: target_batch_size=8192                        |
-|               |             FilterExec: id@0 = 4                                             |
-|               |               MemoryExec: partitions=2, partition_sizes=[2, 2]               |
-|               |                                                                              |
-+---------------+------------------------------------------------------------------------------+
++---------------+----------------------------------------------------------------------------+
+| plan_type     | plan                                                                       |
++---------------+----------------------------------------------------------------------------+
+| logical_plan  | Limit: skip=0, fetch=1                                                     |
+|               |   BytesProcessedNode                                                       |
+|               |     Filter: test_graphql.id = Utf8("4")                                    |
+|               |       TableScan: test_graphql projection=[id, name, posts]                 |
+| physical_plan | GlobalLimitExec: skip=0, fetch=1                                           |
+|               |   CoalescePartitionsExec                                                   |
+|               |     BytesProcessedExec                                                     |
+|               |       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2 |
+|               |         CoalesceBatchesExec: target_batch_size=8192                        |
+|               |           FilterExec: id@0 = 4                                             |
+|               |             MemoryExec: partitions=2, partition_sizes=[2, 2]               |
+|               |                                                                            |
++---------------+----------------------------------------------------------------------------+

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -37,8 +37,9 @@ const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 #[tokio::test]
 async fn test_tls_endpoints() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
-    CryptoProvider::install_default(crypto::aws_lc_rs::default_provider())
-        .expect("valid crypto provider");
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
 
     let span = tracing::info_span!("test_tls_endpoints");
     let _span_guard = span.enter();

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -28,7 +28,6 @@ use arrow_flight::{
 use prost::Message;
 use rand::Rng;
 use runtime::{config::Config, tls::TlsConfig, Runtime};
-use rustls::crypto::{self, CryptoProvider};
 use tonic::transport::Channel;
 use tonic_health::pb::health_client::HealthClient;
 


### PR DESCRIPTION
## 🗣 Description

Upgrades to Arrow 53, DataFusion 42 and DuckDB 1.1

Also upgrades:
- `delta_kernel` to `0.3.1`
- `opentelemetry*` to `0.25`

DuckDB 1.1: https://github.com/spiceai/duckdb-rs/commit/5b98603705a381ceeb5cc371e4f606b7332b57ce
DataFusion 42: https://github.com/spiceai/datafusion/commits/spiceai-42/
DataFusion Table Providers: https://github.com/datafusion-contrib/datafusion-table-providers/pull/111
DataFusion Federation: https://github.com/spiceai/datafusion-federation/commits/spiceai-42/

Along the way I had to fork a few dependencies that hadn't yet upgraded their own dependencies:

```toml
# Required until next release with https://github.com/open-telemetry/opentelemetry-rust/pull/2095 is included
opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "c3b59ba61055b7ec6916b6b88a9ac94f6656922b" }
opentelemetry_sdk = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "c3b59ba61055b7ec6916b6b88a9ac94f6656922b" }
tracing-opentelemetry = { git = "https://github.com/spiceai/tracing-opentelemetry.git", rev = "67d70b46ec463e5eae31e655bad9c05ac760d986" }
opentelemetry-prometheus = { git = "https://github.com/spiceai/opentelemetry-rust.git", rev = "39584779eff60a71ea6b900daca71fd85730e91a" }
```

## 🔨 Related Issues

Closes #2592
