### PR TITLE
Change default task_history captured_output to `none`

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -16,10 +16,7 @@ limitations under the License.
 
 use std::{borrow::Cow, sync::Arc};
 
-use app::{
-    spicepod::component::runtime::{TaskHistoryCapturedOutput, TracingConfig},
-    App,
-};
+use app::{spicepod::component::runtime::TracingConfig, App};
 use futures::future::BoxFuture;
 use opentelemetry::global::Error as OtelError;
 use opentelemetry::trace::TraceError;
@@ -125,11 +122,11 @@ where
     let trace_config = Config::default().with_resource(Resource::empty());
     let app_name = app.as_ref().map(|app| app.name.clone());
 
-    let captured_output = if let Some(app) = app.as_ref() {
-        app.runtime.task_history.get_captured_output()?
-    } else {
-        TaskHistoryCapturedOutput::Truncated
-    };
+    let captured_output = app
+        .as_ref()
+        .map(|app| app.runtime.task_history.get_captured_output())
+        .transpose()?
+        .unwrap_or_default();
 
     let mut exporters: Vec<Box<dyn SpanExporter>> = vec![Box::new(
         task_history::otel_exporter::TaskHistoryExporter::new(df, captured_output),

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -117,7 +117,7 @@ pub struct TelemetryConfig {
 pub struct TaskHistory {
     #[serde(default = "default_true")]
     pub enabled: bool,
-    #[serde(default = "default_truncated")]
+    #[serde(default = "default_none")]
     pub captured_output: Arc<str>,
     #[serde(default = "default_retention_period")]
     pub retention_period: Arc<str>,
@@ -125,8 +125,8 @@ pub struct TaskHistory {
     pub retention_check_interval: Arc<str>,
 }
 
-fn default_truncated() -> Arc<str> {
-    "truncated".into()
+fn default_none() -> Arc<str> {
+    "none".into()
 }
 
 fn default_retention_period() -> Arc<str> {
@@ -141,15 +141,16 @@ impl Default for TaskHistory {
     fn default() -> Self {
         Self {
             enabled: true,
-            captured_output: "truncated".into(),
-            retention_period: "8h".into(),
-            retention_check_interval: "15m".into(),
+            captured_output: default_none(),
+            retention_period: default_retention_period(),
+            retention_check_interval: default_retention_check_interval(),
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum TaskHistoryCapturedOutput {
+    #[default]
     None,
     Truncated,
 }


### PR DESCRIPTION
## 🗣 Description

Changes the default value for `runtime.task_history.captured_output` to `none` (previously `truncated`).

## 🔨 Related Issues

Closes #3597

## 📄 Documentation Requirements

https://github.com/spiceai/docs/pull/648

## 🤔 Concerns

N/A
