### PR TITLE
Have views update on `--pods-watcher-enabled`

### DIFF
--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -40,7 +40,7 @@ use snafu::ResultExt;
 use std::{
     collections::HashMap,
     num::NonZeroUsize,
-    path::{Path, PathBuf},
+    path::Path,
     pin::Pin,
     str::FromStr,
     sync::{

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -40,7 +40,7 @@ use snafu::ResultExt;
 use std::{
     collections::HashMap,
     num::NonZeroUsize,
-    path::Path,
+    path::{Path, PathBuf},
     pin::Pin,
     str::FromStr,
     sync::{
@@ -95,10 +95,10 @@ impl MistralLlama {
         tokenizer_config: &Path,
     ) -> Box<dyn ModelPaths> {
         Box::new(LocalModelPaths::new(
-            tokenizer.map(Into::into).unwrap_or_default(),
+            tokenizer.map_or(PathBuf::default(), Into::into),
             // Not needed for LLama2 / DuckDB Chat, but needed in `EricLBuehler/mistral.rs`.
-            tokenizer.map(Into::into).unwrap_or_default(),
-            tokenizer_config.into(),
+            tokenizer.map_or(PathBuf::default(), Into::into),
+            Some(tokenizer_config.to_path_buf()),
             vec![model_weights.into()],
             None,
             None,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -582,6 +582,20 @@ impl DataFusion {
         self.ctx.catalog(catalog).is_some()
     }
 
+    pub fn remove_view(&self, view_name: &TableReference) -> Result<()> {
+        if !self.ctx.table_exist(view_name.clone()).unwrap_or(false) {
+            return Ok(());
+        }
+
+        if let Err(e) = self.ctx.deregister_table(view_name.clone()) {
+            return UnableToDeleteTableSnafu {
+                reason: e.to_string(),
+            }
+            .fail();
+        }
+        Ok(())
+    }
+
     pub async fn remove_table(&self, dataset_name: &TableReference) -> Result<()> {
         if !self.ctx.table_exist(dataset_name.clone()).unwrap_or(false) {
             return Ok(());

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1653,7 +1653,7 @@ impl Runtime {
 
         // Get ordering of views to load, including those unchanged but with dependencies that have changed
         // If we can't determine the order, we'll just load the views in the order they are in the app
-        let afffected_views_in_order_of_dependencies = match valid_views
+        let affected_views_in_order_of_dependencies = match valid_views
             .iter()
             .map(|v| {
                 let Some(statement) =

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -808,9 +808,32 @@ impl Runtime {
     fn load_view(&self, view: &View) -> Result<()> {
         let df = Arc::clone(&self.df);
         df.register_view(view.name.clone(), view.sql.clone())
-            .context(UnableToAttachViewSnafu)?;
+            .context(UnableToAttachViewSnafu)
+            .inspect_err(|_| {
+                self.status
+                    .update_view(&view.name, status::ComponentStatus::Error);
+            })?;
 
+        self.status
+            .update_view(&view.name, status::ComponentStatus::Ready);
         Ok(())
+    }
+
+    fn remove_view(&self, view: &View) {
+        if self.df.table_exists(view.name.clone()) {
+            if let Err(e) = self.df.remove_view(&view.name) {
+                tracing::warn!("Unable to unload view {}: {}", &view.name, e);
+                return;
+            }
+        }
+        tracing::info!("Unloaded view {}", &view.name);
+    }
+
+    fn update_view(&self, view: &View) {
+        self.status
+            .update_view(&view.name, status::ComponentStatus::Refreshing);
+        self.remove_view(view);
+        let _ = self.load_view(view);
     }
 
     async fn load_catalog_connector(&self, catalog: &Catalog) -> Result<Arc<dyn DataConnector>> {
@@ -1565,6 +1588,113 @@ impl Runtime {
         Ok(())
     }
 
+    async fn apply_model_diff(&self, current_app: &Arc<App>, new_app: &Arc<App>) {
+        for model in &new_app.models {
+            if let Some(current_model) = current_app.models.iter().find(|m| m.name == model.name) {
+                if current_model != model {
+                    self.update_model(model).await;
+                }
+            } else {
+                self.status
+                    .update_model(&model.name, status::ComponentStatus::Initializing);
+                self.load_model(model).await;
+            }
+        }
+
+        // Remove models that are no longer in the app
+        for model in &current_app.models {
+            if !new_app.models.iter().any(|m| m.name == model.name) {
+                self.status
+                    .update_model(&model.name, status::ComponentStatus::Disabled);
+                self.remove_model(model).await;
+            }
+        }
+    }
+
+    fn apply_view_diff(&self, current_app: &Arc<App>, new_app: &Arc<App>) {
+        let valid_views = Self::get_valid_views(new_app, LogErrors(true));
+        let existing_views = Self::get_valid_views(current_app, LogErrors(false));
+        for view in valid_views {
+            if let Some(current_view) = existing_views.iter().find(|v| v.name == view.name) {
+                if view != *current_view {
+                    self.update_view(&view);
+                }
+            } else {
+                self.status
+                    .update_view(&view.name, status::ComponentStatus::Initializing);
+                let _ = self.load_view(&view);
+            }
+        }
+
+        // Remove views that are no longer in the app
+        for view in &current_app.views {
+            if !new_app.views.iter().any(|v| v.name == view.name) {
+                let view = match View::try_from(view.clone()) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::error!("Could not remove view {}: {e}", view.name);
+                        continue;
+                    }
+                };
+                self.status
+                    .update_view(&view.name, status::ComponentStatus::Disabled);
+                self.remove_view(&view);
+            }
+        }
+    }
+
+    async fn apply_dataset_diff(&self, current_app: &Arc<App>, new_app: &Arc<App>) {
+        let valid_datasets = Self::get_valid_datasets(new_app, LogErrors(true));
+        let existing_datasets = Self::get_valid_datasets(current_app, LogErrors(false));
+
+        for ds in valid_datasets {
+            if let Some(current_ds) = existing_datasets.iter().find(|d| d.name == ds.name) {
+                if ds != *current_ds {
+                    self.update_dataset(ds).await;
+                }
+            } else {
+                self.status
+                    .update_dataset(&ds.name, status::ComponentStatus::Initializing);
+                self.load_dataset(ds).await;
+            }
+        }
+
+        // Remove datasets that are no longer in the app
+        for ds in &current_app.datasets {
+            if !new_app.datasets.iter().any(|d| d.name == ds.name) {
+                let ds = match Dataset::try_from(ds.clone()) {
+                    Ok(ds) => ds,
+                    Err(e) => {
+                        tracing::error!("Could not remove dataset {}: {e}", ds.name);
+                        continue;
+                    }
+                };
+                self.status
+                    .update_dataset(&ds.name, status::ComponentStatus::Disabled);
+                self.remove_dataset(&ds).await;
+            }
+        }
+    }
+
+    async fn apply_catalog_diff(&self, current_app: &Arc<App>, new_app: &Arc<App>) {
+        let valid_catalogs = Self::get_valid_catalogs(new_app, LogErrors(true));
+        let existing_catalogs = Self::get_valid_catalogs(current_app, LogErrors(false));
+
+        for catalog in &valid_catalogs {
+            if let Some(current_catalog) = existing_catalogs.iter().find(|c| c.name == catalog.name)
+            {
+                if catalog != current_catalog {
+                    // It isn't currently possible to remove catalogs once they have been loaded in DataFusion. `load_catalog` will overwrite the existing catalog.
+                    self.load_catalog(catalog).await;
+                }
+            } else {
+                self.status
+                    .update_catalog(&catalog.name, status::ComponentStatus::Initializing);
+                self.load_catalog(catalog).await;
+            }
+        }
+    }
+
     async fn start_pods_watcher(&self) -> notify::Result<()> {
         let mut pods_watcher = self.pods_watcher.write().await;
         let Some(mut pods_watcher) = pods_watcher.take() else {
@@ -1583,80 +1713,10 @@ impl Runtime {
                 tracing::debug!("Updated pods information: {:?}", new_app);
                 tracing::debug!("Previous pods information: {:?}", current_app);
 
-                // Check for new and updated catalogs
-                let valid_catalogs = Self::get_valid_catalogs(&new_app, LogErrors(true));
-                let existing_catalogs = Self::get_valid_catalogs(current_app, LogErrors(false));
-
-                for catalog in &valid_catalogs {
-                    if let Some(current_catalog) =
-                        existing_catalogs.iter().find(|c| c.name == catalog.name)
-                    {
-                        if catalog != current_catalog {
-                            // It isn't currently possible to remove catalogs once they have been loaded in DataFusion. `load_catalog` will overwrite the existing catalog.
-                            self.load_catalog(catalog).await;
-                        }
-                    } else {
-                        self.status
-                            .update_catalog(&catalog.name, status::ComponentStatus::Initializing);
-                        self.load_catalog(catalog).await;
-                    }
-                }
-
-                // Check for new and updated datasets
-                let valid_datasets = Self::get_valid_datasets(&new_app, LogErrors(true));
-                let existing_datasets = Self::get_valid_datasets(current_app, LogErrors(false));
-
-                for ds in valid_datasets {
-                    if let Some(current_ds) = existing_datasets.iter().find(|d| d.name == ds.name) {
-                        if ds != *current_ds {
-                            self.update_dataset(ds).await;
-                        }
-                    } else {
-                        self.status
-                            .update_dataset(&ds.name, status::ComponentStatus::Initializing);
-                        self.load_dataset(ds).await;
-                    }
-                }
-
-                // Remove datasets that are no longer in the app
-                for ds in &current_app.datasets {
-                    if !new_app.datasets.iter().any(|d| d.name == ds.name) {
-                        let ds = match Dataset::try_from(ds.clone()) {
-                            Ok(ds) => ds,
-                            Err(e) => {
-                                tracing::error!("Could not remove dataset {}: {e}", ds.name);
-                                continue;
-                            }
-                        };
-                        self.status
-                            .update_dataset(&ds.name, status::ComponentStatus::Disabled);
-                        self.remove_dataset(&ds).await;
-                    }
-                }
-
-                // check for new and updated models
-                for model in &new_app.models {
-                    if let Some(current_model) =
-                        current_app.models.iter().find(|m| m.name == model.name)
-                    {
-                        if current_model != model {
-                            self.update_model(model).await;
-                        }
-                    } else {
-                        self.status
-                            .update_model(&model.name, status::ComponentStatus::Initializing);
-                        self.load_model(model).await;
-                    }
-                }
-
-                // Remove models that are no longer in the app
-                for model in &current_app.models {
-                    if !new_app.models.iter().any(|m| m.name == model.name) {
-                        self.status
-                            .update_model(&model.name, status::ComponentStatus::Disabled);
-                        self.remove_model(model).await;
-                    }
-                }
+                self.apply_catalog_diff(current_app, &new_app).await;
+                self.apply_dataset_diff(current_app, &new_app).await;
+                self.apply_view_diff(current_app, &new_app);
+                self.apply_model_diff(current_app, &new_app).await;
 
                 *current_app = new_app;
             } else {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1616,6 +1616,9 @@ impl Runtime {
         }
     }
 
+    /// Update views based on changed between the current and new app.
+    /// This function will update views that have changed, and remove views that are no longer in the app.
+    /// It will also update views that have dependencies that have changed.
     fn apply_view_diff(&self, current_app: &Arc<App>, new_app: &Arc<App>) {
         let valid_views = Self::get_valid_views(new_app, LogErrors(true));
         let existing_views = Self::get_valid_views(current_app, LogErrors(false));
@@ -1648,7 +1651,8 @@ impl Runtime {
             }
         }
 
-        // Get ordering of views to load, including those unchanged
+        // Get ordering of views to load, including those unchanged but with dependencies that have changed
+        // If we can't determine the order, we'll just load the views in the order they are in the app
         let afffected_views_in_order_of_dependencies = match valid_views
             .iter()
             .map(|v| {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1674,7 +1674,7 @@ impl Runtime {
             Ok(deps) => construct_effected_in_topological_order(deps,&views_that_changed ),
         }.unwrap_or(valid_views.iter().map(|v| v.name.clone()).collect());
 
-        for view_name in afffected_views_in_order_of_dependencies {
+        for view_name in affected_views_in_order_of_dependencies {
             if let Some(view) = valid_views.iter().find(|v| v.name == view_name) {
                 if existing_views.iter().any(|v| v.name == view.name) {
                     // Update view even if unchanged, as it may have dependencies that have changed

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -23,6 +23,8 @@ use std::{collections::HashMap, sync::Arc};
 use crate::auth::EndpointAuth;
 use crate::{dataconnector::DataConnector, datafusion::DataFusion};
 use ::datafusion::error::DataFusionError;
+use ::datafusion::sql::parser::DFParser;
+use ::datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use ::datafusion::sql::{sqlparser, TableReference};
 use ::opentelemetry::KeyValue;
 use accelerated_table::AcceleratedTable;
@@ -43,6 +45,7 @@ use extension::ExtensionFactory;
 use federated_table::FederatedTable;
 use futures::future::join_all;
 use futures::{Future, StreamExt};
+use itertools::Itertools;
 use llms::chat::Chat;
 use llms::embeddings::Embed;
 use model::{
@@ -65,6 +68,7 @@ use tokio::sync::RwLock;
 use tools::builtin::get_builtin_tool_spec;
 use tools::factory as tool_factory;
 use tools::SpiceModelTool;
+use topological_ordering::construct_effected_in_topological_order;
 use tracing_util::dataset_registered_trace;
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 pub use util::shutdown_signal;
@@ -103,6 +107,7 @@ pub mod task_history;
 pub mod timing;
 pub mod tls;
 pub mod tools;
+pub mod topological_ordering;
 pub(crate) mod tracers;
 mod tracing_util;
 mod view;
@@ -1614,17 +1619,18 @@ impl Runtime {
     fn apply_view_diff(&self, current_app: &Arc<App>, new_app: &Arc<App>) {
         let valid_views = Self::get_valid_views(new_app, LogErrors(true));
         let existing_views = Self::get_valid_views(current_app, LogErrors(false));
-        for view in valid_views {
-            if let Some(current_view) = existing_views.iter().find(|v| v.name == view.name) {
-                if view != *current_view {
-                    self.update_view(&view);
+
+        let views_that_changed = valid_views
+            .iter()
+            .filter_map(|v| {
+                let old_v = existing_views.iter().find(|vv| v.name == vv.name)?;
+                if old_v == v {
+                    None
+                } else {
+                    Some(v.name.clone())
                 }
-            } else {
-                self.status
-                    .update_view(&view.name, status::ComponentStatus::Initializing);
-                let _ = self.load_view(&view);
-            }
-        }
+            })
+            .collect_vec();
 
         // Remove views that are no longer in the app
         for view in &current_app.views {
@@ -1639,6 +1645,41 @@ impl Runtime {
                 self.status
                     .update_view(&view.name, status::ComponentStatus::Disabled);
                 self.remove_view(&view);
+            }
+        }
+
+        // Get ordering of views to load, including those unchanged
+        let afffected_views_in_order_of_dependencies = match valid_views
+            .iter()
+            .map(|v| {
+                let Some(statement) =
+                    DFParser::parse_sql_with_dialect(v.sql.as_str(), &PostgreSqlDialect {})
+                        .boxed()?.pop_front() else {
+                            return Err(Box::<dyn std::error::Error + Send + Sync>::from(format!("no statements found in view {}", v.name)));
+                        };
+
+                let deps = view::get_dependent_table_names(&statement);
+                Ok((v.name.clone(), deps))
+            })
+            .collect::<Result<HashMap<TableReference, Vec<TableReference>>, _>>()
+        {
+            Err(e) => {
+                tracing::warn!("Unable to determine order to update views: {e}. Will still attempt to update views.");
+                None
+            }
+            Ok(deps) => construct_effected_in_topological_order(deps,&views_that_changed ),
+        }.unwrap_or(valid_views.iter().map(|v| v.name.clone()).collect());
+
+        for view_name in afffected_views_in_order_of_dependencies {
+            if let Some(view) = valid_views.iter().find(|v| v.name == view_name) {
+                if existing_views.iter().any(|v| v.name == view.name) {
+                    // Update view even if unchanged, as it may have dependencies that have changed
+                    self.update_view(view);
+                } else {
+                    self.status
+                        .update_view(&view.name, status::ComponentStatus::Initializing);
+                    let _ = self.load_view(view);
+                }
             }
         }
     }

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -112,7 +112,7 @@ pub(crate) mod catalogs {
 }
 
 pub(crate) mod views {
-    use super::{global, Counter, LazyLock, Meter};
+    use super::{global, Counter, Gauge, LazyLock, Meter};
 
     pub(crate) static VIEWS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("views"));
 
@@ -120,6 +120,14 @@ pub(crate) mod views {
         VIEWS_METER
             .u64_counter("views_load_error")
             .with_description("Number of errors loading the view.")
+            .init()
+    });
+    pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+        VIEWS_METER
+            .u64_gauge("view_status")
+            .with_description(
+                "Status of the views. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            )
             .init()
     });
 }

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -116,6 +116,11 @@ impl RuntimeStatus {
         self.update_component_status(format!("embedding:{model_name}"), status);
         metrics::embeddings::STATUS.record(status as u64, &[KeyValue::new("model", model_name)]);
     }
+    pub fn update_view(&self, view_name: &TableReference, status: ComponentStatus) {
+        let view_name = view_name.to_string();
+        self.update_component_status(format!("view:{view_name}"), status);
+        metrics::views::STATUS.record(status as u64, &[KeyValue::new("view", view_name)]);
+    }
 
     /// Checks if all registered components have been ready at least once.
     ///

--- a/crates/runtime/src/topological_ordering.rs
+++ b/crates/runtime/src/topological_ordering.rs
@@ -1,0 +1,203 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#![allow(clippy::implicit_hasher)]
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// Construct a topological ordering of a directed acyclic graph (DAG) using
+/// Kahn's algorithm.
+///
+/// `nodes` are represented as a [`HashMap`] where the key is the node and the value is a list of
+/// nodes that have an edge to the key node.
+///
+///
+/// ```
+///     A -> B --> D
+///          |     ^
+///          |     |
+///          +->C--+
+/// ```
+///   Order: D, C, B, A
+///
+/// ```rust
+///     let mut nodes = HashMap::new();
+///     nodes.insert("A", vec!["B".to_string()]);
+///     nodes.insert("B", vec!["D".to_string(), "C".to_string()]);
+///     nodes.insert("C", vec!["D".to_string()]);
+///     nodes.insert("D", vec![]);
+/// ```
+///
+/// Returns None if the graph would have a cycle.
+///
+/// See: `<https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm>`
+#[must_use]
+pub fn construct_topological_ordering<T: Eq + std::hash::Hash + Clone + std::fmt::Debug>(
+    mut nodes: HashMap<T, Vec<T>>,
+) -> Option<Vec<T>> {
+    // Get nodes that have no incoming edges, they do not depend on any other node.
+    let mut independent_nodes = nodes
+        .iter()
+        .filter_map(|(node, dependences)| {
+            if dependences.is_empty() {
+                Some(node.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<VecDeque<_>>();
+
+    for n in &independent_nodes {
+        nodes.remove(n);
+    }
+
+    let mut result = Vec::<T>::with_capacity(nodes.len());
+
+    while let Some(dep) = independent_nodes.pop_front() {
+        result.push(dep.clone());
+
+        let mut to_remove = Vec::new();
+        for (node, dependences) in &mut nodes {
+            // Remove `dep` from dependencies for each node
+            dependences.retain(|n| *n != dep);
+
+            // If node is now empty, add it to independent nodes, and remove from `nodes`.
+            if dependences.is_empty() {
+                independent_nodes.push_back(node.clone());
+                to_remove.push(node.clone());
+            }
+        }
+        for n in &to_remove {
+            nodes.remove(n);
+        }
+    }
+
+    if nodes.is_empty() {
+        Some(result)
+    } else {
+        // Cycle detected
+        None
+    }
+}
+
+/// Construct a topological ordering of `nodes` and any additional nodes that depend on `nodes` in a topological order.
+///
+/// `nodes` are represented as a [`HashMap`] where the key is the node and the value is a list of
+/// nodes that have an edge to the key node.
+///
+/// `nodes` is a subset of the graph.
+///
+/// Returns None if the graph would have a cycle.
+#[must_use]
+pub fn construct_effected_in_topological_order<
+    T: Eq + std::hash::Hash + Clone + std::fmt::Debug,
+>(
+    graph: HashMap<T, Vec<T>>,
+    nodes: &[T],
+) -> Option<Vec<T>> {
+    // Construct map of node -> all nodes that depend on it
+    let mut reverse_graph: HashMap<T, Vec<T>> = HashMap::new();
+    for (node, dependences) in &graph {
+        for dep in dependences {
+            reverse_graph
+                .entry(dep.clone())
+                .or_default()
+                .push(node.clone());
+        }
+    }
+
+    // Find all dependent nodes.
+    let mut dependent_nodes = nodes.iter().cloned().collect::<HashSet<T>>();
+    let mut q = nodes.iter().cloned().collect::<VecDeque<T>>();
+
+    while let Some(node) = q.pop_front() {
+        if let Some(dependents) = reverse_graph.get(&node) {
+            for dep in dependents {
+                if dependent_nodes.insert(dep.clone()) {
+                    // Add to queue if insert was successful (not already in set).
+                    q.push_back(dep.clone());
+                }
+            }
+        }
+    }
+
+    // Construct topological ordering of dependent nodes.
+    let nodes = graph
+        .into_iter()
+        .filter(|(node, _)| dependent_nodes.contains(node))
+        .collect::<HashMap<T, Vec<T>>>();
+
+    construct_topological_ordering(nodes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_construct_topological_ordering() {
+        let mut nodes = HashMap::new();
+        nodes.insert("A", vec!["B"]);
+        nodes.insert("B", vec!["C"]);
+        nodes.insert("C", vec!["D"]);
+        nodes.insert("D", vec![]);
+
+        assert_eq!(
+            construct_topological_ordering(nodes),
+            Some(vec!["D", "C", "B", "A"])
+        );
+    }
+
+    #[test]
+    fn test_disconnected_graph() {
+        let mut nodes = HashMap::new();
+        nodes.insert("A", vec!["B"]);
+        nodes.insert("B", vec!["C"]);
+        nodes.insert("C", vec!["D"]);
+        nodes.insert("D", vec![]);
+        nodes.insert("E", vec!["F"]);
+        nodes.insert("F", vec!["G"]);
+        nodes.insert("G", vec!["H"]);
+        nodes.insert("H", vec![]);
+
+        assert_eq!(
+            construct_topological_ordering(nodes),
+            Some(vec!["H", "D", "G", "C", "F", "B", "E", "A"])
+        );
+    }
+
+    #[test]
+    fn test_many_edges() {
+        let mut nodes = HashMap::new();
+        nodes.insert("A", vec!["B"]);
+        nodes.insert("B", vec!["D", "C"]);
+        nodes.insert("C", vec!["D"]);
+        nodes.insert("D", vec![]);
+
+        assert_eq!(
+            construct_topological_ordering(nodes),
+            Some(vec!["D", "C", "B", "A"])
+        );
+    }
+
+    #[test]
+    fn test_construct_topological_ordering_cycle() {
+        let mut nodes = HashMap::new();
+        nodes.insert("A", vec!["B"]);
+        nodes.insert("B", vec!["C"]);
+        nodes.insert("C", vec!["A"]);
+
+        assert_eq!(construct_topological_ordering(nodes), None);
+    }
+}

--- a/crates/runtime/src/topological_ordering.rs
+++ b/crates/runtime/src/topological_ordering.rs
@@ -117,14 +117,14 @@ pub fn construct_effected_in_topological_order<
         }
     }
 
-    // Find all dependent nodes.
-    let mut dependent_nodes = nodes.iter().cloned().collect::<HashSet<T>>();
+    // Find all effected nodes.
+    let mut effected_nodes = nodes.iter().cloned().collect::<HashSet<T>>();
     let mut q = nodes.iter().cloned().collect::<VecDeque<T>>();
 
     while let Some(node) = q.pop_front() {
         if let Some(dependents) = reverse_graph.get(&node) {
             for dep in dependents {
-                if dependent_nodes.insert(dep.clone()) {
+                if effected_nodes.insert(dep.clone()) {
                     // Add to queue if insert was successful (not already in set).
                     q.push_back(dep.clone());
                 }
@@ -132,10 +132,23 @@ pub fn construct_effected_in_topological_order<
         }
     }
 
-    // Construct topological ordering of dependent nodes.
+    // Construct topological ordering over effected nodes.
     let nodes = graph
         .into_iter()
-        .filter(|(node, _)| dependent_nodes.contains(node))
+        .filter_map(|(node, deps)| {
+            if effected_nodes.contains(&node) {
+                Some((
+                    node,
+                    // Filter out dependencies that are not in effected nodes subtree.
+                    // These are nodes that impact nodes in the subtree, but are not affected by the change.
+                    deps.into_iter()
+                        .filter(|dep| effected_nodes.contains(dep))
+                        .collect(),
+                ))
+            } else {
+                None
+            }
+        })
         .collect::<HashMap<T, Vec<T>>>();
 
     construct_topological_ordering(nodes)
@@ -154,8 +167,27 @@ mod tests {
         nodes.insert("D", vec![]);
 
         assert_eq!(
-            construct_topological_ordering(nodes),
+            construct_topological_ordering(nodes.clone()),
             Some(vec!["D", "C", "B", "A"])
+        );
+
+        assert_eq!(
+            construct_effected_in_topological_order(nodes.clone(), &["D"]),
+            Some(vec!["D", "C", "B", "A"])
+        );
+
+        assert_eq!(
+            construct_effected_in_topological_order(nodes.clone(), &["B"]),
+            Some(vec!["B", "A"])
+        );
+
+        assert_eq!(
+            construct_effected_in_topological_order(nodes.clone(), &["A"]),
+            Some(vec!["A"])
+        );
+        assert_eq!(
+            construct_effected_in_topological_order(nodes.clone(), &[]),
+            Some(vec![])
         );
     }
 
@@ -171,9 +203,15 @@ mod tests {
         nodes.insert("G", vec!["H"]);
         nodes.insert("H", vec![]);
 
+        let result = construct_topological_ordering(nodes.clone()).expect("Should not be None");
+        assert!(
+            result == vec!["H", "D", "G", "C", "F", "B", "E", "A"]
+                || result == vec!["D", "H", "C", "G", "B", "F", "A", "E"]
+        );
+
         assert_eq!(
-            construct_topological_ordering(nodes),
-            Some(vec!["H", "D", "G", "C", "F", "B", "E", "A"])
+            construct_effected_in_topological_order(nodes.clone(), &["H"]),
+            Some(vec!["H", "G", "F", "E"])
         );
     }
 
@@ -198,6 +236,10 @@ mod tests {
         nodes.insert("B", vec!["C"]);
         nodes.insert("C", vec!["A"]);
 
-        assert_eq!(construct_topological_ordering(nodes), None);
+        assert_eq!(construct_topological_ordering(nodes.clone()), None);
+        assert_eq!(
+            construct_effected_in_topological_order(nodes.clone(), &["A"]),
+            None
+        );
     }
 }


### PR DESCRIPTION
## 🗣 Description
 - Using `spiced --pods-watcher-enabled` update views if they are changed.
 - Also, have `view` component statuses (like datasets, models, etc). 
 - When updating views, handle dependencies with views (topological ordering of the DAG). 
 - Refactor `Runtime::start_pods_watcher` for function length.

