### PR TITLE
Add a `/v1/packages/generate` API to generate a Spicepod package from a GitHub repo.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1972,9 +1972,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
 ]
@@ -3462,6 +3462,12 @@ dependencies = [
  "tracing-subscriber",
  "util",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "defmac"
@@ -6139,7 +6145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6336,6 +6342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6454,6 +6466,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -7871,6 +7893,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "package"
+version = "1.0.0-rc.2"
+dependencies = [
+ "bytes",
+ "object_store",
+ "serde_yaml",
+ "snafu",
+ "spicepod",
+ "zip 2.2.1",
+]
+
+[[package]]
 name = "packedvec"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8436,7 +8470,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -8469,7 +8503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -12872,6 +12906,49 @@ dependencies = [
  "indexmap 2.7.0",
  "num_enum",
  "thiserror 1.0.68",
+]
+
+[[package]]
+name = "zip"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d52293fc86ea7cf13971b3bb81eb21683636e7ae24c729cdaf1b7c4157a352"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "hmac",
+ "indexmap 2.7.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 2.0.3",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7541,7 +7541,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=1f37d9eda6da17b7644115f82d209c00c9566733#1f37d9eda6da17b7644115f82d209c00c9566733"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4#cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9371,6 +9371,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk 0.26.0",
  "otel-arrow",
+ "package",
  "percent-encoding",
  "pin-project",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/model_components",
     "crates/ns_lookup",
     "crates/otel-arrow",
+    "crates/package",
     "crates/runtime",
     "crates/runtime-auth",
     "crates/spicepod",
@@ -54,6 +55,7 @@ axum = { version = "0.7.9", features = ["macros"] }
 base64 = "0.22.1"
 bb8 = "0.8"
 bb8-postgres = "0.8"
+bytes = "1.9.0"
 chrono = "0.4.38"
 clap = { version = "4.5.21", features = ["derive"] }
 clickhouse-rs = { git = "https://github.com/spiceai/clickhouse-rs.git", tag = "0.2.1", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "2b93a308f65df1ae0cd8f3f8194b9b60201a500f" }
 
 
-object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "1f37d9eda6da17b7644115f82d209c00c9566733" }
+object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a41d5b2d7b4c4c7abf9bbb777e53b0b9ce8c9f52" }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -18,7 +18,7 @@ async-stream.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 bb8 = {workspace = true, optional = true }
-bytes = "1.6.0"
+bytes.workspace = true
 chrono.workspace = true
 clickhouse-rs = { workspace = true, optional = true }
 datafusion-federation = { workspace = true }

--- a/crates/document_parse/Cargo.toml
+++ b/crates/document_parse/Cargo.toml
@@ -12,5 +12,5 @@ version.workspace = true
 docx-rs = { git = "https://github.com/spiceai/docx-rs", rev="2d86a60b58afb02b157f96b42a92626417e47f71"}
 lopdf = {git = "https://github.com/J-F-Liu/lopdf", rev = "38b8c25f3e92c578baf18928a8ce75d447a6009a" } # "0.34.0"
 snafu.workspace = true
-bytes = "1.6.0"
+bytes.workspace = true
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/flight_client/Cargo.toml
+++ b/crates/flight_client/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 arrow.workspace = true
 arrow-flight = { workspace = true, features = ["flight-sql-experimental"] }
 base64 = "0.22.1"
-bytes = "1.5.0"
+bytes.workspace = true
 futures.workspace = true
 rustls-native-certs = "0.8.1"
 rustls-pemfile = "2.1.3"

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -16,7 +16,7 @@ snafu.workspace = true
 async-openai.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-bytes = "1.6.0"
+bytes.workspace = true
 futures = { workspace = true }
 hf-hub = { version = "0.3.0", features = ["tokio"] }
 insta = { workspace = true, features = ["filters"] }

--- a/crates/package/Cargo.toml
+++ b/crates/package/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "package"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+object_store.workspace = true
+snafu.workspace = true
+serde_yaml.workspace = true
+spicepod = { path = "../spicepod" }
+zip = "2.2.1"
+bytes.workspace = true

--- a/crates/package/src/lib.rs
+++ b/crates/package/src/lib.rs
@@ -24,6 +24,8 @@ use std::{collections::HashSet, io::Write};
 use bytes::Bytes;
 use object_store::{path::Path, ObjectStore};
 use snafu::prelude::*;
+use spicepod::component::view::View;
+use spicepod::component::ComponentOrReference;
 use spicepod::spec::SpicepodDefinition;
 
 #[derive(Debug, Snafu)]
@@ -39,21 +41,69 @@ pub enum Error {
 
     #[snafu(display("Failed to write to zip archive.\n{}", source))]
     FailedToWriteZipFile { source: std::io::Error },
+
+    #[snafu(display(
+        "A file referenced by the Spicepod ({}) could not be retrieved.\n{}",
+        linked_file_path.display(),
+        source
+    ))]
+    FailedToGetLinkedFile {
+        linked_file_path: PathBuf,
+        source: object_store::Error,
+    },
+
+    #[snafu(display("A file referenced by the Spicepod is not a valid path.\n{}", source))]
+    LinkedFileNotAValidPath { source: object_store::path::Error },
+
+    #[snafu(display("Failed to parse the provided Spicepod component.\n{}", source))]
+    UnableToParseSpicepodComponent { source: serde_yaml::Error },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+enum PathReference {
+    Direct(Path),
+    YmlOrYaml {
+        base_path: PathBuf,
+        base_name: &'static str,
+    },
+    Retrieved {
+        file_path: PathBuf,
+        file_bytes: Bytes,
+    },
+}
+
+impl PathReference {
+    fn try_get_path(&self) -> Result<Path> {
+        match self {
+            PathReference::Direct(path) => Ok(path.clone()),
+            PathReference::YmlOrYaml {
+                base_path,
+                base_name,
+            } => Path::parse(
+                base_path
+                    .join(format!("{base_name}.yaml"))
+                    .to_string_lossy(),
+            )
+            .context(LinkedFileNotAValidPathSnafu),
+            PathReference::Retrieved { file_path, .. } => {
+                Path::parse(file_path.to_string_lossy()).context(LinkedFileNotAValidPathSnafu)
+            }
+        }
+    }
+}
 
 /// Creates a zip package from the given object store and path to a spicepod.yaml.
 ///
 /// It will parse the spicepod and find all of the linked files, and add them to the returned zip archive.
 pub async fn make_zip(store: &dyn ObjectStore, spicepod_path: &Path) -> Result<Bytes> {
     let (spicepod_bytes, spicepod) = get_root_spicepod(store, spicepod_path).await?;
-    let linked_file_paths = find_linked_files(&spicepod);
+    let linked_file_paths = find_linked_files(store, &spicepod).await?;
     let mut linked_files = Vec::new();
     for file_path in linked_file_paths {
-        // TODO: Can get in parallel
-        let file_bytes = get_file_bytes(store, &file_path).await?;
-        linked_files.push((file_path, file_bytes));
+        // Can get in parallel
+        let file_bytes = get_file_bytes_from_reference(store, &file_path).await?;
+        linked_files.push((file_path.try_get_path()?, file_bytes));
     }
 
     // Add the root spicepod to the zip
@@ -96,8 +146,135 @@ async fn get_root_spicepod(
     ))
 }
 
-fn find_linked_files(spicepod: &SpicepodDefinition) -> Vec<Path> {
-    vec![]
+/// Finds all of the files that are referenced by the given Spicepod.
+///
+/// References currently include:
+/// - `dependencies` to other Spicepods
+/// - `ref` for component references
+/// - `views.sql_ref` for references to SQL files
+///
+/// This could be improved to also include references to local data files for the file data connector.
+async fn find_linked_files(
+    store: &dyn ObjectStore,
+    spicepod: &SpicepodDefinition,
+) -> Result<Vec<PathReference>> {
+    let mut linked_files = Vec::new();
+
+    for dependency in &spicepod.dependencies {
+        let dependency_path = PathBuf::from("spicepods").join(dependency);
+        linked_files.push(PathReference::YmlOrYaml {
+            base_path: dependency_path,
+            base_name: "spicepod",
+        });
+    }
+
+    add_linked_components(&mut linked_files, &spicepod.catalogs, "catalog");
+    add_linked_components(&mut linked_files, &spicepod.datasets, "dataset");
+    add_linked_views(store, &mut linked_files, &spicepod.views).await?;
+    add_linked_components(&mut linked_files, &spicepod.models, "model");
+    add_linked_components(&mut linked_files, &spicepod.embeddings, "embeddings");
+    add_linked_components(&mut linked_files, &spicepod.tools, "tool");
+
+    Ok(linked_files)
+}
+
+fn add_linked_components<ComponentType>(
+    linked_files: &mut Vec<PathReference>,
+    components: &Vec<ComponentOrReference<ComponentType>>,
+    component_name: &'static str,
+) {
+    for component in components {
+        let ComponentOrReference::Reference(component_ref) = component else {
+            continue;
+        };
+
+        linked_files.push(PathReference::YmlOrYaml {
+            base_path: PathBuf::from(component_ref.r#ref.clone()),
+            base_name: component_name,
+        });
+    }
+}
+
+/// Views are a special case since their referenced components can also reference other SQL files.
+async fn add_linked_views(
+    store: &dyn ObjectStore,
+    linked_files: &mut Vec<PathReference>,
+    views: &Vec<ComponentOrReference<View>>,
+) -> Result<()> {
+    for view in views {
+        if let ComponentOrReference::Component(view) = &view {
+            if let Some(sql_ref) = &view.sql_ref {
+                linked_files.push(PathReference::Direct(
+                    Path::parse(sql_ref).context(LinkedFileNotAValidPathSnafu)?,
+                ));
+            }
+        }
+
+        let ComponentOrReference::Reference(component_ref) = view else {
+            continue;
+        };
+
+        // Need to download the view file to see if there are any `sql_ref`s
+        let referenced_view_bytes = get_file_bytes_from_reference(
+            store,
+            &PathReference::YmlOrYaml {
+                base_path: PathBuf::from(component_ref.r#ref.clone()),
+                base_name: "view",
+            },
+        )
+        .await?;
+
+        let file_path = PathBuf::from(component_ref.r#ref.clone()).join("view.yaml");
+        linked_files.push(PathReference::Retrieved {
+            file_path: file_path.clone(),
+            file_bytes: referenced_view_bytes.clone(),
+        });
+
+        let view_rdr = std::io::Cursor::new(referenced_view_bytes);
+        let view: View =
+            serde_yaml::from_reader(view_rdr).context(UnableToParseSpicepodComponentSnafu)?;
+
+        if let Some(sql_ref) = &view.sql_ref {
+            linked_files.push(PathReference::Direct(
+                Path::parse(sql_ref).context(LinkedFileNotAValidPathSnafu)?,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+async fn get_file_bytes_from_reference(
+    store: &dyn ObjectStore,
+    reference: &PathReference,
+) -> Result<Bytes> {
+    match reference {
+        PathReference::Direct(path) => get_file_bytes(store, path).await,
+        PathReference::YmlOrYaml {
+            base_path,
+            base_name,
+        } => {
+            let yaml_files = vec![format!("{base_name}.yaml"), format!("{base_name}.yml")];
+
+            let mut error: Option<Error> = None;
+            for yaml_file in yaml_files {
+                let file_path = Path::parse(base_path.join(yaml_file).to_string_lossy())
+                    .context(LinkedFileNotAValidPathSnafu)?;
+                match get_file_bytes(store, &file_path).await {
+                    Ok(bytes) => return Ok(bytes),
+                    Err(e) => error = Some(e),
+                }
+            }
+
+            let Some(error) = error else {
+                unreachable!(
+                    "unexpected error while trying to find a yaml file for a component reference"
+                )
+            };
+            Err(error)
+        }
+        PathReference::Retrieved { file_bytes, .. } => Ok(file_bytes.clone()),
+    }
 }
 
 async fn get_file_bytes(store: &dyn ObjectStore, file_path: &Path) -> Result<Bytes> {

--- a/crates/package/src/lib.rs
+++ b/crates/package/src/lib.rs
@@ -1,0 +1,145 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::missing_errors_doc)]
+
+//! Responsible for fetching Spicepods from an object store and packaging them into a zip file.
+
+use std::path::PathBuf;
+use std::{collections::HashSet, io::Write};
+
+use bytes::Bytes;
+use object_store::{path::Path, ObjectStore};
+use snafu::prelude::*;
+use spicepod::spec::SpicepodDefinition;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to read object from object store.\n{}", source))]
+    FailedToReadObject { source: object_store::Error },
+
+    #[snafu(display("Unable to parse the provided Spicepod.\n{}", source))]
+    FailedToParseSpicepod { source: serde_yaml::Error },
+
+    #[snafu(display("Failed to create zip archive.\n{}", source))]
+    FailedToCreateZip { source: zip::result::ZipError },
+
+    #[snafu(display("Failed to write to zip archive.\n{}", source))]
+    FailedToWriteZipFile { source: std::io::Error },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Creates a zip package from the given object store and path to a spicepod.yaml.
+///
+/// It will parse the spicepod and find all of the linked files, and add them to the returned zip archive.
+pub async fn make_zip(store: &dyn ObjectStore, spicepod_path: &Path) -> Result<Bytes> {
+    let (spicepod_bytes, spicepod) = get_root_spicepod(store, spicepod_path).await?;
+    let linked_file_paths = find_linked_files(&spicepod);
+    let mut linked_files = Vec::new();
+    for file_path in linked_file_paths {
+        // TODO: Can get in parallel
+        let file_bytes = get_file_bytes(store, &file_path).await?;
+        linked_files.push((file_path, file_bytes));
+    }
+
+    // Add the root spicepod to the zip
+    let mut zip = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+    zip.start_file("spicepod.yaml", options)
+        .context(FailedToCreateZipSnafu)?;
+    zip.write_all(&spicepod_bytes)
+        .context(FailedToWriteZipFileSnafu)?;
+
+    // Add all of the linked files to the zip
+    let mut directories = HashSet::new();
+    for (file_path, file_bytes) in linked_files {
+        let std_file_path = std::path::Path::new(file_path.as_ref());
+        add_file_to_zip(
+            &mut zip,
+            options,
+            &mut directories,
+            std_file_path,
+            &file_bytes,
+        )?;
+    }
+
+    Ok(Bytes::from(
+        zip.finish().context(FailedToCreateZipSnafu)?.into_inner(),
+    ))
+}
+
+async fn get_root_spicepod(
+    store: &dyn ObjectStore,
+    spicepod_path: &Path,
+) -> Result<(Bytes, SpicepodDefinition)> {
+    let spicepod_bytes = get_file_bytes(store, spicepod_path).await?;
+    // A clone of `Bytes` is just incrementing a reference count, so it's cheap.
+    let cursor = std::io::Cursor::new(spicepod_bytes.clone());
+    Ok((
+        spicepod_bytes,
+        serde_yaml::from_reader(cursor).context(FailedToParseSpicepodSnafu)?,
+    ))
+}
+
+fn find_linked_files(spicepod: &SpicepodDefinition) -> Vec<Path> {
+    vec![]
+}
+
+async fn get_file_bytes(store: &dyn ObjectStore, file_path: &Path) -> Result<Bytes> {
+    store
+        .get(file_path)
+        .await
+        .context(FailedToReadObjectSnafu)?
+        .bytes()
+        .await
+        .context(FailedToReadObjectSnafu)
+}
+
+fn add_file_to_zip(
+    zip: &mut zip::ZipWriter<std::io::Cursor<Vec<u8>>>,
+    options: zip::write::SimpleFileOptions,
+    directories: &mut HashSet<String>,
+    file_path: &std::path::Path,
+    file_bytes: &Bytes,
+) -> Result<()> {
+    let zip_path = file_path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+
+    // Create parent directories if they don't exist.
+    if let Some(parent) = std::path::Path::new(&zip_path).parent() {
+        let mut current = PathBuf::new();
+        for component in parent.components() {
+            current.push(component);
+            let dir_path = current.to_string_lossy().to_string() + "/";
+            if directories.insert(dir_path.clone()) {
+                // Only try to create directory if we haven't yet
+                zip.add_directory(&dir_path, options)
+                    .context(FailedToCreateZipSnafu)?;
+            }
+        }
+    }
+
+    zip.start_file(zip_path, options)
+        .context(FailedToCreateZipSnafu)?;
+    zip.write_all(file_bytes)
+        .context(FailedToWriteZipFileSnafu)?;
+    Ok(())
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -83,6 +83,7 @@ opentelemetry-proto = { version = "0.27", features = [
 ] }
 opentelemetry_sdk.workspace = true
 otel-arrow = { path = "../otel-arrow" }
+package = { path = "../package" }
 percent-encoding.workspace = true
 pin-project.workspace = true
 prometheus.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,7 +27,7 @@ aws-sdk-sts = { version = "1.50.0", optional = true }
 axum.workspace = true
 axum-extra = { version = "0.9.6", features = ["typed-header"] }
 base64.workspace = true
-bytes = { version = "1", default-features = false }
+bytes.workspace = true
 cache = { path = "../cache" }
 chrono = { version = "0.4.38" }
 clap.workspace = true

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -62,7 +62,8 @@ pub(crate) fn routes(
             "/v1/datasets/:name/acceleration",
             patch(v1::datasets::acceleration),
         )
-        .route("/v1/spicepods", get(v1::spicepods::get));
+        .route("/v1/spicepods", get(v1::spicepods::get))
+        .route("/v1/packages/generate", post(v1::packages::generate));
 
     if cfg!(feature = "models") {
         authenticated_router = authenticated_router

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -21,6 +21,7 @@ pub mod embeddings;
 pub mod inference;
 pub mod models;
 pub mod nsql;
+pub mod packages;
 pub mod query;
 pub mod ready;
 pub mod search;

--- a/crates/runtime/src/http/v1/packages.rs
+++ b/crates/runtime/src/http/v1/packages.rs
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{collections::HashMap, sync::Arc};
+
+use crate::datafusion::DataFusion;
+use axum::{
+    body::Bytes,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Extension,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct GeneratePackageRequest {
+    to: String, // github:{org}/{repo}/{sha}/{path_to_spicepod.yaml}
+    // params:
+    //   token: string
+    params: HashMap<String, String>,
+}
+// struct PackageRequest {
+//     org: String,
+//     repo: String,
+//     path: String,
+//     token: Option<String>,
+// }
+
+pub(crate) async fn generate(
+    Extension(df): Extension<Arc<DataFusion>>,
+    Json(payload): Json<PackageRequest>,
+) -> Response {
+    let store = GitHubRawObjectStore::try_new(
+        payload.org,
+        payload.repo,
+        payload.path,
+        payload.token.as_ref(),
+    );
+}

--- a/crates/runtime/src/http/v1/packages.rs
+++ b/crates/runtime/src/http/v1/packages.rs
@@ -49,7 +49,7 @@ pub(crate) async fn generate(Json(payload): Json<GeneratePackageRequest>) -> Res
 
     let parts: Vec<&str> = from.splitn(4, '/').collect();
     let (Some(&org), Some(&repo), Some(&sha), Some(&path)) =
-        (parts.get(0), parts.get(1), parts.get(2), parts.get(3))
+        (parts.first(), parts.get(1), parts.get(2), parts.get(3))
     else {
         return (StatusCode::BAD_REQUEST, "Invalid `from` field, specify a github source and retry (e.g. github:{org}/{repo}/{sha}/{path_to_spicepod.yaml})")
         .into_response();

--- a/crates/runtime/src/http/v1/packages.rs
+++ b/crates/runtime/src/http/v1/packages.rs
@@ -16,37 +16,68 @@ limitations under the License.
 
 use std::{collections::HashMap, sync::Arc};
 
-use crate::datafusion::DataFusion;
+use crate::objectstore::github::GitHubRawObjectStore;
 use axum::{
-    body::Bytes,
-    http::StatusCode,
+    http::{header::CONTENT_TYPE, StatusCode},
     response::{IntoResponse, Response},
-    Extension,
+    Json,
 };
+use object_store::{path::Path, ObjectStore};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct GeneratePackageRequest {
-    to: String, // github:{org}/{repo}/{sha}/{path_to_spicepod.yaml}
-    // params:
-    //   token: string
+pub struct GeneratePackageRequest {
+    from: String,
     params: HashMap<String, String>,
 }
-// struct PackageRequest {
-//     org: String,
-//     repo: String,
-//     path: String,
-//     token: Option<String>,
-// }
 
-pub(crate) async fn generate(
-    Extension(df): Extension<Arc<DataFusion>>,
-    Json(payload): Json<PackageRequest>,
-) -> Response {
-    let store = GitHubRawObjectStore::try_new(
-        payload.org,
-        payload.repo,
-        payload.path,
-        payload.token.as_ref(),
-    );
+pub(crate) async fn generate(Json(payload): Json<GeneratePackageRequest>) -> Response {
+    if !payload.from.starts_with("github:") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(
+                "Invalid `from` field, specify a github source and retry (e.g. github:{org}/{repo}/{sha}/{path_to_spicepod.yaml})",
+            ),
+        )
+            .into_response();
+    }
+
+    let Some(from) = payload.from.split(':').nth(1) else {
+        return (StatusCode::BAD_REQUEST, "Invalid `from` field, specify a github source and retry (e.g. github:{org}/{repo}/{sha}/{path_to_spicepod.yaml})")
+            .into_response();
+    };
+
+    let parts: Vec<&str> = from.splitn(4, '/').collect();
+    let (Some(&org), Some(&repo), Some(&sha), Some(&path)) =
+        (parts.get(0), parts.get(1), parts.get(2), parts.get(3))
+    else {
+        return (StatusCode::BAD_REQUEST, "Invalid `from` field, specify a github source and retry (e.g. github:{org}/{repo}/{sha}/{path_to_spicepod.yaml})")
+        .into_response();
+    };
+
+    let github_token = payload.params.get("github_token").map(String::as_str);
+
+    let store = match GitHubRawObjectStore::try_new(org, repo, sha, github_token) {
+        Ok(store) => Arc::new(store) as Arc<dyn ObjectStore>,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+        }
+    };
+
+    let path = match Path::parse(path) {
+        Ok(path) => path,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    let package_zip_bytes = match package::make_zip(&store, &path).await {
+        Ok(bytes) => bytes,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+
+    (
+        StatusCode::OK,
+        [(CONTENT_TYPE, "application/zip")],
+        package_zip_bytes,
+    )
+        .into_response()
 }

--- a/crates/runtime/src/objectstore/github.rs
+++ b/crates/runtime/src/objectstore/github.rs
@@ -18,11 +18,12 @@ use std::fmt::Display;
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
+use http::{HeaderMap, HeaderValue};
 use object_store::{
     http::{HttpBuilder, HttpStore},
     path::Path,
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOpts,
-    PutOptions, PutPayload, PutResult,
+    ClientOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOpts, PutOptions, PutPayload, PutResult,
 };
 use snafu::prelude::*;
 
@@ -32,6 +33,9 @@ pub enum Error {
         "An internal error occured while connecting to GitHub to download files.\n{source}"
     ))]
     HttpBuilderFailed { source: object_store::Error },
+
+    #[snafu(display("An invalid GitHub token was provided."))]
+    InvalidToken,
 }
 
 /// An implementation of the `ObjectStore` trait for raw.githubusercontent.com
@@ -47,11 +51,21 @@ impl GitHubRawObjectStore {
         org: impl Display,
         repo: impl Display,
         rev: impl Display,
+        token: Option<&str>,
     ) -> Result<Self, Error> {
+        let mut headers = HeaderMap::with_capacity(1);
+        if let Some(token) = token {
+            headers.insert(
+                "Authorization",
+                HeaderValue::from_str(&format!("token {token}"))
+                    .map_err(|_| InvalidTokenSnafu.build())?,
+            );
+        }
         let http_store = HttpBuilder::new()
             .with_url(format!(
-                "https://raw.githubusercontent.com/{org}/{repo}/refs/heads/{rev}"
+                "https://raw.githubusercontent.com/{org}/{repo}/{rev}"
             ))
+            .with_client_options(ClientOptions::default().with_default_headers(headers))
             .build()
             .context(HttpBuilderFailedSnafu)?;
         Ok(Self { http_store })
@@ -130,7 +144,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_opts() {
-        let store = GitHubRawObjectStore::try_new("spiceai", "spiceai", "trunk")
+        let store = GitHubRawObjectStore::try_new("spiceai", "spiceai", "refs/heads/trunk", None)
             .expect("failed to create store");
         let result = store
             .get_opts(&Path::from("README.md"), GetOptions::default())

--- a/crates/runtime/src/objectstore/github.rs
+++ b/crates/runtime/src/objectstore/github.rs
@@ -1,0 +1,141 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::fmt::Display;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use object_store::{
+    http::{HttpBuilder, HttpStore},
+    path::Path,
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOpts,
+    PutOptions, PutPayload, PutResult,
+};
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "An internal error occured while connecting to GitHub to download files.\n{source}"
+    ))]
+    HttpBuilderFailed { source: object_store::Error },
+}
+
+/// An implementation of the `ObjectStore` trait for raw.githubusercontent.com
+///
+/// This is logically a small wrapper on the existing HTTP Object Store, but just constrained to specific GitHub URLs
+#[derive(Debug)]
+pub struct GitHubRawObjectStore {
+    http_store: HttpStore,
+}
+
+impl GitHubRawObjectStore {
+    pub fn try_new(
+        org: impl Display,
+        repo: impl Display,
+        rev: impl Display,
+    ) -> Result<Self, Error> {
+        let http_store = HttpBuilder::new()
+            .with_url(format!(
+                "https://raw.githubusercontent.com/{org}/{repo}/refs/heads/{rev}"
+            ))
+            .build()
+            .context(HttpBuilderFailedSnafu)?;
+        Ok(Self { http_store })
+    }
+}
+
+impl Display for GitHubRawObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GitHubRawObjectStore")
+    }
+}
+
+#[async_trait]
+impl ObjectStore for GitHubRawObjectStore {
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> Result<GetResult, object_store::Error> {
+        self.http_store.get_opts(location, options).await
+    }
+
+    async fn put_opts(
+        &self,
+        _location: &Path,
+        _payload: PutPayload,
+        _opts: PutOptions,
+    ) -> Result<PutResult, object_store::Error> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        _location: &Path,
+        _opts: PutMultipartOpts,
+    ) -> Result<Box<dyn MultipartUpload>, object_store::Error> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn delete(&self, _location: &Path) -> Result<(), object_store::Error> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    fn list(
+        &self,
+        _prefix: Option<&Path>,
+    ) -> BoxStream<'_, Result<ObjectMeta, object_store::Error>> {
+        Box::pin(async_stream::stream! {
+            yield Err(object_store::Error::NotImplemented);
+        })
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        _prefix: Option<&Path>,
+    ) -> Result<ListResult, object_store::Error> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn copy(&self, _from: &Path, _to: &Path) -> Result<(), object_store::Error> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn copy_if_not_exists(
+        &self,
+        _from: &Path,
+        _to: &Path,
+    ) -> Result<(), object_store::Error> {
+        Err(object_store::Error::NotImplemented)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_opts() {
+        let store = GitHubRawObjectStore::try_new("spiceai", "spiceai", "trunk")
+            .expect("failed to create store");
+        let result = store
+            .get_opts(&Path::from("README.md"), GetOptions::default())
+            .await
+            .expect("failed to get README");
+        println!("{result:?}");
+    }
+}

--- a/crates/runtime/src/objectstore/mod.rs
+++ b/crates/runtime/src/objectstore/mod.rs
@@ -16,5 +16,6 @@ limitations under the License.
 
 #[cfg(feature = "ftp")]
 pub mod ftp;
+pub mod github;
 #[cfg(feature = "ftp")]
 pub mod sftp;


### PR DESCRIPTION
# 🗣 Description

Adds a new `POST /v1/packages/generate` API that takes the following input:

```json
{
  "from": "github:spicehq/registry-dev/55ff16006272aa0008233a1728889ede16268549/spicepods/ewgenius/quickstart/spicepod.yaml", 
  "params": {
    "github_token": "{token}"
  }
}
```

And returns a ZIP file of the Spicepod package. The package includes the `spicepod.yaml` and any files that are referenced by the `spicepod.yaml`.

This is implemented by delegating out to a new crate` package` that has a single public function `make_zip` that accepts an ObjectStore and a path to the root Spicepod in the object store.

## 📄 Documentation Updates

Will need a doc update

## 🤔 Concerns

The new `package` crate code duplicates some work that the `spicepod` crate does when loading a spicepod. The `spicepod` crate code should move over to how the `package` crate works, not the other way around.
