### PR TITLE
Improve `spice search` error handling

### DIFF
--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -146,6 +146,12 @@ spice search --cloud
 				slog.Error("reading response from spiced", "error", err)
 				continue
 			}
+
+			if response.StatusCode != 200 {
+				slog.Error("search failed", "error", raw)
+				continue
+			}
+
 			var searchResponse SearchResponse = SearchResponse{}
 			err = json.Unmarshal([]byte(raw), &searchResponse)
 			if err != nil {


### PR DESCRIPTION
## 🗣 Description

Before:

>2024/11/19 11:59:23 ERROR parsing response from spiced error="invalid character 'D' looking for beginning of value"

After:

>2024/11/19 12:37:36 ERROR search failed error="Data source call_center does not contain any embedding columns"

## 🔨 Related Issues

https://github.com/spiceai/spiceai/issues/3570

## 🤔 Concerns

Status check could be part of the `sendSearchRequest`. 