### PR TITLE
Track how many times an acceleration falls back during initialization

### DIFF
--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -53,3 +53,10 @@ pub(crate) static APPEND_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|
         .with_unit("ms")
         .init()
 });
+
+pub(crate) static READY_STATE_FALLBACK: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("accelerated_ready_state_federated_fallback")
+        .with_description("Number of times the federated table was queried due to the accelerated table loading the initial data.")
+        .init()
+});


### PR DESCRIPTION
## 🗣 Description

Adds a new metric `accelerated_ready_state_federated_fallback` that tracks how many times an accelerated dataset falls back to the federated source while the initial data is being loaded. Only happens when `ready_state` is `on_registration`.

