### PR TITLE
Implement `localpod` Data Connector

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -67,6 +67,7 @@ pub mod ftp;
 pub mod github;
 pub mod graphql;
 pub mod https;
+pub mod local;
 #[cfg(feature = "mssql")]
 pub mod mssql;
 #[cfg(feature = "mysql")]

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -67,7 +67,7 @@ pub mod ftp;
 pub mod github;
 pub mod graphql;
 pub mod https;
-pub mod local;
+pub mod localpod;
 #[cfg(feature = "mssql")]
 pub mod mssql;
 #[cfg(feature = "mysql")]

--- a/crates/runtime/src/dataconnector/local.rs
+++ b/crates/runtime/src/dataconnector/local.rs
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Data connector that reads from datasets already registered in Spice.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::catalog::TableProvider;
+use datafusion::sql::TableReference;
+
+use crate::component::dataset::Dataset;
+use crate::datafusion::DataFusion;
+use crate::DataConnector;
+
+#[derive(Clone)]
+pub struct LocalConnector {
+    datafusion: Arc<DataFusion>,
+}
+
+impl LocalConnector {
+    #[must_use]
+    pub fn new(datafusion: Arc<DataFusion>) -> Self {
+        Self { datafusion }
+    }
+}
+
+#[async_trait]
+impl DataConnector for LocalConnector {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
+        let path = dataset.path();
+        let path_table_ref = TableReference::parse_str(&path);
+        self.datafusion.get_table(&path_table_ref).await.ok_or(
+            super::DataConnectorError::InvalidTableName {
+                dataconnector: "local".to_string(),
+                dataset_name: dataset.name.to_string(),
+                table_name: path_table_ref.to_string(),
+            },
+        )
+    }
+}

--- a/crates/runtime/src/dataconnector/localpod.rs
+++ b/crates/runtime/src/dataconnector/localpod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Data connector that reads from datasets already registered in Spice.
+//! Data connector that reads from datasets already registered in the current Spicepod.
 
 use std::any::Any;
 use std::sync::Arc;
@@ -27,12 +27,14 @@ use crate::component::dataset::Dataset;
 use crate::datafusion::DataFusion;
 use crate::DataConnector;
 
+pub const LOCALPOD_DATACONNECTOR: &str = "localpod";
+
 #[derive(Clone)]
-pub struct LocalConnector {
+pub struct LocalPodConnector {
     datafusion: Arc<DataFusion>,
 }
 
-impl LocalConnector {
+impl LocalPodConnector {
     #[must_use]
     pub fn new(datafusion: Arc<DataFusion>) -> Self {
         Self { datafusion }
@@ -40,7 +42,7 @@ impl LocalConnector {
 }
 
 #[async_trait]
-impl DataConnector for LocalConnector {
+impl DataConnector for LocalPodConnector {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -53,7 +55,7 @@ impl DataConnector for LocalConnector {
         let path_table_ref = TableReference::parse_str(&path);
         self.datafusion.get_table(&path_table_ref).await.ok_or(
             super::DataConnectorError::InvalidTableName {
-                dataconnector: "local".to_string(),
+                dataconnector: LOCALPOD_DATACONNECTOR.to_string(),
                 dataset_name: dataset.name.to_string(),
                 table_name: path_table_ref.to_string(),
             },

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -35,7 +35,7 @@ use component::dataset::{self, Dataset};
 use component::view::View;
 use config::Config;
 use dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
-use dataconnector::local::LocalConnector;
+use dataconnector::localpod::{LocalPodConnector, LOCALPOD_DATACONNECTOR};
 use datafusion::SPICE_RUNTIME_SCHEMA;
 use datasets_health_monitor::DatasetsHealthMonitor;
 use embeddings::connector::EmbeddingConnector;
@@ -710,14 +710,14 @@ impl Runtime {
         let valid_datasets = Self::get_valid_datasets(app, LogErrors(true));
         let initialized_datasets = self.initialize_accelerators(&valid_datasets).await;
 
-        // Separate datasets into local and non-local
-        let (local_datasets, non_local_datasets): (Vec<_>, Vec<_>) = initialized_datasets
+        // Separate datasets into localpod and non-localpod
+        let (localpod_datasets, non_localpod_datasets): (Vec<_>, Vec<_>) = initialized_datasets
             .into_iter()
-            .partition(|ds| ds.source() == "local");
+            .partition(|ds| ds.source() == LOCALPOD_DATACONNECTOR);
         let mut futures = vec![];
 
-        // Load non-local datasets first in parallel
-        for ds in non_local_datasets {
+        // Load non-localpod datasets first in parallel
+        for ds in non_localpod_datasets {
             self.status
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
             futures.push(self.load_dataset(ds));
@@ -730,8 +730,8 @@ impl Runtime {
             let _ = join_all(futures).await;
         }
 
-        // Load local datasets
-        for ds in local_datasets {
+        // Load localpod datasets
+        for ds in localpod_datasets {
             self.status
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
             self.load_dataset(ds).await;
@@ -1177,9 +1177,9 @@ impl Runtime {
     ) -> Result<Arc<dyn DataConnector>> {
         let secret_map = self.get_params_with_secrets(&params).await;
 
-        // Unlike most other data connectors, the local connector needs a reference to the current DataFusion instance.
-        if source == "local" {
-            return Ok(Arc::new(LocalConnector::new(Arc::clone(&self.df))));
+        // Unlike most other data connectors, the localpod connector needs a reference to the current DataFusion instance.
+        if source == LOCALPOD_DATACONNECTOR {
+            return Ok(Arc::new(LocalPodConnector::new(Arc::clone(&self.df))));
         }
 
         match dataconnector::create_new_connector(source, secret_map, self.secrets(), metadata)

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -35,6 +35,7 @@ use component::dataset::{self, Dataset};
 use component::view::View;
 use config::Config;
 use dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
+use dataconnector::local::LocalConnector;
 use datafusion::SPICE_RUNTIME_SCHEMA;
 use datasets_health_monitor::DatasetsHealthMonitor;
 use embeddings::connector::EmbeddingConnector;
@@ -707,22 +708,34 @@ impl Runtime {
         };
 
         let valid_datasets = Self::get_valid_datasets(app, LogErrors(true));
+        let initialized_datasets = self.initialize_accelerators(&valid_datasets).await;
+
+        // Separate datasets into local and non-local
+        let (local_datasets, non_local_datasets): (Vec<_>, Vec<_>) = initialized_datasets
+            .into_iter()
+            .partition(|ds| ds.source() == "local");
         let mut futures = vec![];
 
-        // Load only successfully initialized datasets
-        for ds in &self.initialize_accelerators(&valid_datasets).await {
+        // Load non-local datasets first in parallel
+        for ds in non_local_datasets {
             self.status
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
-            futures.push(self.load_dataset(Arc::clone(ds)));
+            futures.push(self.load_dataset(ds));
         }
 
         if let Some(parallel_num) = app.runtime.num_of_parallel_loading_at_start_up {
             let stream = futures::stream::iter(futures).buffer_unordered(parallel_num);
             let _ = stream.collect::<Vec<_>>().await;
-            return;
+        } else {
+            let _ = join_all(futures).await;
         }
 
-        let _ = join_all(futures).await;
+        // Load local datasets
+        for ds in local_datasets {
+            self.status
+                .update_dataset(&ds.name, status::ComponentStatus::Initializing);
+            self.load_dataset(ds).await;
+        }
 
         // After all datasets have loaded, load the views.
         self.load_views(app);
@@ -1163,6 +1176,11 @@ impl Runtime {
         metadata: Option<HashMap<String, String>>,
     ) -> Result<Arc<dyn DataConnector>> {
         let secret_map = self.get_params_with_secrets(&params).await;
+
+        // Unlike most other data connectors, the local connector needs a reference to the current DataFusion instance.
+        if source == "local" {
+            return Ok(Arc::new(LocalConnector::new(Arc::clone(&self.df))));
+        }
 
         match dataconnector::create_new_connector(source, secret_map, self.secrets(), metadata)
             .await


### PR DESCRIPTION
## 🗣 Description

Implements a `localpod` Data Connector to allow configuring a dataset to point to another existing dataset within Spice.

This is useful to implement a pattern of "tiered" acceleration, while only pulling data from the data source once. One dataset could be configured to pull data from the source into a file-based acceleration, and a second dataset could be a localpod dataset that accelerates in-memory.

Currently the acceleration of the `localpod` Data Connector is independent of its connected dataset. One optimization I will make in a follow-on PR is to synchronize the refreshes such that when the data for the upstream dataset is updated, it pushes that update to the local dataset acceleration. There are some complexities associated with that - if the parent dataset has configured partial updates (i.e. CDC or append based refreshes), then the local dataset would need to ensure it gets a consistent snapshot of the full dataset, buffer the updates immediately after the full snapshot is taken, and then apply the updates. I may scope the "synchronized refresh" optimization to apply only when the parent dataset is configured for full refreshes.

Example:

```yaml
- from: postgres:my_test_dataset
  name: test
  params:
    ...
  acceleration:
    enabled: true
    engine: duckdb
    mode: file
    refresh_check_interval: 10s
- from: localpod:test
  name: test_local
  acceleration:
    enabled: true
    refresh_check_interval: 10s
```

## 🔨 Related Issues

Closes #3247
Part of #3185

## 📄 Documentation Requirements

This will need a documentation update for the `localpod` data connector, along with a quickstart.

## 🤔 Concerns

This data connector is the first to break the pattern of being independent of the current runtime instance. The other data connectors can all work independently of the runtime instance, and thus can be registered statically at startup. But this connector can't be registered the same way. 