### PR TITLE
Implement InvalidTypeAction for PostgreSQL Data Connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -3391,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a41d5b2d7b4c4c7abf9bbb777e53b0b9ce8c9f52#a41d5b2d7b4c4c7abf9bbb777e53b0b9ce8c9f52"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=54f82c8891d90a7da86148d7e96702bd3c9e6c8d#54f82c8891d90a7da86148d7e96702bd3c9e6c8d"
 dependencies = [
  "arrow",
  "arrow-json 53.2.0",
@@ -6139,7 +6139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8436,7 +8436,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -8469,7 +8469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=54f82c8891d90a7da86148d7e96702bd3c9e6c8d#54f82c8891d90a7da86148d7e96702bd3c9e6c8d"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=58baab01bdfd282261fbdbc9905a20835fe3cead#58baab01bdfd282261fbdbc9905a20835fe3cead"
 dependencies = [
  "arrow",
  "arrow-json 53.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,8 +149,7 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "2b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "1f37d9eda6da17b7644115f82d209c00c9566733" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
-# TODO: Change to final commit once https://github.com/datafusion-contrib/datafusion-table-providers/pull/191 is merged
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "54f82c8891d90a7da86148d7e96702bd3c9e6c8d" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "58baab01bdfd282261fbdbc9905a20835fe3cead" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "1034c325aee35eb704e741f56ed942ae22ff4e19" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,8 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "2b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "1f37d9eda6da17b7644115f82d209c00c9566733" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a41d5b2d7b4c4c7abf9bbb777e53b0b9ce8c9f52" }
+# TODO: Change to final commit once https://github.com/datafusion-contrib/datafusion-table-providers/pull/191 is merged
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "54f82c8891d90a7da86148d7e96702bd3c9e6c8d" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "1034c325aee35eb704e741f56ed942ae22ff4e19" }
 

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -227,6 +227,14 @@ pub enum DataConnectorError {
         connector_component: ConnectorComponent,
     },
 
+    #[snafu(display("Failed to load the {connector_component} ({dataconnector}).\nThe field '{field_name}' has an unsupported data type: {data_type}.\nSkip loading this field by setting the `invalid_type_action` parameter to `ignore` or `warn` in the dataset configuration.\nFor details, visit: https://docs.spiceai.org/reference/spicepod/datasets#invalid_type_action"))]
+    UnsupportedDataType {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+        data_type: String,
+        field_name: String,
+    },
+
     #[snafu(display("Failed to initialize the {connector_component} (ODBC).\nThe runtime is built without ODBC support.\nBuild Spice.ai OSS with the `odbc` feature enabled or use the Docker image that includes ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
     OdbcNotInstalled {
         connector_component: ConnectorComponent,


### PR DESCRIPTION
# 🗣 Description

Implements the [`InvalidTypeAction`](https://docs.spiceai.org/reference/spicepod/datasets#invalid_type_action) parameter for the PostgreSQL Data Connector.

This change depends on https://github.com/datafusion-contrib/datafusion-table-providers/pull/191 which will no longer panic on unsupported types, and will integrate with the `InvalidTypeAction` specified in the spicepod.

This PR also adds a new DataConnector error message for unsupported types and logs them as an error if they are encountered, to match with the behavior the user specifies for the `InvalidTypeAction`.

If `invalid_type_action: error` (default):

```
2024-12-04T07:49:39.958986Z ERROR runtime::init::dataset: Failed to load the dataset test (postgres).
The field 'the_jsonb_col' has an unsupported data type: jsonb.
Skip loading this field by setting the `invalid_type_action` parameter to `ignore` or `warn` in the dataset configuration.
For details, visit: https://docs.spiceai.org/reference/spicepod/datasets#invalid_type_action
```

If `invalid_type_action: warn`:

```
2024-12-04T07:50:14.808911Z  WARN datafusion_table_providers::sql::db_connection_pool::dbconnection::postgresconn: The field 'the_jsonb_col' has an unsupported data type: jsonb.
```

If `invalid_type_action: ignore`: Nothing is logged, the table silently skips the columns it can't support.

## 📄 Documentation Updates

Will require a small update to docs to include this data connector as supporting the invalid type action parameter.
https://github.com/spiceai/docs/pull/665

## 🤔 Concerns

N/A
