### PR TITLE
Add E2E test for spice search and chat functionality (OpenAI)

### DIFF
--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -39,13 +39,19 @@ jobs:
                 target_os: "linux",
                 target_arch: "x86_64",
                 target_arch_go: "amd64"
+              }, {
+                name: "macOS aarch64 (Apple Silicon)",
+                builder: "macos-14",
+                runner: "macos-14",
+                target_os: "darwin",
+                target_arch: "aarch64",
+                target_arch_go: "arm64"
               }
             ];
 
             return context.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
 
   build:
-    # if: false
     name: Build ${{ matrix.target.name }} binaries
     runs-on: ${{ matrix.target.builder }}
     needs: setup-matrix
@@ -187,6 +193,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y expect
+
+      - name: Install expect (macOS)
+        if: matrix.target.target_os == 'darwin'
+        run: |
+          brew install expect
 
       - name: Test vector search
         run: |

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -1,0 +1,205 @@
+name: E2E Test CI (models)
+
+on:
+  push:
+    branches:
+      - trunk
+      - release-*
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'version.txt'
+      - 'acknowledgements.md'
+
+  workflow_dispatch:
+
+concurrency:
+  # Allow only one workflow per any non-trunk branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+  cancel-in-progress: true
+
+jobs:
+  setup-matrix:
+    name: Setup strategy matrix
+    runs-on: spiceai-runners
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.result }}
+
+    steps:
+      - name: Set up matrix
+        uses: actions/github-script@v7
+        id: setup-matrix
+        with:
+          script: |
+            const matrix = [
+              {
+                name: "Linux x64",
+                builder: "spiceai-runners",
+                runner: "ubuntu-latest",
+                target_os: "linux",
+                target_arch: "x86_64",
+                target_arch_go: "amd64"
+              }
+            ];
+
+            return context.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
+
+  build:
+    # if: false
+    name: Build ${{ matrix.target.name }} binaries
+    runs-on: ${{ matrix.target.builder }}
+    needs: setup-matrix
+    env:
+      GOVER: 1.22.0
+      GOOS: ${{ matrix.target.target_os }}
+      GOARCH: ${{ matrix.target.target_arch_go }}
+
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set REL_VERSION from version.txt
+        run: python3 ./.github/scripts/get_release_version.py
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOVER }}
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: ${{ matrix.target.target_os }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/trunk' }}
+
+      - name: Set up make
+        if: matrix.target.target_os == 'linux'
+        uses: ./.github/actions/setup-make
+
+      - name: Set up cc
+        if: matrix.target.target_os == 'linux'
+        uses: ./.github/actions/setup-cc
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build spiced
+        run: |
+          make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="models"
+
+      - name: Update build cache (macOS)
+        if: matrix.target.target_os == 'darwin'
+        run: |
+          if [ -d /Users/spiceai/build/target ]; then
+            rsync -av target/ /Users/spiceai/build/target/
+          fi
+
+      - name: Update build cache (Linux)
+        if: matrix.target.target_os == 'linux'
+        run: |
+          if [ -d /home/spiceai/build/target ]; then
+            rsync -av target/ /home/spiceai/build/target/
+          fi
+
+      - name: Update build cache (Windows)
+        if: matrix.target.target_os == 'windows'
+        run: |
+          if (Test-Path C:/spiceai/build/target) {
+            Copy-Item -Recurse -Force target/* C:/spiceai/build/target
+          }
+
+      - name: Build spice
+        run: make -C bin/spice
+
+      - name: make spiced executable
+        if: matrix.target.target_os != 'windows'
+        run: |
+          mv target/release/spiced spiced
+          chmod +x spiced
+
+      - name: make spice executable
+        if: matrix.target.target_os != 'windows'
+        run: |
+          mv target/release/spice spice
+          chmod +x spice
+
+      - name: Save spice artifact
+        uses: actions/upload-artifact@v4
+        if: matrix.target.target_os != 'windows'
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: |
+            spice
+            spiced
+
+  test_openai_model:
+    name: 'openai model (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+    runs-on: ${{ matrix.target.runner }}
+    needs:
+      - build
+      - setup-matrix
+
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: ./build
+
+      - name: Install spice
+        uses: ./.github/actions/install-spice
+        with:
+          build-path: ./build
+
+      - name: Init spice app
+        run: |
+          cp ./test/models/spicepod.yml ./spicepod.yaml
+          cat ./spicepod.yaml
+
+      - name: Start spice runtime
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICE_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
+        run: |
+          spice run &> spice.log &
+
+      - name: Wait for Spice runtime is ready
+        timeout-minutes: 1
+        run: |
+          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+      
+      - name: Install expect (linux)
+        if: matrix.target.target_os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y expect
+
+      - name: Test vector search
+        run: |
+          ./test/models/search_01.exp
+
+      - name: Test chat
+        run: |
+          ./test/models/chat_01.exp
+
+      - name: Stop spice and check logs
+        if: always()
+        run: |
+          killall spice || true
+          cat spice.log
+
+  

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -19,51 +19,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup-matrix:
-    name: Setup strategy matrix
-    runs-on: spiceai-runners
-    outputs:
-      matrix: ${{ steps.setup-matrix.outputs.result }}
-
-    steps:
-      - name: Set up matrix
-        uses: actions/github-script@v7
-        id: setup-matrix
-        with:
-          script: |
-            const matrix = [
-              {
-                name: "Linux x64",
-                builder: "spiceai-runners",
-                runner: "ubuntu-latest",
-                target_os: "linux",
-                target_arch: "x86_64",
-                target_arch_go: "amd64"
-              }, {
-                name: "macOS aarch64 (Apple Silicon)",
-                builder: "macos-14",
-                runner: "macos-14",
-                target_os: "darwin",
-                target_arch: "aarch64",
-                target_arch_go: "arm64"
-              }
-            ];
-
-            return context.eventName === 'pull_request' ? matrix.slice(0, 1) : matrix;
-
   build:
     name: Build ${{ matrix.target.name }} binaries
+    timeout-minutes: 30
     runs-on: ${{ matrix.target.builder }}
-    needs: setup-matrix
     env:
       GOVER: 1.22.0
       GOOS: ${{ matrix.target.target_os }}
       GOARCH: ${{ matrix.target.target_arch_go }}
-
     strategy:
       matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-
+        target:
+          - name: "Linux x64"
+            builder: "spiceai-runners"
+            target_os: "linux"
+            target_arch: "x86_64"
+          - name: "macOS aarch64 (Apple Silicon)"
+            builder: "macos-14"
+            target_os: "darwin"
+            target_arch: "aarch64"
     steps:
       - uses: actions/checkout@v4
 
@@ -148,15 +122,21 @@ jobs:
 
   test_openai_model:
     name: 'openai model (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+    timeout-minutes: 10
     runs-on: ${{ matrix.target.runner }}
     needs:
       - build
-      - setup-matrix
-
     strategy:
       matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-
+        target:
+          - name: "Linux x64"
+            runner: "spiceai-runners"
+            target_os: "linux"
+            target_arch: "x86_64"
+          - name: "macOS aarch64 (Apple Silicon)"
+            runner: "macos-14"
+            target_os: "darwin"
+            target_arch: "aarch64"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -122,7 +122,7 @@ jobs:
 
   test_openai_model:
     name: 'openai model (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-    timeout-minutes: 10
+    timeout-minutes: 5
     runs-on: ${{ matrix.target.runner }}
     needs:
       - build

--- a/test/models/chat_01.exp
+++ b/test/models/chat_01.exp
@@ -1,0 +1,115 @@
+#!/usr/bin/expect -f
+
+# Runtime response timeout
+set timeout 15:
+
+spawn spice chat
+
+proc verify_datasets_access {} {
+    global timeout
+
+    set taxi_trips_available 0
+    set gh_issues_available 0
+    set catalog_page_available 0
+
+    send "What datasets you have access to\r"
+
+    expect {
+        "spice.public.taxi_trips" {
+            set taxi_trips_available 1
+            exp_continue
+
+        }
+        "spice.public.issues" {
+            set gh_issues_available 1
+            exp_continue
+        }
+        "spice.public.catalog_page" {
+            set catalog_page_available 1
+            exp_continue
+        }
+        " ERROR " {
+            # allow stream to complete
+            sleep 2
+            send_user "Error detected\n"
+            exit 1
+        }
+        "chat> " {
+            # end of model response
+        }
+        timeout {
+            send_user "Timeout waiting for expected response\n"
+            exit 1
+        }
+    }
+
+    if { $taxi_trips_available == 1 && $gh_issues_available == 1 && $catalog_page_available == 1 } {
+        send_user "Model confirmed access to all datasets\n"
+    } else {
+        send_user "Model does not returned expected response\n"
+        exit 1
+    }
+}
+
+proc verify_num_issues {} {
+    global timeout
+
+    send "How many issues stored in database?\r"
+
+    expect {
+        " ERROR " {
+            # allow stream to complete
+            sleep 2
+            send_user "Error detected\n"
+            exit 1
+        }
+        "chat> " {
+            # end of model response
+        }
+        timeout {
+            send_user "Timeout waiting for expected response\n"
+            exit 1
+        }
+    }
+
+    send_user "Model returned expected response\n"
+}
+
+proc verify_catalog_page {} {
+    global timeout
+
+    send "find top 3 exclusive deals in catalog pages\r"
+
+    expect {
+        " ERROR " {
+            # allow stream to complete
+            sleep 2
+            send_user "Error detected\n"
+            exit 1
+        }
+        "chat> " {
+            # end of model response
+        }
+        timeout {
+            send_user "Timeout waiting for expected response\n"
+            exit 1
+        }
+    }
+
+    send_user "Model returned expected response\n"
+}
+
+expect "chat>"
+
+verify_datasets_access
+sleep 1
+
+verify_num_issues
+sleep 1
+
+verify_catalog_page
+
+# Signal to exit (Ctrl+C)
+send \x03
+
+exit 0

--- a/test/models/search_01.exp
+++ b/test/models/search_01.exp
@@ -30,10 +30,10 @@ proc perform_search {search_term expected_term} {
     }
 }
 expect "search>"
-perform_search "local_model" {Rank 1}
+perform_search "Spice runtime error" {Rank 1,.*spice\.public\.issues}
 
 expect "search>"
-perform_search "friends" {Rank 1}
+perform_search "friends" {Rank 1,.*spice\.public\.catalog_page}
 
 # Signal to exit (Ctrl+C)
 send \x03

--- a/test/models/search_01.exp
+++ b/test/models/search_01.exp
@@ -5,18 +5,18 @@ set timeout 5:
 
 spawn spice search
 
-proc perform_search {search_term} {
+proc perform_search {search_term expected_term} {
     global timeout
 
     send "$search_term\r"
 
     expect {
-        "Rank " {
+        -re $expected_term {
             # allow stream to complete
             sleep 2
-            send_user "Search returned results\n"
+            send_user "Search returned expected result\n"
         }
-        # if there is ERROR message before Rank N, then search failed
+        # if there is ERROR message before the expected term, then search failed
         " ERROR " {
             # allow stream to complete
             sleep 2
@@ -30,10 +30,10 @@ proc perform_search {search_term} {
     }
 }
 expect "search>"
-perform_search "local_model"
+perform_search "local_model" {Rank 1}
 
 expect "search>"
-perform_search "another search term"
+perform_search "friends" {Rank 1}
 
 # Signal to exit (Ctrl+C)
 send \x03

--- a/test/models/search_01.exp
+++ b/test/models/search_01.exp
@@ -1,0 +1,41 @@
+#!/usr/bin/expect -f
+
+# spiced runtime response timeout
+set timeout 5:
+
+spawn spice search
+
+proc perform_search {search_term} {
+    global timeout
+
+    send "$search_term\r"
+
+    expect {
+        "Rank " {
+            # allow stream to complete
+            sleep 2
+            send_user "Search returned results\n"
+        }
+        # if there is ERROR message before Rank N, then search failed
+        " ERROR " {
+            # allow stream to complete
+            sleep 2
+            send_user "Error detected\n"
+            exit 1
+        }
+        timeout {
+            send_user "Timeout waiting for expected response\n"
+            exit 1
+        }
+    }
+}
+expect "search>"
+perform_search "local_model"
+
+expect "search>"
+perform_search "another search term"
+
+# Signal to exit (Ctrl+C)
+send \x03
+
+exit 0

--- a/test/models/spicepod.yml
+++ b/test/models/spicepod.yml
@@ -24,7 +24,7 @@ datasets:
       refresh_sql: "SELECT * FROM issues WHERE created_at='2024-11-09T22:47:45'"
     embeddings:
       - column: body
-        use: hf_minilm
+        use: openai_embeddings
         column_pk:
           - id
     

--- a/test/models/spicepod.yml
+++ b/test/models/spicepod.yml
@@ -1,0 +1,76 @@
+version: v1beta1
+kind: Spicepod
+name: ai-test-spicepod
+
+datasets:
+  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+    name: taxi_trips
+    description: taxi trips in s3
+    params:
+      file_format: parquet
+
+  - from: github:github.com/spiceai/spiceai/issues
+    name: issues
+    description: GitHub Issues for the Spice.ai project (github.com/spiceai/spiceai)
+    metadata:
+      instructions: Always provide reference links. Use the primary key as `issue_id` to generate reference links.
+      reference_url_template: https://github.com/spiceai/spiceai/issues/<issue_id>
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+      github_query_mode: "search"
+    acceleration:
+      enabled: true
+      refresh_retry_max_attempts: 3
+      refresh_sql: "SELECT * FROM issues WHERE created_at='2024-11-09T22:47:45'"
+    embeddings:
+      - column: body
+        use: hf_minilm
+        column_pk:
+          - id
+    
+  - from: s3://spiceai-public-datasets/tpcds/catalog_page/
+    name: catalog_page
+    description: Represents an e-commerce platform's catalog page metadata
+    params:
+      file_format: parquet
+    acceleration:
+      enabled: true
+      refresh_sql: SELECT * FROM catalog_page limit 1;
+    embeddings:
+      - column: cp_description
+        column_pk:
+          - cp_catalog_page_sk
+        use: openai_embeddings
+    
+models:
+  - from: openai:gpt-4o-mini
+    name: openai-gpt
+    params:
+      spice_tools: auto
+      openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
+      system_prompt: |
+        Use the SQL tool when:
+          1. The query involves precise numerical data, statistics, or aggregations
+          2. The user asks for specific counts, sums, averages, or other calculations
+          3. The query requires joining or comparing data from multiple related tables
+
+        Use the document search when:
+          1. The query is about unstructured text information, such as policies, reports, or articles
+          2. The user is looking for qualitative information or explanations
+          3. The query requires understanding context or interpreting written content
+
+        General guidelines:
+          1. If a query could be answered by either tool, prefer SQL for more precise, quantitative answers
+
+        Instructions for Responses: 
+          - Do not include any private metadata provided to the model as context such as \"reference_url_template\" or \"instructions\" in your responses.
+
+embeddings:
+  - from: openai
+    name: openai_embeddings
+    params:
+      openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
+    metadata: {}
+  - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+    name: hf_minilm
+    metadata: {}


### PR DESCRIPTION
## 🗣 Description

Add E2E tests for `spice search` and `spice chat` functionality (OpenA) using [expect](https://core.tcl-lang.org/expect/index) (simple tool for automating interactive applications)
 - `s3://spiceai-public-datasets/tpcds/catalog_page/` is used to test `Utf8View` type  records with NULL values
 - `github:github.com/spiceai/spiceai/issues` covers `Utf8` type and real content characteristics (length variety, etc.)

Example test run: https://github.com/spiceai/spiceai/actions/runs/11950463815

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3009

## 🤔 Concerns

1. OpenAI chat returns stable result for queries like `How many issues stored in database?` so test can include specific number instead of testing that chat request just completed.

