### PR TITLE
Ensure hyperparameters are obeyed in recursive chat/completion calls. 

### DIFF
--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -249,6 +249,16 @@ impl ToolUsingChat {
             let inner_req = self.add_runtime_tools(&req);
 
             let resp = self.inner_chat.chat_request(inner_req.clone()).await?;
+            let proceed_with_tools = resp.choices.first().is_some_and(|c| {
+                c.finish_reason
+                    .is_some_and(|f| matches!(f, FinishReason::ToolCalls))
+            });
+
+            // Return reason was not to call tools, so return early.
+            if !proceed_with_tools {
+                return Ok(resp);
+            }
+
             let usage = resp.usage.clone();
 
             let tools_used = resp
@@ -267,7 +277,7 @@ impl ToolUsingChat {
                 Some(messages) => {
                     let mut resp = self
                         ._chat_request(
-                            create_new_recursive_req(&inner_req, messages),
+                            create_new_recursive_req(&inner_req, messages, &resp.usage),
                             recursion_limit.map(|r| r - 1),
                         )
                         .await?;
@@ -374,6 +384,7 @@ impl Chat for ToolUsingChat {
 fn create_new_recursive_req(
     req: &CreateChatCompletionRequest,
     new_msg: Vec<ChatCompletionRequestMessage>,
+    marginal_usage: &Option<CompletionUsage>,
 ) -> CreateChatCompletionRequest {
     let mut new_req = req.clone();
     new_req.messages = new_msg;
@@ -382,6 +393,15 @@ fn create_new_recursive_req(
         // Auto is default when tools exist.
         new_req.tool_choice = Some(ChatCompletionToolChoiceOption::Auto);
     }
+
+    // Adjust input `max_completion_tokens` if usage is known to ensure we don't exceed the limit.
+    if let Some(max_completion_tokens) = new_req.max_completion_tokens {
+        if let Some(usage) = marginal_usage {
+            new_req.max_completion_tokens =
+                Some(max_completion_tokens.saturating_sub(usage.completion_tokens));
+        }
+    }
+
     new_req
 }
 
@@ -541,7 +561,11 @@ fn make_a_stream(
                             };
 
                             match model
-                                ._chat_stream(create_new_recursive_req(&req, new_messages))
+                                ._chat_stream(create_new_recursive_req(
+                                    &req,
+                                    new_messages,
+                                    &response.usage,
+                                ))
                                 .await
                             {
                                 Ok(mut s) => {

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -30,8 +30,8 @@ use async_openai::types::{
     ChatCompletionRequestMessage, ChatCompletionRequestToolMessageArgs,
     ChatCompletionResponseStream, ChatCompletionTool, ChatCompletionToolChoiceOption,
     ChatCompletionToolType, CompletionUsage, CreateChatCompletionRequest,
-    CreateChatCompletionRequestArgs, CreateChatCompletionResponse,
-    CreateChatCompletionStreamResponse, FinishReason, FunctionCall, FunctionObject,
+    CreateChatCompletionResponse, CreateChatCompletionStreamResponse, FinishReason, FunctionCall,
+    FunctionObject,
 };
 
 use async_trait::async_trait;
@@ -248,7 +248,7 @@ impl ToolUsingChat {
             // Append spiced runtime tools to the request.
             let inner_req = self.add_runtime_tools(&req);
 
-            let resp = self.inner_chat.chat_request(inner_req).await?;
+            let resp = self.inner_chat.chat_request(inner_req.clone()).await?;
             let usage = resp.usage.clone();
 
             let tools_used = resp
@@ -265,12 +265,11 @@ impl ToolUsingChat {
             {
                 // New messages means we have run spice tools locally, ready to recall model.
                 Some(messages) => {
-                    let new_req = CreateChatCompletionRequestArgs::default()
-                        .model(req.model)
-                        .messages(messages)
-                        .build()?;
                     let mut resp = self
-                        ._chat_request(new_req, recursion_limit.map(|r| r - 1))
+                        ._chat_request(
+                            create_new_recursive_req(&inner_req, messages),
+                            recursion_limit.map(|r| r - 1),
+                        )
                         .await?;
                     resp.usage = combine_usage(usage, resp.usage);
                     Ok(resp)
@@ -367,6 +366,23 @@ impl Chat for ToolUsingChat {
     fn as_sql(&self) -> Option<&dyn SqlGeneration> {
         self.inner_chat.as_sql()
     }
+}
+
+/// Create a new [`CreateChatCompletionRequest`] with new messages.
+///
+/// Remove `tool_choice` if it is named (since it was just used), and set it to `Auto`.
+fn create_new_recursive_req(
+    req: &CreateChatCompletionRequest,
+    new_msg: Vec<ChatCompletionRequestMessage>,
+) -> CreateChatCompletionRequest {
+    let mut new_req = req.clone();
+    new_req.messages = new_msg;
+    if let Some(ChatCompletionToolChoiceOption::Named(t)) = new_req.tool_choice {
+        tracing::debug!("Not recursively using tool_choice named={t:?} in subsequent calls.");
+        // Auto is default when tools exist.
+        new_req.tool_choice = Some(ChatCompletionToolChoiceOption::Auto);
+    }
+    new_req
 }
 
 pub fn combine_usage(
@@ -524,9 +540,10 @@ fn make_a_stream(
                                 }
                             };
 
-                            let mut new_req = req.clone();
-                            new_req.messages.clone_from(&new_messages);
-                            match model._chat_stream(new_req).await {
+                            match model
+                                ._chat_stream(create_new_recursive_req(&req, new_messages))
+                                .await
+                            {
                                 Ok(mut s) => {
                                     while let Some(resp) = s.next().await {
                                         // TODO check if this works for choices > 1.


### PR DESCRIPTION
## 🗣 Description
 - Ensure requested `max_completion_tokens` is not violated in total (i.e. across all internal chat/completion calls).
 - Ensure non-core hyperparameters (e.g. `temperature`) are passed through every time (other hyperparameters (e.g. models, tools) were currently done so manually).
 - If first request explicitly asks to call a spiced tool, do not enforce this for subsequent requests (e.g. if first request has `"tool_choice": {"type": "function", "function": {"name": "table_schema"}}`, do not repeatedly call `table_schema`). 

