### PR TITLE
Add special tokens in chunk sizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10782,8 +10782,7 @@ dependencies = [
 [[package]]
 name = "text-splitter"
 version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189450e9eaff1a8037cca4d60ca62c134a7e601187430bdd487c86e25e8d6641"
+source = "git+https://github.com/Jeadie/text-splitter.git?rev=b33e4748576b9a81d436d3f28a6706f860fc45ba#b33e4748576b9a81d436d3f28a6706f860fc45ba"
 dependencies = [
  "ahash 0.8.11",
  "auto_enums",
@@ -10793,7 +10792,7 @@ dependencies = [
  "pulldown-cmark",
  "regex",
  "strum 0.26.3",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "tiktoken-rs",
  "tokenizers",
  "unicode-segmentation",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -33,12 +33,9 @@ tracing.workspace = true
 tracing-futures.workspace = true
 
 ## For Chunking
+text-splitter = {  git = "https://github.com/Jeadie/text-splitter.git", rev = "b33e4748576b9a81d436d3f28a6706f860fc45ba", features = ["markdown", "tokenizers", "tiktoken-rs"]}
+
 pulldown-cmark = "0.12.1"
-text-splitter = { version = "0.18.1", features = [
-    "markdown",
-    "tokenizers",
-    "tiktoken-rs",
-] }
 tiktoken-rs = "0.6.0"
 
 mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "d70715944e30f335eb59e1a712962b86d7a5d026", optional = true }


### PR DESCRIPTION
## 🗣 Description
 - Some inputs have special characters. Our sizing library does not count them as apart of the size.
 - Breaks inputs like this
 ```
 ERROR text_embeddings_core::infer: Input validation error: `inputs` must have less than 512 tokens. Given: 513
 ```
Diff in `text-splitter`: https://github.com/Jeadie/text-splitter/commit/b33e4748576b9a81d436d3f28a6706f860fc45ba 
