### PR TITLE
Remove system message from ToolUsingChat.

### DIFF
--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -26,10 +26,10 @@ use llms::chat::{Chat, Result as ChatResult};
 use async_openai::error::OpenAIError;
 use async_openai::types::{
     ChatChoiceStream, ChatCompletionMessageToolCall, ChatCompletionRequestAssistantMessageArgs,
-    ChatCompletionRequestMessage,
-    ChatCompletionRequestToolMessageArgs, ChatCompletionResponseStream, ChatCompletionTool,
-    ChatCompletionToolChoiceOption, ChatCompletionToolType, CompletionUsage,
-    CreateChatCompletionRequest, CreateChatCompletionRequestArgs, CreateChatCompletionResponse,
+    ChatCompletionRequestMessage, ChatCompletionRequestToolMessageArgs,
+    ChatCompletionResponseStream, ChatCompletionTool, ChatCompletionToolChoiceOption,
+    ChatCompletionToolType, CompletionUsage, CreateChatCompletionRequest,
+    CreateChatCompletionRequestArgs, CreateChatCompletionResponse,
     CreateChatCompletionStreamResponse, FinishReason, FunctionCall, FunctionObject,
 };
 


### PR DESCRIPTION
## 🗣 Description
 - `models` that use tools, currently display two things in a prepended system prompt for each user request:
    1. A list of available datasets, via `list_datasets` 
    2. A list of available tools
 - The former is replaced by prepending assistant & tool response message (e.g. pretend as if the model has already called, and received a response from the tool).
 - The latter is superflous. The underlying request will have tools listed under the `tools` key. 

This lets us support using tools with models that cannot use system prompts.
