### PR TITLE
For Sharepoint connector, if client_secret and auth_code are both provided, default to auth_code

### DIFF
--- a/crates/runtime/src/dataconnector/sharepoint.rs
+++ b/crates/runtime/src/dataconnector/sharepoint.rs
@@ -79,7 +79,8 @@ impl Sharepoint {
                     .with_scope([".default"])
                     .build(),
             ),
-            (None, Some(auth_code)) => {
+            (Some(_), Some(auth_code)) | (None, Some(auth_code)) => {
+                tracing::warn!("Both `params.client_secret` and `params.auth_code` are provided. Using `params.auth_code`.");
                 // Must match the redirect URL used in `spice login sharepoint...`.
                 let redirect_url = Url::parse("http://localhost:8091")
                     .boxed()
@@ -97,11 +98,6 @@ impl Sharepoint {
             (None, None) => {
                 return Err(Error::InvalidParameters {
                     source: "either 'client_secret' or 'auth_code' must be provided".into(),
-                })
-            }
-            (Some(_), Some(_)) => {
-                return Err(Error::InvalidParameters {
-                    source: "both 'client_secret' and 'auth_code' cannot be provided".into(),
                 })
             }
         };

--- a/crates/runtime/src/dataconnector/sharepoint.rs
+++ b/crates/runtime/src/dataconnector/sharepoint.rs
@@ -79,7 +79,7 @@ impl Sharepoint {
                     .with_scope([".default"])
                     .build(),
             ),
-            (Some(_), Some(auth_code)) | (None, Some(auth_code)) => {
+            (Some(_) | None, Some(auth_code)) => {
                 tracing::warn!("Both `params.client_secret` and `params.auth_code` are provided. Using `params.auth_code`.");
                 // Must match the redirect URL used in `spice login sharepoint...`.
                 let redirect_url = Url::parse("http://localhost:8091")


### PR DESCRIPTION
## 🗣 Description
 - Currently, if a user provides both `client_secret` and `auth_code` in the Sharepoint connector, the connector returns an error. This can be confusing for when users are testing with both forms of authorisation.
 - This PR updates the Sharepoint connector to default to using `auth_code` if both `client_secret` and `auth_code` are provided.