### PR TITLE
Add SQLite TPC-DS Limitations: `ROLLUP` and `GROUPING`

### DIFF
--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -247,3 +247,93 @@ Query Error Unable to convert record batch: Invalid argument error: Column 'am_p
 | **Affected queries**     |                          |
 | ------------------------ | ------------------------ |
 | [q90.sql](tpcds/q90.sql) | |
+
+### SQLite does not support `ROLLUP` and `GROUPING`
+
+**Limitation**: SQLite Data Acccelerator does not support advanced grouping features such as `ROLLUP` and `GROUPING`
+
+**Solution**: To achieve similar functionality in SQLite
+
+- Use manual aggregation with `UNION ALL`: write separate queries for each level of aggregation and combine them with `UNION ALL`.
+- Use `CASE` within a `GROUP BY`: simulate `ROLLUP` behavior by applying `CASE` statements within a `GROUP BY` clause.
+
+Example for TPC-DS Q27. Orignal query:
+
+```sql
+select  i_item_id,
+        s_state, grouping(s_state) g_state,
+        avg(ss_quantity) agg1,
+        avg(ss_list_price) agg2,
+        avg(ss_coupon_amt) agg3,
+        avg(ss_sales_price) agg4
+ from store_sales, customer_demographics, date_dim, store, item
+ where ss_sold_date_sk = d_date_sk and
+       ss_item_sk = i_item_sk and
+       ss_store_sk = s_store_sk and
+       ss_cdemo_sk = cd_demo_sk and
+       cd_gender = 'M' and
+       cd_marital_status = 'U' and
+       cd_education_status = 'Secondary' and
+       d_year = 2000 and
+       s_state in ('TN','TN', 'TN', 'TN', 'TN', 'TN')
+ group by rollup (i_item_id, s_state)
+ order by i_item_id
+         ,s_state
+  LIMIT 100;
+```
+
+Rewritten query:
+
+```sql
+SELECT i_item_id,
+       s_state,
+       0 AS g_state,
+       AVG(ss_quantity) AS agg1,
+       AVG(ss_list_price) AS agg2,
+       AVG(ss_coupon_amt) AS agg3,
+       AVG(ss_sales_price) AS agg4
+FROM store_sales
+JOIN customer_demographics ON ss_cdemo_sk = cd_demo_sk
+JOIN date_dim ON ss_sold_date_sk = d_date_sk
+JOIN store ON ss_store_sk = s_store_sk
+JOIN item ON ss_item_sk = i_item_sk
+WHERE cd_gender = 'M'
+  AND cd_marital_status = 'U'
+  AND cd_education_status = 'Secondary'
+  AND d_year = 2000
+  AND s_state IN ('TN')
+GROUP BY i_item_id, s_state
+
+UNION ALL
+
+-- Subtotals by i_item_id
+SELECT i_item_id,
+       NULL AS s_state,
+       1 AS g_state,
+       AVG(ss_quantity) AS agg1,
+       AVG(ss_list_price) AS agg2,
+       AVG(ss_coupon_amt) AS agg3,
+       AVG(ss_sales_price) AS agg4
+FROM store_sales
+JOIN customer_demographics ON ss_cdemo_sk = cd_demo_sk
+JOIN date_dim ON ss_sold_date_sk = d_date_sk
+JOIN store ON ss_store_sk = s_store_sk
+JOIN item ON ss_item_sk = i_item_sk
+WHERE cd_gender = 'M'
+  AND cd_marital_status = 'U'
+  AND cd_education_status = 'Secondary'
+  AND d_year = 2000
+  AND s_state IN ('TN')
+GROUP BY i_item_id
+
+ORDER BY i_item_id, s_state
+LIMIT 100;
+```
+
+| **Affected queries**     |                          |
+| ------------------------ | ------------------------ |
+| [q5.sql](tpcds/q5.sql)   | [q18.sql](tpcds/q18.sql) |
+| [q22.sql](tpcds/q22.sql) | [q27.sql](tpcds/q27.sql) |
+| [q36.sql](tpcds/q36.sql) | [q67.sql](tpcds/q67.sql) |
+| [q70.sql](tpcds/q70.sql) | [q77.sql](tpcds/q77.sql) |
+| [q80.sql](tpcds/q80.sql) | [q44.sql](tpcds/q86.sql) |

--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -333,7 +333,8 @@ LIMIT 100;
 | **Affected queries**     |                          |
 | ------------------------ | ------------------------ |
 | [q5.sql](tpcds/q5.sql)   | [q18.sql](tpcds/q18.sql) |
-| [q22.sql](tpcds/q22.sql) | [q27.sql](tpcds/q27.sql) |
-| [q36.sql](tpcds/q36.sql) | [q67.sql](tpcds/q67.sql) |
-| [q70.sql](tpcds/q70.sql) | [q77.sql](tpcds/q77.sql) |
-| [q80.sql](tpcds/q80.sql) | [q44.sql](tpcds/q86.sql) |
+| [q14.sql](tpcds/q14.sql) | [q27.sql](tpcds/q27.sql) |
+| [q22.sql](tpcds/q22.sql) | [q67.sql](tpcds/q67.sql) |
+| [q36.sql](tpcds/q36.sql) | [q77.sql](tpcds/q77.sql) |
+| [q70.sql](tpcds/q70.sql) | [q86.sql](tpcds/q86.sql) |
+| [q80.sql](tpcds/q80.sql) |  |

--- a/crates/runtime/benches/queries/README.md
+++ b/crates/runtime/benches/queries/README.md
@@ -332,9 +332,9 @@ LIMIT 100;
 
 | **Affected queries**     |                          |
 | ------------------------ | ------------------------ |
-| [q5.sql](tpcds/q5.sql)   | [q18.sql](tpcds/q18.sql) |
-| [q14.sql](tpcds/q14.sql) | [q27.sql](tpcds/q27.sql) |
-| [q22.sql](tpcds/q22.sql) | [q67.sql](tpcds/q67.sql) |
-| [q36.sql](tpcds/q36.sql) | [q77.sql](tpcds/q77.sql) |
-| [q70.sql](tpcds/q70.sql) | [q86.sql](tpcds/q86.sql) |
-| [q80.sql](tpcds/q80.sql) |  |
+| [q5.sql](tpcds/q5.sql)   | [q14.sql](tpcds/q14.sql) |
+| [q18.sql](tpcds/q18.sql) | [q22.sql](tpcds/q22.sql) |
+| [q27.sql](tpcds/q27.sql) | [q36.sql](tpcds/q36.sql) |
+| [q67.sql](tpcds/q67.sql) | [q70.sql](tpcds/q70.sql) |
+| [q77.sql](tpcds/q77.sql) | [q80.sql](tpcds/q80.sql) |
+| [q86.sql](tpcds/q86.sql) |                          |


### PR DESCRIPTION
## 🗣 Description

Add SQLite TPC-DS Limitations: `ROLLUP` and `GROUPING`.

Limitations will be duplicated in docs as well once all TPC-DS queries are processed.

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3028.
Closes https://github.com/spiceai/spiceai/issues/3239 and https://github.com/spiceai/spiceai/issues/3240
