### PR TITLE
Fix Flight `get_schema` to construct logical plan and return that schema.

### DIFF
--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -312,13 +312,7 @@ impl Query {
 
     fn handle_schema_error(self, e: &DataFusionError) {
         // If there is an error getting the schema, we still want to track it in task history
-        let span = tracing::span!(
-            target: "task_history",
-            tracing::Level::INFO,
-            "sql_query",
-            input = %self.sql,
-            runtime_query = false
-        );
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "sql_query", input = %self.sql, runtime_query = false);
         let error_code = ErrorCode::from(e);
         span.in_scope(|| {
             self.finish_with_error(e.to_string(), error_code);

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -311,6 +311,7 @@ impl Query {
     }
 
     fn handle_schema_error(self, e: &DataFusionError) {
+        // If there is an error getting the schema, we still want to track it in task history
         let span = tracing::span!(
             target: "task_history",
             tracing::Level::INFO,

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -118,7 +118,6 @@ thread_local! {
 pub struct Query {
     df: Arc<crate::datafusion::DataFusion>,
     sql: Arc<str>,
-    restricted_sql_options: bool,
     tracker: QueryTracker,
 }
 
@@ -202,17 +201,15 @@ impl Query {
                 tracker = tracker.results_cache_hit(false);
             }
 
-            if ctx.restricted_sql_options {
-                if let Err(e) =
-                    RESTRICTED_SQL_OPTIONS.with(|sql_options| sql_options.verify_plan(&plan))
-                {
-                    handle_error!(
-                        tracker,
-                        ErrorCode::QueryPlanningError,
-                        e,
-                        UnableToExecuteQuery
-                    )
-                }
+            if let Err(e) =
+                RESTRICTED_SQL_OPTIONS.with(|sql_options| sql_options.verify_plan(&plan))
+            {
+                handle_error!(
+                    tracker,
+                    ErrorCode::QueryPlanningError,
+                    e,
+                    UnableToExecuteQuery
+                )
             }
 
             let input_tables = get_logical_plan_input_tables(&plan);
@@ -296,19 +293,10 @@ impl Query {
     }
 
     pub async fn get_schema(self) -> Result<Schema, DataFusionError> {
-        let df = match self.df.ctx.sql(&self.sql).await {
-            Ok(df) => df,
-            Err(e) => {
-                // If there is an error getting the schema, we still want to track it in task history
-                let span = tracing::span!(target: "task_history", tracing::Level::INFO, "sql_query", input = %self.sql, runtime_query = false);
-                let error_code = ErrorCode::from(&e);
-                span.in_scope(|| {
-                    self.finish_with_error(e.to_string(), error_code);
-                });
-                return Err(e);
-            }
-        };
-        Ok(df.schema().into())
+        let session = self.df.ctx.state();
+        let plan = session.create_logical_plan(&self.sql).await?;
+        RESTRICTED_SQL_OPTIONS.with(|sql_options| sql_options.verify_plan(&plan))?;
+        Ok(plan.schema().as_arrow().clone())
     }
 }
 

--- a/crates/runtime/src/datafusion/query/builder.rs
+++ b/crates/runtime/src/datafusion/query/builder.rs
@@ -27,7 +27,6 @@ pub struct QueryBuilder<'a> {
     df: Arc<DataFusion>,
     sql: &'a str,
     query_id: Uuid,
-    restricted_sql_options: bool,
     protocol: Protocol,
 }
 
@@ -37,7 +36,6 @@ impl<'a> QueryBuilder<'a> {
             df,
             sql,
             query_id: Uuid::new_v4(),
-            restricted_sql_options: false,
             protocol,
         }
     }
@@ -45,12 +43,6 @@ impl<'a> QueryBuilder<'a> {
     #[must_use]
     pub fn query_id(mut self, query_id: Uuid) -> Self {
         self.query_id = query_id;
-        self
-    }
-
-    #[must_use]
-    pub fn use_restricted_sql_options(mut self) -> Self {
-        self.restricted_sql_options = true;
         self
     }
 
@@ -66,7 +58,6 @@ impl<'a> QueryBuilder<'a> {
         Query {
             df: Arc::clone(&self.df),
             sql: Arc::clone(&sql),
-            restricted_sql_options: self.restricted_sql_options,
             tracker: QueryTracker {
                 schema: None,
                 query_duration_secs: None,

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -182,7 +182,6 @@ impl Service {
         protocol: Protocol,
     ) -> Result<(BoxStream<'static, Result<FlightData, Status>>, Option<bool>), Status> {
         let query = QueryBuilder::new(sql, Arc::clone(&datafusion), protocol)
-            .use_restricted_sql_options()
             .protocol(protocol)
             .build();
 

--- a/crates/runtime/src/flight/do_exchange.rs
+++ b/crates/runtime/src/flight/do_exchange.rs
@@ -88,11 +88,12 @@ pub(crate) async fn handle(
         (tx, rx)
     };
 
+    let table_provider_stream = Arc::clone(&table_provider);
     let response_stream = stream::unfold(rx, move |mut rx| {
         let encoder = IpcDataGenerator::default();
         let mut tracker = DictionaryTracker::new(false);
         let write_options = writer::IpcWriteOptions::default();
-        let table_provider = Arc::clone(&table_provider);
+        let table_provider = Arc::clone(&table_provider_stream);
         async move {
             match rx.recv().await {
                 Ok(data_update) => {
@@ -169,12 +170,9 @@ pub(crate) async fn handle(
     .flat_map(|x| x);
 
     let datafusion = Arc::clone(&flight_svc.datafusion);
+    let table_provider = Arc::clone(&table_provider);
     tokio::spawn(async move {
-        let Ok(df) = datafusion
-            .ctx
-            .sql(&format!(r#"SELECT * FROM {data_path}"#))
-            .await
-        else {
+        let Ok(df) = datafusion.ctx.read_table(table_provider) else {
             return;
         };
         let Ok(results) = df.collect().await else {

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -102,7 +102,6 @@ fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
 // Runs query and converts query results to HTTP response (as JSON).
 pub async fn sql_to_http_response(df: Arc<DataFusion>, sql: &str, format: ArrowFormat) -> Response {
     let query = QueryBuilder::new(sql, Arc::clone(&df), Protocol::Http)
-        .use_restricted_sql_options()
         .protocol(Protocol::Http)
         .build();
 


### PR DESCRIPTION
## 🗣 Description

Fixes the `get_schema` method on the QueryBuilder to construct the logical plan directly from the SQL string and return the schema from that plan, as opposed to relying on the [`.sql`](https://docs.rs/datafusion/latest/datafusion/execution/context/struct.SessionContext.html#method.sql) method from the DataFusion `SessionContext` directly, since that also starts the initial execution of queries.
