### PR TITLE
Update `spice_sys_dataset_checkpoint` to store federated table schema

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -421,6 +421,7 @@ impl Refresher {
         let initial_load_completed = Arc::clone(&self.initial_load_completed);
 
         let synchronize_with = self.synchronize_with.clone();
+        let federated_schema = self.federated.schema();
 
         // Spawns a tasks that both periodically refreshes the dataset, and upon request, will manually refresh the dataset.
         // The `select!` block handle waiting on both
@@ -483,7 +484,7 @@ impl Refresher {
                             }
 
                             if let Some(checkpointer) = &checkpointer {
-                                if let Err(e) = checkpointer.checkpoint().await {
+                                if let Err(e) = checkpointer.checkpoint(&federated_schema).await {
                                     tracing::warn!("Failed to checkpoint dataset {}: {e}", &dataset_name.to_string());
                                 };
                             }

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use datafusion::arrow::datatypes::SchemaRef;
 use std::sync::Arc;
 
-use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME};
+use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME, SCHEMA_MIGRATION_01_STMT};
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 
 impl DatasetCheckpoint {
@@ -55,78 +56,262 @@ impl DatasetCheckpoint {
         Ok(rows.next().map_err(|e| e.to_string())?.is_some())
     }
 
-    pub(super) fn checkpoint_duckdb(&self, pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
+    pub(super) fn checkpoint_duckdb(
+        &self,
+        pool: &Arc<DuckDbConnectionPool>,
+        schema: &SchemaRef,
+    ) -> Result<()> {
         let mut db_conn = Arc::clone(pool).connect_sync().map_err(|e| e.to_string())?;
         let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
             .map_err(|e| e.to_string())?
             .get_underlying_conn_mut();
 
+        let schema_json = Self::serialize_schema(schema)?;
         let upsert = format!(
-            "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, created_at, updated_at)
-             VALUES (?, now(), now())
-             ON CONFLICT (dataset_name) DO UPDATE SET updated_at = now()"
+            "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, created_at, updated_at, schema_json)
+             VALUES (?, now(), now(), ?)
+             ON CONFLICT (dataset_name) DO UPDATE 
+             SET updated_at = now(), schema_json = excluded.schema_json"
         );
         duckdb_conn
-            .execute(&upsert, [&self.dataset_name])
+            .execute(&upsert, [&self.dataset_name, &schema_json])
             .map_err(|e| e.to_string())?;
 
         Ok(())
+    }
+
+    pub(super) fn migrate_duckdb(pool: &Arc<DuckDbConnectionPool>) -> Result<()> {
+        let mut db_conn = Arc::clone(pool).connect_sync().map_err(|e| e.to_string())?;
+        let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
+            .map_err(|e| e.to_string())?
+            .get_underlying_conn_mut();
+
+        duckdb_conn
+            .execute(SCHEMA_MIGRATION_01_STMT, [])
+            .map_err(|e| e.to_string())?;
+
+        Ok(())
+    }
+
+    pub(super) fn get_schema_duckdb(
+        &self,
+        pool: &Arc<DuckDbConnectionPool>,
+    ) -> Result<Option<SchemaRef>> {
+        let mut db_conn = Arc::clone(pool).connect_sync().map_err(|e| e.to_string())?;
+        let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
+            .map_err(|e| e.to_string())?
+            .get_underlying_conn_mut();
+
+        let query = format!(
+            "SELECT schema_json FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ? LIMIT 1"
+        );
+        let mut stmt = duckdb_conn.prepare(&query).map_err(|e| e.to_string())?;
+        let mut rows = stmt
+            .query([&self.dataset_name])
+            .map_err(|e| e.to_string())?;
+
+        if let Some(row) = rows.next().map_err(|e| e.to_string())? {
+            let schema_json: Option<String> = row.get(0).map_err(|e| e.to_string())?;
+            match schema_json {
+                Some(json) => Ok(Some(Self::deserialize_schema(&json)?)),
+                None => Ok(None),
+            }
+        } else {
+            Ok(None)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::dataaccelerator::spice_sys::AccelerationConnection;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
 
     use super::*;
     use std::sync::Arc;
 
-    fn create_in_memory_duckdb_checkpoint() -> DatasetCheckpoint {
+    fn create_in_memory_duckdb_checkpoint() -> (DatasetCheckpoint, Arc<DuckDbConnectionPool>) {
         let pool = Arc::new(
             DuckDbConnectionPool::new_memory().expect("Failed to create in-memory DuckDB database"),
         );
         DatasetCheckpoint::init_duckdb(&pool).expect("Failed to initialize DuckDB");
-        DatasetCheckpoint {
-            dataset_name: "test_dataset".to_string(),
-            acceleration_connection: AccelerationConnection::DuckDB(pool),
-        }
+        DatasetCheckpoint::migrate_duckdb(&pool).expect("Failed to migrate DuckDB");
+        (
+            DatasetCheckpoint {
+                dataset_name: "test_dataset".to_string(),
+                acceleration_connection: AccelerationConnection::DuckDB(Arc::clone(&pool)),
+            },
+            pool,
+        )
+    }
+
+    fn create_legacy_table(pool: &Arc<DuckDbConnectionPool>) {
+        let mut db_conn = Arc::clone(pool).connect_sync().expect("Failed to connect");
+        let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
+            .expect("Failed to get conn")
+            .get_underlying_conn_mut();
+
+        // Create table without schema_json column
+        duckdb_conn
+            .execute(
+                &format!(
+                    "CREATE TABLE {CHECKPOINT_TABLE_NAME} (
+                dataset_name TEXT PRIMARY KEY,
+                created_at TIMESTAMP,
+                updated_at TIMESTAMP
+            )"
+                ),
+                [],
+            )
+            .expect("Failed to create legacy table");
+
+        // Insert some test data
+        duckdb_conn
+            .execute(
+                &format!(
+                    "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, created_at, updated_at) 
+             VALUES ('legacy_dataset', now(), now())"
+                ),
+                [],
+            )
+            .expect("Failed to insert legacy data");
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_schema_roundtrip() {
+        let (checkpoint, _) = create_in_memory_duckdb_checkpoint();
+
+        // Create a test schema
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let schema_ref = std::sync::Arc::new(schema.clone());
+
+        // Save the schema
+        checkpoint
+            .checkpoint(&schema_ref)
+            .await
+            .expect("Failed to save schema");
+
+        // Retrieve the schema
+        let retrieved_schema = checkpoint
+            .get_schema()
+            .await
+            .expect("Failed to get schema")
+            .expect("Schema should exist");
+
+        assert_eq!(&schema, retrieved_schema.as_ref());
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_migration() {
+        let pool = Arc::new(
+            DuckDbConnectionPool::new_memory().expect("Failed to create in-memory DuckDB database"),
+        );
+
+        // Create legacy table format
+        create_legacy_table(&pool);
+
+        // Create checkpoint which should trigger migration
+        let checkpoint = DatasetCheckpoint {
+            dataset_name: "legacy_dataset".to_string(),
+            acceleration_connection: AccelerationConnection::DuckDB(Arc::clone(&pool)),
+        };
+
+        // Run migration
+        DatasetCheckpoint::migrate_duckdb(&pool).expect("Migration failed");
+
+        // Verify schema column exists by trying to use it
+        let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let schema_ref = std::sync::Arc::new(schema.clone());
+
+        checkpoint
+            .checkpoint(&schema_ref)
+            .await
+            .expect("Failed to save schema after migration");
+
+        let retrieved_schema = checkpoint
+            .get_schema()
+            .await
+            .expect("Failed to get schema")
+            .expect("Schema should exist");
+
+        assert_eq!(&schema, retrieved_schema.as_ref());
+
+        // Verify old data still exists
+        assert!(checkpoint.exists().await);
     }
 
     #[tokio::test]
     async fn test_duckdb_checkpoint_exists() {
-        let checkpoint = create_in_memory_duckdb_checkpoint();
+        let (checkpoint, _) = create_in_memory_duckdb_checkpoint();
 
         // Initially, the checkpoint should not exist
         assert!(!checkpoint.exists().await);
 
-        // Create the checkpoint
+        // Create a test schema
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let schema_ref = std::sync::Arc::new(schema.clone());
+
+        // Create the checkpoint with schema
         checkpoint
-            .checkpoint()
+            .checkpoint(&schema_ref)
             .await
             .expect("Failed to create checkpoint");
 
         // Now the checkpoint should exist
         assert!(checkpoint.exists().await);
+
+        // Verify schema was saved
+        let retrieved_schema = checkpoint
+            .get_schema()
+            .await
+            .expect("Failed to get schema")
+            .expect("Schema should exist");
+        assert_eq!(&schema, retrieved_schema.as_ref());
     }
 
     #[tokio::test]
     async fn test_duckdb_checkpoint_update() {
-        let checkpoint = create_in_memory_duckdb_checkpoint();
+        let (checkpoint, _) = create_in_memory_duckdb_checkpoint();
+
+        // Create initial schema
+        let schema1 = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let schema_ref1 = std::sync::Arc::new(schema1.clone());
 
         // Create the initial checkpoint
         checkpoint
-            .checkpoint()
+            .checkpoint(&schema_ref1)
             .await
             .expect("Failed to create initial checkpoint");
 
         // Sleep for a short time to ensure the timestamp changes
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
-        // Update the checkpoint
+        // Create updated schema
+        let schema2 = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let schema_ref2 = std::sync::Arc::new(schema2.clone());
+
+        // Update the checkpoint with new schema
         checkpoint
-            .checkpoint()
+            .checkpoint(&schema_ref2)
             .await
             .expect("Failed to update checkpoint");
+
+        // Verify the schema was updated
+        let retrieved_schema = checkpoint
+            .get_schema()
+            .await
+            .expect("Failed to get schema")
+            .expect("Schema should exist");
+        assert_eq!(&schema2, retrieved_schema.as_ref());
 
         // Verify that the updated_at timestamp has changed
         if let AccelerationConnection::DuckDB(pool) = &checkpoint.acceleration_connection {

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/postgres.rs
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 
-use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME};
+use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME, SCHEMA_MIGRATION_01_STMT};
 
 impl DatasetCheckpoint {
     pub(super) async fn init_postgres(pool: &PostgresConnectionPool) -> Result<()> {
@@ -50,19 +51,59 @@ impl DatasetCheckpoint {
         Ok(row.is_some())
     }
 
-    pub(super) async fn checkpoint_postgres(&self, pool: &PostgresConnectionPool) -> Result<()> {
+    pub(super) async fn checkpoint_postgres(
+        &self,
+        pool: &PostgresConnectionPool,
+        schema: &SchemaRef,
+    ) -> Result<()> {
         let conn = pool.connect_direct().await.map_err(|e| e.to_string())?;
+        let schema_json = Self::serialize_schema(schema)?;
 
         let upsert = format!(
-            "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, updated_at)
-             VALUES ($1, CURRENT_TIMESTAMP)
-             ON CONFLICT (dataset_name) DO UPDATE SET updated_at = CURRENT_TIMESTAMP"
+            "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, updated_at, schema_json)
+             VALUES ($1, CURRENT_TIMESTAMP, $2)
+             ON CONFLICT (dataset_name) DO UPDATE 
+             SET updated_at = CURRENT_TIMESTAMP, schema_json = $2"
         );
         conn.conn
-            .execute(&upsert, &[&self.dataset_name])
+            .execute(&upsert, &[&self.dataset_name, &schema_json])
             .await
             .map_err(|e| e.to_string())?;
 
         Ok(())
+    }
+
+    pub(super) async fn migrate_postgres(pool: &PostgresConnectionPool) -> Result<()> {
+        let conn = pool.connect_direct().await.map_err(|e| e.to_string())?;
+        conn.conn
+            .execute(SCHEMA_MIGRATION_01_STMT, &[])
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub(super) async fn get_schema_postgres(
+        &self,
+        pool: &PostgresConnectionPool,
+    ) -> Result<Option<SchemaRef>> {
+        let conn = pool.connect_direct().await.map_err(|e| e.to_string())?;
+        let query =
+            format!("SELECT schema_json FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = $1");
+        let row = conn
+            .conn
+            .query_opt(&query, &[&self.dataset_name])
+            .await
+            .map_err(|e| e.to_string())?;
+
+        match row {
+            Some(row) => {
+                let schema_json: Option<String> = row.get(0);
+                match schema_json {
+                    Some(json) => Ok(Some(Self::deserialize_schema(&json)?)),
+                    None => Ok(None),
+                }
+            }
+            None => Ok(None),
+        }
     }
 }

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME};
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion_table_providers::sql::db_connection_pool::{
     dbconnection::sqliteconn::SqliteConnection, sqlitepool::SqliteConnectionPool,
 };
@@ -30,11 +31,39 @@ impl DatasetCheckpoint {
                 let create_table = format!(
                     "CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE_NAME} (
                         dataset_name TEXT PRIMARY KEY,
+                        schema_json TEXT,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                     )"
                 );
                 conn.execute(&create_table, [])?;
+
+                Ok(())
+            })
+            .await
+            .map_err(|e| e.to_string().into())
+    }
+
+    pub(super) async fn migrate_sqlite(pool: &SqliteConnectionPool) -> Result<()> {
+        let conn_sync = pool.connect_sync();
+        let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
+            return Err("Failed to downcast to SqliteConnection".into());
+        };
+
+        conn.conn
+            .call(move |conn| {
+                // Check if schema_json column exists
+                let columns: Vec<String> = conn
+                    .prepare(&format!("PRAGMA table_info({CHECKPOINT_TABLE_NAME})"))?
+                    .query_map([], |row| row.get::<_, String>(1))?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+
+                if !columns.contains(&"schema_json".to_string()) {
+                    conn.execute(
+                        &format!("ALTER TABLE {CHECKPOINT_TABLE_NAME} ADD COLUMN schema_json TEXT"),
+                        [],
+                    )?;
+                }
 
                 Ok(())
             })
@@ -60,37 +89,77 @@ impl DatasetCheckpoint {
             .map_err(|e| e.to_string().into())
     }
 
-    pub(super) async fn checkpoint_sqlite(&self, pool: &SqliteConnectionPool) -> Result<()> {
+    pub(super) async fn checkpoint_sqlite(
+        &self,
+        pool: &SqliteConnectionPool,
+        schema: &SchemaRef,
+    ) -> Result<()> {
         let conn_sync = pool.connect_sync();
         let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
             return Err("Failed to downcast to SqliteConnection".into());
         };
         let dataset_name = self.dataset_name.clone();
+        let schema_json = Self::serialize_schema(schema)?;
+
         conn.conn
             .call(move |conn| {
                 let upsert = format!(
-                    "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, updated_at)
-                 VALUES (?1, CURRENT_TIMESTAMP)
-                 ON CONFLICT (dataset_name) DO UPDATE SET updated_at = CURRENT_TIMESTAMP"
+                    "INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name, schema_json, updated_at)
+                     VALUES (?1, ?2, CURRENT_TIMESTAMP)
+                     ON CONFLICT (dataset_name) DO UPDATE 
+                     SET schema_json = ?2, updated_at = CURRENT_TIMESTAMP"
                 );
-                conn.execute(&upsert, [dataset_name])?;
+                conn.execute(&upsert, [&dataset_name, &schema_json])?;
 
                 Ok(())
             })
             .await
             .map_err(|e| e.to_string().into())
     }
+
+    pub(super) async fn get_schema_sqlite(
+        &self,
+        pool: &SqliteConnectionPool,
+    ) -> Result<Option<SchemaRef>> {
+        let conn_sync = pool.connect_sync();
+        let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
+            return Err("Failed to downcast to SqliteConnection".into());
+        };
+        let dataset_name = self.dataset_name.clone();
+
+        let schema_json: Option<String> = conn
+            .conn
+            .call(move |conn| {
+                let query = format!(
+                    "SELECT schema_json FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ?"
+                );
+                let mut stmt = conn.prepare(&query)?;
+                let mut rows = stmt.query([dataset_name])?;
+
+                if let Some(row) = rows.next()? {
+                    Ok(row.get(0)?)
+                } else {
+                    Ok(None)
+                }
+            })
+            .await
+            .map_err(Box::new)?;
+
+        match schema_json {
+            Some(json) => Ok(Some(Self::deserialize_schema(&json)?)),
+            None => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::dataaccelerator::spice_sys::AccelerationConnection;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion_table_providers::sql::db_connection_pool::{
         sqlitepool::SqliteConnectionPoolFactory, Mode,
     };
-
-    use crate::dataaccelerator::spice_sys::AccelerationConnection;
-
-    use super::*;
 
     async fn create_in_memory_sqlite_checkpoint() -> DatasetCheckpoint {
         let pool = SqliteConnectionPoolFactory::new(
@@ -104,10 +173,122 @@ mod tests {
         DatasetCheckpoint::init_sqlite(&pool)
             .await
             .expect("Failed to initialize SQLite");
+        DatasetCheckpoint::migrate_sqlite(&pool)
+            .await
+            .expect("Failed to migrate SQLite");
         DatasetCheckpoint {
             dataset_name: "test_dataset".to_string(),
             acceleration_connection: AccelerationConnection::SQLite(pool),
         }
+    }
+
+    async fn create_legacy_sqlite_checkpoint() -> (DatasetCheckpoint, SqliteConnectionPool) {
+        let pool = SqliteConnectionPoolFactory::new(
+            "",
+            Mode::Memory,
+            std::time::Duration::from_millis(5000),
+        )
+        .build()
+        .await
+        .expect("to build in-memory sqlite connection pool");
+
+        // Create legacy table without schema_json column
+        let conn_sync = pool.connect_sync();
+        let conn = conn_sync
+            .as_any()
+            .downcast_ref::<SqliteConnection>()
+            .expect("sqlite connection");
+
+        conn.conn
+            .call(move |conn| {
+                conn.execute(
+                    &format!(
+                        "CREATE TABLE {CHECKPOINT_TABLE_NAME} (
+                        dataset_name TEXT PRIMARY KEY,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    )"
+                    ),
+                    [],
+                )?;
+
+                // Insert legacy data
+                conn.execute(
+                    &format!("INSERT INTO {CHECKPOINT_TABLE_NAME} (dataset_name) VALUES (?)"),
+                    ["legacy_dataset"],
+                )?;
+
+                Ok(())
+            })
+            .await
+            .expect("Failed to create legacy table");
+
+        (
+            DatasetCheckpoint {
+                dataset_name: "legacy_dataset".to_string(),
+                acceleration_connection: AccelerationConnection::SQLite(
+                    pool.try_clone().await.expect("to clone pool"),
+                ),
+            },
+            pool,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_migration() {
+        let (checkpoint, pool) = create_legacy_sqlite_checkpoint().await;
+
+        // Run migration
+        DatasetCheckpoint::migrate_sqlite(&pool)
+            .await
+            .expect("Migration failed");
+
+        // Verify schema column exists by trying to use it
+        let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let schema_ref = std::sync::Arc::new(schema.clone());
+
+        checkpoint
+            .checkpoint(&schema_ref)
+            .await
+            .expect("Failed to save schema after migration");
+
+        let retrieved_schema = checkpoint
+            .get_schema()
+            .await
+            .expect("Failed to get schema")
+            .expect("Schema should exist");
+
+        assert_eq!(&schema, retrieved_schema.as_ref());
+
+        // Verify old data still exists
+        assert!(checkpoint.exists().await);
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_schema_roundtrip() {
+        let checkpoint = create_in_memory_sqlite_checkpoint().await;
+
+        // Create a test schema
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let schema_ref = std::sync::Arc::new(schema.clone());
+
+        // Save the schema
+        checkpoint
+            .checkpoint(&schema_ref)
+            .await
+            .expect("Failed to save schema");
+
+        // Retrieve the schema
+        let retrieved_schema = checkpoint
+            .get_schema()
+            .await
+            .expect("Failed to get schema")
+            .expect("Schema should exist");
+
+        assert_eq!(&schema, retrieved_schema.as_ref());
     }
 
     #[tokio::test]
@@ -117,34 +298,68 @@ mod tests {
         // Initially, the checkpoint should not exist
         assert!(!checkpoint.exists().await);
 
-        // Create the checkpoint
+        // Create a test schema
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let schema_ref = std::sync::Arc::new(schema.clone());
+
+        // Create the checkpoint with schema
         checkpoint
-            .checkpoint()
+            .checkpoint(&schema_ref)
             .await
             .expect("Failed to create checkpoint");
 
         // Now the checkpoint should exist
         assert!(checkpoint.exists().await);
+
+        // Verify schema was saved
+        let retrieved_schema = checkpoint
+            .get_schema()
+            .await
+            .expect("Failed to get schema")
+            .expect("Schema should exist");
+        assert_eq!(&schema, retrieved_schema.as_ref());
     }
 
     #[tokio::test]
     async fn test_sqlite_checkpoint_update() {
         let checkpoint = create_in_memory_sqlite_checkpoint().await;
 
+        // Create initial schema
+        let schema1 = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+        let schema_ref1 = std::sync::Arc::new(schema1.clone());
+
         // Create the initial checkpoint
         checkpoint
-            .checkpoint()
+            .checkpoint(&schema_ref1)
             .await
             .expect("Failed to create initial checkpoint");
 
         // Sleep for a short time to ensure the timestamp changes
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
-        // Update the checkpoint
+        // Create updated schema
+        let schema2 = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let schema_ref2 = std::sync::Arc::new(schema2.clone());
+
+        // Update the checkpoint with new schema
         checkpoint
-            .checkpoint()
+            .checkpoint(&schema_ref2)
             .await
             .expect("Failed to update checkpoint");
+
+        // Verify the schema was updated
+        let retrieved_schema = checkpoint
+            .get_schema()
+            .await
+            .expect("Failed to get schema")
+            .expect("Schema should exist");
+        assert_eq!(&schema2, retrieved_schema.as_ref());
 
         // Verify that the updated_at timestamp has changed
         let AccelerationConnection::SQLite(pool) = &checkpoint.acceleration_connection else {


### PR DESCRIPTION
## 🗣 Description

This PR adds a new column `schema_json` to the `spice_sys_dataset_checkpoint` table that is stored in the accelerator engine with the schema of the federated table. This unblocks my next PR which will use this schema to construct the accelerator table even if the federated source is unavailable for schema inference.

This will migrate existing `spice_sys_dataset_checkpoint` tables to have the new column if they already existed.

## 🔨 Related Issues

Part of #3301
Part of #3185

## 📄 Documentation Requirements

N/A
