### PR TITLE
Display shorter name for benchmark workflow matrix

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -51,36 +51,36 @@ env:
   FEATURES: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
 
 jobs:
-  # build-database-bench-binary:
-  #   name: Build Benchmark Test Binary
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
+  build-database-bench-binary:
+    name: Build Benchmark Test Binary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Set up Rust
-  #       uses: ./.github/actions/setup-rust
-  #       with:
-  #         os: 'linux'
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: 'linux'
 
-  #     - name: Install Protoc
-  #       uses: arduino/setup-protoc@v3
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
-  #     - name: Build benchmark binary
-  #       run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
+      - name: Build benchmark binary
+        run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
 
-  #     - name: Find, move, and rename benchmark binary
-  #       run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
+      - name: Find, move, and rename benchmark binary
+        run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
 
-  #     - name: Upload benchmark binary
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: spice_bench
-  #         path: ./spice_bench
+      - name: Upload benchmark binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: spice_bench
+          path: ./spice_bench
 
   run-database-bench:
     name: Run ${{ matrix.name }} ${{ matrix.bench }} Benchmark
     runs-on: ubuntu-latest
-    # needs: build-database-bench-binary
+    needs: build-database-bench-binary
 
     services:
       mysql_tpch:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -51,36 +51,36 @@ env:
   FEATURES: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
 
 jobs:
-  build-database-bench-binary:
-    name: Build Benchmark Test Binary
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+  # build-database-bench-binary:
+  #   name: Build Benchmark Test Binary
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          os: 'linux'
+  #     - name: Set up Rust
+  #       uses: ./.github/actions/setup-rust
+  #       with:
+  #         os: 'linux'
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+  #     - name: Install Protoc
+  #       uses: arduino/setup-protoc@v3
 
-      - name: Build benchmark binary
-        run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
+  #     - name: Build benchmark binary
+  #       run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
 
-      - name: Find, move, and rename benchmark binary
-        run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
+  #     - name: Find, move, and rename benchmark binary
+  #       run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
 
-      - name: Upload benchmark binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: spice_bench
-          path: ./spice_bench
+  #     - name: Upload benchmark binary
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: spice_bench
+  #         path: ./spice_bench
 
   run-database-bench:
-    name: Run Connector/Accelerator Benchmark
+    name: Run ${{ matrix.name }} ${{ matrix.bench }} Benchmark
     runs-on: ubuntu-latest
-    needs: build-database-bench-binary
+    # needs: build-database-bench-binary
 
     services:
       mysql_tpch:


### PR DESCRIPTION
## 🗣 Description

Use a shorter name for tasks in run benchmark job matrix, to make it easier to find specific connector / accelerator and the bench (tpch / tpcds) running

Before:
![image](https://github.com/user-attachments/assets/073b2dc5-8a80-4df3-bbd0-f230f366e8a5)

After: 
![image](https://github.com/user-attachments/assets/123163c3-53e5-4775-b89e-8c58ce19e208)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
