### PR TITLE
Adding multi-line editing and tab indentation to sql REPL

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1001,25 +1001,25 @@ jobs:
           uses: ./.github/actions/run-query
           with:
             fail-on-error: true
-            query: "select number, title, state, labels, updated_at from spiceai.issues order by updated_at desc limit 10"
+            query: "select number, title, state, labels, updated_at from spiceai.issues order by updated_at desc limit 10;"
 
         - name: Run test query (pulls)
           uses: ./.github/actions/run-query
           with:
             fail-on-error: true
-            query: "select number, title, state, merged_at from spiceai.pulls where state = 'MERGED' order by merged_at desc limit 10"
+            query: "select number, title, state, merged_at from spiceai.pulls where state = 'MERGED' order by merged_at desc limit 10;"
 
         - name: Run test query (commits)
           uses: ./.github/actions/run-query
           with:
             fail-on-error: true
-            query: "select message_head_line, author_name, sha from spiceai.commits order by committed_date desc limit 10"
+            query: "select message_head_line, author_name, sha from spiceai.commits order by committed_date desc limit 10;"
 
         - name: Run test query (files)
           uses: ./.github/actions/run-query
           with:
             fail-on-error: true
-            query: "select name, path, download_url, content from spiceai.files limit 1"
+            query: "select name, path, download_url, content from spiceai.files limit 1;"
 
         - name: Run test query (stargazers)
           uses: ./.github/actions/run-query

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1025,7 +1025,7 @@ jobs:
           uses: ./.github/actions/run-query
           with:
             fail-on-error: true
-            query: "select * from spiceai.stargazers limit 10"
+            query: "select * from spiceai.stargazers limit 10;"
     
         - name: Stop spice and check logs
           working-directory: test_app
@@ -1129,7 +1129,7 @@ jobs:
           uses: ./.github/actions/run-query
           with:
             fail-on-error: true
-            query: "select * from test_mssql_table"
+            query: "select * from test_mssql_table;"
     
         - name: Stop spice and check logs
           working-directory: test_app

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -3194,7 +3194,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "paste",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -3915,8 +3915,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set",
- "regex-automata 0.4.8",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -4603,8 +4603,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.8",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -6120,7 +6120,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.4",
  "syn 2.0.77",
 ]
 
@@ -6476,7 +6476,7 @@ dependencies = [
  "rand_isaac",
  "rayon",
  "regex",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.7",
  "reqwest 0.12.7",
  "rustc-hash 2.0.0",
  "schemars",
@@ -7295,12 +7295,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "onig"
@@ -8610,14 +8607,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -8631,13 +8628,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -8654,9 +8651,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "remain"
@@ -9284,10 +9281,22 @@ dependencies = [
  "memchr",
  "nix 0.28.0",
  "radix_trie",
+ "rustyline-derive",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5af959c8bf6af1aff6d2b463a57f71aae53d1332da58419e30ad8dc7011d951"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -10473,18 +10482,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10631,7 +10640,7 @@ dependencies = [
  "rayon",
  "rayon-cond",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.4",
  "serde",
  "serde_json",
  "spm_precompiled",
@@ -10833,9 +10842,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -10853,7 +10862,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.2",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
  "socket2 0.5.7",
  "tokio",

--- a/crates/flightrepl/Cargo.toml
+++ b/crates/flightrepl/Cargo.toml
@@ -20,6 +20,6 @@ prost = { version = "0.13.1", default-features = false, features = [
   "prost-derive",
 ] }
 reqwest.workspace = true
-rustyline = "14.0.0"
+rustyline = { version="14.0.0", features=["custom-bindings", "with-dirs", "with-file-history", "derive"] }
 serde_json.workspace = true
 tonic = { workspace = true, features = ["transport", "tls", "tls-roots"] }

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -36,7 +36,9 @@ use llms::chat::LlmRuntime;
 use prost::Message;
 use reqwest::Client;
 use rustyline::error::ReadlineError;
-use rustyline::DefaultEditor;
+use rustyline::{Editor, EventHandler, Modifiers};
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
+use rustyline::{Completer, Helper, Highlighter, Hinter, ConditionalEventHandler, KeyEvent};
 use serde_json::json;
 use tonic::transport::{Channel, ClientTlsConfig};
 use tonic::{Code, IntoRequest, Status};
@@ -90,6 +92,47 @@ async fn send_nsql_request(
         .await
 }
 
+#[derive(Completer, Helper, Highlighter, Hinter)]
+struct ReplHelper;
+
+impl Validator for ReplHelper {
+    fn validate(&self, ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
+        let input = ctx.input();
+        if !input.trim().ends_with(';') {
+            Ok(ValidationResult::Incomplete)
+        } else {
+            Ok(ValidationResult::Valid(None))
+        }
+    }
+}
+
+#[derive(Clone)]
+struct KeyEventHandler;
+
+impl ConditionalEventHandler for KeyEventHandler {
+    fn handle(
+            &self,
+            evt: &rustyline::Event,
+            _n: rustyline::RepeatCount,
+            _positive: bool,
+            ctx: &rustyline::EventContext,
+        ) -> Option<rustyline::Cmd> {
+        if let Some(k) = evt.get(0) {
+            if *k == KeyEvent::ctrl('C') {
+                if !ctx.line().is_empty() {
+                    Some(rustyline::Cmd::Interrupt)
+                } else {
+                    Some(rustyline::Cmd::EndOfFile)
+                }  
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::missing_errors_doc)]
 pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Error>> {
@@ -122,8 +165,13 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         .max_decoding_message_size(500 * 1024 * 1024)
         .max_encoding_message_size(500 * 1024 * 1024);
 
-    let mut rl = DefaultEditor::new()?;
-
+    let mut rl = Editor::new()?;
+    let helper = ReplHelper {};
+    let key_handler = Box::new(KeyEventHandler {});
+    rl.bind_sequence(KeyEvent::ctrl('C'), EventHandler::Conditional(key_handler));
+    rl.bind_sequence(KeyEvent::ctrl('D'), rustyline::Cmd::Abort);
+    rl.bind_sequence(KeyEvent::new('\t', Modifiers::NONE), rustyline::Cmd::Insert(1, "\t".to_string()));
+    rl.set_helper(Some(helper));
     println!("Welcome to the Spice.ai SQL REPL! Type 'help' for help.\n");
     println!("show tables; -- list available tables");
 
@@ -135,7 +183,11 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         let line_result = rl.readline(&prompt);
         let line = match line_result {
             Ok(line) => line,
-            Err(ReadlineError::Interrupted | ReadlineError::Eof) => {
+            Err(ReadlineError::Interrupted) => {
+                // User canceled the current query
+                continue;
+            }
+            Err(ReadlineError::Eof) => {
                 break;
             }
             Err(err) => {

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -117,19 +117,17 @@ impl ConditionalEventHandler for KeyEventHandler {
         _positive: bool,
         ctx: &rustyline::EventContext,
     ) -> Option<rustyline::Cmd> {
-        if let Some(k) = evt.get(0) {
+        evt.get(0).and_then(|k| {
             if *k == KeyEvent::ctrl('C') {
-                if ctx.line().is_empty() {
-                    Some(rustyline::Cmd::EndOfFile)
+                Some(if ctx.line().is_empty() {
+                    rustyline::Cmd::EndOfFile
                 } else {
-                    Some(rustyline::Cmd::Interrupt)
-                }
+                    rustyline::Cmd::Interrupt
+                })
             } else {
                 None
             }
-        } else {
-            None
-        }
+        })
     }
 }
 

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -95,10 +95,14 @@ async fn send_nsql_request(
 #[derive(Completer, Helper, Highlighter, Hinter)]
 struct ReplHelper;
 
+const SPECIAL_COMMANDS: [&str; 6] = [".exit", "exit", "quit", "q", ".error", "help"];
+
 impl Validator for ReplHelper {
     fn validate(&self, ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
         let input = ctx.input();
-        if input.trim().ends_with(';') {
+        if SPECIAL_COMMANDS.contains(&input.to_ascii_lowercase().trim())
+            || input.trim().ends_with(';')
+        {
             Ok(ValidationResult::Valid(None))
         } else {
             Ok(ValidationResult::Incomplete)

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -169,7 +169,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
     let helper = ReplHelper {};
     let key_handler = Box::new(KeyEventHandler {});
     rl.bind_sequence(KeyEvent::ctrl('C'), EventHandler::Conditional(key_handler));
-    rl.bind_sequence(KeyEvent::ctrl('D'), rustyline::Cmd::Abort);
+    rl.bind_sequence(KeyEvent::ctrl('D'), rustyline::Cmd::EndOfFile);
     rl.bind_sequence(KeyEvent::new('\t', Modifiers::NONE), rustyline::Cmd::Insert(1, "\t".to_string()));
     rl.set_helper(Some(helper));
     println!("Welcome to the Spice.ai SQL REPL! Type 'help' for help.\n");


### PR DESCRIPTION
## 🗣 Description

(Breaking change)

Enhances the SQL REPL with the following changes:

- All SQL statements now require a `;` to end the statement, allowing users to use `Enter` to space their queries for readability using newlines
- Ctrl+C interrupts the REPL so that a user can stop editing the query they're working on without executing it
- Ctrl+C still exits the REPL if there is no query
- Ctrl+D now *always* exits the REPL at any time
- Tab now inserts a tab character for indentation

## 🔨 Related Issues

- Closes #2919 

## 📄 Documentation Requirements

## 🤔 Concerns
