### PR TITLE
fix: Remove login column rename in pulls and update Optimizer

### DIFF
--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -705,7 +705,6 @@ impl GraphQLClient {
         cursor: Option<String>,
     ) -> Result<GraphQLQueryResult> {
         let query_string = query.to_string(limit, cursor);
-        println!("{query_string}");
 
         let body = format!(r#"{{"query": {}}}"#, json!(query_string));
 

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -705,6 +705,7 @@ impl GraphQLClient {
         cursor: Option<String>,
     ) -> Result<GraphQLQueryResult> {
         let query_string = query.to_string(limit, cursor);
+        println!("{query_string}");
 
         let body = format!(r#"{{"query": {}}}"#, json!(query_string));
 

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -438,7 +438,6 @@ pub(crate) fn filter_pushdown(expr: &Expr) -> FilterPushdownResult {
         };
 
         let parameter = format!("{column_name}:{value}");
-        println!("{parameter}");
 
         return FilterPushdownResult {
             filter_pushdown: TableProviderFilterPushDown::Inexact,

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -400,7 +400,7 @@ pub fn parse_globs(input: &str) -> super::DataConnectorResult<Arc<GlobSet>> {
 // TODO: add support for LIKE and IN filters, to support columns like assignees, labels, etc
 // TODO: add support for date comparisons to support columns like updated_at, created_at, closed_at, etc
 const GITHUB_SUPPORTED_FILTER_PUSHDOWN_COLUMNS: &[&str] =
-    &["author", "title", "state", "id", "number"];
+    &["login", "title", "state", "id", "number"];
 
 pub(crate) fn filter_pushdown(expr: &Expr) -> FilterPushdownResult {
     if let Expr::BinaryExpr(binary_expr) = expr {
@@ -424,18 +424,21 @@ pub(crate) fn filter_pushdown(expr: &Expr) -> FilterPushdownResult {
         }
 
         let value = if let ScalarValue::Utf8(Some(v)) = &value {
-            if column == "state".into() {
-                // state enums output their value as uppercase, but search with lowercase
-                // e.g. OPEN -> open
-                ScalarValue::Utf8(Some(v.to_lowercase()))
-            } else {
-                value
+            match column.name.as_str() {
+                "state" => ScalarValue::Utf8(Some(v.to_lowercase())),
+                _ => value.clone(),
             }
         } else {
             value
         };
 
-        let parameter = format!("{column}:{value}", column = column.name);
+        let column_name = match column.name.as_str() {
+            "login" => "author",
+            _ => column.name.as_str(),
+        };
+
+        let parameter = format!("{column_name}:{value}");
+        println!("{parameter}");
 
         return FilterPushdownResult {
             filter_pushdown: TableProviderFilterPushDown::Inexact,

--- a/crates/runtime/src/dataconnector/github/pull_requests.rs
+++ b/crates/runtime/src/dataconnector/github/pull_requests.rs
@@ -85,7 +85,7 @@ impl GitHubTableArgs for PullRequestTableArgs {
                             closed_at: closedAt
                             number
                             reviews {{reviews_count: totalCount}}
-                            author: author {{ author: login }}
+                            author {{ login }}
                             additions
                             deletions
                             changed_files: changedFiles
@@ -124,7 +124,7 @@ impl GitHubTableArgs for PullRequestTableArgs {
                             closed_at: closedAt
                             number
                             reviews {{reviews_count: totalCount}}
-                            author: author {{ author: login }}
+                            author {{ login }}
                             additions
                             deletions
                             changed_files: changedFiles
@@ -159,7 +159,6 @@ fn gql_schema() -> SchemaRef {
             ))),
             true,
         ),
-        Field::new("author", DataType::Utf8, true),
         Field::new("body", DataType::Utf8, true),
         Field::new("changed_files", DataType::Int64, true),
         Field::new(
@@ -194,6 +193,7 @@ fn gql_schema() -> SchemaRef {
             ))),
             true,
         ),
+        Field::new("login", DataType::Utf8, true),
         Field::new(
             "merged_at",
             DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Removes a breaking change for renaming `login` to `author` in the GitHub pulls table
* Because of the column name difference, adds logic to remap column names to search column names

## 🔨 Related Issues

* Part of #2453
