### PR TITLE
Add `spice connect` for connecting to existing Spice.ai instances

### DIFF
--- a/bin/spice/cmd/add.go
+++ b/bin/spice/cmd/add.go
@@ -63,7 +63,7 @@ func getAddOrConnectCmdHandler(connect bool) func(cmd *cobra.Command, args []str
 
 		if connect {
 			if ctx.GetApiKey() == "" {
-				slog.Error("No Spice.ai API key provided, please run `spice login` first.")
+				slog.Error("A valid Spice.ai Cloud Platform API key was not provided. Run `spice login` to authenticate before proceeding.")
 				os.Exit(1)
 			}
 
@@ -144,11 +144,7 @@ func getAddOrConnectCmdHandler(connect bool) func(cmd *cobra.Command, args []str
 			}
 		}
 
-		if connect {
-			slog.Info(fmt.Sprintf("connected to %s\n", relativePath))
-		} else {
-			slog.Info(fmt.Sprintf("added %s\n", relativePath))
-		}
+		slog.Info(fmt.Sprintf("added %s\n", relativePath))
 
 		err = checkLatestCliReleaseVersion()
 		if err != nil && util.IsDebug() {

--- a/bin/spice/cmd/add.go
+++ b/bin/spice/cmd/add.go
@@ -41,7 +41,15 @@ var addCmd = &cobra.Command{
 	Example: `
 spice add spiceai/quickstart
 `,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: getAddOrConnectCmdHandler(false),
+}
+
+func init() {
+	RootCmd.AddCommand(addCmd)
+}
+
+func getAddOrConnectCmdHandler(connect bool) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
 		ctx := context.NewContext()
 		err := ctx.Init()
 		if err != nil {
@@ -53,9 +61,17 @@ spice add spiceai/quickstart
 
 		slog.Info(fmt.Sprintf("Getting Spicepod %s ...\n", podPath))
 
-		if ctx.GetApiKey() == "" {
-			slog.Error("No Spice.ai API key provided, please run `spice login` first.")
-			os.Exit(1)
+		if connect {
+			if ctx.GetApiKey() == "" {
+				slog.Error("No Spice.ai API key provided, please run `spice login` first.")
+				os.Exit(1)
+			}
+
+			headers := map[string]string{
+				"Spice-Target-Source": "spice.ai",
+				"X-API-Key":           ctx.GetApiKey(),
+			}
+			ctx.AddHeaders(headers)
 		}
 
 		r := registry.GetRegistry(podPath)
@@ -128,15 +144,15 @@ spice add spiceai/quickstart
 			}
 		}
 
-		slog.Info(fmt.Sprintf("added %s\n", relativePath))
+		if connect {
+			slog.Info(fmt.Sprintf("connected to %s\n", relativePath))
+		} else {
+			slog.Info(fmt.Sprintf("added %s\n", relativePath))
+		}
 
 		err = checkLatestCliReleaseVersion()
 		if err != nil && util.IsDebug() {
 			slog.Error("failed to check for latest CLI release version", "error", err)
 		}
-	},
-}
-
-func init() {
-	RootCmd.AddCommand(addCmd)
+	}
 }

--- a/bin/spice/cmd/add.go
+++ b/bin/spice/cmd/add.go
@@ -42,12 +42,24 @@ var addCmd = &cobra.Command{
 spice add spiceai/quickstart
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.NewContext()
+		err := ctx.Init()
+		if err != nil {
+			slog.Error("could not initialize runtime context", "error", err)
+			os.Exit(1)
+		}
+
 		podPath := args[0]
 
 		slog.Info(fmt.Sprintf("Getting Spicepod %s ...\n", podPath))
 
+		if ctx.GetApiKey() == "" {
+			slog.Error("No Spice.ai API key provided, please run `spice login` first.")
+			os.Exit(1)
+		}
+
 		r := registry.GetRegistry(podPath)
-		downloadPath, err := r.GetPod(podPath)
+		downloadPath, err := r.GetPod(ctx, podPath)
 		if err != nil {
 			var itemNotFound *registry.RegistryItemNotFound
 			if errors.As(err, &itemNotFound) {

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -259,7 +259,11 @@ func sendChatRequest(rtcontext *context.RuntimeContext, body *ChatRequestBody) (
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	request.Header = rtcontext.GetHeaders()
+	headers := rtcontext.GetHeaders()
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+	request.Header.Set("Content-Type", "application/json")
 
 	response, err := rtcontext.Client().Do(request)
 	if err != nil {

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -81,6 +81,11 @@ spice chat --model <model> --cloud
 	Run: func(cmd *cobra.Command, args []string) {
 		cloud, _ := cmd.Flags().GetBool(cloudKeyFlag)
 		rtcontext := context.NewContext().WithCloud(cloud)
+		err := rtcontext.Init()
+		if err != nil {
+			slog.Error("could not initialize runtime context", "error", err)
+			os.Exit(1)
+		}
 
 		apiKey, _ := cmd.Flags().GetString("api-key")
 		if apiKey != "" {

--- a/bin/spice/cmd/connect.go
+++ b/bin/spice/cmd/connect.go
@@ -22,7 +22,7 @@ import (
 
 var connectCmd = &cobra.Command{
 	Use:   "connect",
-	Short: "Connect the local Spicepod to a running Spice instance in Spice.ai",
+	Short: "Adds the Spice.ai Cloud Platform app Spicepod for local use.",
 	Args:  cobra.MinimumNArgs(1),
 	Example: `
 spice connect spiceai/quickstart

--- a/bin/spice/cmd/connect.go
+++ b/bin/spice/cmd/connect.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var connectCmd = &cobra.Command{
+	Use:   "connect",
+	Short: "Connect the local Spicepod to a running Spice instance in Spice.ai",
+	Args:  cobra.MinimumNArgs(1),
+	Example: `
+spice connect spiceai/quickstart
+`,
+	Run: getAddOrConnectCmdHandler(true),
+}
+
+func init() {
+	RootCmd.AddCommand(connectCmd)
+}

--- a/bin/spice/cmd/nsql.go
+++ b/bin/spice/cmd/nsql.go
@@ -204,7 +204,11 @@ func sendNsqlRequest(rtcontext *context.RuntimeContext, body *NsqlRequest) (*htt
 		return nil, fmt.Errorf("error creating nsql request: %w", err)
 	}
 
-	request.Header = rtcontext.GetHeaders()
+	headers := rtcontext.GetHeaders()
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "text/plain")
 
 	response, err := rtcontext.Client().Do(request)

--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -188,7 +188,11 @@ func sendSearchRequest(rtcontext *context.RuntimeContext, body *SearchRequest) (
 		return nil, fmt.Errorf("error creating search request: %w", err)
 	}
 
-	request.Header = rtcontext.GetHeaders()
+	headers := rtcontext.GetHeaders()
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+	request.Header.Set("Content-Type", "application/json")
 
 	response, err := rtcontext.Client().Do(request)
 	if err != nil {

--- a/bin/spice/pkg/api/client.go
+++ b/bin/spice/pkg/api/client.go
@@ -61,7 +61,7 @@ func NewSpiceApiClient() *SpiceApiClient {
 
 func (s *SpiceApiClient) Init() error {
 	if strings.HasSuffix(version.Version(), "-dev") {
-		s.baseUrl = "https://dev.spice.xyz"
+		s.baseUrl = "https://dev.spice.ai"
 	} else {
 		s.baseUrl = "https://spice.ai"
 	}

--- a/bin/spice/pkg/api/util.go
+++ b/bin/spice/pkg/api/util.go
@@ -44,7 +44,11 @@ func doRuntimeApiRequest[T interface{}](rtcontext *context.RuntimeContext, metho
 		if err != nil {
 			return *new(T), fmt.Errorf("error creating request: %w", err)
 		}
-		request.Header = rtcontext.GetHeaders()
+		headers := rtcontext.GetHeaders()
+		for key, value := range headers {
+			request.Header.Set(key, value)
+		}
+		request.Header.Set("Content-Type", "application/json")
 		resp, err = rtcontext.Client().Do(request)
 	case POST:
 		var reader io.Reader
@@ -56,7 +60,11 @@ func doRuntimeApiRequest[T interface{}](rtcontext *context.RuntimeContext, metho
 		if err != nil {
 			return *new(T), fmt.Errorf("error creating request: %w", err)
 		}
-		request.Header = rtcontext.GetHeaders()
+		headers := rtcontext.GetHeaders()
+		for key, value := range headers {
+			request.Header.Set(key, value)
+		}
+		request.Header.Set("Content-Type", "application/json")
 		resp, err = rtcontext.Client().Do(request)
 	default:
 		return *new(T), fmt.Errorf("unsupported method: %s", method)

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -52,7 +52,7 @@ type RuntimeContext struct {
 	httpClient      *http.Client
 	apiKey          string
 	userAgent       string
-	dotEnvValues    map[string]string
+	extraHeaders    map[string]string
 }
 
 func NewContext() *RuntimeContext {
@@ -61,6 +61,7 @@ func NewContext() *RuntimeContext {
 		metricsEndpoint: "http://127.0.0.1:9090",
 		httpClient:      &http.Client{},
 		userAgent:       util.GetSpiceUserAgent("spice"),
+		extraHeaders:    make(map[string]string),
 	}
 	err := rtcontext.Init()
 	if err != nil {
@@ -146,12 +147,12 @@ func (c *RuntimeContext) Init() error {
 	c.appDir = cwd
 	c.podsDir = filepath.Join(c.appDir, constants.SpicePodsDirectoryName)
 
-	c.dotEnvValues, err = loadDotEnvValues()
+	dotEnvValues, err := loadDotEnvValues()
 	if err != nil {
 		return err
 	}
 
-	if apiKey, ok := c.dotEnvValues["SPICE_SPICEAI_API_KEY"]; ok {
+	if apiKey, ok := dotEnvValues["SPICE_SPICEAI_API_KEY"]; ok {
 		c.apiKey = apiKey
 	}
 
@@ -351,19 +352,28 @@ func (c *RuntimeContext) SetUserAgentClient(client string) {
 	c.userAgent = util.GetSpiceUserAgent(client)
 }
 
-func (c *RuntimeContext) GetHeaders() http.Header {
-	headers := make(http.Header)
-	headers.Set("Content-Type", "application/json")
+func (c *RuntimeContext) AddHeaders(headers map[string]string) {
+	for key, value := range headers {
+		c.extraHeaders[key] = value
+	}
+}
+
+func (c *RuntimeContext) GetHeaders() map[string]string {
+	headers := make(map[string]string)
 
 	if c.isCloud {
 		apiKey := os.Getenv("SPICE_API_KEY")
 		if apiKey != "" {
-			headers.Set("X-API-Key", apiKey)
+			headers["X-API-Key"] = apiKey
 		}
 	}
 
 	if c.apiKey != "" {
-		headers.Set("X-API-Key", c.apiKey)
+		headers["X-API-Key"] = c.apiKey
+	}
+
+	for key, value := range c.extraHeaders {
+		headers[key] = value
 	}
 
 	return headers

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/constants"
 	"github.com/spiceai/spiceai/bin/spice/pkg/github"
@@ -51,6 +52,7 @@ type RuntimeContext struct {
 	httpClient      *http.Client
 	apiKey          string
 	userAgent       string
+	dotEnvValues    map[string]string
 }
 
 func NewContext() *RuntimeContext {
@@ -143,6 +145,15 @@ func (c *RuntimeContext) Init() error {
 
 	c.appDir = cwd
 	c.podsDir = filepath.Join(c.appDir, constants.SpicePodsDirectoryName)
+
+	c.dotEnvValues, err = loadDotEnvValues()
+	if err != nil {
+		return err
+	}
+
+	if apiKey, ok := c.dotEnvValues["SPICE_SPICEAI_API_KEY"]; ok {
+		c.apiKey = apiKey
+	}
 
 	return nil
 }
@@ -324,6 +335,10 @@ func (c *RuntimeContext) SetApiKey(apiKey string) {
 	c.apiKey = apiKey
 }
 
+func (c *RuntimeContext) GetApiKey() string {
+	return c.apiKey
+}
+
 func (c *RuntimeContext) SetUserAgent(userAgent string) {
 	c.userAgent = userAgent
 }
@@ -360,4 +375,15 @@ func (c *RuntimeContext) IsCloud() bool {
 
 func (c *RuntimeContext) SetHttpEndpoint(endpoint string) {
 	c.httpEndpoint = endpoint
+}
+
+func loadDotEnvValues() (map[string]string, error) {
+	env_file := ".env"
+	if _, err := os.Stat(".env.local"); err == nil {
+		env_file = ".env.local"
+	} else if _, err := os.Stat(env_file); err != nil {
+		return nil, nil
+	}
+
+	return godotenv.Read(env_file)
 }

--- a/bin/spice/pkg/registry/local_file.go
+++ b/bin/spice/pkg/registry/local_file.go
@@ -30,7 +30,7 @@ import (
 
 type LocalFileRegistry struct{}
 
-func (r *LocalFileRegistry) GetPod(podPath string) (string, error) {
+func (r *LocalFileRegistry) GetPod(ctx *context.RuntimeContext, podPath string) (string, error) {
 	stat, err := os.Stat(podPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -50,11 +50,9 @@ func (r *LocalFileRegistry) GetPod(podPath string) (string, error) {
 		}
 	}
 
-	rtcontext := context.NewContext()
-
 	// Validate source
 	podManifestFileName := fmt.Sprintf("%s.yaml", strings.ToLower(filepath.Base(podPath)))
-	podManifestPath := filepath.Join(rtcontext.PodsDir(), podManifestFileName)
+	podManifestPath := filepath.Join(ctx.PodsDir(), podManifestFileName)
 
 	if _, err := os.Stat(filepath.Join(podPath, podManifestFileName)); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -64,7 +62,7 @@ func (r *LocalFileRegistry) GetPod(podPath string) (string, error) {
 	}
 
 	// Prepare destination
-	podsDir := rtcontext.PodsDir()
+	podsDir := ctx.PodsDir()
 	if _, err = os.Stat(podsDir); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf("error fetching Spicepod %s: %w", podPath, err)

--- a/bin/spice/pkg/registry/registry.go
+++ b/bin/spice/pkg/registry/registry.go
@@ -19,10 +19,12 @@ package registry
 import (
 	"os"
 	"strings"
+
+	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 )
 
 type SpiceRegistry interface {
-	GetPod(podPath string) (string, error)
+	GetPod(ctx *context.RuntimeContext, podPath string) (string, error)
 }
 
 func GetRegistry(path string) SpiceRegistry {

--- a/bin/spice/pkg/registry/spicerack.go
+++ b/bin/spice/pkg/registry/spicerack.go
@@ -43,13 +43,17 @@ func getSpiceRackBaseUrl() string {
 	}
 }
 
-func (r *SpiceRackRegistry) GetPod(podFullPath string) (string, error) {
+func (r *SpiceRackRegistry) GetPod(ctx *context.RuntimeContext, podFullPath string) (string, error) {
 	parts := strings.Split(podFullPath, "@")
 	podPath := podFullPath
 	podVersion := ""
 	if len(parts) == 2 {
 		podPath = parts[0]
 		podVersion = parts[1]
+	}
+
+	if ctx.GetApiKey() == "" {
+		return "", fmt.Errorf("spicerack registry requires an API key")
 	}
 
 	url := fmt.Sprintf("%s/spicepods/%s", getSpiceRackBaseUrl(), podPath)
@@ -60,6 +64,7 @@ func (r *SpiceRackRegistry) GetPod(podFullPath string) (string, error) {
 
 	response, err := spice_http.Get(url, "application/zip", map[string]string{
 		"Spice-Target-Source": "spice.ai",
+		"X-API-Key":           ctx.GetApiKey(),
 	})
 	if err != nil {
 		slog.Debug(fmt.Sprintf("%s: %s", failureMessage, err.Error()))
@@ -86,7 +91,7 @@ func (r *SpiceRackRegistry) GetPod(podFullPath string) (string, error) {
 		return "", err
 	}
 
-	podsPath := context.NewContext().PodsDir()
+	podsPath := ctx.PodsDir()
 	podsPathWithName := filepath.Join(podsPath, podPath)
 
 	podsPerm, err := util.MkDirAllInheritPerm(podsPathWithName)

--- a/bin/spice/pkg/registry/spicerack.go
+++ b/bin/spice/pkg/registry/spicerack.go
@@ -52,20 +52,13 @@ func (r *SpiceRackRegistry) GetPod(ctx *context.RuntimeContext, podFullPath stri
 		podVersion = parts[1]
 	}
 
-	if ctx.GetApiKey() == "" {
-		return "", fmt.Errorf("spicerack registry requires an API key")
-	}
-
 	url := fmt.Sprintf("%s/spicepods/%s", getSpiceRackBaseUrl(), podPath)
 	if podVersion != "" {
 		url = fmt.Sprintf("%s/%s", url, podVersion)
 	}
 	failureMessage := fmt.Sprintf("An error occurred while fetching Spicepod '%s' from spicerack.org", podFullPath)
 
-	response, err := spice_http.Get(url, "application/zip", map[string]string{
-		"Spice-Target-Source": "spice.ai",
-		"X-API-Key":           ctx.GetApiKey(),
-	})
+	response, err := spice_http.Get(url, "application/zip", ctx.GetHeaders())
 	if err != nil {
 		slog.Debug(fmt.Sprintf("%s: %s", failureMessage, err.Error()))
 		return "", errors.New(failureMessage)


### PR DESCRIPTION
# 🗣 Description

Adds a new command `spice connect` that behaves similarly to `spice add` but will connect to a running Spice instance instead of pulling the original Spicepod. `spice connect` requires that you are already logged in via `spice login`.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
