### PR TITLE
Fix OpenAI models integration tests

### DIFF
--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -272,6 +272,12 @@ fn normalize_chat_completion_response(mut json: Value, normalize_message_content
         if let Some(completion_tokens) = usage.get_mut("completion_tokens") {
             *completion_tokens = json!("completion_tokens_val");
         }
+        if let Some(completion_tokens_details) = usage.get_mut("completion_tokens_details") {
+            *completion_tokens_details = json!("completion_tokens_details_val");
+        }
+        if let Some(prompt_tokens_details) = usage.get_mut("prompt_tokens_details") {
+            *prompt_tokens_details = json!("prompt_tokens_details_val");
+        }
         if let Some(prompt_tokens) = usage.get_mut("prompt_tokens") {
             *prompt_tokens = json!("prompt_tokens_val");
         }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_completion.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_completion.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/runtime/tests/models/openai.rs
 expression: "normalize_chat_completion_response(response, false)"
-snapshot_kind: text
 ---
 {
   "choices": [
@@ -26,7 +25,9 @@ snapshot_kind: text
   "system_fingerprint": "system_fingerprint_val",
   "usage": {
     "completion_tokens": "completion_tokens_val",
+    "completion_tokens_details": "completion_tokens_details_val",
     "prompt_tokens": "prompt_tokens_val",
+    "prompt_tokens_details": "prompt_tokens_details_val",
     "total_tokens": "total_tokens_val"
   }
 }


### PR DESCRIPTION
# 🗣 Description

Fix OpenAI models integration tests: chat_completion_response now contains additional fields (`completion_tokens_details`, `prompt_tokens_details`) that needs to be added to the snapshot

Example test run: https://github.com/spiceai/spiceai/actions/runs/12187616552

