### PR TITLE
fix: Expose GitHub ratelimit errors

### DIFF
--- a/crates/data_components/src/github.rs
+++ b/crates/data_components/src/github.rs
@@ -16,9 +16,10 @@ limitations under the License.
 use async_trait::async_trait;
 use futures::future;
 use globset::GlobSet;
+use serde_json::Value;
 use snafu::{ResultExt, Snafu};
 
-use crate::{arrow::write::MemTable, token_provider::TokenProvider};
+use crate::{arrow::write::MemTable, graphql, token_provider::TokenProvider};
 use arrow::{
     array::{ArrayRef, Int64Builder, RecordBatch, StringBuilder},
     datatypes::{DataType, Field, Schema, SchemaRef},
@@ -44,6 +45,9 @@ pub enum Error {
     GithubApiError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[snafu(display("{message}"))]
+    RateLimited { message: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -289,33 +293,41 @@ impl GithubRestClient {
             return Ok(git_tree);
         }
 
+        let response_headers = response.headers().clone();
+        let response_status = response.status().as_u16();
+        let response: Value = response.json().await?;
+
+        error_checker(&response_headers, &response).map_err(|e| {
+            if let graphql::Error::RateLimited { message } = e {
+                Error::RateLimited { message }
+            } else {
+                Error::GithubApiError { source: e.into() }
+            }
+        })?;
+
         #[allow(clippy::single_match_else)]
-        match response.status().as_u16() {
+        match response_status {
             404 => {
                 let err_msg = format!(
-                    "The Github API ({endpoint}) failed with status code {}; Please check that org `{owner}`, repo `{repo}` and git tree `{tree_sha}`are correct.",
-                    response.status()
+                    "The Github API ({endpoint}) failed with status code {response_status}; Please check that org `{owner}`, repo `{repo}` and git tree `{tree_sha}`are correct.",
                 );
                 Err(err_msg.into())
             }
             401 => {
                 let err_msg = format!(
-                    "The Github API ({endpoint}) failed with status code {}; Please check if the token is correct.",
-                    response.status()
+                    "The Github API ({endpoint}) failed with status code {response_status}; Please check if the token is correct.",
                 );
                 Err(err_msg.into())
             }
             403 => {
                 let err_msg = format!(
-                    "The Github API ({endpoint}) failed with status code {}; Please check if the token has the necessary permissions.",
-                    response.status()
+                    "The Github API ({endpoint}) failed with status code {response_status}; Please check if the token has the necessary permissions.",
                 );
                 Err(err_msg.into())
             }
             _ => {
                 let err_msg = format!(
-                    "The Github API ({endpoint}) failed with status code {}",
-                    response.status()
+                    "The Github API ({endpoint}) failed with status code {response_status}",
                 );
                 Err(err_msg.into())
             }
@@ -378,4 +390,37 @@ struct GitTreeNode {
     sha: String,
     size: Option<i64>,
     url: Option<String>,
+}
+
+// For GitHub, first checks if an explicit rate limit error was returned, then checks the headers
+pub fn error_checker(
+    headers: &HeaderMap<HeaderValue>,
+    response: &Value,
+) -> Result<(), graphql::Error> {
+    // check if there's an explicit rate limit error
+    let rate_limited: Option<bool> = response["message"]
+        .as_str()
+        .map(|s| s.to_lowercase().contains("rate limit"));
+    if let Some(true) = rate_limited {
+        // A secondary rate limit was exceeded
+        return Err(graphql::Error::RateLimited {
+            message: "GitHub GraphQL API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
+        });
+    }
+
+    // Check if the primary rate limit is exceeded
+    if let Some(ratelimit_remaining) = headers.get("x-ratelimit-remaining") {
+        let ratelimit_remaining = ratelimit_remaining
+            .to_str()
+            .unwrap_or("1")
+            .parse::<u32>()
+            .unwrap_or(1);
+        if ratelimit_remaining == 0 {
+            return Err(graphql::Error::RateLimited {
+                message: "GitHub GraphQL API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
+            });
+        }
+    }
+
+    Ok(())
 }

--- a/crates/data_components/src/github.rs
+++ b/crates/data_components/src/github.rs
@@ -404,7 +404,7 @@ pub fn error_checker(
     if let Some(true) = rate_limited {
         // A secondary rate limit was exceeded
         return Err(graphql::Error::RateLimited {
-            message: "GitHub GraphQL API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
+            message: "GitHub API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
         });
     }
 
@@ -417,7 +417,7 @@ pub fn error_checker(
             .unwrap_or(1);
         if ratelimit_remaining == 0 {
             return Err(graphql::Error::RateLimited {
-                message: "GitHub GraphQL API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
+                message: "GitHub API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
             });
         }
     }

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -27,7 +27,7 @@ use datafusion::{
 };
 use std::{any::Any, sync::Arc};
 
-use super::{client::GraphQLClient, GraphQLOptimizer, ResultTransformSnafu};
+use super::{client::GraphQLClient, GraphQLContext, ResultTransformSnafu};
 use super::{client::GraphQLQuery, Result};
 
 pub type TransformFn =
@@ -36,7 +36,7 @@ pub type TransformFn =
 pub struct GraphQLTableProviderBuilder {
     client: GraphQLClient,
     transform_fn: Option<TransformFn>,
-    optimizer: Option<Arc<dyn GraphQLOptimizer>>,
+    optimizer: Option<Arc<dyn GraphQLContext>>,
 }
 
 impl GraphQLTableProviderBuilder {
@@ -56,7 +56,7 @@ impl GraphQLTableProviderBuilder {
     }
 
     #[must_use]
-    pub fn with_optimizer(mut self, optimizer: Arc<dyn GraphQLOptimizer>) -> Self {
+    pub fn with_optimizer(mut self, optimizer: Arc<dyn GraphQLContext>) -> Self {
         self.optimizer = Some(optimizer);
         self
     }
@@ -68,7 +68,16 @@ impl GraphQLTableProviderBuilder {
             return Err(super::Error::NoJsonPointerFound {});
         }
 
-        let result = self.client.execute(&mut query, None, None, None).await?;
+        let result = self
+            .client
+            .execute(
+                &mut query,
+                None,
+                None,
+                None,
+                self.optimizer.clone().and_then(|o| o.error_checker()),
+            )
+            .await?;
 
         let table_schema = match (self.transform_fn, result.records.first()) {
             (Some(transform_fn), Some(record_batch)) => transform_fn(record_batch)
@@ -94,7 +103,7 @@ pub struct GraphQLTableProvider {
     gql_schema: SchemaRef,
     table_schema: SchemaRef,
     transform_fn: Option<TransformFn>,
-    optimizer: Option<Arc<dyn GraphQLOptimizer>>,
+    optimizer: Option<Arc<dyn GraphQLContext>>,
 }
 
 #[async_trait]
@@ -138,18 +147,27 @@ impl TableProvider for GraphQLTableProvider {
         let mut query = GraphQLQuery::try_from(self.base_query.as_str())
             .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
 
-        if let Some(optimizer) = &self.optimizer {
+        let error_checker = if let Some(optimizer) = &self.optimizer {
             let parameters = filters
                 .iter()
                 .map(|f| optimizer.filter_pushdown(f))
                 .collect::<Result<Vec<_>, datafusion::error::DataFusionError>>()?;
 
             optimizer.inject_parameters(&parameters, &mut query)?;
-        }
+
+            optimizer.error_checker()
+        } else {
+            None
+        };
 
         let mut res = self
             .client
-            .execute_paginated(&mut query, Arc::clone(&self.gql_schema), limit)
+            .execute_paginated(
+                &mut query,
+                Arc::clone(&self.gql_schema),
+                limit,
+                error_checker,
+            )
             .await
             .boxed()
             .map_err(DataFusionError::External)?;

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -36,7 +36,7 @@ pub type TransformFn =
 pub struct GraphQLTableProviderBuilder {
     client: GraphQLClient,
     transform_fn: Option<TransformFn>,
-    optimizer: Option<Arc<dyn GraphQLContext>>,
+    context: Option<Arc<dyn GraphQLContext>>,
 }
 
 impl GraphQLTableProviderBuilder {
@@ -45,7 +45,7 @@ impl GraphQLTableProviderBuilder {
         Self {
             client,
             transform_fn: None,
-            optimizer: None,
+            context: None,
         }
     }
 
@@ -56,8 +56,8 @@ impl GraphQLTableProviderBuilder {
     }
 
     #[must_use]
-    pub fn with_optimizer(mut self, optimizer: Arc<dyn GraphQLContext>) -> Self {
-        self.optimizer = Some(optimizer);
+    pub fn with_context(mut self, context: Arc<dyn GraphQLContext>) -> Self {
+        self.context = Some(context);
         self
     }
 
@@ -75,7 +75,7 @@ impl GraphQLTableProviderBuilder {
                 None,
                 None,
                 None,
-                self.optimizer.clone().and_then(|o| o.error_checker()),
+                self.context.clone().and_then(|o| o.error_checker()),
             )
             .await?;
 
@@ -92,7 +92,7 @@ impl GraphQLTableProviderBuilder {
             gql_schema: Arc::clone(&result.schema),
             table_schema,
             transform_fn: self.transform_fn,
-            optimizer: self.optimizer,
+            context: self.context,
         })
     }
 }
@@ -103,7 +103,7 @@ pub struct GraphQLTableProvider {
     gql_schema: SchemaRef,
     table_schema: SchemaRef,
     transform_fn: Option<TransformFn>,
-    optimizer: Option<Arc<dyn GraphQLContext>>,
+    context: Option<Arc<dyn GraphQLContext>>,
 }
 
 #[async_trait]
@@ -124,10 +124,10 @@ impl TableProvider for GraphQLTableProvider {
         &self,
         filters: &[&Expr],
     ) -> Result<Vec<TableProviderFilterPushDown>, datafusion::error::DataFusionError> {
-        if let Some(optimizer) = &self.optimizer {
+        if let Some(context) = &self.context {
             filters
                 .iter()
-                .map(|f| optimizer.filter_pushdown(f).map(|r| r.filter_pushdown))
+                .map(|f| context.filter_pushdown(f).map(|r| r.filter_pushdown))
                 .collect::<Result<Vec<_>, datafusion::error::DataFusionError>>()
         } else {
             Ok(vec![
@@ -147,15 +147,15 @@ impl TableProvider for GraphQLTableProvider {
         let mut query = GraphQLQuery::try_from(self.base_query.as_str())
             .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
 
-        let error_checker = if let Some(optimizer) = &self.optimizer {
+        let error_checker = if let Some(context) = &self.context {
             let parameters = filters
                 .iter()
-                .map(|f| optimizer.filter_pushdown(f))
+                .map(|f| context.filter_pushdown(f))
                 .collect::<Result<Vec<_>, datafusion::error::DataFusionError>>()?;
 
-            optimizer.inject_parameters(&parameters, &mut query)?;
+            context.inject_parameters(&parameters, &mut query)?;
 
-            optimizer.error_checker()
+            context.error_checker()
         } else {
             None
         };

--- a/crates/runtime/src/dataconnector/github/commits.rs
+++ b/crates/runtime/src/dataconnector/github/commits.rs
@@ -15,12 +15,13 @@ limitations under the License.
 */
 
 use super::{
-    commits_inject_parameters, error_checker, filter_pushdown, inject_parameters, GitHubTableArgs,
+    commits_inject_parameters, filter_pushdown, inject_parameters, GitHubTableArgs,
     GitHubTableGraphQLParams,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use data_components::graphql::{
-    client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext,
+use data_components::{
+    github::error_checker,
+    graphql::{client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext},
 };
 use datafusion::prelude::Expr;
 use std::sync::Arc;

--- a/crates/runtime/src/dataconnector/github/commits.rs
+++ b/crates/runtime/src/dataconnector/github/commits.rs
@@ -15,11 +15,13 @@ limitations under the License.
 */
 
 use super::{
-    commits_inject_parameters, filter_pushdown, inject_parameters, GitHubTableArgs,
+    commits_inject_parameters, error_checker, filter_pushdown, inject_parameters, GitHubTableArgs,
     GitHubTableGraphQLParams,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use data_components::graphql::{client::GraphQLQuery, FilterPushdownResult, GraphQLOptimizer};
+use data_components::graphql::{
+    client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext,
+};
 use datafusion::prelude::Expr;
 use std::sync::Arc;
 
@@ -29,7 +31,7 @@ pub struct CommitsTableArgs {
     pub repo: String,
 }
 
-impl GraphQLOptimizer for CommitsTableArgs {
+impl GraphQLContext for CommitsTableArgs {
     fn filter_pushdown(
         &self,
         expr: &Expr,
@@ -43,6 +45,10 @@ impl GraphQLOptimizer for CommitsTableArgs {
         query: &mut GraphQLQuery<'_>,
     ) -> Result<(), datafusion::error::DataFusionError> {
         inject_parameters("history", commits_inject_parameters, filters, query)
+    }
+
+    fn error_checker(&self) -> Option<ErrorChecker> {
+        Some(Arc::new(error_checker))
     }
 }
 

--- a/crates/runtime/src/dataconnector/github/issues.rs
+++ b/crates/runtime/src/dataconnector/github/issues.rs
@@ -15,12 +15,13 @@ limitations under the License.
 */
 
 use super::{
-    error_checker, filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode,
-    GitHubTableArgs, GitHubTableGraphQLParams,
+    filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
+    GitHubTableGraphQLParams,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use data_components::graphql::{
-    client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext, Result,
+use data_components::{
+    github::error_checker,
+    graphql::{client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext, Result},
 };
 use datafusion::{logical_expr::TableProviderFilterPushDown, prelude::Expr};
 use std::sync::Arc;

--- a/crates/runtime/src/dataconnector/github/issues.rs
+++ b/crates/runtime/src/dataconnector/github/issues.rs
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 use super::{
-    filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
-    GitHubTableGraphQLParams,
+    error_checker, filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode,
+    GitHubTableArgs, GitHubTableGraphQLParams,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use data_components::graphql::{
-    client::GraphQLQuery, FilterPushdownResult, GraphQLOptimizer, Result,
+    client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext, Result,
 };
 use datafusion::{logical_expr::TableProviderFilterPushDown, prelude::Expr};
 use std::sync::Arc;
@@ -32,7 +32,7 @@ pub struct IssuesTableArgs {
     pub query_mode: GitHubQueryMode,
 }
 
-impl GraphQLOptimizer for IssuesTableArgs {
+impl GraphQLContext for IssuesTableArgs {
     fn filter_pushdown(
         &self,
         expr: &Expr,
@@ -58,6 +58,10 @@ impl GraphQLOptimizer for IssuesTableArgs {
         }
 
         inject_parameters("search", search_inject_parameters, filters, query)
+    }
+
+    fn error_checker(&self) -> Option<ErrorChecker> {
+        Some(Arc::new(error_checker))
     }
 }
 

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -23,7 +23,6 @@ use commits::CommitsTableArgs;
 use data_components::{
     github::{GithubFilesTableProvider, GithubRestClient},
     graphql::{
-        self,
         builder::GraphQLClientBuilder,
         client::{GraphQLClient, GraphQLQuery, PaginationParameters},
         provider::GraphQLTableProviderBuilder,
@@ -44,11 +43,9 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use graphql_parser::query::{
     Definition, InlineFragment, OperationDefinition, Query, Selection, SelectionSet,
 };
-use http::{HeaderMap, HeaderValue};
 use issues::IssuesTableArgs;
 use lazy_static::lazy_static;
 use pull_requests::PullRequestTableArgs;
-use serde_json::Value;
 use snafu::ResultExt;
 use stargazers::StargazersTableArgs;
 use std::collections::HashMap;
@@ -913,39 +910,6 @@ where
     let (pagination_parameters, json_pointer) = PaginationParameters::parse(&query.ast);
     query.pagination_parameters = pagination_parameters;
     query.json_pointer = json_pointer.map(Arc::from);
-
-    Ok(())
-}
-
-// For GitHub, first checks if an explicit rate limit error was returned, then checks the headers
-pub(crate) fn error_checker(
-    headers: &HeaderMap<HeaderValue>,
-    response: &Value,
-) -> Result<(), graphql::Error> {
-    // check if there's an explicit rate limit error
-    let rate_limited: Option<bool> = response["message"]
-        .as_str()
-        .map(|s| s.to_lowercase().contains("rate limit"));
-    if let Some(true) = rate_limited {
-        // A secondary rate limit was exceeded
-        return Err(graphql::Error::RateLimited {
-            message: "GitHub GraphQL API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
-        });
-    }
-
-    // Check if the primary rate limit is exceeded
-    if let Some(ratelimit_remaining) = headers.get("x-ratelimit-remaining") {
-        let ratelimit_remaining = ratelimit_remaining
-            .to_str()
-            .unwrap_or("1")
-            .parse::<u32>()
-            .unwrap_or(1);
-        if ratelimit_remaining == 0 {
-            return Err(graphql::Error::RateLimited {
-                message: "GitHub GraphQL API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
-            });
-        }
-    }
 
     Ok(())
 }

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -136,7 +136,7 @@ impl Github {
     async fn create_gql_table_provider(
         &self,
         table_args: Arc<dyn GitHubTableArgs>,
-        optimizer: Option<Arc<dyn GraphQLContext>>,
+        context: Option<Arc<dyn GraphQLContext>>,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         let client = self.create_graphql_client(&table_args).context(
             super::UnableToGetReadProviderSnafu {
@@ -147,8 +147,8 @@ impl Github {
         let provider_builder = GraphQLTableProviderBuilder::new(client)
             .with_schema_transform(github_gql_raw_schema_cast);
 
-        let provider_builder = if let Some(optimizer) = optimizer {
-            provider_builder.with_optimizer(optimizer)
+        let provider_builder = if let Some(context) = context {
+            provider_builder.with_context(context)
         } else {
             provider_builder
         };

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -23,10 +23,11 @@ use commits::CommitsTableArgs;
 use data_components::{
     github::{GithubFilesTableProvider, GithubRestClient},
     graphql::{
+        self,
         builder::GraphQLClientBuilder,
         client::{GraphQLClient, GraphQLQuery, PaginationParameters},
         provider::GraphQLTableProviderBuilder,
-        FilterPushdownResult, GraphQLOptimizer,
+        FilterPushdownResult, GraphQLContext,
     },
     token_provider::{StaticTokenProvider, TokenProvider},
 };
@@ -43,9 +44,11 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use graphql_parser::query::{
     Definition, InlineFragment, OperationDefinition, Query, Selection, SelectionSet,
 };
+use http::{HeaderMap, HeaderValue};
 use issues::IssuesTableArgs;
 use lazy_static::lazy_static;
 use pull_requests::PullRequestTableArgs;
+use serde_json::Value;
 use snafu::ResultExt;
 use stargazers::StargazersTableArgs;
 use std::collections::HashMap;
@@ -133,7 +136,7 @@ impl Github {
     async fn create_gql_table_provider(
         &self,
         table_args: Arc<dyn GitHubTableArgs>,
-        optimizer: Option<Arc<dyn GraphQLOptimizer>>,
+        optimizer: Option<Arc<dyn GraphQLContext>>,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         let client = self.create_graphql_client(&table_args).context(
             super::UnableToGetReadProviderSnafu {
@@ -910,6 +913,39 @@ where
     let (pagination_parameters, json_pointer) = PaginationParameters::parse(&query.ast);
     query.pagination_parameters = pagination_parameters;
     query.json_pointer = json_pointer.map(Arc::from);
+
+    Ok(())
+}
+
+// For GitHub, first checks if an explicit rate limit error was returned, then checks the headers
+pub(crate) fn error_checker(
+    headers: &HeaderMap<HeaderValue>,
+    response: &Value,
+) -> Result<(), graphql::Error> {
+    // check if there's an explicit rate limit error
+    let rate_limited: Option<bool> = response["message"]
+        .as_str()
+        .map(|s| s.to_lowercase().contains("rate limit"));
+    if let Some(true) = rate_limited {
+        // A secondary rate limit was exceeded
+        return Err(graphql::Error::RateLimited {
+            message: "GitHub GraphQL API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
+        });
+    }
+
+    // Check if the primary rate limit is exceeded
+    if let Some(ratelimit_remaining) = headers.get("x-ratelimit-remaining") {
+        let ratelimit_remaining = ratelimit_remaining
+            .to_str()
+            .unwrap_or("1")
+            .parse::<u32>()
+            .unwrap_or(1);
+        if ratelimit_remaining == 0 {
+            return Err(graphql::Error::RateLimited {
+                message: "GitHub GraphQL API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.".to_string(),
+            });
+        }
+    }
 
     Ok(())
 }

--- a/crates/runtime/src/dataconnector/github/pull_requests.rs
+++ b/crates/runtime/src/dataconnector/github/pull_requests.rs
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 use super::{
-    filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
-    GitHubTableGraphQLParams,
+    error_checker, filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode,
+    GitHubTableArgs, GitHubTableGraphQLParams,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use data_components::graphql::{
-    client::GraphQLQuery, FilterPushdownResult, GraphQLOptimizer, Result,
+    client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext, Result,
 };
 use datafusion::{logical_expr::TableProviderFilterPushDown, prelude::Expr};
 use std::sync::Arc;
@@ -32,7 +32,7 @@ pub struct PullRequestTableArgs {
     pub query_mode: GitHubQueryMode,
 }
 
-impl GraphQLOptimizer for PullRequestTableArgs {
+impl GraphQLContext for PullRequestTableArgs {
     fn filter_pushdown(
         &self,
         expr: &Expr,
@@ -58,6 +58,10 @@ impl GraphQLOptimizer for PullRequestTableArgs {
         }
 
         inject_parameters("search", search_inject_parameters, filters, query)
+    }
+
+    fn error_checker(&self) -> Option<ErrorChecker> {
+        Some(Arc::new(error_checker))
     }
 }
 

--- a/crates/runtime/src/dataconnector/github/pull_requests.rs
+++ b/crates/runtime/src/dataconnector/github/pull_requests.rs
@@ -15,12 +15,13 @@ limitations under the License.
 */
 
 use super::{
-    error_checker, filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode,
-    GitHubTableArgs, GitHubTableGraphQLParams,
+    filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
+    GitHubTableGraphQLParams,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use data_components::graphql::{
-    client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext, Result,
+use data_components::{
+    github::error_checker,
+    graphql::{client::GraphQLQuery, ErrorChecker, FilterPushdownResult, GraphQLContext, Result},
 };
 use datafusion::{logical_expr::TableProviderFilterPushDown, prelude::Expr};
 use std::sync::Arc;


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Changes `GraphQLOptimizer` to `GraphQLContext`, because it's a useful carrier of other GraphQL related configuration.
* Adds `error_checker` to the `GraphQLContext`, allowing consumers to middle-man the headers and response to return custom errors
* Implements `error_checker` for GitHub, checking for errors relating to rate limits.

This ensures rate limit errors are actually made visible, instead of generic `403 Forbidden` errors.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3257