### PR TITLE
Add spark back to default connectors

### DIFF
--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -52,6 +52,7 @@ default = [
   "clickhouse",
   "sharepoint",
   "snowflake",
+  "spark",
   "ftp",
   "debezium",
   "anonymous_telemetry",


### PR DESCRIPTION
## 🗣 Description

Spark was mistakenly removed from the default connectors in PR https://github.com/spiceai/spiceai/pull/2922
