### PR TITLE
Resolve primary keys for datasets with catalog or schema

### DIFF
--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -331,7 +331,6 @@ impl VectorSearch {
                 source: "No distances returned".into(),
             });
         };
-        println!("distances: {:?}", distances.len());
 
         Ok(VectorSearchTableResult {
             primary_key: primary_keys_records,


### PR DESCRIPTION
## 🗣 Description
 - Issue in how we resolve `datasets[*].embeddings[*].column_pk` for datasets with non-default catalog or schema.
 - Also fix and return a score for `v1/search`.