### PR TITLE
feat: Make REPL identify it's waiting on a new line

### DIFF
--- a/test/repl/show_tables.exp
+++ b/test/repl/show_tables.exp
@@ -1,0 +1,72 @@
+#!/usr/bin/expect -f
+
+# Runtime response timeout
+set timeout 15:
+
+spawn spice sql
+
+proc verify_show_tables {} {
+    global timeout
+
+    set found_task_history 0
+    set reset_repl_prefix 0
+
+    expect {
+        "sql>" {
+            send "show\n"
+        }
+        timeout {
+            send_user "Timeout waiting for expected response\n"
+            exit 1
+        }
+    }
+
+    expect {
+        -- "->" {
+            send "tables\n"
+        }
+        timeout {
+            send_user "Timeout waiting for expected response\n"
+            exit 1
+        }
+    }
+
+    expect {
+        -- "->" {
+            send ";\n"
+        }
+        timeout {
+            send_user "Timeout waiting for expected response\n"
+            exit 1
+        }
+    }
+
+    expect {
+        "task_history" {
+            set found_task_history 1
+            exp_continue
+        }
+        "sql>" {
+            set reset_repl_prefix 1
+        }
+        timeout {
+            send_user "Timeout waiting for expected response\n"
+            exit 1
+        }
+    }
+
+    if { $found_task_history == 1 && $reset_repl_prefix == 1 } {
+        send_user "Validated the REPL has multi-line prompt prefixes.\n"
+    } else {
+        send_user "The REPL didn't have the right multi-line prompt prefixes!\n"
+        exit 1
+    }
+}
+
+verify_show_tables
+sleep 1
+
+# Signal to exit (Ctrl+C)
+send \x03
+
+exit 0


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the REPL to make it identify when it is waiting on more input with `->`

Example:
```bash
sql> explain
  -> select * from
  -> taxi_trips
  -> limit 5;
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #3616

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

* Needs a pass on quickstarts/samples to make sure none need updating from this change.