### PR TITLE
Make integration tests more robust on fewer cores

### DIFF
--- a/crates/runtime/tests/github/mod.rs
+++ b/crates/runtime/tests/github/mod.rs
@@ -135,7 +135,7 @@ async fn test_github_pulls() -> Result<(), String> {
 
     // search should push down the filter, preventing the query from retrieving every pull
     assert!(
-        search_author_elapsed_secs < 10,
+        search_author_elapsed_secs < 15,
         "search_author_elapsed_secs: {search_author_elapsed_secs}"
     );
 

--- a/crates/runtime/tests/postgres/mod.rs
+++ b/crates/runtime/tests/postgres/mod.rs
@@ -169,8 +169,8 @@ CREATE TABLE test (
     assert_eq!(num_rows, 250_000);
 
     assert!(
-        duration_ms < 1000,
-        "Duration {duration_ms}ms was higher than 1000ms",
+        duration_ms < 2000,
+        "Duration {duration_ms}ms was higher than 2000ms",
     );
 
     running_container.remove().await?;

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -39,6 +39,7 @@ use runtime::{
 use spicepod::component::dataset::acceleration::Acceleration;
 use tokio::time;
 use tracing::instrument;
+use util::{fibonacci_backoff::FibonacciBackoffBuilder, retry, RetryError};
 
 const MYSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-refresh-retry-mysql";
 const MYSQL_PORT: u16 = 13307;
@@ -80,8 +81,13 @@ async fn prepare_test_environment() -> Result<RunningContainer<'static>, String>
             e.to_string()
         })?;
     tracing::debug!("Container started");
-    init_mysql_db().await.map_err(|e| {
-        tracing::error!("init_mysql_db: {e}");
+    let retry_strategy = FibonacciBackoffBuilder::new().max_retries(Some(10)).build();
+    retry(retry_strategy, || async {
+        init_mysql_db().await.map_err(RetryError::transient)
+    })
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to initialize MySQL database: {e}");
         e.to_string()
     })?;
 


### PR DESCRIPTION
## 🗣 Description

Since we've started running the integration tests on a smaller runner, they have been less reliable. Attempt to make them more robust by waiting for certain initialization conditions to be met.

## 🔨 Related Issues

N/A

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

This might not fix all of them, but it does make it better.
