### PR TITLE
Add nightly label to spiced version in Cargo.toml

### DIFF
--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rel_version: ${{ steps.set_version.outputs.rel_version }}
+      nightly_label: ${{ steps.set_version.outputs.nightly_label }}
     steps:
       - uses: actions/checkout@v4
 
@@ -60,8 +61,11 @@ jobs:
         id: set_version
         run: |
           commit_hash=$(git rev-parse --short HEAD)
-          version="$(date +%Y%m%d)-${commit_hash}"
+          date="$(date +%Y%m%d)"
+          version="${date}-${commit_hash}"
+          nightly_label="nightly.${date}.${commit_hash}"
           echo "rel_version=${version}" >> $GITHUB_OUTPUT
+          echo "nightly_label=${nightly_label}" >> $GITHUB_OUTPUT
           echo "Preparing to publish nightly build with version: \"${version}\""
 
   build-arm64:
@@ -75,11 +79,10 @@ jobs:
 
       - name: Add nightly postfix to version in Cargo.toml
         env:
-          REL_VERSION: ${{ needs.setup.outputs.rel_version }}
+          NIGHTLY_LABEL: ${{ needs.setup.outputs.nightly_label }}
         run: |
           current_version=$(grep '^version =' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
-          base_version=$(echo $current_version | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-          new_version="${base_version}-nightly-$REL_VERSION"
+          new_version="${current_version}.$NIGHTLY_LABEL"
           sed -i '' "s/^version = \".*\"/version = \"${new_version}\"/" Cargo.toml
           grep '^version =' Cargo.toml
 
@@ -137,11 +140,10 @@ jobs:
 
       - name: Add nightly postfix to version in Cargo.toml
         env:
-          REL_VERSION: ${{ needs.setup.outputs.rel_version }}
+          NIGHTLY_LABEL: ${{ needs.setup.outputs.nightly_label }}
         run: |
           current_version=$(grep '^version =' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
-          base_version=$(echo $current_version | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-          new_version="${base_version}-nightly-$REL_VERSION"
+          new_version="${current_version}.$NIGHTLY_LABEL"
           sed -i '' "s/^version = \".*\"/version = \"${new_version}\"/" Cargo.toml
           grep '^version =' Cargo.toml
 

--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -73,6 +73,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Add nightly postfix to version in Cargo.toml
+        env:
+          REL_VERSION: ${{ needs.setup.outputs.rel_version }}
+        run: |
+          current_version=$(grep '^version =' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
+          base_version=$(echo $current_version | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          new_version="${base_version}-nightly-$REL_VERSION"
+          sed -i '' "s/^version = \".*\"/version = \"${new_version}\"/" Cargo.toml
+          grep '^version =' Cargo.toml
+
       - name: Install docker
         run: |
           sudo apt-get update
@@ -124,6 +134,16 @@ jobs:
     runs-on: spiceai-runners
     steps:
       - uses: actions/checkout@v4
+
+      - name: Add nightly postfix to version in Cargo.toml
+        env:
+          REL_VERSION: ${{ needs.setup.outputs.rel_version }}
+        run: |
+          current_version=$(grep '^version =' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
+          base_version=$(echo $current_version | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+          new_version="${base_version}-nightly-$REL_VERSION"
+          sed -i '' "s/^version = \".*\"/version = \"${new_version}\"/" Cargo.toml
+          grep '^version =' Cargo.toml
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Updates Cargo.toml version with nightly build label, e.g.

`version = "1.0.0-rc.1"` -> `version = "1.0.0-rc.1.nightly.20241127.0114aad6"`