### PR TITLE
Add `microsoft/Phi-3-mini-4k-instruct` to llms crate testing, with `MODEL_SKIPLIST` & `MODEL_ALLOWLIST`

### DIFF
--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -75,6 +75,8 @@ jobs:
         run: |
           echo 'SPICE_ANTHROPIC_API_KEY="${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}"\nSPICE_OPENAI_API_KEY="${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}"' > .env
 
+        # Don't run any local models in the integration test yet.
       - name: Run integration test
         run: |
+          export MODEL_SKIPLIST="hf/phi3,local/phi3"
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/llms_integration_test --nocapture

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -76,7 +76,7 @@ jobs:
           echo 'SPICE_OPENAI_API_KEY="${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}"' > .env
           echo 'SPICE_ANTHROPIC_API_KEY="${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}"' >> .env
 
-        # Don't run any local models in the integration test yet.
+        # Don't run local models in the integration test yet.
       - name: Run integration test
         env:
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}

--- a/crates/llms/src/embeddings/candle/mod.rs
+++ b/crates/llms/src/embeddings/candle/mod.rs
@@ -21,6 +21,7 @@ use serde::Deserialize;
 
 pub mod tei;
 mod util;
+pub use util::link_files_into_tmp_dir;
 
 /// Important fields from a model's `config.json`
 #[derive(Debug, Deserialize)]

--- a/crates/llms/src/embeddings/candle/tei.rs
+++ b/crates/llms/src/embeddings/candle/tei.rs
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use async_openai::{
     error::{ApiError, OpenAIError},
@@ -70,15 +74,15 @@ impl TeiEmbed {
             .to_string();
 
         // `text-embeddings-inference` expects the model artifacts to to be in a single folder with specific filenames.
-        let files: HashMap<String, &Path> = vec![
-            (model_filename, model_path),
-            ("config.json".to_string(), config_path),
-            ("tokenizer.json".to_string(), tokenizer_path),
+        let files: HashMap<String, PathBuf> = vec![
+            (model_filename, model_path.to_path_buf()),
+            ("config.json".to_string(), config_path.to_path_buf()),
+            ("tokenizer.json".to_string(), tokenizer_path.to_path_buf()),
         ]
         .into_iter()
         .collect();
 
-        let model_root = link_files_into_tmp_dir(files)?;
+        let model_root = link_files_into_tmp_dir(files, None)?;
         tracing::trace!(
             "Embedding model has files linked at location={:?}",
             model_root

--- a/crates/llms/src/embeddings/candle/tei.rs
+++ b/crates/llms/src/embeddings/candle/tei.rs
@@ -82,7 +82,7 @@ impl TeiEmbed {
         .into_iter()
         .collect();
 
-        let model_root = link_files_into_tmp_dir(files, None)?;
+        let model_root = link_files_into_tmp_dir(files)?;
         tracing::trace!(
             "Embedding model has files linked at location={:?}",
             model_root

--- a/crates/llms/src/embeddings/candle/util.rs
+++ b/crates/llms/src/embeddings/candle/util.rs
@@ -165,18 +165,11 @@ pub(crate) fn download_hf_artifacts(
 /// ```
 ///
 #[allow(clippy::implicit_hasher)]
-pub fn link_files_into_tmp_dir(
-    files: HashMap<String, PathBuf>,
-    temp_dir_opt: Option<PathBuf>,
-) -> Result<PathBuf> {
-    let temp_dir = if let Some(temp_dir) = temp_dir_opt {
-        temp_dir
-    } else {
-        let temp_dir = tempdir()
-            .boxed()
-            .context(FailedToInstantiateEmbeddingModelSnafu)?;
-        temp_dir.into_path()
-    };
+pub fn link_files_into_tmp_dir(files: HashMap<String, PathBuf>) -> Result<PathBuf> {
+    let temp_dir = tempdir()
+        .boxed()
+        .context(FailedToInstantiateEmbeddingModelSnafu)?
+        .into_path();
 
     for (name, file) in files {
         let Ok(abs_path) = path::absolute(&file) else {

--- a/crates/llms/src/embeddings/candle/util.rs
+++ b/crates/llms/src/embeddings/candle/util.rs
@@ -164,29 +164,38 @@ pub(crate) fn download_hf_artifacts(
 ///
 /// ```
 ///
-pub(crate) fn link_files_into_tmp_dir(files: HashMap<String, &Path>) -> Result<PathBuf> {
-    let temp_dir = tempdir()
-        .boxed()
-        .context(FailedToInstantiateEmbeddingModelSnafu)?;
+#[allow(clippy::implicit_hasher)]
+pub fn link_files_into_tmp_dir(
+    files: HashMap<String, PathBuf>,
+    temp_dir_opt: Option<PathBuf>,
+) -> Result<PathBuf> {
+    let temp_dir = if let Some(temp_dir) = temp_dir_opt {
+        temp_dir
+    } else {
+        let temp_dir = tempdir()
+            .boxed()
+            .context(FailedToInstantiateEmbeddingModelSnafu)?;
+        temp_dir.into_path()
+    };
 
     for (name, file) in files {
-        let Ok(abs_path) = path::absolute(file) else {
+        let Ok(abs_path) = path::absolute(&file) else {
             return Err(Error::FailedToCreateEmbedding {
                 source: format!(
                     "Failed to get absolute path of provided file: {}",
-                    file.as_os_str().to_string_lossy()
+                    file.to_string_lossy()
                 )
                 .into(),
             });
         };
 
         // Hard link so windows can handle it without developer mode.
-        std::fs::hard_link(abs_path, temp_dir.path().join(name))
+        std::fs::hard_link(abs_path, temp_dir.join(name))
             .boxed()
             .context(FailedToInstantiateEmbeddingModelSnafu)?;
     }
 
-    Ok(temp_dir.into_path())
+    Ok(temp_dir)
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]

--- a/crates/llms/tests/integration.rs
+++ b/crates/llms/tests/integration.rs
@@ -15,3 +15,59 @@ limitations under the License.
 */
 
 pub mod llms;
+
+use std::{collections::HashSet, sync::LazyLock};
+
+static TEST_ARGS: LazyLock<TestArgs> = LazyLock::new(|| {
+    let args = TestArgs::from_env();
+    args.validate();
+    args
+});
+
+#[derive(Debug)]
+struct TestArgs {
+    // Model names to skip from testing.
+    model_skiplist: Option<Vec<String>>,
+
+    /// Models to test. If provided, only these models will be tested.
+    model_allow_list: Option<Vec<String>>,
+}
+
+impl TestArgs {
+    fn from_env() -> Self {
+        let model_skiplist: Option<Vec<String>> = std::env::var("MODEL_SKIPLIST")
+            .ok()
+            .map(|s| s.split(',').map(ToString::to_string).collect());
+
+        let model_allow_list: Option<Vec<String>> = std::env::var("MODEL_ALLOWLIST")
+            .ok()
+            .map(|s| s.split(',').map(ToString::to_string).collect());
+
+        TestArgs {
+            model_skiplist,
+            model_allow_list,
+        }
+    }
+
+    fn skip_model(&self, model_name: &str) -> bool {
+        // If allow list set, check if model is in it.
+        if let Some(ref allow_list) = self.model_allow_list {
+            return !allow_list.contains(&model_name.to_string());
+        }
+
+        // If deny list set, check if model is not in it.
+        self.model_skiplist
+            .as_ref()
+            .is_some_and(|skip_list| skip_list.contains(&model_name.to_string()))
+    }
+
+    fn validate(&self) {
+        let skip: HashSet<_> = self.model_skiplist.iter().collect();
+        let allow: HashSet<_> = self.model_allow_list.iter().collect();
+        let overlap = skip.intersection(&allow);
+
+        if overlap.clone().count() > 0 {
+            tracing::warn!("Model allowlist and skiplist have overlapping models: {overlap:?}");
+        }
+    }
+}

--- a/crates/llms/tests/integration.rs
+++ b/crates/llms/tests/integration.rs
@@ -18,6 +18,8 @@ pub mod llms;
 
 use std::{collections::HashSet, sync::LazyLock};
 
+use tracing_subscriber::EnvFilter;
+
 static TEST_ARGS: LazyLock<TestArgs> = LazyLock::new(|| {
     let args = TestArgs::from_env();
     args.validate();
@@ -70,4 +72,18 @@ impl TestArgs {
             tracing::warn!("Model allowlist and skiplist have overlapping models: {overlap:?}");
         }
     }
+}
+
+fn init_tracing(default_level: Option<&str>) -> tracing::subscriber::DefaultGuard {
+    let filter = match (default_level, std::env::var("SPICED_LOG").ok()) {
+        (_, Some(log)) => EnvFilter::new(log),
+        (Some(level), None) => EnvFilter::new(level),
+        _ => EnvFilter::new("llms=TRACE,DEBUG"),
+    };
+
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(filter)
+        .with_ansi(true)
+        .finish();
+    tracing::subscriber::set_default(subscriber)
 }

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -116,8 +116,8 @@ fn download_hf_model_artifacts(
         }
     }
 
-    let dir = link_files_into_tmp_dir(files.clone(), None)
-        .context("Failed to link files into tmp dir")?;
+    let dir =
+        link_files_into_tmp_dir(files.clone()).context("Failed to link files into tmp dir")?;
     Ok((
         dir.clone(),
         weights // Reconstruct absolute model weights path based in the tmp dir.

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -19,20 +19,38 @@ use std::sync::Arc;
 use async_openai::error::OpenAIError;
 use llms::{
     anthropic::{Anthropic, AnthropicConfig},
-    chat::Chat,
+    chat::{create_hf_model, Chat, Error as ChatError},
     openai::Openai,
 };
+use secrecy::Secret;
 
-pub(crate) fn create_openai(model_id: &str) -> Arc<dyn Chat> {
+pub(crate) fn create_openai(model_id: &str) -> Arc<Box<dyn Chat>> {
     let api_key = std::env::var("SPICE_OPENAI_API_KEY").ok();
-    Arc::new(Openai::new(model_id.to_string(), None, api_key, None, None))
+    Arc::new(Box::new(Openai::new(
+        model_id.to_string(),
+        None,
+        api_key,
+        None,
+        None,
+    )))
 }
 
-pub(crate) fn create_anthropic(model_id: Option<&str>) -> Result<Arc<dyn Chat>, OpenAIError> {
+pub(crate) fn create_anthropic(model_id: Option<&str>) -> Result<Arc<Box<dyn Chat>>, OpenAIError> {
     let cfg = AnthropicConfig::default()
         .with_api_key(std::env::var("SPICE_ANTHROPIC_API_KEY").ok())
         .with_auth_token(std::env::var("SPICE_ANTHROPIC_AUTH_TOKEN").ok());
     let model = Anthropic::new(cfg, model_id)?;
 
-    Ok(Arc::new(model))
+    Ok(Arc::new(Box::new(model)))
+}
+
+pub(crate) fn create_hf(model_id: &str) -> Result<Arc<Box<dyn Chat>>, ChatError> {
+    let hf_token = std::env::var("HF_TOKEN").ok().map(Secret::new);
+    let model_type = None;
+
+    Ok(Arc::new(create_hf_model(
+        model_id,
+        &model_type,
+        hf_token.as_ref(),
+    )?))
 }

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -26,6 +26,7 @@ use llms::{
 use secrecy::Secret;
 use std::{
     collections::HashMap,
+    fs,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -100,18 +101,30 @@ fn download_hf_model_artifacts(
     let mut weights = vec![];
     for sibling in api_repo.info()?.siblings {
         if !(sibling.rfilename.ends_with(".py") || sibling.rfilename.ends_with(".md")) {
-            let path = api_repo.download(sibling.rfilename.as_str())?;
-            if path_is_weights(&path) {
-                weights.push(path.to_string_lossy().to_string());
-            }
+            let path = api_repo.get(sibling.rfilename.as_str())?;
+
+            // `abs_path` will have symlinks and relative paths resolved, but will have a hash for a filename. This is fine after its symlinked in `link_files_into_tmp_dir`.
+            // use `path` to get the original filename.
+            let abs_path = fs::canonicalize(path.clone())?;
+
             if let Some(filename) = path.file_name() {
-                files.insert(filename.to_string_lossy().to_string(), path);
+                files.insert(filename.to_string_lossy().to_string(), abs_path);
+                if path_is_weights(&path) {
+                    weights.push(filename.to_string_lossy().to_string());
+                }
             }
         }
     }
 
-    let dir = link_files_into_tmp_dir(files, None).context("Failed to link files into tmp dir")?;
-    Ok((dir, weights))
+    let dir = link_files_into_tmp_dir(files.clone(), None)
+        .context("Failed to link files into tmp dir")?;
+    Ok((
+        dir.clone(),
+        weights // Reconstruct absolute model weights path based in the tmp dir.
+            .iter()
+            .map(|w| dir.join(w).display().to_string())
+            .collect(),
+    ))
 }
 
 /// Attempts to figure out if a given path is a model weights file.
@@ -131,7 +144,7 @@ fn path_is_weights(p: &Path) -> bool {
         .map(str::to_lowercase);
 
     // Common model weight file extensions
-    let weight_extensions = ["bin", "pt", "gguf", "safetensors", "pth", "ckpt", "model"];
+    let weight_extensions = ["bin", "pt", "gguf", "safetensors", "pth", "ckpt"];
 
     // Common weight file patterns
     let weight_patterns = [
@@ -152,9 +165,7 @@ fn path_is_weights(p: &Path) -> bool {
             // Check if filename contains common weight file patterns
             let has_weight_pattern = weight_patterns.iter().any(|pattern| name.contains(pattern));
 
-            // File size heuristic could be added here if needed
-
-            has_weight_extension || has_weight_pattern
+            has_weight_extension && has_weight_pattern
         }
         _ => false,
     }

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -14,15 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
-
+use anyhow::Context;
 use async_openai::error::OpenAIError;
+use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
 use llms::{
     anthropic::{Anthropic, AnthropicConfig},
-    chat::{create_hf_model, Chat, Error as ChatError},
+    chat::{create_hf_model, create_local_model, Chat, Error as ChatError},
+    embeddings::candle::link_files_into_tmp_dir,
     openai::Openai,
 };
 use secrecy::Secret;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 pub(crate) fn create_openai(model_id: &str) -> Arc<Box<dyn Chat>> {
     let api_key = std::env::var("SPICE_OPENAI_API_KEY").ok();
@@ -53,4 +59,103 @@ pub(crate) fn create_hf(model_id: &str) -> Result<Arc<Box<dyn Chat>>, ChatError>
         &model_type,
         hf_token.as_ref(),
     )?))
+}
+
+pub(crate) fn create_local(model_id: &str) -> Result<Arc<Box<dyn Chat>>, anyhow::Error> {
+    let (temp_dir, model_weights) =
+        download_hf_model_artifacts(model_id, None, std::env::var("HF_TOKEN").ok())?;
+
+    let model = create_local_model(
+        &model_weights,
+        temp_dir.join("config.json").to_str(),
+        temp_dir.join("tokenizer.json").to_str(),
+        temp_dir.join("tokenizer_config.json").to_str(),
+        None,
+    )
+    .map_err(anyhow::Error::from)?;
+    Ok(Arc::from(Box::new(model)))
+}
+
+/// For a given `HuggingFace` repo, downloads the specified file and save them into provided folder. Return folder, and which ones are model weights.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn download_hf_model_artifacts(
+    model_id: &str,
+    revision: Option<&str>,
+    hf_token: Option<String>,
+) -> Result<(PathBuf, Vec<String>), anyhow::Error> {
+    let api = ApiBuilder::new()
+        .with_progress(false)
+        .with_token(hf_token)
+        .build()
+        .context("Failed to instantiate API for downloading model artifacts")?;
+
+    let repo = if let Some(revision) = revision {
+        Repo::with_revision(model_id.to_string(), RepoType::Model, revision.to_string())
+    } else {
+        Repo::new(model_id.to_string(), RepoType::Model)
+    };
+    let api_repo = api.repo(repo.clone());
+
+    let mut files = HashMap::<String, PathBuf>::new();
+    let mut weights = vec![];
+    for sibling in api_repo.info()?.siblings {
+        if !(sibling.rfilename.ends_with(".py") || sibling.rfilename.ends_with(".md")) {
+            let path = api_repo.download(sibling.rfilename.as_str())?;
+            if path_is_weights(&path) {
+                weights.push(path.to_string_lossy().to_string());
+            }
+            if let Some(filename) = path.file_name() {
+                files.insert(filename.to_string_lossy().to_string(), path);
+            }
+        }
+    }
+
+    let dir = link_files_into_tmp_dir(files, None).context("Failed to link files into tmp dir")?;
+    Ok((dir, weights))
+}
+
+/// Attempts to figure out if a given path is a model weights file.
+///
+/// This function is not perfect, but should cover all cases needed for testing.
+fn path_is_weights(p: &Path) -> bool {
+    // Get the file extension and convert to lowercase for case-insensitive comparison
+    let extension = p
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_lowercase);
+
+    // Get the file name as string for pattern matching
+    let file_name = p
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_lowercase);
+
+    // Common model weight file extensions
+    let weight_extensions = ["bin", "pt", "gguf", "safetensors", "pth", "ckpt", "model"];
+
+    // Common weight file patterns
+    let weight_patterns = [
+        "weights",
+        "model",
+        "pytorch_model",
+        "params",
+        "parameters",
+        "checkpoint",
+        "ckpt",
+    ];
+
+    match (extension, file_name) {
+        (Some(ext), Some(name)) => {
+            // Check if extension matches known weight file extensions
+            let has_weight_extension = weight_extensions.contains(&ext.as_str());
+
+            // Check if filename contains common weight file patterns
+            let has_weight_pattern = weight_patterns.iter().any(|pattern| name.contains(pattern));
+
+            // File size heuristic could be added here if needed
+
+            has_weight_extension || has_weight_pattern
+        }
+        _ => false,
+    }
 }

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -22,6 +22,8 @@ use std::{
     sync::{Arc, LazyLock},
 };
 
+use crate::{TestArgs, TEST_ARGS};
+
 mod create;
 
 #[derive(Clone)]
@@ -150,26 +152,44 @@ static TEST_CASES: LazyLock<Vec<TestCase>> = LazyLock::new(|| {
 
 /// Model instantiations to test.
 #[allow(clippy::expect_used)]
-static TEST_MODELS: LazyLock<Vec<(&'static str, Arc<dyn Chat>)>> = LazyLock::new(|| {
-    vec![
+static TEST_MODELS: LazyLock<Vec<(&'static str, Arc<Box<dyn Chat>>)>> = LazyLock::new(|| {
+    let model_creators: [(&str, Box<dyn Fn() -> Arc<Box<dyn Chat>>>); 3] = [
         (
             "anthropic",
-            create::create_anthropic(None).expect("failed to create anthropic model"),
+            Box::new(|| create::create_anthropic(None).expect("failed to create anthropic model")),
         ),
-        ("openai", create::create_openai("gpt-4o-mini")),
-    ]
+        ("openai", Box::new(|| create::create_openai("gpt-4o-mini"))),
+        (
+            "hf/phi3",
+            Box::new(|| {
+                create::create_hf("microsoft/Phi-3-mini-4k-instruct")
+                    .expect("failed to create 'microsoft/Phi-3-mini-4k-instruct' from HF")
+            }),
+        ),
+    ];
+
+    model_creators
+        .iter()
+        .filter_map(|(name, creator)| {
+            if TEST_ARGS.skip_model(name) {
+                None
+            } else {
+                Some((*name, creator()))
+            }
+        })
+        .collect()
 });
 
 /// A mapping of model names (in [`TEST_MODELS`]) and test names (in [`TEST_CASES`]) to skip.
 static TEST_DENY_LIST: LazyLock<Vec<(&'static str, &'static str)>> =
-    LazyLock::new(|| vec![("anthropic", "placeholder")]);
+    LazyLock::new(|| vec![("hf/phi3", "tool_use")]);
 
 /// Run a single [`TestCase`] for a model.
 #[allow(clippy::expect_used, clippy::expect_fun_call)]
 async fn run_test_case(
     test: &TestCase,
     model_name: &'static str,
-    model: Arc<dyn Chat>,
+    model: Arc<Box<dyn Chat>>,
 ) -> Result<(), anyhow::Error> {
     let test_name = test.name;
     tracing::info!("Running test {test_name}/{model_name} with {:?}", test.req);

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -174,7 +174,7 @@ static TEST_MODELS: LazyLock<Vec<ModelDef>> = LazyLock::new(|| {
             "local/phi3",
             Box::new(|| {
                 create::create_local("microsoft/Phi-3-mini-4k-instruct")
-                    .expect("failed to create 'microsoft/Phi-3-mini-4k-instruct' from HF")
+                    .expect("failed to create 'microsoft/Phi-3-mini-4k-instruct' from local system")
             }),
         ),
     ];

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -22,7 +22,7 @@ use std::{
     sync::{Arc, LazyLock},
 };
 
-use crate::{TestArgs, TEST_ARGS};
+use crate::{init_tracing, TEST_ARGS};
 
 mod create;
 
@@ -150,10 +150,14 @@ static TEST_CASES: LazyLock<Vec<TestCase>> = LazyLock::new(|| {
     ]
 });
 
-/// Model instantiations to test.
+/// For a given mode name, a function that instantiates the model..
+type ModelFn<'a> = (&'a str, Box<dyn Fn() -> Arc<Box<dyn Chat>>>);
+
+/// A given model to test.
+type ModelDef<'a> = (&'a str, Arc<Box<dyn Chat>>);
 #[allow(clippy::expect_used)]
-static TEST_MODELS: LazyLock<Vec<(&'static str, Arc<Box<dyn Chat>>)>> = LazyLock::new(|| {
-    let model_creators: [(&str, Box<dyn Fn() -> Arc<Box<dyn Chat>>>); 3] = [
+static TEST_MODELS: LazyLock<Vec<ModelDef>> = LazyLock::new(|| {
+    let model_creators: [ModelFn; 4] = [
         (
             "anthropic",
             Box::new(|| create::create_anthropic(None).expect("failed to create anthropic model")),
@@ -163,6 +167,13 @@ static TEST_MODELS: LazyLock<Vec<(&'static str, Arc<Box<dyn Chat>>)>> = LazyLock
             "hf/phi3",
             Box::new(|| {
                 create::create_hf("microsoft/Phi-3-mini-4k-instruct")
+                    .expect("failed to create 'microsoft/Phi-3-mini-4k-instruct' from HF")
+            }),
+        ),
+        (
+            "local/phi3",
+            Box::new(|| {
+                create::create_local("microsoft/Phi-3-mini-4k-instruct")
                     .expect("failed to create 'microsoft/Phi-3-mini-4k-instruct' from HF")
             }),
         ),
@@ -182,7 +193,7 @@ static TEST_MODELS: LazyLock<Vec<(&'static str, Arc<Box<dyn Chat>>)>> = LazyLock
 
 /// A mapping of model names (in [`TEST_MODELS`]) and test names (in [`TEST_CASES`]) to skip.
 static TEST_DENY_LIST: LazyLock<Vec<(&'static str, &'static str)>> =
-    LazyLock::new(|| vec![("hf/phi3", "tool_use")]);
+    LazyLock::new(|| vec![("hf/phi3", "tool_use"), ("local/phi3", "tool_use")]);
 
 /// Run a single [`TestCase`] for a model.
 #[allow(clippy::expect_used, clippy::expect_fun_call)]
@@ -221,6 +232,7 @@ async fn run_test_case(
 async fn run_all_tests() {
     // Set ENV variables before we lazy load `TEST_MODELS`.
     let _ = dotenvy::from_filename(".env").expect("failed to load .env file");
+    init_tracing(None);
 
     for ts in TEST_CASES.iter() {
         for (model_name, model) in TEST_MODELS.iter() {

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -243,6 +243,7 @@ async fn run_all_tests() {
                 tracing::info!("Skipping test {model_name}/{}", ts.name);
                 continue;
             }
+
             run_test_case(ts, model_name, Arc::clone(model))
                 .await
                 .expect(format!("Failed to run test {model_name}/{}", ts.name).as_str());

--- a/crates/llms/tests/llms/snapshots/integration__llms__basic_hf__phi3_message_keys.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__basic_hf__phi3_message_keys.snap
@@ -1,0 +1,10 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  "assistant",
+  [],
+  null
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__basic_hf__phi3_replied_appropriately.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__basic_hf__phi3_replied_appropriately.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__basic_local__phi3_message_keys.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__basic_local__phi3_message_keys.snap
@@ -1,0 +1,10 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  "assistant",
+  [],
+  null
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__basic_local__phi3_replied_appropriately.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__basic_local__phi3_replied_appropriately.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_hf__phi3_assistant_response.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_hf__phi3_assistant_response.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_hf__phi3_replied_appropriately.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_hf__phi3_replied_appropriately.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_local__phi3_assistant_response.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_local__phi3_assistant_response.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_local__phi3_replied_appropriately.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_local__phi3_replied_appropriately.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]


### PR DESCRIPTION
## 🗣 Description
 - Add new local file model to integration testing.
 - Add env variables `MODEL_SKIPLIST` and `MODEL_ALLOWLIST` . For example, see https://github.com/spiceai/spiceai/pull/3690/files#diff-29306580888afce747aae89a524b29aad08258003a80bca1c5113b183e97f621R93. 
    - Ensure to only attempt to load models that satisfy `MODEL_SKIPLIST` and `MODEL_ALLOWLIST` constraints. 

