### PR TITLE
Keep track of accelerated tables and mark queries as accelerated in task_history

### DIFF
--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -229,6 +229,18 @@ impl Query {
                 inner_span.record("runtime_query", true);
             }
 
+            // If any of the input tables are accelerated, mark the query as accelerated
+            let mut is_accelerated = false;
+            for tr in &input_tables {
+                if ctx.df.is_accelerated(tr).await {
+                    is_accelerated = true;
+                    break;
+                }
+            }
+            if is_accelerated {
+                tracker.is_accelerated = Some(true);
+            }
+
             tracker = tracker.datasets(Arc::new(input_tables));
 
             // Start the timer for the query execution

--- a/crates/runtime/src/datafusion/query/builder.rs
+++ b/crates/runtime/src/datafusion/query/builder.rs
@@ -82,6 +82,7 @@ impl<'a> QueryBuilder<'a> {
                 query_execution_duration_secs: None,
                 rows_produced: 0,
                 results_cache_hit: None,
+                is_accelerated: None,
                 error_message: None,
                 error_code: None,
                 query_duration_timer: Instant::now(),

--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -30,6 +30,7 @@ pub(crate) struct QueryTracker {
     pub(crate) query_execution_duration_secs: Option<f32>,
     pub(crate) rows_produced: u64,
     pub(crate) results_cache_hit: Option<bool>,
+    pub(crate) is_accelerated: Option<bool>,
     pub(crate) error_message: Option<String>,
     pub(crate) error_code: Option<ErrorCode>,
     pub(crate) query_duration_timer: Instant,
@@ -143,6 +144,10 @@ fn trace_query(query_tracker: &QueryTracker, truncated_output: &str) {
 
     if let Some(true) = query_tracker.results_cache_hit {
         tracing::info!(target: "task_history", results_cache_hit = true, "labels");
+    }
+
+    if let Some(true) = &query_tracker.is_accelerated {
+        tracing::info!(target: "task_history", accelerated = true, "labels");
     }
 
     let datasets_str = query_tracker

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1001,7 +1001,7 @@ impl Runtime {
                     .await;
             }
 
-            if let Err(e) = self.df.remove_table(&ds.name) {
+            if let Err(e) = self.df.remove_table(&ds.name).await {
                 tracing::warn!("Unable to unload dataset {}: {}", &ds.name, e);
                 return;
             }


### PR DESCRIPTION
## 🗣 Description

Adds a label for `accelerated: true` for SQL queries in the `task_history` table that involve at least one accelerated table.

## 🔨 Related Issues

Closes #1611
Part of #2639

## 📄 Documentation Requirements

Tracked by #2639
