### PR TITLE
Split spiced_docker build across architectures

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - name: Linux x64
-            runner: teraswitch-runners
+            runner: spiceai-runners
             target_os: linux
             target_arch: x86_64
             target_arch_go: amd64

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   setup-matrix:
     name: Setup strategy matrix
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     outputs:
       matrix: ${{ steps.setup-matrix.outputs.result }}
 
@@ -38,7 +38,7 @@ jobs:
             const matrix = [
               {
                 name: "Linux x64",
-                builder: "teraswitch-runners",
+                builder: "spiceai-runners",
                 runner: "ubuntu-latest",
                 target_os: "linux",
                 target_arch: "x86_64",

--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
           - name: Linux x64
-            runner: teraswitch-runners
+            runner: spiceai-runners
             target_os: linux
             target_arch: x86_64
           - name: Linux aarch64

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build:
     name: Features Check
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   license-check-rust:
     name: Check Rust Licenses
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     steps:
       - uses: actions/checkout@v4
 
@@ -50,7 +50,7 @@ jobs:
 
   license-check-go:
     name: Check Golang Licenses
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     env:
       GOVER: 1.22.0
 

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   make_install:
     name: make install*
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     env:
       GOVER: 1.22.0
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
   # `on.pull_requests.paths-ignore`. Instead, we conditionally run the jobs (which report 
   # a sucess when skipped).
   check_changes:
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     outputs:
       relevant_changes: ${{ steps.check_changes.outputs.relevant_changes }}
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   lint:
     name: Run Go & Rust Linters
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     env:
       GOVER: 1.22.0
     needs: check_changes
@@ -123,7 +123,7 @@ jobs:
 
   build:
     name: Build Go & Rust
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     env:
       GOVER: 1.22.0
     needs: check_changes
@@ -153,7 +153,7 @@ jobs:
 
   build-docker:
     name: Build Docker Image
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     needs: check_changes
 
     steps:

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -38,7 +38,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-slim-amd64,dest=/tmp/image-amd64-slim.tar
+          outputs: type=docker,name=localhost:5000/spiceai:slim-amd64,dest=/tmp/image-amd64-slim.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -51,7 +51,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-full-amd64,dest=/tmp/image-amd64-full.tar
+          outputs: type=docker,name=localhost:5000/spiceai:full-amd64,dest=/tmp/image-amd64-full.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -64,7 +64,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-models-amd64,dest=/tmp/image-amd64-models.tar
+          outputs: type=docker,name=localhost:5000/spiceai:models-amd64,dest=/tmp/image-amd64-models.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -114,7 +114,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-slim-arm64,dest=/tmp/image-arm64-slim.tar
+          outputs: type=docker,name=localhost:5000/spiceai:slim-arm64,dest=/tmp/image-arm64-slim.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
@@ -127,7 +127,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-full-arm64,dest=/tmp/image-arm64-full.tar
+          outputs: type=docker,name=localhost:5000/spiceai:full-arm64,dest=/tmp/image-arm64-full.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
@@ -140,7 +140,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-models-arm64,dest=/tmp/image-arm64-models.tar
+          outputs: type=docker,name=localhost:5000/spiceai:models-arm64,dest=/tmp/image-arm64-models.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
@@ -206,15 +206,10 @@ jobs:
             echo "Loading ARM64 image"
             docker load -i /tmp/images-arm64/image-arm64-${variant}.tar
             
-            # Tag images for local registry
-            echo "Tagging images for local registry"
-            docker tag spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64 localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64
-            docker tag spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64 localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
-
             # Push images to local registry
             echo "Pushing images to local registry"
-            docker push localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64
-            docker push localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
+            docker push localhost:5000/spiceai:${variant}-amd64
+            docker push localhost:5000/spiceai:${variant}-arm64
 
             if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
               # Push to GitHub Container Registry
@@ -222,16 +217,16 @@ jobs:
               docker buildx imagetools create \
                 -t ghcr.io/spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
                 -t ghcr.io/spiceai/spiceai:latest${suffix} \
-                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64 \
-                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
+                localhost:5000/spiceai:${variant}-amd64 \
+                localhost:5000/spiceai:${variant}-arm64
               
               # Push to DockerHub
               echo "Pushing to DockerHub"
               docker buildx imagetools create \
                 -t spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
                 -t spiceai/spiceai:latest${suffix} \
-                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64 \
-                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
+                localhost:5000/spiceai:${variant}-amd64 \
+                localhost:5000/spiceai:${variant}-arm64
               
               echo "Verifying GHCR image:"
               docker buildx imagetools inspect ghcr.io/spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}
@@ -242,10 +237,10 @@ jobs:
               echo "Skipping push for non-tag build"
               echo "Creating local manifest for testing:"
               docker buildx imagetools create \
-                -t localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
-                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64 \
-                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
+                -t localhost:5000/spiceai:latest${suffix} \
+                localhost:5000/spiceai:${variant}-amd64 \
+                localhost:5000/spiceai:${variant}-arm64
               
-              docker buildx imagetools inspect localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}
+              docker buildx imagetools inspect localhost:5000/spiceai:latest${suffix}
             fi
           done

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -4,24 +4,150 @@ on:
   push:
     tags:
       - v*
-
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Build Spice linux_amd64/linux_arm64 Docker image
-    runs-on: teraswitch-runners
-
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      rel_version: ${{ steps.set_version.outputs.rel_version }}
     steps:
       - uses: actions/checkout@v4
-
       - name: Set REL_VERSION from version.txt
-        run: python3 ./.github/scripts/get_release_version.py
+        id: set_version
+        run: |
+          python3 ./.github/scripts/get_release_version.py
+          echo "rel_version=${{ env.REL_VERSION }}" >> $GITHUB_OUTPUT
+
+  build-amd64:
+    needs: setup
+    runs-on: teraswitch-runners
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          # Enable docker driver for layer caching
+          driver-opts: |
+            image=moby/buildkit:latest
+      
+      - name: Build AMD64 slim image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          outputs: type=oci,dest=/tmp/image-amd64-slim.tar
+          cache-from: type=gha,scope=build-amd64
+          cache-to: type=gha,scope=build-amd64,mode=max
+          build-args: |
+            REL_VERSION=${{ needs.setup.outputs.rel_version }}
+            CARGO_FEATURES=release
+
+      - name: Build AMD64 full image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          outputs: type=oci,dest=/tmp/image-amd64-full.tar
+          cache-from: type=gha,scope=build-amd64
+          cache-to: type=gha,scope=build-amd64,mode=max
+          build-args: |
+            REL_VERSION=${{ needs.setup.outputs.rel_version }}
+            CARGO_FEATURES=release,odbc
+
+      - name: Build AMD64 models image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          outputs: type=oci,dest=/tmp/image-amd64-models.tar
+          cache-from: type=gha,scope=build-amd64
+          cache-to: type=gha,scope=build-amd64,mode=max
+          build-args: |
+            REL_VERSION=${{ needs.setup.outputs.rel_version }}
+            CARGO_FEATURES=release,models
+
+      - name: Upload AMD64 artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: images-amd64
+          path: /tmp/image-amd64-*.tar
+
+  build-arm64:
+    needs: setup
+    runs-on: hosted-linux-arm-runner
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+
+      - name: Build ARM64 slim image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/arm64
+          outputs: type=oci,dest=/tmp/image-arm64-slim.tar
+          cache-from: type=gha,scope=build-arm64
+          cache-to: type=gha,scope=build-arm64,mode=max
+          build-args: |
+            REL_VERSION=${{ needs.setup.outputs.rel_version }}
+            CARGO_FEATURES=release
+
+      - name: Build ARM64 full image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/arm64
+          outputs: type=oci,dest=/tmp/image-arm64-full.tar
+          cache-from: type=gha,scope=build-arm64
+          cache-to: type=gha,scope=build-arm64,mode=max
+          build-args: |
+            REL_VERSION=${{ needs.setup.outputs.rel_version }}
+            CARGO_FEATURES=release,odbc
+
+      - name: Build ARM64 models image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/arm64
+          outputs: type=oci,dest=/tmp/image-arm64-models.tar
+          cache-from: type=gha,scope=build-arm64
+          cache-to: type=gha,scope=build-arm64,mode=max
+          build-args: |
+            REL_VERSION=${{ needs.setup.outputs.rel_version }}
+            CARGO_FEATURES=release,models
+
+      - name: Upload ARM64 artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: images-arm64
+          path: /tmp/image-arm64-*.tar
+
+  publish:
+    needs: [setup, build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: /tmp
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Package Registry
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -29,69 +155,54 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Sets latest tags for release
+      - name: Import images and create manifests
         run: |
-          echo "LATEST_GHCR_TAG=ghcr.io/spiceai/spiceai:latest" >> $GITHUB_ENV
-          echo "LATEST_DOCKERHUB_TAG=spiceai/spiceai:latest" >> $GITHUB_ENV
-
-      - name: Build and push Docker images (slim)
-        id: docker_build_slim
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ startswith(github.ref, 'refs/tags/v') }}
-          build-args: |
-            REL_VERSION=${{ env.REL_VERSION }}
-            CARGO_FEATURES=release
-          tags: |
-            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}-slim
-            spiceai/spiceai:${{ env.REL_VERSION }}-slim
-            ${{ env.LATEST_GHCR_TAG }}-slim
-            ${{ env.LATEST_DOCKERHUB_TAG }}-slim
-
-      - name: Build and push Docker images (full)
-        id: docker_build_full
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ startswith(github.ref, 'refs/tags/v') }}
-          build-args: |
-            REL_VERSION=${{ env.REL_VERSION }}
-            CARGO_FEATURES=release,odbc
-          tags: |
-            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}
-            spiceai/spiceai:${{ env.REL_VERSION }}
-            ${{ env.LATEST_GHCR_TAG }}
-            ${{ env.LATEST_DOCKERHUB_TAG }}
-
-      - name: Build and push Docker images (models)
-        id: docker_build_models
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ startswith(github.ref, 'refs/tags/v') }}
-          build-args: |
-            REL_VERSION=${{ env.REL_VERSION }}
-            CARGO_FEATURES=release,models
-          tags: |
-            ghcr.io/spiceai/spiceai:${{ env.REL_VERSION }}-models
-            spiceai/spiceai:${{ env.REL_VERSION }}-models
-            ${{ env.LATEST_GHCR_TAG }}-models
-            ${{ env.LATEST_DOCKERHUB_TAG }}-models
-
-      - name: Image digest
-        run: |
-          echo ${{ steps.docker_build_slim.outputs.digest }}
-          echo ${{ steps.docker_build_full.outputs.digest }}
-          echo ${{ steps.docker_build_models.outputs.digest }}
+          variants=("slim" "full" "models")
+          for variant in "${variants[@]}"; do
+            # Set suffix based on variant
+            suffix=""
+            if [ "$variant" != "full" ]; then
+              suffix="-${variant}"
+            fi
+            
+            # Load both architecture images
+            docker load -i /tmp/images-amd64/image-amd64-${variant}.tar
+            docker load -i /tmp/images-arm64/image-arm64-${variant}.tar
+            
+            if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+              # Push to GitHub Container Registry
+              docker buildx imagetools create --push \
+                -t ghcr.io/spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
+                -t ghcr.io/spiceai/spiceai:latest${suffix} \
+                /tmp/images-amd64/image-amd64-${variant}.tar \
+                /tmp/images-arm64/image-arm64-${variant}.tar
+              
+              # Push to DockerHub
+              docker buildx imagetools create --push \
+                -t spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
+                -t spiceai/spiceai:latest${suffix} \
+                /tmp/images-amd64/image-amd64-${variant}.tar \
+                /tmp/images-arm64/image-arm64-${variant}.tar
+              
+              echo "Verifying GHCR image:"
+              docker buildx imagetools inspect ghcr.io/spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}
+              
+              echo "Verifying DockerHub image:"
+              docker buildx imagetools inspect spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}
+            else
+              echo "Skipping push for non-tag build"
+              echo "Creating local manifest for testing:"
+              docker buildx imagetools create \
+                -t spiceai/spiceai:test${suffix} \
+                /tmp/images-amd64/image-amd64-${variant}.tar \
+                /tmp/images-arm64/image-arm64-${variant}.tar
+              
+              docker buildx imagetools inspect spiceai/spiceai:test${suffix}
+            fi
+          done

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -21,7 +21,7 @@ jobs:
 
   build-amd64:
     needs: setup
-    runs-on: teraswitch-runners
+    runs-on: spiceai-runners
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -93,6 +93,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
+      - name: Start Docker service
+        run: |
+          sudo systemctl start docker
+          sudo systemctl status docker
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -161,7 +161,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp
-          merge-multiple: true
 
       - name: Verify artifacts
         run: |

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -88,8 +88,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ca-certificates curl gnupg lsb-release
           sudo mkdir -m 0755 -p /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(lsb_release -i | awk '{ print tolower($3) }') $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(lsb_release -i | awk '{ print tolower($3) }') $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
       

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -161,6 +161,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp
+          pattern: images-*
 
       - name: Verify artifacts
         run: |

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -82,6 +82,16 @@ jobs:
     runs-on: hosted-linux-arm-runner
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install docker
+        run: |
+          apt-get update
+          apt-get install -y ca-certificates curl gnupg lsb-release
+          mkdir -m 0755 -p /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(lsb_release -i | awk '{ print tolower($3) }') $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+          apt-get update
+          apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -79,7 +79,7 @@ jobs:
 
   build-arm64:
     needs: setup
-    runs-on: hosted-linux-arm-runner
+    runs-on: hosted-linux-arm-runner-16-cores
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -72,7 +72,7 @@ jobs:
             CARGO_FEATURES=release,models
 
       - name: Upload AMD64 artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: images-amd64
           path: /tmp/image-amd64-*.tar

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -85,13 +85,13 @@ jobs:
 
       - name: Install docker
         run: |
-          apt-get update
-          apt-get install -y ca-certificates curl gnupg lsb-release
-          mkdir -m 0755 -p /etc/apt/keyrings
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl gnupg lsb-release
+          sudo mkdir -m 0755 -p /etc/apt/keyrings
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(lsb_release -i | awk '{ print tolower($3) }') $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
-          apt-get update
-          apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
+          sudo apt-get update
+          sudo apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -148,7 +148,7 @@ jobs:
             CARGO_FEATURES=release,models
 
       - name: Upload ARM64 artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: images-arm64
           path: /tmp/image-arm64-*.tar
@@ -158,9 +158,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: /tmp
+          merge-multiple: true
+
+      - name: Verify artifacts
+        run: |
+          ls -l /tmp
+          ls -l /tmp/images-amd64
+          ls -l /tmp/images-arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -191,7 +198,9 @@ jobs:
             fi
             
             # Load both architecture images
+            echo "Loading AMD64 image"
             docker load -i /tmp/images-amd64/image-amd64-${variant}.tar
+            echo "Loading ARM64 image"
             docker load -i /tmp/images-arm64/image-arm64-${variant}.tar
             
             if [[ "${{ github.ref }}" == refs/tags/v* ]]; then

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -98,6 +98,11 @@ jobs:
           sudo systemctl start docker
           sudo systemctl status docker
 
+      # Add current user to docker group
+      - name: Add current user to docker group
+        run: |
+          sudo usermod -aG docker $USER
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -38,7 +38,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=oci,dest=/tmp/image-amd64-slim.tar
+          outputs: type=docker,dest=/tmp/image-amd64-slim.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -51,7 +51,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=oci,dest=/tmp/image-amd64-full.tar
+          outputs: type=docker,dest=/tmp/image-amd64-full.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -64,7 +64,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=oci,dest=/tmp/image-amd64-models.tar
+          outputs: type=docker,dest=/tmp/image-amd64-models.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -191,7 +191,6 @@ jobs:
         run: |
           variants=("slim" "full" "models")
           for variant in "${variants[@]}"; do
-            # Set suffix based on variant
             suffix=""
             if [ "$variant" != "full" ]; then
               suffix="-${variant}"
@@ -205,6 +204,7 @@ jobs:
             
             if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
               # Push to GitHub Container Registry
+              echo "Pushing to GHCR"
               docker buildx imagetools create --push \
                 -t ghcr.io/spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
                 -t ghcr.io/spiceai/spiceai:latest${suffix} \
@@ -212,6 +212,7 @@ jobs:
                 /tmp/images-arm64/image-arm64-${variant}.tar
               
               # Push to DockerHub
+              echo "Pushing to DockerHub"
               docker buildx imagetools create --push \
                 -t spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
                 -t spiceai/spiceai:latest${suffix} \

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -91,12 +91,7 @@ jobs:
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(lsb_release -i | awk '{ print tolower($3) }') $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
-          sudo apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
-
-      - name: Start Docker service
-        run: |
-          sudo systemctl start docker
-          sudo systemctl status docker
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -38,7 +38,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=docker,dest=/tmp/image-amd64-slim.tar
+          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-slim-amd64,dest=/tmp/image-amd64-slim.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -51,7 +51,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=docker,dest=/tmp/image-amd64-full.tar
+          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-full-amd64,dest=/tmp/image-amd64-full.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -64,7 +64,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          outputs: type=docker,dest=/tmp/image-amd64-models.tar
+          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-models-amd64,dest=/tmp/image-amd64-models.tar
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
@@ -114,7 +114,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=docker,dest=/tmp/image-arm64-slim.tar
+          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-slim-arm64,dest=/tmp/image-arm64-slim.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
@@ -127,7 +127,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=docker,dest=/tmp/image-arm64-full.tar
+          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-full-arm64,dest=/tmp/image-arm64-full.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
@@ -140,7 +140,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=docker,dest=/tmp/image-arm64-models.tar
+          outputs: type=docker,name=spiceai/spiceai:${{ needs.setup.outputs.rel_version }}-models-arm64,dest=/tmp/image-arm64-models.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
@@ -172,6 +172,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Start local registry
+        run: |
+          docker run -d -p 5000:5000 --restart=always --name registry registry:2
+
       - name: Login to GitHub Package Registry
         if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v3
@@ -202,22 +206,32 @@ jobs:
             echo "Loading ARM64 image"
             docker load -i /tmp/images-arm64/image-arm64-${variant}.tar
             
+            # Tag images for local registry
+            echo "Tagging images for local registry"
+            docker tag spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64 localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64
+            docker tag spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64 localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
+
+            # Push images to local registry
+            echo "Pushing images to local registry"
+            docker push localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64
+            docker push localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
+
             if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
               # Push to GitHub Container Registry
               echo "Pushing to GHCR"
-              docker buildx imagetools create --push \
+              docker buildx imagetools create \
                 -t ghcr.io/spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
                 -t ghcr.io/spiceai/spiceai:latest${suffix} \
-                /tmp/images-amd64/image-amd64-${variant}.tar \
-                /tmp/images-arm64/image-arm64-${variant}.tar
+                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64 \
+                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
               
               # Push to DockerHub
               echo "Pushing to DockerHub"
-              docker buildx imagetools create --push \
+              docker buildx imagetools create \
                 -t spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
                 -t spiceai/spiceai:latest${suffix} \
-                /tmp/images-amd64/image-amd64-${variant}.tar \
-                /tmp/images-arm64/image-arm64-${variant}.tar
+                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64 \
+                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
               
               echo "Verifying GHCR image:"
               docker buildx imagetools inspect ghcr.io/spiceai/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}
@@ -228,10 +242,10 @@ jobs:
               echo "Skipping push for non-tag build"
               echo "Creating local manifest for testing:"
               docker buildx imagetools create \
-                -t spiceai/spiceai:test${suffix} \
-                /tmp/images-amd64/image-amd64-${variant}.tar \
-                /tmp/images-arm64/image-arm64-${variant}.tar
+                -t localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix} \
+                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-amd64 \
+                localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}-arm64
               
-              docker buildx imagetools inspect spiceai/spiceai:test${suffix}
+              docker buildx imagetools inspect localhost:5000/spiceai:${{ needs.setup.outputs.rel_version }}${suffix}
             fi
           done

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -92,7 +92,12 @@ jobs:
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(lsb_release -i | awk '{ print tolower($3) }') $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
-      
+
+      - name: Start Docker service
+        run: |
+          sudo systemctl start docker
+          sudo systemctl status docker
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -98,10 +98,9 @@ jobs:
           sudo systemctl start docker
           sudo systemctl status docker
 
-      # Add current user to docker group
-      - name: Add current user to docker group
+      - name: chown /var/run/docker.sock to current user
         run: |
-          sudo usermod -aG docker $USER
+          sudo chown $USER /var/run/docker.sock
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -114,7 +114,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=oci,dest=/tmp/image-arm64-slim.tar
+          outputs: type=docker,dest=/tmp/image-arm64-slim.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
@@ -127,7 +127,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=oci,dest=/tmp/image-arm64-full.tar
+          outputs: type=docker,dest=/tmp/image-arm64-full.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
@@ -140,7 +140,7 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/arm64
-          outputs: type=oci,dest=/tmp/image-arm64-models.tar
+          outputs: type=docker,dest=/tmp/image-arm64-models.tar
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |

--- a/.github/workflows/types_check.yml
+++ b/.github/workflows/types_check.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - name: "Linux x64"
-            runner: "teraswitch-runners"
+            runner: "spiceai-runners"
             target_os: "linux"
             target_arch: "x86_64"
             target_arch_go: "amd64"

--- a/docs/release_notes/v0.19.1-beta.md
+++ b/docs/release_notes/v0.19.1-beta.md
@@ -36,7 +36,7 @@ None
 * Verify TPCH benchmark query results for Spark connector by @sgrebnov in https://github.com/spiceai/spiceai/pull/2993
 * feat: Add x-spice-user-agent header to Spice REPL by @peasee in https://github.com/spiceai/spiceai/pull/2979
 * Update to object store file formats documentation link by @karifabri in https://github.com/spiceai/spiceai/pull/3036
-* Use teraswitch-runners for Linux x64 workflows + builds by @phillipleblanc in https://github.com/spiceai/spiceai/pull/3042
+* Use spiceai-runners for Linux x64 workflows + builds by @phillipleblanc in https://github.com/spiceai/spiceai/pull/3042
 * feat: Support array contains in GitHub pushdown by @peasee in https://github.com/spiceai/spiceai/pull/2983
 * Bump text-splitter from 0.16.1 to 0.17.0 by @dependabot in https://github.com/spiceai/spiceai/pull/2987
 * Revert integration tests back to hosted runner by @phillipleblanc in https://github.com/spiceai/spiceai/pull/3046


### PR DESCRIPTION
## 🗣 Description

Splits the `spiced_docker` build to run on runners native to the architecture for each layer, and then combine the layers at the end before publishing.

Example run to publish `v0.19.2-beta`: [spiced_docker · spiceai/spiceai@3257f3b](https://github.com/spiceai/spiceai/actions/runs/11483049529/job/31959047271)
