### PR TITLE
Support `jsonl` for object store

### DIFF
--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -153,7 +153,7 @@ pub trait ListingTableConnector: DataConnector {
                 extension.unwrap_or(".csv".to_string()),
             )),
             (Some("jsonl"), _) | (None, Some("jsonl"))=> Ok((
-                Some(Arc::new(JsonFormat::default())),
+                Some(self.get_jsonl_format(dataset, params)?),
                 extension.unwrap_or(".jsonl".to_string()),
             )),
             (Some("parquet"), _) | (None, Some("parquet"))=> Ok((

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -20,7 +20,7 @@ use crate::dataconnector::ConnectorComponent;
 use crate::dataconnector::DataConnector;
 use crate::dataconnector::DataConnectorError;
 use crate::dataconnector::DataConnectorResult;
-use crate::parameters::ParamLookup;
+use crate::parameters::ExposedParamLookup;
 use crate::parameters::Parameters;
 use async_trait::async_trait;
 use data_components::object::metadata::ObjectStoreMetadataTable;
@@ -41,7 +41,6 @@ use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use futures::TryStreamExt;
 use object_store::ObjectStore;
-use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashSet;
@@ -187,21 +186,23 @@ pub trait ListingTableConnector: DataConnector {
     {
         let mut format = JsonFormat::default();
 
-        if let ParamLookup::Present(comp_as_secret) = params.get("compression") {
-            let compression = comp_as_secret.expose_secret().parse::<FileCompressionType>().boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
+        if let ExposedParamLookup::Present(comp_as_str) = params.get("compression").expose() {
+            let compression = comp_as_str.parse::<FileCompressionType>().boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
                     message: format!(
-                        "Invalid JSONL compression_type: {comp_as_secret:?}, supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
+                        "Invalid JSONL compression_type: {comp_as_str}, supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
                     connector_component: ConnectorComponent::from(dataset)
                 })?;
             format = format.with_file_compression_type(compression);
         };
 
-        if let ParamLookup::Present(infer_max_rec_secret) = params.get("schema_infer_max_records") {
-            let schema_infer_max_rec = usize::from_str(infer_max_rec_secret.expose_secret().as_str()).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
+        if let ExposedParamLookup::Present(infer_max_rec_str) =
+            params.get("schema_infer_max_records").expose()
+        {
+            let schema_infer_max_rec = usize::from_str(infer_max_rec_str).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
                     message: format!(
-                        "JSONL parameter 'schema_infer_max_records' must be an integer, received {infer_max_rec_secret:?}"),
+                        "JSONL parameter 'schema_infer_max_records' must be an integer, not {infer_max_rec_str}"),
                     connector_component: ConnectorComponent::from(dataset)
                 })?;
             format = format.with_schema_infer_max_rec(schema_infer_max_rec);

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -20,6 +20,7 @@ use crate::dataconnector::ConnectorComponent;
 use crate::dataconnector::DataConnector;
 use crate::dataconnector::DataConnectorError;
 use crate::dataconnector::DataConnectorResult;
+use crate::parameters::ParamLookup;
 use crate::parameters::Parameters;
 use async_trait::async_trait;
 use data_components::object::metadata::ObjectStoreMetadataTable;
@@ -28,6 +29,7 @@ use datafusion::config::ConfigField;
 use datafusion::config::TableParquetOptions;
 use datafusion::datasource::file_format::csv::CsvFormat;
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
+use datafusion::datasource::file_format::json::JsonFormat;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::listing::{
@@ -39,6 +41,7 @@ use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use futures::TryStreamExt;
 use object_store::ObjectStore;
+use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashSet;
@@ -139,48 +142,72 @@ pub trait ListingTableConnector: DataConnector {
             .expose()
             .ok()
             .map(str::to_string);
+        let file_extension = std::path::Path::new(dataset.path().as_str())
+            .extension()
+            .map(|ext| ext.to_ascii_lowercase().to_string_lossy().to_string());
+        let file_format_param = params.get("file_format").expose().ok();
 
-        match params.get("file_format").expose().ok() {
-            Some("csv") => Ok((
+        match (file_format_param, file_extension.as_deref()) {
+            (Some("csv"), _) | (None, Some("csv")) => Ok((
                 Some(self.get_csv_format(dataset, params)?),
                 extension.unwrap_or(".csv".to_string()),
             )),
-            Some("parquet") => Ok((
+            (Some("jsonl"), _) | (None, Some("jsonl"))=> Ok((
+                Some(Arc::new(JsonFormat::default())),
+                extension.unwrap_or(".jsonl".to_string()),
+            )),
+            (Some("parquet"), _) | (None, Some("parquet"))=> Ok((
                 Some(Arc::new(
                     ParquetFormat::default().with_options(self.get_table_parquet_options(dataset)?),
                 )),
                 extension.unwrap_or(".parquet".to_string()),
             )),
-            Some(format) => Ok((None, format!(".{format}"))),
-            None => {
-                if let Some(ext) = std::path::Path::new(dataset.path().as_str()).extension() {
-                    if ext.eq_ignore_ascii_case("csv") {
-                        return Ok((
-                            Some(self.get_csv_format(dataset, params)?),
-                            extension.unwrap_or(".csv".to_string()),
-                        ));
-                    }
-                    if ext.eq_ignore_ascii_case("parquet") {
-                        return Ok((
-                            Some(Arc::new(
-                                ParquetFormat::default()
-                                    .with_options(self.get_table_parquet_options(dataset)?),
-                            )),
-                            extension.unwrap_or(".parquet".to_string()),
-                        ));
-                    }
-                }
-
-                Err(
+            (Some(format), _) => Ok((None, format!(".{format}"))),
+            (_, _) => Err(
                     crate::dataconnector::DataConnectorError::InvalidConfiguration {
                         dataconnector: format!("{self}"),
                         message: "The required 'file_format' parameter is missing.\nEnsure the parameter is provided, and try again.".to_string(),
                         connector_component: ConnectorComponent::from(dataset),
                         source: "Missing file format".into(),
                     },
-                )
-            }
+                ),
         }
+    }
+
+    /// Returns a [`JsonFormat`] based on the provided [`Datasets`] parameters.
+    ///
+    /// If the [`Dataset`] has the relevant parameter, return an error if the value is invalid.
+    fn get_jsonl_format(
+        &self,
+        dataset: &Dataset,
+        params: &Parameters,
+    ) -> DataConnectorResult<Arc<JsonFormat>>
+    where
+        Self: Display,
+    {
+        let mut format = JsonFormat::default();
+
+        if let ParamLookup::Present(comp_as_secret) = params.get("compression") {
+            let compression = comp_as_secret.expose_secret().parse::<FileCompressionType>().boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
+                    dataconnector: format!("{self}"),
+                    message: format!(
+                        "Invalid JSONL compression_type: {comp_as_secret:?}, supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
+                    connector_component: ConnectorComponent::from(dataset)
+                })?;
+            format = format.with_file_compression_type(compression);
+        };
+
+        if let ParamLookup::Present(infer_max_rec_secret) = params.get("schema_infer_max_records") {
+            let schema_infer_max_rec = usize::from_str(infer_max_rec_secret.expose_secret().as_str()).boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
+                    dataconnector: format!("{self}"),
+                    message: format!(
+                        "JSONL parameter 'schema_infer_max_records' must be an integer, received {infer_max_rec_secret:?}"),
+                    connector_component: ConnectorComponent::from(dataset)
+                })?;
+            format = format.with_schema_infer_max_rec(schema_infer_max_rec);
+        };
+
+        Ok(Arc::new(format))
     }
 
     fn get_csv_format(
@@ -330,6 +357,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
         let (file_format_opt, extension) = self.get_file_format_and_extension(dataset)?;
         match file_format_opt {
             None => {
+                // Assume its unstructured text data. Use a [`ObjectStoreTextTable`].
                 let content_formatter = document_parse::get_parser_factory(extension.as_str())
                     .await
                     .map(|factory| {
@@ -337,7 +365,6 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                         factory.default()
                     });
 
-                // Assume its unstructured text data. Use a [`ObjectStoreTextTable`].
                 Ok(ObjectStoreTextTable::try_new(
                     self.get_object_store(dataset)?,
                     &url.clone(),


### PR DESCRIPTION
## 🗣 Description

```yaml
datasets:
  - name: eval
    from: file:/Users/jeadie/Downloads/samples.jsonl

  - name: evals
    from: file:/Users/jeadie/Downloads/
    params:
      file_format: jsonl
```

```shell
>> curl http://localhost:8090/v1/sql \
    -H "Content-Type: application/json" \
    -d 'select input, ideal from eval limit 2'
```

```json
[
    {
        "input": [
            {
                "content": "You will be given various situations in the game of cricket along with an outcome and you have to answer whether the outcome is possible with a YES or NO and no additional text",
                "role": "system"
            },
            {
                "content": "Is it possible for the batting team to win the match if they need 15 runs to win from 2 balls assuming that the batting team is extremely lucky",
                "role": "user"
            }
        ],
        "ideal": "YES"
    },
    {
        "input": [
            {
                "content": "You will be given various situations in the game of cricket along with an outcome and you have to answer whether the outcome is possible with a YES or NO and no additional text",
                "role": "system"
            },
            {
                "content": "Is it possible for the batting team to win the match if they need 16 runs to win from 2 balls assuming that the batting team is extremely lucky",
                "role": "user"
            }
        ],
        "ideal": "YES"
    }
]
```

## 📄 Documentation Requirements
 - Document JSON options: `compression`, `schema_infer_max_records`.
