### PR TITLE
Update setup-make action

### DIFF
--- a/.github/actions/setup-make/action.yml
+++ b/.github/actions/setup-make/action.yml
@@ -6,4 +6,6 @@ runs:
   steps:
     - name: Install make
       shell: bash
-      run: sudo apt-get install -y make
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y make


### PR DESCRIPTION
## 🗣 Description

Run ` sudo apt-get update` before `sudo apt-get install -y make` in setup-make action to solve the `setup-make` failure on the self hosted runners.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
