### PR TITLE
Allow overriding runtime configuration with `--set-runtime` CLI flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10481,6 +10481,7 @@ dependencies = [
  "rustls 0.23.16",
  "rustls-pemfile 2.2.0",
  "serde_json",
+ "serde_yaml",
  "snafu",
  "snmalloc-rs",
  "spice-cloud",

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -26,6 +26,7 @@ runtime-auth = { path = "../../crates/runtime-auth" }
 rustls.workspace = true
 rustls-pemfile.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 snafu.workspace = true
 snmalloc-rs = "0.3.6"
 spice-cloud = { path = "../../crates/spice_cloud" }

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -85,11 +85,23 @@ pub enum Error {
 
     #[snafu(display("Generic Error: {reason}"))]
     GenericError { reason: String },
+
+    #[snafu(display("Failed to apply the runtime overrides from `--set-runtime`.\n{reason}"))]
+    FailedToApplyOverridesGeneric { reason: String },
+
+    #[snafu(display(
+        "Failed to apply the runtime override from `--set-runtime {path}={value}`.\n{reason}"
+    ))]
+    FailedToApplyOverride {
+        path: String,
+        value: String,
+        reason: String,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[clap(about = "Spice.ai OSS Runtime")]
 #[clap(rename_all = "kebab-case")]
 #[allow(clippy::struct_excessive_bools)]
@@ -148,9 +160,9 @@ pub struct Args {
     #[arg(long)]
     pub very_verbose: bool,
 
-    /// Overrides for the runtime configuration (--set key1.subkey=value1)
+    /// Overrides for the runtime configuration (--set-runtime key1.subkey=value1)
     #[arg(long, action = ArgAction::Append, value_parser = parse_set_string)]
-    pub set: Vec<(String, String)>,
+    pub set_runtime: Vec<(String, String)>,
 }
 
 pub async fn run(args: Args) -> Result<()> {
@@ -161,14 +173,11 @@ pub async fn run(args: Args) -> Result<()> {
         .context(UnableToConstructSpiceAppSnafu)
     {
         Ok(mut app) => {
-            app.runtime = apply_overrides(app.runtime, &args.set);
+            app.runtime = apply_overrides(app.runtime, &args.set_runtime)?;
             Some(Arc::new(app))
         }
         Err(e) => {
-            let subscriber = tracing_subscriber::FmtSubscriber::builder()
-                .with_ansi(true)
-                .finish();
-            subscriber::with_default(subscriber, || {
+            in_tracing_context(|| {
                 tracing::error!("{e}");
             });
             None
@@ -314,35 +323,46 @@ fn parse_set_string(s: &str) -> Result<(String, String), String> {
 fn apply_overrides(
     runtime_config: SpicepodRuntime,
     overrides: &Vec<(String, String)>,
-) -> SpicepodRuntime {
+) -> Result<SpicepodRuntime> {
     if overrides.is_empty() {
-        return runtime_config;
+        return Ok(runtime_config);
     }
 
-    let rt_clone = runtime_config.clone();
     let mut yaml = match serde_yaml::to_value(runtime_config) {
         Ok(yaml) => yaml,
         Err(e) => {
-            tracing::debug!("Failed to convert runtime config to YAML: {e}");
-            return rt_clone;
+            return FailedToApplyOverridesGenericSnafu {
+                reason: format!("Runtime configuration is invalid YAML.\n{e}"),
+            }
+            .fail();
         }
     };
 
     for (path, value) in overrides {
-        match apply_override(&mut yaml, path, Value::String(value.to_string())) {
+        let yaml_value =
+            serde_yaml::from_str(value).unwrap_or_else(|_| Value::String(value.to_string()));
+        match apply_override(&mut yaml, path, yaml_value) {
             Ok(()) => (),
             Err(e) => {
-                tracing::debug!("Failed to apply override {path}={value}: {e}");
-                return rt_clone;
+                return FailedToApplyOverrideSnafu {
+                    path: path.clone(),
+                    value: value.clone(),
+                    reason: format!("{e}"),
+                }
+                .fail();
             }
         };
     }
 
     match serde_yaml::from_value(yaml) {
-        Ok(runtime) => runtime,
+        Ok(runtime) => Ok(runtime),
         Err(e) => {
-            tracing::debug!("Failed to apply overrides: {e}");
-            rt_clone
+            FailedToApplyOverridesGenericSnafu {
+                reason: format!(
+                    "The runtime configuration after applying the overrides from `--set-runtime` is invalid.\n{e}"
+                ),
+            }
+            .fail()
         }
     }
 }
@@ -363,23 +383,48 @@ fn apply_override(
                     map.insert(Value::String(part.to_string()), value);
                     return Ok(());
                 }
-                _ => return Err("Path leads to non-mapping value".into()),
+                Value::Null => {
+                    let mut new_map = serde_yaml::Mapping::new();
+                    new_map.insert(Value::String(part.to_string()), value);
+                    *current = Value::Mapping(new_map);
+                    return Ok(());
+                }
+                _ => {
+                    return Err(format!(
+                        "Unable to apply override for {path}. Validate the override is correct and try again.",
+                    )
+                    .into())
+                }
             }
         }
 
         match current {
             Value::Mapping(map) => {
-                if !map.contains_key(&Value::String(part.to_string())) {
+                if !map.contains_key(Value::String(part.to_string())) {
                     map.insert(
                         Value::String(part.to_string()),
                         Value::Mapping(serde_yaml::Mapping::new()),
                     );
                 }
-                current = map.get_mut(&Value::String(part.to_string())).unwrap();
+                let key = Value::String(part.to_string());
+                let Some(new_current) = map.get_mut(&key) else {
+                    unreachable!("The key was inserted above if it was missing");
+                };
+                current = new_current;
             }
-            _ => return Err("Path leads through non-mapping value".into()),
+            _ => return Err(format!("Unable to apply override for {path}. Validate the override is correct and try again.").into()),
         }
     }
 
     Ok(())
+}
+
+pub fn in_tracing_context<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_ansi(true)
+        .finish();
+    subscriber::with_default(subscriber, f)
 }

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use app::spicepod::component::runtime::TelemetryConfig;
+use app::spicepod::component::runtime::{Runtime as SpicepodRuntime, TelemetryConfig};
 use app::{App, AppBuilder};
 use clap::{ArgAction, Parser};
 use flightrepl::ReplConfig;
@@ -37,6 +37,7 @@ use runtime::datafusion::DataFusion;
 use runtime::podswatcher::PodsWatcher;
 use runtime::spice_metrics;
 use runtime::{auth::EndpointAuth, extension::ExtensionFactory, Runtime};
+use serde_yaml::Value;
 use snafu::prelude::*;
 use spice_cloud::SpiceExtensionFactory;
 use spiced_tracing::LogVerbosity;
@@ -146,6 +147,10 @@ pub struct Args {
     /// Enable very verbose logging. In conjunction with `verbose` can be set via -vv or --very-verbose.
     #[arg(long)]
     pub very_verbose: bool,
+
+    /// Overrides for the runtime configuration (--set key1.subkey=value1)
+    #[arg(long, action = ArgAction::Append, value_parser = parse_set_string)]
+    pub set: Vec<(String, String)>,
 }
 
 pub async fn run(args: Args) -> Result<()> {
@@ -155,7 +160,10 @@ pub async fn run(args: Args) -> Result<()> {
     let app: Option<Arc<App>> = match AppBuilder::build_from_filesystem_path(current_dir.clone())
         .context(UnableToConstructSpiceAppSnafu)
     {
-        Ok(app) => Some(Arc::new(app)),
+        Ok(mut app) => {
+            app.runtime = apply_overrides(app.runtime, &args.set);
+            Some(Arc::new(app))
+        }
         Err(e) => {
             let subscriber = tracing_subscriber::FmtSubscriber::builder()
                 .with_ansi(true)
@@ -292,4 +300,86 @@ async fn start_anonymous_telemetry(
         #[cfg(feature = "anonymous_telemetry")]
         telemetry::anonymous::start(spicepod_name.map_or_else(|| "unknown", String::as_str)).await;
     }
+}
+
+fn parse_set_string(s: &str) -> Result<(String, String), String> {
+    let parts: Vec<&str> = s.split('=').collect();
+    if parts.len() != 2 {
+        return Err("Invalid set format. Use key=value".into());
+    }
+
+    Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+fn apply_overrides(
+    runtime_config: SpicepodRuntime,
+    overrides: &Vec<(String, String)>,
+) -> SpicepodRuntime {
+    if overrides.is_empty() {
+        return runtime_config;
+    }
+
+    let rt_clone = runtime_config.clone();
+    let mut yaml = match serde_yaml::to_value(runtime_config) {
+        Ok(yaml) => yaml,
+        Err(e) => {
+            tracing::debug!("Failed to convert runtime config to YAML: {e}");
+            return rt_clone;
+        }
+    };
+
+    for (path, value) in overrides {
+        match apply_override(&mut yaml, path, Value::String(value.to_string())) {
+            Ok(()) => (),
+            Err(e) => {
+                tracing::debug!("Failed to apply override {path}={value}: {e}");
+                return rt_clone;
+            }
+        };
+    }
+
+    match serde_yaml::from_value(yaml) {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            tracing::debug!("Failed to apply overrides: {e}");
+            rt_clone
+        }
+    }
+}
+
+fn apply_override(
+    yaml: &mut Value,
+    path: &str,
+    value: Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let parts: Vec<&str> = path.split('.').collect();
+    let mut current = yaml;
+
+    let parts_len = parts.len();
+    for (i, part) in parts.into_iter().enumerate() {
+        if i == parts_len - 1 {
+            match current {
+                Value::Mapping(map) => {
+                    map.insert(Value::String(part.to_string()), value);
+                    return Ok(());
+                }
+                _ => return Err("Path leads to non-mapping value".into()),
+            }
+        }
+
+        match current {
+            Value::Mapping(map) => {
+                if !map.contains_key(&Value::String(part.to_string())) {
+                    map.insert(
+                        Value::String(part.to_string()),
+                        Value::Mapping(serde_yaml::Mapping::new()),
+                    );
+                }
+                current = map.get_mut(&Value::String(part.to_string())).unwrap();
+            }
+            _ => return Err("Path leads through non-mapping value".into()),
+        }
+    }
+
+    Ok(())
 }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -66,7 +66,9 @@ fn main() {
     }
 
     if let Err(err) = tokio_runtime.block_on(start_runtime(args)) {
-        eprintln!("Spice Runtime error: {err}");
+        spiced::in_tracing_context(|| {
+            tracing::error!("{err}");
+        });
     }
 
     global::shutdown_tracer_provider();

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -49,7 +49,7 @@ use tonic::{Code, IntoRequest, Status};
 
 mod config;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[clap(about = "Spice.ai SQL REPL")]
 pub struct ReplConfig {
     #[arg(


### PR DESCRIPTION
## 🗣 Description

Allows users to override the runtime configuration of Spice by specifying any number of `--set-runtime` flags.

i.e.
`spice run -- --set-runtime task_history.captured_output=truncated`
`spice run -- --set-runtime cors.enabled=true --set-runtime cors.allowed_origins=[\"http://localhost:3000\"]`
`spice run -- --set-runtime results_cache.enabled=false`

## 🔨 Related Issues

Related to #3597

## 📄 Documentation Requirements

Will require a docs change.

## 🤔 Concerns

I'd appreciate a second set of eyes on the error handling in this PR to ensure it complies with our recently added guidelines.
