### PR TITLE
fix: Handle invalid S3 auth and region better

### DIFF
--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use crate::accelerated_table::AcceleratedTable;
 use crate::component::dataset::Dataset;
 use crate::dataconnector::DataConnector;
+use crate::dataconnector::DataConnectorError;
 use crate::dataconnector::DataConnectorResult;
 use crate::parameters::Parameters;
 use async_trait::async_trait;
@@ -32,6 +33,7 @@ use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
 use datafusion::datasource::TableProvider;
+use datafusion::error::DataFusionError;
 use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use object_store::ObjectStore;
@@ -256,6 +258,16 @@ pub trait ListingTableConnector: DataConnector {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
+
+    fn handle_object_store_error(&self, error: object_store::Error) -> DataConnectorError
+    where
+        Self: Display,
+    {
+        crate::dataconnector::DataConnectorError::UnableToConnectInternal {
+            dataconnector: format!("{self}"),
+            source: error.into(),
+        }
+    }
 }
 
 #[async_trait]
@@ -324,9 +336,14 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                 let resolved_schema = options
                     .infer_schema(&ctx.state(), &table_path)
                     .await
-                    .boxed()
-                    .context(crate::dataconnector::UnableToConnectInternalSnafu {
-                        dataconnector: format!("{self}"),
+                    .map_err(|e| match e {
+                        DataFusionError::ObjectStore(object_store_error) => {
+                            self.handle_object_store_error(object_store_error)
+                        }
+                        e => crate::dataconnector::DataConnectorError::UnableToConnectInternal {
+                            dataconnector: format!("{self}"),
+                            source: e.into(),
+                        },
                     })?;
 
                 // If we should infer partitions and the path is a folder, infer the partitions from the folder structure.

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 use super::{
     listing::{self, ListingTableConnector},
-    DataConnector, DataConnectorFactory, DataConnectorParams, DataConnectorResult, ParameterSpec,
-    Parameters,
+    DataConnector, DataConnectorError, DataConnectorFactory, DataConnectorParams,
+    DataConnectorResult, ParameterSpec, Parameters,
 };
 
 use crate::component::dataset::Dataset;
@@ -30,6 +30,42 @@ use std::pin::Pin;
 use std::string::String;
 use std::sync::Arc;
 use url::Url;
+
+// https://docs.aws.amazon.com/general/latest/gr/rande.html
+pub const AWS_REGIONS: [&str; 32] = [
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2",
+    "af-south-1",
+    "ap-east-1",
+    "ap-south-1",
+    "ap-south-2",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ap-southeast-3",
+    "ap-southeast-4",
+    "ap-southeast-5",
+    "ca-central-1",
+    "ca-west-1",
+    "eu-central-1",
+    "eu-central-2",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "eu-south-1",
+    "eu-south-2",
+    "eu-north-1",
+    "sa-east-1",
+    "il-central-1",
+    "me-south-1",
+    "me-central-1",
+    "us-gov-east-1",
+    "us-gov-west-1",
+];
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -57,6 +93,16 @@ pub enum Error {
         "The 's3_endpoint' parameter must be a HTTP/S URL, but '{endpoint}' was provided.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
     ))]
     InvalidEndpoint { endpoint: String },
+
+    #[snafu(display(
+        "The 's3_region' parameter must be a valid AWS region code, but '{region}' was provided.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
+    ))]
+    InvalidRegion { region: String },
+
+    #[snafu(display("Failed to authenticate using an IAM role.\nAre you sure you're running in an environment with an IAM role?\n{source}\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
+    InvalidIAMRoleAuthentication {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 pub struct S3 {
@@ -126,6 +172,15 @@ impl DataConnectorFactory for S3Factory {
                 if !(endpoint.starts_with("https://") || endpoint.starts_with("http://")) {
                     return Err(Box::new(Error::InvalidEndpoint {
                         endpoint: endpoint.to_string(),
+                    })
+                        as Box<dyn std::error::Error + Send + Sync>);
+                }
+            }
+
+            if let Some(region) = params.parameters.get("region").expose().ok() {
+                if !AWS_REGIONS.contains(&region) {
+                    return Err(Box::new(Error::InvalidRegion {
+                        region: region.to_string(),
                     })
                         as Box<dyn std::error::Error + Send + Sync>);
                 }
@@ -222,5 +277,30 @@ impl ListingTableConnector for S3 {
         )));
 
         Ok(s3_url)
+    }
+
+    fn handle_object_store_error(&self, error: object_store::Error) -> DataConnectorError {
+        match error {
+            object_store::Error::Generic { source, .. } => {
+                if self.params.get("auth").expose().ok() == Some("iam_role") {
+                    let err = Error::InvalidIAMRoleAuthentication { source };
+
+                    DataConnectorError::InvalidConfiguration {
+                        dataconnector: format!("{self}"),
+                        message: format!("{err}"),
+                        source: err.into(),
+                    }
+                } else {
+                    DataConnectorError::UnableToConnectInternal {
+                        dataconnector: format!("{self}"),
+                        source,
+                    }
+                }
+            }
+            error => DataConnectorError::UnableToConnectInternal {
+                dataconnector: format!("{self}"),
+                source: error.into(),
+            },
+        }
     }
 }

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -99,6 +99,11 @@ pub enum Error {
     ))]
     InvalidRegion { region: String },
 
+    #[snafu(display(
+        "The `s3_region` parameter requires a lowercase AWS region code, but '{region}' was provided.\nSpice will automatically convert the region code to lowercase.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
+    ))]
+    InvalidRegionCorrected { region: String },
+
     #[snafu(display("Failed to authenticate using an IAM role.\nAre you sure you're running in an environment with an IAM role?\n{source}\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
     InvalidIAMRoleAuthentication {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -178,11 +183,25 @@ impl DataConnectorFactory for S3Factory {
             }
 
             if let Some(region) = params.parameters.get("region").expose().ok() {
-                if !AWS_REGIONS.contains(&region) {
-                    return Err(Box::new(Error::InvalidRegion {
-                        region: region.to_string(),
-                    })
-                        as Box<dyn std::error::Error + Send + Sync>);
+                if AWS_REGIONS.contains(&region.to_lowercase().as_str())
+                    && !AWS_REGIONS.contains(&region)
+                {
+                    tracing::warn!(
+                        "{}",
+                        Error::InvalidRegionCorrected {
+                            region: region.to_string()
+                        }
+                    );
+                    params
+                        .parameters
+                        .insert("region".to_string(), region.to_lowercase().into());
+                } else if !AWS_REGIONS.contains(&region) {
+                    tracing::warn!(
+                        "{}",
+                        Error::InvalidRegion {
+                            region: region.to_string(),
+                        }
+                    );
                 }
             }
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates `s3_region` validation to check against a hard-coded list of regions, avoiding generic time out errors from trying to access an invalid region.

Regions list is hard coded here, because they're unlikely to change (with the exception of brand new regions) and there isn't a great alternative in the Rust SDK to retrieving the regions.

When failing due to an incorrect region, the error looks like:
```bash
2024-11-20T05:06:38.362997Z  WARN runtime::init::dataset: Error initializing dataset taxi_trips. The 's3_region' parameter must be a valid AWS region code, but 'not-a-real-region' was provided.
For further information, visit: https://docs.spiceai.org/components/data-connectors/s3#params
```

* Adds error handling interception for implementations of `ListingTableConnector`, to override the return error for `object_store` errors

S3 implements this interceptor to handle `Generic` errors when `s3_auth: iam_role`. This is because, when using `s3_auth: iam_role` in a non-IAM role environment, object store will return a generic timeout when trying to reach the AWS instance profile manager to get a token: `http://169.254.169.254/latest/api/token`.

We make an educated guess with the error that it's due to the IAM role environment configuration, with an error that looks like:
```bash
2024-11-20T05:05:56.986759Z  WARN runtime::init::dataset: Invalid configuration for s3. Failed to authenticate using an IAM role.
Are you sure you're running in an environment with an IAM role?
{object store error}
For further information, visit: https://docs.spiceai.org/components/data-connectors/s3#auth
```

With an inner error visible like:
```bash
2024-11-20T05:05:56.986759Z  WARN runtime::init::dataset: Invalid configuration for s3. Failed to authenticate using an IAM role.
Are you sure you're running in an environment with an IAM role?
Error after 10 retries in 16.509493296s, max_retries:10, retry_timeout:180s, source:error sending request for url (http://169.254.169.254/latest/api/token)
For further information, visit: https://docs.spiceai.org/components/data-connectors/s3#auth
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3553