### PR TITLE
Properly drop the read lock on the runtime app in http.start

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -164,6 +164,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:
@@ -233,6 +234,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:
@@ -297,6 +299,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:
@@ -387,6 +390,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:
@@ -519,6 +523,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       fail-fast: false
@@ -673,6 +678,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:
@@ -773,6 +779,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:
@@ -853,6 +860,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       fail-fast: false
@@ -997,6 +1005,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:
@@ -1114,6 +1123,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:
@@ -1248,6 +1258,7 @@ jobs:
     needs:
       - build
       - setup-matrix
+    timeout-minutes: 5
 
     strategy:
       matrix:

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -78,6 +78,7 @@ where
         auth_provider.map(AuthLayer::new),
         &cors_config,
     );
+    drop(app);
 
     let listener = TcpListener::bind(&bind_address)
         .await

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -79,7 +79,15 @@ pub(crate) async fn get(
     Query(filter): Query<DatasetFilter>,
     Query(params): Query<DatasetQueryParams>,
 ) -> Response {
-    let app_lock = app.read().await;
+    let app_lock = tokio::select! {
+        lock = app.read() => lock,
+        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+            return (
+                status::StatusCode::REQUEST_TIMEOUT,
+                "timeout".to_string()
+            ).into_response();
+        }
+    };
     let Some(readable_app) = app_lock.as_ref() else {
         return (
             status::StatusCode::INTERNAL_SERVER_ERROR,
@@ -144,7 +152,15 @@ pub(crate) async fn refresh(
     // This means malformed Json, etc, will simply return None
     // To get around this, we would need to implement a custom extractor
 ) -> Response {
-    let app_lock = app.read().await;
+    let app_lock = tokio::select! {
+        lock = app.read() => lock,
+        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+            return (
+                status::StatusCode::REQUEST_TIMEOUT,
+                "timeout".to_string()
+            ).into_response();
+        }
+    };
     let Some(readable_app) = &*app_lock else {
         return (status::StatusCode::INTERNAL_SERVER_ERROR).into_response();
     };
@@ -205,7 +221,15 @@ pub(crate) async fn acceleration(
     Path(dataset_name): Path<String>,
     Json(payload): Json<AccelerationRequest>,
 ) -> Response {
-    let app_lock = app.read().await;
+    let app_lock = tokio::select! {
+        lock = app.read() => lock,
+        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+            return (
+                status::StatusCode::REQUEST_TIMEOUT,
+                "timeout".to_string()
+            ).into_response();
+        }
+    };
     let Some(readable_app) = &*app_lock else {
         return (status::StatusCode::INTERNAL_SERVER_ERROR).into_response();
     };

--- a/crates/runtime/src/init/pods_watcher.rs
+++ b/crates/runtime/src/init/pods_watcher.rs
@@ -31,6 +31,7 @@ impl Runtime {
             if let Some(current_app) = app_lock.as_mut() {
                 let new_app = Arc::new(new_app);
                 if *current_app == new_app {
+                    drop(app_lock);
                     continue;
                 }
 
@@ -46,6 +47,7 @@ impl Runtime {
             } else {
                 *app_lock = Some(Arc::new(new_app));
             }
+            drop(app_lock);
         }
 
         Ok(())


### PR DESCRIPTION
## 🗣 Description

I took a read lock on the runtime app in `http.start` for the CORS work and didn't drop it, causing the HTTP server to keep the lock forever, which prevented the pods watcher from ever getting a write lock, which then prevented any other components that subsequently wanted a read lock from getting it.

I've also added a 5 minute timeout to all of the E2E Test CI jobs to prevent them from running for 6 hours if this ever happens again.

## 🔨 Related Issues

N/A

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

N/A
