### PR TITLE
Utilize DataConnectorError for MySQL Data Connector Errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b42b2421f0e156d8b61830fb467fa9bd04494238#b42b2421f0e156d8b61830fb467fa9bd04494238"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=c9356e3e7b65848d7dcd42e35557827405e1abc3#c9356e3e7b65848d7dcd42e35557827405e1abc3"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ce
 datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "ce18dfa80684d4084b9822e640c3989946b11e15" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "7c69f7bc5d4f67469aaa215650e89000941d6915" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b42b2421f0e156d8b61830fb467fa9bd04494238" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "c9356e3e7b65848d7dcd42e35557827405e1abc3" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "5b98603705a381ceeb5cc371e4f606b7332b57ce" }
 


### PR DESCRIPTION
## 🗣 Description

Refatcor the MySQL Data Connector Errors to wrap MySQL errors in common DataConnectorError, in order to keep consistency with other data connector errors and for less verbose messages.

- Relevant changes for updating verifying user configurable parameters in Datafusion table provider: https://github.com/datafusion-contrib/datafusion-table-providers/pull/113

Before:
Host invalid:
![image](https://github.com/user-attachments/assets/d28fab4f-b5a6-4803-8c43-770dc53c2e0d)
Port Invalid:
![image](https://github.com/user-attachments/assets/75d7d5c0-20e0-4fa3-bd16-5dba0db217a4)
Database invalid:
![image](https://github.com/user-attachments/assets/0436af22-a2db-4f4a-800e-2d18474b9ff4)
Username/ Password invalid:
![image](https://github.com/user-attachments/assets/30214efe-25e1-4f59-b1fe-cf33dda795be)
SSL mode invalid:
![image](https://github.com/user-attachments/assets/1c0c673d-e1eb-4e40-9156-310633026359)

After
Port / Host Invalid:
![image](https://github.com/user-attachments/assets/235b658a-d5bb-4da1-b569-575e18c58008)
Database invalid:
![image](https://github.com/user-attachments/assets/ca15d158-1cb5-443a-b83e-97f01a68b069)
User / Password invalid:
![image](https://github.com/user-attachments/assets/6ead5d3f-558a-4818-89bf-4080abfc7dfb)
SSL mode invalid:
![image](https://github.com/user-attachments/assets/b67e5099-3214-47c4-8819-22d955141ee3)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->