### PR TITLE
Move "generate_json_schema" workflow back to ubuntu runner

### DIFF
--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   generate_schema:
-    runs-on: teraswitch-runners
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Switch to ubuntu runner, because it needs preinstalled gh cli