### PR TITLE
Accelerate a subset of columns from source dataset in Refresh SQL

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1030,7 +1030,7 @@ jobs:
           if [[ -n "$MODE" ]]; then
             echo "      mode: $MODE" >> spicepod.yaml
           fi
-          echo "      refresh_sql: SELECT * FROM eth.recent_blocks LIMIT 1" >> spicepod.yaml
+          echo "      refresh_sql: SELECT * FROM eth.recent_blocks" >> spicepod.yaml
           echo "    params:" >> spicepod.yaml
           echo "      pg_host: localhost" >> spicepod.yaml
           echo "      pg_port: '5432'" >> spicepod.yaml
@@ -1076,7 +1076,7 @@ jobs:
       - name: Manually refresh dataset (with params)
         working-directory: test_app
         run: |
-          output=$(spice refresh eth.recent_blocks --refresh-jitter-max=1s --refresh-sql='SELECT * FROM eth.recent_blocks LIMIT 2' 2>&1)
+          output=$(spice refresh eth.recent_blocks --refresh-jitter-max=1s --refresh-sql='SELECT * FROM eth.recent_blocks' 2>&1)
           echo "$output"
           if [[ $output == *"Dataset refresh triggered"* ]]; then
             # time to refresh dataset
@@ -1145,7 +1145,7 @@ jobs:
           echo "      file_format: parquet" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: select * from customer limit 1;" >> spicepod.yaml
+          echo "      refresh_sql: select * from customer;" >> spicepod.yaml
           cat spicepod.yaml
 
       - name: Start spice runtime
@@ -1263,7 +1263,7 @@ jobs:
           echo "      include: \"**/*.md\"" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.files LIMIT 20'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.files'" >> spicepod.yaml
 
           echo "  - from: github:github.com/spiceai/spiceai/issues" >> spicepod.yaml
           echo "    name: spiceai.issues" >> spicepod.yaml
@@ -1271,7 +1271,7 @@ jobs:
           echo "      github_token: \${secrets:GITHUB_TOKEN}" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.issues LIMIT 20'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.issues'" >> spicepod.yaml
 
           echo "  - from: github:github.com/spiceai/spiceai/pulls" >> spicepod.yaml
           echo "    name: spiceai.pulls" >> spicepod.yaml
@@ -1279,7 +1279,7 @@ jobs:
           echo "      github_token: \${secrets:GITHUB_TOKEN}" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.pulls LIMIT 20'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.pulls'" >> spicepod.yaml
 
           echo "  - from: github:github.com/spiceai/spiceai/commits" >> spicepod.yaml
           echo "    name: spiceai.commits" >> spicepod.yaml
@@ -1287,7 +1287,7 @@ jobs:
           echo "      github_token: \${secrets:GITHUB_TOKEN}" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.commits LIMIT 20'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.commits'" >> spicepod.yaml
 
 
           echo "  - from: github:github.com/spiceai/spiceai/stargazers" >> spicepod.yaml
@@ -1296,7 +1296,7 @@ jobs:
           echo "      github_token: \${secrets:GITHUB_TOKEN}" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.stargazers LIMIT 20'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.stargazers'" >> spicepod.yaml
 
           cat spicepod.yaml
 

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1030,7 +1030,7 @@ jobs:
           if [[ -n "$MODE" ]]; then
             echo "      mode: $MODE" >> spicepod.yaml
           fi
-          echo "      refresh_sql: SELECT * FROM eth.recent_blocks" >> spicepod.yaml
+          echo "      refresh_sql: SELECT * FROM eth.recent_blocks LIMIT 1" >> spicepod.yaml
           echo "    params:" >> spicepod.yaml
           echo "      pg_host: localhost" >> spicepod.yaml
           echo "      pg_port: '5432'" >> spicepod.yaml
@@ -1076,7 +1076,7 @@ jobs:
       - name: Manually refresh dataset (with params)
         working-directory: test_app
         run: |
-          output=$(spice refresh eth.recent_blocks --refresh-jitter-max=1s --refresh-sql='SELECT * FROM eth.recent_blocks' 2>&1)
+          output=$(spice refresh eth.recent_blocks --refresh-jitter-max=1s --refresh-sql='SELECT * FROM eth.recent_blocks LIMIT 2' 2>&1)
           echo "$output"
           if [[ $output == *"Dataset refresh triggered"* ]]; then
             # time to refresh dataset
@@ -1145,7 +1145,7 @@ jobs:
           echo "      file_format: parquet" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: select * from customer;" >> spicepod.yaml
+          echo "      refresh_sql: select * from customer limit 1;" >> spicepod.yaml
           cat spicepod.yaml
 
       - name: Start spice runtime
@@ -1263,7 +1263,7 @@ jobs:
           echo "      include: \"**/*.md\"" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.files'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.files LIMIT 20'" >> spicepod.yaml
 
           echo "  - from: github:github.com/spiceai/spiceai/issues" >> spicepod.yaml
           echo "    name: spiceai.issues" >> spicepod.yaml
@@ -1271,7 +1271,7 @@ jobs:
           echo "      github_token: \${secrets:GITHUB_TOKEN}" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.issues'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.issues LIMIT 20'" >> spicepod.yaml
 
           echo "  - from: github:github.com/spiceai/spiceai/pulls" >> spicepod.yaml
           echo "    name: spiceai.pulls" >> spicepod.yaml
@@ -1279,7 +1279,7 @@ jobs:
           echo "      github_token: \${secrets:GITHUB_TOKEN}" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.pulls'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.pulls LIMIT 20'" >> spicepod.yaml
 
           echo "  - from: github:github.com/spiceai/spiceai/commits" >> spicepod.yaml
           echo "    name: spiceai.commits" >> spicepod.yaml
@@ -1287,7 +1287,7 @@ jobs:
           echo "      github_token: \${secrets:GITHUB_TOKEN}" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.commits'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.commits LIMIT 20'" >> spicepod.yaml
 
 
           echo "  - from: github:github.com/spiceai/spiceai/stargazers" >> spicepod.yaml
@@ -1296,7 +1296,7 @@ jobs:
           echo "      github_token: \${secrets:GITHUB_TOKEN}" >> spicepod.yaml
           echo "    acceleration:" >> spicepod.yaml
           echo "      enabled: true" >> spicepod.yaml
-          echo "      refresh_sql: 'SELECT * FROM spiceai.stargazers'" >> spicepod.yaml
+          echo "      refresh_sql: 'SELECT * FROM spiceai.stargazers LIMIT 20'" >> spicepod.yaml
 
           cat spicepod.yaml
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -24,7 +24,6 @@ use crate::parameters::ParameterSpec;
 use crate::parameters::Parameters;
 use crate::secrets::Secrets;
 use crate::Runtime;
-use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use datafusion::catalog::CatalogProvider;
@@ -438,7 +437,7 @@ pub async fn get_data(
     table_provider: Arc<dyn TableProvider>,
     sql: Option<String>,
     filters: Vec<Expr>,
-) -> Result<(SchemaRef, SendableRecordBatchStream), DataFusionError> {
+) -> Result<SendableRecordBatchStream, DataFusionError> {
     let mut df = match sql {
         None => {
             let table_source = Arc::new(DefaultTableSource::new(Arc::clone(&table_provider)));
@@ -462,7 +461,7 @@ pub async fn get_data(
     tracing::info!(target: "task_history", sql = %sql, "labels");
 
     let record_batch_stream = df.execute_stream().await.map_err(find_datafusion_root)?;
-    Ok((table_provider.schema(), record_batch_stream))
+    Ok(record_batch_stream)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -95,13 +95,6 @@ pub fn validate_refresh_sql(
                     }
                 );
                 ensure!(
-                    query.limit.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "LIMIT",
-                        expected_table,
-                    }
-                );
-                ensure!(
                     query.offset.is_none(),
                     UnexpectedExpressionSnafu {
                         expr: "OFFSET",

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -238,3 +238,104 @@ fn validate_select_columns(
 
     Ok(Arc::new(Schema::new(fields)))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    fn create_test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, true),
+        ]))
+    }
+
+    #[test]
+    fn test_valid_select_all() -> Result<()> {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT * FROM test_table";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert_eq!(result.fields().len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_valid_select_columns() -> Result<()> {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT id, name FROM test_table";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert_eq!(result.fields().len(), 2);
+        assert_eq!(result.field(0).name(), "id");
+        assert_eq!(result.field(1).name(), "name");
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_column() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT id, invalid_column FROM test_table";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        assert!(matches!(result, Err(Error::ColumnNotFoundInSource { .. })));
+    }
+
+    #[test]
+    fn test_invalid_table() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT id FROM wrong_table";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        assert!(matches!(result, Err(Error::InvalidSqlStatement { .. })));
+    }
+
+    #[test]
+    fn test_invalid_expression() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT id + 1 FROM test_table";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        assert!(matches!(result, Err(Error::OnlyColumnReferences { .. })));
+    }
+
+    #[test]
+    fn test_invalid_alias() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT id as user_id FROM test_table";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        assert!(matches!(result, Err(Error::OnlyColumnReferences { .. })));
+    }
+
+    #[test]
+    fn test_invalid_group_by() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT id FROM test_table GROUP BY id";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        assert!(matches!(result, Err(Error::InvalidSqlStatement { .. })));
+    }
+
+    #[test]
+    fn test_multiple_statements() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT id FROM test_table; SELECT name FROM test_table";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
+        assert!(matches!(
+            result,
+            Err(Error::ExpectedSingleSqlStatement { .. })
+        ));
+    }
+}

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -29,18 +29,26 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Unable to parse the refresh SQL: {source}"))]
+    #[snafu(display(
+        "The provided Refresh SQL could not be parsed.\n{source}\nCheck the SQL for syntax errors."
+    ))]
     UnableToParseSql {
         source: sqlparser::parser::ParserError,
     },
 
     #[snafu(display(
-        "Expected a single SQL statement for the refresh SQL, found {num_statements}"
+        "Expected a single SQL statement for the refresh SQL, found {num_statements}.\nRewrite the SQL to only contain a single SELECT statement."
     ))]
     ExpectedSingleSqlStatement { num_statements: usize },
 
     #[snafu(display("Expected a SQL query starting with SELECT <columns> FROM {expected_table}"))]
     InvalidSqlStatement { expected_table: TableReference },
+
+    #[snafu(display("Unexpected '{expr}' in the Refresh SQL statement.\nRewrite the SQL to only perform WHERE filters, i.e. SELECT col1, col2, col3 FROM {expected_table} WHERE col1 = 'foo'"))]
+    UnexpectedExpression {
+        expr: &'static str,
+        expected_table: TableReference,
+    },
 
     #[snafu(display(
         "Only column references are allowed in the SELECT clause of the refresh SQL, custom expressions and aliases are not supported.\nChange the SQL to only use columns references, i.e. SELECT col1, col2, col3 FROM {expected_table}"
@@ -78,111 +86,231 @@ pub fn validate_refresh_sql(
     let statement = statements.pop_front().context(MissingStatementSnafu)?;
     match statement {
         Statement::Statement(statement) => match statement.as_ref() {
-            SQLStatement::Query(query) => match query.body.as_ref() {
-                SetExpr::Select(select) => {
-                    let refresh_schema = validate_select_columns(
-                        &select.projection,
-                        source_schema,
-                        &expected_table,
-                    )?;
-                    ensure!(
-                        select.from.len() == 1,
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.cluster_by.is_empty(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.connect_by.is_none(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.distinct.is_none(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.distribute_by.is_empty(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    match &select.group_by {
-                        GroupByExpr::All(modifiers) => {
-                            ensure!(
-                                modifiers.is_empty(),
-                                InvalidSqlStatementSnafu { expected_table }
-                            );
-                        }
-                        GroupByExpr::Expressions(exprs, modifiers) => {
-                            ensure!(
-                                exprs.is_empty(),
-                                InvalidSqlStatementSnafu { expected_table }
-                            );
-                            ensure!(
-                                modifiers.is_empty(),
-                                InvalidSqlStatementSnafu { expected_table }
-                            );
-                        }
+            SQLStatement::Query(query) => {
+                ensure!(
+                    query.fetch.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "FETCH",
+                        expected_table,
                     }
-                    ensure!(
-                        select.having.is_none(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.into.is_none(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.lateral_views.is_empty(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.named_window.is_empty(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.prewhere.is_none(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.qualify.is_none(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.sort_by.is_empty(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.top.is_none(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        select.value_table_mode.is_none(),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-
-                    match &select.from[0].relation {
-                        sqlparser::ast::TableFactor::Table { name, .. } => {
-                            let table_name_with_schema = name
-                                .0
-                                .iter()
-                                .map(|x| x.value.as_str())
-                                .collect::<Vec<_>>()
-                                .join(".");
-                            ensure!(
-                                TableReference::parse_str(&table_name_with_schema)
-                                    == expected_table,
-                                InvalidSqlStatementSnafu { expected_table }
-                            );
-                        }
-                        _ => {
-                            InvalidSqlStatementSnafu { expected_table }.fail()?;
-                        }
+                );
+                ensure!(
+                    query.limit.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "LIMIT",
+                        expected_table,
                     }
+                );
+                ensure!(
+                    query.offset.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "OFFSET",
+                        expected_table,
+                    }
+                );
+                ensure!(
+                    query.with.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "WITH",
+                        expected_table,
+                    }
+                );
+                ensure!(
+                    query.order_by.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "ORDER BY",
+                        expected_table,
+                    }
+                );
+                ensure!(
+                    query.fetch.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "FETCH",
+                        expected_table,
+                    }
+                );
+                ensure!(
+                    query.for_clause.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "FOR",
+                        expected_table,
+                    }
+                );
+                ensure!(
+                    query.limit_by.is_empty(),
+                    UnexpectedExpressionSnafu {
+                        expr: "LIMIT BY",
+                        expected_table,
+                    }
+                );
+                ensure!(
+                    query.format_clause.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "FORMAT",
+                        expected_table,
+                    }
+                );
+                ensure!(
+                    query.settings.is_none(),
+                    UnexpectedExpressionSnafu {
+                        expr: "SETTINGS",
+                        expected_table,
+                    }
+                );
+                match query.body.as_ref() {
+                    SetExpr::Select(select) => {
+                        let refresh_schema = validate_select_columns(
+                            &select.projection,
+                            source_schema,
+                            &expected_table,
+                        )?;
+                        ensure!(
+                            select.from.len() == 1,
+                            InvalidSqlStatementSnafu { expected_table }
+                        );
+                        ensure!(
+                            select.cluster_by.is_empty(),
+                            UnexpectedExpressionSnafu {
+                                expr: "CLUSTER BY",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.connect_by.is_none(),
+                            UnexpectedExpressionSnafu {
+                                expr: "CONNECT BY",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.distinct.is_none(),
+                            UnexpectedExpressionSnafu {
+                                expr: "DISTINCT",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.distribute_by.is_empty(),
+                            UnexpectedExpressionSnafu {
+                                expr: "DISTRIBUTE BY",
+                                expected_table,
+                            }
+                        );
+                        match &select.group_by {
+                            GroupByExpr::All(modifiers) => {
+                                ensure!(
+                                    modifiers.is_empty(),
+                                    UnexpectedExpressionSnafu {
+                                        expr: "GROUP BY",
+                                        expected_table,
+                                    }
+                                );
+                            }
+                            GroupByExpr::Expressions(exprs, modifiers) => {
+                                ensure!(
+                                    exprs.is_empty(),
+                                    UnexpectedExpressionSnafu {
+                                        expr: "GROUP BY",
+                                        expected_table,
+                                    }
+                                );
+                                ensure!(
+                                    modifiers.is_empty(),
+                                    UnexpectedExpressionSnafu {
+                                        expr: "GROUP BY",
+                                        expected_table,
+                                    }
+                                );
+                            }
+                        }
+                        ensure!(
+                            select.having.is_none(),
+                            UnexpectedExpressionSnafu {
+                                expr: "HAVING",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.into.is_none(),
+                            UnexpectedExpressionSnafu {
+                                expr: "INTO",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.lateral_views.is_empty(),
+                            UnexpectedExpressionSnafu {
+                                expr: "LATERAL VIEW",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.named_window.is_empty(),
+                            UnexpectedExpressionSnafu {
+                                expr: "WINDOW",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.prewhere.is_none(),
+                            UnexpectedExpressionSnafu {
+                                expr: "PREWHERE",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.qualify.is_none(),
+                            UnexpectedExpressionSnafu {
+                                expr: "QUALIFY",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.sort_by.is_empty(),
+                            UnexpectedExpressionSnafu {
+                                expr: "SORT BY",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.top.is_none(),
+                            UnexpectedExpressionSnafu {
+                                expr: "TOP",
+                                expected_table,
+                            }
+                        );
+                        ensure!(
+                            select.value_table_mode.is_none(),
+                            UnexpectedExpressionSnafu {
+                                expr: "AS VALUE",
+                                expected_table,
+                            }
+                        );
 
-                    Ok(refresh_schema)
+                        match &select.from[0].relation {
+                            sqlparser::ast::TableFactor::Table { name, .. } => {
+                                let table_name_with_schema = name
+                                    .0
+                                    .iter()
+                                    .map(|x| x.value.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join(".");
+                                ensure!(
+                                    TableReference::parse_str(&table_name_with_schema)
+                                        == expected_table,
+                                    InvalidSqlStatementSnafu { expected_table }
+                                );
+                            }
+                            _ => {
+                                InvalidSqlStatementSnafu { expected_table }.fail()?;
+                            }
+                        }
+
+                        Ok(refresh_schema)
+                    }
+                    _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
                 }
-                _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
-            },
+            }
             _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
         },
         _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
@@ -323,7 +451,7 @@ mod tests {
         let sql = "SELECT id FROM test_table GROUP BY id";
 
         let result = validate_refresh_sql(table, sql, Arc::clone(&schema));
-        assert!(matches!(result, Err(Error::InvalidSqlStatement { .. })));
+        assert!(matches!(result, Err(Error::UnexpectedExpression { .. })));
     }
 
     #[test]

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -14,10 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::Schema;
 use datafusion::sql::parser::{DFParser, Statement};
-use datafusion::sql::sqlparser::ast::SetExpr;
+use datafusion::sql::sqlparser::ast::{Expr, GroupByExpr, SelectItem, SetExpr};
 use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::{sqlparser, TableReference};
+use itertools::Itertools;
 use snafu::prelude::*;
 use sqlparser::ast::Statement as SQLStatement;
 
@@ -35,14 +39,33 @@ pub enum Error {
     ))]
     ExpectedSingleSqlStatement { num_statements: usize },
 
-    #[snafu(display("Expected a SQL query starting with SELECT * FROM {expected_table}"))]
+    #[snafu(display("Expected a SQL query starting with SELECT <columns> FROM {expected_table}"))]
     InvalidSqlStatement { expected_table: TableReference },
+
+    #[snafu(display(
+        "Only column references are allowed in the SELECT clause of the refresh SQL, custom expressions and aliases are not supported.\nChange the SQL to only use columns references, i.e. SELECT col1, col2, col3 FROM {expected_table}"
+    ))]
+    OnlyColumnReferences { expected_table: TableReference },
+
+    #[snafu(display(
+        "The column '{column}' is not present in the source table '{expected_table}', valid columns are: {valid_columns}\nRewrite the SQL to only select columns that exist in the source table."
+    ))]
+    ColumnNotFoundInSource {
+        column: Arc<str>,
+        valid_columns: Arc<str>,
+        expected_table: TableReference,
+    },
 
     #[snafu(display("Missing expected SQL statement - this is a bug in Spice.ai"))]
     MissingStatement,
 }
 
-pub fn validate_refresh_sql(expected_table: TableReference, refresh_sql: &str) -> Result<()> {
+#[allow(clippy::too_many_lines)]
+pub fn validate_refresh_sql(
+    expected_table: TableReference,
+    refresh_sql: &str,
+    source_schema: Arc<Schema>,
+) -> Result<Arc<Schema>> {
     let mut statements = DFParser::parse_sql_with_dialect(refresh_sql, &PostgreSqlDialect {})
         .context(UnableToParseSqlSnafu)?;
     if statements.len() != 1 {
@@ -57,19 +80,83 @@ pub fn validate_refresh_sql(expected_table: TableReference, refresh_sql: &str) -
         Statement::Statement(statement) => match statement.as_ref() {
             SQLStatement::Query(query) => match query.body.as_ref() {
                 SetExpr::Select(select) => {
-                    ensure!(
-                        select.projection.len() == 1,
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
-                    ensure!(
-                        matches!(
-                            select.projection[0],
-                            sqlparser::ast::SelectItem::Wildcard(_)
-                        ),
-                        InvalidSqlStatementSnafu { expected_table }
-                    );
+                    let refresh_schema = validate_select_columns(
+                        &select.projection,
+                        source_schema,
+                        &expected_table,
+                    )?;
                     ensure!(
                         select.from.len() == 1,
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.cluster_by.is_empty(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.connect_by.is_none(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.distinct.is_none(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.distribute_by.is_empty(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    match &select.group_by {
+                        GroupByExpr::All(modifiers) => {
+                            ensure!(
+                                modifiers.is_empty(),
+                                InvalidSqlStatementSnafu { expected_table }
+                            );
+                        }
+                        GroupByExpr::Expressions(exprs, modifiers) => {
+                            ensure!(
+                                exprs.is_empty(),
+                                InvalidSqlStatementSnafu { expected_table }
+                            );
+                            ensure!(
+                                modifiers.is_empty(),
+                                InvalidSqlStatementSnafu { expected_table }
+                            );
+                        }
+                    }
+                    ensure!(
+                        select.having.is_none(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.into.is_none(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.lateral_views.is_empty(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.named_window.is_empty(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.prewhere.is_none(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.qualify.is_none(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.sort_by.is_empty(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.top.is_none(),
+                        InvalidSqlStatementSnafu { expected_table }
+                    );
+                    ensure!(
+                        select.value_table_mode.is_none(),
                         InvalidSqlStatementSnafu { expected_table }
                     );
 
@@ -92,7 +179,7 @@ pub fn validate_refresh_sql(expected_table: TableReference, refresh_sql: &str) -
                         }
                     }
 
-                    Ok(())
+                    Ok(refresh_schema)
                 }
                 _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
             },
@@ -100,4 +187,54 @@ pub fn validate_refresh_sql(expected_table: TableReference, refresh_sql: &str) -
         },
         _ => InvalidSqlStatementSnafu { expected_table }.fail()?,
     }
+}
+
+#[allow(clippy::too_many_lines)]
+fn validate_select_columns(
+    select: &Vec<SelectItem>,
+    source_schema: Arc<Schema>,
+    expected_table: &TableReference,
+) -> Result<Arc<Schema>> {
+    // Wildcard will select all columns
+    if select.len() == 1 && matches!(select[0], SelectItem::Wildcard(_)) {
+        return Ok(source_schema);
+    }
+
+    let mut fields = vec![];
+    for select_item in select {
+        match select_item {
+            SelectItem::UnnamedExpr(expr) => match expr {
+                Expr::Identifier(ident) => {
+                    let column_name = ident.value.as_str();
+                    let Ok(field) = source_schema.field_with_name(column_name) else {
+                        return ColumnNotFoundInSourceSnafu {
+                            column: Arc::from(column_name),
+                            valid_columns: Arc::from(
+                                source_schema.fields().iter().map(|f| f.name()).join(", "),
+                            ),
+                            expected_table: expected_table.clone(),
+                        }
+                        .fail();
+                    };
+                    fields.push(field.clone());
+                }
+                _ => {
+                    return OnlyColumnReferencesSnafu {
+                        expected_table: expected_table.clone(),
+                    }
+                    .fail();
+                }
+            },
+            SelectItem::ExprWithAlias { .. }
+            | SelectItem::QualifiedWildcard(..)
+            | SelectItem::Wildcard(..) => {
+                return OnlyColumnReferencesSnafu {
+                    expected_table: expected_table.clone(),
+                }
+                .fail();
+            }
+        }
+    }
+
+    Ok(Arc::new(Schema::new(fields)))
 }

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -68,6 +68,18 @@ pub enum Error {
     MissingStatement,
 }
 
+macro_rules! ensure_no_expr {
+    ($condition:expr, $expr_name:expr, $expected_table:expr) => {
+        ensure!(
+            $condition,
+            UnexpectedExpressionSnafu {
+                expr: $expr_name,
+                expected_table: $expected_table.clone(),
+            }
+        );
+    };
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn validate_refresh_sql(
     expected_table: TableReference,
@@ -87,69 +99,15 @@ pub fn validate_refresh_sql(
     match statement {
         Statement::Statement(statement) => match statement.as_ref() {
             SQLStatement::Query(query) => {
-                ensure!(
-                    query.fetch.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "FETCH",
-                        expected_table,
-                    }
-                );
-                ensure!(
-                    query.offset.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "OFFSET",
-                        expected_table,
-                    }
-                );
-                ensure!(
-                    query.with.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "WITH",
-                        expected_table,
-                    }
-                );
-                ensure!(
-                    query.order_by.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "ORDER BY",
-                        expected_table,
-                    }
-                );
-                ensure!(
-                    query.fetch.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "FETCH",
-                        expected_table,
-                    }
-                );
-                ensure!(
-                    query.for_clause.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "FOR",
-                        expected_table,
-                    }
-                );
-                ensure!(
-                    query.limit_by.is_empty(),
-                    UnexpectedExpressionSnafu {
-                        expr: "LIMIT BY",
-                        expected_table,
-                    }
-                );
-                ensure!(
-                    query.format_clause.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "FORMAT",
-                        expected_table,
-                    }
-                );
-                ensure!(
-                    query.settings.is_none(),
-                    UnexpectedExpressionSnafu {
-                        expr: "SETTINGS",
-                        expected_table,
-                    }
-                );
+                ensure_no_expr!(query.fetch.is_none(), "FETCH", expected_table);
+                ensure_no_expr!(query.offset.is_none(), "OFFSET", expected_table);
+                ensure_no_expr!(query.with.is_none(), "WITH", expected_table);
+                ensure_no_expr!(query.order_by.is_none(), "ORDER BY", expected_table);
+                ensure_no_expr!(query.for_clause.is_none(), "FOR", expected_table);
+                ensure_no_expr!(query.limit_by.is_empty(), "LIMIT BY", expected_table);
+                ensure_no_expr!(query.format_clause.is_none(), "FORMAT", expected_table);
+                ensure_no_expr!(query.settings.is_none(), "SETTINGS", expected_table);
+
                 match query.body.as_ref() {
                     SetExpr::Select(select) => {
                         let refresh_schema = validate_select_columns(
@@ -161,123 +119,42 @@ pub fn validate_refresh_sql(
                             select.from.len() == 1,
                             InvalidSqlStatementSnafu { expected_table }
                         );
-                        ensure!(
-                            select.cluster_by.is_empty(),
-                            UnexpectedExpressionSnafu {
-                                expr: "CLUSTER BY",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
-                            select.connect_by.is_none(),
-                            UnexpectedExpressionSnafu {
-                                expr: "CONNECT BY",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
-                            select.distinct.is_none(),
-                            UnexpectedExpressionSnafu {
-                                expr: "DISTINCT",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
+
+                        ensure_no_expr!(select.cluster_by.is_empty(), "CLUSTER BY", expected_table);
+                        ensure_no_expr!(select.connect_by.is_none(), "CONNECT BY", expected_table);
+                        ensure_no_expr!(select.distinct.is_none(), "DISTINCT", expected_table);
+                        ensure_no_expr!(
                             select.distribute_by.is_empty(),
-                            UnexpectedExpressionSnafu {
-                                expr: "DISTRIBUTE BY",
-                                expected_table,
-                            }
+                            "DISTRIBUTE BY",
+                            expected_table
                         );
+
                         match &select.group_by {
                             GroupByExpr::All(modifiers) => {
-                                ensure!(
-                                    modifiers.is_empty(),
-                                    UnexpectedExpressionSnafu {
-                                        expr: "GROUP BY",
-                                        expected_table,
-                                    }
-                                );
+                                ensure_no_expr!(modifiers.is_empty(), "GROUP BY", expected_table);
                             }
                             GroupByExpr::Expressions(exprs, modifiers) => {
-                                ensure!(
-                                    exprs.is_empty(),
-                                    UnexpectedExpressionSnafu {
-                                        expr: "GROUP BY",
-                                        expected_table,
-                                    }
-                                );
-                                ensure!(
-                                    modifiers.is_empty(),
-                                    UnexpectedExpressionSnafu {
-                                        expr: "GROUP BY",
-                                        expected_table,
-                                    }
-                                );
+                                ensure_no_expr!(exprs.is_empty(), "GROUP BY", expected_table);
+                                ensure_no_expr!(modifiers.is_empty(), "GROUP BY", expected_table);
                             }
                         }
-                        ensure!(
-                            select.having.is_none(),
-                            UnexpectedExpressionSnafu {
-                                expr: "HAVING",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
-                            select.into.is_none(),
-                            UnexpectedExpressionSnafu {
-                                expr: "INTO",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
+
+                        ensure_no_expr!(select.having.is_none(), "HAVING", expected_table);
+                        ensure_no_expr!(select.into.is_none(), "INTO", expected_table);
+                        ensure_no_expr!(
                             select.lateral_views.is_empty(),
-                            UnexpectedExpressionSnafu {
-                                expr: "LATERAL VIEW",
-                                expected_table,
-                            }
+                            "LATERAL VIEW",
+                            expected_table
                         );
-                        ensure!(
-                            select.named_window.is_empty(),
-                            UnexpectedExpressionSnafu {
-                                expr: "WINDOW",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
-                            select.prewhere.is_none(),
-                            UnexpectedExpressionSnafu {
-                                expr: "PREWHERE",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
-                            select.qualify.is_none(),
-                            UnexpectedExpressionSnafu {
-                                expr: "QUALIFY",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
-                            select.sort_by.is_empty(),
-                            UnexpectedExpressionSnafu {
-                                expr: "SORT BY",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
-                            select.top.is_none(),
-                            UnexpectedExpressionSnafu {
-                                expr: "TOP",
-                                expected_table,
-                            }
-                        );
-                        ensure!(
+                        ensure_no_expr!(select.named_window.is_empty(), "WINDOW", expected_table);
+                        ensure_no_expr!(select.prewhere.is_none(), "PREWHERE", expected_table);
+                        ensure_no_expr!(select.qualify.is_none(), "QUALIFY", expected_table);
+                        ensure_no_expr!(select.sort_by.is_empty(), "SORT BY", expected_table);
+                        ensure_no_expr!(select.top.is_none(), "TOP", expected_table);
+                        ensure_no_expr!(
                             select.value_table_mode.is_none(),
-                            UnexpectedExpressionSnafu {
-                                expr: "AS VALUE",
-                                expected_table,
-                            }
+                            "AS VALUE",
+                            expected_table
                         );
 
                         match &select.from[0].relation {

--- a/crates/runtime/src/tracers.rs
+++ b/crates/runtime/src/tracers.rs
@@ -115,3 +115,26 @@ macro_rules! warn_spaced {
         }
     }};
 }
+
+#[macro_export]
+macro_rules! error_spaced {
+    ($tracer:expr, $msg:expr, $key:expr) => {{
+        let mut logged_times = $tracer.logged_times.lock().unwrap_or_else(|poisoned| {
+            tracing::error!("Lock poisoned while logging: {poisoned}");
+            poisoned.into_inner()
+        });
+
+        let now = std::time::Instant::now();
+        let mut should_log = true;
+        if let Some(last_time) = logged_times.get($key) {
+            if now.duration_since(*last_time) < $tracer.interval {
+                should_log = false;
+            }
+        }
+
+        if should_log {
+            logged_times.insert($key.to_string(), now);
+            tracing::error!($msg, $key);
+        }
+    }};
+}


### PR DESCRIPTION
# 🗣 Description

Enables specifiying column references in the Refresh SQL to only accelerate a subset of columns from a source dataset.

i.e. this now works:

```yaml
datasets:
  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
    name: taxi_trips
    description: taxi trips in s3
    params:
      file_format: parquet
    acceleration:
      enabled: true
      refresh_sql: SELECT tpep_pickup_datetime, tpep_dropoff_datetime, trip_distance, total_amount FROM taxi_trips
```

This was fairly straightforward to implement, the bulk of the PR handling various error cases that can come up when parsing the Refresh SQL and validating it against the source schema. We also don't allow changing the schema after the dataset is registered.

## 🔨 Related Issues

Closes #3760

## 📄 Documentation Updates

We can remove the limitation of Refresh SQL not being able to specify column references.
https://github.com/spiceai/docs/pull/664
