### PR TITLE
Add local model test to LLMs integration tests

### DIFF
--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -71,10 +71,10 @@ jobs:
         run: |
           chmod +x ./integration_test/llms_integration_test
 
-      - name: Set up Anthropic API Key
+      - name: Set up API Keys
         run: |
           echo 'SPICE_ANTHROPIC_API_KEY="${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}"\nSPICE_OPENAI_API_KEY="${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}"' > .env
 
       - name: Run integration test
         run: |
-          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/llms_integration_test --nocapture
+          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/llms_integration_test --nocapture --skip test_local_

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::Context;
 use async_openai::error::OpenAIError;
@@ -41,7 +44,7 @@ pub(crate) fn create_anthropic(model_id: Option<&str>) -> Result<Arc<dyn Chat>, 
 }
 
 pub(crate) async fn create_local() -> Result<Arc<dyn Chat>, anyhow::Error> {
-    let temp_dir = local_model_dir("Phi-3-mini-4k-instruct").await;
+    let temp_dir = local_model_dir("Phi-3-mini-4k-instruct").await?;
 
     download_hf_model_artifacts(
         "microsoft/Phi-3-mini-4k-instruct",
@@ -56,8 +59,7 @@ pub(crate) async fn create_local() -> Result<Arc<dyn Chat>, anyhow::Error> {
         ],
         &temp_dir,
     )
-    .await
-    .expect("Failed to download test model artifacts");
+    .await?;
 
     let model_weights = [
         temp_dir
@@ -84,22 +86,17 @@ pub(crate) async fn create_local() -> Result<Arc<dyn Chat>, anyhow::Error> {
 }
 
 /// Creates a directory for the specified model under `.spice/test_models`.
-#[must_use]
-pub async fn local_model_dir(model_name: &str) -> PathBuf {
+pub async fn local_model_dir(model_name: &str) -> Result<PathBuf, anyhow::Error> {
     let working_dir = std::env::current_dir().unwrap_or_else(|_| ".".into());
     let model_dir = working_dir.join(".spice/test_models").join(model_name);
 
     // Remove the directory if it already exists
     if model_dir.exists() {
-        fs::remove_dir_all(&model_dir)
-            .await
-            .expect("Failed to remove existing model directory");
+        fs::remove_dir_all(&model_dir).await?;
     }
-    fs::create_dir_all(&model_dir)
-        .await
-        .expect("Failed to create model directory");
+    fs::create_dir_all(&model_dir).await?;
 
-    model_dir
+    Ok(model_dir)
 }
 
 /// For a given `HuggingFace` repo, downloads the specified file and save them into provided folder
@@ -108,7 +105,7 @@ async fn download_hf_model_artifacts(
     revision: Option<&str>,
     hf_token: Option<String>,
     files: Vec<&str>,
-    target_dir: &PathBuf,
+    target_dir: &Path,
 ) -> Result<(), anyhow::Error> {
     let api = ApiBuilder::new()
         .with_progress(false)

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -14,14 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
+use anyhow::Context;
 use async_openai::error::OpenAIError;
+use hf_hub::{api::tokio::ApiBuilder, Repo, RepoType};
 use llms::{
     anthropic::{Anthropic, AnthropicConfig},
-    chat::Chat,
+    chat::{create_local_model, Chat},
     openai::Openai,
 };
+use tokio::fs;
 
 pub(crate) fn create_openai(model_id: &str) -> Arc<dyn Chat> {
     let api_key = std::env::var("SPICE_OPENAI_API_KEY").ok();
@@ -35,4 +38,103 @@ pub(crate) fn create_anthropic(model_id: Option<&str>) -> Result<Arc<dyn Chat>, 
     let model = Anthropic::new(cfg, model_id)?;
 
     Ok(Arc::new(model))
+}
+
+pub(crate) async fn create_local() -> Result<Arc<dyn Chat>, anyhow::Error> {
+    let temp_dir = local_model_dir("Phi-3-mini-4k-instruct").await;
+
+    download_hf_model_artifacts(
+        "microsoft/Phi-3-mini-4k-instruct",
+        None,
+        std::env::var("SPICE_HF_API_KEY").ok(),
+        vec![
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+            "config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+        ],
+        &temp_dir,
+    )
+    .await
+    .expect("Failed to download test model artifacts");
+
+    let model_weights = [
+        temp_dir
+            .join("model-00001-of-00002.safetensors")
+            .to_str()
+            .unwrap_or_default()
+            .to_string(),
+        temp_dir
+            .join("model-00002-of-00002.safetensors")
+            .to_str()
+            .unwrap_or_default()
+            .to_string(),
+    ];
+
+    let model = create_local_model(
+        &model_weights,
+        temp_dir.join("config.json").to_str(),
+        temp_dir.join("tokenizer.json").to_str(),
+        temp_dir.join("tokenizer_config.json").to_str(),
+        None,
+    )
+    .map_err(anyhow::Error::from)?;
+    Ok(Arc::from(model))
+}
+
+/// Creates a directory for the specified model under `.spice/test_models`.
+#[must_use]
+pub async fn local_model_dir(model_name: &str) -> PathBuf {
+    let working_dir = std::env::current_dir().unwrap_or_else(|_| ".".into());
+    let model_dir = working_dir.join(".spice/test_models").join(model_name);
+
+    // Remove the directory if it already exists
+    if model_dir.exists() {
+        fs::remove_dir_all(&model_dir)
+            .await
+            .expect("Failed to remove existing model directory");
+    }
+    fs::create_dir_all(&model_dir)
+        .await
+        .expect("Failed to create model directory");
+
+    model_dir
+}
+
+/// For a given `HuggingFace` repo, downloads the specified file and save them into provided folder
+async fn download_hf_model_artifacts(
+    model_id: &str,
+    revision: Option<&str>,
+    hf_token: Option<String>,
+    files: Vec<&str>,
+    target_dir: &PathBuf,
+) -> Result<(), anyhow::Error> {
+    let api = ApiBuilder::new()
+        .with_progress(false)
+        .with_token(hf_token)
+        .build()
+        .context("Failed to instantiate API for downloading model artifacts")?;
+
+    let repo = if let Some(revision) = revision {
+        Repo::with_revision(model_id.to_string(), RepoType::Model, revision.to_string())
+    } else {
+        Repo::new(model_id.to_string(), RepoType::Model)
+    };
+    let api_repo = api.repo(repo.clone());
+
+    for file_name in files {
+        let file_path = target_dir.join(file_name);
+        tracing::trace!("Downloading '{}' from {}", file_name, repo.url());
+
+        let source_path = api_repo
+            .get(file_name)
+            .await
+            .with_context(|| format!("Unable to download '{}' from {}", file_name, repo.url()))?;
+
+        std::fs::copy(&source_path, &file_path).with_context(|| {
+            format!("Failed to copy '{}' to {}", file_name, file_path.display())
+        })?;
+    }
+    Ok(())
 }

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -17,12 +17,12 @@ use async_openai::types::CreateChatCompletionRequest;
 use jsonpath_rust::JsonPath;
 use llms::chat::Chat;
 use serde_json::json;
-use tracing_subscriber::EnvFilter;
 use std::{
     future::Future,
     str::FromStr,
     sync::{Arc, LazyLock},
 };
+use tracing_subscriber::EnvFilter;
 
 mod create;
 
@@ -192,7 +192,7 @@ where
     Fut: Future<Output = Result<Arc<dyn Chat>, anyhow::Error>>,
 {
     // Load environment variables
-    dotenvy::from_filename(".env").expect("failed to load .env file");
+    dotenvy::from_filename(".env")?;
 
     let model = create_model().await?;
 

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -152,7 +152,7 @@ static TEST_CASES: LazyLock<Vec<TestCase>> = LazyLock::new(|| {
 
 /// A mapping of model names (in [`TEST_MODELS`]) and test names (in [`TEST_CASES`]) to skip.
 static TEST_DENY_LIST: LazyLock<Vec<(&'static str, &'static str)>> =
-    LazyLock::new(|| vec![("anthropic", "placeholder")]);
+    LazyLock::new(|| vec![("phi-3-mini", "tool_use")]);
 
 /// Run a single [`TestCase`] for a model.
 #[allow(clippy::expect_used, clippy::expect_fun_call)]

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -151,8 +151,12 @@ static TEST_CASES: LazyLock<Vec<TestCase>> = LazyLock::new(|| {
 });
 
 /// A mapping of model names (in [`TEST_MODELS`]) and test names (in [`TEST_CASES`]) to skip.
-static TEST_DENY_LIST: LazyLock<Vec<(&'static str, &'static str)>> =
-    LazyLock::new(|| vec![("phi-3-mini", "tool_use")]);
+static TEST_DENY_LIST: LazyLock<Vec<(&'static str, &'static str)>> = LazyLock::new(|| {
+    vec![
+        // local model does not support tools
+        ("phi-3-mini", "tool_use"),
+    ]
+});
 
 /// Run a single [`TestCase`] for a model.
 #[allow(clippy::expect_used, clippy::expect_fun_call)]

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -17,7 +17,9 @@ use async_openai::types::CreateChatCompletionRequest;
 use jsonpath_rust::JsonPath;
 use llms::chat::Chat;
 use serde_json::json;
+use tracing_subscriber::EnvFilter;
 use std::{
+    future::Future,
     str::FromStr,
     sync::{Arc, LazyLock},
 };
@@ -148,18 +150,6 @@ static TEST_CASES: LazyLock<Vec<TestCase>> = LazyLock::new(|| {
     ]
 });
 
-/// Model instantiations to test.
-#[allow(clippy::expect_used)]
-static TEST_MODELS: LazyLock<Vec<(&'static str, Arc<dyn Chat>)>> = LazyLock::new(|| {
-    vec![
-        (
-            "anthropic",
-            create::create_anthropic(None).expect("failed to create anthropic model"),
-        ),
-        ("openai", create::create_openai("gpt-4o-mini")),
-    ]
-});
-
 /// A mapping of model names (in [`TEST_MODELS`]) and test names (in [`TEST_CASES`]) to skip.
 static TEST_DENY_LIST: LazyLock<Vec<(&'static str, &'static str)>> =
     LazyLock::new(|| vec![("anthropic", "placeholder")]);
@@ -168,7 +158,7 @@ static TEST_DENY_LIST: LazyLock<Vec<(&'static str, &'static str)>> =
 #[allow(clippy::expect_used, clippy::expect_fun_call)]
 async fn run_test_case(
     test: &TestCase,
-    model_name: &'static str,
+    model_name: &str,
     model: Arc<dyn Chat>,
 ) -> Result<(), anyhow::Error> {
     let test_name = test.name;
@@ -196,24 +186,68 @@ async fn run_test_case(
     Ok(())
 }
 
-#[tokio::test]
-#[allow(clippy::expect_used, clippy::expect_fun_call)]
-async fn run_all_tests() {
-    // Set ENV variables before we lazy load `TEST_MODELS`.
-    let _ = dotenvy::from_filename(".env").expect("failed to load .env file");
+async fn run_tests_for_model<F, Fut>(model_name: &str, create_model: F) -> Result<(), anyhow::Error>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<Arc<dyn Chat>, anyhow::Error>>,
+{
+    // Load environment variables
+    dotenvy::from_filename(".env").expect("failed to load .env file");
+
+    let model = create_model().await?;
 
     for ts in TEST_CASES.iter() {
-        for (model_name, model) in TEST_MODELS.iter() {
-            if crate::llms::TEST_DENY_LIST
-                .iter()
-                .any(|(m, t)| m == model_name && *t == ts.name)
-            {
-                tracing::info!("Skipping test {model_name}/{}", ts.name);
-                continue;
-            }
-            run_test_case(ts, model_name, Arc::clone(model))
-                .await
-                .expect(format!("Failed to run test {model_name}/{}", ts.name).as_str());
+        if crate::llms::TEST_DENY_LIST
+            .iter()
+            .any(|(m, t)| *m == model_name && *t == ts.name)
+        {
+            tracing::info!("Skipping test {model_name}/{}", ts.name);
+            continue;
         }
+        run_test_case(ts, model_name, Arc::clone(&model)).await?;
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_anthropic_model() {
+    init_tracing(None);
+    run_tests_for_model("anthropic", || async {
+        create::create_anthropic(None).map_err(anyhow::Error::from)
+    })
+    .await
+    .expect("should pass");
+}
+
+#[tokio::test]
+async fn test_openai_model() {
+    init_tracing(None);
+    run_tests_for_model("openai", || async {
+        Ok(create::create_openai("gpt-4o-mini"))
+    })
+    .await
+    .expect("should pass");
+}
+
+#[tokio::test]
+async fn test_local_model() {
+    init_tracing(None);
+    run_tests_for_model("phi-3-mini", || async { create::create_local().await })
+        .await
+        .expect("should pass");
+}
+
+fn init_tracing(default_level: Option<&str>) -> tracing::subscriber::DefaultGuard {
+    let filter = match (default_level, std::env::var("SPICED_LOG").ok()) {
+        (_, Some(log)) => EnvFilter::new(log),
+        (Some(level), None) => EnvFilter::new(level),
+        _ => EnvFilter::new("llms=TRACE,DEBUG"),
+    };
+
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(filter)
+        .with_ansi(true)
+        .finish();
+    tracing::subscriber::set_default(subscriber)
 }

--- a/crates/llms/tests/llms/snapshots/integration__llms__basic_phi-3-mini_message_keys.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__basic_phi-3-mini_message_keys.snap
@@ -1,0 +1,9 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+---
+[
+  "assistant",
+  [],
+  null
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__basic_phi-3-mini_replied_appropriately.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__basic_phi-3-mini_replied_appropriately.snap
@@ -1,0 +1,7 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_phi-3-mini_assistant_response.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_phi-3-mini_assistant_response.snap
@@ -1,0 +1,7 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_phi-3-mini_replied_appropriately.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_phi-3-mini_replied_appropriately.snap
@@ -1,0 +1,7 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+---
+[
+  1
+]


### PR DESCRIPTION
## 🗣 Description

Add integration test for local model to LLMs testing

## 🔨 Related Issues

https://github.com/spiceai/spiceai/issues/3517


## 🤔 Concerns

Local model inference is very slow and can't be run on GH Hosted runners so temporarily disabled in CI.
