### PR TITLE
Add log when CORS is enabled

### DIFF
--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -147,6 +147,12 @@ fn cors_layer(cors_config: &CorsConfig) -> CorsLayer {
             .into()
     };
 
+    tracing::info!(
+        target: "runtime::http",
+        "CORS (Cross-Origin Resource Sharing) enabled on HTTP endpoint for allowed origins: {:?}",
+        cors_config.allowed_origins
+    );
+
     cors.allow_methods([Method::GET, Method::POST, Method::PATCH])
         .allow_origin(allowed_origins)
 }


### PR DESCRIPTION
## 🗣 Description

Adds a log to indicate to the user when CORS is enabled and on which origins on startup.

`2024-11-26T23:29:59.308332Z  INFO runtime::http: CORS (Cross-Origin Resource Sharing) enabled on HTTP endpoint for allowed origins: ["*"]`

`2024-11-26T23:28:14.253149Z  INFO runtime::http: CORS (Cross-Origin Resource Sharing) enabled on HTTP endpoint for allowed origins: ["http://localhost:3000", "https://team.spice.ai"]`

## 🔨 Related Issues

N/A

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

N/A
