### PR TITLE
E2E: Add a test to confirm refreshing with custom `refresh-sql` via CLI

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -968,7 +968,7 @@ jobs:
       - name: Manually refresh dataset (with params)
         working-directory: test_app
         run: |
-          output=$(spice refresh eth.recent_blocks --refresh-jitter-max=1s --refresh-sql='SELECT * FROM eth.recent_blocks LIMIT 5' 2>&1)
+          output=$(spice refresh eth.recent_blocks --refresh-jitter-max=1s --refresh-sql='SELECT * FROM eth.recent_blocks LIMIT 2' 2>&1)
           echo "$output"
           if [[ $output == *"Dataset refresh triggered"* ]]; then
             # time to refresh dataset
@@ -982,7 +982,7 @@ jobs:
         uses: ./.github/actions/verify-dataset
         with:
           name: eth.recent_blocks
-          expected-rows-count: 5
+          expected-rows-count: 2
 
       - name: Stop spice and check logs
         working-directory: test_app

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -946,7 +946,7 @@ jobs:
         run: |
           while [[ "$(curl -s http://localhost:8090/v1/ready)" != "Ready" ]]; do sleep 1; done
 
-      - name: Manually refresh dataset
+      - name: Manually refresh dataset (no params)
         working-directory: test_app
         run: |
           output=$(spice refresh eth.recent_blocks 2>&1)
@@ -964,6 +964,25 @@ jobs:
         with:
           name: eth.recent_blocks
           expected-rows-count: 1
+      
+      - name: Manually refresh dataset (with params)
+        working-directory: test_app
+        run: |
+          output=$(spice refresh eth.recent_blocks --refresh-jitter-max=1s --refresh-sql='SELECT * FROM eth.recent_blocks LIMIT 5' 2>&1)
+          echo "$output"
+          if [[ $output == *"Dataset refresh triggered"* ]]; then
+            # time to refresh dataset
+            sleep 5
+          else
+            echo "Failed to trigger dataset refresh."
+            exit 1
+          fi
+
+      - name: Verify dataset
+        uses: ./.github/actions/verify-dataset
+        with:
+          name: eth.recent_blocks
+          expected-rows-count: 5
 
       - name: Stop spice and check logs
         working-directory: test_app


### PR DESCRIPTION
## 🗣 Description

E2E: add test to confirm refresh with custom refresh-sql via CLI

Since the initial refresh SQL corresponds to a tested value after first cli refresh call, triggering a refresh without parameters doesn’t actually verify that the CLI triggers a refresh => added another spice refresh command with a different refresh SQL to ensure that the refresh is triggered. I decided to keep the original call to test that a refresh can be triggered without additional parameters, as done in the second call.