### PR TITLE
standardise 'csv_schema_infer_max_records' -> 'schema_infer_max_records'; include deprecation messages for dataset params

### DIFF
--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -142,12 +142,16 @@ const PARAMETERS: &[ParameterSpec] = &[
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),
     ParameterSpec::runtime("file_extension"),
+    ParameterSpec::runtime("schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema."),
     ParameterSpec::runtime("csv_has_header")
         .description("Set true to indicate that the first line is a header."),
     ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
     ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
     ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
+        .description("Set a limit in terms of records to scan to infer the schema.")
+        .deprecated("use 'schema_infer_max_records' instead"),
+
     ParameterSpec::runtime("csv_delimiter")
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -66,12 +66,15 @@ const PARAMETERS: &[ParameterSpec] = &[
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),
     ParameterSpec::runtime("file_extension"),
+    ParameterSpec::runtime("schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema."),
     ParameterSpec::runtime("csv_has_header")
         .description("Set true to indicate that the first line is a header."),
     ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
     ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
     ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
+        .description("Set a limit in terms of records to scan to infer the schema.")
+        .deprecated("use 'schema_infer_max_records' instead"),
     ParameterSpec::runtime("csv_delimiter")
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -63,12 +63,15 @@ const PARAMETERS: &[ParameterSpec] = &[
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),
     ParameterSpec::runtime("file_extension"),
+    ParameterSpec::runtime("schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema."),
     ParameterSpec::runtime("csv_has_header")
         .description("Set true to indicate that the first line is a header."),
     ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
     ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
     ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
+        .description("Set a limit in terms of records to scan to infer the schema.")
+        .deprecated("use 'schema_infer_max_records' instead"),
     ParameterSpec::runtime("csv_delimiter")
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -64,12 +64,15 @@ const PARAMETERS: &[ParameterSpec] = &[
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),
     ParameterSpec::runtime("file_extension"),
+    ParameterSpec::runtime("schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema."),
     ParameterSpec::runtime("csv_has_header")
         .description("Set true to indicate that the first line is a header."),
     ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
     ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
     ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
+        .description("Set a limit in terms of records to scan to infer the schema.")
+        .deprecated("use 'schema_infer_max_records' instead"),
     ParameterSpec::runtime("csv_delimiter")
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -186,7 +186,9 @@ pub trait ListingTableConnector: DataConnector {
     {
         let mut format = JsonFormat::default();
 
-        if let ExposedParamLookup::Present(comp_as_str) = params.get("compression").expose() {
+        if let ExposedParamLookup::Present(comp_as_str) =
+            params.get("file_compression_type").expose()
+        {
             let compression = comp_as_str.parse::<FileCompressionType>().boxed().context(crate::dataconnector::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
                     message: format!(
@@ -235,9 +237,10 @@ pub trait ListingTableConnector: DataConnector {
             .ok()
             .and_then(|f| f.as_bytes().first().copied());
         let schema_infer_max_rec = params
-            .get("csv_schema_infer_max_records")
+            .get("schema_infer_max_records")
             .expose()
             .ok()
+            .or(params.get("csv_schema_infer_max_records").expose().ok()) // For backwards compatibility
             .map_or_else(|| 1000, |f| usize::from_str(f).map_or(1000, |f| f));
         let delimiter = params
             .get("csv_delimiter")
@@ -609,6 +612,7 @@ mod tests {
     const TEST_PARAMETERS: &[ParameterSpec] = &[
         ParameterSpec::runtime("file_extension"),
         ParameterSpec::runtime("file_format"),
+        ParameterSpec::runtime("schema_infer_max_records"),
         ParameterSpec::runtime("csv_has_header"),
         ParameterSpec::runtime("csv_quote"),
         ParameterSpec::runtime("csv_escape"),

--- a/crates/runtime/src/dataconnector/listing/mod.rs
+++ b/crates/runtime/src/dataconnector/listing/mod.rs
@@ -46,6 +46,7 @@ mod tests {
     const TEST_PARAMETERS: &[ParameterSpec] = &[
         ParameterSpec::runtime("file_extension"),
         ParameterSpec::runtime("file_format"),
+        ParameterSpec::runtime("schema_infer_max_records"),
         ParameterSpec::runtime("csv_has_header"),
         ParameterSpec::runtime("csv_quote"),
         ParameterSpec::runtime("csv_escape"),

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -137,12 +137,15 @@ const PARAMETERS: &[ParameterSpec] = &[
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),
     ParameterSpec::runtime("file_extension"),
+    ParameterSpec::runtime("schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema."),
     ParameterSpec::runtime("csv_has_header")
         .description("Set true to indicate that the first line is a header."),
     ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
     ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
     ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
+        .description("Set a limit in terms of records to scan to infer the schema.")
+        .deprecated("use 'schema_infer_max_records' instead"),
     ParameterSpec::runtime("csv_delimiter")
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -72,12 +72,15 @@ const PARAMETERS: &[ParameterSpec] = &[
     // Common listing table parameters
     ParameterSpec::runtime("file_format"),
     ParameterSpec::runtime("file_extension"),
+    ParameterSpec::runtime("schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema."),
     ParameterSpec::runtime("csv_has_header")
         .description("Set true to indicate that the first line is a header."),
     ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
     ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
     ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
+        .description("Set a limit in terms of records to scan to infer the schema")
+        .deprecated("use 'schema_infer_max_records' instead"),
     ParameterSpec::runtime("csv_delimiter")
         .description("The character separating values within a row."),
     ParameterSpec::runtime("file_compression_type")

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -99,6 +99,17 @@ impl Parameters {
             }
         }
 
+        // Check for deprecated parameters
+        for parameter in all_params {
+            if let Some(deprecation_message) = parameter.deprecation_message {
+                if let Some((param, _)) = params.iter().find(|p| p.0 == parameter.name) {
+                    tracing::warn!(
+                        "Parameter '{param}' is deprecated for {component_name}: {deprecation_message}",
+                    );
+                }
+            }
+        }
+
         // Check if all required parameters are present
         for parameter in all_params {
             // If the parameter is missing and has a default value, add it to the params
@@ -268,6 +279,7 @@ pub struct ParameterSpec {
     pub help_link: &'static str,
     pub examples: &'static [&'static str],
     pub r#type: ParameterType,
+    pub deprecation_message: Option<&'static str>,
 }
 
 impl ParameterSpec {
@@ -282,6 +294,7 @@ impl ParameterSpec {
             help_link: "",
             examples: &[],
             r#type: ParameterType::Connector,
+            deprecation_message: None,
         }
     }
 
@@ -296,6 +309,7 @@ impl ParameterSpec {
             help_link: "",
             examples: &[],
             r#type: ParameterType::Runtime,
+            deprecation_message: None,
         }
     }
 
@@ -310,6 +324,7 @@ impl ParameterSpec {
             help_link: "",
             examples: &[],
             r#type: ParameterType::Accelerator,
+            deprecation_message: None,
         }
     }
 
@@ -347,6 +362,16 @@ impl ParameterSpec {
     pub const fn examples(mut self, examples: &'static [&'static str]) -> Self {
         self.examples = examples;
         self
+    }
+
+    #[must_use]
+    pub const fn deprecated(mut self, deprecation_message: &'static str) -> Self {
+        self.deprecation_message = Some(deprecation_message);
+        self
+    }
+
+    pub fn is_deprecated(&self) -> bool {
+        self.deprecation_message.is_some()
     }
 }
 

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -369,10 +369,6 @@ impl ParameterSpec {
         self.deprecation_message = Some(deprecation_message);
         self
     }
-
-    pub fn is_deprecated(&self) -> bool {
-        self.deprecation_message.is_some()
-    }
 }
 
 #[derive(Default, Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
## 🗣 Description
 - Bug introduced in jsonl file format for #3726 when parameters aren't provided. 
 - In noticing this, I see we should use `schema_infer_max_records` and not both:  csv_schema_infer_max_records and jsonl_schema_infer_max_records.
 - To handle this, I introduce the idea of a `ParameterSpec` being deprecated. Will produce this
```shell
  INFO runtime::init::dataset: Initializing dataset evl
  WARN runtime::parameters: Parameter csv_schema_infer_max_records is deprecated for connector file: use 'schema_infer_max_records' instead
```

## 🔨 Related Issues
- #3726

## 📄 Documentation Requirements
 - [ ] Update docs to use `schema_infer_max_records` over `csv_schema_infer_max_records`.
