### PR TITLE
Fix task_history output for sql, add output to table_schema & list_datasets tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
  "arrow-csv",
  "arrow-data",
  "arrow-ipc",
- "arrow-json",
+ "arrow-json 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
@@ -428,6 +428,25 @@ name = "arrow-json"
 version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b198b9c6fcf086501730efbbcb483317b39330a116125af7bb06467d04b352a3"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.6.0",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-json"
+version = "53.1.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=6013498d7d4d59f7b16d0e28b3e0b379732fbf07#6013498d7d4d59f7b16d0e28b3e0b379732fbf07"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3059,7 +3078,7 @@ name = "datafusion-federation"
 version = "0.1.6"
 source = "git+https://github.com/spiceai/datafusion-federation.git?rev=ce1ce6158ce03f88c67cde25fca00f436c3e1690#ce1ce6158ce03f88c67cde25fca00f436c3e1690"
 dependencies = [
- "arrow-json",
+ "arrow-json 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-stream",
  "async-trait",
  "datafusion",
@@ -3315,7 +3334,7 @@ version = "0.1.0"
 source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=2bcf481b4abe9d0bd6bb2479ce49020df66ff97f#2bcf481b4abe9d0bd6bb2479ce49020df66ff97f"
 dependencies = [
  "arrow",
- "arrow-json",
+ "arrow-json 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-stream",
  "async-trait",
  "bb8",
@@ -3398,7 +3417,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-json",
+ "arrow-json 53.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
@@ -4084,7 +4103,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "ansi_term",
  "arrow-flight",
- "arrow-json",
+ "arrow-json 53.1.0 (git+https://github.com/spiceai/arrow-rs.git?rev=6013498d7d4d59f7b16d0e28b3e0b379732fbf07)",
  "clap",
  "datafusion",
  "futures",
@@ -9025,7 +9044,7 @@ dependencies = [
  "arrow-csv",
  "arrow-flight",
  "arrow-ipc",
- "arrow-json",
+ "arrow-json 53.1.0 (git+https://github.com/spiceai/arrow-rs.git?rev=6013498d7d4d59f7b16d0e28b3e0b379732fbf07)",
  "arrow-schema",
  "arrow_sql_gen",
  "arrow_tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10084,6 +10084,7 @@ dependencies = [
  "runtime",
  "rustls 0.23.14",
  "rustls-pemfile 2.2.0",
+ "serde_json",
  "snafu",
  "snmalloc-rs",
  "spice-cloud",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ version = "1.0.0-rc.1"
 arrow = "53"
 arrow-buffer = "53"
 arrow-flight = "53"
-arrow-json = "53"
+# Use published version once https://github.com/apache/arrow-rs/pull/6606 is released
+arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "6013498d7d4d59f7b16d0e28b3e0b379732fbf07" }
 arrow-ipc = "53"
 arrow-schema = "53"
 parquet = "53"

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -111,8 +111,7 @@ spice chat --model <model> --cloud
 				}
 			}
 
-			slog.Info(fmt.Sprintf("Using model: %s\n", selectedModel))
-			fmt.Println()
+			cmd.Printf("Using model: %s\n", selectedModel)
 			model = selectedModel
 		}
 

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -24,6 +24,7 @@ reqwest.workspace = true
 runtime = { path = "../../crates/runtime" }
 rustls.workspace = true
 rustls-pemfile.workspace = true
+serde_json.workspace = true
 snafu.workspace = true
 snmalloc-rs = "0.3.6"
 spice-cloud = { path = "../../crates/spice_cloud" }

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -211,6 +211,7 @@ pub async fn run(args: Args) -> Result<()> {
             "SPICED_LOG",
         ),
     )
+    .await
     .context(UnableToInitializeTracingSnafu)?;
 
     if let Some(metrics_registry) = prometheus_registry {

--- a/crates/runtime/src/datafusion/query/tracker.rs
+++ b/crates/runtime/src/datafusion/query/tracker.rs
@@ -126,7 +126,7 @@ impl QueryTracker {
     }
 }
 
-fn trace_query(query_tracker: &QueryTracker, truncated_output: &str) {
+fn trace_query(query_tracker: &QueryTracker, captured_output: &str) {
     if let Some(error_code) = &query_tracker.error_code {
         tracing::info!(target: "task_history", error_code = %error_code, "labels");
     }
@@ -156,5 +156,5 @@ fn trace_query(query_tracker: &QueryTracker, truncated_output: &str) {
         .collect::<Vec<String>>()
         .join(",");
     tracing::info!(target: "task_history", protocol = ?query_tracker.protocol, datasets = datasets_str, "labels");
-    tracing::info!(target: "task_history", truncated_output = %truncated_output);
+    tracing::info!(target: "task_history", captured_output = %captured_output);
 }

--- a/crates/runtime/src/tools/builtin/list_datasets.rs
+++ b/crates/runtime/src/tools/builtin/list_datasets.rs
@@ -89,7 +89,7 @@ impl SpiceModelTool for ListDatasetsTool {
         arg: &str,
         rt: Arc<Runtime>,
     ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
-        tracing::span!(target: "task_history", tracing::Level::INFO, "tool_use::list_datasets", tool = self.name(), input = arg);
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "tool_use::list_datasets", tool = self.name(), input = arg);
 
         let elements = get_dataset_elements(Arc::clone(&rt), self.table_allowlist.as_deref())
             .await
@@ -97,6 +97,9 @@ impl SpiceModelTool for ListDatasetsTool {
             .map(serde_json::value::to_value)
             .collect::<Result<Vec<Value>, _>>()
             .boxed()?;
+
+        let captured_output_json = serde_json::to_string(&elements).boxed()?;
+        tracing::info!(target: "task_history", parent: &span, captured_output = %captured_output_json);
 
         Ok(Value::Array(elements))
     }

--- a/crates/runtime/src/tools/builtin/table_schema.rs
+++ b/crates/runtime/src/tools/builtin/table_schema.rs
@@ -97,10 +97,19 @@ impl SpiceModelTool for TableSchemaTool {
                 .await
                 .boxed()?;
 
-            let v = serde_json::value::to_value(schema).boxed()?;
+            let schema_value = serde_json::value::to_value(schema).boxed()?;
 
-            table_schemas.push(v);
+            let table_schema = serde_json::json!({
+                "table": t,
+                "schema": schema_value
+            });
+
+            table_schemas.push(table_schema);
         }
+
+        let captured_output_json = serde_json::to_string(&table_schemas).boxed()?;
+        tracing::info!(target: "task_history", parent: &span, captured_output = %captured_output_json);
+
         Ok(Value::Array(table_schemas))
     }
 }


### PR DESCRIPTION
## 🗣 Description

Fixes the task_history output for SQL queries, add the output for the tools `table_schema` and `list_datasets` and use a fork of `arrow-rs` that implements `Decimal128` and `Decimal256` types to ensure we provide output for SQL queries which return decimal values.

Also fixes an issue where if the zipkin endpoint wasn't available, it would prevent the task_history table from being populated due to the opentelemetry exporter timing out.

## 🔨 Related Issues

arrow-rs PR: https://github.com/apache/arrow-rs/pull/6606

## 📄 Documentation Requirements

N/A
