### PR TITLE
Fix Delta DataType `Map` type mapping to arrow type

### DIFF
--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -253,7 +253,21 @@ fn map_delta_data_type_to_arrow_data_type(
         delta_kernel::schema::DataType::Map(map_type) => {
             let key_type = map_delta_data_type_to_arrow_data_type(map_type.key_type());
             let value_type = map_delta_data_type_to_arrow_data_type(map_type.value_type());
-            DataType::Dictionary(Box::new(key_type), Box::new(value_type))
+            DataType::Map(
+                Arc::new(Field::new_struct(
+                    map_type.type_name.clone(),
+                    vec![
+                        Arc::new(Field::new("keys", key_type, false)),
+                        Arc::new(Field::new(
+                            "values",
+                            value_type,
+                            map_type.value_contains_null(),
+                        )),
+                    ],
+                    false,
+                )),
+                false,
+            )
         }
     }
 }

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -257,9 +257,9 @@ fn map_delta_data_type_to_arrow_data_type(
                 Arc::new(Field::new_struct(
                     map_type.type_name.clone(),
                     vec![
-                        Arc::new(Field::new("keys", key_type, false)),
+                        Arc::new(Field::new("key", key_type, false)),
                         Arc::new(Field::new(
-                            "values",
+                            "value",
                             value_type,
                             map_type.value_contains_null(),
                         )),


### PR DESCRIPTION
# 🗣 Description

The equivalent arrow type of `delta_kernel::schema::DataType::Map` type is `DataType::Map`, instead of the `DataType::Dictionary` in current implementation. Update the mapping so that dictionary type data can be succesfully queried from delta table.

The field name and the key / value field name doesn't affect the conversion result.
Nullable of the field / key field / value field follows the [delta convention](https://docs.rs/delta_kernel/latest/src/delta_kernel/schema.rs.html#393) and [arrow convention](https://docs.rs/datafusion/latest/datafusion/common/arrow/ipc/struct.Map.html). 

e2e test of conversion will be covered in the integration test implemented in a later pr

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
