### PR TITLE
Move `ready_state` to dataset level

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -17,8 +17,8 @@ limitations under the License.
 use std::time::SystemTime;
 use std::{any::Any, sync::Arc, time::Duration};
 
-use crate::component::dataset::acceleration::{ReadyState, RefreshMode, ZeroResultsAction};
-use crate::component::dataset::TimeFormat;
+use crate::component::dataset::acceleration::{RefreshMode, ZeroResultsAction};
+use crate::component::dataset::{ReadyState, TimeFormat};
 use crate::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
 use crate::datafusion::error::SpiceExternalError;
 use crate::datafusion::SPICE_RUNTIME_SCHEMA;

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -94,34 +94,6 @@ impl Display for ZeroResultsAction {
     }
 }
 
-/// Controls when the table is marked ready for queries.
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub enum ReadyState {
-    /// The table is ready once the initial load completes.
-    #[default]
-    OnLoad,
-    /// The table is ready immediately, with fallback to federated table for queries until the initial load completes.
-    OnRegistration,
-}
-
-impl From<spicepod_acceleration::ReadyState> for ReadyState {
-    fn from(ready_state: spicepod_acceleration::ReadyState) -> Self {
-        match ready_state {
-            spicepod_acceleration::ReadyState::OnLoad => ReadyState::OnLoad,
-            spicepod_acceleration::ReadyState::OnRegistration => ReadyState::OnRegistration,
-        }
-    }
-}
-
-impl Display for ReadyState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ReadyState::OnLoad => write!(f, "on_load"),
-            ReadyState::OnRegistration => write!(f, "on_registration"),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub enum Engine {
     #[default]
@@ -272,8 +244,6 @@ pub struct Acceleration {
 
     pub on_zero_results: ZeroResultsAction,
 
-    pub ready_state: ReadyState,
-
     pub indexes: HashMap<ColumnReference, IndexType>,
 
     pub primary_key: Option<ColumnReference>,
@@ -391,7 +361,6 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             retention_check_enabled: acceleration.retention_check_enabled,
             disable_query_push_down,
             on_zero_results: ZeroResultsAction::from(acceleration.on_zero_results),
-            ready_state: ReadyState::from(acceleration.ready_state),
             indexes,
             primary_key,
             on_conflict,
@@ -419,7 +388,6 @@ impl Default for Acceleration {
             retention_check_interval: None,
             retention_check_enabled: false,
             on_zero_results: ZeroResultsAction::ReturnEmpty,
-            ready_state: ReadyState::OnLoad,
             indexes: HashMap::default(),
             primary_key: None,
             on_conflict: HashMap::default(),

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -324,6 +324,7 @@ pub async fn register_all() {
         unity_catalog::UnityCatalogFactory::new_arc(),
     )
     .await;
+    register_connector_factory("localpod", localpod::LocalPodFactory::new_arc()).await;
 }
 
 pub trait DataConnectorFactory: Send + Sync {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -745,7 +745,7 @@ impl DataFusion {
 
         accelerated_table_builder.zero_results_action(acceleration_settings.on_zero_results);
 
-        accelerated_table_builder.ready_state(acceleration_settings.ready_state);
+        accelerated_table_builder.ready_state(dataset.ready_state);
 
         accelerated_table_builder.cache_provider(self.cache_provider());
 


### PR DESCRIPTION
## 🗣 Description

Moves the spicepod configuration for `ready_state` from the acceleration node to the dataset node.

i.e.

```yaml
datasets:
  - from: mysql:foo
    name: foo
    ready_state: on_load # new location
    acceleration:
      enabled: true
      ready_state: on_load # deprecated location
```

## 🔨 Related Issues

Closes #3523

## 📄 Documentation Requirements

https://github.com/spiceai/docs/pull/637

## 🤔 Concerns

I've decided to keep backwards compatibility with a deprecation warning for anyone still using the old ready_state parameter in its old location.
