### PR TITLE
Add timeout to `/v1/datasets` APIs when app is locked

### DIFF
--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -79,7 +79,15 @@ pub(crate) async fn get(
     Query(filter): Query<DatasetFilter>,
     Query(params): Query<DatasetQueryParams>,
 ) -> Response {
-    let app_lock = app.read().await;
+    let app_lock = tokio::select! {
+        lock = app.read() => lock,
+        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+            return (
+                status::StatusCode::REQUEST_TIMEOUT,
+                "timeout".to_string()
+            ).into_response();
+        }
+    };
     let Some(readable_app) = app_lock.as_ref() else {
         return (
             status::StatusCode::INTERNAL_SERVER_ERROR,
@@ -144,7 +152,15 @@ pub(crate) async fn refresh(
     // This means malformed Json, etc, will simply return None
     // To get around this, we would need to implement a custom extractor
 ) -> Response {
-    let app_lock = app.read().await;
+    let app_lock = tokio::select! {
+        lock = app.read() => lock,
+        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+            return (
+                status::StatusCode::REQUEST_TIMEOUT,
+                "timeout".to_string()
+            ).into_response();
+        }
+    };
     let Some(readable_app) = &*app_lock else {
         return (status::StatusCode::INTERNAL_SERVER_ERROR).into_response();
     };
@@ -205,7 +221,15 @@ pub(crate) async fn acceleration(
     Path(dataset_name): Path<String>,
     Json(payload): Json<AccelerationRequest>,
 ) -> Response {
-    let app_lock = app.read().await;
+    let app_lock = tokio::select! {
+        lock = app.read() => lock,
+        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+            return (
+                status::StatusCode::REQUEST_TIMEOUT,
+                "timeout".to_string()
+            ).into_response();
+        }
+    };
     let Some(readable_app) = &*app_lock else {
         return (status::StatusCode::INTERNAL_SERVER_ERROR).into_response();
     };


### PR DESCRIPTION
## 🗣 Description

A small fix to timeout the API request to `/v1/datasets` if the app is locked for an extended period of time.

## 🔨 Related Issues

N/A

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

This doesn't fix the underlying issue of the app being locked - that will be fixed in a subsequent PR. This at least allows us to re-enable our E2E tests (which will now fail instead of hang indefinitely) until the actual fix is applied.
