### PR TITLE
Load datasets in parallel

### DIFF
--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -41,6 +41,7 @@ use datafusion::sql::TableReference;
 use futures::{future::join_all, StreamExt};
 use opentelemetry::KeyValue;
 use snafu::prelude::*;
+use tokio::sync::Semaphore;
 use util::{fibonacci_backoff::FibonacciBackoffBuilder, retry, RetryError};
 
 impl Runtime {
@@ -50,12 +51,22 @@ impl Runtime {
             return;
         };
 
+        // Control the number of parallel dataset loads
+        let semaphore = if let Some(parallel_num) = app.runtime.num_of_parallel_loading_at_start_up
+        {
+            Arc::new(Semaphore::new(parallel_num))
+        } else {
+            Arc::new(Semaphore::new(Semaphore::MAX_PERMITS))
+        };
+
         let valid_datasets = Self::get_valid_datasets(app, LogErrors(true));
         let initialized_datasets = self.initialize_accelerators(&valid_datasets).await;
 
         // Create a map of dataset names to their futures
         let mut dataset_futures = HashMap::new();
         let mut localpod_datasets = Vec::new();
+
+        let cloned_self = Arc::new(self.clone());
 
         // First create futures for non-localpod datasets
         for ds in initialized_datasets {
@@ -64,10 +75,16 @@ impl Runtime {
                 continue;
             }
 
-            self.status
+            let cloned_self = Arc::clone(&cloned_self);
+            cloned_self
+                .status
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
-            let future: Pin<Box<dyn Future<Output = ()> + Send>> =
-                Box::pin(self.load_dataset(Arc::clone(&ds)));
+            let ds_clone = Arc::clone(&ds);
+            let future: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
+                let cloned_self = Arc::clone(&cloned_self);
+                cloned_self.load_dataset(ds_clone).await;
+            })
+                as Pin<Box<dyn Future<Output = ()> + Send>>;
             dataset_futures.insert(ds.name.clone(), future);
         }
 
@@ -84,10 +101,11 @@ impl Runtime {
             if let Some(parent_future) = dataset_futures.remove(&path_table_ref) {
                 let ds_clone = Arc::clone(&ds);
 
+                let cloned_self = self.clone();
                 // Chain the localpod dataset load after its parent
                 let chained_future = Box::pin(async move {
                     parent_future.await;
-                    self.load_dataset(ds_clone).await;
+                    cloned_self.load_dataset(ds_clone).await;
                 }) as Pin<Box<dyn Future<Output = ()> + Send>>;
 
                 // Replace parent future with the chained future
@@ -107,14 +125,20 @@ impl Runtime {
             };
         }
 
-        // Load datasets in parallel
-        if let Some(parallel_num) = app.runtime.num_of_parallel_loading_at_start_up {
-            let stream =
-                futures::stream::iter(dataset_futures.into_values()).buffer_unordered(parallel_num);
-            let _ = stream.collect::<Vec<_>>().await;
-        } else {
-            let _ = join_all(dataset_futures.into_values()).await;
+        let mut spawned_tasks = vec![];
+
+        for (_, dataset_load_future) in dataset_futures {
+            let semaphore = Arc::clone(&semaphore);
+            let handle = tokio::spawn(async move {
+                let Ok(_guard) = semaphore.acquire().await else {
+                    unreachable!("Semaphore is never closed.");
+                };
+                dataset_load_future.await;
+            });
+            spawned_tasks.push(handle);
         }
+
+        let _ = join_all(spawned_tasks).await;
 
         // After all datasets have loaded, load the views.
         self.load_views(app);

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -52,8 +52,7 @@ impl Runtime {
         };
 
         // Control the number of parallel dataset loads
-        let semaphore = if let Some(parallel_num) = app.runtime.num_of_parallel_loading_at_start_up
-        {
+        let semaphore = if let Some(parallel_num) = app.runtime.dataset_load_parallelism {
             Arc::new(Semaphore::new(parallel_num))
         } else {
             Arc::new(Semaphore::new(Semaphore::MAX_PERMITS))
@@ -127,12 +126,13 @@ impl Runtime {
 
         let mut spawned_tasks = vec![];
 
-        for (_, dataset_load_future) in dataset_futures {
+        for (ds, dataset_load_future) in dataset_futures {
             let semaphore = Arc::clone(&semaphore);
             let handle = tokio::spawn(async move {
                 let Ok(_guard) = semaphore.acquire().await else {
                     unreachable!("Semaphore is never closed.");
                 };
+                tracing::info!("Initializing dataset {ds}");
                 dataset_load_future.await;
             });
             spawned_tasks.push(handle);

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -65,8 +65,6 @@ impl Runtime {
         let mut dataset_futures = HashMap::new();
         let mut localpod_datasets = Vec::new();
 
-        let cloned_self = Arc::new(self.clone());
-
         // First create futures for non-localpod datasets
         for ds in initialized_datasets {
             if ds.source() == LOCALPOD_DATACONNECTOR {
@@ -74,16 +72,13 @@ impl Runtime {
                 continue;
             }
 
-            let cloned_self = Arc::clone(&cloned_self);
-            cloned_self
-                .status
+            self.status
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
             let ds_clone = Arc::clone(&ds);
-            let future: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
-                let cloned_self = Arc::clone(&cloned_self);
-                cloned_self.load_dataset(ds_clone).await;
-            })
-                as Pin<Box<dyn Future<Output = ()> + Send>>;
+            let cloned_self = self.clone();
+            let future: Pin<Box<dyn Future<Output = ()> + Send>> =
+                Box::pin(async move { cloned_self.load_dataset(ds_clone).await })
+                    as Pin<Box<dyn Future<Output = ()> + Send>>;
             dataset_futures.insert(ds.name.clone(), future);
         }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -461,7 +461,7 @@ impl Runtime {
         });
 
         let datasets = tokio::spawn({
-            let self_clone = self.clone();
+            let self_clone = Arc::new(self.clone());
             async move {
                 self_clone.load_datasets().await;
             }

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -28,7 +28,7 @@ const TASK_HISTORY_RETENTION_MINIMUM: u64 = 60; // 1 minute
 pub struct Runtime {
     #[serde(default)]
     pub results_cache: ResultsCache,
-    pub num_of_parallel_loading_at_start_up: Option<usize>,
+    pub dataset_load_parallelism: Option<usize>,
 
     /// If set, the runtime will configure all endpoints to use TLS
     pub tls: Option<TlsConfig>,


### PR DESCRIPTION
## 🗣 Description

Loads the datasets in parallel. Previously they were loading concurrently on the same thread.

## 🔨 Related Issues

Closes #3544

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

I renamed the config `num_of_parallel_loading_at_start_up` to `dataset_load_parallelism`.

i.e.
```yaml
runtime:
  num_of_parallel_loading_at_start_up: 10 # old
  dataset_load_parallelism: 10 # new
```
