### PR TITLE
Enable `merge_group` checks for PR workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: teraswitch-runners
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -6,6 +6,9 @@ on:
       - trunk
       - release-*
 
+  merge_group:
+    types: [checks_requested]
+
   pull_request:
     branches:
       - trunk
@@ -61,7 +64,7 @@ jobs:
               }
             ];
 
-            return context.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
+            return context.eventName === 'pull_request' || context.eventName === 'merge_group' ? matrix.slice(0, 1) : matrix;
 
   build:
     name: Build ${{ matrix.target.name }} binaries

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,8 @@
 name: integration tests
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     branches:
       - trunk

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -1,6 +1,8 @@
 name: Makefile Targets
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     branches:
       - trunk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,8 @@
 name: pr
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     branches:
       - trunk
@@ -36,6 +38,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "base_ref=${{ github.base_ref }}" >> $GITHUB_OUTPUT
             echo "head_ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "base_ref=${{ github.event.merge_group.base_ref }}" >> $GITHUB_OUTPUT
+            echo "head_ref=${{ github.event.merge_group.head_sha }}" >> $GITHUB_OUTPUT
           else
             echo "base_ref=${{ github.event.inputs.base_ref }}" >> $GITHUB_OUTPUT
             echo "head_ref=${{ github.sha }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 🗣 Description

In preparation to enable the merge group queue, we need to run the workflows in the merge group. https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues
