### PR TITLE
Support for standalone config parameters for MS SQL

### DIFF
--- a/crates/data_components/src/mssql/connection_manager.rs
+++ b/crates/data_components/src/mssql/connection_manager.rs
@@ -22,7 +22,7 @@ use tokio::net::TcpStream;
 
 use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
 
-use super::{InvalidConnectionStringSnafu, SqlServerAccessSnafu};
+use super::SqlServerAccessSnafu;
 
 pub type SqlServerConnectionPool = Pool<SqlServerConnectionManager>;
 
@@ -36,11 +36,7 @@ impl SqlServerConnectionManager {
         Self { config }
     }
 
-    pub async fn create_connection_pool(
-        connection_string: &str,
-    ) -> super::Result<SqlServerConnectionPool> {
-        let config =
-            Config::from_ado_string(connection_string).context(InvalidConnectionStringSnafu)?;
+    pub async fn create(config: Config) -> super::Result<SqlServerConnectionPool> {
         let manager = SqlServerConnectionManager::new(config);
         let pool = bb8::Pool::builder()
             .build(manager)

--- a/crates/data_components/src/mssql/execution_plan.rs
+++ b/crates/data_components/src/mssql/execution_plan.rs
@@ -28,6 +28,7 @@ use datafusion::{
         ExecutionMode, ExecutionPlan, Partitioning, PlanProperties, SendableRecordBatchStream,
     },
     sql::{
+        sqlparser::ast::DataType,
         unparser::{
             dialect::{CustomDialect, CustomDialectBuilder},
             Unparser,
@@ -95,7 +96,9 @@ impl SqlServerExecPlan {
     }
 
     fn dialect() -> CustomDialect {
-        CustomDialectBuilder::new().build()
+        CustomDialectBuilder::new()
+            .with_float64_ast_dtype(DataType::Float(None))
+            .build()
     }
 
     pub fn sql(&self) -> DataFusionResult<String> {

--- a/crates/data_components/src/mssql/mod.rs
+++ b/crates/data_components/src/mssql/mod.rs
@@ -42,9 +42,6 @@ pub enum Error {
     #[snafu(display("Error executing query: {source}"))]
     QueryError { source: tiberius::error::Error },
 
-    #[snafu(display("Invalid connection string: {source}"))]
-    InvalidConnectionStringError { source: tiberius::error::Error },
-
     #[snafu(display("Unable to connect: {source}"))]
     SqlServerAccessError { source: tiberius::error::Error },
 
@@ -78,7 +75,6 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct SqlServerTableProvider {
-    #[allow(dead_code)]
     conn: Arc<SqlServerConnectionPool>,
     schema: SchemaRef,
     table: TableReference,

--- a/crates/runtime/src/dataconnector/mssql.rs
+++ b/crates/runtime/src/dataconnector/mssql.rs
@@ -51,9 +51,9 @@ pub enum Error {
 const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("connection_string").secret(),
     ParameterSpec::connector("username").secret(),
-    ParameterSpec::connector("password"),
-    ParameterSpec::connector("host").secret(),
-    ParameterSpec::connector("port").secret(),
+    ParameterSpec::connector("password").secret(),
+    ParameterSpec::connector("host"),
+    ParameterSpec::connector("port"),
     ParameterSpec::connector("database"),
     ParameterSpec::connector("encrypt"),
     ParameterSpec::connector("trust_server_certificate"),

--- a/crates/runtime/src/dataconnector/mssql.rs
+++ b/crates/runtime/src/dataconnector/mssql.rs
@@ -111,7 +111,7 @@ impl SqlServer {
                         config.encryption(EncryptionLevel::Required);
                     }
                     "false" | "disable" => {
-                        config.encryption(EncryptionLevel::NotSupported);
+                        config.encryption(EncryptionLevel::Off);
                     }
                     _ => InvalidParamValueSnafu {
                         parameter: "encrypt",

--- a/crates/runtime/src/dataconnector/mssql.rs
+++ b/crates/runtime/src/dataconnector/mssql.rs
@@ -22,9 +22,11 @@ use data_components::mssql::{
 };
 use datafusion::datasource::TableProvider;
 use snafu::{ResultExt, Snafu};
+use std::num::ParseIntError;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::{any::Any, future::Future};
+use tiberius::{Config, EncryptionLevel};
 
 use super::{
     DataConnector, DataConnectorFactory, DataConnectorResult, ParameterSpec, Parameters,
@@ -33,16 +35,29 @@ use super::{
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Missing required parameter: {parameter}"))]
+    #[snafu(display("Missing required parameter: '{parameter}'"))]
     MissingParameter { parameter: String },
 
     #[snafu(display("Unable to create MS SQL Server connection pool: {source}"))]
     UnableToCreateConnectionPool { source: mssql::Error },
+
+    #[snafu(display("Invalid connection string: {source}"))]
+    InvalidConnectionStringError { source: tiberius::error::Error },
+
+    #[snafu(display("Invalid paramer '{parameter}': {reason}"))]
+    InvalidParamValueError { parameter: String, reason: String },
 }
 
-const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::connector("connection_string")
-    .secret()
-    .required()];
+const PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::connector("connection_string").secret(),
+    ParameterSpec::connector("username").secret(),
+    ParameterSpec::connector("password"),
+    ParameterSpec::connector("host").secret(),
+    ParameterSpec::connector("port").secret(),
+    ParameterSpec::connector("database"),
+    ParameterSpec::connector("encrypt"),
+    ParameterSpec::connector("trust_server_certificate"),
+];
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -52,12 +67,80 @@ pub struct SqlServer {
 
 impl SqlServer {
     async fn new(params: &Parameters) -> Result<Self> {
-        let conn_string = params
-            .get("connection_string")
-            .expose()
-            .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?;
+        let conn_config = if let Some(conn_string) = params.get("connection_string").expose().ok() {
+            Config::from_ado_string(conn_string).context(InvalidConnectionStringSnafu)?
+        } else {
+            let mut config = Config::default();
 
-        let conn = SqlServerConnectionManager::create_connection_pool(conn_string)
+            config.authentication(tiberius::AuthMethod::sql_server(
+                params
+                    .get("username")
+                    .expose()
+                    .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?,
+                params
+                    .get("password")
+                    .expose()
+                    .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?,
+            ));
+
+            config.host(
+                params
+                    .get("host")
+                    .expose()
+                    .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?,
+            );
+
+            if let Some(port_str) = params.get("port").expose().ok() {
+                let port = port_str.parse::<u16>().map_err(|e: ParseIntError| {
+                    InvalidParamValueSnafu {
+                        parameter: "port".to_string(),
+                        reason: e.to_string(),
+                    }
+                    .build()
+                })?;
+                config.port(port);
+            }
+
+            if let Some(database) = params.get("database").expose().ok() {
+                config.database(database);
+            }
+
+            if let Some(val) = params.get("encrypt").expose().ok() {
+                match val.to_lowercase().as_str() {
+                    "true" | "require" => {
+                        config.encryption(EncryptionLevel::Required);
+                    }
+                    "false" | "disable" => {
+                        config.encryption(EncryptionLevel::NotSupported);
+                    }
+                    _ => InvalidParamValueSnafu {
+                        parameter: "encrypt",
+                        reason: format!("unknown value '{val}'"),
+                    }
+                    .fail()?,
+                }
+            } else {
+                config.encryption(EncryptionLevel::Required);
+            }
+
+            if let Some(val) = params.get("trust_server_certificate").expose().ok() {
+                match val.to_lowercase().as_str() {
+                    "true" => {
+                        config.trust_cert();
+                    }
+                    "false" => (),
+                    _ => InvalidParamValueSnafu {
+                        parameter: "trust_server_certificate",
+                        reason: format!("unknown value '{val}'"),
+                    }
+                    .fail()?,
+                }
+            }
+
+            config
+        };
+
+        let conn = SqlServerConnectionManager::create(conn_config)
             .await
             .context(UnableToCreateConnectionPoolSnafu)?;
 


### PR DESCRIPTION
## 🗣 Description

Support for standalone config parameters in addition to `connection_string` for MSSQL

Configuring connection via standalone parameters is much better UX when you don't have connection string provided so you must construct it yourself. Tools like Azure Data Studio do the same - you can provide pre-configured connection string vs set each param individually.

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/2688
