### PR TITLE
Implement traits & plumbing for pluggable HTTP Auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10455,6 +10455,7 @@ dependencies = [
  "prometheus",
  "reqwest 0.12.9",
  "runtime",
+ "runtime-auth",
  "rustls 0.23.16",
  "rustls-pemfile 2.2.0",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9479,6 +9479,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.9",
+ "runtime-auth",
  "rusqlite",
  "rustls 0.23.16",
  "rustls-pemfile 2.2.0",
@@ -9502,6 +9503,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-health",
+ "tower 0.5.1",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -9510,6 +9512,14 @@ dependencies = [
  "util",
  "uuid 1.11.0",
  "x509-certificate",
+]
+
+[[package]]
+name = "runtime-auth"
+version = "1.0.0-rc.1"
+dependencies = [
+ "app",
+ "axum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
   "crates/model_components",
   "crates/ns_lookup",
   "crates/otel-arrow",
+  "crates/runtime",
+  "crates/runtime-auth",
   "crates/spicepod",
   "crates/spice_cloud",
   "crates/telemetry",
@@ -43,6 +45,7 @@ arrow-flight = "53"
 arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "6013498d7d4d59f7b16d0e28b3e0b379732fbf07" }
 arrow-ipc = "53"
 arrow-schema = "53"
+axum = { version = "0.7.7", features = ["macros"] }
 parquet = "53"
 arrow-odbc = "11.2.0"
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "df4fc93b21711a46e6cd3e91ecea72b4f32c856f" }
@@ -114,6 +117,7 @@ tokio-util = { version = "0.7.11", features = ["compat"] }
 tokio-stream = { version = "0.1.16", features = ["sync"] }
 tonic = { version = "0.12", features = ["gzip", "tls"] }
 tonic-health = { version = "0.12" }
+tower = "0.5.1"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-opentelemetry = "0.27"

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -22,6 +22,7 @@ otel-arrow = { path = "../../crates/otel-arrow" }
 prometheus.workspace = true
 reqwest.workspace = true
 runtime = { path = "../../crates/runtime" }
+runtime-auth = { path = "../../crates/runtime-auth" }
 rustls.workspace = true
 rustls-pemfile.workspace = true
 serde_json.workspace = true

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -226,9 +226,9 @@ pub async fn run(args: Args) -> Result<()> {
     start_anonymous_telemetry(&args, telemetry_config.as_ref(), app_name.as_ref()).await;
 
     let cloned_rt = rt.clone();
-    let endpoint_auth = app.as_ref().map_or_else(EndpointAuth::no_auth, |app| {
-        EndpointAuth::new(Arc::clone(app))
-    });
+    let endpoint_auth = app
+        .as_ref()
+        .map_or_else(EndpointAuth::no_auth, |app| EndpointAuth::new(app));
     let server_thread = tokio::spawn(async move {
         Box::pin(Arc::new(cloned_rt).start_servers(args.runtime, tls_config, endpoint_auth)).await
     });

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -37,6 +37,7 @@ use runtime::datafusion::DataFusion;
 use runtime::podswatcher::PodsWatcher;
 use runtime::spice_metrics;
 use runtime::{extension::ExtensionFactory, Runtime};
+use runtime_auth::EndpointAuth;
 use snafu::prelude::*;
 use spice_cloud::SpiceExtensionFactory;
 use spiced_tracing::LogVerbosity;
@@ -225,8 +226,11 @@ pub async fn run(args: Args) -> Result<()> {
     start_anonymous_telemetry(&args, telemetry_config.as_ref(), app_name.as_ref()).await;
 
     let cloned_rt = rt.clone();
+    let endpoint_auth = app.as_ref().map_or_else(EndpointAuth::no_auth, |app| {
+        EndpointAuth::new(Arc::clone(app))
+    });
     let server_thread = tokio::spawn(async move {
-        Box::pin(Arc::new(cloned_rt).start_servers(args.runtime, tls_config)).await
+        Box::pin(Arc::new(cloned_rt).start_servers(args.runtime, tls_config, endpoint_auth)).await
     });
 
     tokio::select! {

--- a/crates/runtime-auth/Cargo.toml
+++ b/crates/runtime-auth/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+description = "Authentication traits/middleware for the Spice runtime"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "runtime-auth"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+app = { path = "../app" }
+axum.workspace = true

--- a/crates/runtime-auth/src/api_key/mod.rs
+++ b/crates/runtime-auth/src/api_key/mod.rs
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use axum::http;
+
+use crate::{error::Error, AuthVerdict, HttpAuth};
+
+pub struct ApiKeyAuth {
+    api_keys: Vec<String>,
+}
+
+impl ApiKeyAuth {
+    #[must_use]
+    pub fn new(api_keys: Vec<String>) -> Self {
+        Self { api_keys }
+    }
+}
+
+impl HttpAuth for ApiKeyAuth {
+    /// Checks the `X-API-Key` header for a valid API key
+    fn http(&self, request: &http::request::Parts) -> Result<AuthVerdict, Error> {
+        let api_key = request
+            .headers
+            .get("X-API-Key")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+
+        if self.api_keys.iter().any(|key| key == api_key) {
+            Ok(AuthVerdict::Allow)
+        } else {
+            Ok(AuthVerdict::Deny)
+        }
+    }
+}

--- a/crates/runtime-auth/src/error.rs
+++ b/crates/runtime-auth/src/error.rs
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#[derive(Debug)]
+pub enum Error {
+    HttpAuthError(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::HttpAuthError(e) => write!(f, "Error validating HTTP request: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::HttpAuthError(e) => Some(e.as_ref()),
+        }
+    }
+}

--- a/crates/runtime-auth/src/lib.rs
+++ b/crates/runtime-auth/src/lib.rs
@@ -26,25 +26,42 @@ pub use traits::*;
 
 pub struct EndpointAuth {
     pub http_auth: Option<Arc<dyn HttpAuth + Send + Sync>>,
+    pub flight_basic_auth: Option<Arc<dyn FlightBasicAuth + Send + Sync>>,
+    pub grpc_auth: Option<Arc<dyn GrpcAuth + Send + Sync>>,
 }
 
 impl EndpointAuth {
     #[must_use]
-    pub fn new(app: Arc<App>) -> Self {
+    pub fn new(app: &App) -> Self {
         Self {
             http_auth: http_auth(app),
+            flight_basic_auth: flight_basic_auth(app),
+            grpc_auth: grpc_auth(app),
         }
     }
 
     #[must_use]
     pub fn no_auth() -> Self {
-        Self { http_auth: None }
+        Self {
+            http_auth: None,
+            flight_basic_auth: None,
+            grpc_auth: None,
+        }
     }
 }
 
 /// Gets the HTTP auth provider configured for the app, if any
 #[must_use]
-#[allow(clippy::needless_pass_by_value)]
-fn http_auth(_app: Arc<App>) -> Option<Arc<dyn HttpAuth + Send + Sync>> {
+fn http_auth(_app: &App) -> Option<Arc<dyn HttpAuth + Send + Sync>> {
+    None
+}
+
+#[must_use]
+fn flight_basic_auth(_app: &App) -> Option<Arc<dyn FlightBasicAuth + Send + Sync>> {
+    None
+}
+
+#[must_use]
+fn grpc_auth(_app: &App) -> Option<Arc<dyn GrpcAuth + Send + Sync>> {
     None
 }

--- a/crates/runtime-auth/src/lib.rs
+++ b/crates/runtime-auth/src/lib.rs
@@ -14,7 +14,37 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::sync::Arc;
+
+use app::App;
+
+pub mod api_key;
 pub mod error;
 mod traits;
 
 pub use traits::*;
+
+pub struct EndpointAuth {
+    pub http_auth: Option<Arc<dyn HttpAuth + Send + Sync>>,
+}
+
+impl EndpointAuth {
+    #[must_use]
+    pub fn new(app: Arc<App>) -> Self {
+        Self {
+            http_auth: http_auth(app),
+        }
+    }
+
+    #[must_use]
+    pub fn no_auth() -> Self {
+        Self { http_auth: None }
+    }
+}
+
+/// Gets the HTTP auth provider configured for the app, if any
+#[must_use]
+#[allow(clippy::needless_pass_by_value)]
+fn http_auth(_app: Arc<App>) -> Option<Arc<dyn HttpAuth + Send + Sync>> {
+    None
+}

--- a/crates/runtime-auth/src/lib.rs
+++ b/crates/runtime-auth/src/lib.rs
@@ -1,0 +1,20 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+pub mod error;
+mod traits;
+
+pub use traits::*;

--- a/crates/runtime-auth/src/traits.rs
+++ b/crates/runtime-auth/src/traits.rs
@@ -30,3 +30,21 @@ pub trait HttpAuth {
     /// This function will return an error if the validator can't validate the request.
     fn http(&self, request: &http::request::Parts) -> Result<AuthVerdict, Error>;
 }
+
+pub trait FlightBasicAuth {
+    // Receive the username/password for Flight basic auth and return a verdict
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the validator can't validate the request.
+    fn flight_basic(&self, username: String, password: String) -> Result<AuthVerdict, Error>;
+}
+
+pub trait GrpcAuth {
+    // Receive the entire gRPC request object and return a verdict
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the validator can't validate the request.
+    fn grpc(&self, req: &http::request::Parts) -> Result<AuthVerdict, Error>;
+}

--- a/crates/runtime-auth/src/traits.rs
+++ b/crates/runtime-auth/src/traits.rs
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::error::Error;
+use axum::http;
+
+pub enum AuthVerdict {
+    Allow,
+    Deny,
+}
+
+pub trait HttpAuth {
+    /// Receive the entire HTTP request object and return a verdict on whether to allow/deny it
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the validator can't validate the request.
+    fn http(&self, request: &http::request::Parts) -> Result<AuthVerdict, Error>;
+}
+
+// pub trait FlightBasicAuth {
+//     // Receive the username/password for Flight basic auth and return a verdict
+//     fn flight_basic(username: String, password: String) -> Result<AuthVerdict> {}
+// }
+
+// pub trait GrpcAuth {
+//     // Receive the entire gRPC request object and return a verdict
+//     fn grpc(req: GrpcRequest) -> Result<AuthVerdict> {}
+// }

--- a/crates/runtime-auth/src/traits.rs
+++ b/crates/runtime-auth/src/traits.rs
@@ -30,13 +30,3 @@ pub trait HttpAuth {
     /// This function will return an error if the validator can't validate the request.
     fn http(&self, request: &http::request::Parts) -> Result<AuthVerdict, Error>;
 }
-
-// pub trait FlightBasicAuth {
-//     // Receive the username/password for Flight basic auth and return a verdict
-//     fn flight_basic(username: String, password: String) -> Result<AuthVerdict> {}
-// }
-
-// pub trait GrpcAuth {
-//     // Receive the entire gRPC request object and return a verdict
-//     fn grpc(req: GrpcRequest) -> Result<AuthVerdict> {}
-// }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -24,7 +24,7 @@ async-trait.workspace = true
 aws-config = { version = "1.1.10", optional = true }
 aws-sdk-secretsmanager = { version = "1.21.0", optional = true }
 aws-sdk-sts = { version = "1.19.0", optional = true }
-axum = { version = "0.7.4", features = ["macros"] }
+axum.workspace = true
 axum-extra = { version = "0.9.3", features = ["typed-header"] }
 base64.workspace = true
 bytes = { version = "1", default-features = false }
@@ -112,6 +112,7 @@ tokio-util = { workspace = true, optional = true }
 tokio-stream.workspace = true
 tonic-health.workspace = true
 tonic.workspace = true
+tower.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 tract-core = "0.21.0"
@@ -120,6 +121,7 @@ util = { path = "../util" }
 uuid.workspace = true
 x509-certificate.workspace = true
 jsonwebtoken = "9.3.0"
+runtime-auth = { path = "../runtime-auth" }
 
 [dev-dependencies]
 anyhow = "1.0.86"

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -16,7 +16,6 @@ limitations under the License.
 
 use std::{fmt::Debug, sync::Arc};
 
-use app::App;
 use auth::AuthLayer;
 use axum::Router;
 use hyper_util::{

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use std::{collections::HashMap, fmt::Debug, net::SocketAddr, sync::Arc};
 
 use app::App;
+use auth::AuthLayer;
 use axum::Router;
 use hyper_util::{
     rt::{TokioExecutor, TokioIo},
@@ -24,6 +25,7 @@ use hyper_util::{
     service::TowerToHyperService,
 };
 use model_components::model::Model;
+use runtime_auth::HttpAuth;
 use snafu::prelude::*;
 use tokio::{
     net::{TcpListener, TcpStream, ToSocketAddrs},
@@ -40,6 +42,7 @@ use crate::{
     tls::TlsConfig,
 };
 
+mod auth;
 mod metrics;
 mod routes;
 mod v1;
@@ -66,6 +69,7 @@ pub(crate) async fn start<A>(
     config: Arc<config::Config>,
     with_metrics: Option<SocketAddr>,
     tls_config: Option<Arc<TlsConfig>>,
+    auth_provider: Option<Arc<dyn HttpAuth + Send + Sync>>,
 ) -> Result<()>
 where
     A: ToSocketAddrs + Debug,
@@ -75,7 +79,8 @@ where
         Arc::clone(&embeddings),
         parse_explicit_primary_keys(Arc::clone(&app)).await,
     ));
-    let routes = routes::routes(
+
+    let mut routes: Router = routes::routes(
         app,
         df,
         models,
@@ -85,6 +90,10 @@ where
         with_metrics,
         vsearch,
     );
+
+    if let Some(auth_provider) = auth_provider {
+        routes = routes.layer(AuthLayer::new(auth_provider));
+    }
 
     let listener = TcpListener::bind(&bind_address)
         .await

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -68,10 +68,10 @@ where
         Arc::clone(&rt.embeds),
         parse_explicit_primary_keys(Arc::clone(&rt.app)).await,
     ));
-    let routes = routes::routes(&rt, config, vsearch);
+    let mut routes = routes::routes(&rt, config, vsearch);
 
     if let Some(auth_provider) = auth_provider {
-        routes = routes.layer(AuthLayer::new(auth_provider));
+        routes = routes.route_layer(AuthLayer::new(auth_provider));
     }
 
     let listener = TcpListener::bind(&bind_address)

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -67,11 +67,7 @@ where
         Arc::clone(&rt.embeds),
         parse_explicit_primary_keys(Arc::clone(&rt.app)).await,
     ));
-    let mut routes = routes::routes(&rt, config, vsearch);
-
-    if let Some(auth_provider) = auth_provider {
-        routes = routes.route_layer(AuthLayer::new(auth_provider));
-    }
+    let routes = routes::routes(&rt, config, vsearch, auth_provider.map(AuthLayer::new));
 
     let listener = TcpListener::bind(&bind_address)
         .await

--- a/crates/runtime/src/http/auth.rs
+++ b/crates/runtime/src/http/auth.rs
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use axum::{
     body::Body,
     http::StatusCode,

--- a/crates/runtime/src/http/auth.rs
+++ b/crates/runtime/src/http/auth.rs
@@ -1,0 +1,90 @@
+use axum::{
+    body::Body,
+    http::StatusCode,
+    http::{Request, Response},
+};
+use futures::future::BoxFuture;
+use runtime_auth::{AuthVerdict, HttpAuth};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub struct AuthLayer {
+    auth_verifier: Arc<dyn HttpAuth + Send + Sync>,
+}
+
+impl AuthLayer {
+    pub fn new(auth_verifier: Arc<dyn HttpAuth + Send + Sync>) -> Self {
+        Self { auth_verifier }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthMiddleware {
+            inner,
+            auth_verifier: Arc::clone(&self.auth_verifier),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AuthMiddleware<S> {
+    inner: S,
+    auth_verifier: Arc<dyn HttpAuth + Send + Sync>,
+}
+
+impl<S> Service<Request<Body>> for AuthMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Response<Body>, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let auth_verifier = Arc::clone(&self.auth_verifier);
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let (parts, body) = req.into_parts();
+
+            match auth_verifier.http(&parts) {
+                Ok(AuthVerdict::Allow) => inner.call(Request::from_parts(parts, body)).await,
+                Ok(AuthVerdict::Deny) => Ok(unauthorized_response()),
+                Err(e) => {
+                    tracing::error!("{e}");
+                    Ok(internal_server_error_response())
+                }
+            }
+        })
+    }
+}
+
+fn unauthorized_response() -> Response<Body> {
+    match Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .body(Body::from("Unauthorized"))
+    {
+        Ok(response) => response,
+        Err(e) => panic!("Failed to build unauthorized response: {e}"),
+    }
+}
+
+fn internal_server_error_response() -> Response<Body> {
+    match Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::from("Internal Server Error"))
+    {
+        Ok(response) => response,
+        Err(e) => panic!("Failed to build internal server error response: {e}"),
+    }
+}

--- a/crates/runtime/src/http/v1/ready.rs
+++ b/crates/runtime/src/http/v1/ready.rs
@@ -16,15 +16,15 @@ limitations under the License.
 
 use std::sync::Arc;
 
-use crate::datafusion::DataFusion;
+use crate::status::RuntimeStatus;
 use axum::{
     http::status,
     response::{IntoResponse, Response},
     Extension,
 };
 
-pub(crate) async fn get(Extension(df): Extension<Arc<DataFusion>>) -> Response {
-    if df.runtime_status().is_ready() {
+pub(crate) async fn get(Extension(status): Extension<Arc<RuntimeStatus>>) -> Response {
+    if status.is_ready() {
         return (status::StatusCode::OK, "Ready").into_response();
     }
     (status::StatusCode::SERVICE_UNAVAILABLE, "Not Ready").into_response()

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -50,6 +50,7 @@ use model::{
 };
 use model_components::model::Model;
 pub use notify::Error as NotifyError;
+use runtime_auth::EndpointAuth;
 use secrecy::SecretString;
 use secrets::ParamStr;
 use snafu::prelude::*;
@@ -365,6 +366,7 @@ impl Runtime {
         self: Arc<Self>,
         config: Config,
         tls_config: Option<Arc<TlsConfig>>,
+        endpoint_auth: EndpointAuth,
     ) -> Result<()> {
         self.register_metrics_table(self.prometheus_registry.is_some())
             .await?;
@@ -374,7 +376,7 @@ impl Runtime {
             Arc::clone(&self),
             config.clone().into(),
             tls_config.clone(),
-            None,
+            endpoint_auth.http_auth,
         ));
 
         // Spawn the metrics server in the background

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -379,6 +379,7 @@ impl Runtime {
             config.clone().into(),
             self.metrics_endpoint,
             tls_config.clone(),
+            None,
         ));
 
         // Spawn the metrics server in the background

--- a/crates/runtime/tests/tls/mod.rs
+++ b/crates/runtime/tests/tls/mod.rs
@@ -28,6 +28,7 @@ use arrow_flight::{
 use prost::Message;
 use rand::Rng;
 use runtime::{config::Config, tls::TlsConfig, Runtime};
+use runtime_auth::EndpointAuth;
 use tonic::transport::Channel;
 use tonic_health::pb::health_client::HealthClient;
 
@@ -71,7 +72,12 @@ async fn test_tls_endpoints() -> Result<(), anyhow::Error> {
 
     // Start the servers
     tokio::spawn(async move {
-        Box::pin(Arc::new(rt).start_servers(api_config, Some(Arc::new(tls_config)))).await
+        Box::pin(Arc::new(rt).start_servers(
+            api_config,
+            Some(Arc::new(tls_config)),
+            EndpointAuth::no_auth(),
+        ))
+        .await
     });
 
     // Wait for the servers to start


### PR DESCRIPTION
## 🗣 Description

This PR introduces the main traits and plumbing that enables pluggable authentication for the Spice runtime endpoints.

`runtime-auth` - A new crate where the bulk of the new authentication logic will live.

`EndpointAuth` - New struct that is constructed from an App object that will parse the configuration to determine which auth providers to enable, if any. This isn't wired up and always returns `None` for all auth providers.

`AuthVerdict` - An enum that can be either `Allow` or `Deny`. Returned by the implementation of the auth providers on their auth decision.

`HttpAuth` - A new trait that auth providers can implement that receives a request object and returns an `AuthVerdict`. Configured on the HTTP endpoints as a middleware.

`FlightBasicAuth` - A new trait that auth providers can implement that will plug into the Flight BasicAuthenticate flow to authenticate requests. This just receives a username/password and returns an `AuthVerdict`.

`GrpcAuth` - A new trait that auth providers can implement that will plug into the OpenTelemetry gRPC API to authenticate requests. This could also be used on the Flight endpoints if `FlightBasicAuth` isn't secure enough, but that is out of scope for this enhancement.

`ApiKeyAuth` - A simple implementation of `HttpAuth` that receives a list of API keys and verifies that the `X-API-Key` header is present on the request and contains one of the provided API keys. This isn't yet wired up anywhere.

## 🔨 Related Issues

Part of #2670
Closes #3379

## 📄 Documentation Requirements

This will require documentation, tracked in #2670

## 🤔 Concerns

Instead of returning `None` and optionally configuring auth on endpoints, I could implement a no-op Auth provider that just allows everything and the middleware always configures Auth. But I think that would be unnecessary runtime overhead if auth isn't required.
