### PR TITLE
refactor: Update UnableToAttachDataConnector error message

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -25,6 +25,7 @@ use ::datafusion::sql::{sqlparser, TableReference};
 use app::App;
 use builder::RuntimeBuilder;
 use config::Config;
+use dataconnector::ConnectorComponent;
 use datasets_health_monitor::DatasetsHealthMonitor;
 use extension::ExtensionFactory;
 use model::{EmbeddingModelStore, LLMModelStore};
@@ -146,9 +147,10 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Unable to attach data connector {data_connector}: {source}"))]
+    #[snafu(display("Failed to setup the {connector_component} ({data_connector}).\n{source}"))]
     UnableToAttachDataConnector {
         source: datafusion::Error,
+        connector_component: ConnectorComponent,
         data_connector: String,
     },
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the error message of `UnableToAttachDataConnector` to align with the [error handling guidelines](https://github.com/spiceai/spiceai/blob/trunk/docs/dev/error_handling.md)

Before:
```bash
Unable to attach data connector postgres: {err}
```

* What does it mean if a data connector couldn't attach?
* What dataset does this affect?

After:
```bash
Failed to setup the dataset syncs (postgres).
{err}
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #3506 