### PR TITLE
Add integration tests for Search API (OpenAI and HF models)

### DIFF
--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc
+    sync::Arc,
 };
 
 use app::AppBuilder;
@@ -31,7 +31,7 @@ use spicepod::component::{
 use crate::{
     init_tracing,
     models::{
-        get_taxi_trips_dataset, get_tpcds_dataset, send_search_request, verify_search_response,
+        get_taxi_trips_dataset, get_tpcds_dataset, normalize_search_response, send_search_request,
     },
     utils::{runtime_ready_check, verify_env_secret_exists},
 };
@@ -135,14 +135,15 @@ async fn huggingface_search_test() -> Result<(), anyhow::Error> {
     tracing::info!("/v1/search: Ensure simple search request succeeds");
     let response = send_search_request(
         base_url.as_str(),
-        "original item",
-        Some(3),
+        "worldwide school",
+        Some(2),
         Some(vec!["item".to_string()]),
         None,
-        None,
+        Some(vec!["i_color".to_string(), "i_item_id".to_string()]),
     )
     .await?;
-    verify_search_response(&response, 3).map_err(anyhow::Error::msg)?;
+
+    insta::assert_snapshot!(format!("search_1"), normalize_search_response(response));
 
     Ok(())
 }

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
+    sync::Arc
 };
 
 use app::AppBuilder;
@@ -31,8 +31,7 @@ use spicepod::component::{
 use crate::{
     init_tracing,
     models::{
-        get_taxi_trips_dataset, get_tpcds_dataset, json_is_single_row_with_value,
-        send_nsql_request, send_search_request, verify_search_response,
+        get_taxi_trips_dataset, get_tpcds_dataset, send_search_request, verify_search_response,
     },
     utils::{runtime_ready_check, verify_env_secret_exists},
 };
@@ -40,17 +39,20 @@ use crate::{
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
 #[tokio::test]
-async fn openai_nsql_test() -> Result<(), anyhow::Error> {
+async fn huggingface_model_download_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(None);
 
-    verify_env_secret_exists("SPICE_OPENAI_API_KEY")
+    verify_env_secret_exists("SPICE_HF_TOKEN")
         .await
         .map_err(anyhow::Error::msg)?;
 
     let app = AppBuilder::new("text-to-sql")
         .with_dataset(get_taxi_trips_dataset())
-        .with_model(get_openai_model("gpt-4o-mini", "nql"))
-        .with_model(get_openai_model("gpt-4o-mini", "nql-2"))
+        .with_model(get_huggingface_model(
+            "meta-llama/Llama-3.2-1B-Instruct",
+            "llama",
+            "hf_model",
+        ))
         .build();
 
     let http_port = rand::thread_rng().gen_range(50000..60000);
@@ -66,7 +68,8 @@ async fn openai_nsql_test() -> Result<(), anyhow::Error> {
     });
 
     tokio::select! {
-        () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+        // increased timeout to download and load huggingface model
+        () = tokio::time::sleep(std::time::Duration::from_secs(180)) => {
             return Err(anyhow::anyhow!("Timed out waiting for components to load"));
         }
         () = rt.load_components() => {}
@@ -74,77 +77,21 @@ async fn openai_nsql_test() -> Result<(), anyhow::Error> {
 
     runtime_ready_check(&rt).await;
 
-    let base_url = format!("http://localhost:{http_port}");
-
-    // example responses for the test query: '[{"count(*)":10}]', '[{"record_count":10}]'
-
-    tracing::info!("/v1/nsql: Ensure default request succeeds");
-    let response = send_nsql_request(
-        base_url.as_str(),
-        "how many records in taxi_trips dataset?",
-        None,
-        Some(false),
-        None,
-    )
-    .await?;
-
-    assert!(
-        json_is_single_row_with_value(&response, 10),
-        "Expected a single record containing the value 10"
-    );
-
-    tracing::info!("/v1/nsql: Ensure model selection works");
-    let response = send_nsql_request(
-        base_url.as_str(),
-        "how many records in taxi_trips dataset?",
-        Some("nql-2"),
-        Some(false),
-        None,
-    )
-    .await?;
-
-    assert!(
-        json_is_single_row_with_value(&response, 10),
-        "Expected a single record containing the value 10"
-    );
-
-    tracing::info!("/v1/nsql: Ensure error when invalid dataset name is provided");
-    assert!(send_nsql_request(
-        base_url.as_str(),
-        "how many records in taxi_trips dataset?",
-        Some("nql"),
-        Some(false),
-        Some(vec!["dataset_not_in_spice".to_string()]),
-    )
-    .await
-    .is_err());
-
-    tracing::info!("/v1/nsql: Ensure error when invalid model name is provided");
-    assert!(send_nsql_request(
-        base_url.as_str(),
-        "how many records in taxi_trips dataset?",
-        Some("model_not_in_spice"),
-        Some(false),
-        None,
-    )
-    .await
-    .is_err());
-
     Ok(())
 }
 
 #[tokio::test]
-async fn openai_search_test() -> Result<(), anyhow::Error> {
+async fn huggingface_search_test() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(None);
 
-    verify_env_secret_exists("SPICE_OPENAI_API_KEY")
+    verify_env_secret_exists("SPICE_HF_TOKEN")
         .await
         .map_err(anyhow::Error::msg)?;
 
     let mut ds_tpcds_item = get_tpcds_dataset("item");
     ds_tpcds_item.embeddings = vec![ColumnEmbeddingConfig {
         column: "i_item_desc".to_string(),
-        model: "openai_embeddings".to_string(),
+        model: "hf_minilm".to_string(),
         primary_keys: Some(vec!["i_item_sk".to_string()]),
         chunking: Some(EmbeddingChunkConfig {
             enabled: true,
@@ -154,11 +101,12 @@ async fn openai_search_test() -> Result<(), anyhow::Error> {
         }),
     }];
 
-    let app = AppBuilder::new("search_app")
-        // taxi_trips is added to test search against dataset with no embeddings
-        .with_dataset(get_taxi_trips_dataset())
+    let app = AppBuilder::new("text-to-sql")
         .with_dataset(ds_tpcds_item)
-        .with_embedding(get_openai_embeddings("openai_embeddings"))
+        .with_embedding(get_huggingface_embeddings(
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "hf_minilm",
+        ))
         .build();
 
     let http_port = rand::thread_rng().gen_range(50000..60000);
@@ -174,7 +122,7 @@ async fn openai_search_test() -> Result<(), anyhow::Error> {
     });
 
     tokio::select! {
-        () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+        () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
             return Err(anyhow::anyhow!("Timed out waiting for components to load"));
         }
         () = rt.load_components() => {}
@@ -199,20 +147,28 @@ async fn openai_search_test() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn get_openai_model(model: impl Into<String>, name: impl Into<String>) -> Model {
-    let mut model = Model::new(format!("openai:{}", model.into()), name);
-    model.params.insert(
-        "openai_api_key".to_string(),
-        "${ secrets:SPICE_OPENAI_API_KEY }".into(),
-    );
+fn get_huggingface_model(
+    model: impl Into<String>,
+    model_type: impl Into<String>,
+    name: impl Into<String>,
+) -> Model {
+    let mut model = Model::new(format!("huggingface:huggingface.co/{}", model.into()), name);
+    model
+        .params
+        .insert("hf_token".to_string(), "${ secrets:SPICE_HF_TOKEN }".into());
+    model
+        .params
+        .insert("model_type".to_string(), model_type.into().into());
+
     model
 }
 
-fn get_openai_embeddings(name: impl Into<String>) -> Embeddings {
-    let mut embedding = Embeddings::new("openai", name);
-    embedding.params.insert(
-        "openai_api_key".to_string(),
-        "${ secrets:SPICE_OPENAI_API_KEY }".into(),
-    );
-    embedding
+fn get_huggingface_embeddings(model: impl Into<String>, name: impl Into<String>) -> Embeddings {
+    let mut embeddings =
+        Embeddings::new(format!("huggingface:huggingface.co/{}", model.into()), name);
+    embeddings
+        .params
+        .insert("hf_token".to_string(), "${ secrets:SPICE_HF_TOKEN }".into());
+
+    embeddings
 }

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -23,7 +23,7 @@ use app::AppBuilder;
 use rand::Rng;
 use runtime::{auth::EndpointAuth, config::Config, Runtime};
 use spicepod::component::{
-    embeddings::{ColumnEmbeddingConfig, EmbeddingChunkConfig, Embeddings},
+    embeddings::{ColumnEmbeddingConfig, Embeddings},
     model::Model,
 };
 
@@ -36,6 +36,69 @@ use crate::{
 };
 
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+#[tokio::test]
+async fn huggingface_search_test() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(None);
+
+    verify_env_secret_exists("SPICE_HF_TOKEN")
+        .await
+        .map_err(anyhow::Error::msg)?;
+
+    let mut ds_tpcds_item = get_tpcds_dataset("item");
+    ds_tpcds_item.embeddings = vec![ColumnEmbeddingConfig {
+        column: "i_item_desc".to_string(),
+        model: "hf_minilm".to_string(),
+        primary_keys: Some(vec!["i_item_sk".to_string()]),
+        chunking: None,
+    }];
+
+    let app = AppBuilder::new("text-to-sql")
+        .with_dataset(ds_tpcds_item)
+        .with_embedding(get_huggingface_embeddings(
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "hf_minilm",
+        ))
+        .build();
+
+    let http_port = rand::thread_rng().gen_range(50000..60000);
+
+    tracing::debug!("Running Spice runtime with http port: {http_port}");
+
+    let api_config = Config::new().with_http_bind_address(SocketAddr::new(LOCALHOST, http_port));
+    let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+    let rt_ref_copy = Arc::clone(&rt);
+    tokio::spawn(async move {
+        Box::pin(rt_ref_copy.start_servers(api_config, None, EndpointAuth::no_auth())).await
+    });
+
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+            return Err(anyhow::anyhow!("Timed out waiting for components to load"));
+        }
+        () = rt.load_components() => {}
+    }
+
+    runtime_ready_check(&rt).await;
+
+    let base_url = format!("http://localhost:{http_port}");
+
+    tracing::info!("/v1/search: Ensure simple search request succeeds");
+    let response = send_search_request(
+        base_url.as_str(),
+        "new patient",
+        Some(2),
+        Some(vec!["item".to_string()]),
+        None,
+        Some(vec!["i_color".to_string(), "i_item_id".to_string()]),
+    )
+    .await?;
+
+    insta::assert_snapshot!(format!("search_1"), normalize_search_response(response));
+
+    Ok(())
+}
 
 #[tokio::test]
 async fn huggingface_model_download_test() -> Result<(), anyhow::Error> {
@@ -75,74 +138,6 @@ async fn huggingface_model_download_test() -> Result<(), anyhow::Error> {
     }
 
     runtime_ready_check(&rt).await;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn huggingface_search_test() -> Result<(), anyhow::Error> {
-    let _tracing = init_tracing(None);
-
-    verify_env_secret_exists("SPICE_HF_TOKEN")
-        .await
-        .map_err(anyhow::Error::msg)?;
-
-    let mut ds_tpcds_item = get_tpcds_dataset("item");
-    ds_tpcds_item.embeddings = vec![ColumnEmbeddingConfig {
-        column: "i_item_desc".to_string(),
-        model: "hf_minilm".to_string(),
-        primary_keys: Some(vec!["i_item_sk".to_string()]),
-        chunking: Some(EmbeddingChunkConfig {
-            enabled: true,
-            target_chunk_size: 1000,
-            overlap_size: 100,
-            trim_whitespace: true,
-        }),
-    }];
-
-    let app = AppBuilder::new("text-to-sql")
-        .with_dataset(ds_tpcds_item)
-        .with_embedding(get_huggingface_embeddings(
-            "sentence-transformers/all-MiniLM-L6-v2",
-            "hf_minilm",
-        ))
-        .build();
-
-    let http_port = rand::thread_rng().gen_range(50000..60000);
-
-    tracing::debug!("Running Spice runtime with http port: {http_port}");
-
-    let api_config = Config::new().with_http_bind_address(SocketAddr::new(LOCALHOST, http_port));
-    let rt = Arc::new(Runtime::builder().with_app(app).build().await);
-
-    let rt_ref_copy = Arc::clone(&rt);
-    tokio::spawn(async move {
-        Box::pin(rt_ref_copy.start_servers(api_config, None, EndpointAuth::no_auth())).await
-    });
-
-    tokio::select! {
-        () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
-            return Err(anyhow::anyhow!("Timed out waiting for components to load"));
-        }
-        () = rt.load_components() => {}
-    }
-
-    runtime_ready_check(&rt).await;
-
-    let base_url = format!("http://localhost:{http_port}");
-
-    tracing::info!("/v1/search: Ensure simple search request succeeds");
-    let response = send_search_request(
-        base_url.as_str(),
-        "worldwide school",
-        Some(2),
-        Some(vec!["item".to_string()]),
-        None,
-        Some(vec!["i_color".to_string(), "i_item_id".to_string()]),
-    )
-    .await?;
-
-    insta::assert_snapshot!(format!("search_1"), normalize_search_response(response));
 
     Ok(())
 }

--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -57,7 +57,7 @@ fn get_tpcds_dataset(ds_name: &str) -> Dataset {
     ));
     dataset.acceleration = Some(Acceleration {
         enabled: true,
-        refresh_sql: Some(format!("SELECT * FROM {ds_name} LIMIT 10")),
+        refresh_sql: Some(format!("SELECT * FROM {ds_name} LIMIT 20")),
         ..Default::default()
     });
     dataset

--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -15,13 +15,15 @@ limitations under the License.
 */
 
 use reqwest::Client;
-use serde_json::json;
 use spicepod::component::{
     dataset::{acceleration::Acceleration, Dataset},
     params::Params,
 };
 
+use serde_json::{json, Value};
+
 mod openai;
+mod hf;
 
 fn get_taxi_trips_dataset() -> Dataset {
     let mut dataset = Dataset::new("s3://spiceai-demo-datasets/taxi_trips/2024/", "taxi_trips");
@@ -41,13 +43,46 @@ fn get_taxi_trips_dataset() -> Dataset {
     dataset
 }
 
+fn get_tpcds_dataset(ds_name: &str) -> Dataset {
+    let mut dataset = Dataset::new(
+        format!("s3://spiceai-public-datasets/tpcds/{ds_name}/"),
+        ds_name,
+    );
+    dataset.params = Some(Params::from_string_map(
+        vec![
+            ("file_format".to_string(), "parquet".to_string()),
+            ("client_timeout".to_string(), "120s".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    ));
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        refresh_sql: Some(format!("SELECT * FROM {ds_name} LIMIT 10")),
+        ..Default::default()
+    });
+    dataset
+}
+
+fn json_is_single_row_with_value(json: &Value, expected_value: i64) -> bool {
+    json.as_array()
+        .filter(|array| array.len() == 1)
+        .and_then(|array| array.first())
+        .map_or(false, |item| {
+            item.as_object().map_or(false, |map| {
+                map.values()
+                    .any(|value| value == &Value::from(expected_value))
+            })
+        })
+}
+
 async fn send_nsql_request(
     base_url: &str,
     query: &str,
     model: Option<&str>,
     sample_data_enabled: Option<bool>,
     datasets: Option<Vec<String>>,
-) -> Result<String, reqwest::Error> {
+) -> Result<Value, reqwest::Error> {
     let mut request_body = json!({
         "query": query,
     });
@@ -61,13 +96,74 @@ async fn send_nsql_request(
     if let Some(ds) = datasets {
         request_body["datasets"] = json!(ds);
     }
-    Client::new()
+    let response = Client::new()
         .post(format!("{base_url}/v1/nsql"))
         .header("Content-Type", "application/json")
         .json(&request_body)
         .send()
         .await?
         .error_for_status()?
-        .text()
-        .await
+        .json::<Value>()
+        .await?;
+
+    Ok(response)
+}
+
+async fn send_search_request(
+    base_url: &str,
+    text: &str,
+    limit: Option<usize>,
+    datasets: Option<Vec<String>>,
+    where_cond: Option<&str>,
+    additional_columns: Option<Vec<String>>,
+) -> Result<Value, reqwest::Error> {
+    let mut request_body = json!({
+        "text": text,
+    });
+
+    if let Some(limit) = limit {
+        request_body["limit"] = json!(limit);
+    }
+
+    if let Some(ds) = datasets {
+        request_body["datasets"] = json!(ds);
+    }
+
+    if let Some(where_cond) = where_cond {
+        request_body["where_cond"] = json!(where_cond);
+    }
+
+    if let Some(columns) = additional_columns {
+        request_body["additional_columns"] = json!(columns);
+    }
+
+    let response = Client::new()
+        .post(format!("{base_url}/v1/search"))
+        .header("Content-Type", "application/json")
+        .json(&request_body)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Value>()
+        .await?;
+
+    Ok(response)
+}
+
+fn verify_search_response(json: &Value, num_matches_expected: usize) -> Result<(), String> {
+    let matches = json
+        .get("matches")
+        .ok_or("Response does not contain a 'matches' field")?
+        .as_array()
+        .ok_or("The 'matches' field is not an array")?;
+
+    if matches.len() != num_matches_expected {
+        return Err(format!(
+            "Expected {} records in 'matches', but found {}",
+            num_matches_expected,
+            matches.len()
+        ));
+    }
+
+    Ok(())
 }

--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -21,9 +21,8 @@ use spicepod::component::{
 };
 
 use serde_json::{json, Value};
-
-mod openai;
 mod hf;
+mod openai;
 
 fn get_taxi_trips_dataset() -> Dataset {
     let mut dataset = Dataset::new("s3://spiceai-demo-datasets/taxi_trips/2024/", "taxi_trips");
@@ -150,20 +149,18 @@ async fn send_search_request(
     Ok(response)
 }
 
-fn verify_search_response(json: &Value, num_matches_expected: usize) -> Result<(), String> {
-    let matches = json
-        .get("matches")
-        .ok_or("Response does not contain a 'matches' field")?
-        .as_array()
-        .ok_or("The 'matches' field is not an array")?;
-
-    if matches.len() != num_matches_expected {
-        return Err(format!(
-            "Expected {} records in 'matches', but found {}",
-            num_matches_expected,
-            matches.len()
-        ));
+fn normalize_search_response(mut json: Value) -> String {
+    if let Some(matches) = json.get_mut("matches").and_then(|m| m.as_array_mut()) {
+        for m in matches {
+            if let Some(score) = m.get_mut("score") {
+                *score = json!("score_val");
+            }
+        }
     }
 
-    Ok(())
+    if let Some(duration) = json.get_mut("duration_ms") {
+        *duration = json!("duration_ms_val");
+    }
+
+    json.to_string()
 }

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -24,7 +24,7 @@ use app::AppBuilder;
 use rand::Rng;
 use runtime::{auth::EndpointAuth, config::Config, Runtime};
 use spicepod::component::{
-    embeddings::{ColumnEmbeddingConfig, EmbeddingChunkConfig, Embeddings},
+    embeddings::{ColumnEmbeddingConfig, Embeddings},
     model::Model,
 };
 
@@ -146,12 +146,7 @@ async fn openai_search_test() -> Result<(), anyhow::Error> {
         column: "i_item_desc".to_string(),
         model: "openai_embeddings".to_string(),
         primary_keys: Some(vec!["i_item_sk".to_string()]),
-        chunking: Some(EmbeddingChunkConfig {
-            enabled: true,
-            target_chunk_size: 1000,
-            overlap_size: 100,
-            trim_whitespace: true,
-        }),
+        chunking: None,
     }];
 
     let app = AppBuilder::new("search_app")
@@ -187,7 +182,7 @@ async fn openai_search_test() -> Result<(), anyhow::Error> {
     tracing::info!("/v1/search: Ensure simple search request succeeds");
     let response = send_search_request(
         base_url.as_str(),
-        "worldwide school",
+        "vehicles and journalists",
         Some(2),
         Some(vec!["item".to_string()]),
         None,

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
+    time::Duration,
 };
 
 use app::AppBuilder;
@@ -32,7 +33,7 @@ use crate::{
     init_tracing,
     models::{
         get_taxi_trips_dataset, get_tpcds_dataset, json_is_single_row_with_value,
-        send_nsql_request, send_search_request, verify_search_response,
+        normalize_search_response, send_nsql_request, send_search_request,
     },
     utils::{runtime_ready_check, verify_env_secret_exists},
 };
@@ -155,8 +156,6 @@ async fn openai_search_test() -> Result<(), anyhow::Error> {
     }];
 
     let app = AppBuilder::new("search_app")
-        // taxi_trips is added to test search against dataset with no embeddings
-        .with_dataset(get_taxi_trips_dataset())
         .with_dataset(ds_tpcds_item)
         .with_embedding(get_openai_embeddings("openai_embeddings"))
         .build();
@@ -184,17 +183,20 @@ async fn openai_search_test() -> Result<(), anyhow::Error> {
 
     let base_url = format!("http://localhost:{http_port}");
 
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
     tracing::info!("/v1/search: Ensure simple search request succeeds");
     let response = send_search_request(
         base_url.as_str(),
-        "original item",
-        Some(3),
+        "worldwide school",
+        Some(2),
         Some(vec!["item".to_string()]),
         None,
-        None,
+        Some(vec!["i_color".to_string(), "i_item_id".to_string()]),
     )
     .await?;
-    verify_search_response(&response, 3).map_err(anyhow::Error::msg)?;
+
+    insta::assert_snapshot!(format!("search_1"), normalize_search_response(response));
 
     Ok(())
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__hf__search_1.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__hf__search_1.snap
@@ -1,0 +1,5 @@
+---
+source: crates/runtime/tests/models/hf.rs
+expression: normalize_search_response(response)
+---
+{"duration_ms":"duration_ms_val","matches":[{"dataset":"item","metadata":{"i_color":"smoke","i_item_id":"AAAAAAAADBAAAAAA"},"primary_key":{"i_item_sk":19},"score":"score_val","value":"Patient"},{"dataset":"item","metadata":{"i_color":"spring","i_item_id":"AAAAAAAAHAAAAAAA"},"primary_key":{"i_item_sk":7},"score":"score_val","value":"New"}]}

--- a/crates/runtime/tests/models/snapshots/integration_models__models__openai__search_1.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__openai__search_1.snap
@@ -1,0 +1,5 @@
+---
+source: crates/runtime/tests/models/openai.rs
+expression: normalize_search_response(response)
+---
+{"duration_ms":"duration_ms_val","matches":[{"dataset":"item","metadata":{"i_color":"royal","i_item_id":"AAAAAAAAOAAAAAAA"},"primary_key":{"i_item_sk":15},"score":"score_val","value":"Important grounds rip there just big vehicles. Journalists w"},{"dataset":"item","metadata":{"i_color":"red","i_item_id":"AAAAAAAAOAAAAAAA"},"primary_key":{"i_item_sk":14},"score":"score_val","value":"Important grounds rip there just big vehicles. Journalists w"}]}

--- a/crates/spicepod/src/component/embeddings.rs
+++ b/crates/spicepod/src/component/embeddings.rs
@@ -62,6 +62,18 @@ impl WithDependsOn<Embeddings> for Embeddings {
 
 impl Embeddings {
     #[must_use]
+    pub fn new(from: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            name: name.into(),
+            files: Vec::default(),
+            params: HashMap::default(),
+            datasets: Vec::default(),
+            depends_on: Vec::default(),
+        }
+    }
+
+    #[must_use]
     pub fn get_prefix(&self) -> Option<EmbeddingPrefix> {
         EmbeddingPrefix::try_from(self.from.as_str()).ok()
     }


### PR DESCRIPTION
## 🗣 Description
Add integration tests for Search API (OpenAI and HF models)

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3009

## 🤔 Concerns

Was unable to get NSQL functionality working with any of the small local models (models are not supported due to lack of `tool` functionality or unable to generate valid SQL to execute) as a result there is a test to download and initialize the `meta-llama/Llama-3.2-1B-Instruct` local model, this test will be improved to test model can be actually invoked with Spice `chat` functionality
