### PR TITLE
Add `hive_infer_partitions` to remaining object store connectors

### DIFF
--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -142,6 +142,8 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: gzip, bzip2, xz, zstd, uncompressed"),
+    ParameterSpec::runtime("hive_infer_partitions")
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
 ];
 
 impl DataConnectorFactory for AzureBlobFSFactory {

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -75,6 +75,8 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
+    ParameterSpec::runtime("hive_infer_partitions")
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
 ];
 
 impl DataConnectorFactory for FileFactory {

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -73,6 +73,8 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
+    ParameterSpec::runtime("hive_infer_partitions")
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
 ];
 
 impl DataConnectorFactory for FTPFactory {

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -81,6 +81,8 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
+    ParameterSpec::runtime("hive_infer_partitions")
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
 ];
 
 impl DataConnectorFactory for SFTPFactory {


### PR DESCRIPTION
## 🗣 Description

Adds the parameter `hive_infer_partitions` to all object-store based connectors that support it.

## 📄 Documentation Requirements

Documentation is required and will be added in a follow-up PR
