### PR TITLE
refactor: Update accelerated table errors, dataset health monitor errors

### DIFF
--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -50,7 +50,7 @@ pub enum Error {
         source: tonic::metadata::errors::InvalidMetadataValue,
     },
 
-    #[snafu(display("Unable to perform handshake: {source}"))]
+    #[snafu(display("Failed to connect to the Flight server.\n{source}"))]
     UnableToPerformHandshake { source: tonic::Status },
 
     #[snafu(display("Unable to convert metadata to string: {source}"))]

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -68,7 +68,7 @@ mod synchronized_table;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to get data from connector.\n{source}"))]
+    #[snafu(display("Failed to get data from the connector.\n{source}"))]
     UnableToGetDataFromConnector { source: DataFusionError },
 
     #[snafu(display("Failed to refresh the dataset.\n{source}"))]

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -84,7 +84,7 @@ pub enum Error {
         source: datafusion::error::DataFusionError,
     },
 
-    #[snafu(display("Failed to trigger a table refresh.\n{source}"))]
+    #[snafu(display("Failed to refresh the dataset.\n{source}"))]
     FailedToTriggerRefresh {
         source: tokio::sync::mpsc::error::SendError<Option<RefreshOverrides>>,
     },

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -97,7 +97,7 @@ pub enum Error {
     ))]
     RefreshNotSupportedForChildTable { parent_dataset: TableReference },
 
-    #[snafu(display("Failed to find latest timestamp in accelerated table.\nIs your 'time_column' parameter correct?"))]
+    #[snafu(display("Failed to find latest timestamp in accelerated table.\nIs the 'time_column' parameter correct?"))]
     FailedToQueryLatestTimestamp {
         source: datafusion::error::DataFusionError,
     },
@@ -116,13 +116,13 @@ pub enum Error {
     #[snafu(display("The accelerated table does not support delete operations.\nUse a different acceleration engine which supports delete operations.\nFor further information, visit: https://docs.spiceai.org/components/data-accelerators"))]
     AcceleratedTableDoesntSupportDelete {},
 
-    #[snafu(display("Expected the schema to have field '{field_name}', but it did not.\nSpice found the schema: {schema}\nIs your primary key configuration correct?"))]
+    #[snafu(display("Expected the schema to have field '{field_name}', but it did not.\nSpice found the schema: {schema}\nIs the primary key configuration correct?"))]
     PrimaryKeyExpectedSchemaToHaveField {
         field_name: String,
         schema: SchemaRef,
     },
 
-    #[snafu(display("Expected the field in schema '{field_name}' to have type '{expected_data_type}', but it did not.\nSpice found the schema: {schema}\nIs your primary key configuration correct?"))]
+    #[snafu(display("Expected the field in schema '{field_name}' to have type '{expected_data_type}', but it did not.\nSpice found the schema: {schema}\nIs the primary key configuration correct?"))]
     PrimaryKeyArrayDataTypeMismatch {
         field_name: String,
         expected_data_type: String,
@@ -148,7 +148,7 @@ pub enum AcceleratedTableBuilderError {
     #[snafu(display("An append stream is required when `refresh_mode` is set to `append` without a `time_column`.\nFor further information, visit: https://docs.spiceai.org/components/data-accelerators/data-refresh#append"))]
     AppendStreamRequired,
 
-    #[snafu(display("A synchronized accelerated table requires full refresh mode.\nSet your `refresh_mode` to 'full', and try again."))]
+    #[snafu(display("A synchronized accelerated table requires full refresh mode.\nSet `refresh_mode` to 'full', and try again."))]
     SynchronizedAcceleratedTableRequiresFullRefresh,
 }
 

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -68,21 +68,17 @@ mod synchronized_table;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to get data from the connector.\n{source}"))]
+    #[snafu(display("Failed to get data from the connector.\n{source}\nEnsure the dataset configuration is valid, and try again."))]
     UnableToGetDataFromConnector { source: DataFusionError },
 
-    #[snafu(display("Failed to refresh the dataset.\n{source}"))]
+    #[snafu(display("Failed to get data from the connector.\n{source}\nEnsure the dataset configuration is valid, and try again."))]
     FailedToRefreshDataset { source: DataFusionError },
 
-    #[snafu(display("Failed to read from the dataset.\n{source}"))]
-    UnableToScanTableProvider {
-        source: datafusion::error::DataFusionError,
-    },
+    #[snafu(display("Failed to get data from the connector.\n{source}\nEnsure the dataset configuration is valid, and try again."))]
+    UnableToScanTableProvider { source: DataFusionError },
 
-    #[snafu(display("Failed to create an in-memory table from a data update.\n{source}"))]
-    UnableToCreateMemTableFromUpdate {
-        source: datafusion::error::DataFusionError,
-    },
+    #[snafu(display("Failed to get data from the connector.\n{source}\nEnsure the dataset configuration is valid, and try again."))]
+    UnableToCreateMemTableFromUpdate { source: DataFusionError },
 
     #[snafu(display("Failed to refresh the dataset.\n{source}"))]
     FailedToTriggerRefresh {
@@ -98,9 +94,7 @@ pub enum Error {
     RefreshNotSupportedForChildTable { parent_dataset: TableReference },
 
     #[snafu(display("Failed to find latest timestamp in accelerated table.\nIs the 'time_column' parameter correct?"))]
-    FailedToQueryLatestTimestamp {
-        source: datafusion::error::DataFusionError,
-    },
+    FailedToQueryLatestTimestamp { source: DataFusionError },
 
     #[snafu(display("{reason}"))]
     FailedToFindLatestTimestamp { reason: String },
@@ -109,9 +103,7 @@ pub enum Error {
     FailedToFilterUpdates { source: ArrowError },
 
     #[snafu(display("Failed to write data into accelerated table.\n{source}"))]
-    FailedToWriteData {
-        source: datafusion::error::DataFusionError,
-    },
+    FailedToWriteData { source: DataFusionError },
 
     #[snafu(display("The accelerated table does not support delete operations.\nUse a different acceleration engine which supports delete operations.\nFor further information, visit: https://docs.spiceai.org/components/data-accelerators"))]
     AcceleratedTableDoesntSupportDelete {},

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -68,36 +68,36 @@ mod synchronized_table;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to get data from connector: {source}"))]
+    #[snafu(display("Failed to get data from connector.\n{source}"))]
     UnableToGetDataFromConnector { source: DataFusionError },
 
-    #[snafu(display("Dataset refresh failed with error: {source}"))]
+    #[snafu(display("Failed to refresh the dataset.\n{source}"))]
     FailedToRefreshDataset { source: DataFusionError },
 
-    #[snafu(display("Unable to scan table provider: {source}"))]
+    #[snafu(display("Failed to read from the dataset.\n{source}"))]
     UnableToScanTableProvider {
         source: datafusion::error::DataFusionError,
     },
 
-    #[snafu(display("Unable to create MemTable from data update: {source}"))]
+    #[snafu(display("Failed to create an in-memory table from a data update.\n{source}"))]
     UnableToCreateMemTableFromUpdate {
         source: datafusion::error::DataFusionError,
     },
 
-    #[snafu(display("Failed to trigger table refresh: {source}"))]
+    #[snafu(display("Failed to trigger a table refresh.\n{source}"))]
     FailedToTriggerRefresh {
         source: tokio::sync::mpsc::error::SendError<Option<RefreshOverrides>>,
     },
 
-    #[snafu(display("Manual refresh is not supported for `append` mode"))]
+    #[snafu(display("Manual refresh is not supported for `append` mode.\nUse a different acceleration mode to use manual refresh."))]
     ManualRefreshIsNotSupported {},
 
     #[snafu(display(
-        "Refresh must be triggered on '{parent_dataset}', which will propagate to this table."
+        "A refresh must be triggered on the dataset '{parent_dataset}', which will propagate to this table."
     ))]
     RefreshNotSupportedForChildTable { parent_dataset: TableReference },
 
-    #[snafu(display("Failed to find latest timestamp in accelerated table"))]
+    #[snafu(display("Failed to find latest timestamp in accelerated table.\nIs your 'time_column' parameter correct?"))]
     FailedToQueryLatestTimestamp {
         source: datafusion::error::DataFusionError,
     },
@@ -105,24 +105,24 @@ pub enum Error {
     #[snafu(display("{reason}"))]
     FailedToFindLatestTimestamp { reason: String },
 
-    #[snafu(display("Failed to filter update data: {source}"))]
+    #[snafu(display("Failed to filter update data.\n{source}"))]
     FailedToFilterUpdates { source: ArrowError },
 
-    #[snafu(display("Failed to write data into accelerated table: {source}"))]
+    #[snafu(display("Failed to write data into accelerated table.\n{source}"))]
     FailedToWriteData {
         source: datafusion::error::DataFusionError,
     },
 
-    #[snafu(display("The accelerated table does not support delete operations"))]
+    #[snafu(display("The accelerated table does not support delete operations.\nUse a different acceleration engine which supports delete operations.\nFor further information, visit: https://docs.spiceai.org/components/data-accelerators"))]
     AcceleratedTableDoesntSupportDelete {},
 
-    #[snafu(display("Expected schema to have field '{field_name}' schema={schema}"))]
+    #[snafu(display("Expected the schema to have field '{field_name}', but it did not.\nFound the schema: {schema}"))]
     ExpectedSchemaToHaveField {
         field_name: String,
         schema: SchemaRef,
     },
 
-    #[snafu(display("Expected field in schema '{field_name}' to have type '{expected_data_type}' schema={schema}"))]
+    #[snafu(display("Expected the field in schema '{field_name}' to have type '{expected_data_type}', but it did not.\nFound the schema: {schema}"))]
     ArrayDataTypeMismatch {
         field_name: String,
         expected_data_type: String,
@@ -130,7 +130,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "The type of the primary key '{data_type}' is not yet supported for change deletion."
+        "The type of the primary key '{data_type}' is not yet supported for change deletion.\nUse a different primary key or change the data type."
     ))]
     PrimaryKeyTypeNotYetSupported { data_type: String },
 
@@ -142,13 +142,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Snafu)]
 pub enum AcceleratedTableBuilderError {
-    #[snafu(display("Expected changes stream for `RefreshMode::Changes`"))]
+    #[snafu(display("A changes stream is required when `refresh_mode` is set to `changes`.\nFor further information, visit: https://docs.spiceai.org/features/cdc"))]
     ExpectedChangesStream,
 
-    #[snafu(display("Append stream is required for `RefreshMode::Append` without time_column"))]
+    #[snafu(display("An append stream is required when `refresh_mode` is set to `append` without a `time_column`.\nFor further information, visit: https://docs.spiceai.org/components/data-accelerators/data-refresh#append"))]
     AppendStreamRequired,
 
-    #[snafu(display("Synchronized accelerated table requires full refresh mode"))]
+    #[snafu(display("A synchronized accelerated table requires full refresh mode.\nSet your `refresh_mode` to 'full', and try again."))]
     SynchronizedAcceleratedTableRequiresFullRefresh,
 }
 

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -105,7 +105,7 @@ pub enum Error {
     #[snafu(display("Failed to write data into accelerated table.\n{source}"))]
     FailedToWriteData { source: DataFusionError },
 
-    #[snafu(display("The accelerated table does not support delete operations.\nUse a different acceleration engine which supports delete operations.\nFor further information, visit: https://docs.spiceai.org/components/data-accelerators"))]
+    #[snafu(display("The accelerated table does not support delete operations.\nUse a different acceleration engine which supports delete operations.\nFor details, visit: https://docs.spiceai.org/components/data-accelerators"))]
     AcceleratedTableDoesntSupportDelete {},
 
     #[snafu(display("Expected the schema to have field '{field_name}', but it did not.\nSpice found the schema: {schema}\nIs the primary key configuration correct?"))]
@@ -134,10 +134,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Snafu)]
 pub enum AcceleratedTableBuilderError {
-    #[snafu(display("A changes stream is required when `refresh_mode` is set to `changes`.\nFor further information, visit: https://docs.spiceai.org/features/cdc"))]
+    #[snafu(display("A changes stream is required when `refresh_mode` is set to `changes`.\nFor details, visit: https://docs.spiceai.org/features/cdc"))]
     ExpectedChangesStream,
 
-    #[snafu(display("An append stream is required when `refresh_mode` is set to `append` without a `time_column`.\nFor further information, visit: https://docs.spiceai.org/components/data-accelerators/data-refresh#append"))]
+    #[snafu(display("An append stream is required when `refresh_mode` is set to `append` without a `time_column`.\nFor details, visit: https://docs.spiceai.org/components/data-accelerators/data-refresh#append"))]
     AppendStreamRequired,
 
     #[snafu(display("A synchronized accelerated table requires full refresh mode.\nSet `refresh_mode` to 'full', and try again."))]

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -89,7 +89,7 @@ pub enum Error {
         source: tokio::sync::mpsc::error::SendError<Option<RefreshOverrides>>,
     },
 
-    #[snafu(display("Manual refresh is not supported for `append` mode.\nUse a different acceleration mode to use manual refresh."))]
+    #[snafu(display("Manual refresh is not supported for `append` mode.\nOnly `full` refresh mode supports manual refreshes."))]
     ManualRefreshIsNotSupported {},
 
     #[snafu(display(

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -116,14 +116,14 @@ pub enum Error {
     #[snafu(display("The accelerated table does not support delete operations.\nUse a different acceleration engine which supports delete operations.\nFor further information, visit: https://docs.spiceai.org/components/data-accelerators"))]
     AcceleratedTableDoesntSupportDelete {},
 
-    #[snafu(display("Expected the schema to have field '{field_name}', but it did not.\nFound the schema: {schema}"))]
-    ExpectedSchemaToHaveField {
+    #[snafu(display("Expected the schema to have field '{field_name}', but it did not.\nSpice found the schema: {schema}\nIs your primary key configuration correct?"))]
+    PrimaryKeyExpectedSchemaToHaveField {
         field_name: String,
         schema: SchemaRef,
     },
 
-    #[snafu(display("Expected the field in schema '{field_name}' to have type '{expected_data_type}', but it did not.\nFound the schema: {schema}"))]
-    ArrayDataTypeMismatch {
+    #[snafu(display("Expected the field in schema '{field_name}' to have type '{expected_data_type}', but it did not.\nSpice found the schema: {schema}\nIs your primary key configuration correct?"))]
+    PrimaryKeyArrayDataTypeMismatch {
         field_name: String,
         expected_data_type: String,
         schema: SchemaRef,

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -593,7 +593,7 @@ impl RefreshTask {
             .clone()
             .context(super::FailedToFindLatestTimestampSnafu {
             reason:
-                "Failed to get the latest timestamp.\nYou must specify a `time_column` parameter.",
+                "Failed to get the latest timestamp.\nThe `time_column` parameter must be specified.",
         })?;
 
         let df = self
@@ -625,7 +625,7 @@ impl RefreshTask {
         let schema = &self.accelerator.schema();
         let Ok(accelerated_field) = schema.field_with_name(&column) else {
             return Err(super::Error::FailedToFindLatestTimestamp {
-                reason: "Failed to get the latest timestamp.\nYou must specify a `time_column` parameter."
+                reason: "Failed to get the latest timestamp.\nThe `time_column` parameter must be specified."
                     .to_string(),
             });
         };

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -588,13 +588,13 @@ impl RefreshTask {
             .validate_time_format(self.dataset_name.to_string(), &self.accelerator.schema())
             .context(super::InvalidTimeColumnTimeFormatSnafu)?;
 
-        let column =
-            refresh
-                .time_column
-                .clone()
-                .context(super::FailedToFindLatestTimestampSnafu {
-                    reason: "Failed to get latest timestamp due to time column not specified",
-                })?;
+        let column = refresh
+            .time_column
+            .clone()
+            .context(super::FailedToFindLatestTimestampSnafu {
+            reason:
+                "Failed to get the latest timestamp.\nYou must specify a `time_column` parameter.",
+        })?;
 
         let df = self
             .max_timestamp_df(ctx, &column, refresh.sql.as_deref())
@@ -613,7 +613,7 @@ impl RefreshTask {
             .as_any()
             .downcast_ref::<TimestampNanosecondArray>()
             .context(super::FailedToFindLatestTimestampSnafu {
-                reason: "Failed to get latest timestamp during incremental appending process due to time column is unable to cast to timestamp",
+                reason: "Failed to get the latest timestamp during incremental appending.\nFailed to convert the value of the time column to a timestamp. Are you sure the column is a timestamp?",
             })?;
 
         if array.is_empty() {
@@ -625,7 +625,7 @@ impl RefreshTask {
         let schema = &self.accelerator.schema();
         let Ok(accelerated_field) = schema.field_with_name(&column) else {
             return Err(super::Error::FailedToFindLatestTimestamp {
-                reason: "Failed to get latest timestamp due to time column not specified"
+                reason: "Failed to get the latest timestamp.\nYou must specify a `time_column` parameter."
                     .to_string(),
             });
         };

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -266,7 +266,7 @@ impl RefreshTask {
         let sink = &*sink_lock;
 
         if let Err(e) = sink.insert_into(record_batch_stream, overwrite).await {
-            tracing::warn!("Failed to update dataset {dataset_name}: {e}");
+            tracing::warn!("Failed to update the dataset {dataset_name}.\n{e}");
             self.mark_dataset_status(sql, status::ComponentStatus::Error)
                 .await;
             return Err(e);

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -613,7 +613,7 @@ impl RefreshTask {
             .as_any()
             .downcast_ref::<TimestampNanosecondArray>()
             .context(super::FailedToFindLatestTimestampSnafu {
-                reason: "Failed to get the latest timestamp during incremental appending.\nFailed to convert the value of the time column to a timestamp. Are you sure the column is a timestamp?",
+                reason: "Failed to get the latest timestamp during incremental appending.\nFailed to convert the value of the time column to a timestamp. Verify the column is a timestamp.",
             })?;
 
         if array.is_empty() {

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -50,7 +50,7 @@ use tokio::sync::{oneshot, RwLock};
 macro_rules! extract_primary_key {
     ($key_col:expr, $key:expr, $data_schema:expr, $array_type:ty, $data_type_str:expr) => {{
         let key_col = $key_col.as_any().downcast_ref::<$array_type>().context(
-            crate::accelerated_table::ArrayDataTypeMismatchSnafu {
+            crate::accelerated_table::PrimaryKeyArrayDataTypeMismatchSnafu {
                 field_name: $key.to_string(),
                 expected_data_type: $data_type_str.to_string(),
                 schema: Arc::clone(&$data_schema),
@@ -241,7 +241,7 @@ impl RefreshTask {
     ) -> crate::accelerated_table::Result<(String, Expr)> {
         let data_schema = data.schema();
         let (primary_key_idx, field) = data_schema.column_with_name(key).ok_or_else(|| {
-            crate::accelerated_table::ExpectedSchemaToHaveFieldSnafu {
+            crate::accelerated_table::PrimaryKeyExpectedSchemaToHaveFieldSnafu {
                 field_name: key.to_string(),
                 schema: Arc::clone(&data_schema),
             }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -192,7 +192,7 @@ pub enum DataConnectorError {
         message: String,
     },
 
-    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}).\nThe connector '{dataconnector}' is not a valid connector.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors"))]
+    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}).\nThe connector '{dataconnector}' is not a valid connector.\nFor details, visit: https://docs.spiceai.org/components/data-connectors"))]
     InvalidConnectorType {
         dataconnector: String,
         connector_component: ConnectorComponent,

--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -239,7 +239,7 @@ impl ListingTableConnector for AzureBlobFS {
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("{} is not a valid URL. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/abfs#from", &dataset.from),
+                    message: format!("{} is not a valid URL. Ensure the URL is valid and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/abfs#from", &dataset.from),
                     connector_component: ConnectorComponent::from(dataset)
                 })?;
 

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -121,7 +121,7 @@ impl Databricks {
         let Some(catalog_id) = catalog.catalog_id.clone() else {
             return Err(super::DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: "databricks".into(),
-                message: "A Catalog Name is required for the Databricks Unity Catalog.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/databricks#from".into(),
+                message: "A Catalog Name is required for the Databricks Unity Catalog.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#from".into(),
                 connector_component: ConnectorComponent::from(catalog)
             });
         };
@@ -129,14 +129,14 @@ impl Databricks {
         let endpoint = self.params.get("endpoint").expose().ok_or_else(|p| {
             super::DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: "databricks".into(),
-                message: format!("A required parameter was missing: {}.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
+                message: format!("A required parameter was missing: {}.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
                 connector_component: ConnectorComponent::from(catalog)
             }
         })?;
         let token = self.params.get("token").ok_or_else(|p| {
             super::DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: "databricks".into(),
-                message: format!("A required parameter was missing: {}.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
+                message: format!("A required parameter was missing: {}.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
                 connector_component: ConnectorComponent::from(catalog)
             }
         })?;

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -205,7 +205,7 @@ impl DataConnector for Debezium {
             dataset.is_accelerated(),
             super::InvalidConfigurationNoSourceSnafu {
                 dataconnector: "debezium",
-                message: "The Debezium data connector only works with accelerated datasets.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/debezium",
+                message: "The Debezium data connector only works with accelerated datasets.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/debezium",
                 connector_component: ConnectorComponent::from(dataset),
             }
         );
@@ -217,7 +217,7 @@ impl DataConnector for Debezium {
             super::InvalidConfigurationNoSourceSnafu {
                 dataconnector: "debezium",
                 message:
-                    "The Debezium data connector only works with non-Arrow acceleration engines.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/debezium",
+                    "The Debezium data connector only works with non-Arrow acceleration engines.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/debezium",
                 connector_component: ConnectorComponent::from(dataset),
             }
         );
@@ -225,7 +225,7 @@ impl DataConnector for Debezium {
             self.resolve_refresh_mode(acceleration.refresh_mode) == RefreshMode::Changes,
             super::InvalidConfigurationNoSourceSnafu {
                 dataconnector: "debezium",
-                message: "The Debezium data connector only works with 'changes' refresh mode.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/debezium",
+                message: "The Debezium data connector only works with 'changes' refresh mode.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/debezium",
                 connector_component: ConnectorComponent::from(dataset),
             }
         );

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -139,7 +139,7 @@ impl ListingTableConnector for File {
             .boxed()
             .context(InvalidConfigurationSnafu {
                 dataconnector: "file".to_string(),
-                message: "The specified file path created an invalid URL. Check your file path and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/file".to_string(),
+                message: "The specified file path created an invalid URL. Check your file path and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/file".to_string(),
                 connector_component: ConnectorComponent::from(dataset),
             })
     }

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -114,7 +114,7 @@ impl ListingTableConnector for FTP {
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("{} is not a valid URL. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/ftp", dataset.from),
+                    message: format!("{} is not a valid URL. Ensure the URL is valid and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/ftp", dataset.from),
                     connector_component: ConnectorComponent::from(dataset),
                 })?;
 

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -188,7 +188,7 @@ impl Github {
         let Some(tree_sha) = tree_sha.filter(|s| !s.is_empty()) else {
             return Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "github".to_string(),
-                source: format!("The branch or tag name is required in the dataset 'from' and must be in the format 'github.com/{owner}/{repo}/files/<BRANCH_NAME>'.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#querying-github-files").into(),
+                source: format!("The branch or tag name is required in the dataset 'from' and must be in the format 'github.com/{owner}/{repo}/files/<BRANCH_NAME>'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/github#querying-github-files").into(),
                 connector_component: ConnectorComponent::from(dataset),
             });
         };
@@ -375,7 +375,7 @@ impl DataConnector for Github {
             DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "github".to_string(),
                 connector_component: ConnectorComponent::from(dataset),
-                source: format!("Invalid query mode: {e}.\nEnsure a valid query mode is used, and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#common-parameters").into(),
+                source: format!("Invalid query mode: {e}.\nEnsure a valid query mode is used, and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/github#common-parameters").into(),
             }
         })?;
 
@@ -433,19 +433,19 @@ impl DataConnector for Github {
             (Some("github.com"), Some(_), Some(_), Some(invalid_table)) => {
                 Err(DataConnectorError::UnableToGetReadProvider {
                     dataconnector: "github".to_string(),
-                    source: format!("Invalid GitHub table type: {invalid_table}.\nEnsure a valid table type is used, and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration").into(),
+                    source: format!("Invalid GitHub table type: {invalid_table}.\nEnsure a valid table type is used, and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration").into(),
                     connector_component: ConnectorComponent::from(dataset),
                 })
             }
             (_, Some(owner), Some(repo), _) => Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "github".to_string(),
                 connector_component: ConnectorComponent::from(dataset),
-                source: format!("The dataset `from` must start with 'github.com/{owner}/{repo}'.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration").into(),
+                source: format!("The dataset `from` must start with 'github.com/{owner}/{repo}'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration").into(),
             }),
             _ => Err(DataConnectorError::UnableToGetReadProvider {
                 dataconnector: "github".to_string(),
                 connector_component: ConnectorComponent::from(dataset),
-                source: "Invalid GitHub path provided in the dataset 'from'.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration".into(),
+                source: "Invalid GitHub path provided in the dataset 'from'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/github#common-configuration".into(),
             }),
         }
     }

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -126,7 +126,7 @@ impl GraphQL {
         let endpoint = Url::parse(&dataset.path()).map_err(Into::into).context(
             super::InvalidConfigurationSnafu {
                 dataconnector: "graphql",
-                message: "The specified URL in the dataset 'from' is not valid. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/graphql",
+                message: "The specified URL in the dataset 'from' is not valid. Ensure the URL is valid and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/graphql",
                 connector_component: ConnectorComponent::from(dataset),
             },
         )?;
@@ -143,7 +143,7 @@ impl GraphQL {
             .boxed()
             .context(InvalidConfigurationSnafu {
                 dataconnector: "graphql",
-                message: "The `unnest_depth` parameter must be a positive integer.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/graphql#configuration",
+                message: "The `unnest_depth` parameter must be a positive integer.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/graphql#configuration",
                 connector_component: ConnectorComponent::from(dataset),
             })?;
 
@@ -188,7 +188,7 @@ impl DataConnector for GraphQL {
         let query = self.params.get("query").expose().ok_or_else(|p| {
             super::InvalidConfigurationNoSourceSnafu {
                 dataconnector: "graphql",
-                message: format!("A required parameter was missing: `{}`.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/graphql#configuration", p.0),
+                message: format!("A required parameter was missing: `{}`.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/graphql#configuration", p.0),
                 connector_component: ConnectorComponent::from(dataset),
             }
             .build()

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -110,7 +110,7 @@ impl ListingTableConnector for Https {
         let mut u = Url::parse(&dataset.from).boxed().map_err(|e| {
             DataConnectorError::InvalidConfiguration {
                 dataconnector: "https".to_string(),
-                message: "The specified URL in the dataset 'from' is not valid. Ensure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/https".to_string(),
+                message: "The specified URL in the dataset 'from' is not valid. Ensure the URL is valid and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/https".to_string(),
                 connector_component: ConnectorComponent::from(dataset),
                 source: e,
             }
@@ -122,7 +122,7 @@ impl ListingTableConnector for Https {
                 Err(e) => {
                     return Err(DataConnectorError::InvalidConfiguration {
                         dataconnector: "https".to_string(),
-                        message: "The specified `https_port` parameter was invalid. Specify a valid port number and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/https#parameters".to_string(),
+                        message: "The specified `https_port` parameter was invalid. Specify a valid port number and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/https#parameters".to_string(),
                         connector_component: ConnectorComponent::from(dataset),
                         source: Box::new(e),
                     });

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -505,7 +505,7 @@ async fn check_for_files_and_extensions(
         return Err(DataConnectorError::InvalidConfigurationNoSource {
             dataconnector: dataconnector.clone(),
             connector_component: ConnectorComponent::from(dataset),
-            message: format!("Failed to find any files matching the extension '{extension}'.\nIs your `file_format` parameter correct? Spice found the following file extensions: {display_extensions}.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors#object-store-file-formats")
+            message: format!("Failed to find any files matching the extension '{extension}'.\nIs your `file_format` parameter correct? Spice found the following file extensions: {display_extensions}.\nFor details, visit: https://docs.spiceai.org/components/data-connectors#object-store-file-formats")
         });
     }
 

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -69,6 +69,7 @@ pub const AWS_REGIONS: [&str; 32] = [
 
 #[derive(Debug, Snafu)]
 pub enum Error {
+<<<<<<< Updated upstream
     #[snafu(display("S3 auth method 'key' requires an AWS access secret.\nSpecify an access secret with the `s3_secret` parameter.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
     NoAccessSecret,
 
@@ -80,16 +81,43 @@ pub enum Error {
 
     #[snafu(display(
         "The '{parameter}' parameter requires `s3_auth` set to '{auth}'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"
+=======
+    #[snafu(display("The S3 authentication method was set to `key`, but no AWS access secret was provided for credentials.\nSpecify an access secret with the `s3_secret` parameter.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
+    NoAccessSecret,
+
+    #[snafu(display("The S3 authentication method was set to `key`, but no AWS access key was provided for credentials.\nSpecify an access key with the `s3_key` parameter.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
+    NoAccessKey,
+
+    #[snafu(display("Unable to parse URL {url}: {source}"))]
+    UnableToParseURL {
+        url: String,
+        source: url::ParseError,
+    },
+
+    #[snafu(display("The S3 authentication method '{method}' is not supported.\nUpdate the `s3_auth` parameter to use the supported `s3_auth` modes of 'public' (i.e. no auth), 'iam_role', or 'key'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
+    UnsupportedAuthenticationMethod { method: String },
+
+    #[snafu(display(
+        "The '{parameter}' parameter cannot be set unless the `s3_auth` parameter is set to '{auth}'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"
+>>>>>>> Stashed changes
     ))]
     InvalidAuthParameterCombination { parameter: String, auth: String },
 
     #[snafu(display(
+<<<<<<< Updated upstream
         "The `s3_endpoint` parameter must be a HTTP/S URL, but '{endpoint}' was provided.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
+=======
+        "The 's3_endpoint' parameter must be a HTTP/S URL, but '{endpoint}' was provided.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
+>>>>>>> Stashed changes
     ))]
     InvalidEndpoint { endpoint: String },
 
     #[snafu(display(
+<<<<<<< Updated upstream
         "The `s3_region` parameter must be a valid AWS region code, but '{region}' was provided.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
+=======
+        "The 's3_region' parameter must be a valid AWS region code, but '{region}' was provided.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
+>>>>>>> Stashed changes
     ))]
     InvalidRegion { region: String },
 
@@ -98,7 +126,11 @@ pub enum Error {
     ))]
     InvalidRegionCorrected { region: String },
 
+<<<<<<< Updated upstream
     #[snafu(display("IAM role authentication failed.\nAre you sure you're running in an environment with an IAM role?\n{source}\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
+=======
+    #[snafu(display("Failed to authenticate using an IAM role.\nAre you sure you're running in an environment with an IAM role?\n{source}\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
+>>>>>>> Stashed changes
     InvalidIAMRoleAuthentication {
         source: Box<dyn std::error::Error + Send + Sync>,
     },

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -69,7 +69,6 @@ pub const AWS_REGIONS: [&str; 32] = [
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-<<<<<<< Updated upstream
     #[snafu(display("S3 auth method 'key' requires an AWS access secret.\nSpecify an access secret with the `s3_secret` parameter.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
     NoAccessSecret,
 
@@ -81,43 +80,16 @@ pub enum Error {
 
     #[snafu(display(
         "The '{parameter}' parameter requires `s3_auth` set to '{auth}'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"
-=======
-    #[snafu(display("The S3 authentication method was set to `key`, but no AWS access secret was provided for credentials.\nSpecify an access secret with the `s3_secret` parameter.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
-    NoAccessSecret,
-
-    #[snafu(display("The S3 authentication method was set to `key`, but no AWS access key was provided for credentials.\nSpecify an access key with the `s3_key` parameter.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
-    NoAccessKey,
-
-    #[snafu(display("Unable to parse URL {url}: {source}"))]
-    UnableToParseURL {
-        url: String,
-        source: url::ParseError,
-    },
-
-    #[snafu(display("The S3 authentication method '{method}' is not supported.\nUpdate the `s3_auth` parameter to use the supported `s3_auth` modes of 'public' (i.e. no auth), 'iam_role', or 'key'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
-    UnsupportedAuthenticationMethod { method: String },
-
-    #[snafu(display(
-        "The '{parameter}' parameter cannot be set unless the `s3_auth` parameter is set to '{auth}'.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"
->>>>>>> Stashed changes
     ))]
     InvalidAuthParameterCombination { parameter: String, auth: String },
 
     #[snafu(display(
-<<<<<<< Updated upstream
         "The `s3_endpoint` parameter must be a HTTP/S URL, but '{endpoint}' was provided.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
-=======
-        "The 's3_endpoint' parameter must be a HTTP/S URL, but '{endpoint}' was provided.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
->>>>>>> Stashed changes
     ))]
     InvalidEndpoint { endpoint: String },
 
     #[snafu(display(
-<<<<<<< Updated upstream
         "The `s3_region` parameter must be a valid AWS region code, but '{region}' was provided.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
-=======
-        "The 's3_region' parameter must be a valid AWS region code, but '{region}' was provided.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"
->>>>>>> Stashed changes
     ))]
     InvalidRegion { region: String },
 
@@ -126,11 +98,7 @@ pub enum Error {
     ))]
     InvalidRegionCorrected { region: String },
 
-<<<<<<< Updated upstream
     #[snafu(display("IAM role authentication failed.\nAre you sure you're running in an environment with an IAM role?\n{source}\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
-=======
-    #[snafu(display("Failed to authenticate using an IAM role.\nAre you sure you're running in an environment with an IAM role?\n{source}\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#auth"))]
->>>>>>> Stashed changes
     InvalidIAMRoleAuthentication {
         source: Box<dyn std::error::Error + Send + Sync>,
     },

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -123,7 +123,7 @@ impl ListingTableConnector for SFTP {
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("The specified URL is not valid: {}.\nEnsure the URL is valid and try again.\nFor further information, visit: https://docs.spiceai.org/components/data-connectors/ftp", dataset.from),
+                    message: format!("The specified URL is not valid: {}.\nEnsure the URL is valid and try again.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/ftp", dataset.from),
                     connector_component: ConnectorComponent::from(dataset)
                 })?;
 

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -307,7 +307,7 @@ impl DataConnector for SpiceAI {
             return Some(Err(
                 super::DataConnectorError::InvalidConfigurationNoSource {
                     dataconnector: "spice.ai".into(),
-                    message: "A Catalog Name is not supported for the Spice.ai catalog connector.\nRemove the Catalog Name, and use only 'spice.ai' in the 'from' parameter.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/spiceai#from".into(),
+                    message: "A Catalog Name is not supported for the Spice.ai catalog connector.\nRemove the Catalog Name, and use only 'spice.ai' in the 'from' parameter.\nFor details, visit: https://docs.spiceai.org/components/catalogs/spiceai#from".into(),
                     connector_component: ConnectorComponent::from(catalog),
                 },
             ));

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -171,7 +171,7 @@ impl DataConnector for UnityCatalog {
             return Some(Err(
                 super::DataConnectorError::InvalidConfigurationNoSource {
                     dataconnector: "unity_catalog".into(),
-                    message: "A Catalog Path is required for Unity Catalog.\nFor further information, visit: https://docs.spiceai.org/components/catalogs/unity-catalog#from".into(),
+                    message: "A Catalog Path is required for Unity Catalog.\nFor details, visit: https://docs.spiceai.org/components/catalogs/unity-catalog#from".into(),
                     connector_component: ConnectorComponent::from(catalog),
                 },
             ));

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -153,7 +153,7 @@ pub enum Error {
         source: DataFusionError,
     },
 
-    #[snafu(display("Cannot refresh {table_name}: {source}"))]
+    #[snafu(display("Failed to refresh the dataset {table_name}.\n{source}"))]
     UnableToTriggerRefresh {
         table_name: String,
         source: crate::accelerated_table::Error,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -153,9 +153,9 @@ pub enum Error {
         source: DataFusionError,
     },
 
-    #[snafu(display("Failed to refresh the dataset {table_name}.\n{source}"))]
+    #[snafu(display("Failed to refresh the dataset {dataset_name}.\n{source}"))]
     UnableToTriggerRefresh {
-        table_name: String,
+        dataset_name: String,
         source: crate::accelerated_table::Error,
     },
 
@@ -205,8 +205,11 @@ pub enum Error {
     #[snafu(display("Unable to retrieve underlying table provider from federation"))]
     UnableToRetrieveTableFromFederation { table_name: String },
 
-    #[snafu(display("Unable to build accelerated table: {source}"))]
+    #[snafu(display(
+        "Failed to create an accelerated table for the dataset {dataset_name}.\n{source}"
+    ))]
     UnableToBuildAcceleratedTable {
+        dataset_name: String,
         source: AcceleratedTableBuilderError,
     },
 }
@@ -788,7 +791,9 @@ impl DataFusion {
         accelerated_table_builder
             .build()
             .await
-            .context(UnableToBuildAcceleratedTableSnafu)
+            .context(UnableToBuildAcceleratedTableSnafu {
+                dataset_name: dataset.name.to_string(),
+            })
     }
 
     /// Attempt to synchronize refreshes with the parent table for localpod accelerated tables.
@@ -891,7 +896,7 @@ impl DataFusion {
         if let Some(accelerated_table) = table.as_any().downcast_ref::<AcceleratedTable>() {
             return accelerated_table.trigger_refresh(overrides).await.context(
                 UnableToTriggerRefreshSnafu {
-                    table_name: dataset_name.to_string(),
+                    dataset_name: dataset_name.to_string(),
                 },
             );
         }
@@ -920,7 +925,7 @@ impl DataFusion {
                 .update_refresh_sql(refresh_sql)
                 .await
                 .context(UnableToTriggerRefreshSnafu {
-                    table_name: dataset_name.to_string(),
+                    dataset_name: dataset_name.to_string(),
                 })?;
         }
 

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -43,7 +43,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to get table: {source}"))]
+    #[snafu(display("Failed to read the table.\n{source}"))]
     UnableToGetTable { source: DataFusionError },
 
     #[snafu(display("{source}"))]
@@ -51,11 +51,13 @@ pub enum Error {
         source: crate::datafusion::query::Error,
     },
 
-    #[snafu(display("Unable to get recently access datasets: {source}"))]
+    #[snafu(display("Failed to get recently access datasets.\n{source}"))]
     UnableToGetRecentlyAccessedDatasets { source: DataFusionError },
 
-    #[snafu(display("Unexpected data type from task_history query result"))]
-    UnexpectedDataType,
+    #[snafu(display("Spice received an unexpected data type from a `task_history` query: {data_type}\nThis is likely to be a bug in Spice, which you can report here: https://github.com/spiceai/spiceai/issues"))]
+    UnexpectedDataType {
+        data_type: arrow::datatypes::DataType,
+    },
 }
 
 #[derive(Clone)]
@@ -191,7 +193,11 @@ AND labels.error_code IS NULL"
                 arrow::datatypes::DataType::LargeUtf8 => {
                     column.as_string::<i64>().into_iter().flatten().collect()
                 }
-                _ => return UnexpectedDataTypeSnafu.fail(),
+                dt => {
+                    return Err(Error::UnexpectedDataType {
+                        data_type: dt.clone(),
+                    })
+                }
             };
 
             for dataset in datasets {
@@ -258,10 +264,15 @@ AND labels.error_code IS NULL"
                                 {
                                     Ok(()) => AvailabilityVerificationResult::Available,
                                     Err(err) => {
-                                        tracing::error!(target: "task_history", parent: &span, "{err}");
+                                        let err_message = match err.find_root() {
+                                            DataFusionError::Execution(e) => e.to_string(),
+                                            _ => err.to_string(),
+                                        };
+
+                                        tracing::error!(target: "task_history", parent: &span, "{err_message}");
                                         AvailabilityVerificationResult::Unavailable(
                                         item.last_available_time,
-                                        err.to_string(),
+                                        err_message,
                                     )},
                                 };
 
@@ -303,7 +314,7 @@ async fn update_dataset_availability_info(
             report_dataset_unavailable_time(dataset_name, None);
         }
         AvailabilityVerificationResult::Unavailable(last_available_time, err) => {
-            tracing::warn!("Availability verification for dataset {dataset_name} failed: {err}");
+            tracing::warn!("Failed to verify the dataset {dataset_name} was available\n{err}\n");
             report_dataset_unavailable_time(dataset_name, Some(last_available_time));
         }
     }

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -314,7 +314,7 @@ async fn update_dataset_availability_info(
             report_dataset_unavailable_time(dataset_name, None);
         }
         AvailabilityVerificationResult::Unavailable(last_available_time, err) => {
-            tracing::warn!("Failed to verify the dataset {dataset_name} was available\n{err}\n");
+            tracing::warn!("Failed to verify the dataset {dataset_name} was available.\n{err}\n");
             report_dataset_unavailable_time(dataset_name, Some(last_available_time));
         }
     }

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -54,7 +54,7 @@ pub enum Error {
     #[snafu(display("Failed to get recently access datasets.\n{source}"))]
     UnableToGetRecentlyAccessedDatasets { source: DataFusionError },
 
-    #[snafu(display("Spice received an unexpected data type from a `task_history` query: {data_type}\nThis is likely a bug in Spice, which you can report here: https://github.com/spiceai/spiceai/issues"))]
+    #[snafu(display("Spice received an unexpected data type from a `task_history` query: {data_type}\nThis is likely a bug in Spice, which can be reported here: https://github.com/spiceai/spiceai/issues"))]
     UnexpectedDataType {
         data_type: arrow::datatypes::DataType,
     },

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -54,7 +54,7 @@ pub enum Error {
     #[snafu(display("Failed to get recently access datasets.\n{source}"))]
     UnableToGetRecentlyAccessedDatasets { source: DataFusionError },
 
-    #[snafu(display("Spice received an unexpected data type from a `task_history` query: {data_type}\nThis is likely to be a bug in Spice, which you can report here: https://github.com/spiceai/spiceai/issues"))]
+    #[snafu(display("Spice received an unexpected data type from a `task_history` query: {data_type}\nThis is likely a bug in Spice, which you can report here: https://github.com/spiceai/spiceai/issues"))]
     UnexpectedDataType {
         data_type: arrow::datatypes::DataType,
     },

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -95,7 +95,7 @@ impl EmbeddingConnector {
             if !self.embedding_models.read().await.contains_key(model) {
                 return Err(DataConnectorError::InvalidConfigurationNoSource {
                     dataconnector: "EmbeddingConnector".to_string(),
-                    message: format!("The dataset is configured with an embedding model '{model}' to embed column '{column}', but the model '{model}' is not defined in Spicepod (as an 'embeddings').\nFor further information, visit: https://docs.spiceai.org/components/embeddings"),
+                    message: format!("The dataset is configured with an embedding model '{model}' to embed column '{column}', but the model '{model}' is not defined in Spicepod (as an 'embeddings').\nFor details, visit: https://docs.spiceai.org/components/embeddings"),
                     connector_component: dataset.into()
                 });
             }

--- a/crates/runtime/src/embeddings/cosine_distance.rs
+++ b/crates/runtime/src/embeddings/cosine_distance.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 macro_rules! downcast_arg {
     ($ARG:expr, $ARRAY_TYPE:ident) => {{
         $ARG.as_any().downcast_ref::<$ARRAY_TYPE>().ok_or_else(|| {
-            DataFusionError::External(format!("could not cast to {}", type_name::<$ARRAY_TYPE>()))
+            DataFusionError::External(
+                format!("could not cast to {}", type_name::<$ARRAY_TYPE>()).into(),
+            )
         })?
     }};
 }

--- a/crates/runtime/src/embeddings/cosine_distance.rs
+++ b/crates/runtime/src/embeddings/cosine_distance.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 macro_rules! downcast_arg {
     ($ARG:expr, $ARRAY_TYPE:ident) => {{
         $ARG.as_any().downcast_ref::<$ARRAY_TYPE>().ok_or_else(|| {
-            DataFusionError::Internal(format!("could not cast to {}", type_name::<$ARRAY_TYPE>()))
+            DataFusionError::External(format!("could not cast to {}", type_name::<$ARRAY_TYPE>()))
         })?
     }};
 }

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -187,7 +187,7 @@ fn to_sendable_stream(
                         }
                         Err(e) => {
                             tracing::debug!("Error when getting embedding columns: {:?}", e);
-                            yield Err(DataFusionError::Internal(e.to_string()));
+                            yield Err(DataFusionError::External(e.to_string()));
 
                         },
                     };

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -187,7 +187,7 @@ fn to_sendable_stream(
                         }
                         Err(e) => {
                             tracing::debug!("Error when getting embedding columns: {:?}", e);
-                            yield Err(DataFusionError::External(e.to_string()));
+                            yield Err(DataFusionError::External(e.to_string().into()));
 
                         },
                     };

--- a/docs/dev/error_handling.md
+++ b/docs/dev/error_handling.md
@@ -86,7 +86,7 @@ Related reading:
         Cannot setup the dataset taxi_trips (s3) with an invalid configuration.
         Failed to find any files matching the extension '.csv'.
         Is your `file_format` parameter correct? Spice found the following file extensions: '.parquet'.
-        For further information, visit: <https://docs.spiceai.org/components/data-connectors#object-store-file-formats>
+        For details, visit: <https://docs.spiceai.org/components/data-connectors#object-store-file-formats>
     ```
 
     *Bad:*
@@ -130,7 +130,7 @@ Related reading:
         Cannot setup the dataset taxi_trips (s3) with an invalid configuration.
         Failed to find any files matching the extension '.csv'.
         Is your `file_format` parameter correct? Spice found the following file extensions: '.parquet'.
-        For further information, visit: <https://docs.spiceai.org/components/data-connectors#object-store-file-formats>
+        For details, visit: <https://docs.spiceai.org/components/data-connectors#object-store-file-formats>
     ```
 
     *Bad:*


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the format of some accelerated table errors.

Before:
```bash
Failed to update dataset daily_journal: Unable to get data from connector: External error: Internal error: Failed to create embedding: http error: error decoding response body.
```

After:
```bash
Failed to update the dataset daily_journal.
Failed to get data from the connector.
External error: External error: Failed to create embedding: http error: error decoding response body.
```

* Updates to format of dataset availability messages

Before
```bash
Availability verification for dataset spiceai.issues failed: Execution error: Unable to perform handshake: status: Unknown, message: "transport error", details: [], metadata: MetadataMap { headers: {} }
```

After
```bash
Failed to verify the dataset spiceai.issues was available.
Failed to connect to the Flight server.
status: Unknown, message: "transport error", details: [], metadata: MetadataMap { headers: {} }
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #3506

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

* Documentation on what accelerates support delete operations needs to be updated

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->

* This PR does not address the issue of nested `DataFusionError`, although `.find_root()` is used as part of the dataset availability check error handler. This is a PoC to get the lowest nested `DataFusionError`, but `DataFusionError` isn't `.clone()` so some more work is still needed to input these errors back to our `snafu` errors
* Some more work is required for Flight to map tonic status errors to nicer messages