### PR TITLE
Disable results cache for benchmark tests

### DIFF
--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -24,10 +24,13 @@ use runtime::{
     status::{self, RuntimeStatus},
     Runtime,
 };
-use spicepod::component::dataset::{
-    acceleration::{Acceleration, IndexType},
-    replication::Replication,
-    Dataset, Mode,
+use spicepod::component::{
+    dataset::{
+        acceleration::{Acceleration, IndexType},
+        replication::Replication,
+        Dataset, Mode,
+    },
+    runtime::ResultsCache,
 };
 use std::{collections::HashMap, process::Command, sync::Arc, time::Duration};
 use tracing_subscriber::EnvFilter;
@@ -128,7 +131,13 @@ fn build_app(
     acceleration: Option<Acceleration>,
     bench_name: &str,
 ) -> Result<App, String> {
-    let mut app_builder = AppBuilder::new("runtime_benchmark_test");
+    let mut app_builder =
+        AppBuilder::new("runtime_benchmark_test").with_results_cache(ResultsCache {
+            enabled: false,
+            cache_max_size: None,
+            item_ttl: None,
+            eviction_policy: None,
+        });
 
     app_builder = match connector {
         "spice.ai" => Ok(crate::bench_spicecloud::build_app(app_builder)),


### PR DESCRIPTION
## 🗣 Description

Disable the results cache for the benchmark tests. Previously the benchmarks were calling the DataFusion SQL context directly, but now they need to go through the QueryBuilder which has all of our logging/telemetry/caching pipeline. This change properly disables the results cache.

## 🔨 Related Issues

N/A

## 📄 Documentation Requirements

N/A

## 🤔 Concerns

N/A
