### PR TITLE
Add `Extension<Runtime>` to HTTP routes to simplify tooling in NSQL. 

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -225,10 +225,9 @@ pub async fn run(args: Args) -> Result<()> {
     start_anonymous_telemetry(&args, telemetry_config.as_ref(), app_name.as_ref()).await;
 
     let cloned_rt = rt.clone();
-    let server_thread =
-        tokio::spawn(
-            async move { Box::pin(cloned_rt.start_servers(args.runtime, tls_config)).await },
-        );
+    let server_thread = tokio::spawn(async move {
+        Box::pin(Arc::new(cloned_rt).start_servers(args.runtime, tls_config)).await
+    });
 
     tokio::select! {
         () = rt.load_components() => {},

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -14,30 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, fmt::Debug, net::SocketAddr, sync::Arc};
+use std::{fmt::Debug, sync::Arc};
 
-use app::App;
 use axum::Router;
 use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto::Builder,
     service::TowerToHyperService,
 };
-use model_components::model::Model;
 use snafu::prelude::*;
-use tokio::{
-    net::{TcpListener, TcpStream, ToSocketAddrs},
-    sync::RwLock,
-};
+use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
 use tokio_rustls::TlsAcceptor;
 
 use crate::{
     config,
-    datafusion::DataFusion,
     embeddings::vector_search::{self, parse_explicit_primary_keys},
     metrics as runtime_metrics,
-    model::{EmbeddingModelStore, LLMModelStore},
     tls::TlsConfig,
+    Runtime,
 };
 
 mod metrics;
@@ -58,33 +52,19 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn start<A>(
     bind_address: A,
-    app: Arc<RwLock<Option<Arc<App>>>>,
-    df: Arc<DataFusion>,
-    models: Arc<RwLock<HashMap<String, Model>>>,
-    llms: Arc<RwLock<LLMModelStore>>,
-    embeddings: Arc<RwLock<EmbeddingModelStore>>,
+    rt: Arc<Runtime>,
     config: Arc<config::Config>,
-    with_metrics: Option<SocketAddr>,
     tls_config: Option<Arc<TlsConfig>>,
 ) -> Result<()>
 where
     A: ToSocketAddrs + Debug,
 {
     let vsearch = Arc::new(vector_search::VectorSearch::new(
-        Arc::clone(&df),
-        Arc::clone(&embeddings),
-        parse_explicit_primary_keys(Arc::clone(&app)).await,
+        Arc::clone(&rt.df),
+        Arc::clone(&rt.embeds),
+        parse_explicit_primary_keys(Arc::clone(&rt.app)).await,
     ));
-    let routes = routes::routes(
-        app,
-        df,
-        models,
-        llms,
-        embeddings,
-        config,
-        with_metrics,
-        vsearch,
-    );
+    let routes = routes::routes(rt, config, vsearch);
 
     let listener = TcpListener::bind(&bind_address)
         .await

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -63,7 +63,7 @@ where
         Arc::clone(&rt.embeds),
         parse_explicit_primary_keys(Arc::clone(&rt.app)).await,
     ));
-    let routes = routes::routes(rt, config, vsearch);
+    let routes = routes::routes(&rt, config, vsearch);
 
     let listener = TcpListener::bind(&bind_address)
         .await

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -49,7 +49,6 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn start<A>(
     bind_address: A,
     rt: Arc<Runtime>,

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -14,16 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::config;
 use crate::embeddings::vector_search;
-use crate::model::EmbeddingModelStore;
-use crate::model::LLMModelStore;
-use crate::{config, datafusion::DataFusion};
-use app::App;
+use crate::Runtime;
+
 use axum::routing::patch;
-use model_components::model::Model;
 use opentelemetry::KeyValue;
-use std::net::SocketAddr;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use axum::{
     body::Body,
@@ -34,19 +31,13 @@ use axum::{
     routing::{get, post, Router},
     Extension,
 };
-use tokio::{sync::RwLock, time::Instant};
+use tokio::time::Instant;
 
 use super::{metrics, v1};
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn routes(
-    app: Arc<RwLock<Option<Arc<App>>>>,
-    df: Arc<DataFusion>,
-    models: Arc<RwLock<HashMap<String, Model>>>,
-    llms: Arc<RwLock<LLMModelStore>>,
-    embeddings: Arc<RwLock<EmbeddingModelStore>>,
+    rt: Arc<Runtime>,
     config: Arc<config::Config>,
-    with_metrics: Option<SocketAddr>,
     vector_search: Arc<vector_search::VectorSearch>,
 ) -> Router {
     let mut router = Router::new()
@@ -77,16 +68,17 @@ pub(crate) fn routes(
             .route("/v1/chat/completions", post(v1::chat::post))
             .route("/v1/embeddings", post(v1::embeddings::post))
             .route("/v1/search", post(v1::search::post))
-            .layer(Extension(llms))
-            .layer(Extension(models))
+            .layer(Extension(Arc::clone(&rt.llms)))
+            .layer(Extension(Arc::clone(&rt.models)))
             .layer(Extension(vector_search))
-            .layer(Extension(embeddings));
+            .layer(Extension(Arc::clone(&rt.embeds)));
     }
 
     router = router
-        .layer(Extension(app))
-        .layer(Extension(df))
-        .layer(Extension(with_metrics))
+        .layer(Extension(Arc::clone(&rt.app)))
+        .layer(Extension(Arc::clone(&rt.df)))
+        .layer(Extension(Arc::clone(&rt)))
+        .layer(Extension(rt.metrics_endpoint))
         .layer(Extension(config));
     router
 }

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -36,7 +36,7 @@ use tokio::time::Instant;
 use super::{metrics, v1};
 
 pub(crate) fn routes(
-    rt: Arc<Runtime>,
+    rt: &Arc<Runtime>,
     config: Arc<config::Config>,
     vector_search: Arc<vector_search::VectorSearch>,
 ) -> Router {
@@ -77,7 +77,7 @@ pub(crate) fn routes(
     router = router
         .layer(Extension(Arc::clone(&rt.app)))
         .layer(Extension(Arc::clone(&rt.df)))
-        .layer(Extension(Arc::clone(&rt)))
+        .layer(Extension(Arc::clone(rt)))
         .layer(Extension(rt.metrics_endpoint))
         .layer(Extension(config));
     router

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -15,25 +15,21 @@ limitations under the License.
 */
 use crate::{
     datafusion::DataFusion,
-    http::v1::sql_to_http_response,
+    http::v1::{sql_to_http_response, ArrowFormat},
     model::LLMModelStore,
-    tools::builtin::{
-        sample::{
-            distinct::DistinctColumnsParams, random::RandomSampleParams, tool::SampleDataTool,
-            SampleTableParams,
+    tools::{
+        builtin::{
+            sample::{
+                distinct::DistinctColumnsParams, random::RandomSampleParams, tool::SampleDataTool,
+                SampleTableParams,
+            },
+            table_schema::{TableSchemaTool, TableSchemaToolParams},
         },
-        table_schema::{TableSchemaTool, TableSchemaToolParams},
+        create_tool_use_messages,
     },
+    Runtime,
 };
-use async_openai::{
-    error::OpenAIError,
-    types::{
-        ChatCompletionMessageToolCall, ChatCompletionRequestAssistantMessage,
-        ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
-        ChatCompletionRequestToolMessage, ChatCompletionRequestToolMessageArgs,
-        ChatCompletionRequestToolMessageContent, ChatCompletionToolType, FunctionCall,
-    },
-};
+use async_openai::types::ChatCompletionRequestMessage;
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -46,13 +42,10 @@ use headers_accept::Accept;
 use itertools::Itertools;
 use llms::chat::nsql::default::DefaultSqlGeneration;
 use serde::{Deserialize, Serialize};
-use snafu::ResultExt;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::Span;
 use tracing_futures::Instrument;
-
-use super::ArrowFormat;
 
 fn clean_model_based_sql(input: &str) -> String {
     let no_dashes = match input.strip_prefix("--") {
@@ -73,9 +66,9 @@ fn clean_model_based_sql(input: &str) -> String {
 /// Convert the result of a [`SampleDataTool`] call how we would return it to the LLM, (via a [`ChatCompletionRequestToolMessage`]).
 async fn sample_messages(
     sample_from: &[TableReference],
-    df: Arc<DataFusion>,
+    rt: Arc<Runtime>,
 ) -> Result<Vec<ChatCompletionRequestMessage>, Box<dyn std::error::Error + Send + Sync>> {
-    let mut messages = Vec::with_capacity(4 * sample_from.len());
+    let mut messages = Vec::new();
 
     for dataset in sample_from {
         for params in [
@@ -89,82 +82,18 @@ async fn sample_messages(
                 limit: 3,
             }),
         ] {
-            let (req, resp) = call_sample_and_create_messages(Arc::clone(&df), &params)
-                .instrument(Span::current())
-                .await?;
-            messages.push(req.into());
-            messages.push(resp.into());
+            let msgs = create_tool_use_messages(
+                Arc::clone(&rt),
+                &SampleDataTool::new((&params).into()),
+                "id",
+                params,
+            )
+            .instrument(Span::current())
+            .await?;
+            messages.extend(msgs);
         }
     }
     Ok(messages)
-}
-
-/// Runs the [`TableSchemaTool`] on the provided tables and returns an Assistant and Tool message as if requested by a language model.
-async fn schema_messages(
-    df: Arc<DataFusion>,
-    tables: &[TableReference],
-) -> Result<Vec<ChatCompletionRequestMessage>, Box<dyn std::error::Error + Send + Sync>> {
-    let schema_tool = TableSchemaTool::default();
-    let schema_tool_params =
-        TableSchemaToolParams::new(tables.iter().map(ToString::to_string).collect::<Vec<_>>());
-
-    let table_schemas = schema_tool
-        .get_schema(Arc::clone(&df), &schema_tool_params)
-        .instrument(Span::current())
-        .await?;
-    let table_schema_assistant_msg = schema_tool
-        .to_assistant_request_message("schemas-nsql", &schema_tool_params)
-        .boxed()?;
-    let table_schema_tool_msg = schema_tool
-        .to_tool_response_message("schemas-nsql", &table_schemas)
-        .boxed()?;
-
-    Ok(vec![
-        table_schema_assistant_msg.into(),
-        table_schema_tool_msg.into(),
-    ])
-}
-
-/// Call the `sample_data` tool with the given parameters and create associated Assistant and Tool messages.
-async fn call_sample_and_create_messages(
-    df: Arc<DataFusion>,
-    params: &SampleTableParams,
-) -> Result<
-    (
-        ChatCompletionRequestAssistantMessage,
-        ChatCompletionRequestToolMessage,
-    ),
-    Box<dyn std::error::Error + Send + Sync>,
-> {
-    let ds = params.dataset();
-    let result = SampleDataTool::new(params.into())
-        .call_with(params, Arc::clone(&df))
-        .instrument(Span::current())
-        .await?;
-
-    let req = ChatCompletionRequestAssistantMessageArgs::default()
-        .tool_calls(vec![ChatCompletionMessageToolCall {
-            id: format!("distinct-{ds}-nsql"),
-            r#type: ChatCompletionToolType::Function,
-            function: FunctionCall {
-                name: "sample_data".to_string(),
-                arguments: serde_json::to_string(&params)
-                    .map_err(OpenAIError::JSONDeserialize)?
-                    .to_string(),
-            },
-        }])
-        .build()
-        .boxed()?;
-
-    let resp = ChatCompletionRequestToolMessageArgs::default()
-        .tool_call_id(format!("distinct-{ds}-nsql"))
-        .content(ChatCompletionRequestToolMessageContent::Text(
-            result.to_string(),
-        ))
-        .build()
-        .boxed()?;
-
-    Ok((req, resp))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -192,6 +121,7 @@ fn default_model() -> String {
 
 pub(crate) async fn post(
     Extension(df): Extension<Arc<DataFusion>>,
+    Extension(rt): Extension<Arc<Runtime>>,
     Extension(llms): Extension<Arc<RwLock<LLMModelStore>>>,
     accept: Option<TypedHeader<Accept>>,
     Json(payload): Json<Request>,
@@ -205,9 +135,14 @@ pub(crate) async fn post(
         .unwrap_or(df.get_user_table_names());
 
     // Create assistant/tool result messages for calling `table_schema` tool for all or provided tables.
-    let schema_messages = match schema_messages(Arc::clone(&df), &tables)
-        .instrument(span.clone())
-        .await
+    let schema_messages = match create_tool_use_messages(
+        Arc::clone(&rt),
+        &TableSchemaTool::default(),
+        "schemas-nsql",
+        TableSchemaToolParams::new(tables.iter().map(ToString::to_string).collect::<Vec<_>>()),
+    )
+    .instrument(span.clone())
+    .await
     {
         Ok(m) => m,
         Err(e) => {
@@ -217,8 +152,8 @@ pub(crate) async fn post(
     };
 
     // Create sample data assistant/tool messages if user wants to sample from dataset(s).
-    let tool_use_messages = if payload.sample_data_enabled {
-        match sample_messages(&tables, Arc::clone(&df))
+    let sample_data_messages = if payload.sample_data_enabled {
+        match sample_messages(&tables, Arc::clone(&rt))
             .instrument(span.clone())
             .await
         {
@@ -232,41 +167,37 @@ pub(crate) async fn post(
         vec![]
     };
 
-    let sql_query_result = match llms.read().await.get(&payload.model) {
-        Some(nql_model) => {
-            let sql_gen = nql_model.as_sql().unwrap_or(&DefaultSqlGeneration {});
-            let Ok(mut req) = sql_gen.create_request_for_query(&payload.model, &payload.query)
-            else {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "Error preparing data for NQL model".to_string(),
-                )
-                    .into_response();
-            };
+    let models = llms.read().await;
+    let Some(nql_model) = models.get(&payload.model) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("Model {} not found", payload.model),
+        )
+            .into_response();
+    };
+    // for {
+    let sql_gen = nql_model.as_sql().unwrap_or(&DefaultSqlGeneration {});
+    let Ok(mut req) = sql_gen.create_request_for_query(&payload.model, &payload.query) else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Error preparing data for NQL model".to_string(),
+        )
+            .into_response();
+    };
 
-            req.messages.extend(schema_messages);
-            req.messages.extend(tool_use_messages);
+    req.messages.extend(schema_messages);
+    req.messages.extend(sample_data_messages);
 
-            let resp = match nql_model.chat_request(req).instrument(span.clone()).await {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::error!("Error running NQL model: {e}");
-                    return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-                }
-            };
-            sql_gen.parse_response(resp)
-        }
-        None => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Model {} not found", payload.model),
-            )
-                .into_response()
+    let resp = match nql_model.chat_request(req).instrument(span.clone()).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Error running NQL model: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
     };
 
     // Run the SQL from the NSQL model through datafusion.
-    match sql_query_result {
+    match sql_gen.parse_response(resp) {
         Ok(Some(model_sql_query)) => {
             let cleaned_query = clean_model_based_sql(&model_sql_query);
             tracing::trace!("Running query:\n{cleaned_query}");
@@ -291,4 +222,5 @@ pub(crate) async fn post(
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }
     }
+    // }
 }

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -175,7 +175,7 @@ pub(crate) async fn post(
         )
             .into_response();
     };
-    // for {
+
     let sql_gen = nql_model.as_sql().unwrap_or(&DefaultSqlGeneration {});
     let Ok(mut req) = sql_gen.create_request_for_query(&payload.model, &payload.query) else {
         return (
@@ -222,5 +222,4 @@ pub(crate) async fn post(
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }
     }
-    // }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -362,7 +362,7 @@ impl Runtime {
     ///
     /// It is recommended to start the servers in parallel to loading the Runtime components to speed up startup.
     pub async fn start_servers(
-        &self,
+        self: Arc<Self>,
         config: Config,
         tls_config: Option<Arc<TlsConfig>>,
     ) -> Result<()> {
@@ -371,13 +371,8 @@ impl Runtime {
 
         let http_server_future = tokio::spawn(http::start(
             config.http_bind_address,
-            Arc::clone(&self.app),
-            Arc::clone(&self.df),
-            Arc::clone(&self.models),
-            Arc::clone(&self.llms),
-            Arc::clone(&self.embeds),
+            Arc::clone(&self),
             config.clone().into(),
-            self.metrics_endpoint,
             tls_config.clone(),
         ));
 

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -1,3 +1,11 @@
+use async_openai::{
+    error::OpenAIError,
+    types::{
+        ChatCompletionMessageToolCall, ChatCompletionRequestAssistantMessageArgs,
+        ChatCompletionRequestMessage, ChatCompletionRequestToolMessageArgs, ChatCompletionToolType,
+        FunctionCall,
+    },
+};
 /*
 Copyright 2024 The Spice.ai OSS Authors
 
@@ -41,6 +49,46 @@ pub trait SpiceModelTool: Sync + Send {
         arg: &str,
         rt: Arc<Runtime>,
     ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+/// Creates the messages that would be sent and received if a language model were to request the `tool`
+/// to be called (via an assistant message), with defined `arg`, and the response from running the
+/// tool (via a tool message) also as a message.
+///
+/// Useful for constructing [`Vec<ChatCompletionRequestMessage>`], simulating a model already
+/// having requested specific tools.
+pub async fn create_tool_use_messages(
+    rt: Arc<Runtime>,
+    tool: &dyn SpiceModelTool,
+    id: &str,
+    params: impl serde::Serialize,
+) -> Result<Vec<ChatCompletionRequestMessage>, OpenAIError> {
+    let arg =
+        serde_json::to_string(&params).map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+
+    let resp = tool
+        .call(arg.as_str(), rt)
+        .await
+        .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+
+    Ok(vec![
+        ChatCompletionRequestAssistantMessageArgs::default()
+            .tool_calls(vec![ChatCompletionMessageToolCall {
+                id: id.to_string(),
+                r#type: ChatCompletionToolType::Function,
+                function: FunctionCall {
+                    name: tool.name().to_string(),
+                    arguments: arg.to_string(),
+                },
+            }])
+            .build()?
+            .into(),
+        ChatCompletionRequestToolMessageArgs::default()
+            .content(resp.to_string())
+            .tool_call_id(id.to_string())
+            .build()?
+            .into(),
+    ])
 }
 
 /// Construct a [`serde_json::Value`] from a [`JsonSchema`] type.

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -1,11 +1,3 @@
-use async_openai::{
-    error::OpenAIError,
-    types::{
-        ChatCompletionMessageToolCall, ChatCompletionRequestAssistantMessageArgs,
-        ChatCompletionRequestMessage, ChatCompletionRequestToolMessageArgs, ChatCompletionToolType,
-        FunctionCall,
-    },
-};
 /*
 Copyright 2024 The Spice.ai OSS Authors
 
@@ -21,6 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+use async_openai::{
+    error::OpenAIError,
+    types::{
+        ChatCompletionMessageToolCall, ChatCompletionRequestAssistantMessageArgs,
+        ChatCompletionRequestMessage, ChatCompletionRequestToolMessageArgs, ChatCompletionToolType,
+        FunctionCall,
+    },
+};
 use async_trait::async_trait;
 use builtin::get_builtin_tools;
 use options::SpiceToolsOptions;

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -71,7 +71,7 @@ async fn test_tls_endpoints() -> Result<(), anyhow::Error> {
 
     // Start the servers
     tokio::spawn(async move {
-        Box::pin(rt.start_servers(api_config, Some(Arc::new(tls_config)))).await
+        Box::pin(Arc::new(rt).start_servers(api_config, Some(Arc::new(tls_config)))).await
     });
 
     // Wait for the servers to start


### PR DESCRIPTION
## 🗣 Description
 - Standardise how we create chat messages from explicit tool calls (i.e. how we can explicitly add an LLM calling and receiving the results of a tool in `req.messages`). This is done in the function `create_tool_use_messages` and currently used in `nsql.rs`.
 - As a consequence, remove some clippy issues with `#[allow(clippy::too_many_arguments)]`. 
