### PR TITLE
Queries that cannot be planned show up in task history

### DIFF
--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -130,6 +130,11 @@ fn trace_query(query_tracker: &QueryTracker, truncated_output: &str) {
     if let Some(error_code) = &query_tracker.error_code {
         tracing::info!(target: "task_history", error_code = %error_code, "labels");
     }
+
+    if let Some(error_message) = &query_tracker.error_message {
+        tracing::error!(target: "task_history", "{error_message}");
+    }
+
     if let Some(query_execution_duration_secs) = &query_tracker.query_execution_duration_secs {
         tracing::info!(target: "task_history", query_execution_duration_ms = %query_execution_duration_secs * 1000.0, "labels");
     }

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::datafusion::query::error_code::ErrorCode;
 use crate::datafusion::query::{Protocol, QueryBuilder};
 use crate::datafusion::DataFusion;
 use crate::dataupdate::DataUpdate;
@@ -164,15 +163,7 @@ impl Service {
     ) -> Result<Schema, Status> {
         let query = QueryBuilder::new(sql, datafusion, protocol).build();
 
-        let schema = match query.get_schema().await {
-            Ok(schema) => schema,
-            Err(err) => {
-                let error_code = ErrorCode::from(&err);
-                query.finish_with_error(err.to_string(), error_code);
-
-                return Err(handle_datafusion_error(err));
-            }
-        };
+        let schema = query.get_schema().await.map_err(handle_datafusion_error)?;
         Ok(schema)
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1630,7 +1630,7 @@ impl Runtime {
 
         if let Some(app) = app.as_ref() {
             if !app.runtime.task_history.enabled {
-                tracing::debug!("Task history is disabled!");
+                tracing::debug!("Task history is disabled via configuration.");
                 return Ok(());
             }
         }


### PR DESCRIPTION
## 🗣 Description

Queries that cannot be planned (i.e. due to referencing tables that don't exist) will now show up in the task_history table as an error.

Performing a query over Flight is a two-stage process, the first stage is calling `GetFlightInfo` which returns the schema of the query. The second stage is calling `DoGet` which performs the actual query. If the schema couldn't get retrieved because the query couldn't be planned, then the error should still be logged to task_history properly.

## 🔨 Related Issues

Closes #2742
Part of #2639
