### PR TITLE
MSSQL: include table name in schema retrieval error

### DIFF
--- a/crates/data_components/src/mssql.rs
+++ b/crates/data_components/src/mssql.rs
@@ -67,8 +67,8 @@ pub enum Error {
     #[snafu(display("Failed to retrieve table schema"))]
     SchemaRetrieval,
 
-    #[snafu(display("Unable to retrieve table schema: dataset not found"))]
-    SchemaRetrievalTableNotFound,
+    #[snafu(display("Unable to retrieve schema: table '{table}' doesn't exist"))]
+    SchemaRetrievalTableNotFound { table: String },
 
     #[snafu(display("Unsupported data type: {data_type}"))]
     UnsupportedType { data_type: String },
@@ -147,7 +147,9 @@ impl SqlServerTableProvider {
         }
 
         if fields.is_empty() {
-            return Err(Error::SchemaRetrievalTableNotFound {});
+            return Err(Error::SchemaRetrievalTableNotFound {
+                table: table.to_string(),
+            });
         }
 
         tracing::trace!("Retrieved dataset {table_name} schema: {fields:?}");

--- a/crates/data_components/src/mssql.rs
+++ b/crates/data_components/src/mssql.rs
@@ -67,7 +67,7 @@ pub enum Error {
     #[snafu(display("Failed to retrieve table schema"))]
     SchemaRetrieval,
 
-    #[snafu(display("Unable to retrieve schema: table '{table}' doesn't exist"))]
+    #[snafu(display("Unable to retrieve schema: table '{table}' does not exist"))]
     SchemaRetrievalTableNotFound { table: String },
 
     #[snafu(display("Unsupported data type: {data_type}"))]


### PR DESCRIPTION
## 🗣 Description

MSSQL: include table name in schema retrieval error


>2024-09-19T17:56:32.609744Z  WARN runtime: Unable to get read provider for mssql: Unable to retrieve schema: table 'saleslt.customer2' doesn't exist


## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/2688