### PR TITLE
Fix benchmark: Lock poisoning issue from INSTA

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   build-database-bench-binary:
     name: Build Benchmark Test Binary
-    runs-on: spiceai-large-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -67,8 +67,8 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
-      - name: Install the cc tool chain for building benchmark binary
-        uses: ./.github/actions/setup-cc
+      # - name: Install the cc tool chain for building benchmark binary
+      #   uses: ./.github/actions/setup-cc
 
       - name: Build benchmark binary
         run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   build-database-bench-binary:
     name: Build Benchmark Test Binary
-    runs-on: ubuntu-latest
+    runs-on: spiceai-large-runners
     steps:
       - uses: actions/checkout@v4
 
@@ -67,8 +67,8 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
 
-      # - name: Install the cc tool chain for building benchmark binary
-      #   uses: ./.github/actions/setup-cc
+      - name: Install the cc tool chain for building benchmark binary
+        uses: ./.github/actions/setup-cc
 
       - name: Build benchmark binary
         run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
@@ -310,7 +310,7 @@ jobs:
 
       - name: Run benchmark with ${{ matrix.name }}
         if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-        run: ./spice_bench --bench ${{ matrix.cmd }}
+        run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
@@ -380,7 +380,7 @@ jobs:
 
       - name: Run benchmark with ${{ matrix.name }}
         if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-        run: ./spice_bench --bench ${{ matrix.cmd }}
+        run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'


### PR DESCRIPTION
## 🗣 Description

Explicitly set `INSTA_WORKSPACE_ROOT` and `CARGO_MANIFEST_DIR` parameter to avoid lock poisoning issue from [INSTA](https://github.com/mitsuhiko/insta/blob/ef78afba27b41fd37850b8eba293db0759947794/insta/src/env.rs#L451) when running the benchmark binary.

Successful run - no lock poisoning error from INSTA after the changes in this PR: https://github.com/spiceai/spiceai/actions/runs/11788805016/job/32837500150

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns