### PR TITLE
Revert integration tests back to hosted runner

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   build:
     name: Integration Tests
-    runs-on: teraswitch-runners
+    runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## 🗣 Description

The integration tests are proving to be too flaky on the teraswitch runners, revert back to the hosted runners for now.
