### PR TITLE
Disable `hive_infer_partitions` by default

### DIFF
--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -143,7 +143,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: gzip, bzip2, xz, zstd, uncompressed"),
     ParameterSpec::runtime("hive_infer_partitions")
-        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to false."),
 ];
 
 impl DataConnectorFactory for AzureBlobFSFactory {

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -76,7 +76,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
     ParameterSpec::runtime("hive_infer_partitions")
-        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to false."),
 ];
 
 impl DataConnectorFactory for FileFactory {

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -74,7 +74,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
     ParameterSpec::runtime("hive_infer_partitions")
-        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to false."),
 ];
 
 impl DataConnectorFactory for FTPFactory {

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -307,7 +307,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                     })?;
 
                 // If we should infer partitions and the path is a folder, infer the partitions from the folder structure.
-                if dataset.get_param("hive_infer_partitions", true) && table_path.is_collection() {
+                if dataset.get_param("hive_infer_partitions", false) && table_path.is_collection() {
                     let inferred_partitions =
                         infer_partitions_with_types(&ctx.state(), &table_path, &extension).await;
                     match inferred_partitions {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -96,7 +96,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
     ParameterSpec::runtime("hive_infer_partitions")
-        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to false."),
 ];
 
 impl DataConnectorFactory for S3Factory {

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -82,7 +82,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
     ParameterSpec::runtime("hive_infer_partitions")
-        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to true."),
+        .description("Infer the partition columns for hive-style partitioning from the folder structure. Defaults to false."),
 ];
 
 impl DataConnectorFactory for SFTPFactory {


### PR DESCRIPTION
## 🗣 Description

The partition inference can break if the folder to import itself has files at the root level and subfolders which should all be treated as one dataset with no partitions. Given most people know when they have hive-style partitioned data, disable the inference by default.

## 🔨 Related Issues

N/A

## 📄 Documentation Requirements

Yes, will need to update docs to indicate this is disabled by default, add an explainer on hive-style partitioning and that you need to enable `hive_infer_partitions` to have it work.

## 🤔 Concerns

This will be a breaking change for the next release.
