### PR TITLE
Build macOS x64 on macos-14 (Sonoma)

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -37,7 +37,7 @@ jobs:
             target_arch: aarch64
             target_arch_go: arm64
           - name: macOS x64 (Intel)
-            runner: macos-13
+            runner: macos-14-large # https://github.com/actions/runner-images
             target_os: darwin
             target_arch: x86_64
             target_arch_go: amd64

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -52,8 +52,8 @@ jobs:
                 target_arch_go: "arm64"
               }, {
                 name: "macOS x64 (Intel)",
-                builder: "macos-13",
-                runner: "macos-13",
+                builder: "macos-14-large",
+                runner: "macos-14-large",
                 target_os: "darwin",
                 target_arch: "x86_64",
                 target_arch_go: "amd64"


### PR DESCRIPTION
## 🗣 Description

Builds our macOS x64 binary on macos-14 (Sonoma) instead of macos-13 (Ventura). This was in response to a recent build failure of snmalloc-rs on maco13.

According to the list here: https://github.com/actions/runner-images
The correct image for macos-14 x64 is `macos-14-large`


Test build: https://github.com/spiceai/spiceai/actions/runs/11774348885/job/32792750841
