### PR TITLE
Add log if no datasets are configured

### DIFF
--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -61,7 +61,10 @@ impl Runtime {
         let valid_datasets = Self::get_valid_datasets(app, LogErrors(true));
 
         if valid_datasets.is_empty() {
-            tracing::warn!("No datasets were found in the spicepod");
+            tracing::info!(
+                "No datasets were configured in the Spicepod. If this is unexpected, check your Spicepod configuration."
+            );
+            return;
         }
 
         let initialized_datasets = self.initialize_accelerators(&valid_datasets).await;

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -62,7 +62,7 @@ impl Runtime {
 
         if valid_datasets.is_empty() {
             tracing::info!(
-                "No datasets were configured in the Spicepod. If this is unexpected, check your Spicepod configuration."
+                "No datasets were configured. If this is unexpected, check the Spicepod configuration."
             );
             return;
         }

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -51,6 +51,11 @@ impl Runtime {
         };
 
         let valid_datasets = Self::get_valid_datasets(app, LogErrors(true));
+
+        if valid_datasets.is_empty() {
+            tracing::warn!("No datasets were found in the spicepod");
+        }
+
         let initialized_datasets = self.initialize_accelerators(&valid_datasets).await;
 
         // Create a map of dataset names to their futures


### PR DESCRIPTION
## 🗣 Description

Adds an info log if there are no datasets configured to let users that might be expecting them know something is wrong. I didn't set this as a warning, since this might be expected.

## 🔨 Related Issues

Closes #3504

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

N/A
