### PR TITLE
MS SQL connector should ignore all unsupported types

### DIFF
--- a/crates/data_components/src/mssql/convert.rs
+++ b/crates/data_components/src/mssql/convert.rs
@@ -347,8 +347,9 @@ pub(crate) fn map_column_type_to_arrow_type(
     }
 }
 
-pub(crate) fn map_type_name_to_column_type(data_type: &str) -> super::Result<ColumnType> {
+pub(crate) fn map_type_name_to_column_type(data_type: &str) -> Option<ColumnType> {
     // https://github.com/prisma/tiberius/blob/51f0cbb3e430db74ba0ea4830b236e89f1b1e03f/src/tds/codec/token/token_col_metadata.rs#L26
+    // Data types (Transact-SQL): https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql
     let column_type = match data_type.to_lowercase().as_str() {
         "int" => ColumnType::Int4,
         "bigint" => ColumnType::Int8,
@@ -372,15 +373,13 @@ pub(crate) fn map_type_name_to_column_type(data_type: &str) -> super::Result<Col
         "datetime2" => ColumnType::Datetime2,
         "datetimeoffset" => ColumnType::DatetimeOffsetn,
         "bit" => ColumnType::Bit,
-        "geography" => ColumnType::Udt,
-        other => {
-            return Err(super::Error::UnsupportedType {
-                data_type: other.to_string(),
-            })
+        // ColumnType::Udt types such as Spatial/geography are not supported by Tiberius
+        _ => {
+            return None;
         }
     };
 
-    Ok(column_type)
+    Some(column_type)
 }
 
 fn get_column_precision_and_scale(

--- a/crates/data_components/src/mssql/mod.rs
+++ b/crates/data_components/src/mssql/mod.rs
@@ -31,7 +31,6 @@ use datafusion::{
     prelude::Expr,
     sql::TableReference,
 };
-use tiberius::ColumnType;
 
 use std::{any::Any, sync::Arc};
 pub mod connection_manager;
@@ -123,13 +122,10 @@ impl SqlServerTableProvider {
             let numeric_precision: Option<u8> = row.get(2);
             let numeric_scale: Option<i32> = row.get(3);
 
-            let column_type = map_type_name_to_column_type(data_type)?;
-
-            // Tiberius does not support UDTs and will crash
-            if column_type == ColumnType::Udt {
+            let Some(column_type) = map_type_name_to_column_type(data_type) else {
                 tracing::warn!("Column '{column_name}' of table '{table_name}' has unsupported data type '{data_type}' and will be ignored");
                 continue;
-            }
+            };
 
             let arrow_data_type = map_column_type_to_arrow_type(
                 column_type,

--- a/test/scripts/setup-data-mssql.sql
+++ b/test/scripts/setup-data-mssql.sql
@@ -49,7 +49,7 @@ VALUES (
 );
 GO
 
-IINSERT INTO test_mssql_table (
+INSERT INTO test_mssql_table (
     col_int, col_bigint, col_smallint, col_tinyint, col_float, col_real, col_decimal, col_char, col_varchar, col_text, 
     col_nchar, col_nvarchar, col_ntext, col_uniqueidentifier, col_binary, col_varbinary, col_xml, col_money, col_smallmoney, 
     col_date, col_time, col_datetime, col_smalldatetime, col_datetime2, col_datetimeoffset, col_bit, col_geography


### PR DESCRIPTION
## 🗣 Description

Enhance the MS SQL connector to handle unsupported types more gracefully by logging a warning and continuing with dataset registration.

This is potential improvement in case of very rare / exotic types that are not supported by connector. All core data types (Transact-SQL) are supported: https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql
