### PR TITLE
Add the missing winver dependency in runtime crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9353,6 +9353,7 @@ dependencies = [
  "url",
  "util",
  "uuid 1.11.0",
+ "winver",
  "x509-certificate",
 ]
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -192,3 +192,6 @@ sqlite = [
 [[bench]]
 harness = false
 name = "bench"
+
+[target.'cfg(windows)'.dependencies]
+winver = "1.0.0"


### PR DESCRIPTION
## 🗣 Description

Add the missing winver dependency in runtime crate. This will fix the broken build of windows

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 📄 Documentation Requirements

<!-- list any documentation related iusses, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
