### PR TITLE
Use `-build.{GIT_SHA}` for unreleased versions

### DIFF
--- a/bin/spice/Makefile
+++ b/bin/spice/Makefile
@@ -9,11 +9,11 @@ ifdef REL_VERSION
 	SPICE_VERSION := $(REL_VERSION)
 	SPICED_FEATURES := --features release
 else
-	SPICE_VERSION := $(if $(FILE_VERSION),$(FILE_VERSION)-rc.$(GIT_SHA),local)
+	SPICE_VERSION := $(if $(FILE_VERSION),$(FILE_VERSION)-build.$(GIT_SHA),local)
 endif
 
 ifdef DEV
-	SPICE_VERSION := $(if $(FILE_VERSION),$(FILE_VERSION)-rc.$(GIT_SHA)-dev,local-dev)
+	SPICE_VERSION := $(if $(FILE_VERSION),$(FILE_VERSION)-build.$(GIT_SHA)-dev,local-dev)
 endif
 
 LDFLAGS:="-X $(BASE_PACKAGE_NAME)/bin/spice/pkg/version.version=$(SPICE_VERSION)"

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
             println!("v{}{}", env!("CARGO_PKG_VERSION"), build_metadata());
         } else {
             print!(
-                "v{}-rc.{}",
+                "v{}-build.{}",
                 env!("CARGO_PKG_VERSION"),
                 env!("GIT_COMMIT_HASH")
             );


### PR DESCRIPTION
## 🗣 Description

Changes from `-rc.{GIT_SHA}` to `-build.{GIT_SHA}` in the version output for unreleased versions to make it clearer this isn't related to the upcoming `RC` release.

Before:

```bash
❯ spice version
CLI version:     v1.0.0-rc.1-rc.fe01e3b0
Runtime version: v1.0.0-rc.1-rc.fe01e3b0+models
```

Now:

```bash
❯ spice version
CLI version:     v1.0.0-rc.1-build.8285bcc5
Runtime version: v1.0.0-rc.1-build.8285bcc5+models
```

## 🔨 Related Issues

N/A

## 📄 Documentation Requirements

Not required

## 🤔 Concerns

`build` may not be the most appropriate term. I considered `unreleased` or `git` as well.
