### PR TITLE
docs: Document stack overflow workaround, add helper script

### DIFF
--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -38,3 +38,27 @@ SELECT (now() + INTERVAL '30 days');
 | ------------------------ | ------------------------ |
 | [q14.sql](tpcds/q14.sql) | [q23.sql](tpcds/q23.sql) |
 | [q24.sql](tpcds/q24.sql) | [q39.sql](tpcds/q39.sql) |
+
+### Runtime worker has overflowed its stack
+
+**Limitation**: On some platforms (e.g. Linux kernel 6.9.3), the Runtime will encounter a stack overflow when running certain queries.
+
+**Solution**: Increase the stack size when running `spiced`, with `RUST_MIN_STACK=8388608 spiced` to set an 8MB minimum stack size.
+
+Some platforms default to a lower minimum stack size, like 2MB, which is too small when running certain queries.
+
+**Example Error**:
+
+```bash
+thread 'tokio-runtime-worker' has overflowed its stack
+fatal runtime error: stack overflow
+[1]    77809 IOT instruction (core dumped)
+```
+
+| **Affected queries**     |                          |
+| ------------------------ | ------------------------ |
+| [q25.sql](tpcds/q25.sql) | [q29.sql](tpcds/q29.sql) |
+| [q30.sql](tpcds/q30.sql) | [q31.sql](tpcds/q31.sql) |
+| [q33.sql](tpcds/q33.sql) | [q34.sql](tpcds/q34.sql) |
+| [q41.sql](tpcds/q41.sql) | [q44.sql](tpcds/q44.sql) |
+| [q49.sql](tpcds/q49.sql) | [q49.sql](tpcds/q49.sql) |

--- a/test/scripts/run-query.bash
+++ b/test/scripts/run-query.bash
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+clean_up () {
+  ARG=$?
+  rm -f runqueries.tmp.txt
+  exit $ARG
+}
+
+if [ -z "$1" ]; then
+  echo "No query folder provided. Aborting."
+  echo "Usage: $0 <query_folder> <query_name>"
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "No query name specified. Aborting."
+  echo "Usage: $0 <query_folder> <query_name>"
+  exit 1
+fi
+
+# check if folder contains runqueries.tmp.txt
+if [ -f runqueries.tmp.txt ]; then
+  echo "runqueries.tmp.txt already exists. Aborting."
+  exit 1
+fi
+
+trap clean_up EXIT
+
+query_folder=$1;
+failed_queries=()
+i=$query_folder/$2.sql
+echo "Running query in $i.."
+sed '/^--/d' < $i > $i.tmp # remove comments because we compact the query into one line
+tr '\n' ' ' <  $i.tmp | spice sql > runqueries.tmp.txt
+
+rm $i.tmp
+result=`cat runqueries.tmp.txt`
+echo "$result"


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Documents a limitation with stack overflows, encountered when using the MySQL connector. This does not appear to be infinite recursion - confirmed by the fact that a minor stack size bump resolves the error. It appears to be caused by a large number of on-the-stack calls from the MySQL library when streaming results.
* Adds a simple test helper script to run a single query in the REPL.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #3030

## 🤔 Concerns

* I'm not sure if we should add a way to supply this parameter from `spice run` rather than running `spiced` directly? Alternatively, adding a default override to always make it 8MB because that appears to be the default on some other kernels.