### PR TITLE
Temporarily disable tests depending on eth.recent_blocks and _transactions data

### DIFF
--- a/crates/runtime/tests/catalog/mod.rs
+++ b/crates/runtime/tests/catalog/mod.rs
@@ -62,7 +62,7 @@ async fn spiceai_integration_test_catalog() -> Result<(), anyhow::Error> {
 
             let mut result = rt
                 .datafusion()
-                .query_builder("SELECT * FROM spiceai.eth.recent_blocks LIMIT 10")
+                .query_builder("SELECT * FROM spiceai.eth.blocks LIMIT 10")
                 .build()
                 .run()
                 .await?;

--- a/crates/runtime/tests/federation/mod.rs
+++ b/crates/runtime/tests/federation/mod.rs
@@ -36,6 +36,8 @@ fn make_spiceai_dataset(path: &str, name: &str) -> Dataset {
 
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
+// TODO: Re-enable these tests once eth.recent_blocks has values
+#[ignore]
 async fn spiceai_integration_test_single_source_federation_push_down() -> Result<(), String> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _ = rustls::crypto::CryptoProvider::install_default(


### PR DESCRIPTION
# 🗣 Description

Temporarily disable tests depending on eth.recent_blocks and _transactions data

spiceai.eth.recent_blocks and spiceai.eth.transactions are currently empty