### PR TITLE
Remove "nightly-" prefix from tag

### DIFF
--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -60,7 +60,7 @@ jobs:
         id: set_version
         run: |
           commit_hash=$(git rev-parse --short HEAD)
-          version="nightly-$(date +%Y%m%d)-${commit_hash}"
+          version="$(date +%Y%m%d)-${commit_hash}"
           echo "rel_version=${version}" >> $GITHUB_OUTPUT
           echo "Preparing to publish nightly build with version: \"${version}\""
 


### PR DESCRIPTION
Remove the redundant prefix, as nightly builds are published in a separate `spiceai-nightly` image