### PR TITLE
Document DataFusion limitation: The context only support single SQL Statement, Date Arithmetic like date + 3 not supported

### DIFF
--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -1,10 +1,11 @@
 # Spice.ai OSS Benchmarks
 
-## TPC-DS (Decision Support Benchmark)
+## TPC-DS (Decision Support Benchmark) Limitations
 
-### Intervals like 'date + 30 days' are not supported
+### Interval Arithmetic (date + 30 days) Not Supported
 
-To fix: use *INTERVAL* data type.
+**Limitation**: Queries using direct date arithmetic (e.g., date + 30 days) are not supported.
+**Solution**: Use the _INTERVAL_ data type for date arithmetic.
 
 ```sql
 # fail
@@ -14,10 +15,20 @@ SELECT (now() + 30 days);
 SELECT (now() + INTERVAL '30 days');
 ```
 
-| **Affected queries** |  |  |
-| --- | --- | --- |
+| **Affected queries**     |                          |                          |
+| ------------------------ | ------------------------ | ------------------------ |
 | [q5.sql](tpcds/q5.sql)   | [q77.sql](tpcds/q77.sql) | [q16.sql](tpcds/q16.sql) |
 | [q12.sql](tpcds/q12.sql) | [q80.sql](tpcds/q80.sql) | [q20.sql](tpcds/q20.sql) |
 | [q21.sql](tpcds/q21.sql) | [q82.sql](tpcds/q82.sql) | [q32.sql](tpcds/q32.sql) |
 | [q37.sql](tpcds/q37.sql) | [q92.sql](tpcds/q92.sql) | [q40.sql](tpcds/q40.sql) |
 | [q94.sql](tpcds/q94.sql) | [q95.sql](tpcds/q95.sql) | [q98.sql](tpcds/q98.sql) |
+
+### DataFusion Supports Only Single SQL Statement per Query
+
+**Limitation**: DataFusion does not support multiple SQL statements within a single query.
+**Solution**: Ensure each query contains only one SQL statement.
+
+| **Affected queries**     |                          |
+| ------------------------ | ------------------------ |
+| [q14.sql](tpcds/q14.sql) | [q23.sql](tpcds/q23.sql) |
+| [q24.sql](tpcds/q24.sql) | [q39.sql](tpcds/q39.sql) |

--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -2,15 +2,18 @@
 
 ## TPC-DS (Decision Support Benchmark) Limitations
 
-### Interval Arithmetic (date + 30 days) Not Supported
+### Intervals like `date + 30 days` or `date + 5` are not supported
 
-**Limitation**: Queries using direct date arithmetic (e.g., date + 30 days) are not supported.
+**Limitation**: Queries using direct date arithmetic (e.g., `date + 30 days` or `date + 5`) are not supported.
 
 **Solution**: Use the _INTERVAL_ data type for date arithmetic.
 
 ```sql
 # fail
 SELECT (now() + 30 days);
+
+# fail
+SELECT (now() + 30);
 
 # success
 SELECT (now() + INTERVAL '30 days');
@@ -23,6 +26,7 @@ SELECT (now() + INTERVAL '30 days');
 | [q21.sql](tpcds/q21.sql) | [q82.sql](tpcds/q82.sql) | [q32.sql](tpcds/q32.sql) |
 | [q37.sql](tpcds/q37.sql) | [q92.sql](tpcds/q92.sql) | [q40.sql](tpcds/q40.sql) |
 | [q94.sql](tpcds/q94.sql) | [q95.sql](tpcds/q95.sql) | [q98.sql](tpcds/q98.sql) |
+| [q72.sql](tpcds/q72.sql) |                          |                          |
 
 ### DataFusion Supports Only Single SQL Statement per Query
 

--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -5,6 +5,7 @@
 ### Interval Arithmetic (date + 30 days) Not Supported
 
 **Limitation**: Queries using direct date arithmetic (e.g., date + 30 days) are not supported.
+
 **Solution**: Use the _INTERVAL_ data type for date arithmetic.
 
 ```sql
@@ -26,6 +27,7 @@ SELECT (now() + INTERVAL '30 days');
 ### DataFusion Supports Only Single SQL Statement per Query
 
 **Limitation**: DataFusion does not support multiple SQL statements within a single query.
+
 **Solution**: Ensure each query contains only one SQL statement.
 
 | **Affected queries**     |                          |

--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -1,6 +1,6 @@
 # Spice.ai OSS Benchmarks
 
-## TPC-DS (Decision Support Benchmark) Limitations
+## TPC-DS (Decision Support Benchmark)
 
 ### Intervals like `date + 30 days` or `date + 5` are not supported
 

--- a/crates/runtime/benches/queries/tpcds/q72.sql
+++ b/crates/runtime/benches/queries/tpcds/q72.sql
@@ -17,7 +17,7 @@ left outer join promotion on (cs_promo_sk=p_promo_sk)
 left outer join catalog_returns on (cr_item_sk = cs_item_sk and cr_order_number = cs_order_number)
 where d1.d_week_seq = d2.d_week_seq
   and inv_quantity_on_hand < cs_quantity
-  and d3.d_date > d1.d_date + 5
+  and d3.d_date > d1.d_date + INTERVAL '5 days'
   and hd_buy_potential = '501-1000'
   and d1.d_year = 1999
   and cd_marital_status = 'S'


### PR DESCRIPTION
## 🗣 Description

Add the TPCDS benchmark documentation regarding the limitation of DataFusion, including (1) Context only supports a single SQL statement per query. (2) Date arithmetic like 'date + 3' not supported The detailed changes include:

* Document the limitation of Datafusion only supports single SQL statement per query, and document the TPCDS query affected by the limitation.
* Document the limitation of Datafusion not supporting Date arithmetic like 'date + 3', and add the modified version of TPCDS query
* Improve the clarity of doc by adding sections and limitations key words

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/2617
- https://github.com/spiceai/spiceai/issues/2623

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
