### PR TITLE
Upgrade macOS x86_64 test runner to macOS 13.6.9 Ventura

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -45,7 +45,7 @@ jobs:
                 target_arch_go: "arm64"
               }, {
                 name: "macOS x64 (Intel)",
-                runner: "macos-12",
+                runner: "macos-13",
                 target_os: "darwin",
                 target_arch: "x86_64",
                 target_arch_go: "amd64"


### PR DESCRIPTION
## 🗣 Description

Upgrade macOS x86_64 test runner to macOS 13.6.9 Ventura. Current latest is macOS 15 Sequoia.
https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

General upgrade + to fix MySQL installation issue 
