### PR TITLE
Setup nightly docker release workflow

### DIFF
--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -5,6 +5,11 @@ on:
   #   - cron: "0 2 * * *" # Runs the workflow at 2:00 AM UTC every day
 
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the Docker images to the registry
+        required: false
+        default: "false"
 
 jobs:
   check_commits:
@@ -37,8 +42,29 @@ jobs:
           echo "has_new_commits=true" >> $GITHUB_OUTPUT
         shell: bash
 
-  build-arm64:
+  setup:
     needs: check_commits
+    if: needs.check_commits.outputs.has_new_commits == 'true'
+
+    runs-on: ubuntu-latest
+    outputs:
+      rel_version: ${{ steps.set_version.outputs.rel_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Nightly REL_VERSION from current timestamp
+        run: python3 ./.github/scripts/get_release_version.py
+
+      - name: Add REL_VERSION to output
+        id: set_version
+        run: |
+          commit_hash=$(git rev-parse --short HEAD)
+          version="nightly-$(date +%Y%m%d)-${commit_hash}"
+          echo "rel_version=${version}" >> $GITHUB_OUTPUT
+          echo "Preparing to publish nightly build with version: `${version}`"
+
+  build-arm64:
+    needs: [check_commits, setup]
     if: needs.check_commits.outputs.has_new_commits == 'true'
 
     runs-on: hosted-linux-arm-runner-16-cores
@@ -81,7 +107,7 @@ jobs:
           cache-from: type=gha,scope=build-arm64
           cache-to: type=gha,scope=build-arm64,mode=max
           build-args: |
-            REL_VERSION=nightly
+            REL_VERSION=${{ needs.setup.outputs.rel_version }}
             CARGO_FEATURES=release,models
 
       - name: Upload ARM64 artifacts
@@ -91,7 +117,7 @@ jobs:
           path: /tmp/image-arm64-*.tar
 
   build-amd64:
-    needs: check_commits
+    needs: [check_commits, setup]
     if: needs.check_commits.outputs.has_new_commits == 'true'
 
     runs-on: spiceai-runners
@@ -115,7 +141,7 @@ jobs:
           cache-from: type=gha,scope=build-amd64
           cache-to: type=gha,scope=build-amd64,mode=max
           build-args: |
-            REL_VERSION=nightly
+            REL_VERSION=${{ needs.setup.outputs.rel_version }}
             CARGO_FEATURES=release,models
 
       - name: Upload AMD64 artifacts
@@ -124,77 +150,85 @@ jobs:
           name: images-amd64
           path: /tmp/image-amd64-*.tar
 
-  # publish:
-  #   needs: [check_commits, build-amd64]
-  #   if: needs.check_commits.outputs.has_new_commits == 'true'
+  publish:
+    needs: [check_commits, setup, build-amd64, build-arm64]
+    if: needs.check_commits.outputs.has_new_commits == 'true' && (github.event_name == 'schedule' || inputs.publish == 'true')
 
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         path: /tmp
-  #         pattern: images-*
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp
+          pattern: images-*
 
-  #     - name: Verify artifacts
-  #       run: |
-  #         ls -l /tmp
-  #         ls -l /tmp/images-amd64
+      - name: Verify artifacts
+        run: |
+          ls -l /tmp
+          ls -l /tmp/images-amd64
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Start local registry
-  #       run: |
-  #         docker run -d -p 5000:5000 --restart=always --name registry registry:2
+      - name: Start local registry
+        run: |
+          docker run -d -p 5000:5000 --restart=always --name registry registry:2
 
-  #     - name: Login to GitHub Package Registry
-  #       if: startsWith(github.ref, 'refs/tags/v') || inputs.publish == 'true'
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Package Registry
+        if: github.event_name == 'schedule' || inputs.publish == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Import images and create manifests
-  #       env:
-  #         REL_VERSION: nightly
-  #         PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.publish == 'true' }}
-  #       run: |
-  #         echo "REL_VERSION=${REL_VERSION}"
-  #         echo "PUBLISH=${PUBLISH}"
-  #         variants=("default" "odbc" "models")
-  #         for variant in "${variants[@]}"; do
-  #           suffix=""
-  #           if [ "$variant" != "default" ]; then
-  #             suffix="-${variant}"
-  #           fi
+      - name: Import images and create manifests
+        env:
+          REL_VERSION: ${{ needs.setup.outputs.rel_version }}
+          PUBLISH: ${{ github.event_name == 'schedule' || inputs.publish == 'true' }}
+        run: |
+          echo "REL_VERSION=${REL_VERSION}"
+          echo "PUBLISH=${PUBLISH}"
+          variants=("default" "odbc" "models")
+          for variant in "${variants[@]}"; do
+            suffix=""
+            if [ "$variant" != "default" ]; then
+              suffix="-${variant}"
+            fi
 
-  #           # Load both architecture images
-  #           echo "Loading AMD64 image"
-  #           docker load -i /tmp/images-amd64/image-amd64-${variant}.tar
+            # Load both architecture images
+            echo "Loading AMD64 image"
+            docker load -i /tmp/images-amd64/image-amd64-${variant}.tar
 
-  #           # Push images to local registry
-  #           echo "Pushing images to local registry"
-  #           docker push localhost:5000/spiceai:${variant}-amd64
+            # Push images to local registry
+            echo "Pushing images to local registry"
+            docker push localhost:5000/spiceai:${variant}-amd64
 
-  #           if [[ "${PUBLISH}" == "true" ]]; then
-  #             # Push to GitHub Container Registry
-  #             echo "Pushing to GHCR"
-  #             docker buildx imagetools create \
-  #               -t ghcr.io/spiceai/spiceai:${REL_VERSION}${suffix} \
-  #               -t ghcr.io/spiceai/spiceai:latest${suffix} \
-  #               localhost:5000/spiceai:${variant}-amd64
+            if [[ "${PUBLISH}" == "true" ]]; then
+              # Push to GitHub Container Registry
+              echo "Pushing to GHCR"
+              docker buildx imagetools create \
+                -t ghcr.io/spiceai/spiceai-nightly:${REL_VERSION}${suffix} \
+                -t ghcr.io/spiceai/spiceai-nightly:latest${suffix} \
+                localhost:5000/spiceai:${variant}-amd64
 
-  #             echo "Verifying GHCR image:"
-  #             docker buildx imagetools inspect ghcr.io/spiceai/spiceai:${REL_VERSION}${suffix}
-  #           else
-  #             echo "Skipping push for non-tag build"
-  #             echo "Creating local manifest for testing:"
-  #             docker buildx imagetools create \
-  #               -t localhost:5000/spiceai:latest${suffix} \
-  #               localhost:5000/spiceai:${variant}-amd64
+              echo "Verifying GHCR image:"
+              docker buildx imagetools inspect ghcr.io/spiceai/spiceai-nightly:${REL_VERSION}${suffix}
+            else
+              echo "Skipping push for non-tag build"
+              echo "Creating local manifest for testing:"
+              docker buildx imagetools create \
+                -t localhost:5000/spiceai:latest${suffix} \
+                localhost:5000/spiceai:${variant}-amd64
 
-  #             docker buildx imagetools inspect localhost:5000/spiceai:latest${suffix}
-  #           fi
-  #         done
+              docker buildx imagetools inspect localhost:5000/spiceai:latest${suffix}
+            fi
+          done
+
+      - name: Update nightly tag
+        if: github.event_name == 'schedule' || inputs.publish == 'true'
+        run: |
+          git tag -f nightly
+          git push origin nightly --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -2,7 +2,7 @@ name: spiced_docker_nightly
 
 on:
   schedule:
-    - cron: "0 2 * * *" # Runs the workflow at 2:00 AM UTC every day
+    - cron: "0 9 * * *" # Runs the workflow at 9:00 AM UTC (1AM PT) every day
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -64,7 +64,7 @@ jobs:
           commit_hash=$(git rev-parse --short HEAD)
           version="nightly-$(date +%Y%m%d)-${commit_hash}"
           echo "rel_version=${version}" >> $GITHUB_OUTPUT
-          echo "Preparing to publish nightly build with version: `${version}`"
+          echo "Preparing to publish nightly build with version: \"${version}\""
 
   build-arm64:
     needs: [check_commits, setup]

--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -1,11 +1,8 @@
 name: spiced_docker_nightly
 
 on:
-  # schedule:
-  #   - cron: "0 2 * * *" # Runs the workflow at 2:00 AM UTC every day
-  push:
-    branches:
-      - evgenii/nightly-release-workflow
+  schedule:
+    - cron: "0 2 * * *" # Runs the workflow at 2:00 AM UTC every day
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -3,6 +3,9 @@ name: spiced_docker_nightly
 on:
   # schedule:
   #   - cron: "0 2 * * *" # Runs the workflow at 2:00 AM UTC every day
+  push:
+    branches:
+      - evgenii/nightly-release-workflow
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -1,0 +1,200 @@
+name: spiced_docker_nightly
+
+on:
+  # schedule:
+  #   - cron: "0 2 * * *" # Runs the workflow at 2:00 AM UTC every day
+
+  workflow_dispatch:
+
+jobs:
+  check_commits:
+    runs-on: ubuntu-latest
+    outputs:
+      has_new_commits: ${{ steps.check_commits.outputs.has_new_commits }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check new commits since latest nightly build
+        id: check_commits
+        run: |
+          # Get the latest commit hash from the default branch
+          latest_commit=$(git rev-parse HEAD)
+
+          # Attempt to get the commit hash of the current nightly tag
+          nightly_commit=$(git rev-list -n 1 nightly 2>/dev/null || echo "")
+
+          # Check if there are new commits since the last nightly tag
+          if [ "$latest_commit" = "$nightly_commit" ]; then
+            echo "No new commits since the last nightly build. Exiting..."
+            echo "has_new_commits=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "New commits found. Proceeding with the build."
+          echo "has_new_commits=true" >> $GITHUB_OUTPUT
+        shell: bash
+
+  build-arm64:
+    needs: check_commits
+    if: needs.check_commits.outputs.has_new_commits == 'true'
+
+    runs-on: hosted-linux-arm-runner-16-cores
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install docker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl gnupg lsb-release
+          sudo mkdir -m 0755 -p /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$(lsb_release -i | awk '{ print tolower($3) }') $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+      - name: Start Docker service
+        run: |
+          sudo systemctl start docker
+          sudo systemctl status docker
+
+      - name: chown /var/run/docker.sock to current user
+        run: |
+          sudo chown $USER /var/run/docker.sock
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+
+      - name: Build ARM64 models image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/arm64
+          outputs: type=docker,name=localhost:5000/spiceai:models-arm64,dest=/tmp/image-arm64-models.tar
+          cache-from: type=gha,scope=build-arm64
+          cache-to: type=gha,scope=build-arm64,mode=max
+          build-args: |
+            REL_VERSION=nightly
+            CARGO_FEATURES=release,models
+
+      - name: Upload ARM64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: images-arm64
+          path: /tmp/image-arm64-*.tar
+
+  build-amd64:
+    needs: check_commits
+    if: needs.check_commits.outputs.has_new_commits == 'true'
+
+    runs-on: spiceai-runners
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          # Enable docker driver for layer caching
+          driver-opts: |
+            image=moby/buildkit:latest
+
+      - name: Build AMD64 models image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          outputs: type=docker,name=localhost:5000/spiceai:models-amd64,dest=/tmp/image-amd64-models.tar
+          cache-from: type=gha,scope=build-amd64
+          cache-to: type=gha,scope=build-amd64,mode=max
+          build-args: |
+            REL_VERSION=nightly
+            CARGO_FEATURES=release,models
+
+      - name: Upload AMD64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: images-amd64
+          path: /tmp/image-amd64-*.tar
+
+  # publish:
+  #   needs: [check_commits, build-amd64]
+  #   if: needs.check_commits.outputs.has_new_commits == 'true'
+
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download all artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         path: /tmp
+  #         pattern: images-*
+
+  #     - name: Verify artifacts
+  #       run: |
+  #         ls -l /tmp
+  #         ls -l /tmp/images-amd64
+
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+
+  #     - name: Start local registry
+  #       run: |
+  #         docker run -d -p 5000:5000 --restart=always --name registry registry:2
+
+  #     - name: Login to GitHub Package Registry
+  #       if: startsWith(github.ref, 'refs/tags/v') || inputs.publish == 'true'
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Import images and create manifests
+  #       env:
+  #         REL_VERSION: nightly
+  #         PUBLISH: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.publish == 'true' }}
+  #       run: |
+  #         echo "REL_VERSION=${REL_VERSION}"
+  #         echo "PUBLISH=${PUBLISH}"
+  #         variants=("default" "odbc" "models")
+  #         for variant in "${variants[@]}"; do
+  #           suffix=""
+  #           if [ "$variant" != "default" ]; then
+  #             suffix="-${variant}"
+  #           fi
+
+  #           # Load both architecture images
+  #           echo "Loading AMD64 image"
+  #           docker load -i /tmp/images-amd64/image-amd64-${variant}.tar
+
+  #           # Push images to local registry
+  #           echo "Pushing images to local registry"
+  #           docker push localhost:5000/spiceai:${variant}-amd64
+
+  #           if [[ "${PUBLISH}" == "true" ]]; then
+  #             # Push to GitHub Container Registry
+  #             echo "Pushing to GHCR"
+  #             docker buildx imagetools create \
+  #               -t ghcr.io/spiceai/spiceai:${REL_VERSION}${suffix} \
+  #               -t ghcr.io/spiceai/spiceai:latest${suffix} \
+  #               localhost:5000/spiceai:${variant}-amd64
+
+  #             echo "Verifying GHCR image:"
+  #             docker buildx imagetools inspect ghcr.io/spiceai/spiceai:${REL_VERSION}${suffix}
+  #           else
+  #             echo "Skipping push for non-tag build"
+  #             echo "Creating local manifest for testing:"
+  #             docker buildx imagetools create \
+  #               -t localhost:5000/spiceai:latest${suffix} \
+  #               localhost:5000/spiceai:${variant}-amd64
+
+  #             docker buildx imagetools inspect localhost:5000/spiceai:latest${suffix}
+  #           fi
+  #         done

--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -192,7 +192,7 @@ jobs:
         run: |
           echo "REL_VERSION=${REL_VERSION}"
           echo "PUBLISH=${PUBLISH}"
-          variants=("default" "odbc" "models")
+          variants=("models") # we might need to include other variants in future
           for variant in "${variants[@]}"; do
             suffix=""
             if [ "$variant" != "default" ]; then


### PR DESCRIPTION
- will run if no `nightly` tag is set yet, or it is behind recent trunk commit
- sets version to `nightly-YYYYMMDD-<commit_hash>`
- build arm and amd images, with `models` flag enabled, and publish to `spiceai/spiceai-nightly` GHCR image repository
- after publishing, it will update the `nightly` tag to the trunk head