### PR TITLE
Sort vector search results based on similarity score

### DIFF
--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -420,13 +420,21 @@ pub struct Match {
     metadata: HashMap<String, serde_json::Value>,
 }
 
-pub fn to_matches(result: &VectorSearchResult) -> Result<Vec<Match>> {
+pub fn to_matches_sorted(result: &VectorSearchResult) -> Result<Vec<Match>> {
     let output = result
         .iter()
         .map(|(a, b)| b.to_matches(a))
         .collect::<Result<Vec<_>>>()?;
 
-    Ok(output.into_iter().flatten().collect_vec())
+    let mut matches: Vec<_> = output.into_iter().flatten().collect();
+    // Sort by score in descending order
+    matches.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(matches)
 }
 
 impl VectorSearch {

--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use crate::embeddings::vector_search::{
-    to_matches, Match, SearchRequest, SearchRequestJson, VectorSearch,
+    to_matches_sorted, Match, SearchRequest, SearchRequestJson, VectorSearch,
 };
 use axum::{
     http::StatusCode,
@@ -56,7 +56,7 @@ pub(crate) async fn post(
     };
 
     match vs.search(&search_request).await {
-        Ok(resp) => match to_matches(&resp) {
+        Ok(resp) => match to_matches_sorted(&resp) {
             Ok(m) => (
                 StatusCode::OK,
                 Json(SearchResponse {


### PR DESCRIPTION
## 🗣 Description

Sort vector search results based on similarity score

Currently Ranks don't correspond to the similarity score of the search results.
```
Rank 1, Score: 55.6, Datasets [spice.public.catalog_page] cp_catalog_page_sk=1
In general basic characters welcome. Clearly lively friends conv

Rank 2, Score: 77.0, Datasets [spice.public.issues] id=I_kwDOF31SUc6dwFXZ
## Describe the bug
```

