### PR TITLE
Run models integration tests on self-hosted macOS runners

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -22,25 +22,14 @@ concurrency:
 jobs:
   build:
     name: Build Test Binary
-    runs-on: spiceai-runners
+    runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          os: "linux"
-
-      - name: Set up make
-        uses: ./.github/actions/setup-make
-
-      - name: Set up cc
-        uses: ./.github/actions/setup-cc
 
       # Build the test binary without running tests
       - name: Build AI integration test binary
         run: |
-          TEST_BINARY_PATH=$(cargo test -p runtime --test integration_models --features models --no-run --message-format=json | jq -r 'select(.reason == "compiler-artifact" and (.target.kind | contains(["test"])) and .executable != null) | .executable')
+          TEST_BINARY_PATH=$(cargo test -p runtime --test integration_models --features models,metal --no-run --message-format=json | jq -r 'select(.reason == "compiler-artifact" and (.target.kind | contains(["test"])) and .executable != null) | .executable')
           cp $TEST_BINARY_PATH ./ai_integration_test
 
       # Upload the test binary as an artifact
@@ -51,20 +40,14 @@ jobs:
           path: ./ai_integration_test
           retention-days: 1
 
-  test:
-    name: AI Integration Tests
+  test-openai:
+    name: Test OpenAI Models
     needs: build
     permissions: read-all
-    runs-on: ubuntu-latest-16-cores
+    runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          os: "linux"
-
-      # Download the test binary artifact
       - name: Download test binary
         uses: actions/download-artifact@v4
         with:
@@ -88,5 +71,27 @@ jobs:
             echo "Error: OpenAI API key is not defined."
             exit 1
           fi
-          # Local and Huggingface models testing is not supported yet
-          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture --skip huggingface_test
+          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture openai_test
+
+  test-hf:
+    name: Test Huggingface Models
+    needs: build
+    permissions: read-all
+    runs-on: [self-hosted, macOS]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download test binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ai-integration-test-binary
+          path: ./integration_test
+
+      - name: Mark test binary as executable
+        run: |
+          ls -l ./integration_test
+          chmod +x ./integration_test/ai_integration_test
+
+      - name: Run integration test
+        run: |
+          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture huggingface_test


### PR DESCRIPTION
# 🗣 Description

Run models integration tests on self-hosted macOS runner

Example tests run: https://github.com/spiceai/spiceai/actions/runs/12186244097

Note: next step will be enabling local models tests on every PR once tests are stabilized/fixed (see concerns section)

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3728

## 🤔 Concerns

Tests are currently failing (unrelated to this change) and will be fixed in a follow-up PR
