### PR TITLE
feat: Add RateLimited DataConnectorError

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -145,6 +145,15 @@ pub enum DataConnectorError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    #[snafu(display(
+        "The {connector_component} ({dataconnector}) has been rate limited.\n{source}"
+    ))]
+    RateLimited {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     #[snafu(display("Cannot setup the {connector_component} ({dataconnector}) with an invalid configuration.\n{message}"))]
     InvalidConfiguration {
         dataconnector: String,


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds an error enum variant for `RateLimited` and implements it for the GitHub connector

Before:
```bash
Failed to load the dataset pulls (github).
GitHub API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.
```

After:
```bash
The dataset pulls (github) has been rate limited.
GitHub API rate limit exceeded. Try again later, and add a LIMIT clause to your query to reduce the number of requests.
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3574 
* Part of #3506 