### PR TITLE
fix: Dataset refresh

### DIFF
--- a/bin/spice/cmd/refresh.go
+++ b/bin/spice/cmd/refresh.go
@@ -45,9 +45,6 @@ type DatasetRefreshApiRequest struct {
 
 func constructRequest(sql string, mode string, max_jitter string) (*string, error) {
 	r := DatasetRefreshApiRequest{}
-	if sql == "" && mode == "" && max_jitter == "" {
-		return nil, nil
-	}
 	if sql != "" {
 		r.RefreshSQL = &sql
 	}
@@ -57,8 +54,8 @@ func constructRequest(sql string, mode string, max_jitter string) (*string, erro
 	if max_jitter != "" {
 		r.MaxJitter = &max_jitter
 	}
-	bytz, err := json.Marshal(r)
-	s := string(bytz)
+	bytes, err := json.Marshal(r)
+	s := string(bytes)
 
 	return &s, err
 }
@@ -99,6 +96,7 @@ spice refresh taxi_trips
 			slog.Error("constructing request", "error", err)
 			return
 		}
+
 		res, err := api.PostRuntime[DatasetRefreshApiResponse](rtcontext, url, body)
 		if err != nil {
 			slog.Error("refreshing dataset", "error", err)

--- a/bin/spice/pkg/api/util.go
+++ b/bin/spice/pkg/api/util.go
@@ -58,11 +58,16 @@ func doRuntimeApiRequest[T interface{}](rtcontext *context.RuntimeContext, metho
 	}
 	defer resp.Body.Close()
 
-	var result T
-	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return *new(T), fmt.Errorf("error decoding response: %w", err)
+	if resp.StatusCode > 200 && resp.StatusCode < 400 {
+		var result T
+		if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return *new(T), fmt.Errorf("error decoding response: %w", err)
+		}
+
+		return result, nil
+	} else {
+		return *new(T), fmt.Errorf("error response from runtime: %s", resp.Status)
 	}
-	return result, nil
 }
 
 func GetData[T interface{}](rtcontext *context.RuntimeContext, path string) ([]T, error) {

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -79,10 +79,14 @@ pub struct RefreshOverrides {
     #[serde(default, rename = "refresh_sql")]
     pub sql: Option<String>,
 
-    #[serde(rename = "refresh_mode")]
+    #[serde(default, rename = "refresh_mode")]
     pub mode: Option<RefreshMode>,
 
-    #[serde(rename = "refresh_jitter_max", deserialize_with = "parse_max_jitter")]
+    #[serde(
+        default,
+        rename = "refresh_jitter_max",
+        deserialize_with = "parse_max_jitter"
+    )]
     pub max_jitter: Option<Duration>,
 }
 

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -139,7 +139,7 @@ pub(crate) async fn refresh(
     Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
     Extension(df): Extension<Arc<DataFusion>>,
     Path(dataset_name): Path<String>,
-    overrides_opt: Option<Json<RefreshOverrides>>,
+    overrides: Json<RefreshOverrides>,
 ) -> Response {
     let app_lock = app.read().await;
     let Some(readable_app) = &*app_lock else {
@@ -172,13 +172,7 @@ pub(crate) async fn refresh(
             .into_response();
     };
 
-    match df
-        .refresh_table(
-            &dataset.name,
-            overrides_opt.map(|Json(overrides)| overrides),
-        )
-        .await
-    {
+    match df.refresh_table(&dataset.name, Some(overrides.0)).await {
         Ok(()) => (
             status::StatusCode::CREATED,
             Json(MessageResponse {


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Makes `RefreshOverrides` a non-optional body, as it was silencing `JsonRejection` errors
* Adds `default` to `refresh_mode` and `refresh_jitter_max` properties, as when these fields were missing they were causing `JsonRejection` errors because they could not default to `None`

Raised a future enhancement to update the response error in the event of a JSON rejection, as the default error is plaintext and not a JSON object like an API consumer might expect: https://github.com/spiceai/spiceai/issues/3146 

There's an ongoing issue to allow custom `JsonRejection` messages in axum, so if we wait a little bit we might be able to utilise that instead of writing completely custom `Json` extractors.

This update should not break compatibility with SDKs, as none that use refreshes deserialise the response into an object.
