### PR TITLE
Improve REPL error handling for multiline error messages

### DIFF
--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -475,40 +475,55 @@ fn display_grpc_error(err: &Status) {
         Code::Ok => return,
         Code::Unknown | Code::Internal | Code::DataLoss | Code::FailedPrecondition => (
             "Internal Error",
-            "An unexpected internal error occurred. Execute '.error' for details.",
+            "An unexpected internal error occurred. Execute '.error' for details.".to_string(),
         ),
         Code::InvalidArgument | Code::AlreadyExists | Code::NotFound | Code::Unavailable => {
-            let message = err.message().split('\n').next().unwrap_or(err.message());
+            let mut lines = err.message().split('\n');
+            let first_line = lines.next().unwrap_or_default();
+            let has_more_lines = lines.next().is_some();
+
+            let message = if has_more_lines {
+                format!("{first_line} Execute '.error' for details.")
+            } else {
+                first_line.to_string()
+            };
+
             ("Query Error", message)
         }
         Code::Cancelled => (
             "Cancelled",
-            "The operation was cancelled before completion.",
+            "The operation was cancelled before completion.".to_string(),
         ),
-        Code::Aborted => ("Aborted", "The operation was aborted before completion."),
+        Code::Aborted => (
+            "Aborted",
+            "The operation was aborted before completion.".to_string(),
+        ),
         Code::DeadlineExceeded => (
             "Timeout Error",
-            "The operation could not complete within the allowed time limit.",
+            "The operation could not complete within the allowed time limit.".to_string(),
         ),
         Code::Unauthenticated => (
             "Authentication Error",
-            "Access denied. Invalid credentials.",
+            "Access denied. Invalid credentials.".to_string(),
         ),
         Code::PermissionDenied => (
             "Authorization Error",
-            "Access denied. Insufficient permisions to complete the request.",
+            "Access denied. Insufficient permisions to complete the request.".to_string(),
         ),
         Code::ResourceExhausted => (
             "Resource Limit Exceeded",
-            "The operation could not be completed because the server resources are exhausted.",
+            "The operation could not be completed because the server resources are exhausted."
+                .to_string(),
         ),
         Code::Unimplemented => (
             "Unsupported Operation",
-            "The query could not be completed because the requested operation is not supported.",
+            "The query could not be completed because the requested operation is not supported."
+                .to_string(),
         ),
         Code::OutOfRange => (
             "Result Limit Exceeded",
-            "The query result exceeds allowable limits. Consider using a `limit` clause.",
+            "The query result exceeds allowable limits. Consider using a `limit` clause."
+                .to_string(),
         ),
     };
 


### PR DESCRIPTION
## 🗣 Description

Improve REPL error handling for multiline messages

Before:

```
Query Error Execution error: Unable to query arrow: Query execution failed.
sql> 
```
<img width="535" alt="image" src="https://github.com/user-attachments/assets/8ea71d87-0abd-49ba-858e-62b64ddd9af6">


After:

```
Query Error Execution error: Unable to query arrow: Query execution failed. Execute '.error' for details.
sql> .error
Status { code: InvalidArgument, message: "Execution error: Unable to query arrow: Query execution failed.\ndb error: ERROR: missing FROM-clause entry for table \"date_dim\"\nFor details, refer to the PostgreSQL manual: https://www.postgresql.org/docs/17/index.html", source: None }
sql> 
```

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/01c668cb-da49-40c0-8c4a-dbc4c598e3bc">

## Concerns

First line error might be improved IMO
Query Error Execution error: Unable to query arrow: Query execution failed.
->
Query Error Execution error: Query execution failed.


The `Unable to query arrow:` part is redundant IMO

https://github.com/datafusion-contrib/datafusion-table-providers/blob/6e422901e68cee88a323031efe17b40c29591fda/src/sql/db_connection_pool/dbconnection.rs#L30-L31

```rust
#[snafu(display("Unable to query arrow: {source}"))]
UnableToQueryArrow { source: GenericError },
```