### PR TITLE
Enable "rc" feature for serde in spicepod crate

### DIFF
--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 fundu.workspace = true
 schemars = { version = "0.8.19", optional = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 serde-value = "0.7.0"


### PR DESCRIPTION
The `"rc"` feature is necessary to enable serialization for fields of the `Arc<T>` type, added in #2784 
The runtime build didn't fail because the feature was derived from a dependency, but spicepod crate compilation was failing.

That will fix json schema generation.