### PR TITLE
Don't call GetComponentStatuses when --metrics not enabled

### DIFF
--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -64,7 +64,7 @@ spice search --cloud
 			cmd.PrintErrln(err.Error())
 		}
 
-		var searchDatasets []string
+		searchDatasets := make([]string, 0)
 		for _, dataset := range datasets {
 			if dataset.Status != api.Ready.String() && dataset.Status != api.Refreshing.String() {
 				cmd.PrintErrln(fmt.Sprintf("Warning: Dataset %s is not ready (%s) and will not be included in search.", dataset.Name, dataset.Status))

--- a/bin/spice/pkg/api/status.go
+++ b/bin/spice/pkg/api/status.go
@@ -122,7 +122,6 @@ FROM
 WHERE
     rn = 1 AND name NOT LIKE 'runtime.%';
 `
-
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/v1/sql", rtContext.HttpEndpoint()), bytes.NewReader([]byte(componentStatusQuery)))
 	if err != nil {
 		return nil, nil, err
@@ -136,6 +135,17 @@ WHERE
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+
+		// If 400, it could be that metric service is disabled and `runtime.metrics` table doesn't exist. This isn't an error.
+		if resp.StatusCode == http.StatusBadRequest {
+			disabled, err := IsMetricsDisabled(rtContext)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get service status: %v", err)
+			}
+			if disabled {
+				return nil, nil, nil
+			}
+		}
 		return nil, nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 	// Parse the JSON response
@@ -158,4 +168,20 @@ WHERE
 		}
 	}
 	return modelStatusMap, datasetsStatusMap, nil
+}
+
+// Returns true iff the metrics service and endpoints on the spiced instance are disabled.
+func IsMetricsDisabled(rtContext *context.RuntimeContext) (bool, error) {
+	s, err := GetData[Service](rtContext, "/v1/status")
+	if err != nil {
+		return false, fmt.Errorf("failed to get service status: %v", err)
+	}
+	for _, service := range s {
+		if service.Name == "metrics" {
+			if service.Status == "Disabled" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
## 🗣 Description
 - [GetComponentStatuses](https://github.com/spiceai/spiceai/blob/700830157ae3d8e0e35c30c4edf29173abd8a810/bin/spice/pkg/api/status.go#L86) relies on the `runtime.metrics` existing. This only occurs when `--metrics` is specified.  
 - If we get a 400 from the `/v1/sql`, check `v1/status` to see if `metrics` services is `ENDPOINT=N/A` and `STATUS=Disabled`.