### PR TITLE
Implement better error handling for spicepods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9283,6 +9283,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9733,6 +9743,7 @@ version = "0.18.1-beta"
 dependencies = [
  "schemars",
  "serde",
+ "serde-value",
  "serde_json",
  "serde_yaml",
  "snafu",

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -39,6 +39,7 @@ use runtime::spice_metrics;
 use runtime::{extension::ExtensionFactory, Runtime};
 use snafu::prelude::*;
 use spice_cloud::SpiceExtensionFactory;
+use tracing::subscriber;
 
 #[path = "tracing.rs"]
 mod spiced_tracing;
@@ -143,7 +144,12 @@ pub async fn run(args: Args) -> Result<()> {
     {
         Ok(app) => Some(Arc::new(app)),
         Err(e) => {
-            tracing::warn!("{}", e);
+            let subscriber = tracing_subscriber::FmtSubscriber::builder()
+                .with_ansi(true)
+                .finish();
+            subscriber::with_default(subscriber, || {
+                tracing::error!("{e}");
+            });
             None
         }
     };

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -12,6 +12,7 @@ schemars = { version = "0.8.19", optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
+serde-value = "0.7.0"
 snafu.workspace = true
 tracing.workspace = true
 

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -53,6 +53,7 @@ impl std::fmt::Display for TimeFormat {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Dataset {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub from: String,
@@ -237,6 +238,7 @@ pub mod acceleration {
     #[allow(clippy::struct_excessive_bools)]
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+    #[serde(deny_unknown_fields)]
     pub struct Acceleration {
         #[serde(default = "default_true")]
         pub enabled: bool,


### PR DESCRIPTION
## 🗣 Description

Adds better error handling when Spice isn't able to parse a Spicepod. For the `ComponentOrReference` enum, I implemented a custom deserializer that tries to deserialize it as a Component first, and if that fails tries to deserialize it as a Reference - and if that also fails, it returns the error message from the component deserialization. This in general gives much better error messages:

```yaml
datasets:
- from: https://public-data.spiceai.org/decimal.parquet
  name: decimal
  acceleration:
    enabled: true
    engine: duckdb
    mode: file
    params:
      duckdb_file: # TODO, add file
```

<img width="914" alt="Screenshot 2024-09-20 at 3 21 06 PM" src="https://github.com/user-attachments/assets/f4ea239a-62bb-40dd-ba09-387e8424b1c3">

```yaml
datasets:
- from: https://public-data.spiceai.org/decimal.parquet
  name: decimal
  time_format: foobar
  acceleration:
    enabled: true
    engine: duckdb
```

<img width="917" alt="Screenshot 2024-09-20 at 3 21 45 PM" src="https://github.com/user-attachments/assets/7fd990b3-81f4-4718-8b98-62358aea046a">

```yaml
datasets:
- from: https://public-data.spiceai.org/decimal.parquet
  name: decimal
  acceleration:
    enabled: true
    engine: duckdb
    moder: file
    params:
      duckdb_file: my_file.db
```

<img width="916" alt="Screenshot 2024-09-20 at 3 22 07 PM" src="https://github.com/user-attachments/assets/eb8156fa-7e84-480f-94e7-9e17d3d74701">


## 🔨 Related Issues

Closes #2691 
Closes #2750

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->