### PR TITLE
Update benchmark workflow to create PR for updating snapshot

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -356,7 +356,7 @@ jobs:
           git config --global user.email 'bench-snapshot-update-bot@spice.ai'
           git checkout -b bench-snapshot-update/${GITHUB_RUN_ID}
           git add '*.snap'
-          git commit -m "Update benchmark snapshots for ${{ matrix.name }} and ${{ matrix.bench }}""
+          git commit -m "Update benchmark snapshots for ${{ matrix.name }} and ${{ matrix.bench }}"
           git pull --rebase origin bench-snapshot-update/${{ github.run_id }}
           git push origin bench-snapshot-update/${GITHUB_RUN_ID}
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -355,7 +355,7 @@ jobs:
           git config --global user.name 'Spice Benchmark Snapshot Update Bot'
           git config --global user.email 'bench-snapshot-update-bot@spice.ai'
           git checkout -b bench-snapshot-update/${GITHUB_RUN_ID}
-          git add .
+          git add '*.snap'
           git commit -m "Update benchmark snapshots"
           git push origin bench-snapshot-update/${GITHUB_RUN_ID}
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -356,7 +356,8 @@ jobs:
           git config --global user.email 'bench-snapshot-update-bot@spice.ai'
           git checkout -b bench-snapshot-update/${GITHUB_RUN_ID}
           git add '*.snap'
-          git commit -m "Update benchmark snapshots"
+          git commit -m "Update benchmark snapshots for ${{ matrix.name }} and ${{ matrix.bench }}""
+          git pull --rebase origin bench-snapshot-update/${{ github.run_id }}
           git push origin bench-snapshot-update/${GITHUB_RUN_ID}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -48,44 +48,52 @@ on:
           - 'sqlite accelerator (memory mode)'
           - 'sqlite accelerator (file mode)'
           - 'postgres accelerator'
+      update_snapshots:
+        description: 'Create PR to update snapshots'
+        required: false
+        default: 'no'
+        type: choice
+        options:
+          - 'always'
+          - 'no'
 
 env:
   FEATURES: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
 
 jobs:
-  build-database-bench-binary:
-    name: Build Benchmark Test Binary
-    runs-on: spiceai-large-runners
-    steps:
-      - uses: actions/checkout@v4
+  # build-database-bench-binary:
+  #   name: Build Benchmark Test Binary
+  #   runs-on: spiceai-large-runners
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          os: 'linux'
+  #     - name: Set up Rust
+  #       uses: ./.github/actions/setup-rust
+  #       with:
+  #         os: 'linux'
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+  #     - name: Install Protoc
+  #       uses: arduino/setup-protoc@v3
 
-      - name: Install the cc tool chain for building benchmark binary
-        uses: ./.github/actions/setup-cc
+  #     - name: Install the cc tool chain for building benchmark binary
+  #       uses: ./.github/actions/setup-cc
 
-      - name: Build benchmark binary
-        run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
+  #     - name: Build benchmark binary
+  #       run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
 
-      - name: Find, move, and rename benchmark binary
-        run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
+  #     - name: Find, move, and rename benchmark binary
+  #       run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
 
-      - name: Upload benchmark binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: spice_bench
-          path: ./spice_bench
+  #     - name: Upload benchmark binary
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: spice_bench
+  #         path: ./spice_bench
 
   run-database-bench:
     name: Run ${{ matrix.name }} ${{ matrix.bench }} Benchmark
     runs-on: ubuntu-latest
-    needs: build-database-bench-binary
+    # needs: build-database-bench-binary
 
     services:
       mysql_tpch:
@@ -152,84 +160,84 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cmd: '-c spice.ai'
-            name: 'spice.ai connector'
-            bench: 'tpch'
-          - cmd: '-c s3'
-            name: 's3 connector'
-            bench: 'tpch'
-          - cmd: '-c s3 -b tpcds'
-            name: 's3 connector'
-            bench: 'tpcds'
-          - cmd: '-c abfs'
-            name: 'abfs connector'
-            bench: 'tpch'
-          - cmd: '-c spark'
-            name: 'spark connector'
-            bench: 'tpch'
-          - cmd: '-c postgres'
-            name: 'postgres connector'
-            bench: 'tpch'
-          - cmd: '-c postgres -b tpcds'
-            name: 'postgres connector'
-            bench: 'tpcds'
-          - cmd: '-c mysql'
-            name: 'mysql connector'
-            bench: 'tpch'
-          - cmd: '-c duckdb'
-            name: 'duckdb connector'
-            bench: 'tpch'
-          - cmd: '-c duckdb -b tpcds'
-            name: 'duckdb connector'
-            bench: 'tpcds'
-          - cmd: '-c mysql -b tpcds'
-            name: 'mysql connector'
-            bench: 'tpcds'
-          - cmd: '-c odbc-databricks'
-            name: 'odbc-databricks connector'
-            bench: 'tpch'
-          - cmd: '-c odbc-athena'
-            name: 'odbc-athena connector'
-            bench: 'tpch'
-          - cmd: '-c delta_lake'
-            name: 'delta_lake connector'
-            bench: 'tpch'
+          # - cmd: '-c spice.ai'
+          #   name: 'spice.ai connector'
+          #   bench: 'tpch'
+          # - cmd: '-c s3'
+          #   name: 's3 connector'
+          #   bench: 'tpch'
+          # - cmd: '-c s3 -b tpcds'
+          #   name: 's3 connector'
+          #   bench: 'tpcds'
+          # - cmd: '-c abfs'
+          #   name: 'abfs connector'
+          #   bench: 'tpch'
+          # - cmd: '-c spark'
+          #   name: 'spark connector'
+          #   bench: 'tpch'
+          # - cmd: '-c postgres'
+          #   name: 'postgres connector'
+          #   bench: 'tpch'
+          # - cmd: '-c postgres -b tpcds'
+          #   name: 'postgres connector'
+          #   bench: 'tpcds'
+          # - cmd: '-c mysql'
+          #   name: 'mysql connector'
+          #   bench: 'tpch'
+          # - cmd: '-c duckdb'
+          #   name: 'duckdb connector'
+          #   bench: 'tpch'
+          # - cmd: '-c duckdb -b tpcds'
+          #   name: 'duckdb connector'
+          #   bench: 'tpcds'
+          # - cmd: '-c mysql -b tpcds'
+          #   name: 'mysql connector'
+          #   bench: 'tpcds'
+          # - cmd: '-c odbc-databricks'
+          #   name: 'odbc-databricks connector'
+          #   bench: 'tpch'
+          # - cmd: '-c odbc-athena'
+          #   name: 'odbc-athena connector'
+          #   bench: 'tpch'
+          # - cmd: '-c delta_lake'
+          #   name: 'delta_lake connector'
+          #   bench: 'tpch'
           - cmd: '-a arrow'
             name: 'arrow accelerator (memory mode)'
             bench: 'tpch'
           - cmd: '-a duckdb -m memory'
             name: 'duckdb accelerator (memory mode)'
             bench: 'tpch'
-          - cmd: '-a duckdb -m file'
-            name: 'duckdb accelerator (file mode)'
-            bench: 'tpch'
-          - cmd: '-a sqlite -m memory'
-            name: 'sqlite accelerator (memory mode)'
-            bench: 'tpch'
-          - cmd: '-a sqlite -m file'
-            name: 'sqlite accelerator (file mode)'
-            bench: 'tpch'
-          - cmd: '-a postgres'
-            name: 'postgres accelerator'
-            bench: 'tpch'
-          - cmd: '-a arrow -b tpcds'
-            name: 'arrow accelerator (memory mode)'
-            bench: 'tpcds'
-          - cmd: '-a duckdb -m memory -b tpcds'
-            name: 'duckdb accelerator (memory mode)'
-            bench: 'tpcds'
-          - cmd: '-a duckdb -m file -b tpcds'
-            name: 'duckdb accelerator (file mode)'
-            bench: 'tpcds'
-          - cmd: '-a sqlite -m memory -b tpcds'
-            name: 'sqlite accelerator (memory mode)'
-            bench: 'tpcds'
-          - cmd: '-a sqlite -m file -b tpcds'
-            name: 'sqlite accelerator (file mode)'
-            bench: 'tpcds'
-          - cmd: '-a postgres -b tpcds'
-            name: 'postgres accelerator'
-            bench: 'tpcds'
+          # - cmd: '-a duckdb -m file'
+          #   name: 'duckdb accelerator (file mode)'
+          #   bench: 'tpch'
+          # - cmd: '-a sqlite -m memory'
+          #   name: 'sqlite accelerator (memory mode)'
+          #   bench: 'tpch'
+          # - cmd: '-a sqlite -m file'
+          #   name: 'sqlite accelerator (file mode)'
+          #   bench: 'tpch'
+          # - cmd: '-a postgres'
+          #   name: 'postgres accelerator'
+          #   bench: 'tpch'
+          # - cmd: '-a arrow -b tpcds'
+          #   name: 'arrow accelerator (memory mode)'
+          #   bench: 'tpcds'
+          # - cmd: '-a duckdb -m memory -b tpcds'
+          #   name: 'duckdb accelerator (memory mode)'
+          #   bench: 'tpcds'
+          # - cmd: '-a duckdb -m file -b tpcds'
+          #   name: 'duckdb accelerator (file mode)'
+          #   bench: 'tpcds'
+          # - cmd: '-a sqlite -m memory -b tpcds'
+          #   name: 'sqlite accelerator (memory mode)'
+          #   bench: 'tpcds'
+          # - cmd: '-a sqlite -m file -b tpcds'
+          #   name: 'sqlite accelerator (file mode)'
+          #   bench: 'tpcds'
+          # - cmd: '-a postgres -b tpcds'
+          #   name: 'postgres accelerator'
+          #   bench: 'tpcds'
 
     steps:
       - name: Checkout repository
@@ -251,11 +259,17 @@ jobs:
           sudo swapon /swapfile
           sudo swapon --show
 
-      - name: Download benchmark binary
-        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-        uses: actions/download-artifact@v4
-        with:
-          name: spice_bench
+      # - name: Download benchmark binary
+      #   if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: spice_bench
+
+      - name: Download artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/test-bench/spice_bench -O spice_bench
 
       - name: 'Restart accelerator service container with customize configurations'
         if: ( matrix.cmd == '-a postgres' || matrix.cmd == '-a postgres -b tpcds') && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
@@ -310,7 +324,7 @@ jobs:
 
       - name: Run benchmark with ${{ matrix.name }}
         if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-        run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./spice_bench --bench ${{ matrix.cmd }}
+        run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" INSTA_UPDATE=${{ github.event.inputs.update_snapshots}} ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
@@ -335,55 +349,84 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ATHENA_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_ATHENA_SECRET_ACCESS_KEY }}
 
-  run-clickbench:
-    name: Run ${{ matrix.name }} Clickbench
-    runs-on: spiceai-large-runners
-    needs: build-database-bench-binary
+      - name: Create PR to update snapshots
+        if: github.event.inputs.update_snapshots == 'always' && (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+        run: |
+          git config --global user.name 'Spice Benchmark Snapshot Update Bot'
+          git config --global user.email 'bench-snapshot-update-bot@spice.ai'
+          git checkout -b bench-snapshot-update/${GITHUB_RUN_ID}
+          git add .
+          git commit -m "Update benchmark snapshots"
+          git push origin bench-snapshot-update/${GITHUB_RUN_ID}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        include:
-          - cmd: '-a arrow -b clickbench'
-            name: 'arrow accelerator (file mode)'
-            bench: 'clickbench'
-          - cmd: '-a duckdb -m file -b clickbench'
-            name: 'duckdb accelerator (file mode)'
-            bench: 'clickbench'
-          - cmd: '-a duckdb -m memory -b clickbench'
-            name: 'duckdb accelerator (memory mode)'
-            bench: 'clickbench'
-
+  create-pr:
+    runs-on: ubuntu-latest
+    needs: run-database-bench
     steps:
       - name: Checkout repository
-        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         uses: actions/checkout@v4
 
-      - name: Install required packages
-        run: sudo apt-get update && sudo apt-get install -y unixodbc-dev unixodbc wget
-
-      - name: Set up Spice.ai API Key
-        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+      - name: Create PR
         run: |
-          echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
-
-      - name: Download benchmark binary
-        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-        uses: actions/download-artifact@v4
-        with:
-          name: spice_bench
-
-      - name: Make benchmark binary executable
-        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-        run: chmod +x ./spice_bench
-
-      - name: Run benchmark with ${{ matrix.name }}
-        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-        run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./spice_bench --bench ${{ matrix.cmd }}
-        continue-on-error: true
+          git config --global user.name 'Spice Benchmark Snapshot Update Bot'
+          git config --global user.email 'bench-snapshot-update-bot@spice.ai'
+          git fetch origin bench-snapshot-update/${GITHUB_RUN_ID}
+          git checkout bench-snapshot-update/${GITHUB_RUN_ID}
+          gh pr create --title "Update benchmark snapshots" --body "Updated benchmark snapshots" --base trunk --head bench-snapshot-update/${GITHUB_RUN_ID}
         env:
-          UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
-          CLICKBENCH_S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
-          CLICKBENCH_S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
-          CLICKBENCH_S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # run-clickbench:
+  #   name: Run ${{ matrix.name }} Clickbench
+  #   runs-on: spiceai-large-runners
+  #   needs: build-database-bench-binary
+
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 1
+  #     matrix:
+  #       include:
+  #         - cmd: '-a arrow -b clickbench'
+  #           name: 'arrow accelerator (file mode)'
+  #           bench: 'clickbench'
+  #         - cmd: '-a duckdb -m file -b clickbench'
+  #           name: 'duckdb accelerator (file mode)'
+  #           bench: 'clickbench'
+  #         - cmd: '-a duckdb -m memory -b clickbench'
+  #           name: 'duckdb accelerator (memory mode)'
+  #           bench: 'clickbench'
+
+  #   steps:
+  #     - name: Checkout repository
+  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+  #       uses: actions/checkout@v4
+
+  #     - name: Install required packages
+  #       run: sudo apt-get update && sudo apt-get install -y unixodbc-dev unixodbc wget
+
+  #     - name: Set up Spice.ai API Key
+  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+  #       run: |
+  #         echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
+
+  #     - name: Download benchmark binary
+  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: spice_bench
+
+  #     - name: Make benchmark binary executable
+  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+  #       run: chmod +x ./spice_bench
+
+  #     - name: Run benchmark with ${{ matrix.name }}
+  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+  #       run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./spice_bench --bench ${{ matrix.cmd }}
+  #       continue-on-error: true
+  #       env:
+  #         UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
+  #         CLICKBENCH_S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
+  #         CLICKBENCH_S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
+  #         CLICKBENCH_S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -354,11 +354,13 @@ jobs:
         run: |
           git config --global user.name 'Spice Benchmark Snapshot Update Bot'
           git config --global user.email 'bench-snapshot-update-bot@spice.ai'
-          git checkout -b bench-snapshot-update/${GITHUB_RUN_ID}
+          git checkout -b bench-snapshot-update/${{ github.run_id }}
           git add '*.snap'
           git commit -m "Update benchmark snapshots for ${{ matrix.name }} and ${{ matrix.bench }}"
-          git pull --rebase origin bench-snapshot-update/${{ github.run_id }}
-          git push origin bench-snapshot-update/${GITHUB_RUN_ID}
+          if git ls-remote --exit-code --heads origin bench-snapshot-update/${{ github.run_id }}; then
+            git pull --rebase origin bench-snapshot-update/${{ github.run_id }}
+          fi
+          git push origin bench-snapshot-update/${{ github.run_id }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -373,9 +375,9 @@ jobs:
         run: |
           git config --global user.name 'Spice Benchmark Snapshot Update Bot'
           git config --global user.email 'bench-snapshot-update-bot@spice.ai'
-          git fetch origin bench-snapshot-update/${GITHUB_RUN_ID}
-          git checkout bench-snapshot-update/${GITHUB_RUN_ID}
-          gh pr create --title "Update benchmark snapshots" --body "Updated benchmark snapshots" --base trunk --head bench-snapshot-update/${GITHUB_RUN_ID}
+          git fetch origin bench-snapshot-update/${{ github.run_id }}
+          git checkout bench-snapshot-update/${{ github.run_id }}
+          gh pr create --title "Update benchmark snapshots" --body "Updated benchmark snapshots" --base trunk --head bench-snapshot-update/${{ github.run_id }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -343,7 +343,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ATHENA_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_ATHENA_SECRET_ACCESS_KEY }}
 
-      - name: Create PR to update snapshots
+      - name: Upload benchmark snapshots to branch
         if: github.event.inputs.update_snapshots == 'always' && (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: |
           git config --global user.name 'Spice Benchmark Snapshot Update Bot'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,39 +61,39 @@ env:
   FEATURES: 'postgres,spark,mysql,odbc,delta_lake,databricks,duckdb,sqlite'
 
 jobs:
-  # build-database-bench-binary:
-  #   name: Build Benchmark Test Binary
-  #   runs-on: spiceai-large-runners
-  #   steps:
-  #     - uses: actions/checkout@v4
+  build-database-bench-binary:
+    name: Build Benchmark Test Binary
+    runs-on: spiceai-large-runners
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Set up Rust
-  #       uses: ./.github/actions/setup-rust
-  #       with:
-  #         os: 'linux'
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: 'linux'
 
-  #     - name: Install Protoc
-  #       uses: arduino/setup-protoc@v3
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
 
-  #     - name: Install the cc tool chain for building benchmark binary
-  #       uses: ./.github/actions/setup-cc
+      - name: Install the cc tool chain for building benchmark binary
+        uses: ./.github/actions/setup-cc
 
-  #     - name: Build benchmark binary
-  #       run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
+      - name: Build benchmark binary
+        run: cargo bench -p runtime --features ${{ env.FEATURES }} --profile release --no-run
 
-  #     - name: Find, move, and rename benchmark binary
-  #       run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
+      - name: Find, move, and rename benchmark binary
+        run: find target/release/deps -type f -name "bench-*" ! -name "*.d" -exec mv {} ./spice_bench \;
 
-  #     - name: Upload benchmark binary
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: spice_bench
-  #         path: ./spice_bench
+      - name: Upload benchmark binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: spice_bench
+          path: ./spice_bench
 
   run-database-bench:
     name: Run ${{ matrix.name }} ${{ matrix.bench }} Benchmark
     runs-on: ubuntu-latest
-    # needs: build-database-bench-binary
+    needs: build-database-bench-binary
 
     services:
       mysql_tpch:
@@ -160,84 +160,84 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - cmd: '-c spice.ai'
-          #   name: 'spice.ai connector'
-          #   bench: 'tpch'
-          # - cmd: '-c s3'
-          #   name: 's3 connector'
-          #   bench: 'tpch'
-          # - cmd: '-c s3 -b tpcds'
-          #   name: 's3 connector'
-          #   bench: 'tpcds'
-          # - cmd: '-c abfs'
-          #   name: 'abfs connector'
-          #   bench: 'tpch'
-          # - cmd: '-c spark'
-          #   name: 'spark connector'
-          #   bench: 'tpch'
-          # - cmd: '-c postgres'
-          #   name: 'postgres connector'
-          #   bench: 'tpch'
-          # - cmd: '-c postgres -b tpcds'
-          #   name: 'postgres connector'
-          #   bench: 'tpcds'
-          # - cmd: '-c mysql'
-          #   name: 'mysql connector'
-          #   bench: 'tpch'
-          # - cmd: '-c duckdb'
-          #   name: 'duckdb connector'
-          #   bench: 'tpch'
-          # - cmd: '-c duckdb -b tpcds'
-          #   name: 'duckdb connector'
-          #   bench: 'tpcds'
-          # - cmd: '-c mysql -b tpcds'
-          #   name: 'mysql connector'
-          #   bench: 'tpcds'
-          # - cmd: '-c odbc-databricks'
-          #   name: 'odbc-databricks connector'
-          #   bench: 'tpch'
-          # - cmd: '-c odbc-athena'
-          #   name: 'odbc-athena connector'
-          #   bench: 'tpch'
-          # - cmd: '-c delta_lake'
-          #   name: 'delta_lake connector'
-          #   bench: 'tpch'
+          - cmd: '-c spice.ai'
+            name: 'spice.ai connector'
+            bench: 'tpch'
+          - cmd: '-c s3'
+            name: 's3 connector'
+            bench: 'tpch'
+          - cmd: '-c s3 -b tpcds'
+            name: 's3 connector'
+            bench: 'tpcds'
+          - cmd: '-c abfs'
+            name: 'abfs connector'
+            bench: 'tpch'
+          - cmd: '-c spark'
+            name: 'spark connector'
+            bench: 'tpch'
+          - cmd: '-c postgres'
+            name: 'postgres connector'
+            bench: 'tpch'
+          - cmd: '-c postgres -b tpcds'
+            name: 'postgres connector'
+            bench: 'tpcds'
+          - cmd: '-c mysql'
+            name: 'mysql connector'
+            bench: 'tpch'
+          - cmd: '-c duckdb'
+            name: 'duckdb connector'
+            bench: 'tpch'
+          - cmd: '-c duckdb -b tpcds'
+            name: 'duckdb connector'
+            bench: 'tpcds'
+          - cmd: '-c mysql -b tpcds'
+            name: 'mysql connector'
+            bench: 'tpcds'
+          - cmd: '-c odbc-databricks'
+            name: 'odbc-databricks connector'
+            bench: 'tpch'
+          - cmd: '-c odbc-athena'
+            name: 'odbc-athena connector'
+            bench: 'tpch'
+          - cmd: '-c delta_lake'
+            name: 'delta_lake connector'
+            bench: 'tpch'
           - cmd: '-a arrow'
             name: 'arrow accelerator (memory mode)'
             bench: 'tpch'
           - cmd: '-a duckdb -m memory'
             name: 'duckdb accelerator (memory mode)'
             bench: 'tpch'
-          # - cmd: '-a duckdb -m file'
-          #   name: 'duckdb accelerator (file mode)'
-          #   bench: 'tpch'
-          # - cmd: '-a sqlite -m memory'
-          #   name: 'sqlite accelerator (memory mode)'
-          #   bench: 'tpch'
-          # - cmd: '-a sqlite -m file'
-          #   name: 'sqlite accelerator (file mode)'
-          #   bench: 'tpch'
-          # - cmd: '-a postgres'
-          #   name: 'postgres accelerator'
-          #   bench: 'tpch'
-          # - cmd: '-a arrow -b tpcds'
-          #   name: 'arrow accelerator (memory mode)'
-          #   bench: 'tpcds'
-          # - cmd: '-a duckdb -m memory -b tpcds'
-          #   name: 'duckdb accelerator (memory mode)'
-          #   bench: 'tpcds'
-          # - cmd: '-a duckdb -m file -b tpcds'
-          #   name: 'duckdb accelerator (file mode)'
-          #   bench: 'tpcds'
-          # - cmd: '-a sqlite -m memory -b tpcds'
-          #   name: 'sqlite accelerator (memory mode)'
-          #   bench: 'tpcds'
-          # - cmd: '-a sqlite -m file -b tpcds'
-          #   name: 'sqlite accelerator (file mode)'
-          #   bench: 'tpcds'
-          # - cmd: '-a postgres -b tpcds'
-          #   name: 'postgres accelerator'
-          #   bench: 'tpcds'
+          - cmd: '-a duckdb -m file'
+            name: 'duckdb accelerator (file mode)'
+            bench: 'tpch'
+          - cmd: '-a sqlite -m memory'
+            name: 'sqlite accelerator (memory mode)'
+            bench: 'tpch'
+          - cmd: '-a sqlite -m file'
+            name: 'sqlite accelerator (file mode)'
+            bench: 'tpch'
+          - cmd: '-a postgres'
+            name: 'postgres accelerator'
+            bench: 'tpch'
+          - cmd: '-a arrow -b tpcds'
+            name: 'arrow accelerator (memory mode)'
+            bench: 'tpcds'
+          - cmd: '-a duckdb -m memory -b tpcds'
+            name: 'duckdb accelerator (memory mode)'
+            bench: 'tpcds'
+          - cmd: '-a duckdb -m file -b tpcds'
+            name: 'duckdb accelerator (file mode)'
+            bench: 'tpcds'
+          - cmd: '-a sqlite -m memory -b tpcds'
+            name: 'sqlite accelerator (memory mode)'
+            bench: 'tpcds'
+          - cmd: '-a sqlite -m file -b tpcds'
+            name: 'sqlite accelerator (file mode)'
+            bench: 'tpcds'
+          - cmd: '-a postgres -b tpcds'
+            name: 'postgres accelerator'
+            bench: 'tpcds'
 
     steps:
       - name: Checkout repository
@@ -259,17 +259,11 @@ jobs:
           sudo swapon /swapfile
           sudo swapon --show
 
-      # - name: Download benchmark binary
-      #   if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: spice_bench
-
-      - name: Download artifact
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/test-bench/spice_bench -O spice_bench
+      - name: Download benchmark binary
+        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+        uses: actions/download-artifact@v4
+        with:
+          name: spice_bench
 
       - name: 'Restart accelerator service container with customize configurations'
         if: ( matrix.cmd == '-a postgres' || matrix.cmd == '-a postgres -b tpcds') && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
@@ -356,7 +350,7 @@ jobs:
           git config --global user.email 'bench-snapshot-update-bot@spice.ai'
           git checkout -b bench-snapshot-update/${{ github.run_id }}
           git add '*.snap'
-          git commit -m "Update benchmark snapshots for ${{ matrix.name }} and ${{ matrix.bench }}"
+          git commit -m "Update benchmark snapshots for ${{ matrix.name }} ${{ matrix.bench }}"
           if git ls-remote --exit-code --heads origin bench-snapshot-update/${{ github.run_id }}; then
             git pull --rebase origin bench-snapshot-update/${{ github.run_id }}
           fi
@@ -367,6 +361,7 @@ jobs:
   create-pr:
     runs-on: ubuntu-latest
     needs: run-database-bench
+    if: always()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -381,55 +376,55 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # run-clickbench:
-  #   name: Run ${{ matrix.name }} Clickbench
-  #   runs-on: spiceai-large-runners
-  #   needs: build-database-bench-binary
+  run-clickbench:
+    name: Run ${{ matrix.name }} Clickbench
+    runs-on: spiceai-large-runners
+    needs: build-database-bench-binary
 
-  #   strategy:
-  #     fail-fast: false
-  #     max-parallel: 1
-  #     matrix:
-  #       include:
-  #         - cmd: '-a arrow -b clickbench'
-  #           name: 'arrow accelerator (file mode)'
-  #           bench: 'clickbench'
-  #         - cmd: '-a duckdb -m file -b clickbench'
-  #           name: 'duckdb accelerator (file mode)'
-  #           bench: 'clickbench'
-  #         - cmd: '-a duckdb -m memory -b clickbench'
-  #           name: 'duckdb accelerator (memory mode)'
-  #           bench: 'clickbench'
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - cmd: '-a arrow -b clickbench'
+            name: 'arrow accelerator (file mode)'
+            bench: 'clickbench'
+          - cmd: '-a duckdb -m file -b clickbench'
+            name: 'duckdb accelerator (file mode)'
+            bench: 'clickbench'
+          - cmd: '-a duckdb -m memory -b clickbench'
+            name: 'duckdb accelerator (memory mode)'
+            bench: 'clickbench'
 
-  #   steps:
-  #     - name: Checkout repository
-  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository
+        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+        uses: actions/checkout@v4
 
-  #     - name: Install required packages
-  #       run: sudo apt-get update && sudo apt-get install -y unixodbc-dev unixodbc wget
+      - name: Install required packages
+        run: sudo apt-get update && sudo apt-get install -y unixodbc-dev unixodbc wget
 
-  #     - name: Set up Spice.ai API Key
-  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-  #       run: |
-  #         echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
+      - name: Set up Spice.ai API Key
+        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+        run: |
+          echo 'SPICEAI_API_KEY="${{ secrets.SPICE_SECRET_SPICEAI_BENCHMARK_KEY }}"' > .env
 
-  #     - name: Download benchmark binary
-  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: spice_bench
+      - name: Download benchmark binary
+        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+        uses: actions/download-artifact@v4
+        with:
+          name: spice_bench
 
-  #     - name: Make benchmark binary executable
-  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-  #       run: chmod +x ./spice_bench
+      - name: Make benchmark binary executable
+        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+        run: chmod +x ./spice_bench
 
-  #     - name: Run benchmark with ${{ matrix.name }}
-  #       if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
-  #       run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./spice_bench --bench ${{ matrix.cmd }}
-  #       continue-on-error: true
-  #       env:
-  #         UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
-  #         CLICKBENCH_S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
-  #         CLICKBENCH_S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
-  #         CLICKBENCH_S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
+      - name: Run benchmark with ${{ matrix.name }}
+        if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
+        run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./spice_bench --bench ${{ matrix.cmd }}
+        continue-on-error: true
+        env:
+          UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
+          CLICKBENCH_S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
+          CLICKBENCH_S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
+          CLICKBENCH_S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -358,24 +358,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  create-pr:
-    runs-on: ubuntu-latest
-    needs: run-database-bench
-    if: always()
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Create PR
-        run: |
-          git config --global user.name 'Spice Benchmark Snapshot Update Bot'
-          git config --global user.email 'bench-snapshot-update-bot@spice.ai'
-          git fetch origin bench-snapshot-update/${{ github.run_id }}
-          git checkout bench-snapshot-update/${{ github.run_id }}
-          gh pr create --title "Update benchmark snapshots" --body "Updated benchmark snapshots" --base trunk --head bench-snapshot-update/${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   run-clickbench:
     name: Run ${{ matrix.name }} Clickbench
     runs-on: spiceai-large-runners
@@ -428,3 +410,21 @@ jobs:
           CLICKBENCH_S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           CLICKBENCH_S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
           CLICKBENCH_S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
+
+  create-pr:
+    runs-on: ubuntu-latest
+    needs: run-database-bench
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create PR
+        run: |
+          git config --global user.name 'Spice Benchmark Snapshot Update Bot'
+          git config --global user.email 'bench-snapshot-update-bot@spice.ai'
+          git fetch origin bench-snapshot-update/${{ github.run_id }}
+          git checkout bench-snapshot-update/${{ github.run_id }}
+          gh pr create --title "Update benchmark snapshots" --body "Updated benchmark snapshots" --base trunk --head bench-snapshot-update/${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -414,7 +414,7 @@ jobs:
   create-pr:
     runs-on: ubuntu-latest
     needs: run-database-bench
-    if: always()
+    if: always() && github.event.inputs.update_snapshots == 'always'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## 🗣 Description

Add a choice to update snapshots for benchmarks in benchmark workflow.

Benchmarks can be updated by choosing `always` in the following choice
![image](https://github.com/user-attachments/assets/3cd6e3b0-a146-4cf5-9922-a86e4631c251)

When choosing `always`, benchmark test will be run with INSTA_UPDATE=always, changes will be uploaded to branch `bench-snapshot-update/${{ github.run_id }}` and PRs will be created to update snapshots for the benchmark

Successful run using a subset of benchmarks can be viewed here: https://github.com/spiceai/spiceai/pull/3480

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
