### PR TITLE
Update Results Cache metrics according to metrics naming guidelines

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -124,7 +124,7 @@ impl QueryResultsCacheProvider {
             ignore_schemas,
         };
 
-        metrics::MAX_SIZE.record(cache_max_size, &[]);
+        metrics::MAX_SIZE_BYTES.record(cache_max_size, &[]);
 
         Ok(cache_provider)
     }
@@ -133,10 +133,10 @@ impl QueryResultsCacheProvider {
     ///
     /// Will return `Err` if method fails to access the cache
     pub async fn get(&self, plan: &LogicalPlan) -> Result<Option<CachedQueryResult>> {
-        metrics::REQUEST_COUNT.add(1, &[]);
+        metrics::REQUESTS.add(1, &[]);
         match self.cache.get(plan).await {
             Ok(Some(cached_result)) => {
-                metrics::HIT_COUNT.add(1, &[]);
+                metrics::HITS.add(1, &[]);
                 Ok(Some(cached_result))
             }
             Ok(None) => Ok(None),
@@ -168,8 +168,8 @@ impl QueryResultsCacheProvider {
         if now_seconds - self.metrics_reported_last_time.load(Ordering::Relaxed) >= 5 {
             self.metrics_reported_last_time
                 .store(now_seconds, Ordering::Relaxed);
-            metrics::SIZE.record(self.size(), &[]);
-            metrics::ITEM_COUNT.add(self.item_count(), &[]);
+            metrics::SIZE_BYTES.record(self.size(), &[]);
+            metrics::ITEMS.add(self.item_count(), &[]);
         }
     }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -169,7 +169,7 @@ impl QueryResultsCacheProvider {
             self.metrics_reported_last_time
                 .store(now_seconds, Ordering::Relaxed);
             metrics::SIZE_BYTES.record(self.size(), &[]);
-            metrics::ITEMS.add(self.item_count(), &[]);
+            metrics::ITEMS.record(self.item_count(), &[]);
         }
     }
 

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -53,9 +53,9 @@ pub(crate) static HITS: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .init()
 });
 
-pub(crate) static ITEMS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+pub(crate) static ITEMS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("results_cache_items")
-        .with_description("Number of items in the cache.")
+        .u64_gauge("results_cache_items_count")
+        .with_description("Number of items currently in the cache.")
         .init()
 });

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -23,39 +23,39 @@ use opentelemetry::{
 
 static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("results_cache"));
 
-pub(crate) static SIZE: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+pub(crate) static SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("results_cache_size")
+        .u64_gauge("results_cache_size_bytes")
         .with_description("Size of the cache in bytes.")
-        .with_unit("b")
+        .with_unit("By")
         .init()
 });
 
-pub(crate) static MAX_SIZE: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+pub(crate) static MAX_SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("results_cache_max_size")
+        .u64_gauge("results_cache_max_size_bytes")
         .with_description("Maximum allowed size of the cache in bytes.")
-        .with_unit("b")
+        .with_unit("By")
         .init()
 });
 
-pub(crate) static REQUEST_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+pub(crate) static REQUESTS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("results_cache_request_count")
+        .u64_counter("results_cache_requests")
         .with_description("Number of requests to get a key from the cache.")
         .init()
 });
 
-pub(crate) static HIT_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+pub(crate) static HITS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("results_cache_hit_count")
-        .with_description("Cache hit count")
+        .u64_counter("results_cache_hits")
+        .with_description("Cache hit count.")
         .init()
 });
 
-pub(crate) static ITEM_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+pub(crate) static ITEMS: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("results_cache_item_count")
-        .with_description("Number of items currently in the cache.")
+        .u64_counter("results_cache_items")
+        .with_description("Number of items in the cache.")
         .init()
 });


### PR DESCRIPTION
## 🗣 Description

Update Results Cache according to [Metrics naming principles and guidelines](https://github.com/spiceai/spiceai/pull/3516)

Dashboards will be updated/tested separately

**This is a Breaking Change**, changes are tracked as part of https://github.com/spiceai/spiceai/issues/3450

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3450

## Concenrs
`results_cache_items` might be updated from counter to u64_gauge and `results_cache_items_count` name to better represent target intent of tracking number of items currently stored in cache instead of aggregating number of items in cache