### PR TITLE
Extend `v1/datasets` api to indicate if dataset can be used in vector search

### DIFF
--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -78,7 +78,7 @@ pub(crate) struct DatasetResponseItem {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Property {
-    pub name: String,
+    pub key: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<serde_json::Value>, // support any valid JSON type (String, Int, Object, etc)
 }
@@ -337,7 +337,7 @@ fn dataset_properties(ds: &Dataset) -> Vec<Property> {
 
     #[cfg(feature = "models")]
     properties.push(Property {
-        name: "vector_search".to_string(),
+        key: "vector_search".to_string(),
         value: if ds.has_embeddings() {
             Some(serde_json::Value::String("supported".to_string()))
         } else {

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -68,6 +68,8 @@ pub(crate) struct DatasetResponseItem {
     pub name: String,
     pub replication_enabled: bool,
     pub acceleration_enabled: bool,
+    #[cfg(feature = "models")]
+    pub vector_search_enabled: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<ComponentStatus>,
@@ -112,6 +114,8 @@ pub(crate) async fn get(
             name: d.name.to_quoted_string(),
             replication_enabled: d.replication.as_ref().is_some_and(|f| f.enabled),
             acceleration_enabled: d.acceleration.as_ref().is_some_and(|f| f.enabled),
+            #[cfg(feature = "models")]
+            vector_search_enabled: d.has_embeddings(),
             status: if params.status {
                 Some(dataset_status(&df, d))
             } else {

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -68,11 +68,19 @@ pub(crate) struct DatasetResponseItem {
     pub name: String,
     pub replication_enabled: bool,
     pub acceleration_enabled: bool,
-    #[cfg(feature = "models")]
-    pub vector_search_enabled: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<ComponentStatus>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub properties: Vec<Property>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Property {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>, // support any valid JSON type (String, Int, Object, etc)
 }
 
 pub(crate) async fn get(
@@ -114,8 +122,7 @@ pub(crate) async fn get(
             name: d.name.to_quoted_string(),
             replication_enabled: d.replication.as_ref().is_some_and(|f| f.enabled),
             acceleration_enabled: d.acceleration.as_ref().is_some_and(|f| f.enabled),
-            #[cfg(feature = "models")]
-            vector_search_enabled: d.has_embeddings(),
+            properties: dataset_properties(d),
             status: if params.status {
                 Some(dataset_status(&df, d))
             } else {
@@ -323,4 +330,20 @@ pub(crate) async fn sample(
         Ok(body) => (StatusCode::OK, body).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
+}
+
+fn dataset_properties(ds: &Dataset) -> Vec<Property> {
+    let mut properties = vec![];
+
+    #[cfg(feature = "models")]
+    properties.push(Property {
+        name: "vector_search".to_string(),
+        value: if ds.has_embeddings() {
+            Some(serde_json::Value::String("available".to_string()))
+        } else {
+            Some(serde_json::Value::String("unavailable".to_string()))
+        },
+    });
+
+    properties
 }

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -339,9 +339,9 @@ fn dataset_properties(ds: &Dataset) -> Vec<Property> {
     properties.push(Property {
         name: "vector_search".to_string(),
         value: if ds.has_embeddings() {
-            Some(serde_json::Value::String("available".to_string()))
+            Some(serde_json::Value::String("supported".to_string()))
         } else {
-            Some(serde_json::Value::String("unavailable".to_string()))
+            Some(serde_json::Value::String("unsupported".to_string()))
         },
     });
 

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     accelerated_table::refresh::RefreshOverrides,
@@ -37,6 +37,7 @@ use datafusion::sql::TableReference;
 use headers_accept::Accept;
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tokio::sync::RwLock;
 use tract_core::tract_data::itertools::Itertools;
 
@@ -72,8 +73,8 @@ pub(crate) struct DatasetResponseItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<ComponentStatus>,
 
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub properties: Vec<Property>,
+    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+    pub properties: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -332,18 +333,18 @@ pub(crate) async fn sample(
     }
 }
 
-fn dataset_properties(ds: &Dataset) -> Vec<Property> {
-    let mut properties = vec![];
+fn dataset_properties(ds: &Dataset) -> HashMap<String, Value> {
+    let mut properties = HashMap::new();
 
     #[cfg(feature = "models")]
-    properties.push(Property {
-        key: "vector_search".to_string(),
-        value: if ds.has_embeddings() {
-            Some(serde_json::Value::String("supported".to_string()))
+    properties.insert(
+        "vector_search".to_string(),
+        if ds.has_embeddings() {
+            Value::String("supported".to_string())
         } else {
-            Some(serde_json::Value::String("unsupported".to_string()))
+            Value::String("unsupported".to_string())
         },
-    });
+    );
 
     properties
 }

--- a/crates/runtime/src/tools/builtin/list_datasets.rs
+++ b/crates/runtime/src/tools/builtin/list_datasets.rs
@@ -109,7 +109,7 @@ pub async fn get_dataset_elements(
             table: TableReference::parse_str(&d.name)
                 .resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
                 .to_string(),
-            can_search_documents: !d.embeddings.is_empty(),
+            can_search_documents: d.has_embeddings(),
             description: d.description.clone(),
             metadata: d.metadata.clone(),
         })

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -153,6 +153,11 @@ impl Dataset {
             ready_state: ReadyState::default(),
         }
     }
+
+    #[must_use]
+    pub fn has_embeddings(&self) -> bool {
+        self.embeddings.is_empty() || self.columns.iter().any(|c| !c.embeddings.is_empty())
+    }
 }
 
 impl WithDependsOn<Dataset> for Dataset {


### PR DESCRIPTION
## 🗣 Description

PR extends `v1/datasets` API by adding `properties` field  and `vector_search` property support to indicate if dataset has embeddings defined and  can be used in vector similarity search. 

```console
curl -s 127.0.0.1:8090/v1/datasets | jq
[
  {
    "from": "file:./data/test.txt",
    "name": "test",
    "replication_enabled": false,
    "acceleration_enabled": false,
    "properties": {
      "vector_search": "unsupported"
    }
  },
  {
    "from": "github:github.com/spiceai/spiceai/issues",
    "name": "issues",
    "replication_enabled": false,
    "acceleration_enabled": true,
    "properties": {
      "vector_search": "supported"
    }
  }
]
```

Motivation: Tools like `spice search` are able to use this information to track the state of datasets and interact more intelligently. For example, they can provide warnings or feedback if some datasets involved in the search are not yet ready and will be excluded

## 📄 Documentation Requirements

Api documentation must be updated to include new field.

## Concerns

When models are supported, the `vector_search` property is always present. Alternatively, we can avoid adding it when embeddings are not configured. The current approach was selected to provide a consistent structure, reduce client-side ambiguity, and improve discoverability of available features. This aligns with the S3 `describe-buckets` API, where the feature is present even if it's not configured or available..

https://docs.aws.amazon.com/cli/latest/reference/macie2/describe-buckets.html
>accessControlList -> (structure)

The permissions settings of the access control list (ACL) for the bucket. This value is null if an ACL hasn't been defined for the bucket.