### PR TITLE
refactor: Rename GitHub pulls login to author

### DIFF
--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -431,10 +431,10 @@ lazy_static! {
     static ref GITHUB_FILTER_PUSHDOWNS_SUPPORTED: HashMap<&'static str, GitHubPushdownSupport> = {
         let mut m = HashMap::new();
         m.insert(
-            "login",
+            "author",
             GitHubPushdownSupport {
                 ops: vec![Operator::Eq, Operator::NotEq],
-                remaps: Some(vec![GitHubFilterRemap::Column("author")]),
+                remaps: None,
                 uses_modifiers: true
             },
         );

--- a/crates/runtime/src/dataconnector/github/pull_requests.rs
+++ b/crates/runtime/src/dataconnector/github/pull_requests.rs
@@ -86,7 +86,7 @@ impl GitHubTableArgs for PullRequestTableArgs {
                             closed_at: closedAt
                             number
                             reviews {{reviews_count: totalCount}}
-                            author {{ login }}
+                            author: author {{ author: login }}
                             additions
                             deletions
                             changed_files: changedFiles
@@ -125,7 +125,7 @@ impl GitHubTableArgs for PullRequestTableArgs {
                             closed_at: closedAt
                             number
                             reviews {{reviews_count: totalCount}}
-                            author {{ login }}
+                            author: author {{ author: login }}
                             additions
                             deletions
                             changed_files: changedFiles
@@ -160,6 +160,7 @@ fn gql_schema() -> SchemaRef {
             ))),
             true,
         ),
+        Field::new("author", DataType::Utf8, true),
         Field::new("body", DataType::Utf8, true),
         Field::new("changed_files", DataType::Int64, true),
         Field::new(
@@ -194,7 +195,6 @@ fn gql_schema() -> SchemaRef {
             ))),
             true,
         ),
-        Field::new("login", DataType::Utf8, true),
         Field::new(
             "merged_at",
             DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None),


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Renames the `login` column to `author` for the GitHub pulls connector

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #2453

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

* https://github.com/spiceai/docs/issues/436