### PR TITLE
Allow E2E model tests to complete even if parallel platform tests failed

### DIFF
--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -127,6 +127,7 @@ jobs:
     needs:
       - build
     strategy:
+      fail-fast: false
       matrix:
         target:
           - name: "Linux x64"


### PR DESCRIPTION
## 🗣 Description

Parallel platform tests should not cause tests on other platforms to stop/fail
