### PR TITLE
Set `Spice-Target-Source` header for `spice add`

### DIFF
--- a/bin/spice/pkg/http/client.go
+++ b/bin/spice/pkg/http/client.go
@@ -38,19 +38,23 @@ func RetryableClient() *retryablehttp.Client {
 	return client
 }
 
-func Get(url string, accept string) (*net_http.Response, error) {
+func Get(url string, accept string, headers map[string]string) (*net_http.Response, error) {
 	req, err := retryablehttp.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return do(req, accept)
+	return do(req, accept, headers)
 }
 
-func do(req *retryablehttp.Request, accept string) (*net_http.Response, error) {
+func do(req *retryablehttp.Request, accept string, headers map[string]string) (*net_http.Response, error) {
 	req.Header.Set("User-Agent", userAgent())
 	if accept != "" {
 		req.Header.Set("Accept", accept)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := RetryableClient().Do(req)

--- a/bin/spice/pkg/registry/spicerack.go
+++ b/bin/spice/pkg/registry/spicerack.go
@@ -58,7 +58,9 @@ func (r *SpiceRackRegistry) GetPod(podFullPath string) (string, error) {
 	}
 	failureMessage := fmt.Sprintf("An error occurred while fetching Spicepod '%s' from spicerack.org", podFullPath)
 
-	response, err := spice_http.Get(url, "application/zip")
+	response, err := spice_http.Get(url, "application/zip", map[string]string{
+		"Spice-Target-Source": "spice.ai",
+	})
 	if err != nil {
 		slog.Debug(fmt.Sprintf("%s: %s", failureMessage, err.Error()))
 		return "", errors.New(failureMessage)


### PR DESCRIPTION
# 🗣 Description

Adds the header `Spice-Target-Source` to rewrite the spicerack spicepods to reference the running spice instance.
