### PR TITLE
Update Datafusion Table Provider patch to fix MySQL refresh append mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=2ef1f891705cad8c165996f08905bcad10e224d6#2ef1f891705cad8c165996f08905bcad10e224d6"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=c0fa84c54808e04ef001056796967bea1e24c0ae#c0fa84c54808e04ef001056796967bea1e24c0ae"
 dependencies = [
  "arrow",
  "arrow-json 53.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "1f37d9eda6da17b7644115f82d209c00c9566733" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "2ef1f891705cad8c165996f08905bcad10e224d6" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "c0fa84c54808e04ef001056796967bea1e24c0ae" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "d6f8c3e0dc1ba073a86756eba4dacf044dfa892d" }
 


### PR DESCRIPTION
## 🗣 Description

Update Datafusion Table Provider patch to include the following changes:
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/174
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/173 

By implementing this change, all MySQL Timestamp types will have UTC timestamp value within Spice, keeping a consistency with Datafusion & Spice operating in UTC timezone by default.

 ## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
