### PR TITLE
docs: Fix typo for S3 release status in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Currently supported data connectors for upstream datasets. More coming soon.
 | `github`        | GitHub                                | Release Candidate |                                            |
 | `mysql`         | MySQL                                 | Release Candidate |                                            |
 | `postgres`      | PostgreSQL                            | Release Candidate |                                            |
-| `s3`            | [S3][s3]                              | Rekease Candidate | Parquet, CSV                               |
+| `s3`            | [S3][s3]                              | Release Candidate | Parquet, CSV                               |
 | `databricks`    | [Databricks][databricks]              | Beta              | [Spark Connect][spark] <br/> S3/Delta Lake |
 | `delta_lake`    | Delta Lake                            | Beta              | Delta Lake                                 |
 | `flightsql`     | FlightSQL                             | Beta              | Arrow Flight SQL                           |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Currently supported data connectors for upstream datasets. More coming soon.
 | `github`        | GitHub                                | Release Candidate |                                            |
 | `mysql`         | MySQL                                 | Release Candidate |                                            |
 | `postgres`      | PostgreSQL                            | Release Candidate |                                            |
-| `s3`            | [S3][s3]                              | Release           | Parquet, CSV                               |
+| `s3`            | [S3][s3]                              | Rekease Candidate | Parquet, CSV                               |
 | `databricks`    | [Databricks][databricks]              | Beta              | [Spark Connect][spark] <br/> S3/Delta Lake |
 | `delta_lake`    | Delta Lake                            | Beta              | Delta Lake                                 |
 | `flightsql`     | FlightSQL                             | Beta              | Arrow Flight SQL                           |


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Fixes a typo from #3362 where the S3 release status is `Release` instead of `Release Candidate`