### PR TITLE
Don't provide runtime tools to health check.

### DIFF
--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -411,7 +411,8 @@ pub trait Chat: Sync + Send {
 
         if let Err(e) = self
             .chat_request(CreateChatCompletionRequest {
-                max_completion_tokens: None,
+                // Cannot be set too low. Some providers will error if it cannot complete in < `max_completion_tokens`.
+                max_completion_tokens: Some(100),
                 messages: vec![ChatCompletionRequestMessage::User(
                     ChatCompletionRequestUserMessage {
                         name: None,

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -379,6 +379,11 @@ impl Chat for ToolUsingChat {
     fn as_sql(&self) -> Option<&dyn SqlGeneration> {
         self.inner_chat.as_sql()
     }
+
+    /// Override health endpoint to 1. avoid passing tools in request, 2. pre-calling `list_datasets` in [`ToolUsingChat::prepare_req`].
+    async fn health(&self) -> ChatResult<()> {
+        self.inner_chat.health().await
+    }
 }
 
 /// Create a new [`CreateChatCompletionRequest`] with new messages.


### PR DESCRIPTION
## 🗣 Description
 - Don't provide runtime tools to health check.
 - Logically, reorder structs used in LLMs (when model using tools).
 

**Currently**
 ```
+---------------------------+
|      ToolUsingChat        |
|  +----------------------+ |
|  |    ChatWrapper       | |
|  |  +--------------+    | |
|  |  |  BaseModel   |    | |
|  |  |              |    | |
|  |  +--------------+    | |
|  |                      | |
|  +----------------------+ |
|                           |
+---------------------------+
 ```

**Now**
 ```
+---------------------------+
|      ChatWrapper          |
|  +----------------------+ |
|  |    ToolUsingChat     | |
|  |  +--------------+    | |
|  |  |  BaseModel   |    | |
|  |  |              |    | |
|  |  +--------------+    | |
|  |                      | |
|  +----------------------+ |
|                           |
+---------------------------+
 ```