### PR TITLE
allow setting of replicaCount to a falsy-value

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: spiceai
 description: Spice.ai OSS
-version: 0.1.35
+version: 0.1.36

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
   name: {{ template "spiceai.fullname" .  }}
   namespace: {{ template "spiceai.namespace" . }}
 spec:
+  {{- if .Values.replicaCount }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "spiceai.selectorLabels" . | indent 6 }}


### PR DESCRIPTION
## 🗣 Description

this will not set replicas at all which helps when the deployment is behind a horizontal autoscaler and managed via CI/CD tooling (a la Argo).

in the above situation, if you set `replicaCount` to something truthy and you have an HPA setup, then Argo will detect the incorrect replica count and try to resolve the difference.
