### PR TITLE
Implement vector search benchmark initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9312,6 +9312,7 @@ dependencies = [
  "graph-rs-sdk",
  "graphql-parser",
  "headers-accept",
+ "hf-hub",
  "http 1.1.0",
  "http-body-util",
  "hyper 1.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ futures = "0.3.30"
 globset = "0.4.15"
 graph-rs-sdk = { git = "https://github.com/spiceai/graph-rs-sdk", rev = "f8703df260146b313461029d41c4a021306832b8" }
 graphql-parser = "0.4.0"
+hf-hub = { version = "0.3.0", features = ["tokio"] }
 http = "1.1.0"
 insta = { version = "1.41.1", features = ["filters"] }
 itertools = "0.13"

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,14 @@ test-integration-models-without-openai:
 test-bench:
 	@cargo bench -p runtime --features postgres,spark,mysql
 
+PHONY: test-bench-vector-search
+test-bench-vector-search:
+	@cargo bench -p runtime --bench vector_search --features models
+
+PHONY: test-bench-vector-search-with-metal
+test-bench-vector-search-with-metal:
+	@cargo bench -p runtime --bench vector_search --features models,metal
+
 .PHONY: lint lint-go lint-rust
 lint: lint-go lint-rust
 

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -18,7 +18,7 @@ async-stream.workspace = true
 async-trait.workspace = true
 bytes = "1.6.0"
 futures = { workspace = true }
-hf-hub = { version = "0.3.0", features = ["tokio"] }
+hf-hub.workspace = true
 insta = { workspace = true, features = ["filters"] }
 regex = "1.10.4"
 reqwest.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -134,6 +134,7 @@ azure_storage = "0.21.0"
 azure_storage_blobs = "0.21.0"
 bollard = "0.18.1"
 flightrepl = { path = "../flightrepl" }
+hf-hub = { workspace = true }
 insta.workspace = true
 jsonpath-rust = "0.7.3"
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio-current-thread"] }
@@ -193,6 +194,10 @@ sqlite = [
 [[bench]]
 harness = false
 name = "bench"
+
+[[bench]]
+name = "vector_search"
+harness = false
 
 [target.'cfg(windows)'.dependencies]
 winver = "1.0.0"

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -45,6 +45,7 @@ use spicepod::component::params::Params;
 
 mod results;
 mod setup;
+mod utils;
 
 mod bench_object_store;
 mod bench_spicecloud;

--- a/crates/runtime/benches/bench_search/datasets.rs
+++ b/crates/runtime/benches/bench_search/datasets.rs
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use app::AppBuilder;
+use hf_hub::{api::tokio::ApiBuilder, Repo, RepoType};
+use spicepod::component::{
+    dataset::{acceleration::Acceleration, Dataset},
+    embeddings::ColumnEmbeddingConfig,
+};
+
+/// The `QuoraRetrieval` MTEB dataset is a benchmark dataset used for evaluating retrieval models.
+/// It consists of 177,163 rows and 1000 test queries.
+/// `https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/`
+pub(crate) async fn add_mtep_quora_retrieval_dataset(
+    app_builder: AppBuilder,
+    acceleration: Option<Acceleration>,
+) -> Result<AppBuilder, String> {
+    let hf_api = ApiBuilder::new()
+        .with_progress(false)
+        .build()
+        .map_err(|e| format!("Failed to initialize api to download huggingface dataset: {e}"))?;
+
+    let repo = Repo::new(
+        "datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2".to_string(),
+        RepoType::Model,
+    );
+
+    let api_repo = hf_api.repo(repo);
+
+    let data_path = api_repo
+        .get("corpus/test-00000-of-00001.parquet")
+        .await
+        .map_err(|e| format!("Failed to download huggingface file: {e}"))?;
+    let data_path_str = data_path
+        .to_str()
+        .ok_or("Failed to convert PathBuf to str")?;
+
+    let test_queries_path = api_repo
+        .get("queries/test-00000-of-00001.parquet")
+        .await
+        .map_err(|e| format!("Failed to download huggingface file: {e}"))?;
+    let test_queries_path_str = test_queries_path
+        .to_str()
+        .ok_or("Failed to convert PathBuf to str")?;
+
+    let tests_path = api_repo
+        .get("queries/test-00000-of-00001.parquet")
+        .await
+        .map_err(|e| format!("Failed to download huggingface file: {e}"))?;
+    let tests_path_str = tests_path
+        .to_str()
+        .ok_or("Failed to convert PathBuf to str")?;
+
+    let mut ds_data = make_local_file_dataset(data_path_str, "data");
+    ds_data.acceleration = acceleration;
+    ds_data.embeddings = vec![ColumnEmbeddingConfig {
+        column: "text".to_string(),
+        model: "test_model".to_string(),
+        primary_keys: Some(vec!["_id".to_string()]),
+        chunking: None,
+    }];
+
+    Ok(app_builder
+        .with_dataset(ds_data)
+        .with_dataset(make_local_file_dataset(test_queries_path_str, "test_query"))
+        .with_dataset(make_local_file_dataset(tests_path_str, "tests")))
+}
+
+fn make_local_file_dataset(path: &str, name: &str) -> Dataset {
+    Dataset::new(format!("file:{path}"), name.to_string())
+}

--- a/crates/runtime/benches/bench_search/mod.rs
+++ b/crates/runtime/benches/bench_search/mod.rs
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+mod datasets;
+pub mod setup;

--- a/crates/runtime/benches/bench_search/setup.rs
+++ b/crates/runtime/benches/bench_search/setup.rs
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use runtime::Runtime;
+
+use crate::utils::init_tracing;
+
+use app::AppBuilder;
+use spicepod::component::{
+    dataset::acceleration::Acceleration, embeddings::Embeddings, runtime::ResultsCache,
+};
+
+pub(crate) async fn setup_benchmark(
+    test_dataset: &str,
+    embeddings_model: &str,
+    acceleration: Option<Acceleration>,
+) -> Result<Runtime, String> {
+    init_tracing();
+
+    let app = build_bench_app(test_dataset, embeddings_model, acceleration)
+        .await?
+        .build();
+
+    let rt = Runtime::builder().with_app(app).build().await;
+
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(5 * 60)) => {
+            panic!("Timed out waiting for datasets to load in setup_benchmark()");
+        }
+        () = rt.load_components() => {}
+    }
+
+    Ok(rt)
+}
+
+async fn build_bench_app(
+    test_dataset: &str,
+    embeddings_model: &str,
+    acceleration: Option<Acceleration>,
+) -> Result<AppBuilder, String> {
+    let app_builder = AppBuilder::new("vector_search_benchmark_test")
+        .with_results_cache(ResultsCache {
+            enabled: false,
+            cache_max_size: None,
+            item_ttl: None,
+            eviction_policy: None,
+        })
+        .with_embedding(Embeddings::new(embeddings_model, "test_model"));
+
+    add_benchmark_dataset(app_builder, test_dataset, acceleration).await
+}
+
+async fn add_benchmark_dataset(
+    app_builder: AppBuilder,
+    dataset: &str,
+    acceleration: Option<Acceleration>,
+) -> Result<AppBuilder, String> {
+    match dataset {
+        "QuoraRetrieval" => {
+            super::datasets::add_mtep_quora_retrieval_dataset(app_builder, acceleration).await
+        }
+        _ => Err(format!("Unknown benchmark dataset: {dataset}")),
+    }
+}

--- a/crates/runtime/benches/utils/mod.rs
+++ b/crates/runtime/benches/utils/mod.rs
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{future::Future, time::Duration};
+
+use runtime::Runtime;
+use tracing_subscriber::EnvFilter;
+
+pub(crate) fn init_tracing() {
+    let filter = match std::env::var("SPICED_LOG").ok() {
+        Some(level) => EnvFilter::new(level),
+        _ => EnvFilter::new(
+            "runtime=TRACE,datafusion-federation=TRACE,datafusion-federation-sql=TRACE,bench=TRACE",
+        ),
+    };
+
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(filter)
+        .with_ansi(true)
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+pub(crate) async fn runtime_ready_check(rt: &Runtime, wait_time: Duration) {
+    assert!(wait_until_true(wait_time, || async { rt.status().is_ready() }).await);
+}
+
+pub(crate) async fn wait_until_true<F, Fut>(max_wait: Duration, mut f: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let start = std::time::Instant::now();
+    while start.elapsed() < max_wait {
+        if f().await {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    false
+}

--- a/crates/runtime/benches/vector_search.rs
+++ b/crates/runtime/benches/vector_search.rs
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{sync::Arc, time::Duration};
+
+use bench_search::setup::setup_benchmark;
+use runtime::request::{Protocol, RequestContext, UserAgent};
+use spicepod::component::dataset::acceleration::Acceleration;
+use utils::runtime_ready_check;
+
+mod bench_search;
+mod utils;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    let request_context = Arc::new(
+        RequestContext::builder(Protocol::Internal)
+            .with_user_agent(UserAgent::from_ua_str(&format!(
+                "spicebench/{}",
+                env!("CARGO_PKG_VERSION")
+            )))
+            .build(),
+    );
+
+    Box::pin(request_context.scope(vector_search_benchmark())).await
+}
+
+async fn vector_search_benchmark() -> Result<(), String> {
+    let acceleration = Some(Acceleration {
+        enabled: true,
+        // TODO: temporary limit amout of data to speed up developement/testing. This will be removed in the future.
+        refresh_sql: Some("select * from data limit 5000".into()),
+        ..Default::default()
+    });
+
+    let rt = setup_benchmark(
+        "QuoraRetrieval",
+        "huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2",
+        acceleration,
+    )
+    .await?;
+
+    // wait untill embeddings are created during initial data load
+    runtime_ready_check(&rt, Duration::from_secs(5 * 60)).await;
+
+    Ok(())
+}


### PR DESCRIPTION
# 🗣 Description

Implement vector search benchmark initialization:
 - Tracing
 - Test Spicepod  with [MTEB Quora Retrieval dataset](https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/) initialization


```shell
make test-bench-vector-search
```
or 
```shell
make test-bench-vector-search-with-metal
```

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3012

Closes https://github.com/spiceai/spiceai/issues/3768

