### PR TITLE
Change `BytesProcessedRule` to be an optimizer rather than an analyzer rule

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -50,7 +50,7 @@ use datafusion::sql::parser::DFParser;
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::{sqlparser, TableReference};
 use datafusion_federation::{FederatedTableProviderAdaptor, FederationAnalyzerRule};
-use extension::{bytes_processed::BytesProcessedAnalyzerRule, SpiceQueryPlanner};
+use extension::{bytes_processed::BytesProcessedOptimizerRule, SpiceQueryPlanner};
 use query::{Protocol, QueryBuilder};
 use snafu::prelude::*;
 use tokio::spawn;
@@ -280,7 +280,7 @@ impl DataFusion {
 
         let ctx = SessionContext::new_with_state(state);
         ctx.add_analyzer_rule(Arc::new(FederationAnalyzerRule::new()));
-        ctx.add_analyzer_rule(Arc::new(BytesProcessedAnalyzerRule::new()));
+        ctx.add_optimizer_rule(Arc::new(BytesProcessedOptimizerRule::new()));
         ctx.register_udf(embeddings::array_distance::ArrayDistance::new().into());
         ctx.register_udf(crate::datafusion::udf::Greatest::new().into());
         ctx.register_udf(crate::datafusion::udf::Least::new().into());


### PR DESCRIPTION
## 🗣 Description

DataFusion has two kinds of rules that can rewrite LogicalPlans, `AnalyzerRule`s and `OptimizerRules`. `AnalyzerRule`s can be used to change the semantic meaning of the query, while `OptimizerRule`s are not allowed to change the semantic meaning of the query, but to compute it in some "better" way.

The rule `PushDownLimit` is responsible for pushing down the limit to a `TableScan` node, but it doesn't support the ability to push down limits beyond extension nodes. #2850 showed that this caused an issue for us, since AnalyzerRules always run before OptimizerRules - and we inserted the `BytesProcessedNode` extension into the plan, and thus it wasn't able to properly push down the limit.

By making the rule to add the `BytesProcessedNode` an `OptimizerRule`, we can add it to the end of the list which will ensure the `PushDownLimit` node has a chance to run first, which means by the time the `BytesProcessedRule` runs, the limit is already applied.

## 🔨 Related Issues

#2850
