### PR TITLE
Update metric name from `query_invocations` to `query_executions`

### DIFF
--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -254,8 +254,8 @@ pub(crate) mod telemetry {
 
     static QUERY_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
         TELEMETRY_METER
-            .u64_counter("query_invocations")
-            .with_description("Number of queries run.")
+            .u64_counter("query_executions")
+            .with_description("Number of query executions.")
             .with_unit("queries")
             .init()
     });

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -31,8 +31,8 @@ mod meter;
 
 static QUERY_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("query_invocations")
-        .with_description("Number of queries run.")
+        .u64_counter("query_executions")
+        .with_description("Number of query executions.")
         .with_unit("queries")
         .init()
 });


### PR DESCRIPTION
## 🗣 Description

Update metric name from `query_invocations` to `query_executions`

Following [metric naming principles](https://github.com/spiceai/spiceai/blob/trunk/docs/dev/metrics.md), `query_invocations` is renamed to `query_executions` as it is more recognized, easier to use, and widely adopted in the industry.