### PR TITLE
Make Debezium connector MySQL compatible

### DIFF
--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -141,12 +141,12 @@ pub struct Source {
     pub ts_ms: i64,
     pub snapshot: String,
     pub db: String,
-    pub sequence: String,
-    pub schema: String,
     pub table: String,
+    pub sequence: Option<String>,
+    pub schema: Option<String>,
     #[serde(rename = "txId")]
-    pub tx_id: i64,
-    pub lsn: i64,
+    pub tx_id: Option<i64>,
+    pub lsn: Option<i64>,
     pub xmin: Option<serde_json::Value>,
 }
 

--- a/crates/data_components/src/debezium/change_event.rs
+++ b/crates/data_components/src/debezium/change_event.rs
@@ -142,12 +142,6 @@ pub struct Source {
     pub snapshot: String,
     pub db: String,
     pub table: String,
-    pub sequence: Option<String>,
-    pub schema: Option<String>,
-    #[serde(rename = "txId")]
-    pub tx_id: Option<i64>,
-    pub lsn: Option<i64>,
-    pub xmin: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
## 🗣 Description

Make the Debezium data connector compatible with MySQL data sources.

This just required a simple change to remove some Postgres-specific properties in the `Source` struct that we weren't actually using.

## 🔨 Related Issues

Part of #3355

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
