### PR TITLE
refactor: First pass data connector error messages update

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -543,8 +543,12 @@ impl DataConnectorParamsBuilder {
         runtime: &Runtime,
     ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
         match &self.component {
-            ConnectorComponent::Catalog(_) => {
-                todo!();
+            ConnectorComponent::Catalog(catalog) => {
+                let secrets = runtime.secrets();
+                let params = runtime.get_params_with_secrets(&catalog.params).await;
+                let params = self.without_runtime(params, secrets).await?;
+
+                Ok(params)
             }
             ConnectorComponent::Dataset(dataset) => {
                 let secrets = runtime.secrets();
@@ -563,38 +567,30 @@ impl DataConnectorParamsBuilder {
         params: HashMap<String, SecretString>,
         secrets: Arc<RwLock<Secrets>>,
     ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
-        match &self.component {
-            ConnectorComponent::Catalog(_) => {
-                todo!();
-            }
-            ConnectorComponent::Dataset(_) => {
-                let name = self.connector.to_string();
-                let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
+        let name = self.connector.to_string();
+        let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
 
-                let connector_factory = guard.get(&name);
+        let connector_factory = guard.get(&name);
 
-                let factory =
-                    connector_factory.ok_or(DataConnectorError::InvalidConnectorType {
-                        dataconnector: name.clone(),
-                        connector_component: self.component.clone(),
-                    })?;
+        let factory = connector_factory.ok_or(DataConnectorError::InvalidConnectorType {
+            dataconnector: name.clone(),
+            connector_component: self.component.clone(),
+        })?;
 
-                let parameters = Parameters::try_new(
-                    &format!("connector {name}"),
-                    params.into_iter().collect(),
-                    factory.prefix(),
-                    secrets,
-                    factory.parameters(),
-                )
-                .await?;
+        let parameters = Parameters::try_new(
+            &format!("connector {name}"),
+            params.into_iter().collect(),
+            factory.prefix(),
+            secrets,
+            factory.parameters(),
+        )
+        .await?;
 
-                Ok(DataConnectorParams {
-                    parameters,
-                    metadata: HashMap::new(),
-                    invalid_type_action: None,
-                    component: self.component.clone(),
-                })
-            }
-        }
+        Ok(DataConnectorParams {
+            parameters,
+            metadata: HashMap::new(),
+            invalid_type_action: None,
+            component: self.component.clone(),
+        })
     }
 }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -543,7 +543,7 @@ impl DataConnectorParamsBuilder {
         runtime: &Runtime,
     ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
         match &self.component {
-            ConnectorComponent::Catalog(catalog) => {
+            ConnectorComponent::Catalog(_) => {
                 todo!();
             }
             ConnectorComponent::Dataset(dataset) => {
@@ -564,7 +564,7 @@ impl DataConnectorParamsBuilder {
         secrets: Arc<RwLock<Secrets>>,
     ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
         match &self.component {
-            ConnectorComponent::Catalog(catalog) => {
+            ConnectorComponent::Catalog(_) => {
                 todo!();
             }
             ConnectorComponent::Dataset(_) => {

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -129,105 +129,132 @@ pub enum Error {
 
 #[derive(Debug, Snafu)]
 pub enum DataConnectorError {
-    #[snafu(display("Cannot connect to {dataconnector}. {source}"))]
+    #[snafu(display("Cannot connect to the {connector_component} ({dataconnector}).\n{source}"))]
     UnableToConnectInternal {
         dataconnector: String,
+        connector_component: ConnectorComponent,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Cannot connect to {dataconnector} on {host}:{port}. Ensure that the host and port are correctly configured in the spicepod, and that the host is reachable."))]
+    #[snafu(display("Cannot connect to the {connector_component} ({dataconnector}) on {host}:{port}.\nEnsure that the host and port are correctly configured in the spicepod, and that the host is reachable."))]
     UnableToConnectInvalidHostOrPort {
         dataconnector: String,
+        connector_component: ConnectorComponent,
         host: String,
         port: String,
     },
 
-    #[snafu(display("Cannot connect to {dataconnector}. Authentication failed. Ensure that the username and password are correctly configured in the spicepod."))]
-    UnableToConnectInvalidUsernameOrPassword { dataconnector: String },
+    #[snafu(display("Cannot connect to the {connector_component} ({dataconnector}). Authentication failed.\nEnsure that the username and password are correctly configured in the spicepod."))]
+    UnableToConnectInvalidUsernameOrPassword {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+    },
 
-    #[snafu(display("Cannot connect to {dataconnector}. Ensure that the corresponding secure option is configured to match the data connector's TLS security requirements."))]
-    UnableToConnectTlsError { dataconnector: String },
+    #[snafu(display("Cannot connect to the {connector_component} ({dataconnector}). A TLS error occurred.\nEnsure that the corresponding TLS/secure option is configured to match the data connector's TLS security requirements."))]
+    UnableToConnectTlsError {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+    },
 
-    #[snafu(display("Unable to get read provider for {dataconnector}: {source}"))]
+    #[snafu(display("Failed to load the {connector_component} ({dataconnector}).\n{source}"))]
     UnableToGetReadProvider {
         dataconnector: String,
+        connector_component: ConnectorComponent,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Unable to get read write provider for {dataconnector}: {source}"))]
+    #[snafu(display("Failed to load the {connector_component} ({dataconnector}).\n{source}"))]
     UnableToGetReadWriteProvider {
         dataconnector: String,
+        connector_component: ConnectorComponent,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Unable to get catalog provider for {dataconnector}: {source}"))]
+    #[snafu(display("Failed to setup the {connector_component} ({dataconnector}).\n{source}"))]
     UnableToGetCatalogProvider {
         dataconnector: String,
+        connector_component: ConnectorComponent,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Unable to read the secrets for {dataconnector}: {source}"))]
-    UnableToReadSecrets {
+    #[snafu(display("Failed to read secrets while setting up the {connector_component} ({dataconnector}).\n{source}"))]
+    UnableToReadDatasetSecrets {
         dataconnector: String,
+        connector_component: ConnectorComponent,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Invalid configuration for {dataconnector}. {message}"))]
+    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}) with an invalid configuration.\n{message}"))]
     InvalidConfiguration {
         dataconnector: String,
+        connector_component: ConnectorComponent,
         message: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display(
-        "Unable to load {dataconnector} dataset {dataset_name}. Table {table_name} not found. Verify the source table name in the Spicepod configuration."
-    ))]
-    InvalidTableName {
-        dataconnector: String,
-        dataset_name: String,
-        table_name: String,
-    },
-
-    #[snafu(display(
-        "Failed to get schema for {dataconnector} dataset {dataset_name}. Ensure the table '{table_name}' exists in the data source."
-    ))]
-    UnableToGetSchema {
-        dataconnector: String,
-        dataset_name: String,
-        table_name: String,
-    },
-
-    #[snafu(display("{dataconnector} Data Connector Error: {source}"))]
-    InternalWithSource {
-        dataconnector: String,
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    #[snafu(display(
-        "An internal error occurred in the {dataconnector} Data Connector. Report a bug on GitHub (github.com/spiceai/spiceai) and reference the code: {code}"
-    ))]
-    Internal {
-        dataconnector: String,
-        code: String,
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
-    #[snafu(display("Invalid configuration for {dataconnector}. {message}"))]
+    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}) with an invalid configuration.\n{message}"))]
     InvalidConfigurationNoSource {
         dataconnector: String,
+        connector_component: ConnectorComponent,
         message: String,
     },
 
-    #[snafu(display("Invalid glob pattern {pattern}: {source}"))]
+    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}).\nThe connector, {dataconnector}, is not a valid connector.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors"))]
+    InvalidConnectorType {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+    },
+
+    #[snafu(display("Failed to load the {connector_component} ({dataconnector}).\n An invalid glob pattern was provided '{pattern}'. Ensure the glob pattern is valid.\n{source}"))]
     InvalidGlobPattern {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
         pattern: String,
         source: globset::Error,
     },
 
     #[snafu(display(
-        "Invalid type action is not supported for the {dataconnector} Data Connector."
+        "Failed to load the {connector_component} ({dataconnector}).\nThe table, '{table_name}', was not found. Verify the source table name in the Spicepod configuration."
     ))]
-    UnsupportedInvalidTypeAction { dataconnector: String },
+    InvalidTableName {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+        table_name: String,
+    },
+
+    #[snafu(display(
+        "Failed to load the {connector_component} ({dataconnector}).\nFailed to detect a table schema. Ensure the table, '{table_name}', exists in the data source."
+    ))]
+    UnableToGetSchema {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+        table_name: String,
+    },
+
+    #[snafu(display("Failed to load the {connector_component} ({dataconnector}).\nAn unknown Data Connector Error occurred: {source}\nPlease report a bug on GitHub: https://github.com/spiceai/spiceai/issues"))]
+    InternalWithSource {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display(
+        "Failed to load the {connector_component} ({dataconnector}).\nAn internal error occurred in the {dataconnector} Data Connector.\nReport a bug on GitHub (https://github.com/spiceai/spiceai/issues) and reference the code: {code}"
+    ))]
+    Internal {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+        code: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display(
+        "Failed to load the {connector_component} ({dataconnector}).\nInvalid type action is not supported for the {dataconnector} Data Connector.\nRemove the parameter from your dataset configuration."
+    ))]
+    UnsupportedInvalidTypeAction {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -267,6 +294,7 @@ pub async fn create_new_connector(
     if params.invalid_type_action.is_some() && !factory.supports_invalid_type_action() {
         return Some(Err(DataConnectorError::UnsupportedInvalidTypeAction {
             dataconnector: name.to_string(),
+            connector_component: params.component.clone(),
         }
         .into()));
     }
@@ -456,65 +484,117 @@ pub async fn get_data(
     Ok((table_provider.schema(), record_batch_stream))
 }
 
+#[derive(Debug, Clone)]
+pub enum ConnectorComponent {
+    Catalog(Arc<Catalog>),
+    Dataset(Arc<Dataset>),
+}
+
+impl From<&Dataset> for ConnectorComponent {
+    fn from(dataset: &Dataset) -> Self {
+        ConnectorComponent::Dataset(Arc::new(dataset.clone()))
+    }
+}
+
+impl From<&Arc<Dataset>> for ConnectorComponent {
+    fn from(dataset: &Arc<Dataset>) -> Self {
+        ConnectorComponent::Dataset(Arc::clone(dataset))
+    }
+}
+
+impl From<&Catalog> for ConnectorComponent {
+    fn from(catalog: &Catalog) -> Self {
+        ConnectorComponent::Catalog(Arc::new(catalog.clone()))
+    }
+}
+
+impl std::fmt::Display for ConnectorComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectorComponent::Catalog(catalog) => write!(f, "catalog {}", catalog.name),
+            ConnectorComponent::Dataset(dataset) => write!(f, "dataset {}", dataset.name),
+        }
+    }
+}
+
 pub struct DataConnectorParams {
     pub(crate) parameters: Parameters,
     pub(crate) metadata: HashMap<String, String>,
     pub(crate) invalid_type_action: Option<InvalidTypeAction>,
+    pub(crate) component: ConnectorComponent,
 }
 
-impl DataConnectorParams {
-    pub async fn from_dataset(
-        runtime: &Runtime,
-        dataset: Arc<Dataset>,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let name = dataset.source();
-        let params = dataset.params.clone();
-        let mut params = Self::from_params(runtime, &name, params).await?;
-        params.metadata.clone_from(&dataset.metadata);
-        params.invalid_type_action = dataset.invalid_type_action.map(Into::into);
+pub struct DataConnectorParamsBuilder {
+    connector: Arc<str>,
+    component: ConnectorComponent,
+}
 
-        Ok(params)
+impl DataConnectorParamsBuilder {
+    #[must_use]
+    pub fn new(connector: Arc<str>, component: ConnectorComponent) -> Self {
+        Self {
+            connector,
+            component,
+        }
     }
 
-    pub async fn from_secrets(
-        name: &str,
+    pub async fn with_runtime(
+        &self,
+        runtime: &Runtime,
+    ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
+        match &self.component {
+            ConnectorComponent::Catalog(catalog) => {
+                todo!();
+            }
+            ConnectorComponent::Dataset(dataset) => {
+                let secrets = runtime.secrets();
+                let params = runtime.get_params_with_secrets(&dataset.params).await;
+                let mut params = self.without_runtime(params, secrets).await?;
+                params.metadata.clone_from(&dataset.metadata);
+                params.invalid_type_action = dataset.invalid_type_action.map(Into::into);
+
+                Ok(params)
+            }
+        }
+    }
+
+    pub async fn without_runtime(
+        &self,
         params: HashMap<String, SecretString>,
         secrets: Arc<RwLock<Secrets>>,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
+    ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
+        match &self.component {
+            ConnectorComponent::Catalog(catalog) => {
+                todo!();
+            }
+            ConnectorComponent::Dataset(_) => {
+                let name = self.connector.to_string();
+                let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
 
-        let connector_factory = guard.get(name);
+                let connector_factory = guard.get(&name);
 
-        let factory =
-            connector_factory.ok_or(DataConnectorError::InvalidConfigurationNoSource {
-                dataconnector: name.to_string(),
-                message: "No source found for data connector".to_string(),
-            })?;
+                let factory =
+                    connector_factory.ok_or(DataConnectorError::InvalidConnectorType {
+                        dataconnector: name.clone(),
+                        connector_component: self.component.clone(),
+                    })?;
 
-        let parameters = Parameters::try_new(
-            &format!("connector {name}"),
-            params.into_iter().collect(),
-            factory.prefix(),
-            secrets,
-            factory.parameters(),
-        )
-        .await?;
+                let parameters = Parameters::try_new(
+                    &format!("connector {name}"),
+                    params.into_iter().collect(),
+                    factory.prefix(),
+                    secrets,
+                    factory.parameters(),
+                )
+                .await?;
 
-        Ok(Self {
-            parameters,
-            metadata: HashMap::new(),
-            invalid_type_action: None,
-        })
-    }
-
-    pub async fn from_params(
-        runtime: &Runtime,
-        name: &str,
-        parameters: HashMap<String, String>,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let params = runtime.get_params_with_secrets(&parameters).await;
-        let secrets = runtime.secrets();
-
-        Self::from_secrets(name, params, secrets).await
+                Ok(DataConnectorParams {
+                    parameters,
+                    metadata: HashMap::new(),
+                    invalid_type_action: None,
+                    component: self.component.clone(),
+                })
+            }
+        }
     }
 }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -177,13 +177,6 @@ pub enum DataConnectorError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Failed to read secrets while setting up the {connector_component} ({dataconnector}).\n{source}"))]
-    UnableToReadDatasetSecrets {
-        dataconnector: String,
-        connector_component: ConnectorComponent,
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
-
     #[snafu(display("Cannot setup the {connector_component} ({dataconnector}) with an invalid configuration.\n{message}"))]
     InvalidConfiguration {
         dataconnector: String,

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -199,7 +199,7 @@ pub enum DataConnectorError {
         message: String,
     },
 
-    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}).\nThe connector, {dataconnector}, is not a valid connector.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors"))]
+    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}).\nThe connector '{dataconnector}' is not a valid connector.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors"))]
     InvalidConnectorType {
         dataconnector: String,
         connector_component: ConnectorComponent,

--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 use super::listing::{build_fragments, ListingTableConnector};
 use super::{
-    DataConnector, DataConnectorFactory, DataConnectorParams, DataConnectorResult, ParameterSpec,
-    Parameters,
+    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams,
+    DataConnectorResult, ParameterSpec, Parameters,
 };
 
 use crate::component::dataset::Dataset;
@@ -239,7 +239,8 @@ impl ListingTableConnector for AzureBlobFS {
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("{} is not a valid URL", &dataset.from),
+                    message: format!("{} is not a valid URL. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/abfs#from", &dataset.from),
+                    connector_component: ConnectorComponent::from(dataset)
                 })?;
 
         let params = build_fragments(

--- a/crates/runtime/src/dataconnector/clickhouse.rs
+++ b/crates/runtime/src/dataconnector/clickhouse.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
+use super::ConnectorComponent;
 use super::DataConnectorParams;
 use super::{DataConnector, DataConnectorError, DataConnectorFactory, Parameters};
 use crate::parameters::{ParamLookup, ParameterSpec};
@@ -148,6 +149,7 @@ impl DataConnectorFactory for ClickhouseFactory {
                     Error::InvalidUsernameOrPasswordError { .. } => Err(
                         DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
                             dataconnector: "clickhouse".to_string(),
+                            connector_component: params.component,
                         }
                         .into(),
                     ),
@@ -157,6 +159,7 @@ impl DataConnectorFactory for ClickhouseFactory {
                         source: _,
                     } => Err(DataConnectorError::UnableToConnectInvalidHostOrPort {
                         dataconnector: "clickhouse".to_string(),
+                        connector_component: params.component,
                         host,
                         port,
                     }
@@ -164,11 +167,13 @@ impl DataConnectorFactory for ClickhouseFactory {
                     Error::ConnectionTlsError { source: _ } => {
                         Err(DataConnectorError::UnableToConnectTlsError {
                             dataconnector: "clickhouse".to_string(),
+                            connector_component: params.component,
                         }
                         .into())
                     }
                     _ => Err(DataConnectorError::UnableToConnectInternal {
                         dataconnector: "clickhouse".to_string(),
+                        connector_component: params.component,
                         source: Box::new(e),
                     }
                     .into()),
@@ -204,6 +209,7 @@ impl DataConnector for Clickhouse {
         .await
         .context(super::UnableToGetReadProviderSnafu {
             dataconnector: "clickhouse",
+            connector_component: ConnectorComponent::from(dataset),
         })?)
     }
 }

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -142,7 +142,7 @@ impl Databricks {
         let token = self.params.get("token").ok_or_else(|p| {
             super::DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: "databricks".into(),
-                message: format!("Missing required parameter: {}.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
+                message: format!("A required parameter was missing: {}.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
                 connector_component: ConnectorComponent::from(catalog)
             }
         })?;

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -34,7 +34,10 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::{collections::HashMap, future::Future};
 
-use super::{DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec, Parameters};
+use super::{
+    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+    Parameters,
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -124,20 +127,23 @@ impl Databricks {
         let Some(catalog_id) = catalog.catalog_id.clone() else {
             return Err(super::DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: "databricks".into(),
-                message: "Catalog ID is required for Databricks Unity Catalog".into(),
+                message: "A Catalog Name is required for the Databricks Unity Catalog.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/databricks#from".into(),
+                connector_component: ConnectorComponent::from(catalog)
             });
         };
 
         let endpoint = self.params.get("endpoint").expose().ok_or_else(|p| {
             super::DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: "databricks".into(),
-                message: format!("Missing required parameter: {}", p.0),
+                message: format!("A required parameter was missing: {}.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
+                connector_component: ConnectorComponent::from(catalog)
             }
         })?;
         let token = self.params.get("token").ok_or_else(|p| {
             super::DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: "databricks".into(),
-                message: format!("Missing required parameter: {}", p.0),
+                message: format!("Missing required parameter: {}.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
+                connector_component: ConnectorComponent::from(catalog)
             }
         })?;
 
@@ -168,6 +174,7 @@ impl Databricks {
         .await
         .context(super::InternalWithSourceSnafu {
             dataconnector: "databricks".to_string(),
+            connector_component: ConnectorComponent::from(catalog),
         })?;
 
         let mode = self.params.get("mode").expose().ok();
@@ -181,6 +188,7 @@ impl Databricks {
                 super::DataConnectorError::UnableToGetCatalogProvider {
                     dataconnector: "databricks".to_string(),
                     source: source.into(),
+                    connector_component: ConnectorComponent::from(catalog),
                 }
             }) {
                 Ok(dataset_databricks) => dataset_databricks,
@@ -207,6 +215,7 @@ impl Databricks {
                 return Err(super::DataConnectorError::UnableToGetCatalogProvider {
                     dataconnector: "databricks".to_string(),
                     source: Box::new(e),
+                    connector_component: ConnectorComponent::from(catalog),
                 })
             }
         };
@@ -324,6 +333,7 @@ impl DataConnector for Databricks {
             .await
             .context(super::UnableToGetReadProviderSnafu {
                 dataconnector: "databricks",
+                connector_component: ConnectorComponent::from(dataset),
             })?)
     }
 

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -25,7 +25,10 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use super::{DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec, Parameters};
+use super::{
+    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+    Parameters,
+};
 
 pub struct DeltaLake {
     delta_table_factory: DeltaTableFactory,
@@ -135,6 +138,7 @@ impl DataConnector for DeltaLake {
         .await
         .context(super::UnableToGetReadProviderSnafu {
             dataconnector: "delta_lake",
+            connector_component: ConnectorComponent::from(dataset),
         })?)
     }
 }

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use super::ConnectorComponent;
 use super::DataConnector;
 use super::DataConnectorFactory;
 use super::DataConnectorParams;
@@ -184,13 +185,14 @@ impl DataConnector for Dremio {
                     tracing::debug!("{e}");
                     return Err(DataConnectorError::UnableToGetSchema {
                         dataconnector: "dremio".to_string(),
-                        dataset_name: dataset.name.to_string(),
                         table_name: table.clone(),
+                        connector_component: ConnectorComponent::from(dataset),
                     });
                 }
 
                 return Err(DataConnectorError::UnableToGetReadProvider {
                     dataconnector: "dremio".to_string(),
+                    connector_component: ConnectorComponent::from(dataset),
                     source: e,
                 });
             }
@@ -209,6 +211,7 @@ impl DataConnector for Dremio {
         .await
         .context(super::UnableToGetReadWriteProviderSnafu {
             dataconnector: "dremio",
+            connector_component: ConnectorComponent::from(dataset),
         });
 
         Some(read_write_result)

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::{DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec};
+use super::{
+    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+};
 use crate::component::dataset::Dataset;
 use arrow_flight::sql::client::FlightSqlServiceClient;
 use async_trait::async_trait;
@@ -126,6 +128,7 @@ impl DataConnector for FlightSQL {
         .await
         .context(super::UnableToGetReadProviderSnafu {
             dataconnector: "flightsql",
+            connector_component: ConnectorComponent::from(dataset),
         })?)
     }
 }

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -22,7 +22,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use url::Url;
 
-use super::{listing, DataConnectorParams};
+use super::{listing, ConnectorComponent, DataConnectorParams};
 use super::{
     listing::ListingTableConnector, DataConnector, DataConnectorFactory, DataConnectorResult,
     ParameterSpec, Parameters,
@@ -114,7 +114,8 @@ impl ListingTableConnector for FTP {
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("{} is not a valid URL", dataset.from),
+                    message: format!("{} is not a valid URL. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/ftp", dataset.from),
+                    connector_component: ConnectorComponent::from(dataset),
                 })?;
 
         ftp_url.set_fragment(Some(&listing::build_fragments(

--- a/crates/runtime/src/dataconnector/github/commits.rs
+++ b/crates/runtime/src/dataconnector/github/commits.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::dataconnector::ConnectorComponent;
+
 use super::{
     commits_inject_parameters, filter_pushdown, inject_parameters, GitHubTableArgs,
     GitHubTableGraphQLParams,
@@ -31,6 +33,7 @@ use std::sync::Arc;
 pub struct CommitsTableArgs {
     pub owner: String,
     pub repo: String,
+    pub component: ConnectorComponent,
 }
 
 impl GraphQLContext for CommitsTableArgs {
@@ -55,6 +58,10 @@ impl GraphQLContext for CommitsTableArgs {
 }
 
 impl GitHubTableArgs for CommitsTableArgs {
+    fn get_component(&self) -> ConnectorComponent {
+        self.component.clone()
+    }
+
     fn get_graphql_values(&self) -> GitHubTableGraphQLParams {
         let query = format!(
             r#"{{

--- a/crates/runtime/src/dataconnector/github/issues.rs
+++ b/crates/runtime/src/dataconnector/github/issues.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::dataconnector::ConnectorComponent;
+
 use super::{
     filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
     GitHubTableGraphQLParams,
@@ -32,6 +34,7 @@ pub struct IssuesTableArgs {
     pub owner: String,
     pub repo: String,
     pub query_mode: GitHubQueryMode,
+    pub component: ConnectorComponent,
 }
 
 impl GraphQLContext for IssuesTableArgs {
@@ -68,6 +71,10 @@ impl GraphQLContext for IssuesTableArgs {
 }
 
 impl GitHubTableArgs for IssuesTableArgs {
+    fn get_component(&self) -> ConnectorComponent {
+        self.component.clone()
+    }
+
     fn get_graphql_values(&self) -> GitHubTableGraphQLParams {
         let query = match self.query_mode {
             GitHubQueryMode::Search => format!(

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -53,8 +53,8 @@ use std::{any::Any, future::Future, pin::Pin, str::FromStr, sync::Arc};
 use url::Url;
 
 use super::{
-    graphql::default_spice_client, DataConnector, DataConnectorError, DataConnectorFactory,
-    DataConnectorParams, ParameterSpec, Parameters,
+    graphql::default_spice_client, ConnectorComponent, DataConnector, DataConnectorError,
+    DataConnectorFactory, DataConnectorParams, ParameterSpec, Parameters,
 };
 
 mod commits;
@@ -99,6 +99,7 @@ impl GitHubTableGraphQLParams {
 
 pub trait GitHubTableArgs: Send + Sync {
     fn get_graphql_values(&self) -> GitHubTableGraphQLParams;
+    fn get_component(&self) -> ConnectorComponent;
 }
 
 impl Github {
@@ -138,6 +139,7 @@ impl Github {
         let client = self.create_graphql_client(&table_args).context(
             super::UnableToGetReadProviderSnafu {
                 dataconnector: "github".to_string(),
+                connector_component: table_args.get_component(),
             },
         )?;
 
@@ -157,6 +159,7 @@ impl Github {
                 .boxed()
                 .context(super::UnableToGetReadProviderSnafu {
                     dataconnector: "github".to_string(),
+                    connector_component: table_args.get_component(),
                 })?,
         ))
     }
@@ -185,7 +188,8 @@ impl Github {
         let Some(tree_sha) = tree_sha.filter(|s| !s.is_empty()) else {
             return Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "github".to_string(),
-                source: format!("Branch or tag name is required in dataset definition; must be 'github.com/{owner}/{repo}/files/BRANCH_NAME'").into(),
+                source: format!("The branch or tag name is required in the dataset 'from' and must be in the format'github.com/{owner}/{repo}/files/<BRANCH_NAME>'.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#querying-github-files").into(),
+                connector_component: ConnectorComponent::from(dataset),
             });
         };
 
@@ -193,10 +197,11 @@ impl Github {
             .create_rest_client()
             .context(super::UnableToGetReadProviderSnafu {
                 dataconnector: "github".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
             })?;
 
         let include = match self.params.get("include").expose().ok() {
-            Some(pattern) => Some(parse_globs(pattern)?),
+            Some(pattern) => Some(parse_globs(&ConnectorComponent::from(dataset), pattern)?),
             None => None,
         };
 
@@ -213,6 +218,7 @@ impl Github {
             .boxed()
             .context(super::UnableToGetReadProviderSnafu {
                 dataconnector: "github".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
             })?,
         ))
     }
@@ -336,16 +342,13 @@ pub(crate) enum GitHubQueryMode {
 }
 
 impl std::str::FromStr for GitHubQueryMode {
-    type Err = DataConnectorError;
+    type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "auto" => Ok(Self::Auto),
             "search" => Ok(Self::Search),
-            s => Err(DataConnectorError::UnableToGetReadProvider {
-                dataconnector: "github".to_string(),
-                source: format!("Invalid value for 'github_query_mode' parameter: {s}").into(),
-            }),
+            s => Err(s.to_string()),
         }
     }
 }
@@ -368,7 +371,13 @@ impl DataConnector for Github {
             .get("github_query_mode")
             .map_or("auto", |v| v);
 
-        let query_mode = GitHubQueryMode::from_str(query_mode)?;
+        let query_mode = GitHubQueryMode::from_str(query_mode).map_err(|e| {
+            DataConnectorError::UnableToGetReadProvider {
+                dataconnector: "github".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: format!("Invalid query mode: {e}.\nEnsure a valid query mode is used, and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#common-parameters").into(),
+            }
+        })?;
 
         match (parts.next(), parts.next(), parts.next(), parts.next()) {
             (Some("github.com"), Some(owner), Some(repo), Some("pulls")) => {
@@ -376,6 +385,7 @@ impl DataConnector for Github {
                     owner: owner.to_string(),
                     repo: repo.to_string(),
                     query_mode,
+                    component: ConnectorComponent::from(dataset),
                 });
                 self.create_gql_table_provider(
                     Arc::clone(&table_args) as Arc<dyn GitHubTableArgs>,
@@ -387,6 +397,7 @@ impl DataConnector for Github {
                 let table_args = Arc::new(CommitsTableArgs {
                     owner: owner.to_string(),
                     repo: repo.to_string(),
+                    component: ConnectorComponent::from(dataset),
                 });
                 self.create_gql_table_provider(
                     Arc::clone(&table_args) as Arc<dyn GitHubTableArgs>,
@@ -399,6 +410,7 @@ impl DataConnector for Github {
                     owner: owner.to_string(),
                     repo: repo.to_string(),
                     query_mode,
+                    component: ConnectorComponent::from(dataset),
                 });
                 self.create_gql_table_provider(
                     Arc::clone(&table_args) as Arc<dyn GitHubTableArgs>,
@@ -410,6 +422,7 @@ impl DataConnector for Github {
                 let table_args = Arc::new(StargazersTableArgs {
                     owner: owner.to_string(),
                     repo: repo.to_string(),
+                    component: ConnectorComponent::from(dataset),
                 });
                 self.create_gql_table_provider(table_args, None).await
             }
@@ -420,22 +433,28 @@ impl DataConnector for Github {
             (Some("github.com"), Some(_), Some(_), Some(invalid_table)) => {
                 Err(DataConnectorError::UnableToGetReadProvider {
                     dataconnector: "github".to_string(),
-                    source: format!("Invalid Github table type: {invalid_table}").into(),
+                    source: format!("Invalid GitHub table type: {invalid_table}.\nEnsure a valid table type is used, and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration").into(),
+                    connector_component: ConnectorComponent::from(dataset),
                 })
             }
             (_, Some(owner), Some(repo), _) => Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "github".to_string(),
-                source: format!("`from` must start with 'github.com/{owner}/{repo}'").into(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: format!("The dataset `from` must start with 'github.com/{owner}/{repo}'.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration").into(),
             }),
             _ => Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "github".to_string(),
-                source: "Invalid Github dataset path".into(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: "Invalid GitHub path provided in the dataset 'from'.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration".into(),
             }),
         }
     }
 }
 
-pub fn parse_globs(input: &str) -> super::DataConnectorResult<Arc<GlobSet>> {
+pub fn parse_globs(
+    component: &ConnectorComponent,
+    input: &str,
+) -> super::DataConnectorResult<Arc<GlobSet>> {
     let patterns: Vec<&str> = input.split(&[',', ';'][..]).collect();
     let mut builder = GlobSetBuilder::new();
 
@@ -443,14 +462,20 @@ pub fn parse_globs(input: &str) -> super::DataConnectorResult<Arc<GlobSet>> {
         let trimmed_pattern = pattern.trim();
         if !trimmed_pattern.is_empty() {
             builder.add(
-                Glob::new(trimmed_pattern).context(super::InvalidGlobPatternSnafu { pattern })?,
+                Glob::new(trimmed_pattern).context(super::InvalidGlobPatternSnafu {
+                    pattern,
+                    dataconnector: "github".to_string(),
+                    connector_component: component.clone(),
+                })?,
             );
         }
     }
 
-    let glob_set = builder
-        .build()
-        .context(super::InvalidGlobPatternSnafu { pattern: input })?;
+    let glob_set = builder.build().context(super::InvalidGlobPatternSnafu {
+        pattern: input,
+        dataconnector: "github".to_string(),
+        connector_component: component.clone(),
+    })?;
     Ok(Arc::new(glob_set))
 }
 

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -188,7 +188,7 @@ impl Github {
         let Some(tree_sha) = tree_sha.filter(|s| !s.is_empty()) else {
             return Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "github".to_string(),
-                source: format!("The branch or tag name is required in the dataset 'from' and must be in the format'github.com/{owner}/{repo}/files/<BRANCH_NAME>'.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#querying-github-files").into(),
+                source: format!("The branch or tag name is required in the dataset 'from' and must be in the format 'github.com/{owner}/{repo}/files/<BRANCH_NAME>'.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#querying-github-files").into(),
                 connector_component: ConnectorComponent::from(dataset),
             });
         };

--- a/crates/runtime/src/dataconnector/github/pull_requests.rs
+++ b/crates/runtime/src/dataconnector/github/pull_requests.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::dataconnector::ConnectorComponent;
+
 use super::{
     filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
     GitHubTableGraphQLParams,
@@ -32,6 +34,7 @@ pub struct PullRequestTableArgs {
     pub owner: String,
     pub repo: String,
     pub query_mode: GitHubQueryMode,
+    pub component: ConnectorComponent,
 }
 
 impl GraphQLContext for PullRequestTableArgs {
@@ -68,6 +71,10 @@ impl GraphQLContext for PullRequestTableArgs {
 }
 
 impl GitHubTableArgs for PullRequestTableArgs {
+    fn get_component(&self) -> ConnectorComponent {
+        self.component.clone()
+    }
+
     fn get_graphql_values(&self) -> GitHubTableGraphQLParams {
         let query = match self.query_mode {
             GitHubQueryMode::Search => {

--- a/crates/runtime/src/dataconnector/github/stargazers.rs
+++ b/crates/runtime/src/dataconnector/github/stargazers.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::dataconnector::ConnectorComponent;
+
 use super::{GitHubTableArgs, GitHubTableGraphQLParams};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use std::sync::Arc;
@@ -22,9 +24,14 @@ use std::sync::Arc;
 pub struct StargazersTableArgs {
     pub owner: String,
     pub repo: String,
+    pub component: ConnectorComponent,
 }
 
 impl GitHubTableArgs for StargazersTableArgs {
+    fn get_component(&self) -> ConnectorComponent {
+        self.component.clone()
+    }
+
     fn get_graphql_values(&self) -> GitHubTableGraphQLParams {
         let query = format!(
             r#"{{

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -22,12 +22,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 use url::Url;
 
-use super::DataConnectorParams;
 use super::{
     listing::{self, ListingTableConnector},
     DataConnector, DataConnectorError, DataConnectorFactory, DataConnectorResult, ParameterSpec,
     Parameters,
 };
+use super::{ConnectorComponent, DataConnectorParams};
 
 pub struct Https {
     params: Parameters,
@@ -110,7 +110,8 @@ impl ListingTableConnector for Https {
         let mut u = Url::parse(&dataset.from).boxed().map_err(|e| {
             DataConnectorError::InvalidConfiguration {
                 dataconnector: "https".to_string(),
-                message: format!("Invalid URL: {e}"),
+                message: format!("The specified URL in the dataset 'from' is not valid. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/https"),
+                connector_component: ConnectorComponent::from(dataset),
                 source: e,
             }
         })?;
@@ -121,10 +122,8 @@ impl ListingTableConnector for Https {
                 Err(e) => {
                     return Err(DataConnectorError::InvalidConfiguration {
                         dataconnector: "https".to_string(),
-                        message: format!(
-                            "Invalid `{}` parameter: {e}",
-                            self.params.user_param("port")
-                        ),
+                        message: "The specified `https_port` parameter was invalid. Specify a valid port number and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/https#parameters".to_string(),
+                        connector_component: ConnectorComponent::from(dataset),
                         source: Box::new(e),
                     });
                 }
@@ -137,6 +136,7 @@ impl ListingTableConnector for Https {
                 return Err(
                     DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
                         dataconnector: "https".to_string(),
+                        connector_component: ConnectorComponent::from(dataset),
                     },
                 );
             };
@@ -147,6 +147,7 @@ impl ListingTableConnector for Https {
                 return Err(
                     DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
                         dataconnector: "https".to_string(),
+                        connector_component: ConnectorComponent::from(dataset),
                     },
                 );
             };

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -110,7 +110,7 @@ impl ListingTableConnector for Https {
         let mut u = Url::parse(&dataset.from).boxed().map_err(|e| {
             DataConnectorError::InvalidConfiguration {
                 dataconnector: "https".to_string(),
-                message: format!("The specified URL in the dataset 'from' is not valid. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/https"),
+                message: "The specified URL in the dataset 'from' is not valid. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/https".to_string(),
                 connector_component: ConnectorComponent::from(dataset),
                 source: e,
             }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -610,7 +610,7 @@ mod tests {
             Ok(_) => panic!("Unexpected success"),
             Err(e) => assert_eq!(
                 e.to_string(),
-                "Invalid configuration for TestConnector. Missing required file_format parameter."
+                "Cannot setup the dataset test (TestConnector) with an invalid configuration.\nThe required 'file_format' parameter is missing.\nEnsure the parameter is provided, and try again."
             ),
         }
     }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use crate::accelerated_table::AcceleratedTable;
 use crate::component::dataset::Dataset;
+use crate::dataconnector::ConnectorComponent;
 use crate::dataconnector::DataConnector;
 use crate::dataconnector::DataConnectorError;
 use crate::dataconnector::DataConnectorResult;
@@ -77,6 +78,7 @@ pub trait ListingTableConnector: DataConnector {
         let listing_store_url = ListingTableUrl::parse(store_url.clone()).boxed().context(
             crate::dataconnector::UnableToConnectInternalSnafu {
                 dataconnector: format!("{self}"),
+                connector_component: ConnectorComponent::from(dataset),
             },
         )?;
         Self::get_session_context()
@@ -85,6 +87,7 @@ pub trait ListingTableConnector: DataConnector {
             .boxed()
             .context(crate::dataconnector::UnableToConnectInternalSnafu {
                 dataconnector: format!("{self}"),
+                connector_component: ConnectorComponent::from(dataset),
             })
     }
 
@@ -103,9 +106,10 @@ pub trait ListingTableConnector: DataConnector {
             .context(crate::dataconnector::InvalidConfigurationSnafu {
             dataconnector: format!("{self}"),
             message: format!(
-                "Invalid extension ({extension}) for source ({})",
+                "Invalid file extension ({extension}) for source ({})",
                 dataset.name
             ),
+            connector_component: ConnectorComponent::from(dataset),
         })?;
         Ok(table as Arc<dyn TableProvider>)
     }
@@ -138,12 +142,12 @@ pub trait ListingTableConnector: DataConnector {
 
         match params.get("file_format").expose().ok() {
             Some("csv") => Ok((
-                Some(self.get_csv_format(params)?),
+                Some(self.get_csv_format(dataset, params)?),
                 extension.unwrap_or(".csv".to_string()),
             )),
             Some("parquet") => Ok((
                 Some(Arc::new(
-                    ParquetFormat::default().with_options(self.get_table_parquet_options()?),
+                    ParquetFormat::default().with_options(self.get_table_parquet_options(dataset)?),
                 )),
                 extension.unwrap_or(".parquet".to_string()),
             )),
@@ -152,7 +156,7 @@ pub trait ListingTableConnector: DataConnector {
                 if let Some(ext) = std::path::Path::new(dataset.path().as_str()).extension() {
                     if ext.eq_ignore_ascii_case("csv") {
                         return Ok((
-                            Some(self.get_csv_format(params)?),
+                            Some(self.get_csv_format(dataset, params)?),
                             extension.unwrap_or(".csv".to_string()),
                         ));
                     }
@@ -160,7 +164,7 @@ pub trait ListingTableConnector: DataConnector {
                         return Ok((
                             Some(Arc::new(
                                 ParquetFormat::default()
-                                    .with_options(self.get_table_parquet_options()?),
+                                    .with_options(self.get_table_parquet_options(dataset)?),
                             )),
                             extension.unwrap_or(".parquet".to_string()),
                         ));
@@ -170,7 +174,8 @@ pub trait ListingTableConnector: DataConnector {
                 Err(
                     crate::dataconnector::DataConnectorError::InvalidConfiguration {
                         dataconnector: format!("{self}"),
-                        message: "Missing required file_format parameter.".to_string(),
+                        message: "The required 'file_format' parameter is missing.\nEnsure the parameter is provided, and try again.".to_string(),
+                        connector_component: ConnectorComponent::from(dataset),
                         source: "Missing file format".into(),
                     },
                 )
@@ -178,7 +183,11 @@ pub trait ListingTableConnector: DataConnector {
         }
     }
 
-    fn get_csv_format(&self, params: &Parameters) -> DataConnectorResult<Arc<CsvFormat>>
+    fn get_csv_format(
+        &self,
+        dataset: &Dataset,
+        params: &Parameters,
+    ) -> DataConnectorResult<Arc<CsvFormat>>
     where
         Self: Display,
     {
@@ -226,12 +235,16 @@ pub trait ListingTableConnector: DataConnector {
                         .context(crate::dataconnector::InvalidConfigurationSnafu {
                             dataconnector: format!("{self}"),
                             message: format!("Invalid CSV compression_type: {compression_type}, supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
+                            connector_component: ConnectorComponent::from(dataset)
                         })?,
                 ),
         ))
     }
 
-    fn get_table_parquet_options(&self) -> DataConnectorResult<TableParquetOptions>
+    fn get_table_parquet_options(
+        &self,
+        dataset: &Dataset,
+    ) -> DataConnectorResult<TableParquetOptions>
     where
         Self: Display,
     {
@@ -241,6 +254,7 @@ pub trait ListingTableConnector: DataConnector {
             .map_err(
                 |e| crate::dataconnector::DataConnectorError::UnableToConnectInternal {
                     dataconnector: format!("{self}"),
+                    connector_component: ConnectorComponent::from(dataset),
                     source: Box::new(e),
                 },
             )?;
@@ -261,12 +275,17 @@ pub trait ListingTableConnector: DataConnector {
         Ok(())
     }
 
-    fn handle_object_store_error(&self, error: object_store::Error) -> DataConnectorError
+    fn handle_object_store_error(
+        &self,
+        dataset: &Dataset,
+        error: object_store::Error,
+    ) -> DataConnectorError
     where
         Self: Display,
     {
         crate::dataconnector::DataConnectorError::UnableToConnectInternal {
             dataconnector: format!("{self}"),
+            connector_component: ConnectorComponent::from(dataset),
             source: error.into(),
         }
     }
@@ -303,6 +322,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
         let table_path = ListingTableUrl::parse(url.clone()).boxed().context(
             crate::dataconnector::InternalSnafu {
                 dataconnector: format!("{self}"),
+                connector_component: ConnectorComponent::from(dataset),
                 code: "LTC-RP-LTUP".to_string(), // ListingTableConnector-ReadProvider-ListingTableUrlParse
             },
         )?;
@@ -326,8 +346,9 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                 )
                 .context(crate::dataconnector::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
+                    connector_component: ConnectorComponent::from(dataset),
                     message: format!(
-                        "Invalid extension ({extension}) for source ({})",
+                        "Invalid file extension ({extension}) for source ({})",
                         dataset.name
                     ),
                 })?)
@@ -336,6 +357,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                 let object_store = self.get_object_store(dataset)?;
                 check_for_files_and_extensions(
                     format!("{self}"),
+                    dataset,
                     &extension,
                     table_path.clone(),
                     &ctx,
@@ -350,10 +372,11 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                     .await
                     .map_err(|e| match e {
                         DataFusionError::ObjectStore(object_store_error) => {
-                            self.handle_object_store_error(object_store_error)
+                            self.handle_object_store_error(dataset, object_store_error)
                         }
                         e => crate::dataconnector::DataConnectorError::UnableToConnectInternal {
                             dataconnector: format!("{self}"),
+                            connector_component: ConnectorComponent::from(dataset),
                             source: e.into(),
                         },
                     })?;
@@ -391,6 +414,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                 let table = ListingTable::try_new(config).boxed().context(
                     crate::dataconnector::InternalSnafu {
                         dataconnector: format!("{self}"),
+                        connector_component: ConnectorComponent::from(dataset),
                         code: "LTC-RP-LTTN".to_string(), // ListingTableConnector-ReadProvider-ListingTableTryNew
                     },
                 )?;
@@ -425,6 +449,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
 /// - If no files with the specified extension are found
 async fn check_for_files_and_extensions(
     dataconnector: String,
+    dataset: &Dataset,
     extension: &str,
     table_path: ListingTableUrl,
     ctx: &SessionContext,
@@ -435,18 +460,21 @@ async fn check_for_files_and_extensions(
         .await
         .map_err(|err| DataConnectorError::UnableToConnectInternal {
             dataconnector: dataconnector.clone(),
+            connector_component: ConnectorComponent::from(dataset),
             source: err.into(),
         })?
         .try_collect()
         .await
         .map_err(|err| DataConnectorError::UnableToConnectInternal {
             dataconnector: dataconnector.clone(),
+            connector_component: ConnectorComponent::from(dataset),
             source: err.into(),
         })?;
 
     if files.is_empty() {
         return Err(DataConnectorError::InvalidConfigurationNoSource {
             dataconnector: dataconnector.clone(),
+            connector_component: ConnectorComponent::from(dataset),
             message:
                 // Url could contain access keys from e.g. S3, so we don't want to log it.
                 "Failed to find any files at the specified path. Check the path and try again."
@@ -463,6 +491,7 @@ async fn check_for_files_and_extensions(
         if extensions.is_empty() {
             return Err(DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: dataconnector.clone(),
+            connector_component: ConnectorComponent::from(dataset),
                 message: format!("Failed to find any files matching the extension '{extension}'.\nSpice could not find any files with extensions at the specified path. Check the path and try again."),
             });
         }
@@ -475,6 +504,7 @@ async fn check_for_files_and_extensions(
 
         return Err(DataConnectorError::InvalidConfigurationNoSource {
             dataconnector: dataconnector.clone(),
+            connector_component: ConnectorComponent::from(dataset),
             message: format!("Failed to find any files matching the extension '{extension}'.\nIs your `file_format` parameter correct? Spice found the following file extensions: {display_extensions}.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors#object-store-file-formats")
         });
     }
@@ -537,11 +567,12 @@ mod tests {
             &self.params
         }
 
-        fn get_object_store_url(&self, _dataset: &Dataset) -> DataConnectorResult<Url> {
+        fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
             Url::parse("test")
                 .boxed()
                 .context(crate::dataconnector::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
+                    connector_component: ConnectorComponent::from(dataset),
                     message: "Invalid URL".to_string(),
                 })
         }

--- a/crates/runtime/src/dataconnector/localpod.rs
+++ b/crates/runtime/src/dataconnector/localpod.rs
@@ -29,7 +29,7 @@ use crate::datafusion::DataFusion;
 use crate::DataConnector;
 use crate::{component::dataset::Dataset, parameters::ParameterSpec};
 
-use super::{DataConnectorFactory, DataConnectorParams};
+use super::{ConnectorComponent, DataConnectorFactory, DataConnectorParams};
 
 pub const LOCALPOD_DATACONNECTOR: &str = "localpod";
 
@@ -51,13 +51,14 @@ impl LocalPodFactory {
 impl DataConnectorFactory for LocalPodFactory {
     fn create(
         &self,
-        _params: DataConnectorParams,
+        params: DataConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             Err(Box::new(super::DataConnectorError::Internal {
                 dataconnector: LOCALPOD_DATACONNECTOR.to_string(),
                 code: "LPF-Create".to_string(), // LocalPodFactory - Create
                 source: "Unexpected error. Localpod connector should not be created directly from the factory.".into(),
+                connector_component: params.component.clone()
             }) as Box<dyn std::error::Error + Send + Sync>)
         })
     }
@@ -98,8 +99,8 @@ impl DataConnector for LocalPodConnector {
         self.datafusion.get_table(&path_table_ref).await.ok_or(
             super::DataConnectorError::InvalidTableName {
                 dataconnector: LOCALPOD_DATACONNECTOR.to_string(),
-                dataset_name: dataset.name.to_string(),
                 table_name: path_table_ref.to_string(),
+                connector_component: ConnectorComponent::from(dataset),
             },
         )
     }

--- a/crates/runtime/src/dataconnector/memory.rs
+++ b/crates/runtime/src/dataconnector/memory.rs
@@ -26,7 +26,8 @@ use datafusion::datasource::TableProvider;
 use futures::Future;
 
 use super::{
-    DataConnector, DataConnectorError, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
+    DataConnectorParams, ParameterSpec,
 };
 
 /// A connector that wraps a [`MemTable`] initialised without data, that can be
@@ -89,6 +90,7 @@ impl DataConnector for MemoryConnector {
         let Some(schema) = Self::schema_from_path(path.as_str()) else {
             return Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "memory".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
                 source: Box::<dyn std::error::Error + Send + Sync>::from(format!(
                     "Invalid path: {path}"
                 )),
@@ -97,6 +99,7 @@ impl DataConnector for MemoryConnector {
         let table = MemTable::try_new(schema, vec![]).boxed().map_err(|e| {
             DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "memory".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
                 source: e,
             }
         })?;
@@ -112,6 +115,7 @@ impl DataConnector for MemoryConnector {
         let Some(schema) = Self::schema_from_path(path.as_str()) else {
             return Some(Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "memory".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
                 source: Box::<dyn std::error::Error + Send + Sync>::from(format!(
                     "Invalid path: {path}"
                 )),
@@ -122,6 +126,7 @@ impl DataConnector for MemoryConnector {
             Ok(table) => Some(Ok(Arc::new(table) as Arc<dyn TableProvider>)),
             Err(e) => Some(Err(DataConnectorError::UnableToGetReadWriteProvider {
                 dataconnector: "memory".to_string(),
+                connector_component: ConnectorComponent::from(dataset),
                 source: Box::<dyn std::error::Error + Send + Sync>::from(e.message().to_string()),
             })),
         }

--- a/crates/runtime/src/dataconnector/mssql.rs
+++ b/crates/runtime/src/dataconnector/mssql.rs
@@ -29,8 +29,8 @@ use std::{any::Any, future::Future};
 use tiberius::{Config, EncryptionLevel};
 
 use super::{
-    DataConnector, DataConnectorFactory, DataConnectorParams, DataConnectorResult, ParameterSpec,
-    Parameters, UnableToGetReadProviderSnafu,
+    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams,
+    DataConnectorResult, ParameterSpec, Parameters, UnableToGetReadProviderSnafu,
 };
 
 #[derive(Debug, Snafu)]
@@ -199,6 +199,7 @@ impl DataConnector for SqlServer {
             .boxed()
             .context(UnableToGetReadProviderSnafu {
                 dataconnector: "mssql",
+                connector_component: ConnectorComponent::from(dataset),
             })?;
 
         Ok(Arc::new(provider))

--- a/crates/runtime/src/dataconnector/odbc.rs
+++ b/crates/runtime/src/dataconnector/odbc.rs
@@ -31,7 +31,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use super::{DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec};
+use super::{
+    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -243,6 +245,7 @@ where
                 .await
                 .context(super::UnableToGetReadProviderSnafu {
                     dataconnector: "odbc",
+                    connector_component: ConnectorComponent::from(dataset),
                 })?,
         )
     }

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -31,7 +31,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    DataConnector, DataConnectorError, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
+    DataConnectorParams, ParameterSpec,
 };
 
 #[derive(Debug, Snafu)]
@@ -88,6 +89,7 @@ impl DataConnectorFactory for PostgresFactory {
                     postgrespool::Error::InvalidUsernameOrPassword { .. } => Err(
                         DataConnectorError::UnableToConnectInvalidUsernameOrPassword {
                             dataconnector: "postgres".to_string(),
+                            connector_component: params.component.clone(),
                         }
                         .into(),
                     ),
@@ -98,6 +100,7 @@ impl DataConnectorFactory for PostgresFactory {
                         source: _,
                     } => Err(DataConnectorError::UnableToConnectInvalidHostOrPort {
                         dataconnector: "postgres".to_string(),
+                        connector_component: params.component.clone(),
                         host,
                         port: format!("{port}"),
                     }
@@ -105,6 +108,7 @@ impl DataConnectorFactory for PostgresFactory {
 
                     _ => Err(DataConnectorError::UnableToConnectInternal {
                         dataconnector: "postgres".to_string(),
+                        connector_component: params.component.clone(),
                         source: Box::new(e),
                     }
                     .into()),
@@ -149,7 +153,7 @@ impl DataConnector for Postgres {
                     {
                         return Err(DataConnectorError::InvalidTableName {
                             dataconnector: "postgres".to_string(),
-                            dataset_name: dataset.name.to_string(),
+                            connector_component: ConnectorComponent::from(dataset),
                             table_name: table_name.clone(),
                         });
                     }
@@ -157,6 +161,7 @@ impl DataConnector for Postgres {
 
                 return Err(DataConnectorError::UnableToGetReadProvider {
                     dataconnector: "postgres".to_string(),
+                    connector_component: ConnectorComponent::from(dataset),
                     source: e,
                 });
             }

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -22,11 +22,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 use url::Url;
 
-use super::DataConnectorParams;
 use super::{
     listing::{self, ListingTableConnector},
     DataConnector, DataConnectorFactory, DataConnectorResult, ParameterSpec, Parameters,
 };
+use super::{ConnectorComponent, DataConnectorParams};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -123,7 +123,8 @@ impl ListingTableConnector for SFTP {
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("{} is not a valid URL", dataset.from),
+                    message: format!("The specified URL is not valid: {}.\nEnsure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/ftp", dataset.from),
+                    connector_component: ConnectorComponent::from(dataset)
                 })?;
 
         ftp_url.set_fragment(Some(&listing::build_fragments(

--- a/crates/runtime/src/dataconnector/sharepoint.rs
+++ b/crates/runtime/src/dataconnector/sharepoint.rs
@@ -33,8 +33,8 @@ use std::sync::Arc;
 use url::Url;
 
 use super::{
-    DataConnector, DataConnectorFactory, DataConnectorParams, DataConnectorResult, ParameterSpec,
-    Parameters, UnableToGetReadProviderSnafu,
+    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams,
+    DataConnectorResult, ParameterSpec, Parameters, UnableToGetReadProviderSnafu,
 };
 
 #[derive(Debug, Snafu)]
@@ -176,6 +176,7 @@ impl DataConnector for Sharepoint {
             .boxed()
             .context(UnableToGetReadProviderSnafu {
                 dataconnector: "sharepoint",
+                connector_component: ConnectorComponent::from(dataset),
             })?;
         Ok(Arc::new(SharepointTableProvider::new(
             client,
@@ -197,6 +198,7 @@ impl DataConnector for Sharepoint {
             .boxed()
             .context(UnableToGetReadProviderSnafu {
                 dataconnector: "sharepoint",
+                connector_component: ConnectorComponent::from(dataset),
             }) {
             Ok(client) => Some(Ok(Arc::new(SharepointTableProvider::new(
                 client,

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use super::ConnectorComponent;
 use super::DataConnector;
 use super::DataConnectorFactory;
 use super::DataConnectorParams;
@@ -130,6 +131,7 @@ impl DataConnector for Snowflake {
                 .await
                 .context(super::UnableToGetReadProviderSnafu {
                     dataconnector: "snowflake",
+                    connector_component: ConnectorComponent::from(dataset),
                 })?,
         )
     }

--- a/crates/runtime/src/dataconnector/spark.rs
+++ b/crates/runtime/src/dataconnector/spark.rs
@@ -28,8 +28,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    DataConnector, DataConnectorError, DataConnectorFactory, DataConnectorParams, ParameterSpec,
-    Parameters,
+    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
+    DataConnectorParams, ParameterSpec, Parameters,
 };
 
 #[derive(Debug, Snafu)]
@@ -106,6 +106,7 @@ impl DataConnectorFactory for SparkFactory {
                         source: _,
                     } => Err(DataConnectorError::InvalidConfiguration {
                         dataconnector: "spark".to_string(),
+                        connector_component: params.component.clone(),
                         message: e.to_string(),
                         source: e.into(),
                     }
@@ -113,6 +114,7 @@ impl DataConnectorFactory for SparkFactory {
                     Error::UnableToConstructSparkConnect { source } => {
                         Err(DataConnectorError::UnableToConnectInternal {
                             dataconnector: "spark".to_string(),
+                            connector_component: params.component.clone(),
                             source,
                         }
                         .into())
@@ -148,6 +150,7 @@ impl DataConnector for Spark {
             .await
             .context(super::UnableToGetReadProviderSnafu {
                 dataconnector: "spark",
+                connector_component: ConnectorComponent::from(dataset),
             })?)
     }
 }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use super::ConnectorComponent;
 use super::DataConnector;
 use super::DataConnectorError;
 use super::DataConnectorFactory;
@@ -210,6 +211,7 @@ impl DataConnector for SpiceAI {
                     .boxed()
                     .context(UnableToGetReadProviderSnafu {
                         dataconnector: "spice.ai",
+                        connector_component: ConnectorComponent::from(dataset),
                     })?,
                 ));
             }
@@ -232,13 +234,14 @@ impl DataConnector for SpiceAI {
                     tracing::debug!("{e}");
                     return Err(DataConnectorError::UnableToGetSchema {
                         dataconnector: "spice.ai".to_string(),
-                        dataset_name: dataset.name.to_string(),
+                        connector_component: ConnectorComponent::from(dataset),
                         table_name: table.clone(),
                     });
                 }
 
                 return Err(DataConnectorError::UnableToGetReadProvider {
                     dataconnector: "spice.ai".to_string(),
+                    connector_component: ConnectorComponent::from(dataset),
                     source: e,
                 });
             }
@@ -257,6 +260,7 @@ impl DataConnector for SpiceAI {
         .await
         .context(super::UnableToGetReadWriteProviderSnafu {
             dataconnector: "spice.ai",
+            connector_component: ConnectorComponent::from(dataset),
         });
 
         Some(read_write_result)
@@ -303,7 +307,8 @@ impl DataConnector for SpiceAI {
             return Some(Err(
                 super::DataConnectorError::InvalidConfigurationNoSource {
                     dataconnector: "spice.ai".into(),
-                    message: "Catalog ID is not supported for SpiceAI data connector".into(),
+                    message: "A Catalog Name is not supported for the Spice.ai catalog connector.\nRemove the Catalog Name, and use only 'spice.ai' in the 'from' parameter.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/spiceai#from".into(),
+                    connector_component: ConnectorComponent::from(catalog),
                 },
             ));
         }

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use super::ConnectorComponent;
 use super::DataConnector;
 use super::DataConnectorFactory;
 use super::DataConnectorParams;
@@ -152,11 +153,12 @@ impl DataConnector for UnityCatalog {
 
     async fn read_provider(
         &self,
-        _dataset: &Dataset,
+        dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         Err(super::DataConnectorError::UnableToGetReadProvider {
             dataconnector: "unity_catalog".to_string(),
-            source: "Unity Catalog only support catalogs, not individual datasets.".into(),
+            source: "The Unity Catalog only supports catalogs, not individual datasets.\nSetup a Unity Catalog instead: https://docs.spiceai.org/components/catalogs/unity-catalog".into(),
+            connector_component: ConnectorComponent::from(dataset)
         })
     }
 
@@ -169,7 +171,8 @@ impl DataConnector for UnityCatalog {
             return Some(Err(
                 super::DataConnectorError::InvalidConfigurationNoSource {
                     dataconnector: "unity_catalog".into(),
-                    message: "Catalog ID is required for Unity Catalog".into(),
+                    message: "A Catalog Path is required for Unity Catalog.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/unity-catalog#from".into(),
+                    connector_component: ConnectorComponent::from(catalog),
                 },
             ));
         };
@@ -179,6 +182,7 @@ impl DataConnector for UnityCatalog {
         let (endpoint, catalog_id) = match UnityCatalogClient::parse_catalog_url(&catalog_id)
             .map_err(|e| super::DataConnectorError::InvalidConfiguration {
                 dataconnector: "unity_catalog".to_string(),
+                connector_component: ConnectorComponent::from(catalog),
                 message: e.to_string(),
                 source: Box::new(e),
             }) {
@@ -218,6 +222,7 @@ impl DataConnector for UnityCatalog {
             Err(e) => {
                 return Some(Err(super::DataConnectorError::UnableToGetCatalogProvider {
                     dataconnector: "unity_catalog".to_string(),
+                    connector_component: ConnectorComponent::from(catalog),
                     source: Box::new(e),
                 }))
             }

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -60,10 +60,9 @@ impl EmbeddingConnector {
         if !cfg!(feature = "models") {
             return Err(DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: dataset.source(),
-                message: format!(
-                "Dataset '{}' expects to use an embedding model, but the runtime is not built with model support. {ENABLE_MODEL_SUPPORT_MESSAGE}",
-                dataset.name
-            )});
+                message: format!("The dataset is configured with an embedding model, but the runtime is not built with model support.\n{ENABLE_MODEL_SUPPORT_MESSAGE}"),
+                connector_component: dataset.into()
+            });
         }
 
         // Add in embedding columns from `dataset.columns.embeddings`.
@@ -96,10 +95,9 @@ impl EmbeddingConnector {
             if !self.embedding_models.read().await.contains_key(model) {
                 return Err(DataConnectorError::InvalidConfigurationNoSource {
                     dataconnector: "EmbeddingConnector".to_string(),
-                    message: format!(
-                    "Dataset '{}' expects to use embedding model '{model}' to embed column '{column}', but the model '{model}' is not defined in Spicepod (as an 'embeddings').",
-                    dataset.name
-                )});
+                    message: format!("The dataset is configured with an embedding model '{model}' to embed column '{column}', but the model '{model}' is not defined in Spicepod (as an 'embeddings').\nFor further information, visit: https://docs.spiceai.org/components/embeddings"),
+                    connector_component: dataset.into()
+                });
             }
         }
 

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -21,7 +21,6 @@ use crate::{
     dataconnector::{DataConnector, DataConnectorParamsBuilder},
     metrics, status, warn_spaced, DataConnectorDoesntSupportCatalogsSnafu, LogErrors, Result,
     Runtime, UnableToInitializeDataConnectorSnafu, UnableToLoadCatalogConnectorSnafu,
-    UnableToLoadDatasetConnectorSnafu,
 };
 use app::App;
 use futures::future::join_all;
@@ -65,7 +64,7 @@ impl Runtime {
             };
 
             if let Err(err) = self.register_catalog(catalog, connector).await {
-                tracing::error!("Unable to register catalog {}: {err}", &catalog.name);
+                tracing::error!("{err}");
                 return Err(RetryError::transient(err));
             };
 
@@ -87,21 +86,20 @@ impl Runtime {
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
 
-        let data_connector: Arc<dyn DataConnector> =
-            match self.get_dataconnector_from_source(&source, params).await {
-                Ok(data_connector) => data_connector,
-                Err(err) => {
-                    let catalog_name = &catalog.name;
-                    self.status
-                        .update_catalog(catalog_name, status::ComponentStatus::Error);
-                    metrics::catalogs::LOAD_ERROR.add(1, &[]);
-                    warn_spaced!(spaced_tracer, "{} {err}", catalog_name);
-                    return UnableToLoadDatasetConnectorSnafu {
-                        dataset: catalog_name.clone(),
-                    }
-                    .fail();
-                }
-            };
+        let data_connector: Arc<dyn DataConnector> = match self
+            .get_dataconnector_from_source(&source, params)
+            .await
+        {
+            Ok(data_connector) => data_connector,
+            Err(err) => {
+                let catalog_name = &catalog.name;
+                self.status
+                    .update_catalog(catalog_name, status::ComponentStatus::Error);
+                metrics::catalogs::LOAD_ERROR.add(1, &[]);
+                warn_spaced!(spaced_tracer, "{} {err}", catalog_name);
+                return Err(crate::Error::UnableToInitializeDataConnector { source: err.into() });
+            }
+        };
 
         Ok(data_connector)
     }
@@ -144,9 +142,7 @@ impl Runtime {
                 dataconnector: catalog.provider.clone(),
             })?
             .boxed()
-            .context(UnableToLoadCatalogConnectorSnafu {
-                catalog: catalog.name.clone(),
-            })?;
+            .context(UnableToInitializeDataConnectorSnafu)?;
         let num_schemas = catalog_provider
             .schema_names()
             .iter()

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use crate::{
     component::catalog::Catalog,
-    dataconnector::{DataConnector, DataConnectorParams, DataConnectorParamsBuilder},
+    dataconnector::{DataConnector, DataConnectorParamsBuilder},
     metrics, status, warn_spaced, DataConnectorDoesntSupportCatalogsSnafu, LogErrors, Result,
     Runtime, UnableToInitializeDataConnectorSnafu, UnableToLoadCatalogConnectorSnafu,
     UnableToLoadDatasetConnectorSnafu,

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use crate::{
     component::catalog::Catalog,
-    dataconnector::{DataConnector, DataConnectorParams},
+    dataconnector::{DataConnector, DataConnectorParams, DataConnectorParamsBuilder},
     metrics, status, warn_spaced, DataConnectorDoesntSupportCatalogsSnafu, LogErrors, Result,
     Runtime, UnableToInitializeDataConnectorSnafu, UnableToLoadCatalogConnectorSnafu,
     UnableToLoadDatasetConnectorSnafu,
@@ -81,11 +81,12 @@ impl Runtime {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
         let catalog = catalog.clone();
 
-        let source = catalog.provider;
-        let params = catalog.params.clone();
-        let params = DataConnectorParams::from_params(self, &source, params)
+        let source = catalog.provider.clone();
+        let params = DataConnectorParamsBuilder::new(source.clone().into(), (&catalog).into())
+            .with_runtime(self)
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
+
         let data_connector: Arc<dyn DataConnector> =
             match self.get_dataconnector_from_source(&source, params).await {
                 Ok(data_connector) => data_connector,

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -173,25 +173,24 @@ impl Runtime {
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
 
-        let data_connector: Arc<dyn DataConnector> =
-            match self.get_dataconnector_from_source(&source, params).await {
-                Ok(data_connector) => data_connector,
-                Err(err) => {
-                    let ds_name = &ds.name;
-                    self.status
-                        .update_dataset(ds_name, status::ComponentStatus::Error);
-                    metrics::datasets::LOAD_ERROR.add(1, &[]);
-                    warn_spaced!(
-                        spaced_tracer,
-                        "Error initializing dataset {}. {err}",
-                        ds_name.table()
-                    );
-                    return UnableToLoadDatasetConnectorSnafu {
-                        dataset: ds.name.clone(),
-                    }
-                    .fail();
-                }
-            };
+        let data_connector: Arc<dyn DataConnector> = match self
+            .get_dataconnector_from_source(&source, params)
+            .await
+        {
+            Ok(data_connector) => data_connector,
+            Err(err) => {
+                let ds_name = &ds.name;
+                self.status
+                    .update_dataset(ds_name, status::ComponentStatus::Error);
+                metrics::datasets::LOAD_ERROR.add(1, &[]);
+                warn_spaced!(
+                    spaced_tracer,
+                    "Error initializing dataset {}. {err}",
+                    ds_name.table()
+                );
+                return Err(crate::Error::UnableToInitializeDataConnector { source: err.into() });
+            }
+        };
 
         Ok(data_connector)
     }

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -23,7 +23,7 @@ use crate::{
     dataconnector::{
         self,
         localpod::{LocalPodConnector, LOCALPOD_DATACONNECTOR},
-        DataConnector, DataConnectorParams,
+        DataConnector, DataConnectorParams, DataConnectorParamsBuilder,
     },
     embeddings::connector::EmbeddingConnector,
     federated_table::FederatedTable,
@@ -168,7 +168,8 @@ impl Runtime {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
 
         let source = ds.source();
-        let params = DataConnectorParams::from_dataset(self, Arc::clone(&ds))
+        let params = DataConnectorParamsBuilder::new(source.clone().into(), (&ds).into())
+            .with_runtime(self)
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
 

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -34,7 +34,9 @@ use runtime::{
         Dataset, Mode, TimeFormat,
     },
     dataaccelerator::{self, create_accelerator_table},
-    dataconnector::{create_new_connector, DataConnector, DataConnectorError, DataConnectorParams},
+    dataconnector::{
+        create_new_connector, DataConnector, DataConnectorError, DataConnectorParamsBuilder,
+    },
     extension::{Error as ExtensionError, Extension, ExtensionFactory, ExtensionManifest, Result},
     federated_table::FederatedTable,
     secrets::{ExposeSecret, Secrets},
@@ -316,9 +318,11 @@ async fn get_spiceai_table_provider(
     dataset.mode = Mode::ReadWrite;
     dataset.replication = Some(Replication { enabled: true });
 
-    let params = DataConnectorParams::from_secrets(name, HashMap::new(), secrets)
+    let params = DataConnectorParamsBuilder::new(name.into(), (&dataset).into())
+        .without_runtime(HashMap::new(), secrets)
         .await
         .context(UnableToCreateDataConnectorSnafu)?;
+
     let data_connector = create_new_connector("spice.ai", params)
         .await
         .ok_or_else(|| NoReadWriteProviderSnafu {}.build())?


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the format of data connector error messages to ensure every error contains a reference to the originating component (e.g the catalog or dataset that called on the connector)
* Makes some changes to error messages in data connectors to provide more informative errors with actions

A new error example for S3:

```bash
2024-11-21T04:07:44.614888Z  WARN runtime::init::dataset: Cannot setup the dataset taxi_trips (s3) with an invalid configuration.
Failed to find any files matching the extension '.csv'.
Is your `file_format` parameter correct? Spice found the following file extensions: '.parquet'.
For further information, visit: https://docs.spiceai.org/components/data-connectors#object-store-file-formats
```

A catalog failure:

```bash
2024-11-21T06:07:40.211079Z ERROR runtime::init::catalog: Cannot setup the catalog spiceai (spice.ai) with an invalid configuration.
A Catalog Name is not supported for the Spice.ai catalog connector.
Remove the Catalog Name, and use only 'spice.ai' in the 'from' parameter.
For further information, visit: https://docs.spiceai.org/components/catalogs/spiceai#from
```

A data connector type that is unknown:

```bash
2024-11-21T06:13:26.339562Z  WARN runtime::init::dataset: something Cannot setup the dataset something (odbc).
The connector 'odbc' is not a valid connector.
For further information, visit: https://docs.spiceai.org/components/data-connectors
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3573
* Part of #3506

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

* Quickstarts which include error messages will need to be updated. There will need to be a pass on quickstarts/samples once the parent enhancement is complete.

## 🤔 Concerns

Note how in the above example though, the dataset name is repeated at the beginning of the last message like `something Cannot setup the dataset ...`.

This is because these errors are wrapped in transient retries, and are warning logged with the [`warn_spaced!` macro](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/init/dataset.rs#L212). These calls need to be updated to remove the dataset name from the beginning of the message, as it clutters the rest of the error message (which now contains the component name). This will be addressed in a future PR.
