### PR TITLE
feat: GraphQL commit query parameters

### DIFF
--- a/crates/runtime/src/dataconnector/github/commits.rs
+++ b/crates/runtime/src/dataconnector/github/commits.rs
@@ -14,14 +14,49 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::{GitHubTableArgs, GitHubTableGraphQLParams};
+use super::{
+    commits_inject_parameters, filter_pushdown, inject_parameters, GitHubQueryMode,
+    GitHubTableArgs, GitHubTableGraphQLParams,
+};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use data_components::graphql::{client::GraphQLQuery, FilterPushdownResult, GraphQLOptimizer};
+use datafusion::{logical_expr::TableProviderFilterPushDown, prelude::Expr};
 use std::sync::Arc;
 
 // https://docs.github.com/en/graphql/reference/objects#commit
 pub struct CommitsTableArgs {
     pub owner: String,
     pub repo: String,
+    pub query_mode: GitHubQueryMode,
+}
+
+impl GraphQLOptimizer for CommitsTableArgs {
+    fn filter_pushdown(
+        &self,
+        expr: &Expr,
+    ) -> Result<FilterPushdownResult, datafusion::error::DataFusionError> {
+        if self.query_mode == GitHubQueryMode::Auto {
+            return Ok(FilterPushdownResult {
+                filter_pushdown: TableProviderFilterPushDown::Unsupported,
+                expr: expr.clone(),
+                context: None,
+            });
+        }
+
+        Ok(filter_pushdown(expr))
+    }
+
+    fn inject_parameters(
+        &self,
+        filters: &[FilterPushdownResult],
+        query: &mut GraphQLQuery<'_>,
+    ) -> Result<(), datafusion::error::DataFusionError> {
+        if self.query_mode == GitHubQueryMode::Auto {
+            return Ok(());
+        }
+
+        inject_parameters("history", commits_inject_parameters, filters, query)
+    }
 }
 
 impl GitHubTableArgs for CommitsTableArgs {

--- a/crates/runtime/src/dataconnector/github/issues.rs
+++ b/crates/runtime/src/dataconnector/github/issues.rs
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 use super::{
-    filter_pushdown, inject_parameters, GitHubQueryMode, GitHubTableArgs, GitHubTableGraphQLParams,
+    filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
+    GitHubTableGraphQLParams,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use data_components::graphql::{
@@ -56,7 +57,7 @@ impl GraphQLOptimizer for IssuesTableArgs {
             return Ok(());
         }
 
-        inject_parameters(filters, query)
+        inject_parameters("search", search_inject_parameters, filters, query)
     }
 }
 

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -343,7 +343,6 @@ impl DataConnector for Github {
                 let table_args = Arc::new(CommitsTableArgs {
                     owner: owner.to_string(),
                     repo: repo.to_string(),
-                    query_mode,
                 });
                 self.create_gql_table_provider(
                     Arc::clone(&table_args) as Arc<dyn GitHubTableArgs>,

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -416,13 +416,17 @@ enum GitHubFilterRemap {
 }
 
 struct GitHubPushdownSupport {
+    // which operators are permitted to be pushed down
     ops: Vec<Operator>,
+    // if the column name needs to be changed for the query, include a remap
+    // remaps can be operator dependent. For example, the "since" and "until" operators for "committed_date"
     remaps: Option<Vec<GitHubFilterRemap>>,
+    // Whether this query parameter permits the use of modifiers like <, >, -, etc
     uses_modifiers: bool,
 }
 
-// TODO: add support for LIKE and IN filters, to support columns like assignees, labels, etc
-// TODO: add support for date comparisons to support columns like updated_at, created_at, closed_at, etc
+// TODO: add support for IN filters, to support columns like assignees, labels, etc.
+// Table currently doesn't support IN at all though, with or without pushdown, so that needs to be fixed first
 lazy_static! {
     static ref GITHUB_FILTER_PUSHDOWNS_SUPPORTED: HashMap<&'static str, GitHubPushdownSupport> = {
         let mut m = HashMap::new();

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -36,7 +36,9 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use globset::{Glob, GlobSet, GlobSetBuilder};
-use graphql_parser::query::{Definition, OperationDefinition, Query, SelectionSet};
+use graphql_parser::query::{
+    Definition, InlineFragment, OperationDefinition, Query, Selection, SelectionSet,
+};
 use issues::IssuesTableArgs;
 use lazy_static::lazy_static;
 use pull_requests::PullRequestTableArgs;
@@ -341,8 +343,13 @@ impl DataConnector for Github {
                 let table_args = Arc::new(CommitsTableArgs {
                     owner: owner.to_string(),
                     repo: repo.to_string(),
+                    query_mode,
                 });
-                self.create_gql_table_provider(table_args, None).await
+                self.create_gql_table_provider(
+                    Arc::clone(&table_args) as Arc<dyn GitHubTableArgs>,
+                    Some(table_args),
+                )
+                .await
             }
             (Some("github.com"), Some(owner), Some(repo), Some("issues")) => {
                 let table_args = Arc::new(IssuesTableArgs {
@@ -404,9 +411,14 @@ pub fn parse_globs(input: &str) -> super::DataConnectorResult<Arc<GlobSet>> {
     Ok(Arc::new(glob_set))
 }
 
+enum GitHubFilterRemap {
+    Column(&'static str),
+    Operator((Operator, &'static str)),
+}
+
 struct GitHubPushdownSupport {
     ops: Vec<Operator>,
-    remap: Option<&'static str>,
+    remaps: Option<Vec<GitHubFilterRemap>>,
 }
 
 // TODO: add support for LIKE and IN filters, to support columns like assignees, labels, etc
@@ -418,7 +430,15 @@ lazy_static! {
             "login",
             GitHubPushdownSupport {
                 ops: vec![Operator::Eq, Operator::NotEq],
-                remap: Some("author"),
+                remaps: Some(vec![GitHubFilterRemap::Column("author")]),
+            },
+        );
+
+        m.insert(
+            "author_name",
+            GitHubPushdownSupport {
+                ops: vec![Operator::Eq],
+                remaps: Some(vec![GitHubFilterRemap::Column("author")]),
             },
         );
 
@@ -432,7 +452,7 @@ lazy_static! {
                     Operator::NotLikeMatch,
                     Operator::NotILikeMatch,
                 ],
-                remap: None,
+                remaps: None,
             },
         );
 
@@ -440,7 +460,7 @@ lazy_static! {
             "state",
             GitHubPushdownSupport {
                 ops: vec![Operator::Eq, Operator::NotEq],
-                remap: None,
+                remaps: None,
             },
         );
 
@@ -454,7 +474,7 @@ lazy_static! {
                     Operator::NotLikeMatch,
                     Operator::NotILikeMatch,
                 ],
-                remap: None,
+                remaps: None,
             },
         );
 
@@ -468,7 +488,7 @@ lazy_static! {
                     Operator::Gt,
                     Operator::GtEq,
                 ],
-                remap: Some("created"),
+                remaps: Some(vec![GitHubFilterRemap::Column("created")]),
             },
         );
 
@@ -482,7 +502,7 @@ lazy_static! {
                     Operator::Gt,
                     Operator::GtEq,
                 ],
-                remap: Some("updated"),
+                remaps: Some(vec![GitHubFilterRemap::Column("updated")]),
             },
         );
 
@@ -496,7 +516,7 @@ lazy_static! {
                     Operator::Gt,
                     Operator::GtEq,
                 ],
-                remap: Some("closed"),
+                remaps: Some(vec![GitHubFilterRemap::Column("closed")]),
             },
         );
 
@@ -510,7 +530,25 @@ lazy_static! {
                     Operator::Gt,
                     Operator::GtEq,
                 ],
-                remap: Some("merged"),
+                remaps: Some(vec![GitHubFilterRemap::Column("merged")]),
+            },
+        );
+
+        m.insert(
+            "committed_date",
+            GitHubPushdownSupport {
+                // e.g. committed_date > '2024-09-14'
+                ops: vec![
+                    Operator::Lt,
+                    Operator::LtEq,
+                    Operator::Gt,
+                    Operator::GtEq,
+                ],
+                remaps: Some(vec![
+                    GitHubFilterRemap::Operator((Operator::Gt, "since")),
+                    GitHubFilterRemap::Operator((Operator::GtEq, "since")),
+                    GitHubFilterRemap::Operator((Operator::Lt, "until")),
+                    GitHubFilterRemap::Operator((Operator::LtEq, "until"))]),
             },
         );
 
@@ -518,6 +556,7 @@ lazy_static! {
     };
 }
 
+#[allow(clippy::too_many_lines)]
 pub(crate) fn filter_pushdown(expr: &Expr) -> FilterPushdownResult {
     let column_matches = match expr {
         Expr::BinaryExpr(binary_expr) => {
@@ -558,6 +597,26 @@ pub(crate) fn filter_pushdown(expr: &Expr) -> FilterPushdownResult {
                 };
             }
 
+            let column_name = if let Some(remaps) = &column_support.remaps {
+                let mut column_name: Option<&str> = None;
+                for remap in remaps {
+                    match remap {
+                        GitHubFilterRemap::Column(remap_column) => {
+                            column_name = Some(remap_column);
+                        }
+                        GitHubFilterRemap::Operator((remap_op, remap_column)) => {
+                            if *remap_op == op {
+                                column_name = Some(remap_column);
+                            }
+                        }
+                    }
+                }
+
+                column_name.unwrap_or(column.name.as_str())
+            } else {
+                column.name.as_str()
+            };
+
             let value = match value {
                 ScalarValue::Utf8(Some(v)) => {
                     if column.name == "state" {
@@ -578,7 +637,17 @@ pub(crate) fn filter_pushdown(expr: &Expr) -> FilterPushdownResult {
                 ScalarValue::TimestampMillisecond(Some(millis), _) => {
                     let dt = Utc.timestamp_millis_opt(millis);
                     match dt {
-                        LocalResult::Single(dt) => dt.to_rfc3339(),
+                        LocalResult::Single(dt) => match column_name {
+                            "updated" | "created" | "closed" | "merged" => dt.to_rfc3339(),
+                            "since" | "until" => dt.format("%Y-%m-%d").to_string(),
+                            _ => {
+                                return FilterPushdownResult {
+                                    filter_pushdown: TableProviderFilterPushDown::Unsupported,
+                                    expr: expr.clone(),
+                                    context: None,
+                                }
+                            }
+                        },
                         _ => {
                             return FilterPushdownResult {
                                 filter_pushdown: TableProviderFilterPushDown::Unsupported,
@@ -589,12 +658,6 @@ pub(crate) fn filter_pushdown(expr: &Expr) -> FilterPushdownResult {
                     }
                 }
                 _ => value.to_string(),
-            };
-
-            let column_name = if let Some(remap) = column_support.remap {
-                remap
-            } else {
-                column.name.as_str()
             };
 
             let neq = match op {
@@ -631,57 +694,12 @@ pub(crate) fn filter_pushdown(expr: &Expr) -> FilterPushdownResult {
     }
 }
 
-pub(crate) fn inject_parameters(
-    filters: &[FilterPushdownResult],
-    query: &mut GraphQLQuery<'_>,
+pub(crate) fn search_inject_parameters(
+    field: &mut graphql_parser::query::Field<'_, String>,
+    filters: &[&FilterPushdownResult],
 ) -> Result<(), datafusion::error::DataFusionError> {
-    if filters.is_empty() {
-        return Ok(());
-    }
-
-    // only inject filters that aren't unsupported
-    let filters: Vec<&FilterPushdownResult> = filters
-        .iter()
-        .filter(|f| f.filter_pushdown != TableProviderFilterPushDown::Unsupported)
-        .collect();
-
-    // find the search() field leaf in the AST
-    let search_field = query.ast
-            .definitions
-            .iter_mut()
-            .find_map(|def| match def {
-                Definition::Operation(OperationDefinition::Query(Query {
-                    selection_set, ..
-                })) => selection_set.items.iter_mut().find_map(|item| match item {
-                    graphql_parser::query::Selection::Field(field) => {
-                        if field.name == "search" {
-                            Some(field)
-                        } else {
-                            None
-                        }
-                    }
-                    _ => None,
-                }),
-
-                Definition::Operation(OperationDefinition::SelectionSet(SelectionSet {
-                    items,
-                    ..
-                })) => items.iter_mut().find_map(|item| match item {
-                    graphql_parser::query::Selection::Field(field) => {
-                        if field.name == "search" {
-                            Some(field)
-                        } else {
-                            None
-                        }
-                    }
-                    _ => None,
-                }),
-                _ => None,
-            })
-            .ok_or_else(|| DataFusionError::Execution("GitHub GraphQL query did not contain a 'search()' statement, when one was expected".to_string()))?;
-
     // get the query: argument from the search() field
-    let query_arg = search_field.arguments.iter_mut().find_map(|arg| {
+    let query_arg = field.arguments.iter_mut().find_map(|arg| {
             if arg.0 == "query" {
                 Some(arg)
             } else {
@@ -716,6 +734,111 @@ pub(crate) fn inject_parameters(
         query_arg.0.clone(),
         graphql_parser::query::Value::String(query_value),
     );
+
+    Ok(())
+}
+
+pub(crate) fn commits_inject_parameters(
+    field: &mut graphql_parser::query::Field<'_, String>,
+    filters: &[&FilterPushdownResult],
+) -> Result<(), datafusion::error::DataFusionError> {
+    for filter in filters {
+        if let Some(context) = &filter.context {
+            let Some((column, value)) = context.split_once(':') else {
+                return Err(DataFusionError::Execution(
+                    "GitHub GraphQL query argument was not in the expected format of '<column>:<value>'".to_string(),
+                ));
+            };
+
+            field.arguments.push((
+                column.to_string(),
+                graphql_parser::query::Value::String::<String>(value.to_string()),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn inject_parameters<F>(
+    target_field_name: &str,
+    field_modifier: F,
+    filters: &[FilterPushdownResult],
+    query: &mut GraphQLQuery<'_>,
+) -> Result<(), datafusion::error::DataFusionError>
+where
+    F: Fn(
+        &mut graphql_parser::query::Field<'_, String>,
+        &[&FilterPushdownResult],
+    ) -> Result<(), datafusion::error::DataFusionError>,
+{
+    if filters.is_empty() {
+        return Ok(());
+    }
+
+    // only inject filters that aren't unsupported
+    let filters: Vec<&FilterPushdownResult> = filters
+        .iter()
+        .filter(|f| f.filter_pushdown != TableProviderFilterPushDown::Unsupported)
+        .collect();
+
+    // find the history() field leaf in the AST
+    let mut all_selections: Vec<&mut Selection<'_, String>> = Vec::new();
+    for def in &mut query.ast.definitions {
+        let selections = match def {
+            Definition::Operation(OperationDefinition::Query(Query { selection_set, .. })) => {
+                &mut selection_set.items
+            }
+            Definition::Operation(OperationDefinition::SelectionSet(SelectionSet {
+                items,
+                ..
+            })) => items,
+            _ => continue,
+        };
+
+        all_selections.extend(selections.iter_mut());
+    }
+
+    let mut target_field = None;
+    // loop over inner selection sets to find the target field if it's deep in a nest
+    loop {
+        let Some(selection) = all_selections.pop() else {
+            break;
+        };
+
+        match selection {
+            graphql_parser::query::Selection::InlineFragment(InlineFragment {
+                selection_set,
+                ..
+            }) => {
+                selection_set
+                    .items
+                    .iter_mut()
+                    .for_each(|item| all_selections.push(item));
+            }
+            graphql_parser::query::Selection::Field(field) => {
+                if field.name == target_field_name {
+                    target_field = Some(field);
+                    break;
+                }
+
+                field
+                    .selection_set
+                    .items
+                    .iter_mut()
+                    .for_each(|item| all_selections.push(item));
+            }
+            graphql_parser::query::Selection::FragmentSpread(_) => continue,
+        }
+    }
+
+    let target_field = target_field.ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "GitHub GraphQL query did not contain a '{target_field_name}()' statement, when one was expected"
+        ))
+    })?;
+
+    field_modifier(target_field, &filters)?;
 
     // update any change in JSON pointer and pagination parameters
     let (pagination_parameters, json_pointer) = PaginationParameters::parse(&query.ast);

--- a/crates/runtime/src/dataconnector/github/pull_requests.rs
+++ b/crates/runtime/src/dataconnector/github/pull_requests.rs
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 use super::{
-    filter_pushdown, inject_parameters, GitHubQueryMode, GitHubTableArgs, GitHubTableGraphQLParams,
+    filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
+    GitHubTableGraphQLParams,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use data_components::graphql::{
@@ -56,7 +57,7 @@ impl GraphQLOptimizer for PullRequestTableArgs {
             return Ok(());
         }
 
-        inject_parameters(filters, query)
+        inject_parameters("search", search_inject_parameters, filters, query)
     }
 }
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds support for using the `since` and `until` query parameters in the GraphQL query for commits
* In the process of adding support, refactors some of the functions to support reusing them more generically
* Updates the GraphQL AST field finder to properly recurse nested fields to find the target field

Enables filter push down on any query mode when searching on `committed_date` like:

```bash
sql> select sha from spiceai.commits where committed_date < '2024-09-24' and committed_date
 > '2024-09-14'
+------------------------------------------+
| sha                                      |
+------------------------------------------+
| 44917e212e6392d75fbb1742e22368af89fe3f81 |
| 9c862a78376e01dcf515f9a699eb01353eed3b23 |
| 269e8d9ee028e011a22bc0ab0f4db0ff39b55b6c |
| 269aad2798c77585e2c4deb486ddbe62357200c7 |
| 36f38ea34fde947854cb9bd84f3912dac1ae4b7b |
| d75b9f88712594a5b8fd0e4dad23afeb24dfcc4b |
| 72fed656586dd71d44b7f139fea0caaf14647da0 |
| fca3ab602b1e1e8d11e3dab5a6348eceb03fd893 |
| 3f985d3714228467e9db7434e48ee491edb49d31 |
| 11f79e33b5321a8a86a048cde4212635147f0808 |
| c86b7ff5e581aa6fc3183cbeb074156b7c13993d |
| 678176dc2e004f8f5c117df31aa6c2e309e20bbb |
| 8851f2d9ede8a2d4964fb57b2a7d49b3cc73a1ca |
| aceda51de62d045fe96df600a1082ef256441e1f |
| 6723fe8307b282ad519c5225fb27528394c6db0e |
| 5e776741e27151f3d2a604ccd2a3f3036796dbdd |
| bcfe39f81bbc4c947035e8db1b130e4b15371222 |
| e70249c67e7c8cc71e2ed439a5b0079faaa657a0 |
| f3285f3d4f3c54dc5b5683dfc7a0bddf1e4b2826 |
| e68728e6b0ec3c4b69846a3487cc69b289669797 |
| 23a247ac8b7f31104aba1fdcdb94d0aa1d4ff382 |
| 793f083e3ca6baafbb8ea699802c55a190f4b2ae |
| 463438cb3758109a84869ffda3ae8716be08963a |
| 700830157ae3d8e0e35c30c4edf29173abd8a810 |
| a49c430adae829234b182f9488055b442389ec27 |
| 145e696619ae01d34ba321fc9f33bc061b358de3 |
| bb6fa845ba1327a6ea9c0e280fc8f018c2601e27 |
| 5cd8f2521b8a48f0bf736fb7ae92f3293e83fa25 |
| 3250850d42bacd98f830bb53630bf75598427baf |
| 7874bb81b48550d4472fef1a213dc341770b9c15 |
| 268689ca09ebcdd664b8ca5a1f72bf02f4859fb8 |
| 674b39fbb1d94d1550b2d0b0725caf98b2b38cd5 |
| 5b82cbd45176244df9fe7100b9de47030f80d57c |
| 617f0b588ea77d8a0b195ee74fa1be7618b5edfb |
| a0d5587ec5146f020190e9c6685d76b5d0d05170 |
| 73a680089f2822a5a6a4cba74abe9adbcb232ff4 |
| 365c8e3bb880e0783365b44d42215162f3556743 |
| f6bd8d4f0ab5a660f6ee875f1584166d5de17a9a |
| 30254fbdc39e79ad108400b9e2ec1c1030648787 |
| e57680199b97a9f3a91e7819bbca4b16f7740efb |
| e340d19fdbef0f5b249a6ad6cc4465af3b3dc3f8 |
| 8f33c309063168795d6a949149a66c8d3a9d2f2b |
| 25417b9c5011dade1f7c74d85f0725b2ec085e45 |
| 61d8e1b9512deca1f2c38662ba2caf28480c5b03 |
| cdce71a475607ab60d0b6caadbd147f330069dea |
| a0e1e881e5b9cba3c08e93fc8f48d1c2a8dfb6a8 |
| 5e1fc3e48309d6aa7cdd3ad9c15dda027abf528d |
| 5358de18bccd1145c1cf00f8be61fdc4ec96fe4d |
| 68cad8e53d529b77416f660b4ea0e18b548db46b |
| 5cfeca37c7e69b1e86f58d0eb8158b48a28492c1 |
| 005215a1d6214944a2a3b317d5d16d4a3f05c4fd |
| 32768b9ffa58fb7927122b638f0597f7dab38dd4 |
| 1bd40eed716d7e11e1d0ee59d78bcd103b68687b |
| a5833fe96803b9e7113c83851d8a68faacbd4bd0 |
| 2e9e766e94b70af914b0b5ed6156f579f0ed6e1f |
| 7b99ca1e1124c82f3920dadf76dace3a9c5c2f11 |
| fa176b086bf171666ae7cb453ae87b00be150ca1 |
| 6134f086c40448b4f7eb742a4e165560395b36f9 |
| 4e11257698e1ecaba3677e14f0ab8664f0677e77 |
| 08dd47cfb00cf4435f37898a631f3a298677f45c |
| ccd722f5d30d13c0bf4bea494acb897db769c8f9 |
| 1b7e8906f74fe5740a1a3f4494426152844456d7 |
| c5dcb108f3ec5513e8010e9a46db1338e4fef87e |
| 61720d9e2401b0d632ab18142b5b2f7f8b1ebabe |
| 95f53d7d3f12bd5bb6faf5850d5882037da71fc2 |
| a3d64982b6707fa1b18593319f8b0b66d0d0d880 |
| f148d43e291f23249fbd8746979bba334809c653 |
| 7d6ca635c2865daafb0c8209e1081f888aa35507 |
| 8321d118eff75373aa52ff0399e3dddb51e5347a |
| 954b63d0422e9acaa4f6ff0c033569b5091b08e0 |
| de48742dc8ae3157f98dfbe49bd8cdd8d5d80655 |
| 6911ce98cc869fda4b9fc2bfc2eac02c3bd4710e |
| 7e8149e9cca6f2627aab509b55611f079b9c7099 |
| d2a3a6e001134f3135ab7db94055d5b9dc47d222 |
| 06d97d7f4d6aacea1079304f50b8c27ffc5285a3 |
+------------------------------------------+

Time: 0.918523286 seconds. 75 rows.
```

Query mode currently has no effect for commits, as it would be implemented in #2835

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #2838
