### PR TITLE
Skip reqwest_retry::middleware tracing in non verbose configuration

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -62,7 +62,7 @@ impl LogVerbosity {
 impl From<LogVerbosity> for EnvFilter {
     fn from(v: LogVerbosity) -> Self {
         match v {
-            LogVerbosity::Default => EnvFilter::new("task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO,llms=INFO,WARN"),
+            LogVerbosity::Default => EnvFilter::new("task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO,llms=INFO,reqwest_retry::middleware=off,WARN"),
             LogVerbosity::Verbose => EnvFilter::new("task_history=DEBUG,spiced=DEBUG,runtime=DEBUG,secrets=DEBUG,data_components=DEBUG,cache=DEBUG,extensions=DEBUG,spice_cloud=DEBUG,llms=DEBUG,INFO"),
             LogVerbosity::VeryVerbose => EnvFilter::new("task_history=TRACE,spiced=TRACE,runtime=TRACE,secrets=TRACE,data_components=TRACE,cache=TRACE,extensions=TRACE,spice_cloud=TRACE,llms=TRACE,DEBUG"),
             LogVerbosity::Specific(filter) => EnvFilter::new(filter),


### PR DESCRIPTION
## 🗣 Description

If one of the dependencies uses the [reqwest-retry](https://crates.io/crates/reqwest-retry) module (for example [snowflake-rs](https://github.com/spiceai/snowflake-rs/blob/spiceai/snowflake-api/Cargo.toml#L36)), retry attempts are traced as warnings (note: the `tracing` feature of `reqwest-retry` can be disabled, but by default, [it is enabled](https://github.com/TrueLayer/reqwest-middleware/blob/9ea95201d07fcc758babbecec1c5b7c0e4e3c2fc/reqwest-retry/Cargo.toml#L13)).

Retries are expected behavior, and we have upper-level logic to trace warnings/errors for underlying functionality so `reqwest-retry` attempts should NOT be traced as warnings, as this might confuse and mislead.

## 🔨 Related Issues

Closes: https://github.com/spiceai/spiceai/issues/2775

##  Concerns

This PR disables tracing from the `reqwest-retry` crate in non-verbose configurations only. Verbose modes (`-v` / `-vv`) will include these traces, which may be helpful for troubleshooting connection/performance issues.

An alternative approach considered was to disable tracing directly in `snowflake-api`. The current approach was selected as a more robust solution for handling similar cases, should another dependency use `reqwest-retry`.

```console
⚡ cargo tree -i reqwest-retry
reqwest-retry v0.5.0
└── snowflake-api v0.9.0 (https://github.com/spiceai/snowflake-rs.git?rev=f95bd4715b9b9e3eaa425d7a775b49e1dcbb1212#f95bd471)
    ├── data_components v1.0.0-rc.1 (/Users/sg/spice/spiceai/crates/data_components)
    │   └── runtime v1.0.0-rc.1 (/Users/sg/spice/spiceai/crates/runtime)
    │       ├── spice-cloud v1.0.0-rc.1 (/Users/sg/spice/spiceai/crates/spice_cloud)
    │       │   └── spiced v1.0.0-rc.1 (/Users/sg/spice/spiceai/bin/spiced)
    │       └── spiced v1.0.0-rc.1 (/Users/sg/spice/spiceai/bin/spiced)
    ├── db_connection_pool v1.0.0-rc.1 (/Users/sg/spice/spiceai/crates/db_connection_pool)
    │   ├── data_components v1.0.0-rc.1 (/Users/sg/spice/spiceai/crates/data_components) (*)
    │   └── runtime v1.0.0-rc.1 (/Users/sg/spice/spiceai/crates/runtime) (*)
    └── runtime v1.0.0-rc.1 (/Users/sg/spice/spiceai/crates/runtime) (*)
```
