### PR TITLE
Don't run unsupported TPC-DS queries

### DIFF
--- a/crates/runtime/benches/bench_object_store/mod.rs
+++ b/crates/runtime/benches/bench_object_store/mod.rs
@@ -176,6 +176,7 @@ fn get_tpch_test_queries() -> Vec<(&'static str, &'static str)> {
 #[allow(clippy::too_many_lines)]
 fn get_tpcds_test_queries(engine: &Option<String>) -> Vec<(&'static str, &'static str)> {
     let test_queries = vec![
+        // see workarounds for more information on skipped queries: https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/benches/queries/README.md
         ("tpcds_q1", include_str!("../queries/tpcds/q1.sql")),
         ("tpcds_q2", include_str!("../queries/tpcds/q2.sql")),
         ("tpcds_q3", include_str!("../queries/tpcds/q3.sql")),
@@ -183,13 +184,13 @@ fn get_tpcds_test_queries(engine: &Option<String>) -> Vec<(&'static str, &'stati
         ("tpcds_q5", include_str!("../queries/tpcds/q5.sql")),
         ("tpcds_q6", include_str!("../queries/tpcds/q6.sql")),
         ("tpcds_q7", include_str!("../queries/tpcds/q7.sql")),
-        ("tpcds_q8", include_str!("../queries/tpcds/q8.sql")),
+        // ("tpcds_q8", include_str!("../queries/tpcds/q8.sql")), // EXCEPT and INTERSECT aren't supported
         ("tpcds_q9", include_str!("../queries/tpcds/q9.sql")),
         ("tpcds_q10", include_str!("../queries/tpcds/q10.sql")),
         ("tpcds_q11", include_str!("../queries/tpcds/q11.sql")),
         ("tpcds_q12", include_str!("../queries/tpcds/q12.sql")),
         ("tpcds_q13", include_str!("../queries/tpcds/q13.sql")),
-        ("tpcds_q14", include_str!("../queries/tpcds/q14.sql")),
+        // ("tpcds_q14", include_str!("../queries/tpcds/q14.sql")), // EXCEPT and INTERSECT aren't supported
         ("tpcds_q15", include_str!("../queries/tpcds/q15.sql")),
         ("tpcds_q16", include_str!("../queries/tpcds/q16.sql")),
         ("tpcds_q17", include_str!("../queries/tpcds/q17.sql")),
@@ -198,8 +199,8 @@ fn get_tpcds_test_queries(engine: &Option<String>) -> Vec<(&'static str, &'stati
         ("tpcds_q20", include_str!("../queries/tpcds/q20.sql")),
         ("tpcds_q21", include_str!("../queries/tpcds/q21.sql")),
         ("tpcds_q22", include_str!("../queries/tpcds/q22.sql")),
-        ("tpcds_q23", include_str!("../queries/tpcds/q23.sql")),
-        ("tpcds_q24", include_str!("../queries/tpcds/q24.sql")),
+        // ("tpcds_q23", include_str!("../queries/tpcds/q23.sql")), // this query contains multiple queries, which aren't supported
+        // ("tpcds_q24", include_str!("../queries/tpcds/q24.sql")), // this query contains multiple queries, which aren't supported
         ("tpcds_q25", include_str!("../queries/tpcds/q25.sql")),
         ("tpcds_q26", include_str!("../queries/tpcds/q26.sql")),
         ("tpcds_q27", include_str!("../queries/tpcds/q27.sql")),
@@ -213,8 +214,8 @@ fn get_tpcds_test_queries(engine: &Option<String>) -> Vec<(&'static str, &'stati
         ("tpcds_q35", include_str!("../queries/tpcds/q35.sql")),
         ("tpcds_q36", include_str!("../queries/tpcds/q36.sql")),
         ("tpcds_q37", include_str!("../queries/tpcds/q37.sql")),
-        ("tpcds_q38", include_str!("../queries/tpcds/q38.sql")),
-        ("tpcds_q39", include_str!("../queries/tpcds/q39.sql")),
+        // ("tpcds_q38", include_str!("../queries/tpcds/q38.sql")), // EXCEPT and INTERSECT aren't supported
+        // ("tpcds_q39", include_str!("../queries/tpcds/q39.sql")), // this query contains multiple queries, which aren't supported
         ("tpcds_q40", include_str!("../queries/tpcds/q40.sql")),
         ("tpcds_q41", include_str!("../queries/tpcds/q41.sql")),
         ("tpcds_q42", include_str!("../queries/tpcds/q42.sql")),
@@ -226,7 +227,7 @@ fn get_tpcds_test_queries(engine: &Option<String>) -> Vec<(&'static str, &'stati
         ("tpcds_q48", include_str!("../queries/tpcds/q48.sql")),
         ("tpcds_q49", include_str!("../queries/tpcds/q49.sql")),
         ("tpcds_q50", include_str!("../queries/tpcds/q50.sql")),
-        ("tpcds_q51", include_str!("../queries/tpcds/q51.sql")),
+        // ("tpcds_q51", include_str!("../queries/tpcds/q51.sql")), // MySQL does not support FULL JOIN
         ("tpcds_q52", include_str!("../queries/tpcds/q52.sql")),
         ("tpcds_q53", include_str!("../queries/tpcds/q53.sql")),
         ("tpcds_q54", include_str!("../queries/tpcds/q54.sql")),
@@ -262,7 +263,7 @@ fn get_tpcds_test_queries(engine: &Option<String>) -> Vec<(&'static str, &'stati
         ("tpcds_q84", include_str!("../queries/tpcds/q84.sql")),
         ("tpcds_q85", include_str!("../queries/tpcds/q85.sql")),
         ("tpcds_q86", include_str!("../queries/tpcds/q86.sql")),
-        ("tpcds_q87", include_str!("../queries/tpcds/q87.sql")),
+        // ("tpcds_q87", include_str!("../queries/tpcds/q87.sql")), // EXCEPT and INTERSECT aren't supported
         ("tpcds_q88", include_str!("../queries/tpcds/q88.sql")),
         ("tpcds_q89", include_str!("../queries/tpcds/q89.sql")),
         ("tpcds_q90", include_str!("../queries/tpcds/q90.sql")),

--- a/crates/runtime/benches/bench_postgres/mod.rs
+++ b/crates/runtime/benches/bench_postgres/mod.rs
@@ -208,13 +208,13 @@ pub(crate) fn get_tpcds_test_queries() -> Vec<(&'static str, &'static str)> {
         ("tpcds_q5", include_str!("../queries/tpcds/q5.sql")),
         ("tpcds_q6", include_str!("../queries/tpcds/q6.sql")),
         ("tpcds_q7", include_str!("../queries/tpcds/q7.sql")),
-        ("tpcds_q8", include_str!("../queries/tpcds/q8.sql")),
+        // ("tpcds_q8", include_str!("../queries/tpcds/q8.sql")), // EXCEPT and INTERSECT aren't supported
         ("tpcds_q9", include_str!("../queries/tpcds/q9.sql")),
         ("tpcds_q10", include_str!("../queries/tpcds/q10.sql")),
         ("tpcds_q11", include_str!("../queries/tpcds/q11.sql")),
         ("tpcds_q12", include_str!("../queries/tpcds/q12.sql")),
         ("tpcds_q13", include_str!("../queries/tpcds/q13.sql")),
-        ("tpcds_q14", include_str!("../queries/tpcds/q14.sql")),
+        // ("tpcds_q14", include_str!("../queries/tpcds/q14.sql")), // EXCEPT and INTERSECT aren't supported
         ("tpcds_q15", include_str!("../queries/tpcds/q15.sql")),
         ("tpcds_q16", include_str!("../queries/tpcds/q16.sql")),
         ("tpcds_q17", include_str!("../queries/tpcds/q17.sql")),
@@ -223,8 +223,8 @@ pub(crate) fn get_tpcds_test_queries() -> Vec<(&'static str, &'static str)> {
         ("tpcds_q20", include_str!("../queries/tpcds/q20.sql")),
         ("tpcds_q21", include_str!("../queries/tpcds/q21.sql")),
         ("tpcds_q22", include_str!("../queries/tpcds/q22.sql")),
-        ("tpcds_q23", include_str!("../queries/tpcds/q23.sql")),
-        ("tpcds_q24", include_str!("../queries/tpcds/q24.sql")),
+        // ("tpcds_q23", include_str!("../queries/tpcds/q23.sql")), // this query contains multiple queries, which aren't supported
+        // ("tpcds_q24", include_str!("../queries/tpcds/q24.sql")), // this query contains multiple queries, which aren't supported
         ("tpcds_q25", include_str!("../queries/tpcds/q25.sql")),
         ("tpcds_q26", include_str!("../queries/tpcds/q26.sql")),
         ("tpcds_q27", include_str!("../queries/tpcds/q27.sql")),
@@ -238,8 +238,8 @@ pub(crate) fn get_tpcds_test_queries() -> Vec<(&'static str, &'static str)> {
         ("tpcds_q35", include_str!("../queries/tpcds/q35.sql")),
         ("tpcds_q36", include_str!("../queries/tpcds/q36.sql")),
         ("tpcds_q37", include_str!("../queries/tpcds/q37.sql")),
-        ("tpcds_q38", include_str!("../queries/tpcds/q38.sql")),
-        ("tpcds_q39", include_str!("../queries/tpcds/q39.sql")),
+        // ("tpcds_q38", include_str!("../queries/tpcds/q38.sql")), // EXCEPT and INTERSECT aren't supported
+        // ("tpcds_q39", include_str!("../queries/tpcds/q39.sql")), // this query contains multiple queries, which aren't supported
         ("tpcds_q40", include_str!("../queries/tpcds/q40.sql")),
         ("tpcds_q41", include_str!("../queries/tpcds/q41.sql")),
         ("tpcds_q42", include_str!("../queries/tpcds/q42.sql")),
@@ -287,7 +287,7 @@ pub(crate) fn get_tpcds_test_queries() -> Vec<(&'static str, &'static str)> {
         ("tpcds_q84", include_str!("../queries/tpcds/q84.sql")),
         ("tpcds_q85", include_str!("../queries/tpcds/q85.sql")),
         ("tpcds_q86", include_str!("../queries/tpcds/q86.sql")),
-        ("tpcds_q87", include_str!("../queries/tpcds/q87.sql")),
+        // ("tpcds_q87", include_str!("../queries/tpcds/q87.sql")), // EXCEPT and INTERSECT aren't supported
         ("tpcds_q88", include_str!("../queries/tpcds/q88.sql")),
         ("tpcds_q89", include_str!("../queries/tpcds/q89.sql")),
         ("tpcds_q90", include_str!("../queries/tpcds/q90.sql")),


### PR DESCRIPTION
## 🗣 Description

Avoid running unsupported TPC-DS queries to prevent expected errors in logs and benchmark test results. Unsupported tests will be marked as skipped rather than failed.