### PR TITLE
Move `generate_acknowledgements.yml` back to Github runners

### DIFF
--- a/.github/workflows/generate_acknowledgements.yml
+++ b/.github/workflows/generate_acknowledgements.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   generate:
     name: Generate Acknowledgements
-    runs-on: teraswitch-runners
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
## 🗣 Description
 - Issue with Go buildchain in private runners, see: https://github.com/spiceai/spiceai/actions/runs/11450158419/job/31857106370#step:3:10