### PR TITLE
Give local models some love

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6792,7 +6792,7 @@ checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 [[package]]
 name = "mistralrs"
 version = "0.3.1"
-source = "git+https://github.com/spiceai/mistral.rs?rev=60e9375b6049eead77cbda7cb3d3d83187f501a2#60e9375b6049eead77cbda7cb3d3d83187f501a2"
+source = "git+https://github.com/spiceai/mistral.rs?rev=c43f27decbeef1267a2685c6f0126766fbc0ee87#c43f27decbeef1267a2685c6f0126766fbc0ee87"
 dependencies = [
  "anyhow",
  "candle-core 0.7.2 (git+https://github.com/EricLBuehler/candle.git?rev=20a57c4)",
@@ -6811,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.3.1"
-source = "git+https://github.com/spiceai/mistral.rs?rev=60e9375b6049eead77cbda7cb3d3d83187f501a2#60e9375b6049eead77cbda7cb3d3d83187f501a2"
+source = "git+https://github.com/spiceai/mistral.rs?rev=c43f27decbeef1267a2685c6f0126766fbc0ee87#c43f27decbeef1267a2685c6f0126766fbc0ee87"
 dependencies = [
  "akin",
  "anyhow",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.3.1"
-source = "git+https://github.com/spiceai/mistral.rs?rev=60e9375b6049eead77cbda7cb3d3d83187f501a2#60e9375b6049eead77cbda7cb3d3d83187f501a2"
+source = "git+https://github.com/spiceai/mistral.rs?rev=c43f27decbeef1267a2685c6f0126766fbc0ee87#c43f27decbeef1267a2685c6f0126766fbc0ee87"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.6",
@@ -6890,7 +6890,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.3.1"
-source = "git+https://github.com/spiceai/mistral.rs?rev=60e9375b6049eead77cbda7cb3d3d83187f501a2#60e9375b6049eead77cbda7cb3d3d83187f501a2"
+source = "git+https://github.com/spiceai/mistral.rs?rev=c43f27decbeef1267a2685c6f0126766fbc0ee87#c43f27decbeef1267a2685c6f0126766fbc0ee87"
 dependencies = [
  "bindgen_cuda 0.1.5",
  "byteorder",
@@ -6907,7 +6907,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-vision"
 version = "0.3.1"
-source = "git+https://github.com/spiceai/mistral.rs?rev=60e9375b6049eead77cbda7cb3d3d83187f501a2#60e9375b6049eead77cbda7cb3d3d83187f501a2"
+source = "git+https://github.com/spiceai/mistral.rs?rev=c43f27decbeef1267a2685c6f0126766fbc0ee87#c43f27decbeef1267a2685c6f0126766fbc0ee87"
 dependencies = [
  "candle-core 0.7.2 (git+https://github.com/EricLBuehler/candle.git?rev=20a57c4)",
  "image 0.25.4",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -16,40 +16,56 @@ snafu.workspace = true
 async-openai.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-serde_json.workspace = true
-tokio.workspace = true
-schemars  = "0.8.19"
 futures = { workspace = true }
-insta = { workspace = true, features = ["filters"] }
 hf-hub = { version = "0.3.0", features = ["tokio"] }
+insta = { workspace = true, features = ["filters"] }
+regex = "1.10.4"
 reqwest.workspace = true
 reqwest-eventsource = "0.6.0"
-serde = { workspace = true, features = ["derive"] }
+schemars = "0.8.19"
 secrecy.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 tokenizers = { version = "0.20.0" }
+tokio.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
-regex = "1.10.4"
 
 ## For Chunking
-text-splitter = { version =  "0.18.1", features = ["markdown", "tokenizers", "tiktoken-rs"]}
 pulldown-cmark = "0.12.1"
+text-splitter = { version = "0.18.1", features = [
+    "markdown",
+    "tokenizers",
+    "tiktoken-rs",
+] }
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "60e9375b6049eead77cbda7cb3d3d83187f501a2", optional = true }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "60e9375b6049eead77cbda7cb3d3d83187f501a2", optional = true, package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "c43f27decbeef1267a2685c6f0126766fbc0ee87", optional = true }
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "c43f27decbeef1267a2685c6f0126766fbc0ee87", optional = true, package = "mistralrs-core" }
 rand = "0.8.5"
+tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "afbb039cc50354e9c591d9126d08c1647429151d", features = [
+    "candle",
+] }
 tei_backend_core = { package = "text-embeddings-backend-core", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "afbb039cc50354e9c591d9126d08c1647429151d" }
 tei_candle = { package = "text-embeddings-backend-candle", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "afbb039cc50354e9c591d9126d08c1647429151d" }
-tei_core = { package = "text-embeddings-core",  git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "afbb039cc50354e9c591d9126d08c1647429151d" }
-tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "afbb039cc50354e9c591d9126d08c1647429151d", features = ["candle"] }
+tei_core = { package = "text-embeddings-core", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "afbb039cc50354e9c591d9126d08c1647429151d" }
 
-tempfile = "3.13.0"
-indexmap = "2.3.0"
 either = "1.13.0"
+indexmap = "2.3.0"
+tempfile = "3.13.0"
 
 [features]
+cuda = [
+    "tei_backend/cuda",
+    "tei_candle/cuda",
+    "mistralrs-core/cuda",
+    "mistralrs/cuda",
+]
 default = ["mistralrs"]
-metal = ["tei_backend/metal", "tei_candle/metal", "mistralrs-core/metal", "mistralrs/metal"]
-cuda = ["tei_backend/cuda", "tei_candle/cuda", "mistralrs-core/cuda", "mistralrs/cuda"]
+metal = [
+    "tei_backend/metal",
+    "tei_candle/metal",
+    "mistralrs-core/metal",
+    "mistralrs/metal",
+]
 mistralrs = ["dep:mistralrs", "dep:mistralrs-core"]

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -109,7 +109,7 @@ impl Display for ModelSource {
             ModelSource::OpenAi => write!(f, "openai"),
             ModelSource::Anthropic => write!(f, "anthropic"),
             ModelSource::HuggingFace => write!(f, "huggingface:huggingface.co"),
-            ModelSource::File => write!(f, "file:"),
+            ModelSource::File => write!(f, "file"),
             ModelSource::SpiceAI => write!(f, "spiceai"),
         }
     }


### PR DESCRIPTION
## 🗣 Description
 - Don't force GGUF to have extra files (when they don't need it)
 - Add param `chat_template` for local model, which is a string literal for chat template (many GGUF do not have chat_templates baked in). 
 - Simplify local model code. 
 - Enable local model code for non-GGUF/GGML.

## 🔨 Related Issues/PRs
 - Changes to mistral.rs library: https://github.com/spiceai/mistral.rs/pull/8 

## 📄 Documentation Requirements
 - [ ] Add `params.chat_template` to docs.
