### PR TITLE
`spice search` to warn if dataset is not ready and won't be included in search

### DIFF
--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -66,7 +66,11 @@ spice search --cloud
 
 		for _, dataset := range datasets {
 			if dataset.Status != api.Ready.String() && dataset.Status != api.Refreshing.String() {
-				slog.Warn(fmt.Sprintf("Dataset %s is not ready (%s) and will not be included in search.", dataset.Name, dataset.Status))
+				// warn only if vector_search is supported by the dataset
+				prop_val, _ := dataset.GetPropertyValue("vector_search")
+				if prop_val == "supported" {
+					slog.Warn(fmt.Sprintf("Dataset %s is not ready (%s) at the moment and will be excluded from the search if it is not ready when the search is performed.", dataset.Name, dataset.Status))
+				}
 			}
 		}
 

--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -69,7 +69,7 @@ spice search --cloud
 				// warn only if vector_search is supported by the dataset
 				prop_val, _ := dataset.GetPropertyValue("vector_search")
 				if prop_val == "supported" {
-					slog.Warn(fmt.Sprintf("Dataset %s is not ready (%s) at the moment and will be excluded from the search if it is not ready when the search is performed.", dataset.Name, dataset.Status))
+					slog.Warn(fmt.Sprintf("Dataset %s is not ready (%s) and will be excluded from the search.", dataset.Name, dataset.Status))
 				}
 			}
 		}

--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/peterh/liner"
 	"github.com/spf13/cobra"
+	"github.com/spiceai/spiceai/bin/spice/pkg/api"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
@@ -57,6 +58,17 @@ spice search --cloud
 		rtcontext := context.NewContext().WithCloud(cloud)
 
 		rtcontext.RequireModelsFlavor(cmd)
+
+		datasets, err := api.GetDatasetsWithStatus(rtcontext)
+		if err != nil {
+			slog.Error("could not list datasets", "error", err)
+		}
+
+		for _, dataset := range datasets {
+			if dataset.Status != api.Ready.String() && dataset.Status != api.Refreshing.String() {
+				slog.Warn(fmt.Sprintf("Dataset %s is not ready (%s) and will not be included in search.", dataset.Name, dataset.Status))
+			}
+		}
 
 		httpEndpoint, err := cmd.Flags().GetString("http-endpoint")
 		if err != nil {

--- a/bin/spice/pkg/api/dataset.go
+++ b/bin/spice/pkg/api/dataset.go
@@ -29,6 +29,6 @@ func (ds *Dataset) GetPropertyValue(key string) (interface{}, bool) {
 	if ds.Properties == nil {
 		return nil, false
 	}
-	value, exists := ds.Properties[key]
-	return value, exists
+	value, ok := ds.Properties[key]
+	return value, ok
 }

--- a/bin/spice/pkg/api/dataset.go
+++ b/bin/spice/pkg/api/dataset.go
@@ -17,9 +17,18 @@ limitations under the License.
 package api
 
 type Dataset struct {
-	From                string `json:"from,omitempty" csv:"from" yaml:"from,omitempty"`
-	Name                string `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
-	ReplicationEnabled  bool   `json:"replication_enabled,omitempty" csv:"replication_enabled" yaml:"replication_enabled,omitempty"`
-	AccelerationEnabled bool   `json:"acceleration_enabled,omitempty" csv:"acceleration_enabled" yaml:"acceleration_enabled,omitempty"`
-	Status              string `json:"status,omitempty" csv:"status,omitempty" yaml:"status,omitempty"`
+	From                string                 `json:"from,omitempty" csv:"from" yaml:"from,omitempty"`
+	Name                string                 `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
+	ReplicationEnabled  bool                   `json:"replication_enabled,omitempty" csv:"replication_enabled" yaml:"replication_enabled,omitempty"`
+	AccelerationEnabled bool                   `json:"acceleration_enabled,omitempty" csv:"acceleration_enabled" yaml:"acceleration_enabled,omitempty"`
+	Status              string                 `json:"status,omitempty" csv:"status,omitempty" yaml:"status,omitempty"`
+	Properties          map[string]interface{} `json:"properties,omitempty"`
+}
+
+func (ds *Dataset) GetPropertyValue(key string) (interface{}, bool) {
+	if ds.Properties == nil {
+		return nil, false
+	}
+	value, exists := ds.Properties[key]
+	return value, exists
 }

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -51,8 +51,8 @@ pub enum Error {
     #[snafu(display("Data sources [{}] does not exist", data_source.iter().map(TableReference::to_quoted_string).join(", ")))]
     DataSourcesNotFound { data_source: Vec<TableReference> },
 
-    #[snafu(display("Failed to retrive table {} data source", data_source.to_quoted_string()))]
-    DataSourceNotFound { data_source: TableReference },
+    #[snafu(display("Failed to find table '{}'. An internal error occurred during vector search.\nPlease report a bug on GitHub: https://github.com/spiceai/spiceai/issues", table.to_quoted_string()))]
+    DataSourceNotFound { table: TableReference },
 
     #[snafu(display("There are no tables with embeddings ready for search"))]
     NoTablesWithEmbeddingsFound {},
@@ -709,9 +709,8 @@ impl VectorSearch {
                 .df
                 .get_table(&t)
                 .await
-                .context(DataSourceNotFoundSnafu {
-                    data_source: t.clone(),
-                })?;
+                // we should not fail here, as we are iterating over the tables that we know exist
+                .context(DataSourceNotFoundSnafu { table: t.clone() })?;
             if get_embedding_table(&table_provider).await.is_some() {
                 tables_with_embeddings.push(t);
             }

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -51,6 +51,12 @@ pub enum Error {
     #[snafu(display("Data sources [{}] does not exist", data_source.iter().map(TableReference::to_quoted_string).join(", ")))]
     DataSourcesNotFound { data_source: Vec<TableReference> },
 
+    #[snafu(display("Failed to retrive table {} data source", data_source.to_quoted_string()))]
+    DataSourceNotFound { data_source: TableReference },
+
+    #[snafu(display("There are no tables with embeddings ready for search"))]
+    NoTablesWithEmbeddingsFound {},
+
     #[snafu(display("Vector search cannot be run on {}.", data_source.to_quoted_string()))]
     CannotVectorSearchDataset { data_source: TableReference },
 
@@ -597,12 +603,7 @@ impl VectorSearch {
         };
 
         if tables.is_empty() {
-            return Err(Error::DataSourcesNotFound {
-                data_source: data_source_opt
-                    .as_ref()
-                    .map(|ts| ts.iter().map(TableReference::from).collect())
-                    .unwrap_or_default(),
-            });
+            return Err(Error::NoTablesWithEmbeddingsFound {});
         }
 
         let span = match Span::current() {
@@ -700,8 +701,8 @@ impl VectorSearch {
                 .df
                 .get_table(&t)
                 .await
-                .context(DataSourcesNotFoundSnafu {
-                    data_source: vec![t.clone()],
+                .context(DataSourceNotFoundSnafu {
+                    data_source: t.clone(),
                 })?;
             if get_embedding_table(&table_provider).await.is_some() {
                 tables_with_embeddings.push(t);

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -54,7 +54,7 @@ pub enum Error {
     #[snafu(display("Failed to find table '{}'. An internal error occurred during vector search.\nPlease report a bug on GitHub: https://github.com/spiceai/spiceai/issues", table.to_quoted_string()))]
     DataSourceNotFound { table: TableReference },
 
-    #[snafu(display("There are no tables with embeddings ready for search"))]
+    #[snafu(display("Vector search failed: No tables with embeddings are available. Ensure embeddings are configured and try again."))]
     NoTablesWithEmbeddingsFound {},
 
     #[snafu(display("Vector search cannot be run on {}.", data_source.to_quoted_string()))]


### PR DESCRIPTION
## 🗣 Description

Add back logic to warn if dataset is not ready and won't be included in search removed in [spice search to default to only datasets with embeddings](https://github.com/spiceai/spiceai/pull/3588)

Also improve error message if there are no datasets available for search

## 🤔 Concerns

~Converted to DRAFT as We should warn only if dataset has embeddings defined (improve `api.GetDatasetsWithStatus` to include can_search_documents ). Plan to improve this otherwise such message for a dataset w/o embeddings can confuse.~
