### PR TITLE
Improve ClickBench setup script: avoid re-downloading test data every time

### DIFF
--- a/test/scripts/clickbench/setup-clickbench-spicepod.bash
+++ b/test/scripts/clickbench/setup-clickbench-spicepod.bash
@@ -67,9 +67,11 @@ if ! type "duckdb" 1> /dev/null 2>&1; then
   echo "'duckdb' is required"
 fi
 
-# Download clickbench data
-wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
-gzip -d hits.csv.gz
+# Download clickbench data if not already downloaded and uncompressed
+if [ ! -f hits.csv ]; then
+  wget --no-verbose --continue 'https://datasets.clickhouse.com/hits_compatible/hits.csv.gz'
+  gzip -d hits.csv.gz
+fi
 
 # Command to load clickbench data into DuckDB
 dbname="clickbench.db"


### PR DESCRIPTION
## 🗣 Description

Improve ClickBench setup script to download ClickBench data only if it hasn't already been downloaded and decompressed.

Uncompressed size is 75.56GB


