### PR TITLE
docs: Add workaround for TPC-DS Q97 in MySQL

### DIFF
--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -56,6 +56,7 @@ WHERE ws_item_sk NOT IN (
     SELECT DISTINCT ss_item_sk FROM store_sales
 );
 ```
+
 | **Affected queries**     |                          |
 | ------------------------ | ------------------------ |
 | [q8.sql](tpcds/q8.sql)   | [q38.sql](tpcds/q38.sql) |
@@ -100,7 +101,6 @@ LIMIT 100;
 | ------------------------ | ------------------------ |
 | [q35.sql](tpcds/q35.sql) | |
 
-
 ### DataFusion Supports Only Single SQL Statement per Query
 
 **Limitation**: DataFusion does not support multiple SQL statements within a single query.
@@ -135,3 +135,38 @@ fatal runtime error: stack overflow
 | [q33.sql](tpcds/q33.sql) | [q34.sql](tpcds/q34.sql) |
 | [q41.sql](tpcds/q41.sql) | [q44.sql](tpcds/q44.sql) |
 | [q49.sql](tpcds/q49.sql) | [q49.sql](tpcds/q49.sql) |
+
+## MySQL does not support FULL JOIN
+
+**Limitation**: The MySQL connector does not support `FULL JOIN` or `FULL OUTER JOIN` statements.
+
+**Solution**: Rewrite your query to use `UNION` or `UNION ALL`, for example:
+
+```sql
+SELECT * FROM t1
+LEFT JOIN t2 ON t1.id = t2.id
+UNION
+SELECT * FROM t1
+RIGHT JOIN t2 ON t1.id = t2.id
+```
+
+`UNION` removes duplicate records, so if you require duplicate records to remain after your union, use `UNION ALL` like:
+
+```sql
+SELECT * FROM t1
+LEFT JOIN t2 ON t1.id = t2.id
+UNION ALL
+SELECT * FROM t1
+RIGHT JOIN t2 ON t1.id = t2.id
+WHERE t1.id IS NULL
+```
+
+**Example Error**:
+
+```bash
+Query Error Execution error: Unable to query arrow: Server error: `ERROR 42000 (1064): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FULL JOIN (SELECT `catalog_sales`.`cs_bill_customer_sk` AS `customer_sk`, `catal' at line 1
+```
+
+| **Affected queries**     |                          |
+| ------------------------ | ------------------------ |
+| [q97.sql](tpcds/q97.sql) | |


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds a TPC-DS workaround for Q97 because MySQL does not support `FULL OUTER JOIN`.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3075
