### PR TITLE
Upgrade runtime along with CLI on `spice upgrade`

### DIFF
--- a/bin/spice/cmd/install.go
+++ b/bin/spice/cmd/install.go
@@ -70,7 +70,7 @@ spice install ai
 			}
 			installed = true
 		} else {
-			installed, err = runtime.EnsureInstalled(flavor)
+			installed, err = runtime.EnsureInstalled(flavor, true)
 			if err != nil {
 				slog.Error("verifying runtime install", "error", err)
 				os.Exit(1)

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -121,7 +121,7 @@ spice upgrade
 			flavor = "ai"
 		}
 
-		upgraded, err := runtime.EnsureInstalled(flavor)
+		upgraded, err := runtime.EnsureInstalled(flavor, true)
 		if err != nil {
 			slog.Error("upgrading the spice runtime", "error", err)
 			return

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spiceai/spiceai/bin/spice/pkg/constants"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/github"
+	"github.com/spiceai/spiceai/bin/spice/pkg/runtime"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 	"github.com/spiceai/spiceai/bin/spice/pkg/version"
 )
@@ -47,10 +48,15 @@ spice upgrade
 		}
 
 		rtcontext := context.NewContext()
+		err = rtcontext.Init()
+		if err != nil {
+			slog.Error("initializing runtime context", "error", err)
+			os.Exit(1)
+		}
 		cliVersion := version.Version()
 
 		if cliVersion == release.TagName {
-			slog.Info(fmt.Sprintf("Using the latest version %s. No upgrade required.\n", release.TagName))
+			slog.Info(fmt.Sprintf("Using the latest version %s. No upgrade required.", release.TagName))
 			return
 		}
 
@@ -108,7 +114,22 @@ spice upgrade
 			return
 		}
 
-		slog.Info(fmt.Sprintf("Spice.ai CLI upgraded to %s successfully.\n", release.TagName))
+		slog.Info(fmt.Sprintf("Spice.ai CLI upgraded to %s successfully.", release.TagName))
+
+		flavor := ""
+		if rtcontext.ModelsFlavorInstalled() {
+			flavor = "ai"
+		}
+
+		upgraded, err := runtime.EnsureInstalled(flavor)
+		if err != nil {
+			slog.Error("upgrading the spice runtime", "error", err)
+			return
+		}
+
+		if upgraded {
+			slog.Info(fmt.Sprintf("Spice runtime upgraded to %s successfully.", release.TagName))
+		}
 	},
 }
 

--- a/bin/spice/pkg/runtime/runtime.go
+++ b/bin/spice/pkg/runtime/runtime.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Ensures the runtime is installed. Returns true if the runtime was installed or upgraded, false if it was already installed.
-func EnsureInstalled(flavor string) (bool, error) {
+func EnsureInstalled(flavor string, autoUpgrade bool) (bool, error) {
 	if flavor != "ai" && flavor != "" {
 		return false, fmt.Errorf("invalid flavor: %s", flavor)
 	}
@@ -47,7 +47,7 @@ func EnsureInstalled(flavor string) (bool, error) {
 		upgradeVersion, err = rtcontext.IsRuntimeUpgradeAvailable()
 		if err != nil {
 			slog.Warn("error checking for runtime upgrade", "error", err)
-		} else if upgradeVersion != "" {
+		} else if upgradeVersion != "" && autoUpgrade {
 			shouldInstall = true
 		}
 	}
@@ -76,7 +76,7 @@ func Run(args []string) error {
 		os.Exit(1)
 	}
 
-	_, err = EnsureInstalled("")
+	_, err = EnsureInstalled("", false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 🗣 Description

When using the CLI to upgrade via `spice upgrade`, it will now automatically upgrade the runtime as well.

`spice run` no longer automatically upgrades the runtime, it must explicitly be upgraded.

Example:

```bash
~/c/s/spiceai ❯ spice version
CLI version:     v0.18.0-beta
Runtime version: v0.18.0-beta
2024/11/04 11:42:56 INFO 
CLI version v0.19.4-beta is now available!
To upgrade, run "spice upgrade".
~/c/s/spiceai ❯ spice upgrade
2024/11/04 11:43:04 INFO Checking for latest Spice CLI release...
2024/11/04 11:43:04 INFO Upgrading the Spice.ai CLI ...
2024/11/04 11:43:12 INFO Spice.ai CLI upgraded to v0.19.4-beta successfully.
2024/11/04 11:43:12 INFO Downloading and installing Spice.ai Runtime v0.19.4-beta ...
2024/11/04 11:43:12 INFO Downloading the Spice runtime..., spiced_darwin_aarch64.tar.gz
2024/11/04 11:43:28 INFO Spice runtime installed into /Users/phillip/.spice/bin successfully.
2024/11/04 11:43:28 INFO Spice runtime upgraded to v0.19.4-beta successfully.
~/c/s/spiceai ❯ spice version
CLI version:     v0.19.4-beta
Runtime version: v0.19.4-beta
```

## 🔨 Related Issues

Closes #2694

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

N/A
