### PR TITLE
Set log level for anonymous telemetry traces to `trace`

### DIFF
--- a/crates/telemetry/src/anonymous.rs
+++ b/crates/telemetry/src/anonymous.rs
@@ -94,7 +94,7 @@ pub async fn start(spicepod_name: &str) {
         .set(GlobalMeterProvider::new(provider))
         .is_err()
     {
-        tracing::error!("Failed to set global meter provider for the anonymous telemetry, already set by another codepath?");
+        tracing::trace!("Failed to set global meter provider for the anonymous telemetry, already set by another codepath?");
     }
 
     // Send an initial telemetry event to indicate the start of telemetry collection
@@ -106,17 +106,17 @@ pub async fn start(spicepod_name: &str) {
     };
 
     if let Err(err) = initial_reader.collect(&mut rm) {
-        tracing::error!("Failed to collect initial telemetry: {:?}", err);
+        tracing::trace!("Failed to collect initial telemetry: {:?}", err);
     };
 
     oss_telemetry_exporter
         .export(&mut rm)
         .await
         .unwrap_or_else(|err| {
-            tracing::error!("Failed to export initial telemetry: {:?}", err);
+            tracing::trace!("Failed to export initial telemetry: {:?}", err);
         });
 
-    tracing::debug!("Started anonymous telemetry collection to {}", *ENDPOINT);
+    tracing::trace!("Started anonymous telemetry collection to {}", *ENDPOINT);
 }
 
 #[derive(Debug, Clone)]

--- a/crates/telemetry/src/exporter.rs
+++ b/crates/telemetry/src/exporter.rs
@@ -37,7 +37,7 @@ impl AnonymousTelemetryExporter {
         let flight_client = match FlightClient::try_new(url, Credentials::anonymous(), None).await {
             Ok(client) => Some(client),
             Err(e) => {
-                tracing::error!("Unable to initialize anonymous telemetry: {e}");
+                tracing::trace!("Unable to initialize anonymous telemetry: {e}");
                 None
             }
         };
@@ -68,7 +68,7 @@ impl otel_arrow::ArrowExporter for AnonymousTelemetryExporter {
         };
 
         if let Err(e) = flight_client.publish("oss_telemetry", vec![metrics]).await {
-            tracing::error!("Unable to publish anonymous telemetry: {e}");
+            tracing::trace!("Unable to publish anonymous telemetry: {e}");
         };
 
         Ok(())


### PR DESCRIPTION
## 🗣 Description

Tunes the log level for all traces emitted by the anonymous telemetry module to `trace` to prevent them from showing up in normal logs.

## 🔨 Related Issues

Closes #2994

## 📄 Documentation Requirements

N/A
