### PR TITLE
feat: Render multiline errors better in REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4110,6 +4110,7 @@ dependencies = [
  "arrow-json 53.1.0",
  "clap",
  "datafusion",
+ "flight_client",
  "futures",
  "llms",
  "prost 0.13.3",

--- a/crates/flightrepl/Cargo.toml
+++ b/crates/flightrepl/Cargo.toml
@@ -23,6 +23,7 @@ reqwest.workspace = true
 rustyline = { version="15.0.0", features=["custom-bindings", "with-dirs", "with-file-history", "derive"] }
 serde_json.workspace = true
 tonic = { workspace = true, features = ["transport", "tls", "tls-roots"] }
+flight_client = { path = "../flight_client" }
 
 [target.'cfg(windows)'.dependencies]
 winver = "1.0.0"

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -33,6 +33,7 @@ use datafusion::dataframe::DataFrame;
 use datafusion::datasource::{provider_as_source, MemTable};
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
+use flight_client::TonicStatusError;
 use futures::{StreamExt, TryStreamExt};
 use llms::chat::LlmRuntime;
 use prost::Message;
@@ -231,7 +232,10 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
             ".exit" | "exit" | "quit" | "q" => break,
             ".error" => {
                 match last_error {
-                    Some(ref err) => println!("{err:?}"),
+                    Some(ref err) => {
+                        let err = TonicStatusError::from(err.clone());
+                        println!("{err}");
+                    },
                     None => println!("No error to display"),
                 }
                 continue;
@@ -475,42 +479,70 @@ fn display_grpc_error(err: &Status) {
         Code::Ok => return,
         Code::Unknown | Code::Internal | Code::DataLoss | Code::FailedPrecondition => (
             "Internal Error",
-            "An unexpected internal error occurred. Execute '.error' for details.",
+            "An unexpected internal error occurred. Execute '.error' for details.".to_string(),
         ),
         Code::InvalidArgument | Code::AlreadyExists | Code::NotFound | Code::Unavailable => {
-            let message = err.message().split('\n').next().unwrap_or(err.message());
-            ("Query Error", message)
+            // let message = err.message().split('\n').next().unwrap_or(err.message());
+            let message = err.message();
+            let lines = message.split('\n').collect::<Vec<_>>();
+            let truncate = !lines
+                .iter()
+                .filter(|line| line.len() > 120)
+                .collect::<Vec<_>>()
+                .is_empty();
+
+            let first_line = lines.first().unwrap_or(&message);
+            match (truncate, lines.len() > 1) {
+                (true, true) => {
+                    // truncating due to length, and multiple error lines
+                    ("Query Error", format!("{first_line}\nThis error message has been truncated.\nFor the full error message, execute `.error`."))
+                }
+                (true, false) => {
+                    // truncating due to length, but only one line
+                    ("Query Error", "Failed to execute query.\nThis error message has been truncated.\nFor the full error message, execute `.error`.".to_string())
+                }
+                _ => ("Query Error", message.to_string()),
+            }
         }
         Code::Cancelled => (
             "Cancelled",
-            "The operation was cancelled before completion.",
+            "The operation was cancelled before completion.".to_string(),
         ),
-        Code::Aborted => ("Aborted", "The operation was aborted before completion."),
+        Code::Aborted => (
+            "Aborted",
+            "The operation was aborted before completion.".to_string(),
+        ),
         Code::DeadlineExceeded => (
             "Timeout Error",
-            "The operation could not complete within the allowed time limit.",
+            "The operation could not complete within the allowed time limit.".to_string(),
         ),
         Code::Unauthenticated => (
             "Authentication Error",
-            "Access denied. Invalid credentials.",
+            "Access denied. Invalid credentials.".to_string(),
         ),
         Code::PermissionDenied => (
             "Authorization Error",
-            "Access denied. Insufficient permisions to complete the request.",
+            "Access denied. Insufficient permisions to complete the request.".to_string(),
         ),
         Code::ResourceExhausted => (
             "Resource Limit Exceeded",
-            "The operation could not be completed because the server resources are exhausted.",
+            "The operation could not be completed because the server resources are exhausted."
+                .to_string(),
         ),
         Code::Unimplemented => (
             "Unsupported Operation",
-            "The query could not be completed because the requested operation is not supported.",
+            "The query could not be completed because the requested operation is not supported."
+                .to_string(),
         ),
         Code::OutOfRange => (
             "Result Limit Exceeded",
-            "The query result exceeds allowable limits. Consider using a `limit` clause.",
+            "The query result exceeds allowable limits. Consider using a `limit` clause."
+                .to_string(),
         ),
     };
 
-    println!("{} {user_err_msg}", Colour::Red.paint(error_type));
+    println!(
+        "{} {user_err_msg}",
+        Colour::Red.paint(format!("{error_type}:"))
+    );
 }

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -474,6 +474,11 @@ fn json_array_to_jsonl(json_array_str: &str) -> Result<String, Box<dyn std::erro
     Ok(jsonl_str)
 }
 
+/// Returns a boolean indicating if a message needs truncation, from a given input of lines.
+fn lines_need_truncation(lines: &[&str]) -> bool {
+    lines.iter().any(|line| line.len() > 120)
+}
+
 fn display_grpc_error(err: &Status) {
     let (error_type, user_err_msg) = match err.code() {
         Code::Ok => return,
@@ -482,14 +487,9 @@ fn display_grpc_error(err: &Status) {
             "An unexpected internal error occurred. Execute '.error' for details.".to_string(),
         ),
         Code::InvalidArgument | Code::AlreadyExists | Code::NotFound | Code::Unavailable => {
-            // let message = err.message().split('\n').next().unwrap_or(err.message());
             let message = err.message();
             let lines = message.split('\n').collect::<Vec<_>>();
-            let truncate = !lines
-                .iter()
-                .filter(|line| line.len() > 120)
-                .collect::<Vec<_>>()
-                .is_empty();
+            let truncate = lines_need_truncation(&lines);
 
             let first_line = lines.first().unwrap_or(&message);
             match (truncate, lines.len() > 1) {


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Suffixes the `error_type` in REPL error rendering with `:` to clearly separate the error type from the error message.
* Updates error returns from the `do_get` Runtime Flight handler to ensure DataFusion errors are handled with `handle_datafusion_error`. This removes the `Execution error:` prefix messages from the tonic errors.
* Updates the REPL to support outputting multi-line errors. Checks for the length of error message lines to determine if they should be truncated.
* Updates the REPL to render tonic status errors using the `TonicStatusError` newtype wrapper implemented for the Flight client, to output nicer errors in `.error`.

Before:
```bash
sql> SELECT ws_item_sk FROM web_sales
INTERSECT
SELECT ss_item_sk FROM store_sales;
Query Error Execution error: Unable to query arrow: Parser Error: syntax error at or near "SEMI"
sql> .error
Status { code: InvalidArgument, message: "Execution error: Unable to query arrow: Parser Error: syntax error at or near \"SEMI\"\nLINE 1: ...es\".\"ws_item_sk\" FROM \"web_sales\" LEFT SEMI JOIN (SELECT \"store_sales\".\"ss_ite...\n                                                  ^", source: None }
```

After:
```bash
sql> SELECT ws_item_sk FROM web_sales
INTERSECT
SELECT ss_item_sk FROM store_sales;
Query Error: Unable to query arrow: Parser Error: syntax error at or near "SEMI"
LINE 1: ...es"."ws_item_sk" FROM "web_sales" LEFT SEMI JOIN (SELECT "store_sales"."ss_ite...
                                                  ^
sql> .error
Client specified an invalid argument.
Unable to query arrow: Parser Error: syntax error at or near "SEMI"
LINE 1: ...es"."ws_item_sk" FROM "web_sales" LEFT SEMI JOIN (SELECT "store_sales"."ss_ite...
                                                  ^
```

After (truncated):
```bash
sql> SELECT ws_item_sk FROM web_sales
INTERSECT
SELECT ss_item_sk FROM store_sales;
Query Error: Unable to query arrow: Parser Error: syntax error at or near "SEMI"
This error message has been truncated.
For the full error message, execute `.error`.
sql> .error
Client specified an invalid argument.
Unable to query arrow: Parser Error: syntax error at or near "SEMI"
LINE 1: ...es"."ws_item_sk" FROM "web_sales" LEFT SEMI JOIN (SELECT "store_sales"."ss_ite...
                                                  ^
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3700