### PR TITLE
docs: Add localpod to connectors, re-format table

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Currently supported data connectors for upstream datasets. More coming soon.
 | `sharepoint`  | Microsoft SharePoint                                                                           | Alpha             | Unstructured UTF-8 documents                                                                       |
 | `mssql`       | Microsoft SQL Server                                                                           | Alpha             | Tabular Data Stream (TDS)                                                                          |
 | `abfs`        | Azure BlobFS                                                                                   | Alpha             | Parquet, CSV                                                                                       |
+| `localpod`    | [Local dataset replication](https://github.com/spiceai/quickstarts/blob/trunk/localpod/README.md)                                                                                   | -             |                                                                                        |
 
 ### Supported Data Stores/Accelerators
 

--- a/README.md
+++ b/README.md
@@ -81,42 +81,53 @@ Spice makes it easy and fast to query data from one or more sources using SQL. Y
 
 Currently supported data connectors for upstream datasets. More coming soon.
 
-| Name          | Description                                                                                    | Status            | Protocol/Format                                                                                    |
-| ------------- | ---------------------------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------- |
-| `mysql` | MySQL | Release Candidate | |
-| `databricks` | [Databricks](https://github.com/spiceai/quickstarts/tree/trunk/databricks#spice-on-databricks) | Beta | [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) <br/> S3/Delta Lake |
-| `delta_lake` | Delta Lake | Beta | Delta Lake |
-| `flightsql` | FlightSQL | Beta | Arrow Flight SQL |
-| `github` | GitHub | Beta | |
-| `odbc` | ODBC | Beta | ODBC |
-| `postgres` | PostgreSQL | Beta | |
-| `s3` | [S3](https://github.com/spiceai/quickstarts/tree/trunk/s3#readme) | Beta | Parquet, CSV |
-| `spiceai` | [Spice.ai](https://github.com/spiceai/quickstarts/tree/trunk/spiceai#readme) | Beta | Arrow Flight |
-| `abfs` | Azure BlobFS | Alpha | Parquet, CSV |
-| `clickhouse` | Clickhouse | Alpha | |
-| `debezium` | Debezium CDC | Alpha | Kafka + JSON |
-| `dremio` | [Dremio](https://github.com/spiceai/quickstarts/tree/trunk/dremio#readme) | Alpha | Arrow Flight |
-| `duckdb` | DuckDB | Alpha | |
-| `file` | File | Alpha | Parquet, CSV |
-| `ftp`, `sftp` | FTP/SFTP | Alpha | Parquet, CSV |
-| `graphql` | GraphQL | Alpha | JSON |
-| `http`, `https` | HTTP(s) | Alpha | Parquet, CSV |
-| `localpod` | [Local dataset replication](https://github.com/spiceai/quickstarts/blob/trunk/localpod/README.md) | Alpha | |
-| `mssql` | Microsoft SQL Server | Alpha | Tabular Data Stream (TDS) |
-| `sharepoint` | Microsoft SharePoint | Alpha | Unstructured UTF-8 documents |
-| `snowflake` | Snowflake | Alpha | Arrow |
-| `spark` | Spark | Alpha | [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) |
+| Name            | Description                           | Status            | Protocol/Format                            |
+| --------------- | ------------------------------------- | ----------------- | ------------------------------------------ |
+| `mysql`         | MySQL                                 | Release Candidate |                                            |
+| `databricks`    | [Databricks][databricks]              | Beta              | [Spark Connect][spark] <br/> S3/Delta Lake |
+| `delta_lake`    | Delta Lake                            | Beta              | Delta Lake                                 |
+| `flightsql`     | FlightSQL                             | Beta              | Arrow Flight SQL                           |
+| `github`        | GitHub                                | Beta              |                                            |
+| `odbc`          | ODBC                                  | Beta              | ODBC                                       |
+| `postgres`      | PostgreSQL                            | Beta              |                                            |
+| `s3`            | [S3][s3]                              | Beta              | Parquet, CSV                               |
+| `spiceai`       | [Spice.ai][spiceai]                   | Beta              | Arrow Flight                               |
+| `abfs`          | Azure BlobFS                          | Alpha             | Parquet, CSV                               |
+| `clickhouse`    | Clickhouse                            | Alpha             |                                            |
+| `debezium`      | Debezium CDC                          | Alpha             | Kafka + JSON                               |
+| `dremio`        | [Dremio][dremio]                      | Alpha             | Arrow Flight                               |
+| `duckdb`        | DuckDB                                | Alpha             |                                            |
+| `file`          | File                                  | Alpha             | Parquet, CSV                               |
+| `ftp`, `sftp`   | FTP/SFTP                              | Alpha             | Parquet, CSV                               |
+| `graphql`       | GraphQL                               | Alpha             | JSON                                       |
+| `http`, `https` | HTTP(s)                               | Alpha             | Parquet, CSV                               |
+| `localpod`      | [Local dataset replication][localpod] | Alpha             |                                            |
+| `mssql`         | Microsoft SQL Server                  | Alpha             | Tabular Data Stream (TDS)                  |
+| `sharepoint`    | Microsoft SharePoint                  | Alpha             | Unstructured UTF-8 documents               |
+| `snowflake`     | Snowflake                             | Alpha             | Arrow                                      |
+| `spark`         | Spark                                 | Alpha             | [Spark Connect][spark]                     |
+
+[databricks]: https://github.com/spiceai/quickstarts/tree/trunk/databricks#spice-on-databricks
+[spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
+[s3]: https://github.com/spiceai/quickstarts/tree/trunk/s3#readme
+[spiceai]: https://github.com/spiceai/quickstarts/tree/trunk/spiceai#readme
+[dremio]: https://github.com/spiceai/quickstarts/tree/trunk/dremio#readme
+[localpod]: https://github.com/spiceai/quickstarts/blob/trunk/localpod/README.md
 
 ### Supported Data Stores/Accelerators
 
 Currently supported data stores for local materialization/acceleration. More coming soon.
 
-| Name       | Description                                                                                                   | Status | Engine Modes     |
-| ---------- | ------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
-| `duckdb` | Embedded [DuckDB](https://docs.spiceai.org/data-accelerators/duckdb) | Beta | `memory`, `file` |
-| `postgres` | Attached [PostgreSQL](https://github.com/spiceai/quickstarts/tree/trunk/postgres#postgresql-data-accelerator) | Beta | |
-| `arrow` | In-Memory Arrow Records | Beta | `memory` |
-| `sqlite` | Embedded [SQLite](https://docs.spiceai.org/data-accelerators/sqlite) | Alpha | `memory`, `file` |
+| Name       | Description                     | Status | Engine Modes     |
+| ---------- | ------------------------------- | ------ | ---------------- |
+| `duckdb`   | Embedded [DuckDB][duckdb]       | Beta   | `memory`, `file` |
+| `postgres` | Attached [PostgreSQL][postgres] | Beta   |                  |
+| `arrow`    | In-Memory Arrow Records         | Beta   | `memory`         |
+| `sqlite`   | Embedded [SQLite][sqlite]       | Alpha  | `memory`, `file` |
+
+[duckdb]: https://docs.spiceai.org/data-accelerators/duckdb
+[postgres]: https://github.com/spiceai/quickstarts/tree/trunk/postgres#postgresql-data-accelerator
+[sqlite]: https://docs.spiceai.org/data-accelerators/sqlite
 
 ⚠️ **DEVELOPER PREVIEW** Spice is under active **beta** stage development and is not intended to be used in production until its **1.0-stable** release. If you are interested in running Spice in production, please get in touch so we can support you (See Connect with us below).
 

--- a/README.md
+++ b/README.md
@@ -83,27 +83,29 @@ Currently supported data connectors for upstream datasets. More coming soon.
 
 | Name          | Description                                                                                    | Status            | Protocol/Format                                                                                    |
 | ------------- | ---------------------------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------- |
-| `mysql`       | MySQL                                                                                          | Release Candidate |                                                                                                    |
-| `databricks`  | [Databricks](https://github.com/spiceai/quickstarts/tree/trunk/databricks#spice-on-databricks) | Beta              | [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html)<br>S3/Delta Lake |
-| `github`      | GitHub                                                                                         | Beta              |                                                                                                    |
-| `postgres`    | PostgreSQL                                                                                     | Beta              |                                                                                                    |
-| `spiceai`     | [Spice.ai](https://github.com/spiceai/quickstarts/tree/trunk/spiceai#readme)                   | Beta              | Arrow Flight                                                                                       |
-| `s3`          | [S3](https://github.com/spiceai/quickstarts/tree/trunk/s3#readme)                              | Beta              | Parquet, CSV                                                                                       |
-| `odbc`        | ODBC                                                                                           | Beta              | ODBC                                                                                               |
-| `delta_lake`  | [Delta Lake](https://delta.io/)                                                                | Alpha             | [Delta Lake](https://delta.io/)                                                                    |
-| `dremio`      | [Dremio](https://github.com/spiceai/quickstarts/tree/trunk/dremio#readme)                      | Alpha             | Arrow Flight                                                                                       |
-| `duckdb`      | DuckDB                                                                                         | Alpha             |                                                                                                    |
-| `clickhouse`  | Clickhouse                                                                                     | Alpha             |                                                                                                    |
-| `spark`       | Spark                                                                                          | Alpha             | [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html)                  |
-| `flightsql`   | Apache Arrow Flight SQL                                                                        | Alpha             | Arrow Flight SQL                                                                                   |
-| `snowflake`   | Snowflake                                                                                      | Alpha             | Arrow                                                                                              |
-| `ftp`, `sftp` | FTP/SFTP                                                                                       | Alpha             | Parquet, CSV, Markdown                                                                             |
-| `graphql`     | GraphQL                                                                                        | Alpha             | JSON                                                                                               |
-| `debezium`    | Debezium CDC                                                                                   | Alpha             | Kafka + JSON                                                                                       |
-| `sharepoint`  | Microsoft SharePoint                                                                           | Alpha             | Unstructured UTF-8 documents                                                                       |
-| `mssql`       | Microsoft SQL Server                                                                           | Alpha             | Tabular Data Stream (TDS)                                                                          |
-| `abfs`        | Azure BlobFS                                                                                   | Alpha             | Parquet, CSV                                                                                       |
-| `localpod`    | [Local dataset replication](https://github.com/spiceai/quickstarts/blob/trunk/localpod/README.md)                                                                                   | -             |                                                                                        |
+| `mysql` | MySQL | Release Candidate | |
+| `databricks` | [Databricks](https://github.com/spiceai/quickstarts/tree/trunk/databricks#spice-on-databricks) | Beta | [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) <br/> S3/Delta Lake |
+| `delta_lake` | Delta Lake | Beta | Delta Lake |
+| `flightsql` | FlightSQL | Beta | Arrow Flight SQL |
+| `github` | GitHub | Beta | |
+| `odbc` | ODBC | Beta | ODBC |
+| `postgres` | PostgreSQL | Beta | |
+| `s3` | [S3](https://github.com/spiceai/quickstarts/tree/trunk/s3#readme) | Beta | Parquet, CSV |
+| `spiceai` | [Spice.ai](https://github.com/spiceai/quickstarts/tree/trunk/spiceai#readme) | Beta | Arrow Flight |
+| `abfs` | Azure BlobFS | Alpha | Parquet, CSV |
+| `clickhouse` | Clickhouse | Alpha | |
+| `debezium` | Debezium CDC | Alpha | Kafka + JSON |
+| `dremio` | [Dremio](https://github.com/spiceai/quickstarts/tree/trunk/dremio#readme) | Alpha | Arrow Flight |
+| `duckdb` | DuckDB | Alpha | |
+| `file` | File | Alpha | Parquet, CSV |
+| `ftp`, `sftp` | FTP/SFTP | Alpha | Parquet, CSV |
+| `graphql` | GraphQL | Alpha | JSON |
+| `http`, `https` | HTTP(s) | Alpha | Parquet, CSV |
+| `localpod` | [Local dataset replication](https://github.com/spiceai/quickstarts/blob/trunk/localpod/README.md) | Alpha | |
+| `mssql` | Microsoft SQL Server | Alpha | Tabular Data Stream (TDS) |
+| `sharepoint` | Microsoft SharePoint | Alpha | Unstructured UTF-8 documents |
+| `snowflake` | Snowflake | Alpha | Arrow |
+| `spark` | Spark | Alpha | [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) |
 
 ### Supported Data Stores/Accelerators
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Currently supported data stores for local materialization/acceleration. More com
 
 | Name       | Description                                                                                                   | Status | Engine Modes     |
 | ---------- | ------------------------------------------------------------------------------------------------------------- | ------ | ---------------- |
-| `duckdb`   | Embedded [DuckDB](https://docs.spiceai.org/data-accelerators/duckdb)                                          | Beta   | `memory`, `file` |
-| `postgres` | Attached [PostgreSQL](https://github.com/spiceai/quickstarts/tree/trunk/postgres#postgresql-data-accelerator) | Beta   | `file`           |
-| `arrow`    | In-Memory Arrow Records                                                                                       | Beta   | `memory`         |
-| `sqlite`   | Embedded [SQLite](https://docs.spiceai.org/data-accelerators/sqlite)                                          | Alpha  | `memory`, `file` |
+| `duckdb` | Embedded [DuckDB](https://docs.spiceai.org/data-accelerators/duckdb) | Beta | `memory`, `file` |
+| `postgres` | Attached [PostgreSQL](https://github.com/spiceai/quickstarts/tree/trunk/postgres#postgresql-data-accelerator) | Beta | |
+| `arrow` | In-Memory Arrow Records | Beta | `memory` |
+| `sqlite` | Embedded [SQLite](https://docs.spiceai.org/data-accelerators/sqlite) | Alpha | `memory`, `file` |
 
 ⚠️ **DEVELOPER PREVIEW** Spice is under active **beta** stage development and is not intended to be used in production until its **1.0-stable** release. If you are interested in running Spice in production, please get in touch so we can support you (See Connect with us below).
 

--- a/docs/criteria/connectors/alpha.md
+++ b/docs/criteria/connectors/alpha.md
@@ -17,6 +17,7 @@ All criteria must be met for the connector to be considered Alpha. As Alpha sign
 | GraphQL                 | ❌ |  |
 | GitHub                  | ✅ | @peasee |
 | HTTP/HTTPS              | ❌ |  |
+| Localpod                | ❌ |  |
 | MS SQL                  | ❌ |  |
 | MySQL                   | ✅ | @peasee |
 | ODBC                    | ❌ |  |

--- a/docs/criteria/connectors/beta.md
+++ b/docs/criteria/connectors/beta.md
@@ -17,6 +17,7 @@ All criteria must be met for the connector to be considered Beta, with exception
 | GraphQL                 | ❌ |  |
 | GitHub                  | ✅ | @peasee |
 | HTTP/HTTPS              | ❌ |  |
+| Localpod                | ❌ |  |
 | MS SQL                  | ❌ |  |
 | MySQL                   | ✅ | @peasee |
 | ODBC                    | ❌ |  |

--- a/docs/criteria/connectors/rc.md
+++ b/docs/criteria/connectors/rc.md
@@ -17,6 +17,7 @@ All criteria must be met for the connector to be considered [RC](../definitions.
 | GraphQL                 | ❌ |  |
 | GitHub                  | ❌ |  |
 | HTTP/HTTPS              | ❌ |  |
+| Localpod                | ❌ |  |
 | MS SQL                  | ❌ |  |
 | MySQL                   | ✅ | @peasee |
 | ODBC                    | ❌ |  |


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds `localpod` to the list of connectors in the README
* Also adds `file` and `http/s` connectors because they were missing
* Re-formats the connector and accelerator tables to have matched spacing again, moving long links out into reference links
* Removes the `file` supported mode from the `postgres` accelerator, because it's not valid

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

Related docs PR that adds DuckDB to the table of connectors: https://github.com/spiceai/docs/pull/571