### PR TITLE
fix: Infer if the specified file format is correct in object store

### DIFF
--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use crate::accelerated_table::AcceleratedTable;
 use crate::component::dataset::Dataset;
 use crate::dataconnector::DataConnector;
+use crate::dataconnector::DataConnectorError;
 use crate::dataconnector::DataConnectorResult;
 use crate::parameters::Parameters;
 use async_trait::async_trait;
@@ -34,9 +35,11 @@ use datafusion::datasource::listing::{
 use datafusion::datasource::TableProvider;
 use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
+use futures::TryStreamExt;
 use object_store::ObjectStore;
 use snafu::prelude::*;
 use std::any::Any;
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -319,6 +322,16 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                 })?)
             }
             Some(file_format) => {
+                let object_store = self.get_object_store(dataset)?;
+                check_for_files_and_extensions(
+                    format!("{self}"),
+                    &extension,
+                    table_path.clone(),
+                    &ctx,
+                    &object_store,
+                )
+                .await?;
+
                 let mut options = ListingOptions::new(file_format).with_file_extension(&extension);
 
                 let resolved_schema = options
@@ -385,6 +398,65 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
         ListingTableConnector::on_accelerated_table_registration(self, dataset, accelerated_table)
             .await
     }
+}
+
+async fn check_for_files_and_extensions(
+    dataconnector: String,
+    extension: &str,
+    table_path: ListingTableUrl,
+    ctx: &SessionContext,
+    object_store: &Arc<dyn ObjectStore>,
+) -> DataConnectorResult<()> {
+    let files: Vec<_> = table_path
+        .list_all_files(&ctx.state(), object_store, "")
+        .await
+        .map_err(|err| DataConnectorError::UnableToConnectInternal {
+            dataconnector: dataconnector.clone(),
+            source: err.into(),
+        })?
+        .try_collect()
+        .await
+        .map_err(|err| DataConnectorError::UnableToConnectInternal {
+            dataconnector: dataconnector.clone(),
+            source: err.into(),
+        })?;
+
+    if files.is_empty() {
+        return Err(DataConnectorError::InvalidConfigurationNoSource {
+            dataconnector: dataconnector.clone(),
+            message:
+                // Url could contain access keys from e.g. S3, so we don't want to log it.
+                "Failed to find any files at the specified path. Check the path and try again."
+                    .to_string(),
+        });
+    }
+
+    let extensions = files
+        .iter()
+        .filter_map(|file| file.location.extension().map(|e| format!(".{e}")))
+        .collect::<HashSet<_>>();
+
+    if !extensions.contains(extension) {
+        if extensions.is_empty() {
+            return Err(DataConnectorError::InvalidConfigurationNoSource {
+                dataconnector: dataconnector.clone(),
+                message: format!("Failed to find any files matching the extension '{extension}'.\nSpice could not find any files with extensions at the specified path. Check the path and try again."),
+            });
+        }
+
+        let display_extensions = extensions
+            .iter()
+            .map(|e| format!("'{e}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        return Err(DataConnectorError::InvalidConfigurationNoSource {
+            dataconnector: dataconnector.clone(),
+            message: format!("Failed to find any files matching the extension '{extension}'.\nIs your `file_format` parameter correct? Spice found the following file extensions: {display_extensions}.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors#object-store-file-formats")
+        });
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -400,6 +400,13 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
     }
 }
 
+/// Lists the available files for a ListingTableConnector/ObjectStore
+/// Infers if the file_format specified is valid, based on the existence of files with the required extension
+///
+/// # Errors
+///
+/// - If no files are found at the specified path
+/// - If no files with the specified extension are found
 async fn check_for_files_and_extensions(
     dataconnector: String,
     extension: &str,

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -401,7 +401,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
 }
 
 /// Lists the available files for a ListingTableConnector/ObjectStore
-/// Infers if the file_format specified is valid, based on the existence of files with the required extension
+/// Infers if the `file_format` specified is valid, based on the existence of files with the required extension
 ///
 /// # Errors
 ///


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the `read_provider` for the `ListingTableConnector` to infer if the specified `file_format` is correct

This is because if a user specifies the wrong `file_format`, like `csv` when the path contains `parquet` files, the Runtime will simply return `No results.` instead of erroring. Now, the Runtime will return a more informative error detailing any identified extensions and a link to the documentation for available file formats.

When files with extensions are present:
```bash
2024-11-20T03:05:12.650761Z  WARN runtime::init::dataset: Invalid configuration for s3. Failed to find any files matching the extension '.csv'.
Is your `file_format` parameter correct? Spice found the following file extensions: '.parquet'.
For further information, visit: https://docs.spiceai.org/components/data-connectors#object-store-file-formats
```

When files with no extensions are present (or folders, like how S3 represents):
```bash
2024-11-20T03:03:51.670986Z  WARN runtime::init::dataset: Invalid configuration for s3. Failed to find any files matching the extension '.parquet'.
Spice could not find any files with extensions at the specified path. Check the path and try again.
```

Additionally, because we do not currently support schema evolution when new files appear at a location, also checks if there are any files to begin with. If there are no files, the `ListingTableConnector` would normally create a table with an empty schema which provides results with no columns if files are then created. This PR changes this behavior to instead outright error when there are no files:

```bash
2024-11-20T02:57:57.422333Z  WARN runtime::init::dataset: Invalid configuration for file. Failed to find any files at the specified path. Please check the path and try again.
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3557
* Closes #3556