### PR TITLE
[cli] Include 200 in acceptable response codes for `doRuntimeApiRequest`

### DIFF
--- a/bin/spice/pkg/api/util.go
+++ b/bin/spice/pkg/api/util.go
@@ -58,7 +58,7 @@ func doRuntimeApiRequest[T interface{}](rtcontext *context.RuntimeContext, metho
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode > 200 && resp.StatusCode < 400 {
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
 		var result T
 		if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
 			return *new(T), fmt.Errorf("error decoding response: %w", err)


### PR DESCRIPTION
## 🗣 Description

Fixes a regression introduced in #3147 where a `200 OK` response was considered an error when calling `spice chat` in the CLI.

## 🔨 Related Issues

#3147

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

None
