### PR TITLE
Fix spark-connect to use native roots for TLS again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "spark-connect-core"
 version = "0.0.1-beta.4"
-source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=bf6309f0934c646fafb423ed6114fb739f38ddc3#bf6309f0934c646fafb423ed6114fb739f38ddc3"
+source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=9282dcd1bc18f9cbf925916fac0d536217d24569#9282dcd1bc18f9cbf925916fac0d536217d24569"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -9595,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "spark-connect-rs"
 version = "0.0.1-beta.4"
-source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=bf6309f0934c646fafb423ed6114fb739f38ddc3#bf6309f0934c646fafb423ed6114fb739f38ddc3"
+source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=9282dcd1bc18f9cbf925916fac0d536217d24569#9282dcd1bc18f9cbf925916fac0d536217d24569"
 dependencies = [
  "spark-connect-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "spark-connect-core"
 version = "0.0.1-beta.4"
-source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=9282dcd1bc18f9cbf925916fac0d536217d24569#9282dcd1bc18f9cbf925916fac0d536217d24569"
+source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=81b159ccd10f806fcb2d30f86715f77350ba24a2#81b159ccd10f806fcb2d30f86715f77350ba24a2"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -9595,7 +9595,7 @@ dependencies = [
 [[package]]
 name = "spark-connect-rs"
 version = "0.0.1-beta.4"
-source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=9282dcd1bc18f9cbf925916fac0d536217d24569#9282dcd1bc18f9cbf925916fac0d536217d24569"
+source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=81b159ccd10f806fcb2d30f86715f77350ba24a2#81b159ccd10f806fcb2d30f86715f77350ba24a2"
 dependencies = [
  "spark-connect-core",
 ]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -50,7 +50,7 @@ serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
-spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "bf6309f0934c646fafb423ed6114fb739f38ddc3", features = [
+spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "81b159ccd10f806fcb2d30f86715f77350ba24a2", features = [
   "tls",
 ], optional = true }
 tiberius = { workspace = true, optional = true }


### PR DESCRIPTION
## 🗣 Description

The upgrade to tonic had a breaking change which disable automatic loading of TLS root certificates from the system store. I added this back to `spark_connect_rs` in https://github.com/spiceai/spark-connect-rs/pull/7, and this PR updates to that version.
