### PR TITLE
feat: Add enabled config option for task_history

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -164,7 +164,7 @@ pub async fn run(args: Args) -> Result<()> {
     let telemetry_config = runtime_config.and_then(|rt| rt.telemetry.clone());
 
     let rt: Runtime = Runtime::builder()
-        .with_app_opt(app)
+        .with_app_opt(app.clone())
         // User configured extensions
         .with_extensions(extension_factories)
         // Extensions that will be auto-loaded if not explicitly loaded and requested by a component
@@ -178,7 +178,7 @@ pub async fn run(args: Args) -> Result<()> {
         .build()
         .await;
 
-    spiced_tracing::init_tracing(app_name.clone(), tracing_config.as_ref(), rt.datafusion())
+    spiced_tracing::init_tracing(app, tracing_config.as_ref(), rt.datafusion())
         .context(UnableToInitializeTracingSnafu)?;
 
     if let Some(metrics_registry) = prometheus_registry {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1630,6 +1630,16 @@ impl Runtime {
     }
 
     pub async fn init_query_history(&self) -> Result<()> {
+        let app = self.app.read().await;
+        if let Some(app) = app.as_ref() {
+            if let Some(task_history) = app.runtime.task_history.as_ref() {
+                if !task_history.enabled {
+                    tracing::debug!("Task history is disabled!");
+                    return Ok(());
+                }
+            }
+        }
+
         let query_history_table_reference = TableReference::partial(
             SPICE_RUNTIME_SCHEMA,
             query_history::DEFAULT_QUERY_HISTORY_TABLE,

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -31,6 +31,8 @@ pub struct Runtime {
     pub tracing: Option<TracingConfig>,
 
     pub telemetry: Option<TelemetryConfig>,
+
+    pub task_history: Option<TaskHistory>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -90,5 +92,12 @@ pub struct TracingConfig {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct TelemetryConfig {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct TaskHistory {
     pub enabled: bool,
 }


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds `enabled` as a spicepod configuration option for `task_history` in the Runtime, like:

```
runtime:
    task_history:
        enabled: false/true
```

When set to `false`, disables the creation of the `task_history` table and all associated logging.

When set to `true` or unset, `task_history` remains enabled by default per existing behavior.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #2753 