### PR TITLE
Statically compile OpenSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7778,6 +7778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.2+3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7785,6 +7794,7 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -42,7 +42,7 @@ graph-rs-sdk = {workspace = true, optional=true}
 graphql-parser.workspace = true
 http = {version= "1.1.0", optional=true}
 object_store = { workspace = true }
-rdkafka = { version = "0.36.2", features = ["ssl"], optional = true }
+rdkafka = { version = "0.36.2", features = ["ssl-vendored"], optional = true }
 regex = "1.10.4"
 reqwest.workspace = true
 rusqlite = { workspace = true, optional = true }


### PR DESCRIPTION
## 🗣 Description

The PR https://github.com/spiceai/spiceai/pull/3419 added the feature `ssl` to `rdkafka` which by default will dynamically link against OpenSSL and expect to find it on the target system, erroring if the library isn't installed or discoverable by Spice.

This change statically compiles and links OpenSSL to prevent those issues, at the expense of a longer build time.

## 🤔 Concerns

Build times will get longer because of this change, but it will make it more portable to run.
