### PR TITLE
Use updated lopdf and add error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,8 +5972,7 @@ dependencies = [
 [[package]]
 name = "lopdf"
 version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+source = "git+https://github.com/J-F-Liu/lopdf?rev=38b8c25f3e92c578baf18928a8ce75d447a6009a#38b8c25f3e92c578baf18928a8ce75d447a6009a"
 dependencies = [
  "chrono",
  "encoding_rs",

--- a/crates/document_parse/Cargo.toml
+++ b/crates/document_parse/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 
 [dependencies]
 docx-rs = { git = "https://github.com/spiceai/docx-rs", rev="2d86a60b58afb02b157f96b42a92626417e47f71"}
-lopdf = "0.34.0"
+lopdf = {git = "https://github.com/J-F-Liu/lopdf", rev = "38b8c25f3e92c578baf18928a8ce75d447a6009a" } # "0.34.0"
 snafu.workspace = true
 bytes = "1.6.0"
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/document_parse/src/lib.rs
+++ b/crates/document_parse/src/lib.rs
@@ -82,7 +82,7 @@ pub trait Document {
     fn type_(&self) -> DocumentType;
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DocumentType {
     Pdf,
     Docx,


### PR DESCRIPTION
## 🗣 Description
 - Issue with `lopdf` limits the type of PDFs that can be parsed. Update dependency
 - Also improve error messaging to show specific file with parsing error.
 ```shell
2024-09-24T00:56:54.286363Z  WARN runtime::accelerated_table::refresh_task: Failed to update dataset pdf: External error: Execution error: External error: Error parsing document Users/jeadie/Github/spiceai/data/pdf/s41586-021-03819-2.pdf: Internal parsing PDF document. Error: ToUnicodeCMap(Parse(Error))
```

## 🔨 Related Issues
 - https://github.com/J-F-Liu/lopdf/issues/319

## 🤔 Concerns
 - Does not yet resolve all PDF formats.
