### PR TITLE
Add verbosity flags for spiced, spice: `-v`, `-vv`, `--verbose`, `--very-verbose`.

### DIFF
--- a/bin/spice/cmd/add.go
+++ b/bin/spice/cmd/add.go
@@ -124,6 +124,5 @@ spice add spiceai/quickstart
 }
 
 func init() {
-	addCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	RootCmd.AddCommand(addCmd)
 }

--- a/bin/spice/cmd/dataset.go
+++ b/bin/spice/cmd/dataset.go
@@ -228,9 +228,7 @@ spice dataset configure
 }
 
 func init() {
-	configureCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	datasetCmd.AddCommand(configureCmd)
 
-	datasetCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	RootCmd.AddCommand(datasetCmd)
 }

--- a/bin/spice/cmd/init.go
+++ b/bin/spice/cmd/init.go
@@ -78,6 +78,5 @@ spice init my_app
 }
 
 func init() {
-	initCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	RootCmd.AddCommand(initCmd)
 }

--- a/bin/spice/cmd/install.go
+++ b/bin/spice/cmd/install.go
@@ -84,7 +84,6 @@ spice install ai
 }
 
 func init() {
-	installCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	installCmd.Flags().BoolP("force", "f", false, "Force installation of the latest released runtime")
 	RootCmd.AddCommand(installCmd)
 }

--- a/bin/spice/cmd/login.go
+++ b/bin/spice/cmd/login.go
@@ -530,7 +530,6 @@ func mergeAuthConfig(cmd *cobra.Command, updatedAuthName string, updatedAuthConf
 }
 
 func init() {
-	dremioCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	dremioCmd.Flags().StringP(usernameFlag, "u", "", "Username")
 	dremioCmd.Flags().StringP(passwordFlag, "p", "", "Password")
 	loginCmd.AddCommand(dremioCmd)
@@ -552,21 +551,17 @@ func init() {
 	deltaLakeCmd.Flags().String(gcpServiceAccountPath, "", "Google Service Account Path")
 	loginCmd.AddCommand(deltaLakeCmd)
 
-	sharepointCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	sharepointCmd.Flags().StringP(m365TenantId, "t", "", "Microsoft organization tenant ID")
 	sharepointCmd.Flags().StringP(m365ClientId, "c", "", "Microsoft Azure AD application client ID")
 	loginCmd.AddCommand(sharepointCmd)
 
-	s3Cmd.Flags().BoolP("help", "h", false, "Print this help message")
 	s3Cmd.Flags().StringP(accessKeyFlag, "k", "", "Access key")
 	s3Cmd.Flags().StringP(accessSecretFlag, "s", "", "Access Secret")
 	loginCmd.AddCommand(s3Cmd)
 
-	postgresCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	postgresCmd.Flags().StringP(passwordFlag, "p", "", "Password")
 	loginCmd.AddCommand(postgresCmd)
 
-	snowflakeCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	snowflakeCmd.Flags().StringP(accountFlag, "a", "", "Account identifier")
 	snowflakeCmd.Flags().StringP(usernameFlag, "u", "", "Username")
 	snowflakeCmd.Flags().StringP(passwordFlag, "p", "", "Password")
@@ -574,11 +569,9 @@ func init() {
 	snowflakeCmd.Flags().StringP(passphraseFlag, "s", "", "Passphrase")
 	loginCmd.AddCommand(snowflakeCmd)
 
-	sparkCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	sparkCmd.Flags().String(sparkRemoteFlag, "", "Spark Remote")
 	loginCmd.AddCommand(sparkCmd)
 
-	loginCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	loginCmd.Flags().StringP(apiKeyFlag, "k", "", "API key")
 	RootCmd.AddCommand(loginCmd)
 }

--- a/bin/spice/cmd/refresh.go
+++ b/bin/spice/cmd/refresh.go
@@ -109,7 +109,6 @@ spice refresh taxi_trips
 }
 
 func init() {
-	refreshCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	refreshCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	refreshCmd.Flags().String(refreshSqlFlag, "", "'refresh_sql' to refresh a dataset.")
 	refreshCmd.Flags().String(refreshModeFlag, "", "'refresh_mode', one of: full, append")

--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -56,6 +56,5 @@ spice run
 }
 
 func init() {
-	runCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	RootCmd.AddCommand(runCmd)
 }

--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -17,7 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/runtime"
@@ -37,6 +39,12 @@ spice run
 		err := checkLatestCliReleaseVersion()
 		if err != nil && util.IsDebug() {
 			cmd.PrintErrf("failed to check for latest CLI release version: %s\n", err.Error())
+		}
+
+		// Pass through verbosity of `spice run`
+		level := verbosity.GetLevel()
+		if level > 0 {
+			args = append(args, fmt.Sprintf("-%s", strings.Repeat("v", level)))
 		}
 
 		err = runtime.Run(args)

--- a/bin/spice/cmd/spice.go
+++ b/bin/spice/cmd/spice.go
@@ -22,7 +22,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
+
+var verbosity = util.NewVerbosity()
 
 var RootCmd = &cobra.Command{
 	Use:   "spice",
@@ -37,6 +40,12 @@ func Execute() {
 		RootCmd.Println(err)
 		os.Exit(-1)
 	}
+}
+
+func init() {
+	RootCmd.PersistentFlags().CountVarP(&verbosity.VerbosityCount, "verbose", "v", "Verbose logging")
+	RootCmd.PersistentFlags().BoolVar(&verbosity.VeryVerbose, "very-verbose", false, "Very verbose logging")
+	RootCmd.PersistentFlags().BoolP("help", "h", false, "Print this help message")
 }
 
 func initConfig() {

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -75,6 +75,5 @@ sql> show tables
 
 func init() {
 	sqlCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
-	sqlCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	RootCmd.AddCommand(sqlCmd)
 }

--- a/bin/spice/pkg/util/verbosity.go
+++ b/bin/spice/pkg/util/verbosity.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+type Verbosity struct {
+	VerbosityCount int
+	VeryVerbose    bool
+}
+
+func NewVerbosity() *Verbosity {
+	return &Verbosity{}
+}
+
+func (v *Verbosity) GetLevel() int {
+	if v.VerbosityCount > 2 {
+		return v.VerbosityCount
+	}
+
+	if v.VeryVerbose {
+		return 2
+	}
+
+	return v.VerbosityCount
+}

--- a/bin/spice/pkg/util/verbosity.go
+++ b/bin/spice/pkg/util/verbosity.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package util
 
+// Verbosity is a struct to handle the complexity of verbosity level from the CLI flags.
+// Specifically, it lets us have both `--verbose` and `--very-verbose` flags.
+//
+// VeryVerbose is a boolean flag to indicate at least 2 levels of verbosity.
+// If `VerbosityCount` is greater than 2, it will be ignored, otherwise it will
+// be set to 2 if `VeryVerbose` is true.
 type Verbosity struct {
 	VerbosityCount int
 	VeryVerbose    bool

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -199,7 +199,7 @@ pub async fn run(args: Args) -> Result<()> {
         tracing_config.as_ref(),
         rt.datafusion(),
         LogVerbosity::from_flags_and_env(
-            args.verbose == 1, // -v or --verbose
+            args.verbose == 1,                      // -v or --verbose
             args.verbose >= 2 || args.very_verbose, // -vv or --very-verbose
             "SPICED_LOG",
         ),

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -136,9 +136,10 @@ pub struct Args {
     #[arg(long)]
     pub telemetry_enabled: Option<bool>,
 
-    #[arg(long)]
-    pub verbose: bool,
+    #[arg(short, long, action = ArgAction::Count)]
+    pub verbose: u8,
 
+    /// Enable very verbose logging. In conjunction with `verbose` can be set via -vv or --very-verbose.
     #[arg(long)]
     pub very_verbose: bool,
 }
@@ -197,7 +198,11 @@ pub async fn run(args: Args) -> Result<()> {
         &app,
         tracing_config.as_ref(),
         rt.datafusion(),
-        LogVerbosity::from_flags_and_env(args.verbose, args.very_verbose, "SPICED_LOG"),
+        LogVerbosity::from_flags_and_env(
+            args.verbose == 1, // -v or --verbose
+            args.verbose >= 2 || args.very_verbose, // -vv or --very-verbose
+            "SPICED_LOG",
+        ),
     )
     .context(UnableToInitializeTracingSnafu)?;
 


### PR DESCRIPTION
## 🗣 Description
 - Add support for specifying log verbosity as flags `--very-verbose` `--verbose` and shorthand. 
 - In spiced, this overrides the `EnvFilter` used by tracing to set the log level. These flags take precedence over the `SPICED_LOG` environment variable that currently dictates `EnvFilter`. 
 - In spice, verbosity flags are just passed to spice. 
 - Also, I made `-h` a global flag in spice.

### Examples
```shell
>> spiced --verbose

>> spice run -vv

// --very-verbose overrides the SPICED_LOG
>> SPICED_LOG="spiced=WARN,runtime=WARN,data_components=WARN,cache=WARN" spice run --very-verbose
```


## 🔨 Related Issues
 - #2301 

## 🤔 Concerns
 - Currently -v, -vv in spice are only used to pass into spiced. In spice, our current logging does not support log levels (using https://pkg.go.dev/log). We would have to migrate to https://pkg.go.dev/log/slog@go1.23.1 or similar.
