### PR TITLE
Fix `TableReference` quoting for MySQL

### DIFF
--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -356,7 +356,6 @@ impl Dataset {
     /// For [`Dataset`]s where the path in the `from` field is a [`TableReference`], parse and return the [`TableReference`].
     ///
     ///
-    #[must_use]
     pub fn parse_path(
         &self,
         case_sensitive: bool,

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -357,7 +357,7 @@ impl Dataset {
     ///
     ///
     #[must_use]
-    pub fn table_reference_path(
+    pub fn parse_path(
         &self,
         case_sensitive: bool,
         dialect: Option<&dyn Dialect>,

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -17,7 +17,13 @@ limitations under the License.
 use acceleration::Engine;
 use app::App;
 use arrow::datatypes::SchemaRef;
-use datafusion::sql::TableReference;
+use datafusion::sql::{
+    sqlparser::{
+        dialect::{Dialect, GenericDialect},
+        parser::{Parser, ParserError},
+    },
+    TableReference,
+};
 use datafusion_table_providers::util::column_reference;
 use snafu::prelude::*;
 use spicepod::component::{
@@ -64,6 +70,9 @@ pub enum Error {
         field: String,
         source: fundu::ParseError,
     },
+
+    #[snafu(display("Error parsing `from` path {path} as table reference: {source}"))]
+    UnableToParseTableReferenceFromPath { path: String, source: ParserError },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -341,6 +350,56 @@ impl Dataset {
         match self.from.find(':') {
             Some(index) => self.from[index + 1..].to_string(),
             None => self.from.clone(),
+        }
+    }
+
+    /// For [`Dataset`]s where the path in the `from` field is a [`TableReference`], parse and return the [`TableReference`].
+    ///
+    ///
+    #[must_use]
+    pub fn table_reference_path(
+        &self,
+        case_sensitive: bool,
+        dialect: Option<&dyn Dialect>,
+    ) -> Result<TableReference> {
+        // Manually parse the table reference to avoid case folding.
+        if case_sensitive {
+            let path_str = self.path();
+            let dialect = dialect.unwrap_or(&GenericDialect {});
+            let mut parts = Parser::new(dialect)
+                .try_with_sql(path_str.as_str())
+                .context(UnableToParseTableReferenceFromPathSnafu {
+                    path: path_str.clone(),
+                })?
+                .parse_multipart_identifier()
+                .context(UnableToParseTableReferenceFromPathSnafu {
+                    path: path_str.clone(),
+                })?
+                .iter()
+                .map(|i| i.value.clone())
+                .collect::<Vec<_>>()
+                .into_iter();
+
+            let tbl = match (parts.next(), parts.next(), parts.next()) {
+                (Some(catalog), Some(schema), Some(table)) => TableReference::Full {
+                    catalog: catalog.into(),
+                    schema: schema.into(),
+                    table: table.into(),
+                },
+                (Some(schema), Some(table), None) => TableReference::Partial {
+                    schema: schema.into(),
+                    table: table.into(),
+                },
+                (Some(table), None, None) => TableReference::Bare {
+                    table: table.into(),
+                },
+                _ => TableReference::Bare {
+                    table: self.path().into(),
+                },
+            };
+            Ok(tbl)
+        } else {
+            Ok(self.path().into())
         }
     }
 

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -18,6 +18,7 @@ use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::Read;
 use datafusion::datasource::TableProvider;
+use datafusion::sql::sqlparser::dialect::MySqlDialect;
 use datafusion_table_providers::mysql::MySQLTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::{
     dbconnection,
@@ -142,9 +143,16 @@ impl DataConnector for MySQL {
         &self,
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        match Read::table_provider(&self.mysql_factory, dataset.path().into(), dataset.schema())
-            .await
-        {
+        let tbl = dataset
+            .table_reference_path(true, Some(&MySqlDialect {}))
+            .boxed()
+            .map_err(|e| super::DataConnectorError::InvalidConfiguration {
+                dataconnector: "mysql".to_string(),
+                source: e,
+                message: format!("Invalid table '{}' in dataset path", dataset.path()),
+            })?;
+
+        match Read::table_provider(&self.mysql_factory, tbl, dataset.schema()).await {
             Ok(provider) => Ok(provider),
             Err(e) => {
                 if let Some(err_source) = e.source() {

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -144,7 +144,7 @@ impl DataConnector for MySQL {
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         let tbl = dataset
-            .table_reference_path(true, Some(&MySqlDialect {}))
+            .parse_path(true, Some(&MySqlDialect {}))
             .boxed()
             .map_err(|e| super::DataConnectorError::InvalidConfiguration {
                 dataconnector: "mysql".to_string(),


### PR DESCRIPTION
## 🗣 Description
 - `TableReference::parse_str(` does not handle non-default quotations. MySQL has non-default quotations. 

## 🔨 Related Issues
 - Need https://github.com/datafusion-contrib/datafusion-table-providers/pull/166 
