### PR TITLE
More types support for MS SQL data connector

### DIFF
--- a/crates/data_components/src/mssql/convert.rs
+++ b/crates/data_components/src/mssql/convert.rs
@@ -137,7 +137,23 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
                         None => builder.append_null(),
                     }
                 }
-
+                ColumnType::Datetime2 => {
+                    let Some(builder) = builder
+                        .as_any_mut()
+                        .downcast_mut::<TimestampNanosecondBuilder>()
+                    else {
+                        return super::FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<NaiveDateTime, usize>(i);
+                    match v {
+                        Some(v) => builder
+                            .append_value(v.and_utc().timestamp_nanos_opt().unwrap_or_default()),
+                        None => builder.append_null(),
+                    }
+                }
                 ColumnType::DatetimeOffsetn => {
                     let Some(builder) = builder
                         .as_any_mut()

--- a/crates/data_components/src/mssql/convert.rs
+++ b/crates/data_components/src/mssql/convert.rs
@@ -16,17 +16,17 @@ limitations under the License.
 
 use std::sync::Arc;
 
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
 use datafusion_table_providers::sql::arrow_sql_gen::arrow::map_data_type_to_array_builder;
-use tiberius::{numeric::Numeric, ColumnType, Row};
+use tiberius::{numeric::Numeric, xml::XmlData, ColumnType, Row};
 use uuid::Uuid;
 
 use arrow::{
     array::{
-        ArrayBuilder, ArrayRef, BooleanBuilder, Date32Builder, Decimal128Builder, Float32Builder,
-        Float64Builder, Int16Builder, Int32Builder, Int64Builder, NullBuilder, RecordBatch,
-        RecordBatchOptions, StringBuilder, Time64NanosecondBuilder, TimestampMillisecondBuilder,
-        TimestampNanosecondBuilder, UInt8Builder,
+        ArrayBuilder, ArrayRef, BinaryBuilder, BooleanBuilder, Date32Builder, Decimal128Builder,
+        Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder, NullBuilder,
+        RecordBatch, RecordBatchOptions, StringBuilder, Time64NanosecondBuilder,
+        TimestampMillisecondBuilder, TimestampNanosecondBuilder, UInt8Builder,
     },
     datatypes::{DataType, Date32Type, SchemaRef, TimeUnit},
 };
@@ -137,7 +137,8 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
                         None => builder.append_null(),
                     }
                 }
-                ColumnType::Datetime2 => {
+
+                ColumnType::DatetimeOffsetn => {
                     let Some(builder) = builder
                         .as_any_mut()
                         .downcast_mut::<TimestampNanosecondBuilder>()
@@ -147,10 +148,14 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
                         }
                         .fail();
                     };
-                    let v = row.get::<NaiveDateTime, usize>(i);
+
+                    let v = row.get::<DateTime<chrono::FixedOffset>, usize>(i);
                     match v {
-                        Some(v) => builder
-                            .append_value(v.and_utc().timestamp_nanos_opt().unwrap_or_default()),
+                        Some(v) => {
+                            let utc_value = v.with_timezone(&chrono::Utc);
+                            builder
+                                .append_value(utc_value.timestamp_nanos_opt().unwrap_or_default());
+                        }
                         None => builder.append_null(),
                     }
                 }
@@ -215,11 +220,36 @@ pub(crate) fn rows_to_arrow(rows: &[Row], schema: &SchemaRef) -> super::Result<R
                         None => builder.append_null(),
                     }
                 }
+                ColumnType::Xml => {
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<StringBuilder>() else {
+                        return super::FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<&XmlData, usize>(i);
+                    match v {
+                        Some(v) => builder.append_value(v),
+                        None => builder.append_null(),
+                    }
+                }
+                ColumnType::Image | ColumnType::BigVarBin | ColumnType::BigBinary => {
+                    let Some(builder) = builder.as_any_mut().downcast_mut::<BinaryBuilder>() else {
+                        return super::FailedToDowncastBuilderSnafu {
+                            mssql_type: format!("{mssql_type:?}"),
+                        }
+                        .fail();
+                    };
+                    let v = row.get::<&[u8], usize>(i);
+                    match v {
+                        Some(v) => builder.append_value(v),
+                        None => builder.append_null(),
+                    }
+                }
                 ColumnType::BigVarChar
                 | ColumnType::BigChar
                 | ColumnType::NVarchar
                 | ColumnType::NChar
-                | ColumnType::Xml
                 | ColumnType::Udt
                 | ColumnType::Text
                 | ColumnType::NText
@@ -275,8 +305,9 @@ pub(crate) fn map_column_type_to_arrow_type(
         ColumnType::Datetime4 | ColumnType::Datetime | ColumnType::Datetimen => {
             DataType::Timestamp(TimeUnit::Millisecond, None)
         }
-        ColumnType::Datetime2 | ColumnType::DatetimeOffsetn => {
-            DataType::Timestamp(TimeUnit::Nanosecond, None)
+        ColumnType::Datetime2 => DataType::Timestamp(TimeUnit::Nanosecond, None),
+        ColumnType::DatetimeOffsetn => {
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()))
         }
         ColumnType::Decimaln | ColumnType::Numericn => {
             let precision = decimal_precision.unwrap_or(38);
@@ -317,6 +348,7 @@ pub(crate) fn map_type_name_to_column_type(data_type: &str) -> super::Result<Col
         "varbinary" | "image" => ColumnType::BigVarBin,
         "xml" => ColumnType::Xml,
         "money" => ColumnType::Money,
+        "smallmoney" => ColumnType::Money4,
         "date" => ColumnType::Daten,
         "time" => ColumnType::Timen,
         "datetime" => ColumnType::Datetime,
@@ -324,6 +356,7 @@ pub(crate) fn map_type_name_to_column_type(data_type: &str) -> super::Result<Col
         "datetime2" => ColumnType::Datetime2,
         "datetimeoffset" => ColumnType::DatetimeOffsetn,
         "bit" => ColumnType::Bit,
+        "geography" => ColumnType::Udt,
         other => {
             return Err(super::Error::UnsupportedType {
                 data_type: other.to_string(),

--- a/crates/data_components/src/mssql/mod.rs
+++ b/crates/data_components/src/mssql/mod.rs
@@ -31,6 +31,7 @@ use datafusion::{
     prelude::Expr,
     sql::TableReference,
 };
+use tiberius::ColumnType;
 
 use std::{any::Any, sync::Arc};
 pub mod connection_manager;
@@ -123,6 +124,13 @@ impl SqlServerTableProvider {
             let numeric_scale: Option<i32> = row.get(3);
 
             let column_type = map_type_name_to_column_type(data_type)?;
+
+            // Tiberius does not support UDTs and will crash
+            if column_type == ColumnType::Udt {
+                tracing::warn!("Column '{column_name}' of table '{table_name}' has unsupported data type '{data_type}' and will be ignored");
+                continue;
+            }
+
             let arrow_data_type = map_column_type_to_arrow_type(
                 column_type,
                 numeric_precision,

--- a/test/scripts/setup-data-mssql.sql
+++ b/test/scripts/setup-data-mssql.sql
@@ -19,41 +19,44 @@ CREATE TABLE test_mssql_table (
     col_nvarchar NVARCHAR(50),
     col_ntext NTEXT,
     col_uniqueidentifier UNIQUEIDENTIFIER,
-    -- col_binary BINARY(10), -- not currently supported, to be added in the future
-    -- col_varbinary VARBINARY(50), -- not currently supported, to be added in the future
-    -- col_xml XML, -- not currently supported, to be added in the future
+    col_binary BINARY(10),
+    col_varbinary VARBINARY(50),
+    col_xml XML,
     col_money MONEY,
+    col_smallmoney SMALLMONEY,
     col_date DATE,
     col_time TIME,
     col_datetime DATETIME,
     col_smalldatetime SMALLDATETIME,
     col_datetime2 DATETIME2,
-    -- col_datetimeoffset DATETIMEOFFSET,-- not currently supported, to be added in the future
-    col_bit BIT
+    col_datetimeoffset DATETIMEOFFSET,
+    col_bit BIT,
+    col_geography GEOGRAPHY
 );
 GO
 
 INSERT INTO test_mssql_table (
     col_int, col_bigint, col_smallint, col_tinyint, col_float, col_real, col_decimal, col_char, col_varchar, col_text, 
-    col_nchar, col_nvarchar, col_ntext, col_uniqueidentifier, col_money, col_date, 
-    col_time, col_datetime, col_smalldatetime, col_datetime2, col_bit
+    col_nchar, col_nvarchar, col_ntext, col_uniqueidentifier, col_binary, col_varbinary, col_xml, col_money, col_smallmoney, 
+    col_date, col_time, col_datetime, col_smalldatetime, col_datetime2, col_datetimeoffset, col_bit, col_geography
 )
 VALUES (
     123, 9223372036854775807, 32767, 255, 123.456, 123.456, 12345.67, 'char_val', 'varchar_val', 'text_val', 
     N'nchar_val', N'nvarchar_val', N'ntext_val', '6F9619FF-8B86-D011-B42D-00C04FC964FF', 
-    12345.67, '2024-01-01', '12:34:56', '2024-01-01 12:34:56', 
-    '2024-01-01 12:00:00', '2024-01-01 12:34:56.1234567', 1
+    0x1234567890, 0xabcdef, '<root><value>test</value></root>', 12345.67, 1234.56, '2024-01-01', 
+    '12:34:56', '2024-01-01 12:34:56', '2024-01-01 12:00:00', '2024-01-01 12:34:56.1234567', '2024-01-01 12:34:56.1234567 +02:00', 1, 
+    geography::STGeomFromText('POINT(47.6062 -22.3321)', 4326)
 );
 GO
 
-INSERT INTO test_mssql_table (
+IINSERT INTO test_mssql_table (
     col_int, col_bigint, col_smallint, col_tinyint, col_float, col_real, col_decimal, col_char, col_varchar, col_text, 
-    col_nchar, col_nvarchar, col_ntext, col_uniqueidentifier, col_money, col_date, 
-    col_time, col_datetime, col_smalldatetime, col_datetime2, col_bit
+    col_nchar, col_nvarchar, col_ntext, col_uniqueidentifier, col_binary, col_varbinary, col_xml, col_money, col_smallmoney, 
+    col_date, col_time, col_datetime, col_smalldatetime, col_datetime2, col_datetimeoffset, col_bit, col_geography
 )
 VALUES (
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-    NULL, NULL, NULL, NULL, NULL, NULL
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
 );
 GO


### PR DESCRIPTION
## 🗣 Description

PR adds support for the following types: `DATETIMEOFFSET`, `SMALLMONEY`, `XML`, `BINARY` to MS SQL data connector.

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/2688

## 📄 Documentation Requirements

Limitation that `geography` type is not supported and will be ignored must be added to MS SQL data connector documentation

## 🤔 Concerns

An alternative approach to handling unsupported geography types could be to fail the dataset registration. However, ignoring unsupported columns with a warning provides a better user experience (UX) in my opinion, allowing users to continue working with the dataset.

