### PR TITLE
Use spiceai-large-runners to build benchmark binary

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
+      - name: Install Required Packages
+        uses: sudo apt install build-essential
+
       - name: Build benchmark binary
         run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
-      - name: Set up cc
+      - name: Install the cc tool chain for building benchmark binary
         uses: ./.github/actions/setup-cc
 
       - name: Build benchmark binary

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -54,7 +54,7 @@ env:
 jobs:
   build-database-bench-binary:
     name: Build Benchmark Test Binary
-    runs-on: ubuntu-latest
+    runs-on: spiceai-large-runners
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,10 +66,13 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
-      - name: Install Required Packages
-        run: |
-          sudo apt-get update
-          sudo apt install -y build-essential unixodbc-dev unixodbc
+      - name: Set up cc
+        uses: ./.github/actions/setup-cc
+
+      # - name: Install Required Packages
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt install -y build-essential unixodbc-dev unixodbc
 
       - name: Build benchmark binary
         run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,7 +67,7 @@ jobs:
         uses: arduino/setup-protoc@v3
 
       - name: Install Required Packages
-        uses: sudo apt install build-essential
+        run: sudo apt install build-essential
 
       - name: Build benchmark binary
         run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,11 +69,6 @@ jobs:
       - name: Set up cc
         uses: ./.github/actions/setup-cc
 
-      # - name: Install Required Packages
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt install -y build-essential unixodbc-dev unixodbc
-
       - name: Build benchmark binary
         run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,7 +67,9 @@ jobs:
         uses: arduino/setup-protoc@v3
 
       - name: Install Required Packages
-        run: sudo apt install build-essential
+        run: |
+          sudo apt-get update
+          sudo apt install -y build-essential unixodbc-dev unixodbc
 
       - name: Build benchmark binary
         run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run


### PR DESCRIPTION
## 🗣 Description

Use runner group `spiceai-large-runners` to speed up building benchmark binary.
This will reduce the benchmark bianry build time to ~10 minutes.
Successful run: https://github.com/spiceai/spiceai/actions/runs/11785897780

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
