### PR TITLE
Support Kafka-native authentication and TLS connections for Debezium connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9027,6 +9027,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum 0.5.11",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -42,7 +42,7 @@ graph-rs-sdk = {workspace = true, optional=true}
 graphql-parser.workspace = true
 http = {version= "1.1.0", optional=true}
 object_store = { workspace = true }
-rdkafka = { version = "0.36.2", optional = true }
+rdkafka = { version = "0.36.2", features = ["ssl"], optional = true }
 regex = "1.10.4"
 reqwest.workspace = true
 rusqlite = { workspace = true, optional = true }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -147,24 +147,24 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description(
             "A list of host/port pairs for establishing the initial Kafka cluster connection.",
         ),
-    ParameterSpec::runtime("kafka_security_protocol")
+     ParameterSpec::runtime("kafka_security_protocol")
         .default("sasl_ssl")
-        .description("The security protocol to use. The default is sasl_ssl. Valid values: plaintext, ssl, sasl_plaintext, sasl_ssl."),
+        .description("Security protocol for Kafka connections. Default: 'sasl_ssl'. Options: 'plaintext', 'ssl', 'sasl_plaintext', 'sasl_ssl'."),
     ParameterSpec::runtime("kafka_sasl_mechanism")
         .default("SCRAM-SHA-512")
-        .description("The SASL mechanism to use. The default is SCRAM-SHA-512. Valid values: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512."),
+        .description("SASL authentication mechanism. Default: 'SCRAM-SHA-512'. Options: 'PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512'."),
     ParameterSpec::runtime("kafka_sasl_username")
         .secret()
-        .description("The SASL username to use."),
+        .description("SASL username."),
     ParameterSpec::runtime("kafka_sasl_password")
         .secret()
-        .description("The SASL password to use."),
+        .description("SASL password."),
     ParameterSpec::runtime("kafka_ssl_ca_location")
         .secret()
-        .description("The location of the SSL/TLS CA certificate file to use to verify the server's certificate."),
+        .description("Path to the SSL/TLS CA certificate file for server verification."),
     ParameterSpec::runtime("kafka_enable_ssl_certificate_verification")
         .default("true")
-        .description("Whether to enable SSL/TLS certificate verification. The default is true."),
+        .description("Enable SSL/TLS certificate verification. Default: 'true'."),
 ];
 
 impl DataConnectorFactory for DebeziumFactory {

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -25,7 +25,7 @@ use data_components::cdc::ChangesStream;
 use data_components::debezium::change_event::{ChangeEvent, ChangeEventKey};
 use data_components::debezium::{self, change_event};
 use data_components::debezium_kafka::DebeziumKafka;
-use data_components::kafka::KafkaConsumer;
+use data_components::kafka::{KafkaConfig, KafkaConsumer};
 use datafusion::datasource::TableProvider;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -53,7 +53,7 @@ pub enum Error {
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct Debezium {
-    kafka_brokers: String,
+    kafka_config: KafkaConfig,
 }
 
 impl Debezium {
@@ -70,15 +70,51 @@ impl Debezium {
             return InvalidMessageFormatSnafu.fail();
         }
 
-        let kakfa_brokers = params
-            .get("kafka_bootstrap_servers")
-            .expose()
-            .ok()
-            .context(MissingKafkaBootstrapServersSnafu)?;
+        let kafka_config = KafkaConfig {
+            brokers: params
+                .get("kafka_bootstrap_servers")
+                .expose()
+                .ok()
+                .context(MissingKafkaBootstrapServersSnafu)?
+                .to_string(),
+            security_protocol: params
+                .get("kafka_security_protocol")
+                .expose()
+                .ok()
+                .unwrap_or("sasl_ssl")
+                .to_string(),
+            sasl_mechanism: params
+                .get("kafka_sasl_mechanism")
+                .expose()
+                .ok()
+                .unwrap_or("SCRAM-SHA-512")
+                .to_string(),
+            sasl_username: params
+                .get("kafka_sasl_username")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
+            sasl_password: params
+                .get("kafka_sasl_password")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
+            ssl_ca_location: params
+                .get("kafka_ssl_ca_location")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
+            enable_ssl_certificate_verification: params
+                .get("kafka_enable_ssl_certificate_verification")
+                .expose()
+                .ok()
+                .unwrap_or("true")
+                .to_string()
+                .parse()
+                .unwrap_or(true),
+        };
 
-        Ok(Self {
-            kafka_brokers: kakfa_brokers.to_string(),
-        })
+        Ok(Self { kafka_config })
     }
 }
 
@@ -111,6 +147,24 @@ const PARAMETERS: &[ParameterSpec] = &[
         .description(
             "A list of host/port pairs for establishing the initial Kafka cluster connection.",
         ),
+    ParameterSpec::runtime("kafka_security_protocol")
+        .default("sasl_ssl")
+        .description("The security protocol to use. The default is sasl_ssl. Valid values: plaintext, ssl, sasl_plaintext, sasl_ssl."),
+    ParameterSpec::runtime("kafka_sasl_mechanism")
+        .default("SCRAM-SHA-512")
+        .description("The SASL mechanism to use. The default is SCRAM-SHA-512. Valid values: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512."),
+    ParameterSpec::runtime("kafka_sasl_username")
+        .secret()
+        .description("The SASL username to use."),
+    ParameterSpec::runtime("kafka_sasl_password")
+        .secret()
+        .description("The SASL password to use."),
+    ParameterSpec::runtime("kafka_ssl_ca_location")
+        .secret()
+        .description("The location of the SSL/TLS CA certificate file to use to verify the server's certificate."),
+    ParameterSpec::runtime("kafka_enable_ssl_certificate_verification")
+        .default("true")
+        .description("Whether to enable SSL/TLS certificate verification. The default is true."),
 ];
 
 impl DataConnectorFactory for DebeziumFactory {
@@ -189,7 +243,7 @@ impl DataConnector for Debezium {
             Some(metadata) => {
                 let kafka_consumer = KafkaConsumer::create_with_existing_group_id(
                     &metadata.consumer_group_id,
-                    self.kafka_brokers.clone(),
+                    self.kafka_config.clone(),
                 )
                 .boxed()
                 .context(super::UnableToGetReadProviderSnafu {
@@ -220,7 +274,7 @@ impl DataConnector for Debezium {
 
                 (kafka_consumer, metadata, Arc::new(schema))
             }
-            None => get_metadata_from_kafka(dataset, &topic, self.kafka_brokers.clone()).await?,
+            None => get_metadata_from_kafka(dataset, &topic, self.kafka_config.clone()).await?,
         };
 
         let debezium_kafka = Arc::new(DebeziumKafka::new(
@@ -276,15 +330,14 @@ async fn set_metadata_to_accelerator(
 async fn get_metadata_from_kafka(
     dataset: &Dataset,
     topic: &str,
-    kafka_brokers: String,
+    kafka_config: KafkaConfig,
 ) -> super::DataConnectorResult<(KafkaConsumer, DebeziumKafkaMetadata, SchemaRef)> {
     let dataset_name = dataset.name.to_string();
-    let kafka_consumer =
-        KafkaConsumer::create_with_generated_group_id(&dataset_name, kafka_brokers)
-            .boxed()
-            .context(super::UnableToGetReadProviderSnafu {
-                dataconnector: "debezium",
-            })?;
+    let kafka_consumer = KafkaConsumer::create_with_generated_group_id(&dataset_name, kafka_config)
+        .boxed()
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "debezium",
+        })?;
 
     kafka_consumer
         .subscribe(topic)


### PR DESCRIPTION
## 🗣 Description

Adds support for Kafka SASL authentication (Simple Authentication and Security Layer), along with supporting connections over TLS (called by its deprecated name SSL in the Kafka parameters).

There weren't any major changes needed to support this, mostly just documenting new parameters and wiring them up the underlying library (rdkafka) config. I've created a new sample that demonstrates these new parameters: https://github.com/spiceai/samples/pull/132

With this change, the default `kafka_security_protocol` will change from `PLAINTEXT` to `SASL_SSL`, in line with our secure by default principle.

New parameters:
- `kafka_security_protocol`: The security protocol to use. The default is sasl_ssl. Valid values: plaintext, ssl, sasl_plaintext, sasl_ssl.
- `kafka_sasl_mechanism`: The SASL mechanism to use. The default is SCRAM-SHA-512. Valid values: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512.
- `kafka_sasl_username`: Optional. The SASL username to use.
- `kafka_sasl_password`: Optional. The SASL password to use.
- `kafka_ssl_ca_location`: Optional. The location of the SSL/TLS CA certificate file to use to verify the server's certificate.
- `kafka_enable_ssl_certificate_verification`: Whether to enable SSL/TLS certificate verification. The default is true.

The names of these parameters are derived from their underlying config names in librdkafka: https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html

## 🔨 Related Issues

Part of #3355

## 📄 Documentation Requirements

Will require a docs change for documenting these new parameters.

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
