### PR TITLE
fix: Add explicit message for ODBC connector when not installed

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -228,9 +228,8 @@ pub enum DataConnectorError {
         connector_component: ConnectorComponent,
     },
 
-    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}).\nThe Runtime is running without ODBC support.\nBuild Spice with the `odbc` feature, or use the docker image with ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
+    #[snafu(display("Cannot setup the {connector_component} (odbc).\nThe Runtime is running without ODBC support.\nBuild Spice with the `odbc` feature, or use the docker image with ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
     OdbcNotInstalled {
-        dataconnector: String,
         connector_component: ConnectorComponent,
     },
 }
@@ -557,7 +556,6 @@ impl DataConnectorParamsBuilder {
         let factory = connector_factory.ok_or_else(|| {
             if name == ODBC_DATACONNECTOR {
                 DataConnectorError::OdbcNotInstalled {
-                    dataconnector: name.clone(),
                     connector_component: self.component.clone(),
                 }
             } else {

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -79,6 +79,8 @@ pub mod mssql;
 pub mod mysql;
 #[cfg(feature = "odbc")]
 pub mod odbc;
+pub const ODBC_DATACONNECTOR: &str = "odbc"; // const needs to be accessible when ODBC isn't built
+
 #[cfg(feature = "postgres")]
 pub mod postgres;
 pub mod s3;
@@ -222,6 +224,12 @@ pub enum DataConnectorError {
         "Failed to load the {connector_component} ({dataconnector}).\nInvalid type action is not supported for the {dataconnector} Data Connector.\nRemove the parameter from your dataset configuration."
     ))]
     UnsupportedInvalidTypeAction {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+    },
+
+    #[snafu(display("Cannot setup the {connector_component} ({dataconnector}).\nThe Runtime is running without ODBC support.\nBuild Spice with the `odbc` feature, or use the docker image with ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
+    OdbcNotInstalled {
         dataconnector: String,
         connector_component: ConnectorComponent,
     },
@@ -546,10 +554,21 @@ impl DataConnectorParamsBuilder {
 
         let connector_factory = guard.get(&name);
 
-        let factory = connector_factory.ok_or(DataConnectorError::InvalidConnectorType {
-            dataconnector: name.clone(),
-            connector_component: self.component.clone(),
-        })?;
+        let factory = connector_factory.ok_or_else(|| {
+            if name == ODBC_DATACONNECTOR {
+                DataConnectorError::OdbcNotInstalled {
+                    dataconnector: name.clone(),
+                    connector_component: self.component.clone(),
+                }
+            } else {
+                DataConnectorError::InvalidConnectorType {
+                    dataconnector: name.clone(),
+                    connector_component: self.component.clone(),
+                }
+            }
+        });
+
+        let factory = factory?;
 
         let parameters = Parameters::try_new(
             &format!("connector {name}"),

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -228,7 +228,7 @@ pub enum DataConnectorError {
         connector_component: ConnectorComponent,
     },
 
-    #[snafu(display("Cannot setup the {connector_component} (odbc).\nThe Runtime is running without ODBC support.\nBuild Spice with the `odbc` feature, or use the docker image with ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
+    #[snafu(display("Failed to initialize the {connector_component} (ODBC).\nThe runtime is built without ODBC support.\nBuild Spice.ai OSS with the `odbc` feature enabled or use the Docker image that includes ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
     OdbcNotInstalled {
         connector_component: ConnectorComponent,
     },

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -134,6 +134,9 @@ pub enum Error {
     #[snafu(display("Unknown data connector: {data_connector}"))]
     UnknownDataConnector { data_connector: String },
 
+    #[snafu(display("The Runtime is running without ODBC support.\nBuild Spice with the `odbc` feature, or use the docker image with ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
+    OdbcNotInstalled,
+
     #[snafu(display("Unable to load secrets for data connector: {data_connector}"))]
     UnableToLoadDataConnectorSecrets { data_connector: String },
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -134,7 +134,7 @@ pub enum Error {
     #[snafu(display("Unknown data connector: {data_connector}"))]
     UnknownDataConnector { data_connector: String },
 
-    #[snafu(display("The Runtime is running without ODBC support.\nBuild Spice with the `odbc` feature, or use the docker image with ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
+    #[snafu(display("The runtime is built without ODBC support.\nBuild Spice.ai OSS with the `odbc` feature enabled or use the Docker image that includes ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
     OdbcNotInstalled,
 
     #[snafu(display("Unable to load secrets for data connector: {data_connector}"))]


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the error message for when a data connector isn't valid to to explicitly check for ODBC and return a message about installing with ODBC support.

Before:
```bash
2024-12-02T03:57:24.187884Z  WARN runtime::init::dataset: test Cannot setup the dataset test (odbc).
The connector 'odbc' is not a valid connector.
For details, visit: https://docs.spiceai.org/components/data-connectors
```

After:
```bash
2024-12-02T04:04:44.851287Z  WARN runtime::init::dataset: test Cannot setup the dataset test (odbc).
The Runtime is running without ODBC support.
Build Spice with the `odbc` feature, or use the docker image with ODBC support.
For details, visit: https://docs.spiceai.org/components/data-connectors/odbc
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #3560 