### PR TITLE
Determine support_filter_pushdown based on Accelerator federated reader & ZeroResultsAction

### DIFF
--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -7,7 +7,7 @@ use datafusion::{
     common::Constraints,
     datasource::{TableProvider, TableType},
     error::Result as DataFusionResult,
-    logical_expr::{dml::InsertOp, LogicalPlan},
+    logical_expr::{dml::InsertOp, LogicalPlan, TableProviderFilterPushDown},
     physical_plan::ExecutionPlan,
     prelude::Expr,
 };

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -98,6 +98,13 @@ impl TableProvider for PolyTableProvider {
         self.write.get_column_default(column)
     }
 
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        self.fed.supports_filters_pushdown(filters)
+    }
+
     async fn scan(
         &self,
         state: &dyn Session,

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -666,7 +666,15 @@ impl TableProvider for AcceleratedTable {
         &self,
         filters: &[&Expr],
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
-        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+        match self.zero_results_action {
+            // Filter pushdown for all accelerators are currently exact
+            ZeroResultsAction::ReturnEmpty => {
+                Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
+            }
+            ZeroResultsAction::UseSource => {
+                Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+            }
+        }
     }
 
     async fn scan(

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -667,7 +667,6 @@ impl TableProvider for AcceleratedTable {
         filters: &[&Expr],
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
         match self.zero_results_action {
-            // Filter pushdown for all accelerators are currently exact
             ZeroResultsAction::ReturnEmpty => self.accelerator.supports_filters_pushdown(filters),
             ZeroResultsAction::UseSource => {
                 Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -668,9 +668,7 @@ impl TableProvider for AcceleratedTable {
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
         match self.zero_results_action {
             // Filter pushdown for all accelerators are currently exact
-            ZeroResultsAction::ReturnEmpty => {
-                Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
-            }
+            ZeroResultsAction::ReturnEmpty => self.accelerator.supports_filters_pushdown(filters),
             ZeroResultsAction::UseSource => {
                 Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
             }


### PR DESCRIPTION
## 🗣 Description

Determine support_filter_pushdown based on Accelerator federated reader & ZeroResultsAction.

When `ZeroResultsAction` is `ReturnEmpty`, the query won't fall back to the source. Therefore the query plan could be based on the filter push down rule of the federated accelerator, which is determined by the `supports_filter_pushdown` of the `PolyTableProvider.fed`.

After this change, the filter pushdown will be determined by the federated reader of PolyTableProvider when  `ZeroResultsAction` is `ReturnEmpty`. For arrow accelerator it will be unsupported, since arrow accelerator `MemTable` doesn't implement `supports_filter_pushdown`. For DuckDB / Postgres / SQLite tables it will be based on the `supports_filter_pushdown` of `SqlTable`, which is the same rule that Postgres/ DuckDB /etc. federated connectors are following. 

Successful benchmark test run, Postgres accelerator time reduced from 2.22 hours to 30 minutes. No regression on query results is observed. Noted that TPCH snapshots for arrow accelerator needs to be updated due to the plan change (Pushdown changed from inexact -> unsupported )https://github.com/spiceai/spiceai/actions/runs/12041194445

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/3689

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns