### PR TITLE
Add ability to configure CORS on the HTTP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6239,7 +6239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9517,6 +9517,7 @@ dependencies = [
  "tonic",
  "tonic-health",
  "tower 0.5.1",
+ "tower-http",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
@@ -11502,6 +11503,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ tokio-util = { version = "0.7.11", features = ["compat"] }
 tonic = { version = "0.12", features = ["gzip", "tls"] }
 tonic-health = { version = "0.12" }
 tower = "0.5.1"
+tower-http = { version = "0.6.2", features = ["cors"] }
 tracing = "0.1.40"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry = "0.27"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -27,7 +27,7 @@ use spicepod::{
         embeddings::Embeddings,
         extension::Extension,
         model::Model,
-        runtime::{ResultsCache, Runtime, TlsConfig},
+        runtime::{CorsConfig, ResultsCache, Runtime, TlsConfig},
         secret::Secret,
         tool::Tool,
         view::View,
@@ -213,6 +213,12 @@ impl AppBuilder {
     #[must_use]
     pub fn with_runtime_params(mut self, params: HashMap<String, String>) -> AppBuilder {
         self.runtime.params = params;
+        self
+    }
+
+    #[must_use]
+    pub fn with_cors_config(mut self, cors_config: CorsConfig) -> AppBuilder {
+        self.runtime.cors = cors_config;
         self
     }
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -115,6 +115,7 @@ tokio-util = { workspace = true, optional = true }
 tonic.workspace = true
 tonic-health.workspace = true
 tower.workspace = true
+tower-http.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 tract-core = "0.21.0"

--- a/crates/runtime/tests/cors/mod.rs
+++ b/crates/runtime/tests/cors/mod.rs
@@ -28,7 +28,7 @@ use spicepod::component::runtime::CorsConfig;
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
 #[tokio::test]
-async fn test_default_cors_endpoints() -> Result<(), anyhow::Error> {
+async fn test_enabled_cors_endpoints() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     let span = tracing::info_span!("test_cors_endpoints");
     let _span_guard = span.enter();
@@ -48,7 +48,17 @@ async fn test_default_cors_endpoints() -> Result<(), anyhow::Error> {
         .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
         .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
 
-    let rt = Runtime::builder().build().await;
+    let rt = Runtime::builder()
+        .with_app(
+            AppBuilder::new("test")
+                .with_cors_config(CorsConfig {
+                    enabled: true,
+                    allowed_origins: vec!["*".to_string()],
+                })
+                .build(),
+        )
+        .build()
+        .await;
 
     // Start the servers
     tokio::spawn(async move {
@@ -104,15 +114,9 @@ async fn test_disabled_cors_endpoints() -> Result<(), anyhow::Error> {
         .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
         .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
 
+    // Default cors config is disabled
     let rt = Runtime::builder()
-        .with_app(
-            AppBuilder::new("test")
-                .with_cors_config(CorsConfig {
-                    enabled: false,
-                    allowed_origins: vec![],
-                })
-                .build(),
-        )
+        .with_app(AppBuilder::new("test").build())
         .build()
         .await;
 

--- a/crates/runtime/tests/cors/mod.rs
+++ b/crates/runtime/tests/cors/mod.rs
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+
+use crate::init_tracing;
+use app::AppBuilder;
+use rand::Rng;
+use runtime::{auth::EndpointAuth, config::Config, Runtime};
+use spicepod::component::runtime::CorsConfig;
+
+const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+#[tokio::test]
+async fn test_default_cors_endpoints() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let span = tracing::info_span!("test_cors_endpoints");
+    let _span_guard = span.enter();
+
+    let mut rng = rand::thread_rng();
+    let http_port: u16 = rng.gen_range(50000..60000);
+    let flight_port: u16 = http_port + 1;
+    let otel_port: u16 = http_port + 2;
+    let metrics_port: u16 = http_port + 3;
+
+    tracing::debug!(
+        "CORS Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
+    );
+
+    let api_config = Config::new()
+        .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+        .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
+        .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+
+    let rt = Runtime::builder().build().await;
+
+    // Start the servers
+    tokio::spawn(async move {
+        Box::pin(Arc::new(rt).start_servers(api_config, None, EndpointAuth::no_auth())).await
+    });
+
+    // Wait for the servers to start
+    tracing::info!("Waiting for servers to start...");
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let http_client = reqwest::Client::builder().build()?;
+
+    let http_url = format!("http://127.0.0.1:{http_port}/health");
+    let request_builder = http_client.request(http::Method::OPTIONS, &http_url);
+    let response = request_builder.send().await.expect("valid response");
+    assert!(response.status().is_success());
+    tracing::info!("HTTP health check passed");
+
+    // Verify that the CORS headers are set
+    let cors_origin_header = response
+        .headers()
+        .get("access-control-allow-origin")
+        .expect("cors header is present");
+    assert_eq!(cors_origin_header, "*");
+
+    let cors_allow_methods_header = response
+        .headers()
+        .get("access-control-allow-methods")
+        .expect("cors header is present");
+    assert_eq!(cors_allow_methods_header, "GET,POST,PATCH");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disabled_cors_endpoints() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let span = tracing::info_span!("test_disabled_cors_endpoints");
+    let _span_guard = span.enter();
+
+    let mut rng = rand::thread_rng();
+    let http_port: u16 = rng.gen_range(50000..60000);
+    let flight_port: u16 = http_port + 1;
+    let otel_port: u16 = http_port + 2;
+    let metrics_port: u16 = http_port + 3;
+
+    tracing::debug!(
+        "CORS Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}, metrics: {metrics_port}"
+    );
+
+    let api_config = Config::new()
+        .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+        .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
+        .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+
+    let rt = Runtime::builder()
+        .with_app(
+            AppBuilder::new("test")
+                .with_cors_config(CorsConfig {
+                    enabled: false,
+                    allowed_origins: vec![],
+                })
+                .build(),
+        )
+        .build()
+        .await;
+
+    // Start the servers
+    tokio::spawn(async move {
+        Box::pin(Arc::new(rt).start_servers(api_config, None, EndpointAuth::no_auth())).await
+    });
+
+    // Wait for the servers to start
+    tracing::info!("Waiting for servers to start...");
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let http_client = reqwest::Client::builder().build()?;
+
+    let http_url = format!("http://127.0.0.1:{http_port}/health");
+    let request_builder = http_client.request(http::Method::OPTIONS, &http_url);
+    let response = request_builder.send().await.expect("valid response");
+    assert!(response.status().is_success());
+    tracing::info!("HTTP health check passed");
+
+    // Verify that the CORS headers are set
+    assert!(response
+        .headers()
+        .get("access-control-allow-origin")
+        .is_none());
+
+    assert!(response
+        .headers()
+        .get("access-control-allow-methods")
+        .is_none());
+
+    Ok(())
+}

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -28,6 +28,7 @@ use tracing_subscriber::EnvFilter;
 mod abfs;
 mod acceleration;
 mod catalog;
+mod cors;
 #[cfg(feature = "delta_lake")]
 mod delta_lake;
 mod docker;

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -46,6 +46,9 @@ pub struct Runtime {
 
     #[serde(default)]
     pub auth: Option<Auth>,
+
+    #[serde(default)]
+    pub cors: CorsConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -207,4 +210,27 @@ pub struct ApiKeyAuth {
     #[serde(default = "default_true")]
     pub enabled: bool,
     pub keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct CorsConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_allowed_origins")]
+    pub allowed_origins: Vec<String>,
+}
+
+fn default_allowed_origins() -> Vec<String> {
+    vec!["*".to_string()]
+}
+
+impl Default for CorsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            allowed_origins: default_allowed_origins(),
+        }
+    }
 }

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -216,7 +216,7 @@ pub struct ApiKeyAuth {
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct CorsConfig {
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub enabled: bool,
     #[serde(default = "default_allowed_origins")]
     pub allowed_origins: Vec<String>,
@@ -229,7 +229,7 @@ fn default_allowed_origins() -> Vec<String> {
 impl Default for CorsConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: false,
             allowed_origins: default_allowed_origins(),
         }
     }


### PR DESCRIPTION
## 🗣 Description

Adds the ability to configure [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS) on the HTTP server. Off by default. Adds a new runtime configuration to configure the CORS behavior:

Default:
```yaml
runtime:
  cors:
    enabled: false
```

Enabled for all origins:
```yaml
runtime:
  cors:
    enabled: true
```

Specific origin:
```yaml
runtime:
  cors:
    enabled: true
    allowed_origins:
      - "localhost:8090"
```

Example curl

```bash
 curl -XOPTIONS -i http://localhost:8090/health
HTTP/1.1 200 OK
vary: origin, access-control-request-method, access-control-request-headers
access-control-allow-methods: GET,POST,PATCH
access-control-allow-origin: *
allow: GET,HEAD
content-length: 0
date: Wed, 20 Nov 2024 04:23:45 GMT
```

## 🔨 Related Issues

N/A

## 📄 Documentation Requirements

https://github.com/spiceai/docs/pull/644

## 🤔 Concerns

N/A
