### PR TITLE
Upgrade OTEL to v0.26 and make seconds based metrics reported precisely 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,7 +2097,7 @@ dependencies = [
  "fundu",
  "futures",
  "moka",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "snafu",
  "spicepod",
  "tokio",
@@ -7470,7 +7470,22 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.25.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=c3b59ba61055b7ec6916b6b88a9ac94f6656922b#c3b59ba61055b7ec6916b6b88a9ac94f6656922b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803801d3d3b71cd026851a53f974ea03df3d179cb758b260136a6c9e22e196af"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -7482,25 +7497,25 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8c2b76e5f7848a289aa9666dbe56b16f8a22a4c5246ef37a14941818d2913"
+checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.1.0",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "reqwest 0.12.8",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
 version = "0.17.0"
-source = "git+https://github.com/spiceai/opentelemetry-rust.git?rev=39584779eff60a71ea6b900daca71fd85730e91a#39584779eff60a71ea6b900daca71fd85730e91a"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=e91138351a689cd21923c15eb48f5fbc95ded807#e91138351a689cd21923c15eb48f5fbc95ded807"
 dependencies = [
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.26.0",
+ "opentelemetry_sdk 0.26.0",
  "prometheus",
  "protobuf",
 ]
@@ -7512,8 +7527,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c43620e8f93359eb7e627a3b16ee92d8585774986f24f2ab010817426c5ce61"
 dependencies = [
  "hex",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.25.0",
+ "opentelemetry_sdk 0.25.0",
  "prost 0.13.3",
  "serde",
  "tonic",
@@ -7521,24 +7536,24 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b8e442487022a943e2315740e443dc5ee95fd541c18f509a5a6251b408a9f95"
+checksum = "db945c1eaea8ac6a9677185357480d215bb6999faa9f691d0c4d4d641eab7a09"
 
 [[package]]
 name = "opentelemetry-zipkin"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75b57e1df6d1a6dbb21193f501d3db0c65580d29fa739d902d33aba2323d3ad"
+checksum = "dd5f25a628014191d3e98bb4794e37771b580e9c3de341cf1c813019aa721278"
 dependencies = [
  "async-trait",
  "futures-core",
  "http 1.1.0",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.26.0",
  "reqwest 0.12.8",
  "serde",
  "serde_json",
@@ -7549,7 +7564,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.25.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=c3b59ba61055b7ec6916b6b88a9ac94f6656922b#c3b59ba61055b7ec6916b6b88a9ac94f6656922b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0da0d6b47a3dbc6e9c9e36a0520e25cf943e046843818faaa3f87365a548c82"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -7557,7 +7573,26 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.25.0",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry 0.26.0",
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
@@ -7607,8 +7642,8 @@ dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.26.0",
+ "opentelemetry_sdk 0.26.0",
 ]
 
 [[package]]
@@ -9109,10 +9144,10 @@ dependencies = [
  "ns_lookup",
  "object_store",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "opentelemetry-prometheus",
  "opentelemetry-proto",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.26.0",
  "otel-arrow",
  "pin-project",
  "prometheus",
@@ -10076,11 +10111,11 @@ dependencies = [
  "clap",
  "flightrepl",
  "futures",
- "opentelemetry",
+ "opentelemetry 0.26.0",
  "opentelemetry-http",
  "opentelemetry-prometheus",
  "opentelemetry-zipkin",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.26.0",
  "otel-arrow",
  "prometheus",
  "reqwest 0.12.8",
@@ -10503,8 +10538,8 @@ dependencies = [
  "async-trait",
  "flight_client",
  "hostname 0.4.0",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.26.0",
+ "opentelemetry_sdk 0.26.0",
  "otel-arrow",
  "sha2",
  "tokio",
@@ -11166,13 +11201,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.26.0"
-source = "git+https://github.com/spiceai/tracing-opentelemetry.git?rev=67d70b46ec463e5eae31e655bad9c05ac760d986#67d70b46ec463e5eae31e655bad9c05ac760d986"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.26.0",
+ "opentelemetry_sdk 0.26.0",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,11 +78,11 @@ lazy_static = "1.5.0"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }
 object_store = { version = "0.11" }
 odbc-api = { version = "8.1.2" }
-opentelemetry = { version = "0.25", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.25", default-features = false, features = ["metrics", "rt-tokio", "trace"] }
+opentelemetry = { version = "0.26", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.26", default-features = false, features = ["metrics", "rt-tokio", "trace"] }
 opentelemetry-prometheus = "0.17"
-opentelemetry-zipkin = { version = "0.25", default-features = false, features = ["reqwest", "reqwest-rustls"] }
-opentelemetry-http = { version = "0.25", features = ["reqwest-rustls"] }
+opentelemetry-zipkin = { version = "0.26", default-features = false, features = ["reqwest", "reqwest-rustls"] }
+opentelemetry-http = { version = "0.26", features = ["reqwest-rustls"] }
 pem = "3.0.4"
 prometheus = "0.13"
 r2d2 = "0.8.10"
@@ -115,7 +115,7 @@ tonic = { version = "0.12", features = ["gzip", "tls"] }
 tonic-health = { version = "0.12" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing-opentelemetry = "0.26"
+tracing-opentelemetry = "0.27"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 uuid = "1.9.1"
 x509-certificate = "0.23.1"
@@ -137,8 +137,5 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-# Required until next release with https://github.com/open-telemetry/opentelemetry-rust/pull/2095 is included
-opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "c3b59ba61055b7ec6916b6b88a9ac94f6656922b" }
-opentelemetry_sdk = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "c3b59ba61055b7ec6916b6b88a9ac94f6656922b" }
-tracing-opentelemetry = { git = "https://github.com/spiceai/tracing-opentelemetry.git", rev = "67d70b46ec463e5eae31e655bad9c05ac760d986" }
-opentelemetry-prometheus = { git = "https://github.com/spiceai/opentelemetry-rust.git", rev = "39584779eff60a71ea6b900daca71fd85730e91a" }
+# Required until next release with opentelemetry 0.26 support: https://github.com/open-telemetry/opentelemetry-rust/pull/2183 to be merged 
+opentelemetry-prometheus = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "e91138351a689cd21923c15eb48f5fbc95ded807" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,5 +137,5 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-# Required until next release with opentelemetry 0.26 support: https://github.com/open-telemetry/opentelemetry-rust/pull/2183 to be merged 
+# Required until next release with opentelemetry 0.26 support: https://github.com/open-telemetry/opentelemetry-rust/pull/2183
 opentelemetry-prometheus = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "e91138351a689cd21923c15eb48f5fbc95ded807" }

--- a/crates/otel-arrow/src/exporter.rs
+++ b/crates/otel-arrow/src/exporter.rs
@@ -20,14 +20,14 @@ use opentelemetry::metrics::MetricsError;
 use opentelemetry_sdk::metrics::{
     data::{ResourceMetrics, Temporality},
     exporter::PushMetricsExporter,
-    reader::{AggregationSelector, TemporalitySelector},
-    Aggregation, InstrumentKind,
+    reader::TemporalitySelector,
+    InstrumentKind,
 };
 
 use crate::converter::OtelToArrowConverter;
 
 #[async_trait]
-pub trait ArrowExporter: AggregationSelector + TemporalitySelector + Send + Sync + 'static {
+pub trait ArrowExporter: TemporalitySelector + Send + Sync + 'static {
     async fn export(&self, metrics: RecordBatch) -> Result<(), MetricsError>;
 
     async fn force_flush(&self) -> Result<(), MetricsError>;
@@ -61,12 +61,6 @@ impl<E: ArrowExporter> OtelArrowExporter<E> {
 impl<E: ArrowExporter> TemporalitySelector for OtelArrowExporter<E> {
     fn temporality(&self, kind: InstrumentKind) -> Temporality {
         self.exporter.temporality(kind)
-    }
-}
-
-impl<E: ArrowExporter> AggregationSelector for OtelArrowExporter<E> {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.exporter.aggregation(kind)
     }
 }
 

--- a/crates/runtime/src/datafusion/query/metrics.rs
+++ b/crates/runtime/src/datafusion/query/metrics.rs
@@ -28,6 +28,7 @@ pub(crate) static DURATION_SECONDS: LazyLock<Histogram<f64>> = LazyLock::new(|| 
         .f64_histogram("query_duration_seconds")
         .with_description("Duration in seconds to execute a query.")
         .with_unit("s")
+        .with_boundaries(telemetry::HISTOGRAM_BOUNDARIES_PRECISE_FLOAT.clone())
         .init()
 });
 

--- a/crates/runtime/src/http/metrics.rs
+++ b/crates/runtime/src/http/metrics.rs
@@ -30,5 +30,6 @@ pub(crate) static REQUESTS_DURATION_SECONDS: LazyLock<Histogram<f64>> = LazyLock
     METER
         .f64_histogram("http_requests_duration_seconds")
         .with_unit("s")
+        .with_boundaries(telemetry::HISTOGRAM_BOUNDARIES_PRECISE_FLOAT.clone())
         .init()
 });

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -22,10 +22,8 @@ use async_trait::async_trait;
 use datafusion::sql::TableReference;
 use opentelemetry::metrics::MetricsError;
 use opentelemetry_sdk::metrics::data::Temporality;
-use opentelemetry_sdk::metrics::reader::{
-    AggregationSelector, DefaultAggregationSelector, TemporalitySelector,
-};
-use opentelemetry_sdk::metrics::{Aggregation, InstrumentKind};
+use opentelemetry_sdk::metrics::reader::TemporalitySelector;
+use opentelemetry_sdk::metrics::InstrumentKind;
 use snafu::prelude::*;
 use tokio::sync::RwLock;
 
@@ -50,21 +48,11 @@ pub enum Error {
 
 pub struct SpiceMetricsExporter {
     datafusion: Arc<DataFusion>,
-    aggregation_selector: DefaultAggregationSelector,
 }
 
 impl SpiceMetricsExporter {
     pub fn new(datafusion: Arc<DataFusion>) -> Self {
-        SpiceMetricsExporter {
-            datafusion,
-            aggregation_selector: DefaultAggregationSelector::new(),
-        }
-    }
-}
-
-impl AggregationSelector for SpiceMetricsExporter {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.aggregation_selector.aggregation(kind)
+        SpiceMetricsExporter { datafusion }
     }
 }
 

--- a/crates/telemetry/src/anonymous.rs
+++ b/crates/telemetry/src/anonymous.rs
@@ -20,13 +20,13 @@ use std::{
 };
 
 use crate::exporter::AnonymousTelemetryExporter;
-use opentelemetry::{global::GlobalMeterProvider, KeyValue};
+use opentelemetry::KeyValue;
 use opentelemetry_sdk::{
     metrics::{
         data::{ResourceMetrics, Temporality},
         exporter::PushMetricsExporter,
-        reader::{AggregationSelector, MetricReader, TemporalitySelector},
-        Aggregation, InstrumentKind, ManualReader, PeriodicReader, Pipeline, SdkMeterProvider,
+        reader::{MetricReader, TemporalitySelector},
+        InstrumentKind, ManualReader, PeriodicReader, Pipeline, SdkMeterProvider,
     },
     runtime::Tokio,
     Resource,
@@ -91,7 +91,7 @@ pub async fn start(spicepod_name: &str) {
         .build();
 
     if crate::meter::METER_PROVIDER_ONCE
-        .set(GlobalMeterProvider::new(provider))
+        .set(Arc::new(provider))
         .is_err()
     {
         tracing::trace!("Failed to set global meter provider for the anonymous telemetry, already set by another codepath?");
@@ -153,11 +153,5 @@ impl MetricReader for InitialReader {
 impl TemporalitySelector for InitialReader {
     fn temporality(&self, kind: InstrumentKind) -> Temporality {
         self.reader.temporality(kind)
-    }
-}
-
-impl AggregationSelector for InitialReader {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.reader.aggregation(kind)
     }
 }

--- a/crates/telemetry/src/exporter.rs
+++ b/crates/telemetry/src/exporter.rs
@@ -20,15 +20,10 @@ use arrow::array::RecordBatch;
 use async_trait::async_trait;
 use flight_client::{Credentials, FlightClient};
 use opentelemetry::metrics::MetricsError;
-use opentelemetry_sdk::metrics::{
-    data::Temporality,
-    reader::{AggregationSelector, DefaultAggregationSelector, TemporalitySelector},
-    Aggregation, InstrumentKind,
-};
+use opentelemetry_sdk::metrics::{data::Temporality, reader::TemporalitySelector, InstrumentKind};
 
 #[derive(Debug, Clone)]
 pub struct AnonymousTelemetryExporter {
-    aggregation_selector: DefaultAggregationSelector,
     flight_client: Option<FlightClient>,
 }
 
@@ -41,16 +36,7 @@ impl AnonymousTelemetryExporter {
                 None
             }
         };
-        Self {
-            aggregation_selector: DefaultAggregationSelector::new(),
-            flight_client,
-        }
-    }
-}
-
-impl AggregationSelector for AnonymousTelemetryExporter {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.aggregation_selector.aggregation(kind)
+        Self { flight_client }
     }
 }
 

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -95,6 +95,17 @@ pub fn track_query_execution_duration(duration: Duration, protocol: Arc<str>) {
     QUERY_EXECUTION_DURATION.record(duration.as_secs_f64() * 1000.0, &dimensions);
 }
 
+/// This set of boundaries enhances precision for tracking smaller values compared to the default boundaries (below).
+/// It includes additional buckets for better granularity in the lower range.
+///
+/// Default: [0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0]
+pub static HISTOGRAM_BOUNDARIES_PRECISE_FLOAT: LazyLock<Vec<f64>> = LazyLock::new(|| {
+    vec![
+        0.0, 0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5,
+        5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0,
+    ]
+});
+
 fn create_dimensions(protocol: Arc<str>) -> [KeyValue; 1] {
     [KeyValue::new("protocol", protocol)]
 }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -102,7 +102,7 @@ pub fn track_query_execution_duration(duration: Duration, protocol: Arc<str>) {
 pub static HISTOGRAM_BOUNDARIES_PRECISE_FLOAT: LazyLock<Vec<f64>> = LazyLock::new(|| {
     vec![
         0.0, 0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5,
-        5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0,
+        5.0, 10.0,
     ]
 });
 


### PR DESCRIPTION
## 🗣 Description

Upgrade `open-telemetry` to `0.26` to include the following improvement: [Add with_boundaries hint API for explicit bucket histograms](https://github.com/open-telemetry/opentelemetry-rust/pull/2135)

This allows to override default boundaries/buckets that are used to calculate histogram information (quantiles) for `http_requests_duration_seconds` and `http_requests_duration_seconds` metrics that are in float seconds but must be reported precisely. There are also `datasets_unavailable_time`  and `datasets_acceleration_last_refresh_time` metrics in seconds as well but default boundaries/precision is enough for them IMO.

```console
# TYPE http_requests_duration_seconds histogram
http_requests_duration_seconds_bucket{method="POST",path="/v1/sql",status="400",le="0"} 0
http_requests_duration_seconds_bucket{method="POST",path="/v1/sql",status="400",le="0.0001"} 0
http_requests_duration_seconds_bucket{method="POST",path="/v1/sql",status="400",le="0.0005"} 1
http_requests_duration_seconds_bucket{method="POST",path="/v1/sql",status="400",le="0.001"} 5
http_requests_duration_seconds_bucket{method="POST",path="/v1/sql",status="400",le="0.0025"} 8
http_requests_duration_seconds_bucket{method="POST",path="/v1/sql",status="400",le="0.005"} 9
...
http_requests_duration_seconds_sum{method="POST",path="/v1/sql",status="400"} 0.009356208
http_requests_duration_seconds_count{method="POST",path="/v1/sql",status="400"} 9
# TYPE http_requests_total counter
http_requests_total{method="POST",path="/v1/sql",status="400"} 9
# HELP http_requests_duration_seconds_summary Summary derived from histogram http_requests_duration_seconds
# TYPE http_requests_duration_seconds_summary summary
http_requests_duration_seconds_summary{method="POST",path="/v1/sql",status="400",quantile="0.5"} 0.0009375
http_requests_duration_seconds_summary{method="POST",path="/v1/sql",status="400",quantile="0.9"} 0.002749999999999999
http_requests_duration_seconds_summary{method="POST",path="/v1/sql",status="400",quantile="0.95"} 0.0038749999999999974
http_requests_duration_seconds_summary{method="POST",path="/v1/sql",status="400",quantile="0.99"} 0.004775000000000001
http_requests_duration_seconds_summary_sum{method="POST",path="/v1/sql",status="400"} 0.009356208
http_requests_duration_seconds_summary_count{method="POST",path="/v1/sql",status="400"} 9
```

0.26 contained the following breaking changes so the code was updated:
- https://github.com/open-telemetry/opentelemetry-rust/pull/2085
- https://github.com/open-telemetry/opentelemetry-rust/pull/2112

## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/3153 
