### PR TITLE
Optimize build & release workflow for trunk builds

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -56,12 +56,17 @@ jobs:
               }
             ];
 
+            // PR TEST ONLY
             if (context.eventName === 'workflow_dispatch') {
-              console.log(context)
-              return matrix.slice(0, 3);
+              return matrix.filter(target => target.runner !== 'macos-14-large');
             }
 
-            return context.eventName === 'pull_request' ? matrix.slice(0, 3) : matrix;
+            // Filter out macos-14-large runner for trunk pushes
+            if (context.eventName === 'push' && context.ref === 'refs/heads/trunk') {
+              return matrix.filter(target => target.runner !== 'macos-14-large');
+            }
+
+            return matrix;
 
   build:
     name: Build ${{ matrix.target.name }} binaries

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -56,6 +56,11 @@ jobs:
               }
             ];
 
+            if (context.eventName === 'workflow_dispatch') {
+              console.log(context)
+              return matrix.slice(0, 3);
+            }
+
             return context.eventName === 'pull_request' ? matrix.slice(0, 3) : matrix;
 
   build:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -10,42 +10,66 @@ on:
   workflow_dispatch:
 
 jobs:
+  setup-matrix:
+    name: Setup strategy matrix
+    runs-on: spiceai-runners
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.result }}
+
+    steps:
+      - name: Set up matrix
+        uses: actions/github-script@v7
+        id: setup-matrix
+        with:
+          script: |
+            const matrix = [
+              {
+                name: "Linux x64",
+                runner: "spiceai-runners",
+                target_os: "linux",
+                target_arch: "x86_64",
+                target_arch_go: "amd64"
+              }, {
+                name: "Linux aarch64",
+                runner: "hosted-linux-arm-runner",
+                target_os: "linux",
+                target_arch: "aarch64",
+                target_arch_go: "arm64"
+              }, {
+                name: "macOS aarch64 (Apple Silicon)",
+                runner: "macos-14",
+                target_os: "darwin",
+                target_arch: "aarch64",
+                target_arch_go: "arm64"
+              }, {
+                name: "Windows x64",
+                runner: "rust-windows-x64",
+                target_os: "windows",
+                target_arch: "x86_64",
+                target_arch_go: "amd64"
+              }, {
+                name: "macOS x64 (Intel)",
+                runner: "macos-14-large",
+                target_os: "darwin",
+                target_arch: "x86_64",
+                target_arch_go: "amd64"
+              }
+            ];
+
+            return context.eventName === 'pull_request' ? matrix.slice(0, 3) : matrix;
+
   build:
-    name: Build ${{ matrix.name }} binaries
-    runs-on: ${{ matrix.runner }}
+    name: Build ${{ matrix.target.name }} binaries
+    runs-on: ${{ matrix.target.runner }}
+    needs: setup-matrix
     env:
       GOVER: 1.22.0
-      GOOS: ${{ matrix.target_os }}
-      GOARCH: ${{ matrix.target_arch_go }}
+      GOOS: ${{ matrix.target.target_os }}
+      GOARCH: ${{ matrix.target.target_arch_go }}
 
     strategy:
       matrix:
-        include:
-          - name: Linux x64
-            runner: spiceai-runners
-            target_os: linux
-            target_arch: x86_64
-            target_arch_go: amd64
-          - name: Linux aarch64
-            runner: hosted-linux-arm-runner
-            target_os: linux
-            target_arch: aarch64
-            target_arch_go: arm64
-          - name: macOS aarch64 (Apple Silicon)
-            runner: macos-14
-            target_os: darwin
-            target_arch: aarch64
-            target_arch_go: arm64
-          - name: macOS x64 (Intel)
-            runner: macos-14-large # https://github.com/actions/runner-images
-            target_os: darwin
-            target_arch: x86_64
-            target_arch_go: amd64
-          - name: Windows x64
-            runner: rust-windows-x64
-            target_os: windows
-            target_arch: x86_64
-            target_arch_go: amd64
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -61,18 +85,18 @@ jobs:
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:
-          os: ${{ matrix.target_os }}
+          os: ${{ matrix.target.target_os }}
 
       - name: Set up make
-        if: matrix.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         uses: ./.github/actions/setup-make
 
       - name: Set up cc
-        if: matrix.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         uses: ./.github/actions/setup-cc
 
       - name: Restore build cache (macOS)
-        if: matrix.target_os == 'darwin'
+        if: matrix.target.target_os == 'darwin'
         run: |
           mkdir -p target
           if [ -d /Users/spiceai/build/target ]; then
@@ -80,7 +104,7 @@ jobs:
           fi
 
       - name: Restore build cache (Linux)
-        if: matrix.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         run: |
           mkdir -p target
           if [ -d /home/spiceai/build/target ]; then
@@ -89,19 +113,19 @@ jobs:
 
       # The aarch64 runner does not have any tools pre-installed
       - name: Install missing tools (Linux aarch64)
-        if: matrix.target_os == 'linux' && matrix.target_arch == 'aarch64'
+        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'aarch64'
         run: |
           sudo apt-get update
           sudo apt-get install build-essential libssl-dev pkg-config cmake protobuf-compiler unixodbc unixodbc-dev -y
 
       # The x86_64 runner does not unixodbc pre-installed
       - name: Install missing tools (Linux x86_64)
-        if: matrix.target_os == 'linux' && matrix.target_arch == 'x86_64'
+        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'x86_64'
         run: |
           sudo apt-get install unixodbc unixodbc-dev -y
 
       - name: Install missing tools (Mac)
-        if: matrix.target_os == 'darwin'
+        if: matrix.target.target_os == 'darwin'
         run: |
           brew install protobuf
           brew install cmake
@@ -109,7 +133,7 @@ jobs:
           echo "RUSTFLAGS=-L /opt/homebrew/lib" >> $GITHUB_ENV
 
       - name: Restore build cache (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: |
           mkdir -p target
           if (Test-Path C:/spiceai/build/target) {
@@ -121,129 +145,129 @@ jobs:
         run: make -C bin/spiced
 
       - name: tar binary
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: |
           mv target/release/spiced spiced
           chmod +x spiced
-          tar czf spiced_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced
+          tar czf spiced_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz spiced
 
       - name: tar binary (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: |
           mv target/release/spiced.exe spiced.exe
-          tar czf spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced.exe
+          tar czf spiced.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz spiced.exe
 
       - name: Print version
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: ./spiced --version
       
       - name: Print version (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: ./spiced.exe --version
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         with:
-          name: spiced_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: spiced_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+          name: spiced_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: spiced_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         with:
-          name: spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: spiced.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+          name: spiced.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: spiced.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
       ## Models flavor
       - name: Build spiced (models)
         run: make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="models"
 
       - name: tar binary (models)
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: |
           mv target/release/spiced spiced
           chmod +x spiced
-          tar czf spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced
+          tar czf spiced_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz spiced
 
       - name: tar binary (models) (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: |
           rm spiced.exe
           mv target/release/spiced.exe spiced.exe
-          tar czf spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spiced.exe
+          tar czf spiced.exe_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz spiced.exe
 
       - name: Print version (models)
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: ./spiced --version
       
       - name: Print version (models) (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: ./spiced.exe --version
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         with:
-          name: spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: spiced_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+          name: spiced_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: spiced_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         with:
-          name: spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: spiced.exe_models_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+          name: spiced.exe_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: spiced.exe_models_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
       ## CLI build
       - name: Build spice
         run: make -C bin/spice
 
       - name: tar binary
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: |
           mv target/release/spice spice
           chmod +x spice
-          tar czf spice_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spice
+          tar czf spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz spice
 
       - name: tar binary (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: |
           mv target/release/spice.exe spice.exe
-          tar czf spice.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz spice.exe
+          tar czf spice.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz spice.exe
 
       - name: Print version
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: ./spice version
       
       - name: Print version (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: ./spice.exe version
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         with:
-          name: spice_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: spice_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+          name: spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         with:
-          name: spice.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: spice.exe_${{ matrix.target_os }}_${{ matrix.target_arch }}.tar.gz
+          name: spice.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: spice.exe_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
       
       - name: Update build cache (macOS)
-        if: matrix.target_os == 'darwin'
+        if: matrix.target.target_os == 'darwin'
         run: |
           if [ -d /Users/spiceai/build/target ]; then
             rsync -av target/ /Users/spiceai/build/target/
           fi
 
       - name: Update build cache (Linux)
-        if: matrix.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         run: |
           if [ -d /home/spiceai/build/target ]; then
             rsync -av target/ /home/spiceai/build/target/
           fi
 
       - name: Update build cache (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: |
           if (Test-Path C:/spiceai/build/target) {
             Copy-Item -Recurse -Force target/* C:/spiceai/build/target

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -56,11 +56,6 @@ jobs:
               }
             ];
 
-            // PR TEST ONLY
-            if (context.eventName === 'workflow_dispatch') {
-              return matrix.filter(target => target.runner !== 'macos-14-large');
-            }
-
             // Filter out macos-14-large runner for trunk pushes
             if (context.eventName === 'push' && context.ref === 'refs/heads/trunk') {
               return matrix.filter(target => target.runner !== 'macos-14-large');


### PR DESCRIPTION
# 🗣 Description

Optimize the builds that run on trunk to remove the macOS Intel build, since it runs on a fairly expensive runner and we don't need to run on every commit.
