### PR TITLE
'spice version' without structured logging

### DIFF
--- a/bin/spice/cmd/version.go
+++ b/bin/spice/cmd/version.go
@@ -40,7 +40,9 @@ var versionCmd = &cobra.Command{
 spice version
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		slog.Info(fmt.Sprintf("CLI version:     %s\n", version.Version()))
+
+		// Intentionally without structured logging
+		cmd.Printf("CLI version:     %s\n", version.Version())
 
 		var rtversion string
 		var err error
@@ -62,7 +64,8 @@ spice version
 			}
 		}
 
-		slog.Info(fmt.Sprintf("Runtime version: %s\n", rtversion))
+		// Intentionally without structured logging
+		cmd.Printf("Runtime version: %s\n", rtversion)
 
 		err = checkLatestCliReleaseVersion()
 		if err != nil && util.IsDebug() {


### PR DESCRIPTION
## 🗣 Description
 - Prior PR to move spice CLI to use `log/slog` resulted in `spice version` emitting structured logs. 
 - This caused problems for automated release CI, e.g: https://github.com/spiceai/spiceai/blob/87b753ae9a1e986d292c98358841212f1183eb99/.github/workflows/e2e_test_release_install.yml#L124-L128
 -  More broadly, for output that is not logging (i.e. intentionally outputted by CLI), we should not default to structured logging.

## 🔨 Related Issues
 - Prior PR #2859 