### PR TITLE
Upgrade datafusion-functions-json to 0.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,8 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-json"
-version = "0.42.0"
-source = "git+https://github.com/spiceai/datafusion-functions-json.git?rev=eb734ebdf806449e79318f4bec540b0138df98af#eb734ebdf806449e79318f4bec540b0138df98af"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744cf7ae121977c453586f3f098239e50da6b0cfcf2de3ccb9338a4896f97dc0"
 dependencies = [
  "datafusion",
  "jiter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ datafusion-execution = "43"
 datafusion-expr = "43"
 datafusion-federation = "0.1"
 datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
-datafusion-functions-json = { git = "https://github.com/spiceai/datafusion-functions-json.git", rev = "eb734ebdf806449e79318f4bec540b0138df98af" }
+datafusion-functions-json = "0.43"
 datafusion-table-providers = "0.1"
 dotenvy = "0.15"
 duckdb = "1.1.1"


### PR DESCRIPTION
## 🗣 Description

`datafusion-functions-json` released a new version on DF 43, so we can upgrade to it instead of our forked version.

## 🔨 Related Issues

Part of #3385 

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

N/A
