### PR TITLE
Support runtime parameter for `sql_query_keep_partition_by_columns` & enable by default

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -177,6 +177,12 @@ impl AppBuilder {
     }
 
     #[must_use]
+    pub fn with_runtime_params(mut self, params: HashMap<String, String>) -> AppBuilder {
+        self.runtime.params = params;
+        self
+    }
+
+    #[must_use]
     pub fn build(self) -> App {
         App {
             name: self.name,

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -39,7 +39,7 @@ const ITERATIONS: i32 = 5;
 ///
 /// 1) Sets the number of `target_partitions` to 4, by default its the number of CPU cores available.
 fn get_test_datafusion(status: Arc<RuntimeStatus>) -> Arc<DataFusion> {
-    let mut df = DataFusion::new(status);
+    let mut df = DataFusion::builder(status).build();
 
     // Set the target partitions to 3 to make RepartitionExec show consistent partitioning across machines with different CPU counts.
     let mut new_state = df.ctx.state();

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -226,7 +226,7 @@ fn get_bool_param(app: &Option<Arc<App>>, param: &str, default_value: bool) -> b
     match value.parse::<bool>() {
         Ok(b) => b,
         Err(_) => {
-            tracing::warn!(
+            eprintln!(
                 "runtime.params.{param} is not a valid boolean, defaulting to {default_value}"
             );
             default_value

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -80,6 +80,11 @@ impl DataFusionBuilder {
         self
     }
 
+    /// Builds the DataFusion instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the DataFusion instance cannot be built due to errors in registering functions or schemas.
     #[must_use]
     pub fn build(self) -> DataFusion {
         let mut state = SessionStateBuilder::new()

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+};
+
+use cache::QueryResultsCacheProvider;
+use datafusion::{
+    catalog_common::{CatalogProvider, MemoryCatalogProvider},
+    execution::SessionStateBuilder,
+    prelude::{SessionConfig, SessionContext},
+};
+use datafusion_federation::FederationAnalyzerRule;
+use tokio::sync::RwLock as TokioRwLock;
+
+use crate::{embeddings, object_store_registry::default_runtime_env, status};
+
+use super::{
+    extension::{bytes_processed::BytesProcessedOptimizerRule, SpiceQueryPlanner},
+    schema::SpiceSchemaProvider,
+    DataFusion, SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA, SPICE_METADATA_SCHEMA,
+    SPICE_RUNTIME_SCHEMA,
+};
+
+pub struct DataFusionBuilder {
+    config: SessionConfig,
+    status: Arc<status::RuntimeStatus>,
+    cache_provider: Option<Arc<QueryResultsCacheProvider>>,
+}
+
+impl DataFusionBuilder {
+    pub fn new(status: Arc<status::RuntimeStatus>) -> Self {
+        let mut df_config = SessionConfig::new()
+            .with_information_schema(true)
+            .with_create_default_catalog_and_schema(false);
+
+        df_config.options_mut().sql_parser.dialect = "PostgreSQL".to_string();
+        df_config.options_mut().catalog.default_catalog = SPICE_DEFAULT_CATALOG.to_string();
+        df_config.options_mut().catalog.default_schema = SPICE_DEFAULT_SCHEMA.to_string();
+        df_config.options_mut().execution.keep_partition_by_columns = true;
+        df_config
+            .options_mut()
+            .execution
+            .listing_table_ignore_subdirectory = false;
+
+        Self {
+            config: df_config,
+            status,
+            cache_provider: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_cache_provider(mut self, cache_provider: Arc<QueryResultsCacheProvider>) -> Self {
+        self.cache_provider = Some(cache_provider);
+        self
+    }
+
+    #[must_use]
+    pub fn keep_partition_by_columns(mut self, keep_partition_by_columns: bool) -> Self {
+        self.config
+            .options_mut()
+            .execution
+            .keep_partition_by_columns = keep_partition_by_columns;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> DataFusion {
+        let mut state = SessionStateBuilder::new()
+            .with_config(self.config)
+            .with_default_features()
+            .with_query_planner(Arc::new(SpiceQueryPlanner::new()))
+            .with_runtime_env(default_runtime_env())
+            .build();
+
+        if let Err(e) = datafusion_functions_json::register_all(&mut state) {
+            panic!("Unable to register JSON functions: {e}");
+        };
+
+        let ctx = SessionContext::new_with_state(state);
+        ctx.add_analyzer_rule(Arc::new(FederationAnalyzerRule::new()));
+        ctx.add_optimizer_rule(Arc::new(BytesProcessedOptimizerRule::new()));
+        ctx.register_udf(embeddings::cosine_distance::CosineDistance::new().into());
+        ctx.register_udf(crate::datafusion::udf::Greatest::new().into());
+        ctx.register_udf(crate::datafusion::udf::Least::new().into());
+        let catalog = MemoryCatalogProvider::new();
+        let default_schema = SpiceSchemaProvider::new();
+        let runtime_schema = SpiceSchemaProvider::new();
+        let metadata_schema = SpiceSchemaProvider::new();
+
+        match catalog.register_schema(SPICE_DEFAULT_SCHEMA, Arc::new(default_schema)) {
+            Ok(_) => {}
+            Err(e) => {
+                panic!("Unable to register default schema: {e}");
+            }
+        }
+
+        match catalog.register_schema(SPICE_RUNTIME_SCHEMA, Arc::new(runtime_schema)) {
+            Ok(_) => {}
+            Err(e) => {
+                panic!("Unable to register spice runtime schema: {e}");
+            }
+        }
+
+        match catalog.register_schema(SPICE_METADATA_SCHEMA, Arc::new(metadata_schema)) {
+            Ok(_) => {}
+            Err(e) => {
+                panic!("Unable to register spice runtime schema: {e}");
+            }
+        }
+
+        ctx.register_catalog(SPICE_DEFAULT_CATALOG, Arc::new(catalog));
+
+        DataFusion {
+            runtime_status: self.status,
+            ctx: Arc::new(ctx),
+            data_writers: RwLock::new(HashSet::new()),
+            cache_provider: RwLock::new(self.cache_provider),
+            pending_sink_tables: TokioRwLock::new(Vec::new()),
+            accelerated_tables: TokioRwLock::new(HashSet::new()),
+        }
+    }
+}

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -44,6 +44,7 @@ pub struct DataFusionBuilder {
 }
 
 impl DataFusionBuilder {
+    #[must_use]
     pub fn new(status: Arc<status::RuntimeStatus>) -> Self {
         let mut df_config = SessionConfig::new()
             .with_information_schema(true)
@@ -80,11 +81,11 @@ impl DataFusionBuilder {
         self
     }
 
-    /// Builds the DataFusion instance.
+    /// Builds the `DataFusion` instance.
     ///
     /// # Panics
     ///
-    /// Panics if the DataFusion instance cannot be built due to errors in registering functions or schemas.
+    /// Panics if the `DataFusion` instance cannot be built due to errors in registering functions or schemas.
     #[must_use]
     pub fn build(self) -> DataFusion {
         let mut state = SessionStateBuilder::new()

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -389,7 +389,7 @@ mod test {
     }
 
     fn create_test_datafusion() -> Arc<DataFusion> {
-        let df = Arc::new(DataFusion::new(RuntimeStatus::new()));
+        let df = Arc::new(DataFusion::builder(RuntimeStatus::new()).build());
 
         let catalog = df.ctx.catalog("spice").expect("default catalog is spice");
 

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -58,7 +58,7 @@ mod rehydration;
 ///
 /// 1) Sets the number of `target_partitions` to 3, by default its the number of CPU cores available.
 fn get_test_datafusion(status: Arc<status::RuntimeStatus>) -> Arc<DataFusion> {
-    let mut df = DataFusion::new(status);
+    let mut df = DataFusion::builder(status).build();
 
     // Set the target partitions to 3 to make RepartitionExec show consistent partitioning across machines with different CPU counts.
     let mut new_state = df.ctx.state();

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{error::Error, sync::Arc};
+use std::{collections::HashMap, error::Error, sync::Arc};
 
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
@@ -35,6 +35,10 @@ pub struct Runtime {
     pub tracing: Option<TracingConfig>,
 
     pub telemetry: Option<TelemetryConfig>,
+
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
+    pub params: HashMap<String, String>,
 
     #[serde(default)]
     pub task_history: TaskHistory,


### PR DESCRIPTION
## 🗣 Description

Adds a new `runtime` params object that can be used for runtime-wide settings. The first one to be enabled is `sql_query_keep_partition_by_columns` which maps to a Datafusion setting: `datafusion.execution.keep_partition_by_columns`
This setting controls whether the partition column in a hive-style partitioning system is returned in the result-set, i.e.:

`/data/sales/year=2023/month=10/day=09/part-00000.parquet`

In the above example, columns for `year`, `month` and `day` would be injected into the results with their respective values.


Example config:

```yaml
runtime:
  params:
    sql_query_keep_partition_by_columns: true
```