### PR TITLE
Upgrade to Rust 1.82

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -34,10 +34,10 @@ runs:
       if: inputs.os != 'windows'
       shell: bash
       run: |
-        rustup toolchain install 1.81
+        rustup toolchain install 1.82
 
     - name: Install latest Rust stable toolchain (Windows)
       if: inputs.os == 'windows'
       shell: pwsh
       run: |
-        rustup toolchain install 1.81
+        rustup toolchain install 1.82

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -35,9 +35,11 @@ runs:
       shell: bash
       run: |
         rustup toolchain install 1.82
+        rustup default 1.82
 
     - name: Install latest Rust stable toolchain (Windows)
       if: inputs.os == 'windows'
       shell: pwsh
       run: |
         rustup toolchain install 1.82
+        rustup default 1.82

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [".github/"]
 homepage = "https://spice.ai"
 license = "Apache-2.0"
 repository = "https://github.com/spiceai/spiceai"
-rust-version = "1.81"
+rust-version = "1.82"
 version = "1.0.0-rc.1"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.81
+ARG RUST_VERSION=1.82
 FROM rust:${RUST_VERSION}-slim-bookworm as build
 
 # cache mounts below may already exist and owned by root


### PR DESCRIPTION
## 🗣 Description

Upgrades the runtime to build on Rust 1.82.

## 🔨 Related Issues

Follow up to #3134

## 📄 Documentation Requirements

Will need a line in the next release notes.

## 🤔 Concerns

None
