### PR TITLE
Fix regression in inferring embedding model vector size for non-default models

### DIFF
--- a/crates/llms/src/openai/embed.rs
+++ b/crates/llms/src/openai/embed.rs
@@ -104,7 +104,7 @@ impl Embed for Openai {
         match self.model.as_str() {
             "text-embedding-3-large" => 3_072,
             "text-embedding-3-small" | "text-embedding-ada-002" => 1_536,
-            _ => 0, // unreachable. If not a valid model, it won't create embeddings.
+            _ => -1, // unreachable. If not a valid model, it won't create embeddings.
         }
     }
 


### PR DESCRIPTION

## 🗣 Description
 - Originally changed to `-1` for OpenAI so that non-openai models can have their sized inferred. https://github.com/spiceai/spiceai/pull/3045 
 - Regressed in https://github.com/spiceai/spiceai/pull/3087  when refactoring to `crates/llms/src/openai/`.
