### PR TITLE
Add spiced arg `--pods-watcher-enabled`. Watcher disabled by default for spiced.

### DIFF
--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -278,7 +278,10 @@ func (c *RuntimeContext) GetSpiceAppRelativePath(absolutePath string) string {
 func (c *RuntimeContext) GetRunCmd(args []string) (*exec.Cmd, error) {
 	spiceCMD := c.binaryFilePath("spiced")
 
-	spiceArgs := []string{"--metrics", "127.0.0.1:9090"}
+	spiceArgs := []string{
+		"--metrics", "127.0.0.1:9090",
+		"--pods-watcher-enabled",
+	}
 	args = append(spiceArgs, args...)
 
 	cmd := exec.Command(spiceCMD, args...)

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 
 [dependencies]
 app = { path = "../../crates/app" }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 flightrepl = { path = "../../crates/flightrepl" }
 futures.workspace = true
 opentelemetry.workspace = true

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 
 [dependencies]
 app = { path = "../../crates/app" }
-clap = { workspace = true, features = ["derive", "env"] }
+clap = { workspace = true, features = ["derive"] }
 flightrepl = { path = "../../crates/flightrepl" }
 futures.workspace = true
 opentelemetry.workspace = true

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -136,9 +136,9 @@ pub struct Args {
     #[arg(long)]
     pub telemetry_enabled: Option<bool>,
 
-    /// Disable pods watcher.
-    #[arg(long, env, action = ArgAction::SetTrue)]
-    pub no_pods_watcher: bool,
+    /// Enable pods watcher (disabled by default).
+    #[arg(long, default_value_t = false, action = ArgAction::SetTrue)]
+    pub pods_watcher_enabled: bool,
 
     #[arg(short, long, action = ArgAction::Count)]
     pub verbose: u8,
@@ -194,7 +194,7 @@ pub async fn run(args: Args) -> Result<()> {
         .with_datasets_health_monitor()
         .with_metrics_server_opt(args.metrics, prometheus_registry.clone());
 
-    if !args.no_pods_watcher {
+    if args.pods_watcher_enabled {
         let pods_watcher = PodsWatcher::new(current_dir.clone());
         builder = builder.with_pods_watcher(pods_watcher);
     }

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -137,7 +137,7 @@ pub struct Args {
     pub telemetry_enabled: Option<bool>,
 
     /// Disable pods watcher.
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, env, action = ArgAction::SetTrue)]
     pub no_pods_watcher: bool,
 
     #[arg(short, long, action = ArgAction::Count)]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -397,7 +397,12 @@ impl Runtime {
             Arc::clone(&self.df),
             tls_config.clone(),
         ));
-        let pods_watcher_future = self.start_pods_watcher();
+
+        let pods_watcher_future = if self.pods_watcher.read().await.is_some() {
+            Some(self.start_pods_watcher())
+        } else {
+            None
+        };
 
         if let Some(tls_config) = tls_config {
             match tls_config.subject_name() {
@@ -435,7 +440,15 @@ impl Runtime {
                     }
                 }
             },
-            pods_watcher_res = pods_watcher_future => pods_watcher_res.context(UnableToInitializePodsWatcherSnafu),
+            pods_watcher_res = async {
+                if let Some(fut) = pods_watcher_future {
+                    fut.await
+                } else {
+                    futures::future::pending().await
+                }
+            } => {
+                pods_watcher_res.context(UnableToInitializePodsWatcherSnafu)
+            },
             () = shutdown_signal() => {
                 tracing::info!("Goodbye!");
                 Ok(())


### PR DESCRIPTION
By default, Spiced will start with the watcher disabled. 

Added an optional `--pods-watcher-enabled` flag to enable.

`spice run` will use it by default.

```console
➜ spiced --help
      <...>
      --pods-watcher-enabled
          Enable pods watcher (disabled by default)
```