### PR TITLE
feat: Unnest DataFusion errors

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -723,10 +723,6 @@ impl RefreshTask {
 
     async fn log_refresh_error(&self, error: &super::Error, refresh_sql: Option<&str>) {
         if let super::Error::UnableToGetDataFromConnector { source } = error {
-            // let Some(datafusion_error) = downcast_boxed_datafusion_error(source) else {
-            //     return;
-            // };
-
             if let Some(SpiceExternalError::AccelerationNotReady { dataset_name }) =
                 get_spice_df_error(source)
             {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -32,7 +32,7 @@ use tracing::{Instrument, Span};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{retry, RetryError};
 
-use crate::datafusion::error::{get_spice_df_error, SpiceExternalError};
+use crate::datafusion::error::{find_datafusion_root, get_spice_df_error, SpiceExternalError};
 use crate::datafusion::schema::BaseSchema;
 use crate::federated_table::FederatedTable;
 use crate::timing::MultiTimeMeasurement;
@@ -717,6 +717,10 @@ impl RefreshTask {
 
     async fn log_refresh_error(&self, error: &super::Error, refresh_sql: Option<&str>) {
         if let super::Error::UnableToGetDataFromConnector { source } = error {
+            // let Some(datafusion_error) = downcast_boxed_datafusion_error(source) else {
+            //     return;
+            // };
+
             if let Some(SpiceExternalError::AccelerationNotReady { dataset_name }) =
                 get_spice_df_error(source)
             {
@@ -804,9 +808,13 @@ fn filter_records(
 
 pub(crate) fn retry_from_df_error(error: DataFusionError) -> RetryError<super::Error> {
     if is_retriable_error(&error) {
-        return RetryError::transient(super::Error::UnableToGetDataFromConnector { source: error });
+        return RetryError::transient(super::Error::UnableToGetDataFromConnector {
+            source: find_datafusion_root(error),
+        });
     }
-    RetryError::permanent(super::Error::FailedToRefreshDataset { source: error })
+    RetryError::permanent(super::Error::FailedToRefreshDataset {
+        source: find_datafusion_root(error),
+    })
 }
 
 fn inner_err_from_retry(error: RetryError<super::Error>) -> super::Error {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -338,6 +338,7 @@ impl RefreshTask {
         };
 
         let streaming_update = StreamingDataUpdate::try_from(data_update)
+            .map_err(find_datafusion_root)
             .context(UnableToCreateMemTableFromUpdateSnafu)?;
 
         self.write_streaming_data_update(start_time, streaming_update, sql.as_deref())
@@ -553,11 +554,14 @@ impl RefreshTask {
                 refresh.sql.as_deref(),
             )
             .await
+            .map_err(find_datafusion_root)
             .context(super::UnableToScanTableProviderSnafu)?
             .filter(filter_converter.convert(value, Operator::Gt))
+            .map_err(find_datafusion_root)
             .context(super::UnableToScanTableProviderSnafu)?
             .collect()
             .await
+            .map_err(find_datafusion_root)
             .context(super::UnableToScanTableProviderSnafu)?;
 
         let filter_schema = BaseSchema::get_schema(&federated_provider);
@@ -599,10 +603,12 @@ impl RefreshTask {
         let df = self
             .max_timestamp_df(ctx, &column, refresh.sql.as_deref())
             .await
+            .map_err(find_datafusion_root)
             .context(super::UnableToScanTableProviderSnafu)?;
         let result = &df
             .collect()
             .await
+            .map_err(find_datafusion_root)
             .context(super::FailedToQueryLatestTimestampSnafu)?;
 
         let Some(result) = result.first() else {

--- a/crates/runtime/src/accelerated_table/sink/multi.rs
+++ b/crates/runtime/src/accelerated_table/sink/multi.rs
@@ -38,6 +38,7 @@ use util::RetryError;
 
 use crate::{
     accelerated_table::{refresh_task::retry_from_df_error, synchronized_table::SynchronizedTable},
+    datafusion::error::find_datafusion_root,
     dataupdate::StreamingDataUpdateExecutionPlan,
 };
 
@@ -80,7 +81,7 @@ impl MultiSink {
             .await
             .map_err(|e| {
                 RetryError::permanent(crate::accelerated_table::Error::FailedToWriteData {
-                    source: e,
+                    source: find_datafusion_root(e),
                 })
             })?;
 

--- a/crates/runtime/src/accelerated_table/sink/table.rs
+++ b/crates/runtime/src/accelerated_table/sink/table.rs
@@ -23,7 +23,7 @@ use datafusion::{
 use util::RetryError;
 
 use crate::{
-    accelerated_table::refresh_task::retry_from_df_error,
+    accelerated_table::refresh_task::retry_from_df_error, datafusion::error::find_datafusion_root,
     dataupdate::StreamingDataUpdateExecutionPlan,
 };
 
@@ -56,7 +56,9 @@ impl TableSink {
             Err(e) => {
                 // Should not retry if we are unable to create execution plan to insert data
                 return Err(RetryError::permanent(
-                    crate::accelerated_table::Error::FailedToWriteData { source: e },
+                    crate::accelerated_table::Error::FailedToWriteData {
+                        source: find_datafusion_root(e),
+                    },
                 ));
             }
         };

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -18,6 +18,7 @@ use crate::accelerated_table::AcceleratedTable;
 use crate::component::catalog::Catalog;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
+use crate::datafusion::error::find_datafusion_root;
 use crate::federated_table::FederatedTable;
 use crate::parameters::ParameterSpec;
 use crate::parameters::Parameters;
@@ -425,22 +426,26 @@ pub async fn get_data(
     let mut df = match sql {
         None => {
             let table_source = Arc::new(DefaultTableSource::new(Arc::clone(&table_provider)));
-            let logical_plan =
-                LogicalPlanBuilder::scan(table_name.clone(), table_source, None)?.build()?;
+            let logical_plan = LogicalPlanBuilder::scan(table_name.clone(), table_source, None)
+                .map_err(find_datafusion_root)?
+                .build()
+                .map_err(find_datafusion_root)?;
 
             DataFrame::new(ctx.state(), logical_plan)
         }
-        Some(sql) => ctx.sql(&sql).await?,
+        Some(sql) => ctx.sql(&sql).await.map_err(find_datafusion_root)?,
     };
 
     for filter in filters {
-        df = df.filter(filter)?;
+        df = df.filter(filter).map_err(find_datafusion_root)?;
     }
 
-    let sql = Unparser::default().plan_to_sql(df.logical_plan())?;
+    let sql = Unparser::default()
+        .plan_to_sql(df.logical_plan())
+        .map_err(find_datafusion_root)?;
     tracing::info!(target: "task_history", sql = %sql, "labels");
 
-    let record_batch_stream = df.execute_stream().await?;
+    let record_batch_stream = df.execute_stream().await.map_err(find_datafusion_root)?;
     Ok((table_provider.schema(), record_batch_stream))
 }
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -95,39 +95,6 @@ pub mod spiceai;
 pub mod unity_catalog;
 
 #[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(display("Unable to scan table provider: {source}"))]
-    UnableToScanTableProvider {
-        source: datafusion::error::DataFusionError,
-    },
-
-    #[snafu(display("Unable to construct logical plan builder: {source}"))]
-    UnableToConstructLogicalPlanBuilder {
-        source: datafusion::error::DataFusionError,
-    },
-
-    #[snafu(display("Unable to build logical plan: {source}"))]
-    UnableToBuildLogicalPlan {
-        source: datafusion::error::DataFusionError,
-    },
-
-    #[snafu(display("Unable to register table provider: {source}"))]
-    UnableToRegisterTableProvider {
-        source: datafusion::error::DataFusionError,
-    },
-
-    #[snafu(display("Unable to create data frame: {source}"))]
-    UnableToCreateDataFrame {
-        source: datafusion::error::DataFusionError,
-    },
-
-    #[snafu(display("Unable to filter data frame: {source}"))]
-    UnableToFilterDataFrame {
-        source: datafusion::error::DataFusionError,
-    },
-}
-
-#[derive(Debug, Snafu)]
 pub enum DataConnectorError {
     #[snafu(display("Cannot connect to the {connector_component} ({dataconnector}).\n{source}"))]
     UnableToConnectInternal {
@@ -250,7 +217,7 @@ pub enum DataConnectorError {
     },
 }
 
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = DataConnectorError> = std::result::Result<T, E>;
 pub type AnyErrorResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 pub type DataConnectorResult<T> = std::result::Result<T, DataConnectorError>;
 

--- a/crates/runtime/src/dataconnector/github/commits.rs
+++ b/crates/runtime/src/dataconnector/github/commits.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::dataconnector::ConnectorComponent;
+use crate::{dataconnector::ConnectorComponent, datafusion::error::find_datafusion_root};
 
 use super::{
     commits_inject_parameters, filter_pushdown, inject_parameters, GitHubTableArgs,
@@ -50,6 +50,7 @@ impl GraphQLContext for CommitsTableArgs {
         query: &mut GraphQLQuery<'_>,
     ) -> Result<(), datafusion::error::DataFusionError> {
         inject_parameters("history", commits_inject_parameters, filters, query)
+            .map_err(find_datafusion_root)
     }
 
     fn error_checker(&self) -> Option<ErrorChecker> {

--- a/crates/runtime/src/dataconnector/github/issues.rs
+++ b/crates/runtime/src/dataconnector/github/issues.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::dataconnector::ConnectorComponent;
+use crate::{dataconnector::ConnectorComponent, datafusion::error::find_datafusion_root};
 
 use super::{
     filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
@@ -63,6 +63,7 @@ impl GraphQLContext for IssuesTableArgs {
         }
 
         inject_parameters("search", search_inject_parameters, filters, query)
+            .map_err(find_datafusion_root)
     }
 
     fn error_checker(&self) -> Option<ErrorChecker> {

--- a/crates/runtime/src/dataconnector/github/pull_requests.rs
+++ b/crates/runtime/src/dataconnector/github/pull_requests.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::dataconnector::ConnectorComponent;
+use crate::{dataconnector::ConnectorComponent, datafusion::error::find_datafusion_root};
 
 use super::{
     filter_pushdown, inject_parameters, search_inject_parameters, GitHubQueryMode, GitHubTableArgs,
@@ -63,6 +63,7 @@ impl GraphQLContext for PullRequestTableArgs {
         }
 
         inject_parameters("search", search_inject_parameters, filters, query)
+            .map_err(find_datafusion_root)
     }
 
     fn error_checker(&self) -> Option<ErrorChecker> {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -51,6 +51,7 @@ use datafusion::sql::parser::DFParser;
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::{sqlparser, TableReference};
 use datafusion_federation::FederatedTableProviderAdaptor;
+use error::find_datafusion_root;
 use itertools::Itertools;
 use query::{Protocol, QueryBuilder};
 use snafu::prelude::*;
@@ -320,6 +321,7 @@ impl DataFusion {
         if let Some(runtime_schema) = self.runtime_schema() {
             runtime_schema
                 .register_table(table_name.table().to_string(), table)
+                .map_err(find_datafusion_root)
                 .context(UnableToRegisterTableToDataFusionSchemaSnafu { schema: "runtime" })?;
 
             self.data_writers
@@ -361,9 +363,11 @@ impl DataFusion {
                             Arc::new(
                                 Arc::new(accelerated_table)
                                     .create_federated_table_provider()
+                                    .map_err(find_datafusion_root)
                                     .context(UnableToRegisterTableToDataFusionSnafu)?,
                             ),
                         )
+                        .map_err(find_datafusion_root)
                         .context(UnableToRegisterTableToDataFusionSnafu)?;
                 } else if source.as_any().downcast_ref::<SinkConnector>().is_some() {
                     // Sink connectors don't know their schema until the first data is received. Park this registration until the schema is known via the first write.
@@ -429,6 +433,7 @@ impl DataFusion {
                 let table_provider = schema
                     .table(table_name)
                     .await
+                    .map_err(find_datafusion_root)
                     .context(UnableToGetTableSnafu)?
                     .ok_or_else(|| {
                         TableMissingSnafu {
@@ -448,6 +453,7 @@ impl DataFusion {
             .ctx
             .table_provider(TableReference::bare(table_name.to_string()))
             .await
+            .map_err(find_datafusion_root)
             .context(UnableToGetTableSnafu)?;
 
         Ok(table_provider)
@@ -540,6 +546,7 @@ impl DataFusion {
         };
 
         let streaming_update = StreamingDataUpdate::try_from(data_update)
+            .map_err(find_datafusion_root)
             .context(UnableToCreateStreamingUpdateSnafu)?;
 
         let insert_plan = table_provider
@@ -549,15 +556,17 @@ impl DataFusion {
                 overwrite,
             )
             .await
+            .map_err(find_datafusion_root)
             .context(UnableToPlanTableInsertSnafu {
                 table_name: table_reference.to_string(),
             })?;
 
-        let _ = collect(insert_plan, self.ctx.task_ctx()).await.context(
-            UnableToExecuteTableInsertSnafu {
+        let _ = collect(insert_plan, self.ctx.task_ctx())
+            .await
+            .map_err(find_datafusion_root)
+            .context(UnableToExecuteTableInsertSnafu {
                 table_name: table_reference.to_string(),
-            },
-        )?;
+            })?;
 
         self.runtime_status
             .update_dataset(&table_reference, status::ComponentStatus::Ready);
@@ -570,6 +579,7 @@ impl DataFusion {
             .ctx
             .table(dataset)
             .await
+            .map_err(find_datafusion_root)
             .context(UnableToGetTableSnafu)?;
         Ok(Schema::from(data_frame.schema()))
     }
@@ -863,9 +873,11 @@ impl DataFusion {
                 Arc::new(
                     Arc::new(accelerated_table)
                         .create_federated_table_provider()
+                        .map_err(find_datafusion_root)
                         .context(UnableToRegisterTableToDataFusionSnafu)?,
                 ),
             )
+            .map_err(find_datafusion_root)
             .context(UnableToRegisterTableToDataFusionSnafu)?;
 
         self.register_metadata_table(&dataset, Arc::clone(&source))
@@ -932,6 +944,7 @@ impl DataFusion {
             .ctx
             .table_provider(dataset_name)
             .await
+            .map_err(find_datafusion_root)
             .context(UnableToGetTableSnafu)?;
         if let Some(adaptor) = table
             .as_any()
@@ -983,6 +996,7 @@ impl DataFusion {
 
         self.ctx
             .register_table(dataset.name.clone(), source_table_provider)
+            .map_err(find_datafusion_root)
             .context(UnableToRegisterTableToDataFusionSnafu)?;
 
         Ok(())
@@ -1006,6 +1020,7 @@ impl DataFusion {
                     TableReference::partial(SPICE_METADATA_SCHEMA, dataset.name.to_string()),
                     table,
                 )
+                .map_err(find_datafusion_root)
                 .context(UnableToRegisterTableToDataFusionSnafu)?;
         };
         Ok(())

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -118,9 +118,6 @@ pub enum Error {
     #[snafu(display("Table {table_name} is expected to provide metadata, but the underlying provider does not support this."))]
     MetadataProviderNotImplemented { table_name: String },
 
-    #[snafu(display("Unable to register table: {source}"))]
-    UnableToRegisterTable { source: crate::dataconnector::Error },
-
     #[snafu(display("Unable to register table in DataFusion: {source}"))]
     UnableToRegisterTableToDataFusion { source: DataFusionError },
 

--- a/crates/runtime/src/datafusion/error.rs
+++ b/crates/runtime/src/datafusion/error.rs
@@ -16,8 +16,9 @@ limitations under the License.
 
 //! Spice specific errors that are returned as part of `DataFusionError::External`.
 
-use std::fmt::Display;
+use std::{any::Any, borrow::Cow, error::Error, fmt::Display, ops::Deref, sync::Arc};
 
+use arrow_schema::ArrowError;
 use datafusion::error::DataFusionError;
 use datafusion_table_providers::util::retriable_error::RetriableError;
 
@@ -66,5 +67,33 @@ pub fn get_spice_df_error(e: &DataFusionError) -> Option<&SpiceExternalError> {
             }
         }
         _ => None,
+    }
+}
+
+/// Finds the root `DataFusionError` if multiple errors are nested, maintaining ownership of the `DataFusionError`.
+/// We implement a custom matcher because we need to retain ownership of the `DataFusionError`, but `DataFusionError::find_root()` returns a reference.
+///
+/// This function does not unnest `Box<Arc<DataFusionError>>` because it cannot take ownership of the inner `DataFusionError`.
+#[must_use]
+pub fn find_datafusion_root(e: DataFusionError) -> DataFusionError {
+    let mut last_error = e;
+
+    loop {
+        match last_error {
+            DataFusionError::External(err) => match err.downcast::<DataFusionError>() {
+                Ok(inner) => last_error = *inner,
+                Err(err) => return DataFusionError::External(err),
+            },
+            DataFusionError::Context(_, err) => last_error = *err,
+            DataFusionError::ArrowError(ArrowError::ExternalError(err), message) => {
+                match err.downcast::<DataFusionError>() {
+                    Ok(inner) => last_error = *inner,
+                    Err(err) => {
+                        return DataFusionError::ArrowError(ArrowError::ExternalError(err), message)
+                    }
+                }
+            }
+            _ => return last_error,
+        }
     }
 }

--- a/crates/runtime/src/datafusion/error.rs
+++ b/crates/runtime/src/datafusion/error.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 //! Spice specific errors that are returned as part of `DataFusionError::External`.
 
-use std::{any::Any, borrow::Cow, error::Error, fmt::Display, ops::Deref, sync::Arc};
+use std::{fmt::Display, sync::Arc};
 
 use arrow_schema::ArrowError;
 use datafusion::error::DataFusionError;
@@ -78,19 +78,42 @@ pub fn get_spice_df_error(e: &DataFusionError) -> Option<&SpiceExternalError> {
 pub fn find_datafusion_root(e: DataFusionError) -> DataFusionError {
     let mut last_error = e;
 
+    tracing::debug!("Finding root of DataFusionError: {:?}", last_error);
+
     loop {
         match last_error {
             DataFusionError::External(err) => match err.downcast::<DataFusionError>() {
                 Ok(inner) => last_error = *inner,
-                Err(err) => return DataFusionError::External(err),
+                Err(err) => match err.downcast::<Arc<DataFusionError>>() {
+                    Ok(inner) => {
+                        tracing::debug!("Found Arc<DataFusionError> in External: {:?}", inner);
+                        return DataFusionError::External(inner);
+                    }
+                    Err(err) => return DataFusionError::External(err),
+                },
             },
             DataFusionError::Context(_, err) => last_error = *err,
             DataFusionError::ArrowError(ArrowError::ExternalError(err), message) => {
                 match err.downcast::<DataFusionError>() {
                     Ok(inner) => last_error = *inner,
-                    Err(err) => {
-                        return DataFusionError::ArrowError(ArrowError::ExternalError(err), message)
-                    }
+                    Err(err) => match err.downcast::<Arc<DataFusionError>>() {
+                        Ok(inner) => {
+                            tracing::debug!(
+                                "Found Arc<DataFusionError> in ArrowError: {:?}",
+                                inner
+                            );
+                            return DataFusionError::ArrowError(
+                                ArrowError::ExternalError(inner),
+                                message,
+                            );
+                        }
+                        Err(err) => {
+                            return DataFusionError::ArrowError(
+                                ArrowError::ExternalError(err),
+                                message,
+                            )
+                        }
+                    },
                 }
             }
             _ => return last_error,

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -31,7 +31,7 @@ use tracing_futures::Instrument;
 
 use crate::{
     component::dataset::Dataset,
-    datafusion::{query::Protocol, DataFusion},
+    datafusion::{error::find_datafusion_root, query::Protocol, DataFusion},
     metrics,
 };
 
@@ -151,6 +151,7 @@ impl DatasetsHealthMonitor {
             .ctx
             .table_provider(table_ref)
             .await
+            .map_err(find_datafusion_root)
             .context(UnableToGetTableSnafu)?;
 
         Ok(table)
@@ -178,6 +179,7 @@ AND labels.error_code IS NULL"
             .data
             .try_collect::<Vec<RecordBatch>>()
             .await
+            .map_err(find_datafusion_root)
             .context(UnableToGetRecentlyAccessedDatasetsSnafu)?;
 
         let mut datasets_with_recent_activity_set: HashSet<String> = HashSet::new();
@@ -351,11 +353,17 @@ async fn test_connectivity(
 ) -> std::result::Result<(), DataFusionError> {
     let plan = table_provider
         .scan(&df.ctx.state(), None, &[], Some(1))
-        .await?;
+        .await
+        .map_err(find_datafusion_root)?;
 
-    let stream = plan.execute(0, df.ctx.state().task_ctx())?;
+    let stream = plan
+        .execute(0, df.ctx.state().task_ctx())
+        .map_err(find_datafusion_root)?;
 
-    stream.try_collect::<Vec<RecordBatch>>().await?;
+    stream
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(find_datafusion_root)?;
 
     Ok(())
 }

--- a/crates/runtime/tests/acceleration/on_conflict.rs
+++ b/crates/runtime/tests/acceleration/on_conflict.rs
@@ -18,7 +18,7 @@ use crate::{get_test_datafusion, init_tracing, postgres::common, utils::runtime_
 use app::AppBuilder;
 use datafusion::assert_batches_eq;
 use rand::Rng;
-use runtime::{status, Runtime};
+use runtime::{datafusion::error::find_datafusion_root, status, Runtime};
 use spicepod::component::{
     dataset::{
         acceleration::{Acceleration, Mode, OnConflictBehavior, RefreshMode},
@@ -292,7 +292,13 @@ async fn get_query_result(
     rt: &Arc<Runtime>,
     sql: &str,
 ) -> Result<Vec<arrow::array::RecordBatch>, datafusion::error::DataFusionError> {
-    rt.datafusion().ctx.sql(sql).await?.collect().await
+    rt.datafusion()
+        .ctx
+        .sql(sql)
+        .await
+        .map_err(find_datafusion_root)?
+        .collect()
+        .await
 }
 
 fn create_postgres_test_dataset(


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Removes some error variants that were unused.
* Adds a handler to unnest `DataFusionError`s into their lowest, owned, `DataFusionError`.

Example error output after:
```bash
Failed to update dataset daily_journal.
Unable to get data from connector.
External error: Failed to create embedding: http error: error decoding response body.
```

Example error output before:
```bash
Failed to update dataset daily_journal.
Unable to get data from connector.
External error: External error: Failed to create embedding: http error: error decoding response body.
```

A minor UX improvement, but removes repetition of error output like `External error: External error:`

**Why an owned `DataFusionError`?**

Using an owned `DataFusionError` makes the call stack easier when consuming the errors in e.g. our snafu error enum variants.

An alternative would be using a named lifetime, but that would require adding a named lifetime to any error variant which consumes a `DataFusionError` and as a result a named lifetime on any higher error which consumes that enum.

**What about an `Arc<DataFusionError>`?**

`DataFusionError` is neither `Copy` nor `Clone`, so putting the value into an `Arc` will make it impossible to get the owned value back out of the `Arc`.

For this reason, we also do not unnest `Arc<DataFusionError>` because we cannot take ownership of the inner value. `Arc<DataFusionError>`s do not appear to occur frequently, so they are excluded from unnesting as edge cases.

**Why not implement `Clone` on `DataFusionError`?**

Implementing `Clone` is not possible, because `DataFusionError` has error variants with inner values that are not `Clone`. For example, `ArrowError` and `std::io::Error`.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3638 
* Part of #3506