### PR TITLE
fix: Prevent acceleration files outside of working directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3461,7 +3461,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b4f88a0af15f010b1ff20bac453e34e2ad04df14#b4f88a0af15f010b1ff20bac453e34e2ad04df14"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b8aadcba0a1768962ff4130c5cb0b6f185982046#b8aadcba0a1768962ff4130c5cb0b6f185982046"
 dependencies = [
  "arrow",
  "arrow-json 53.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "bd7210a4873a74445cf0286ff87f207f41cd1ec0"}
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "0aabd423ef8aea0ae05479331d1486e9ef8f8061" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b4f88a0af15f010b1ff20bac453e34e2ad04df14" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b8aadcba0a1768962ff4130c5cb0b6f185982046" }
 
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "dfb1e03a5f0702c1a318db5abf40e762d6b2bcc2" }

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -151,13 +151,15 @@ pub trait DataAccelerator: Send + Sync {
 
     /// For file-based accelerators, return the file path
     /// For any other accelerator, return None
-    fn file_path(&self, _dataset: &Dataset) -> Option<String> {
-        None
+    fn file_path(&self, _dataset: &Dataset) -> Result<String> {
+        Err(Error::InvalidConfiguration {
+            msg: "File path not supported for this accelerator".to_string(),
+        })
     }
 
     /// Check if the file path is valid
     fn is_valid_file(&self, dataset: &Dataset) -> bool {
-        if let Some(path) = self.file_path(dataset) {
+        if let Ok(path) = self.file_path(dataset) {
             let path = std::path::Path::new(&path);
 
             !path.is_dir()
@@ -171,7 +173,7 @@ pub trait DataAccelerator: Send + Sync {
 
     /// Check if the file path exists
     fn has_existing_file(&self, dataset: &Dataset) -> bool {
-        if let Some(path) = self.file_path(dataset) {
+        if let Ok(path) = self.file_path(dataset) {
             let path = std::path::Path::new(&path);
             path.is_file()
         } else {

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -440,9 +440,7 @@ mod test {
     async fn test_file_mode_duckdb_creation() {
         use std::{fs, path::Path};
 
-        let tmp_dir = std::env::temp_dir();
-        let path = format!("{}/abc-duckdb.db", tmp_dir.display());
-
+        let path = "./abc-duckdb.db".to_string();
         let params = HashMap::from([("duckdb_file".to_string(), path.clone())]);
 
         register_all().await;
@@ -475,9 +473,7 @@ mod test {
     async fn test_file_mode_sqlite_creation() {
         use std::{fs, path::Path};
 
-        let tmp_dir = std::env::temp_dir();
-        let path = format!("{}/abc-sqlite.db", tmp_dir.display());
-
+        let path = "./abc-sqlite.db".to_string();
         let params = HashMap::from([("sqlite_file".to_string(), path.clone())]);
 
         register_all().await;

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -68,6 +68,9 @@ pub enum Error {
     AccelerationCreationFailed {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[snafu(display("File mode is not supported for this accelerator engine."))]
+    FileModeUnsupported {},
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -152,9 +155,7 @@ pub trait DataAccelerator: Send + Sync {
     /// For file-based accelerators, return the file path
     /// For any other accelerator, return None
     fn file_path(&self, _dataset: &Dataset) -> Result<String> {
-        Err(Error::InvalidConfiguration {
-            msg: "File path not supported for this accelerator".to_string(),
-        })
+        Err(Error::FileModeUnsupported {})
     }
 
     /// Check if the file path is valid

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -237,48 +237,40 @@ impl DataAccelerator for DuckDBAccelerator {
         }
 
         if let Some(this_dataset) = dataset {
-            // If the user didn't specify a DuckDB file and this is a file-mode DuckDB,
-            // then use the shared DuckDB file `accelerated_duckdb.db`
-            if !cmd.options.contains_key("open") && this_dataset.is_file_accelerated() {
-                let duckdb_file = self.duckdb_file_path(this_dataset)?;
-                cmd.options.insert("open".to_string(), duckdb_file);
-            }
+            if this_dataset.is_file_accelerated() {
+                // If the user didn't specify a DuckDB file and this is a file-mode DuckDB,
+                // then use the shared DuckDB file `accelerated_duckdb.db`
+                if !cmd.options.contains_key("open") {
+                    let duckdb_file = self.duckdb_file_path(this_dataset)?;
+                    cmd.options.insert("open".to_string(), duckdb_file);
+                }
 
-            if let Some(app) = &this_dataset.app {
-                let datasets =
-                    Runtime::get_initialized_datasets(app, crate::LogErrors(false)).await;
-                let self_path = self.file_path(this_dataset)?;
-                let attach_databases = datasets
-                    .iter()
-                    .filter_map(|other_dataset| {
-                        if other_dataset.acceleration.as_ref().map_or(false, |a| {
-                            a.engine == Engine::DuckDB && a.mode == Mode::File
-                        }) {
-                            if **other_dataset == *this_dataset {
-                                None
+                if let Some(app) = &this_dataset.app {
+                    let datasets =
+                        Runtime::get_initialized_datasets(app, crate::LogErrors(false)).await;
+                    let self_path = self.file_path(this_dataset)?;
+                    let attach_databases = datasets
+                        .iter()
+                        .filter_map(|other_dataset| {
+                            if other_dataset.acceleration.as_ref().map_or(false, |a| {
+                                a.engine == Engine::DuckDB && a.mode == Mode::File
+                            }) {
+                                if **other_dataset == *this_dataset {
+                                    None
+                                } else {
+                                    let other_path = self.file_path(other_dataset);
+                                    other_path.ok().filter(|p| p != &self_path)
+                                }
                             } else {
-                                let other_path = self.file_path(other_dataset);
-                                other_path.ok().filter(|p| p != &self_path)
-                                // match (self_path, other_path) {
-                                //     (Ok(self_path), Ok(other_path)) => {
-                                //         if other_path == self_path {
-                                //             None
-                                //         } else {
-                                //             Some(other_path)
-                                //         }
-                                //     }
-                                //     _ => None,
-                                // }
+                                None
                             }
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>();
+                        })
+                        .collect::<Vec<_>>();
 
-                if !attach_databases.is_empty() {
-                    cmd.options
-                        .insert("attach_databases".to_string(), attach_databases.join(";"));
+                    if !attach_databases.is_empty() {
+                        cmd.options
+                            .insert("attach_databases".to_string(), attach_databases.join(";"));
+                    }
                 }
             }
         }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -38,7 +38,7 @@ use crate::{
     spice_data_base_path, Runtime,
 };
 
-use super::DataAccelerator;
+use super::{DataAccelerator, Error as DataAcceleratorError};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -89,24 +89,27 @@ impl DuckDBAccelerator {
     }
 
     /// Returns the `DuckDB` file path that would be used for a file-based `DuckDB` accelerator from this dataset
-    #[must_use]
-    pub fn duckdb_file_path(&self, dataset: &Dataset) -> Option<String> {
+    pub fn duckdb_file_path(&self, dataset: &Dataset) -> Result<String> {
         if !dataset.is_file_accelerated() {
-            return None;
-        }
-        let acceleration = dataset.acceleration.as_ref()?;
+            Err(Error::InvalidConfiguration {
+                detail: Arc::from("Dataset is not file accelerated"),
+            })
+        } else if let Some(acceleration) = dataset.acceleration.as_ref() {
+            let mut params = acceleration.params.clone();
+            params.insert("data_directory".to_string(), spice_data_base_path());
 
-        let mut params = acceleration.params.clone();
-        params.insert("data_directory".to_string(), spice_data_base_path());
+            if let Some(duckdb_file) = params.remove("duckdb_file") {
+                params.insert("duckdb_open".to_string(), duckdb_file.to_string());
+            }
 
-        if let Some(duckdb_file) = params.remove("duckdb_file") {
-            params.insert("duckdb_open".to_string(), duckdb_file.to_string());
-        }
-
-        Some(
             self.duckdb_factory
-                .duckdb_file_path("accelerated_duckdb", &mut params),
-        )
+                .duckdb_file_path("accelerated_duckdb", &mut params)
+                .map_err(|err| Error::InvalidConfiguration {
+                    detail: Arc::from(err.to_string()),
+                })
+        } else {
+            unreachable!("Expected dataset to have acceleration parameters, but none were found")
+        }
     }
 
     /// Returns an existing `DuckDB` connection pool for the given dataset, or creates a new one if it doesn't exist.
@@ -120,29 +123,22 @@ impl DuckDBAccelerator {
                 dataset: dataset.name.to_string(),
             })?;
 
-        let pool = match (acceleration.mode, duckdb_file) {
-            (Mode::File, Some(duckdb_file)) => self
+        let pool = match (duckdb_file, acceleration.mode) {
+            (Ok(duckdb_file), Mode::File) => self
                 .duckdb_factory
                 .get_or_init_file_instance(duckdb_file)
                 .await
                 .boxed()
                 .context(AccelerationCreationFailedSnafu)?,
-            (Mode::Memory, None) => self
+            (_, Mode::Memory) => self
                 .duckdb_factory
                 .get_or_init_memory_instance()
                 .await
                 .boxed()
                 .context(AccelerationCreationFailedSnafu)?,
-            (Mode::File, None) => {
+            (Err(e), Mode::File) => {
                 return Err(Error::InvalidConfiguration {
-                    detail: Arc::from("duckdb_file parameter is required for file acceleration"),
-                })
-            }
-            (Mode::Memory, Some(_)) => {
-                return Err(Error::InvalidConfiguration {
-                    detail: Arc::from(
-                        "memory acceleration mode does not accept a duckdb_file parameter",
-                    ),
+                    detail: Arc::from(e.to_string()),
                 })
             }
         };
@@ -176,8 +172,9 @@ impl DataAccelerator for DuckDBAccelerator {
         vec!["db", "ddb", "duckdb"]
     }
 
-    fn file_path(&self, dataset: &Dataset) -> Option<String> {
+    fn file_path(&self, dataset: &Dataset) -> Result<String, DataAcceleratorError> {
         self.duckdb_file_path(dataset)
+            .map_err(|e| DataAcceleratorError::InvalidConfiguration { msg: e.to_string() })
     }
 
     fn is_initialized(&self, dataset: &Dataset) -> bool {
@@ -197,19 +194,19 @@ impl DataAccelerator for DuckDBAccelerator {
             return Ok(());
         }
 
-        let path = self.file_path(dataset);
+        let path = self.file_path(dataset)?;
 
-        if let (Some(path), Some(acceleration)) = (&path, &dataset.acceleration) {
+        if let Some(acceleration) = &dataset.acceleration {
             if !acceleration.params.contains_key("duckdb_file") {
                 make_spice_data_directory().map_err(|err| {
                     Error::AccelerationInitializationFailed { source: err.into() }
                 })?;
             } else if !self.is_valid_file(dataset) {
-                if std::path::Path::new(path).is_dir() {
+                if std::path::Path::new(&path).is_dir() {
                     return Err(Error::InvalidFileIsDirectory.into());
                 }
 
-                let extension = std::path::Path::new(path)
+                let extension = std::path::Path::new(&path)
                     .extension()
                     .and_then(OsStr::to_str)
                     .unwrap_or("");
@@ -243,16 +240,14 @@ impl DataAccelerator for DuckDBAccelerator {
             // If the user didn't specify a DuckDB file and this is a file-mode DuckDB,
             // then use the shared DuckDB file `accelerated_duckdb.db`
             if !cmd.options.contains_key("open") && this_dataset.is_file_accelerated() {
-                let duckdb_file = self.duckdb_file_path(this_dataset);
-                if let Some(duckdb_file) = duckdb_file {
-                    cmd.options.insert("open".to_string(), duckdb_file);
-                }
+                let duckdb_file = self.duckdb_file_path(this_dataset)?;
+                cmd.options.insert("open".to_string(), duckdb_file);
             }
 
             if let Some(app) = &this_dataset.app {
                 let datasets =
                     Runtime::get_initialized_datasets(app, crate::LogErrors(false)).await;
-                let self_path = self.file_path(this_dataset);
+                let self_path = self.file_path(this_dataset)?;
                 let attach_databases = datasets
                     .iter()
                     .filter_map(|other_dataset| {
@@ -263,11 +258,17 @@ impl DataAccelerator for DuckDBAccelerator {
                                 None
                             } else {
                                 let other_path = self.file_path(other_dataset);
-                                if other_path == self_path {
-                                    None
-                                } else {
-                                    other_path
-                                }
+                                other_path.ok().filter(|p| p != &self_path)
+                                // match (self_path, other_path) {
+                                //     (Ok(self_path), Ok(other_path)) => {
+                                //         if other_path == self_path {
+                                //             None
+                                //         } else {
+                                //             Some(other_path)
+                                //         }
+                                //     }
+                                //     _ => None,
+                                // }
                             }
                         } else {
                             None
@@ -556,7 +557,7 @@ mod tests {
             .expect("initialization should be successful");
 
         assert!(accelerator.is_initialized(&dataset));
-        assert!(accelerator.file_path(&dataset).is_some());
+        assert!(accelerator.file_path(&dataset).is_ok());
 
         let path = accelerator.file_path(&dataset).expect("path should exist");
         assert!(std::path::Path::new(&path).exists());

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -72,9 +72,7 @@ async fn acceleration_connection(
                 .downcast_ref::<DuckDBAccelerator>()
                 .ok_or("Accelerator is not a DuckDBAccelerator")?;
 
-            let duckdb_file = duckdb_accelerator
-                .duckdb_file_path(dataset)
-                .ok_or("Acceleration mode is not file-based.")?;
+            let duckdb_file = duckdb_accelerator.duckdb_file_path(dataset)?;
             if !create_table_if_not_exists && !Path::new(&duckdb_file).exists() {
                 return Err("DuckDB file does not exist.".into());
             }
@@ -98,9 +96,7 @@ async fn acceleration_connection(
                 .downcast_ref::<SqliteAccelerator>()
                 .ok_or("Accelerator is not a SqliteAccelerator")?;
 
-            let sqlite_file = sqlite_accelerator
-                .sqlite_file_path(dataset)
-                .ok_or("Acceleration mode is not file-based.")?;
+            let sqlite_file = sqlite_accelerator.sqlite_file_path(dataset)?;
             if !create_table_if_not_exists && !Path::new(&sqlite_file).exists() {
                 return Err("Sqlite file does not exist.".into());
             }

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -38,7 +38,7 @@ use crate::{
     spice_data_base_path, Runtime,
 };
 
-use super::DataAccelerator;
+use super::{DataAccelerator, Error as DataAcceleratorError};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -73,6 +73,9 @@ pub enum Error {
 
     #[snafu(display("Acceleration not enabled for dataset: {dataset}"))]
     AccelerationNotEnabled { dataset: Arc<str> },
+
+    #[snafu(display("Invalid SQLite acceleration configuration: {detail}"))]
+    InvalidConfiguration { detail: Arc<str> },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -96,21 +99,24 @@ impl SqliteAccelerator {
     }
 
     /// Returns the `Sqlite` file path that would be used for a file-based `Sqlite` accelerator from this dataset
-    #[must_use]
-    pub fn sqlite_file_path(&self, dataset: &Dataset) -> Option<String> {
+    pub fn sqlite_file_path(&self, dataset: &Dataset) -> Result<String> {
         if !dataset.is_file_accelerated() {
-            return None;
-        }
+            Err(Error::InvalidConfiguration {
+                detail: Arc::from("Dataset is not file accelerated"),
+            })
+        } else if let Some(acceleration) = dataset.acceleration.as_ref() {
+            let mut acceleration_params = acceleration.params.clone();
 
-        let acceleration = dataset.acceleration.as_ref()?;
-        let mut acceleration_params = acceleration.params.clone();
+            acceleration_params.insert("data_directory".to_string(), spice_data_base_path());
 
-        acceleration_params.insert("data_directory".to_string(), spice_data_base_path());
-
-        Some(
             self.sqlite_factory
-                .sqlite_file_path("accelerated", &acceleration_params),
-        )
+                .sqlite_file_path("accelerated", &acceleration_params)
+                .map_err(|err| Error::InvalidConfiguration {
+                    detail: Arc::from(err.to_string()),
+                })
+        } else {
+            unreachable!("Expected dataset to have acceleration parameters, but none were found")
+        }
     }
 
     /// Returns the `Sqlite` `busy_timeout` param that would be used for setting the `busy_timeout` in `Sqlite` accelerator for this dataset, default to 5000 milliseconds
@@ -127,7 +133,7 @@ impl SqliteAccelerator {
 
     /// Returns an existing `SQLite` connection pool for the given dataset, or creates a new one if it doesn't exist.
     pub async fn get_shared_pool(&self, dataset: &Dataset) -> Result<SqliteConnectionPool> {
-        let sqlite_file = self.sqlite_file_path(dataset);
+        let sqlite_file = self.sqlite_file_path(dataset)?;
 
         let acceleration = dataset
             .acceleration
@@ -140,7 +146,7 @@ impl SqliteAccelerator {
             Mode::File => datafusion_table_providers::sql::db_connection_pool::Mode::File,
             Mode::Memory => datafusion_table_providers::sql::db_connection_pool::Mode::Memory,
         };
-        let file_path: Arc<str> = sqlite_file.map_or_else(|| "".into(), Arc::from);
+        let file_path: Arc<str> = sqlite_file.into();
         let busy_timeout = self.sqlite_busy_timeout(dataset)?;
 
         let pool = self
@@ -180,8 +186,11 @@ impl DataAccelerator for SqliteAccelerator {
         vec!["sqlite", "db"]
     }
 
-    fn file_path(&self, dataset: &Dataset) -> Option<String> {
+    fn file_path(&self, dataset: &Dataset) -> Result<String, DataAcceleratorError> {
         self.sqlite_file_path(dataset)
+            .map_err(|err| DataAcceleratorError::InvalidConfiguration {
+                msg: err.to_string(),
+            })
     }
 
     fn is_initialized(&self, dataset: &Dataset) -> bool {
@@ -205,18 +214,18 @@ impl DataAccelerator for SqliteAccelerator {
             return Ok(());
         }
 
-        let path = self.file_path(dataset);
+        let path = self.file_path(dataset)?;
 
-        if let (Some(path), Some(acceleration)) = (&path, &dataset.acceleration) {
+        if let Some(acceleration) = &dataset.acceleration {
             if !acceleration.params.contains_key("sqlite_file") {
                 make_spice_data_directory()
                     .map_err(|err| Error::AccelerationCreationFailed { source: err.into() })?;
             } else if !self.is_valid_file(dataset) {
-                if std::path::Path::new(path).is_dir() {
+                if std::path::Path::new(&path).is_dir() {
                     return Err(Error::InvalidFileIsDirectory.into());
                 }
 
-                let extension = std::path::Path::new(path)
+                let extension = std::path::Path::new(&path)
                     .extension()
                     .and_then(OsStr::to_str)
                     .unwrap_or("");
@@ -246,15 +255,14 @@ impl DataAccelerator for SqliteAccelerator {
             // If the user didn't specify a SQLite file and this is a file-mode SQLite,
             // then use the shared SQLite file `accelerated_sqlite.db`
             if !cmd.options.contains_key("file") && this_dataset.is_file_accelerated() {
-                let sqlite_file = self.sqlite_file_path(this_dataset);
-                if let Some(sqlite_file) = sqlite_file {
-                    cmd.options.insert("file".to_string(), sqlite_file);
-                }
+                let sqlite_file = self.sqlite_file_path(this_dataset)?;
+                cmd.options.insert("file".to_string(), sqlite_file);
             }
 
             if let Some(app) = &this_dataset.app {
                 let datasets =
                     Runtime::get_initialized_datasets(app, crate::LogErrors(false)).await;
+                let self_path = self.file_path(this_dataset)?;
                 let attach_databases = datasets
                     .iter()
                     .filter_map(|other_dataset| {
@@ -264,7 +272,8 @@ impl DataAccelerator for SqliteAccelerator {
                             if **other_dataset == *this_dataset {
                                 None
                             } else {
-                                self.file_path(other_dataset)
+                                let other_path = self.file_path(other_dataset);
+                                other_path.ok().filter(|p| p != &self_path)
                             }
                         } else {
                             None
@@ -454,7 +463,7 @@ mod tests {
             .expect("initialization should be successful");
 
         assert!(accelerator.is_initialized(&dataset));
-        assert!(accelerator.file_path(&dataset).is_some());
+        assert!(accelerator.file_path(&dataset).is_ok());
 
         let path = accelerator.file_path(&dataset).expect("path should exist");
         assert!(std::path::Path::new(&path).exists());

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -252,38 +252,40 @@ impl DataAccelerator for SqliteAccelerator {
         let mut cmd = cmd.clone();
 
         if let Some(this_dataset) = dataset {
-            // If the user didn't specify a SQLite file and this is a file-mode SQLite,
-            // then use the shared SQLite file `accelerated_sqlite.db`
-            if !cmd.options.contains_key("file") && this_dataset.is_file_accelerated() {
-                let sqlite_file = self.sqlite_file_path(this_dataset)?;
-                cmd.options.insert("file".to_string(), sqlite_file);
-            }
+            if this_dataset.is_file_accelerated() {
+                // If the user didn't specify a SQLite file and this is a file-mode SQLite,
+                // then use the shared SQLite file `accelerated_sqlite.db`
+                if !cmd.options.contains_key("file") {
+                    let sqlite_file = self.sqlite_file_path(this_dataset)?;
+                    cmd.options.insert("file".to_string(), sqlite_file);
+                }
 
-            if let Some(app) = &this_dataset.app {
-                let datasets =
-                    Runtime::get_initialized_datasets(app, crate::LogErrors(false)).await;
-                let self_path = self.file_path(this_dataset)?;
-                let attach_databases = datasets
-                    .iter()
-                    .filter_map(|other_dataset| {
-                        if other_dataset.acceleration.as_ref().map_or(false, |a| {
-                            a.engine == Engine::Sqlite && a.mode == Mode::File
-                        }) {
-                            if **other_dataset == *this_dataset {
-                                None
+                if let Some(app) = &this_dataset.app {
+                    let datasets =
+                        Runtime::get_initialized_datasets(app, crate::LogErrors(false)).await;
+                    let self_path = self.file_path(this_dataset)?;
+                    let attach_databases = datasets
+                        .iter()
+                        .filter_map(|other_dataset| {
+                            if other_dataset.acceleration.as_ref().map_or(false, |a| {
+                                a.engine == Engine::Sqlite && a.mode == Mode::File
+                            }) {
+                                if **other_dataset == *this_dataset {
+                                    None
+                                } else {
+                                    let other_path = self.file_path(other_dataset);
+                                    other_path.ok().filter(|p| p != &self_path)
+                                }
                             } else {
-                                let other_path = self.file_path(other_dataset);
-                                other_path.ok().filter(|p| p != &self_path)
+                                None
                             }
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>();
+                        })
+                        .collect::<Vec<_>>();
 
-                if !attach_databases.is_empty() {
-                    cmd.options
-                        .insert("attach_databases".to_string(), attach_databases.join(";"));
+                    if !attach_databases.is_empty() {
+                        cmd.options
+                            .insert("attach_databases".to_string(), attach_databases.join(";"));
+                    }
                 }
             }
         }

--- a/crates/runtime/tests/acceleration/single_instance_duckdb.rs
+++ b/crates/runtime/tests/acceleration/single_instance_duckdb.rs
@@ -85,11 +85,11 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
 
     runtime_ready_check(&rt).await;
 
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     drop(rt);
     runtime::dataaccelerator::clear_registry().await;
     runtime::dataaccelerator::register_all().await;
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
     let pool =
         DuckDbConnectionPool::new_file(expected_path, &AccessMode::ReadWrite).expect("valid path");


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates `datafusion-table-providers` bringing in a change that limits the creation of DuckDB and SQLite acceleration database files to within the current working directory of the Runtime.