### PR TITLE
Handle empty embeds by allowing for nulls

### DIFF
--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -342,7 +342,7 @@ async fn get_vectors(
     arr: impl Iterator<Item = Option<&str>>,
     model: &dyn Embed,
 ) -> Result<FixedSizeListArray, Box<dyn std::error::Error + Send + Sync>> {
-    // Filter out nulls or empty strings before caling [`Embed::embed`].
+    // Filter out nulls or empty strings before calling [`Embed::embed`].
     let (null_pairs, values): (Vec<_>, Vec<_>) = arr
         .enumerate()
         .partition(|(_, o)| o.is_none() || o.is_some_and(str::is_empty));

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -322,7 +322,7 @@ async fn get_vectors(
     // Filter out nulls or empty strings before caling [`Embed::embed`].
     let (null_pairs, values): (Vec<_>, Vec<_>) = arr
         .enumerate()
-        .partition(|(_, o)| o.is_none() || o.is_some_and(|v| v.is_empty()));
+        .partition(|(_, o)| o.is_none() || o.is_some_and(str::is_empty));
     let nulls: Vec<usize> = null_pairs.into_iter().map(|(i, _)| i).collect();
 
     let column: Vec<String> = values
@@ -340,7 +340,8 @@ async fn get_vectors(
         ),
         vector_length as i32,
         embedded_data.len() + nulls.len(),
-    );
+    )
+    .with_field(Arc::new(Field::new("item", DataType::Float32, false)));
 
     let mut i: usize = 0;
     for vector in embedded_data {
@@ -407,18 +408,21 @@ async fn get_vectors_with_chunker(
     let vector_length = model.size();
 
     let capacity = chunks_per_row.iter().sum();
+
     #[allow(clippy::cast_sign_loss)]
     let mut vectors_builder = FixedSizeListBuilder::with_capacity(
         PrimitiveBuilder::<Float32Type>::with_capacity(capacity * (vector_length as usize)),
         vector_length,
         capacity,
-    );
+    )
+    .with_field(Arc::new(Field::new("item", DataType::Float32, false)));
 
     let mut chunks_builder = FixedSizeListBuilder::with_capacity(
         PrimitiveBuilder::<Int32Type>::with_capacity(capacity),
         2,
         capacity,
-    );
+    )
+    .with_field(Arc::new(Field::new("item", DataType::Int32, false)));
 
     let mut lengths = Vec::with_capacity(chunks_per_row.len());
     let mut curr = 0;
@@ -428,27 +432,13 @@ async fn get_vectors_with_chunker(
         clippy::cast_sign_loss
     )]
     for chunkz_in_row in chunks_per_row {
-        lengths.push(chunkz_in_row);
-
         // Get the actual vectors
-        let inner = embedded_data.as_slice()[curr..curr + chunkz_in_row]
-            .iter()
-            .flatten()
-            .copied()
-            .collect_vec();
-
-        // Handling Nulls
-        if chunkz_in_row == 0 {
-            vectors_builder
-                .values()
-                .append_nulls(vector_length as usize);
-            chunks_builder.values().append_nulls(vector_length as usize);
-            vectors_builder.append(true);
-            chunks_builder.append(true);
-            continue;
+        for i in curr..curr + chunkz_in_row {
+            if let Some(v) = embedded_data.get(i) {
+                vectors_builder.values().append_slice(v); // I believe this is a clone under the hood.
+                vectors_builder.append(true);
+            }
         }
-
-        vectors_builder.values().append_slice(&inner); // I believe this is a clone under the hood.
 
         // Explicitly find `end` to handle when chunks have overlap.
         for i in 0..chunkz_in_row {
@@ -462,11 +452,10 @@ async fn get_vectors_with_chunker(
 
             chunks_builder.values().append_value(start as i32);
             chunks_builder.values().append_value(end as i32);
+            chunks_builder.append(true);
         }
-
         curr += chunkz_in_row;
-        vectors_builder.append(true);
-        chunks_builder.append(true);
+        lengths.push(chunkz_in_row);
     }
 
     // These are offsets for both the vectors and the content offsets.

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -532,6 +532,7 @@ async fn get_vectors_with_chunker(
     Ok((vectors, content_offsets))
 }
 
+#[allow(clippy::float_cmp)]
 #[cfg(test)]
 mod tests {
 

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -443,6 +443,8 @@ async fn get_vectors_with_chunker(
                 .values()
                 .append_nulls(vector_length as usize);
             chunks_builder.values().append_nulls(vector_length as usize);
+            vectors_builder.append(true);
+            chunks_builder.append(true);
             continue;
         }
 
@@ -463,6 +465,8 @@ async fn get_vectors_with_chunker(
         }
 
         curr += chunkz_in_row;
+        vectors_builder.append(true);
+        chunks_builder.append(true);
     }
 
     // These are offsets for both the vectors and the content offsets.

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -322,7 +322,7 @@ async fn get_vectors(
     // Filter out nulls or empty strings before caling [`Embed::embed`].
     let (null_pairs, values): (Vec<_>, Vec<_>) = arr
         .enumerate()
-        .partition(|(_, o)| o.is_none() || o.is_some_and(|v| !v.is_empty()));
+        .partition(|(_, o)| o.is_none() || o.is_some_and(|v| v.is_empty()));
     let nulls: Vec<usize> = null_pairs.into_iter().map(|(i, _)| i).collect();
 
     let column: Vec<String> = values

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -355,7 +355,6 @@ async fn get_vectors(
     let embedded_data = model.embed(EmbeddingInput::StringArray(column)).await?;
     let vector_length = embedded_data.first().map(Vec::len).unwrap_or_default();
 
-    // Add back nulls into the ordering of embedding data.
     let mut builder = FixedSizeListBuilder::with_capacity(
         PrimitiveBuilder::<Float32Type>::with_capacity(
             (embedded_data.len() + nulls.len()) * vector_length,
@@ -370,6 +369,8 @@ async fn get_vectors(
 
     // Index into `nulls` array. Value at i'th position is index into output order that should be nulled.
     let mut null_ptr = 0;
+
+    // Reconstruct correct output order by adding back nulls based on original indexes of nulls.
     for vector in embedded_data {
         // Keep inserting nulls until we reach the next non-null value.
         while nulls.get(null_ptr).is_some_and(|&idx| idx == output_ptr) {
@@ -490,7 +491,7 @@ async fn get_vectors_with_chunker(
     }
 
     // These are offsets for both the vectors and the content offsets.
-    // They tell the [`ListArray`] how many vectors/offsets are for each row of the input table.
+    // They tell the [`ListArray`] how many vectors/offsets are in each row of the input/output table.
     let offsets = OffsetBuffer::<i32>::from_lengths(lengths.into_iter());
 
     let vectors = ListArray::try_new(

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -314,6 +314,29 @@ pub(crate) async fn compute_additional_embedding_columns(
 /// +---------------------+      +-------------+
 ///     [`StringArray`]        [`FixedSizeListArray`]
 /// ```
+///
+/// Elements of `arr` that are `Some("")` or `None` should not be passed into
+/// [`Embed`]. This means that `arr` must be partitioned, then reconstructed
+/// after the non empty/null inputs are embedded.
+///
+/// ```text
+///                                     +- Embedding Model -+
+/// +---------------------+             |                   v
+/// | "Hello"             |      +--------------+    +------------+
+/// | None                | ---> | "Hello"      |    | [0.1, 1.2] |
+/// | ""                  |      | "Valid text" |    | [0.8, 0.9] |
+/// | "Valid text"        |      +--------------+    +------------+
+/// +---------------------+                             |  |
+///    [`StringArray`]                                  |  |
+///                   +------------+                    |  |
+///                   | [0.1, 0.2] | <------------------+  |
+///                   | None       |                       |
+///                   | None       |                       |
+///                   | [0.8, 0.9] | <---------------------+
+///                   +------------+
+///
+///                 [`FixedSizeListArray`]
+/// ```
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 async fn get_vectors(
     arr: impl Iterator<Item = Option<&str>>,
@@ -324,7 +347,6 @@ async fn get_vectors(
         .enumerate()
         .partition(|(_, o)| o.is_none() || o.is_some_and(str::is_empty));
     let nulls: Vec<usize> = null_pairs.into_iter().map(|(i, _)| i).collect();
-
     let column: Vec<String> = values
         .iter()
         .filter_map(|(_, s)| s.map(ToString::to_string))
@@ -343,16 +365,23 @@ async fn get_vectors(
     )
     .with_field(Arc::new(Field::new("item", DataType::Float32, false)));
 
-    let mut i: usize = 0;
+    // Current index into offset of the outputted [`FixedSizeList`].
+    let mut output_ptr: usize = 0;
+
+    // Index into `nulls` array. Value at i'th position is index into output order that should be nulled.
+    let mut null_ptr = 0;
     for vector in embedded_data {
-        let null_input = nulls.first().is_some_and(|&idx| idx == i);
-        if null_input {
+        // Keep inserting nulls until we reach the next non-null value.
+        while nulls.get(null_ptr).is_some_and(|&idx| idx == output_ptr) {
             builder.values().append_nulls(vector_length);
-        } else {
-            builder.values().append_slice(&vector);
-            i += 1;
+            null_ptr += 1;
+            output_ptr += 1;
+            builder.append(false);
         }
-        builder.append(null_input);
+
+        builder.values().append_slice(&vector);
+        output_ptr += 1;
+        builder.append(true);
     }
     Ok(builder.finish())
 }
@@ -366,12 +395,14 @@ async fn get_vectors(
 /// +---------------------+  +-------------------------------+  +--------------------------------------+
 /// | "Hello, World!"     |  | ["Hello, ", ", World!"]       |  | [[0.1, 1.2], [0.3, 0.4]]             |
 /// | "How are you doing?"|  | ["How ", "are you ", "doing?"]|  | [[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]] |
+/// | ""                  |  | []                            |  | []                                   |
 /// | "I'm doing well."   |  | ["I'm doing ", "doing well."] |  | [[1.1, 1.2], [1.3, 1.4]]             |
 /// +---------------------+  +-------------------------------+  +--------------------------------------+
 ///     [`StringArray`]                     +                             [`ListArray`]
 ///                          +-------------------------------+
 ///                          | [[0, 7], [7, 15]              |
 ///                          | [[0, 4], [4, 12], [12, 18]]   |
+///                          | []                            |
 ///                          | [[0, 10], [10, 21]]           |
 ///                          +-------------------------------+
 /// ```

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 use arrow::array::{
-    Array, ArrayRef, FixedSizeListArray, Float32Array, Int32Array, ListArray, RecordBatch,
-    StringArray, StringViewArray,
+    Array, ArrayRef, FixedSizeListArray, FixedSizeListBuilder, ListArray, PrimitiveBuilder,
+    RecordBatch, StringArray, StringViewArray,
 };
 use arrow::buffer::OffsetBuffer;
-use arrow::datatypes::{DataType, Field, SchemaRef};
+use arrow::datatypes::{DataType, Field, Float32Type, Int32Type, SchemaRef};
 
 use arrow::error::ArrowError;
 use async_openai::types::EmbeddingInput;
@@ -314,24 +314,46 @@ pub(crate) async fn compute_additional_embedding_columns(
 /// +---------------------+      +-------------+
 ///     [`StringArray`]        [`FixedSizeListArray`]
 /// ```
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 async fn get_vectors(
     arr: impl Iterator<Item = Option<&str>>,
     model: &dyn Embed,
 ) -> Result<FixedSizeListArray, Box<dyn std::error::Error + Send + Sync>> {
-    let field = Arc::new(Field::new("item", DataType::Float32, false));
-    let column: Vec<String> = arr.filter_map(|s| s.map(ToString::to_string)).collect();
+    // Filter out nulls or empty strings before caling [`Embed::embed`].
+    let (null_pairs, values): (Vec<_>, Vec<_>) = arr
+        .enumerate()
+        .partition(|(_, o)| o.is_none() || o.is_some_and(|v| !v.is_empty()));
+    let nulls: Vec<usize> = null_pairs.into_iter().map(|(i, _)| i).collect();
+
+    let column: Vec<String> = values
+        .iter()
+        .filter_map(|(_, s)| s.map(ToString::to_string))
+        .collect();
+
     let embedded_data = model.embed(EmbeddingInput::StringArray(column)).await?;
     let vector_length = embedded_data.first().map(Vec::len).unwrap_or_default();
-    let processed = embedded_data.iter().flatten().copied().collect_vec();
 
-    let values = Float32Array::try_new(processed.into(), None)?;
-    FixedSizeListArray::try_new(
-        Arc::clone(&field),
-        i32::try_from(vector_length)?,
-        Arc::new(values),
-        None,
-    )
-    .boxed()
+    // Add back nulls into the ordering of embedding data.
+    let mut builder = FixedSizeListBuilder::with_capacity(
+        PrimitiveBuilder::<Float32Type>::with_capacity(
+            (embedded_data.len() + nulls.len()) * vector_length,
+        ),
+        vector_length as i32,
+        embedded_data.len() + nulls.len(),
+    );
+
+    let mut i: usize = 0;
+    for vector in embedded_data {
+        let null_input = nulls.first().is_some_and(|&idx| idx == i);
+        if null_input {
+            builder.values().append_nulls(vector_length);
+        } else {
+            builder.values().append_slice(&vector);
+            i += 1;
+        }
+        builder.append(null_input);
+    }
+    Ok(builder.finish())
 }
 
 /// Embed a [`StringArray`] using the provided [`Embed`] model and [`Chunker`]. The output is a [`ListArray`],
@@ -352,6 +374,7 @@ async fn get_vectors(
 ///                          | [[0, 10], [10, 21]]           |
 ///                          +-------------------------------+
 /// ```
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 async fn get_vectors_with_chunker(
     arr: impl Iterator<Item = Option<&str>>,
     chunker: Arc<dyn Chunker>,
@@ -359,16 +382,17 @@ async fn get_vectors_with_chunker(
 ) -> Result<(ListArray, ListArray), Box<dyn std::error::Error + Send + Sync>> {
     // Iterate over (chunks per row, (starting_offset into row, chunk))
     let (chunks_per_row, chunks_in_row): (Vec<_>, Vec<_>) = arr
-        .filter_map(|s| match s {
-            // TODO: filter_map doesn't handle nulls
-            Some(s) => {
+        // TODO: filter_map doesn't handle nulls
+        .map(|s| match s {
+            Some(s) if !s.is_empty() => {
                 let chunks = chunker
                     .chunk_indices(s)
                     .map(|(idx, s)| (idx, s.to_string()))
                     .collect_vec();
-                Some((chunks.len(), chunks))
+                (chunks.len(), chunks)
             }
-            None => None,
+            // None, or empty string.
+            _ => (0, vec![]),
         })
         .unzip();
 
@@ -379,17 +403,30 @@ async fn get_vectors_with_chunker(
         .await
         .boxed()?;
 
-    // `model.size()` is a `u32` for for compatibility with `FixedSizeList(FieldRef, i32)`.
     #[allow(clippy::cast_sign_loss)]
-    let vector_length = model.size() as usize;
+    let vector_length = model.size();
 
-    let mut values = Float32Array::builder(embedded_data.len() * vector_length);
-    let mut chunk_values = Int32Array::builder(embedded_data.len() * 2);
+    let capacity = chunks_per_row.iter().sum();
+    #[allow(clippy::cast_sign_loss)]
+    let mut vectors_builder = FixedSizeListBuilder::with_capacity(
+        PrimitiveBuilder::<Float32Type>::with_capacity(capacity * (vector_length as usize)),
+        vector_length,
+        capacity,
+    );
+
+    let mut chunks_builder = FixedSizeListBuilder::with_capacity(
+        PrimitiveBuilder::<Int32Type>::with_capacity(capacity),
+        2,
+        capacity,
+    );
 
     let mut lengths = Vec::with_capacity(chunks_per_row.len());
     let mut curr = 0;
-
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss
+    )]
     for chunkz_in_row in chunks_per_row {
         lengths.push(chunkz_in_row);
 
@@ -399,11 +436,19 @@ async fn get_vectors_with_chunker(
             .flatten()
             .copied()
             .collect_vec();
-        values.append_slice(&inner); // I believe this is a clone under the hood.
 
-        // Create flattened version of [(start, end), (start, end), ...]
+        // Handling Nulls
+        if chunkz_in_row == 0 {
+            vectors_builder
+                .values()
+                .append_nulls(vector_length as usize);
+            chunks_builder.values().append_nulls(vector_length as usize);
+            continue;
+        }
+
+        vectors_builder.values().append_slice(&inner); // I believe this is a clone under the hood.
+
         // Explicitly find `end` to handle when chunks have overlap.
-        let mut inner_offsets = Vec::with_capacity(2 * chunkz_in_row);
         for i in 0..chunkz_in_row {
             let start = chunk_offsets[curr + i];
             let end = start
@@ -412,66 +457,43 @@ async fn get_vectors_with_chunker(
                     .get(curr + i)
                     .map(String::len)
                     .unwrap_or_default();
-            inner_offsets.push(start as i32);
-            inner_offsets.push(end as i32);
+
+            chunks_builder.values().append_value(start as i32);
+            chunks_builder.values().append_value(end as i32);
         }
-        chunk_values.append_slice(inner_offsets.as_slice());
 
         curr += chunkz_in_row;
     }
 
-    // These are offsets for both the vectors and the content offsets
+    // These are offsets for both the vectors and the content offsets.
+    // They tell the [`ListArray`] how many vectors/offsets are for each row of the input table.
     let offsets = OffsetBuffer::<i32>::from_lengths(lengths.into_iter());
 
-    let vectors = {
-        let scalar_field = Arc::new(Field::new("item", DataType::Float32, false));
+    let vectors = ListArray::try_new(
+        Arc::new(Field::new_fixed_size_list(
+            "item",
+            Arc::new(Field::new("item", DataType::Float32, false)),
+            vector_length,
+            false,
+        )),
+        offsets.clone(),
+        Arc::new(vectors_builder.finish()),
+        None,
+    )
+    .boxed()?;
 
-        // Inner FixedSizeListArray
-        let fixed_size_list_array = FixedSizeListArray::try_new(
-            Arc::clone(&scalar_field),
-            i32::try_from(vector_length).boxed()?,
-            Arc::new(values.finish()),
-            None,
-        )
-        .boxed()?;
-
-        ListArray::try_new(
-            Arc::new(Field::new_fixed_size_list(
-                "item",
-                Arc::clone(&scalar_field),
-                i32::try_from(vector_length).boxed()?,
-                false,
-            )),
-            offsets.clone(),
-            Arc::new(fixed_size_list_array),
-            None,
-        )
-        .boxed()?
-    };
-
-    let content_offsets = {
-        let scalar_field = Arc::new(Field::new("item", DataType::Int32, false));
-        let fixed_size_list_array = FixedSizeListArray::try_new(
-            Arc::clone(&scalar_field),
+    let content_offsets = ListArray::try_new(
+        Arc::new(Field::new_fixed_size_list(
+            "item",
+            Arc::new(Field::new("item", DataType::Int32, false)),
             2,
-            Arc::new(chunk_values.finish()),
-            None,
-        )
-        .boxed()?;
-
-        ListArray::try_new(
-            Arc::new(Field::new_fixed_size_list(
-                "item",
-                Arc::clone(&scalar_field),
-                2,
-                false,
-            )),
-            offsets,
-            Arc::new(fixed_size_list_array),
-            None,
-        )
-        .boxed()?
-    };
+            false,
+        )),
+        offsets,
+        Arc::new(chunks_builder.finish()),
+        None,
+    )
+    .boxed()?;
 
     Ok((vectors, content_offsets))
 }

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -384,6 +384,15 @@ async fn get_vectors(
         output_ptr += 1;
         builder.append(true);
     }
+
+    // Handle any trailing nulls/empty strings.
+    while nulls.get(null_ptr).is_some_and(|&idx| idx == output_ptr) {
+        builder.values().append_nulls(vector_length);
+        null_ptr += 1;
+        output_ptr += 1;
+        builder.append(false);
+    }
+
     Ok(builder.finish())
 }
 
@@ -521,4 +530,108 @@ async fn get_vectors_with_chunker(
     .boxed()?;
 
     Ok((vectors, content_offsets))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::embeddings::execution_plan::get_vectors;
+    use arrow::{
+        array::{Array, AsArray},
+        datatypes::Float32Type,
+    };
+    use async_openai::types::EmbeddingInput;
+    use async_trait::async_trait;
+    use llms::embeddings::{self, Embed};
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    pub(crate) struct MockEmbedder {
+        pub map: HashMap<String, Vec<f32>>,
+    }
+
+    impl MockEmbedder {
+        pub fn with_pair(mut self, input: &'static str, output: Vec<f32>) -> Self {
+            self.map.insert(input.to_string(), output);
+            self
+        }
+    }
+
+    #[async_trait]
+    impl Embed for MockEmbedder {
+        fn size(&self) -> i32 {
+            -1
+        }
+
+        async fn embed(&self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>, embeddings::Error> {
+            match input {
+                EmbeddingInput::String(s) => {
+                    let v = self.map.get(&s).cloned().unwrap_or_default();
+                    Ok(vec![v])
+                }
+                EmbeddingInput::StringArray(arr) => {
+                    let v = arr
+                        .iter()
+                        .map(|s| self.map.get(s).cloned().unwrap_or_default())
+                        .collect();
+                    Ok(v)
+                }
+                _ => Err(embeddings::Error::FailedToCreateEmbedding {
+                    source: Box::<dyn std::error::Error + Send + Sync>::from(
+                        "Unsupported input type",
+                    ),
+                }),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_vectors_basic() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let fixed_size_array = get_vectors(
+            vec![Some("hello"), Some("world")].into_iter(),
+            &MockEmbedder::default()
+                .with_pair("hello", vec![0.1, 0.2])
+                .with_pair("world", vec![0.3, 0.4]),
+        )
+        .await?;
+
+        let values = fixed_size_array.values().as_primitive::<Float32Type>();
+
+        assert_eq!(fixed_size_array.len(), 2);
+        assert_eq!(values.value(0), 0.1);
+        assert_eq!(values.value(1), 0.2);
+        assert_eq!(values.value(2), 0.3);
+        assert_eq!(values.value(3), 0.4);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_vectors_with_nulls_and_empty(
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let result = get_vectors(
+            vec![None, Some("world"), Some(""), Some("hello"), None].into_iter(),
+            &MockEmbedder::default()
+                .with_pair("hello", vec![0.1, 0.2])
+                .with_pair("world", vec![0.3, 0.4]),
+        )
+        .await?;
+
+        assert_eq!(result.len(), 5);
+
+        assert!(result.is_null(0));
+        assert!(!result.is_null(1));
+        assert!(result.is_null(2));
+        assert!(!result.is_null(3));
+        assert!(result.is_null(4));
+
+        let values = result.values().as_primitive::<Float32Type>();
+        assert_eq!(values.len(), 10);
+        assert_eq!(values.value(2), 0.3);
+        assert_eq!(values.value(3), 0.4);
+        assert_eq!(values.value(6), 0.1);
+        assert_eq!(values.value(7), 0.2);
+
+        Ok(())
+    }
 }

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -397,7 +397,7 @@ impl EmbeddingTable {
                         cfg.vector_size,
                         false,
                     ),
-                    false,
+                    true,
                 )),
                 Arc::new(Field::new_list(
                     offset_col!(field.name()),
@@ -407,7 +407,7 @@ impl EmbeddingTable {
                         2,
                         false,
                     ),
-                    false,
+                    true,
                 )),
             ]
         } else {
@@ -415,7 +415,7 @@ impl EmbeddingTable {
                 embedding_col!(field.name()),
                 Field::new("item", DataType::Float32, false),
                 cfg.vector_size,
-                false,
+                true,
             ))]
         }
     }

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -397,7 +397,7 @@ impl EmbeddingTable {
                         cfg.vector_size,
                         false,
                     ),
-                    true,
+                    false,
                 )),
                 Arc::new(Field::new_list(
                     offset_col!(field.name()),
@@ -407,7 +407,7 @@ impl EmbeddingTable {
                         2,
                         false,
                     ),
-                    true,
+                    false,
                 )),
             ]
         } else {

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -548,11 +548,14 @@ impl VectorSearch {
             )
         } else {
             format!(
-                "SELECT
-                    {projection_str},
-                    cosine_distance({embedding_column}_embedding, {embedding:?}) as {VECTOR_DISTANCE_COLUMN_NAME}
-                FROM {tbl}
-                {where_str}
+                "SELECT * FROM (
+                    SELECT
+                        {projection_str},
+                        cosine_distance({embedding_column}_embedding, {embedding:?}) as {VECTOR_DISTANCE_COLUMN_NAME}
+                    FROM {tbl}
+                    {where_str}
+                ) subq
+                WHERE {VECTOR_DISTANCE_COLUMN_NAME} IS NOT NULL
                 ORDER BY {VECTOR_DISTANCE_COLUMN_NAME} ASC
                 LIMIT {n}", projection_str=projection.iter().join(", ")
             )


### PR DESCRIPTION
## 🗣 Description
 - Since switching to complete text-embedding-inference solution, inputs cannot be empty/null. 
 - This PR handles empty/null inputs in a dataset embedding column by avoiding providing these inputs to the embedding models. 
 - The output format for embedding columns are:
     - Standard embedding column: null embedding element in column
     - Chunked embedding column: empty array for both `_embedding` and `_offset`. 

#### Example (Standard)
```
>> select b, b is null, b_embedding is null, b_embedding from test;
+---------------------------+----------------+--------------------------+------------------------------+
| b                         | test.b IS NULL | test.b_embedding IS NULL |          b_embedding         |
+---------------------------+----------------+--------------------------+------------------------------+
| hello world               | false          | false                    | [0.030892028, 0.13509002,... |
|                           | true           | true                     |                              |
|                           | true           | true                     |                              |
| hello worldhello world... | false          | false                    | [0.06095122,  0.0672081,...  |
+---------------------------+----------------+--------------------------+------------------------------+
```

#### Example (Chunked)
```
>> select b, b is null, array_length(b_embedding) from test;
+------------------------------------------------------------------------------------------+----------------+--------------------------------+
| b                                                                                        | test.b IS NULL | array_length(test.b_embedding) |
+------------------------------------------------------------------------------------------+----------------+--------------------------------+
| hello world                                                                              | false          | 1                              |
|                                                                                          | true           | 0                              |
|                                                                                          | true           | 0                              |
| hello worldhello worldhello worldhello worldhello worldhello worldhello worldhello world | false          | 7                              |
+------------------------------------------------------------------------------------------+----------------+--------------------------------+
```

## 🔨 Related Issues
 - https://github.com/spiceai/spiceai/pull/3199 

## 📄 Documentation Requirements
 - [ ] Update requirement of inheriting embedding dataset columns.
