### PR TITLE
Add Markdown aware chunker when `params.file_format: md`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3194,7 +3194,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "paste",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3915,8 +3915,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4540,6 +4540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4594,8 +4603,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -6056,6 +6065,7 @@ dependencies = [
  "indexmap 2.5.0",
  "mistralrs",
  "mistralrs-core",
+ "pulldown-cmark",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6110,7 +6120,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "syn 2.0.77",
 ]
 
@@ -6466,7 +6476,7 @@ dependencies = [
  "rand_isaac",
  "rayon",
  "regex",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "reqwest 0.12.7",
  "rustc-hash 2.0.0",
  "schemars",
@@ -7285,9 +7295,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "onig"
@@ -8193,6 +8206,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666f0f59e259aea2d72e6012290c09877a780935cc3c18b1ceded41f3890d59c"
+dependencies = [
+ "bitflags 2.6.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "pulp"
 version = "0.18.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8578,14 +8610,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -8599,13 +8631,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -8622,9 +8654,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remain"
@@ -10432,6 +10464,7 @@ dependencies = [
  "either",
  "itertools 0.13.0",
  "once_cell",
+ "pulldown-cmark",
  "regex",
  "strum 0.26.3",
  "thiserror",
@@ -10440,18 +10473,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10598,7 +10631,7 @@ dependencies = [
  "rayon",
  "rayon-cond",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "serde",
  "serde_json",
  "spm_precompiled",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -25,7 +25,8 @@ serde = { workspace = true, features = ["derive"] }
 tokenizers = { version = "0.19.1" }
 tracing.workspace = true
 tracing-futures.workspace = true
-text-splitter = "0.16.1"
+text-splitter = {version =  "0.16.1", features = ["markdown"]}
+pulldown-cmark = "0.12.1"
 
 ## `candle` feature packages
 mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "cfc0fa7ffaed0ca71cf86caff4dbd950d08626d8", optional = true }

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -97,6 +97,7 @@ impl EmbeddingConnector {
                             target_chunk_size: chunk_cfg.target_chunk_size,
                             overlap_size: chunk_cfg.overlap_size,
                             trim_whitespace: chunk_cfg.trim_whitespace,
+                            file_format: dataset.params.get("file_format").map(String::as_str),
                         },
                     )
                 })

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -65,7 +65,7 @@ impl EmbeddingTable {
         base_table: Arc<dyn TableProvider>,
         embedded_columns: HashMap<String, String>,
         embedding_models: Arc<RwLock<EmbeddingModelStore>>,
-        embed_chunker_config: HashMap<String, ChunkingConfig>,
+        embed_chunker_config: HashMap<String, ChunkingConfig<'_>>,
     ) -> Self {
         let sizes = Self::precompute_embedding_sizes(&embedded_columns, &embedding_models).await;
         let chunkers = Self::prepare_chunkers(
@@ -110,7 +110,7 @@ impl EmbeddingTable {
 
     /// For a given set of columns that should be chunked (i.e. keys of `cfgs`), prepare the chunkers based on the column's embedding model in [`EmbeddingModelStore`].
     async fn prepare_chunkers(
-        cfgs: HashMap<String, ChunkingConfig>,
+        cfgs: HashMap<String, ChunkingConfig<'_>>,
         embedding_models: &Arc<RwLock<EmbeddingModelStore>>,
         column_to_model: HashMap<String, String>,
     ) -> HashMap<String, Arc<dyn Chunker>> {


### PR DESCRIPTION
## 🗣 Description
 - When using chunking, instead of preserving semantics based on plaintext, for markdown files, use markdown semantics.
 - This is practically implemented in the choice of `text_splitter` provided to `EmbeddingTable`. Based on `params.file_format`, use markdown formatter where appropriate.
 - This gives future viability to other formats, e.g. code.
