### PR TITLE
`params.tools`, not `params.spice_tools`. Allow backwards compatibility to `params.spice_tools`.

### DIFF
--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -98,7 +98,7 @@ pub enum Error {
     #[snafu(display("No model from {from} currently supports {task}"))]
     UnsupportedTaskForModel { from: String, task: String },
 
-    #[snafu(display("Invalid value for 'params.spice_tools'"))]
+    #[snafu(display("Invalid value for 'params.tools'"))]
     UnsupportedSpiceToolUseParameterError {},
 
     #[snafu(display("Runtime does not currently support the {modality} modality"))]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1415,8 +1415,8 @@ impl Runtime {
 
         // Load all built-in tools, regardless if they are in the spicepod.
         // This will enable loading each tool in the catalog, and the catalog as a whole. E.g:
-        //   `spice_tools: models, builtin`
-        //   `spice_tools: sql, load_memory`
+        //   `tools: models, builtin`
+        //   `tools: sql, load_memory`
         for ctlg in default_available_catalogs() {
             self.insert_tool_catalog(&ctlg).await;
             for tool in ctlg.all().await {

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -59,7 +59,8 @@ pub async fn try_to_chat_model<S: ::std::hash::BuildHasher>(
     let model = construct_model(component, params)?;
 
     // Handle tool usage
-    let spice_tool_opt: Option<SpiceToolsOptions> = extract_secret!(params, "spice_tools")
+    let spice_tool_opt: Option<SpiceToolsOptions> = extract_secret!(params, "tools")
+        .or(extract_secret!(params, "spice_tools"))
         .map(|x| x.parse())
         .transpose()
         .map_err(|_| LlmError::UnsupportedSpiceToolUseParameterError {})?;

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -241,7 +241,7 @@ async fn huggingface_test_chat_completion() -> Result<(), anyhow::Error> {
     let mut model_with_tools = get_huggingface_model(HF_TEST_MODEL, HF_TEST_MODEL_TYPE, "hf_model");
     model_with_tools
         .params
-        .insert("spice_tools".to_string(), "auto".into());
+        .insert("tools".to_string(), "auto".into());
 
     let app = AppBuilder::new("text-to-sql")
         .with_dataset(get_taxi_trips_dataset())

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -279,7 +279,7 @@ async fn openai_test_chat_completion() -> Result<(), anyhow::Error> {
     let mut model_with_tools = get_openai_model("gpt-4o-mini", "openai_model");
     model_with_tools
         .params
-        .insert("spice_tools".to_string(), "auto".into());
+        .insert("tools".to_string(), "auto".into());
 
     let app = AppBuilder::new("text-to-sql")
         .with_dataset(get_taxi_trips_dataset())
@@ -350,7 +350,7 @@ async fn openai_test_chat_messages() -> Result<(), anyhow::Error> {
     let mut model_with_tools = get_openai_model("gpt-4o-mini", "openai_model");
     model_with_tools
         .params
-        .insert("spice_tools".to_string(), "auto".into());
+        .insert("tools".to_string(), "auto".into());
 
     let model_secrets = get_params_with_secrets(&model_with_tools.params, &rt).await;
 


### PR DESCRIPTION
## 🗣 Description
 - Change UX for LLMs `params.spice_tools` to `params.tools`.