### PR TITLE
Update Datafusion and Datafusion-Table-Providers patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -3166,7 +3166,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "log",
  "tokio",
@@ -3199,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "arrow",
  "chrono",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3324,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3348,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
@@ -3384,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3393,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3452,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3501,7 +3501,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd#e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -3166,7 +3166,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "log",
  "tokio",
@@ -3199,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "arrow",
  "chrono",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3324,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3348,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
@@ -3384,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3393,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3452,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3501,7 +3501,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=0c3bbc37de5b1cf340692c7527903cdca1f4f07f#0c3bbc37de5b1cf340692c7527903cdca1f4f07f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=aaa46be22cff778e0e618b5eaeee3c2830d4e7ee#aaa46be22cff778e0e618b5eaeee3c2830d4e7ee"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=dbe51242e5a4bdbe237e4ff471e7c7e7f77e08fa#dbe51242e5a4bdbe237e4ff471e7c7e7f77e08fa"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b0837f4ca5a013f863c708e4284e083409872a7f#b0837f4ca5a013f863c708e4284e083409872a7f"
 dependencies = [
  "arrow",
  "arrow-json 53.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,10 +138,10 @@ uuid = "1.9.1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "e8e0f5bd4d5413d8fba0e48a39656bccd5be96fd" }
 
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "1f37d9eda6da17b7644115f82d209c00c9566733" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,15 +138,15 @@ uuid = "1.9.1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "0c3bbc37de5b1cf340692c7527903cdca1f4f07f" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "0c3bbc37de5b1cf340692c7527903cdca1f4f07f" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "0c3bbc37de5b1cf340692c7527903cdca1f4f07f" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "0c3bbc37de5b1cf340692c7527903cdca1f4f07f" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "aaa46be22cff778e0e618b5eaeee3c2830d4e7ee" }
 
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "1f37d9eda6da17b7644115f82d209c00c9566733" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "dbe51242e5a4bdbe237e4ff471e7c7e7f77e08fa" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b0837f4ca5a013f863c708e4284e083409872a7f" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "d6f8c3e0dc1ba073a86756eba4dacf044dfa892d" }
 


### PR DESCRIPTION
## 🗣 Description

Update Datafusion and Datafusion-Table-Providers patch to include recent fixes for DuckDB
- Datafusion changes: https://github.com/spiceai/datafusion/pull/64, https://github.com/spiceai/datafusion/pull/63, https://github.com/spiceai/datafusion/pull/59, https://github.com/spiceai/datafusion/pull/61
- Datafusion Table provider changes: https://github.com/datafusion-contrib/datafusion-table-providers/pull/170

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
