### PR TITLE
Make integration tests more robust

### DIFF
--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -33,7 +33,7 @@ mod single_instance_duckdb;
 
 // Several acceleration tests need to use shared state from the acceleration registry.
 // To avoid race conditions, use a mutex to ensure that the acceleration tests are run serially.
-static ACCELERATION_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+pub static ACCELERATION_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn get_params(mode: &Mode, file: Option<String>, engine: &str) -> Option<Params> {
     let param_name = format!("{engine}_file",);


### PR DESCRIPTION
## 🗣 Description

Makes the integration tests more robust for the acceleration case by serializing the acceleration tests and cleaning up the shared state when the runtime is restarted.
