### PR TITLE
Add allow_http parameter for S3 data connector

### DIFF
--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -82,7 +82,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("client_timeout")
         .description("The timeout setting for S3 client."),
     ParameterSpec::runtime("allow_http")
-        .description("Allow HTTP protocal for S3 endpoint."),
+        .description("Allow HTTP protocol for S3 endpoint."),
 
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -81,6 +81,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("auth").description("Configures the authentication method for S3. Supported methods are: public (i.e. no auth), iam_role, key.").secret(),
     ParameterSpec::runtime("client_timeout")
         .description("The timeout setting for S3 client."),
+    ParameterSpec::runtime("allow_http")
+        .description("Allow HTTP protocal for S3 endpoint."),
 
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),
@@ -175,6 +177,7 @@ impl ListingTableConnector for S3 {
                 "key",
                 "secret",
                 "client_timeout",
+                "allow_http",
                 "auth",
             ],
         )));

--- a/crates/runtime/src/object_store_registry.rs
+++ b/crates/runtime/src/object_store_registry.rs
@@ -73,6 +73,14 @@ impl SpiceObjectStoreRegistry {
                     DataFusionError::Configuration(format!("Unable to parse timeout: {timeout}",))
                 })?);
         }
+        if let Some(allow_http) = params.get("allow_http") {
+            let as_bool = allow_http.parse::<bool>().map_err(|_| {
+                DataFusionError::Configuration(format!(
+                    "{allow_http} is not a valid boolean for allow_http"
+                ))
+            })?;
+            client_options = client_options.with_allow_http(as_bool);
+        }
         if let (Some(key), Some(secret)) = (params.get("key"), params.get("secret")) {
             s3_builder = s3_builder.with_access_key_id(key);
             s3_builder = s3_builder.with_secret_access_key(secret);


### PR DESCRIPTION
## 🗣 Description

Add `allow_http` parameter for S3 data connector. This parameter configures the object store http client to allow for HTTP protocol. This allows for connection to `s3_endpoint` with HTTP protocol, e.g. `http://my-minio-server`

The `allow_http` parameter is [defaulted to false](https://docs.rs/object_store/latest/object_store/struct.ClientOptions.html#method.with_allow_http), and won't affect any existing user of S3 connector until explicitly specify the `allow_http` parameter to be true.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

Should the `allow_http` parameter be prefixed with `s3_allow_http`. We don't prefix `client_timeout` parameter, which is also a object store client configuration in S3 connector. But all object store client configuration in [abfs](https://docs.spiceai.org/components/data-connectors/abfs#params) are prefixed with `abfs`. Consistency needs to be determined here.

