### PR TITLE
Wrap Server-Sent-Events chat errors as OpenAI error events

### DIFF
--- a/crates/runtime/src/http/v1/chat.rs
+++ b/crates/runtime/src/http/v1/chat.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use core::time;
-use std::{sync::Arc, time::Duration};
+use std::{convert::Infallible, sync::Arc, time::Duration};
 
 use async_openai::types::{ChatCompletionResponseStream, CreateChatCompletionRequest};
 use async_stream::stream;
@@ -101,11 +101,13 @@ fn create_sse_response(
                         }
                     }
 
-                    yield Ok::<_, axum::Error>(Event::default().json_data(resp).unwrap_or_else(|e| {
+                    yield Ok::<Event, Infallible>(Event::default().json_data(resp).unwrap_or_else(|e| {
+                        tracing::error!("Failed to serialize chat completion message: {e}");
                         to_openai_error_event(e.to_string())
                     }));
                 },
                 Err(e) => {
+                    tracing::error!("Error encountered in chat completion stream: {e}");
                     yield Ok(to_openai_error_event(e.to_string()));
                     break;
                 }

--- a/crates/runtime/src/http/v1/chat.rs
+++ b/crates/runtime/src/http/v1/chat.rs
@@ -28,6 +28,7 @@ use axum::{
     Extension, Json,
 };
 use futures::StreamExt;
+use serde::Serialize;
 use tokio::sync::RwLock;
 use tracing::{Instrument, Span};
 
@@ -99,14 +100,13 @@ fn create_sse_response(
                             chat_output.push_str(intermediate_chat_output);
                         }
                     }
-                    let y = Event::default();
-                    match y.json_data(resp).map_err(axum::Error::new) {
-                        Ok(a) => yield Ok(a),
-                        Err(e) => yield Err(e),
-                    }
+
+                    yield Ok::<_, axum::Error>(Event::default().json_data(resp).unwrap_or_else(|e| {
+                        to_openai_error_event(e.to_string())
+                    }));
                 },
                 Err(e) => {
-                    yield Err(axum::Error::new(e.to_string()));
+                    yield Ok(to_openai_error_event(e.to_string()));
                     break;
                 }
             }
@@ -116,4 +116,36 @@ fn create_sse_response(
     }))
     .keep_alive(KeepAlive::new().interval(keep_alive_interval))
     .into_response()
+}
+
+/// Create an [`Event`] that corresponds to an `OpenAI` error event.
+///
+/// `https://platform.openai.com/docs/api-reference/realtime-server-events/error`
+fn to_openai_error_event(err: impl Into<String>) -> Event {
+    Event::default()
+        .event("error")
+        .json_data(OpenaiErrorEvent::new(err))
+        .unwrap_or_default()
+}
+
+#[derive(Serialize)]
+pub struct ApiError {
+    message: String,
+}
+
+#[derive(Serialize)]
+pub struct OpenaiErrorEvent {
+    r#type: String,
+    error: ApiError,
+}
+
+impl OpenaiErrorEvent {
+    pub fn new(err: impl Into<String>) -> Self {
+        Self {
+            r#type: "error".to_string(),
+            error: ApiError {
+                message: err.into(),
+            },
+        }
+    }
 }


### PR DESCRIPTION
## 🗣 Description

PR updates the SSE stream error handling to report errors as [OpenAI error server events](https://platform.openai.com/docs/api-reference/realtime-server-events/error) and gracefully complete the stream instead of terminating it  on error which was not perviously propagated.

Hugging Face api does the same:
https://github.com/huggingface/text-generation-inference/blob/ab7ccf5bc3c84e07d0faf0d950421fcdc29743b5/router/src/server.rs#L1371

Example console log

```console
⚡ spice chat                    
Using model: nql22
chat> ping
All system components are ready and functioning correctly.

chat> how many records in test dataset
The test dataset contains 1 record.

chat> aggregated all information from this dataset
⢿ 2024/11/22 12:38:06 ERROR chat request failed error="stream failed: Invalid status code: 400 Bad Request"


chat> test table schema
The test dataset has the following schema:
```

## 🤔 Concerns

Some propagated errors are not user friendly, specific and actionable, this will be investigated next. Not related to errors propagation improvement.

>stream failed: Invalid status code: 400 Bad Request
