### PR TITLE
Enable `trace_id` & `parent_span_id` overrides for `v1/chat/completion`

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -63,7 +63,11 @@ hyper-util = { version = "0.1.6", features = ["service"] }
 indexmap = "2"
 itertools.workspace = true
 jsonwebtoken = "9.3.0"
-keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "linux-native"], optional = true }
+keyring = { version = "3.6.1", features = [
+    "apple-native",
+    "windows-native",
+    "linux-native",
+], optional = true }
 lazy_static.workspace = true
 llms = { path = "../llms" }
 logos = "0.14.0"
@@ -197,8 +201,8 @@ harness = false
 name = "bench"
 
 [[bench]]
-name = "vector_search"
 harness = false
+name = "vector_search"
 
 [target.'cfg(windows)'.dependencies]
 winver = "1.0.0"

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -38,6 +38,8 @@ use crate::{
 
 mod metrics;
 mod routes;
+mod traceparent;
+
 mod v1;
 
 #[derive(Debug, Snafu)]

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -84,7 +84,6 @@ pub(crate) fn routes(
             .layer(Extension(vector_search))
             .layer(Extension(Arc::clone(&rt.embeds)));
     }
-
     authenticated_router = authenticated_router
         .layer(Extension(Arc::clone(&rt.app)))
         .layer(Extension(Arc::clone(&rt.df)))

--- a/crates/runtime/src/http/traceparent.rs
+++ b/crates/runtime/src/http/traceparent.rs
@@ -1,0 +1,99 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use axum::http::HeaderMap;
+use opentelemetry::trace::{SpanId, TraceId};
+use tracing::Span;
+
+const MAX_VERSION: u8 = 254;
+const TRACEPARENT_HEADER: &str = "traceparent";
+
+/// Use the span context from the traceparent header to override the `trace_id` & `parent_span_id` columns in the task history table.
+///
+/// Errors are not returned, invalid traceparent headers must be ignored.
+///
+/// This should not be used for any span within a HTTP API that has [HTTP Spans](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) created, as they are incompatible (both the `span` input and the span created for the HTTP handler will have the same `parent_span_id`, even though the `input` span would become a child of the HTTP span).
+pub(super) fn override_task_history_with_traceparent(span: &Span, headers: &HeaderMap) {
+    match extract_traceparent(headers) {
+        Ok(Some((trace_id, span_id))) => {
+            tracing::info!(target: "task_history", parent: span, trace_id = %trace_id, parent_id = %span_id);
+        }
+        Err(e) => {
+            tracing::warn!("Recieved invalid `traceparent` HTTP header: {e}");
+        }
+        _ => {}
+    }
+}
+
+fn extract_traceparent(headers: &HeaderMap) -> Result<Option<(TraceId, SpanId)>, String> {
+    let Some(header_value) = headers.get(TRACEPARENT_HEADER).map(|v| v.to_str()) else {
+        return Ok(None);
+    };
+    let header_value = header_value.map_err(|e| {
+        format!("In traceparent header, invalid traceparent header value, expected string, got {e}")
+    })?;
+    let parts = header_value.split_terminator('-').collect::<Vec<&str>>();
+    // Ensure parts are not out of range.
+    if parts.len() < 4 {
+        return Err(format!(
+            "In traceparent header, invalid traceparent header, expected 4 parts, got {}",
+            parts.len()
+        ));
+    }
+
+    // Ensure version is within range, for version 0 there must be 4 parts.
+    let version = u8::from_str_radix(parts[0], 16).map_err(|e| {
+        format!("In traceparent header, invalid traceparent version, expected hex value, got {e}")
+    })?;
+    if version > MAX_VERSION || version == 0 && parts.len() != 4 {
+        return Err(format!(
+            "In traceparent header, invalid traceparent version {version}"
+        ));
+    }
+
+    // Ensure trace id is lowercase
+    if parts[1].chars().any(|c| c.is_ascii_uppercase()) {
+        return Err(format!(
+            "In traceparent header, invalid trace id. Expected lowercase hex value, got {}",
+            parts[1]
+        ));
+    }
+
+    // Parse trace id section
+    let trace_id = TraceId::from_hex(parts[1]).map_err(|e| {
+        format!("In traceparent header, invalid trace id. Expected 32 character hex value: {e}")
+    })?;
+
+    // Ensure span id is lowercase
+    if parts[2].chars().any(|c| c.is_ascii_uppercase()) {
+        return Err(format!(
+            "In traceparent header, invalid span id. Expected lowercase hex value, got {}",
+            parts[2]
+        ));
+    }
+
+    // Parse span id section
+    let span_id = SpanId::from_hex(parts[2]).map_err(|e| {
+        format!("In traceparent header, invalid span id. Expected 16 character hex value: {e}")
+    })?;
+
+    // Parse trace flags section solely to ensure they're valid.
+    let _ = u8::from_str_radix(parts[3], 16).map_err(|e| {
+        format!("In traceparent header, invalid trace flags. Expected hex value, got {e}")
+    })?;
+
+    Ok(Some((trace_id, span_id)))
+}

--- a/crates/runtime/src/http/v1/chat.rs
+++ b/crates/runtime/src/http/v1/chat.rs
@@ -41,6 +41,12 @@ pub(crate) async fn post(
     let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_chat", input = %serde_json::to_string(&req).unwrap_or_default());
     span.in_scope(|| tracing::info!(target: "task_history", model = %req.model, "labels"));
 
+    if let Some(ref metadata) = req.metadata {
+        if let Some(serde_json::Value::String(trace_id)) = metadata.get("trace_id") {
+            tracing::info!(target: "task_history", parent: &span.clone(), trace_id = %trace_id);
+        }
+    };
+
     let span_clone = span.clone();
     async move {
         let model_id = req.model.clone();

--- a/crates/runtime/src/http/v1/chat.rs
+++ b/crates/runtime/src/http/v1/chat.rs
@@ -17,10 +17,11 @@ limitations under the License.
 use core::time;
 use std::{convert::Infallible, sync::Arc, time::Duration};
 
+use crate::{http::traceparent::override_task_history_with_traceparent, model::LLMModelStore};
 use async_openai::types::{ChatCompletionResponseStream, CreateChatCompletionRequest};
 use async_stream::stream;
 use axum::{
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse, Response,
@@ -32,20 +33,20 @@ use serde::Serialize;
 use tokio::sync::RwLock;
 use tracing::{Instrument, Span};
 
-use crate::model::LLMModelStore;
-
 pub(crate) async fn post(
     Extension(llms): Extension<Arc<RwLock<LLMModelStore>>>,
+    headers: HeaderMap,
     Json(req): Json<CreateChatCompletionRequest>,
 ) -> Response {
-    let span = tracing::span!(target: "task_history", tracing::Level::INFO, "ai_chat", input = %serde_json::to_string(&req).unwrap_or_default());
+    let span = tracing::span!(
+        target: "task_history",
+        tracing::Level::INFO,
+        "ai_chat",
+        input = %serde_json::to_string(&req).unwrap_or_default()
+    );
     span.in_scope(|| tracing::info!(target: "task_history", model = %req.model, "labels"));
 
-    if let Some(ref metadata) = req.metadata {
-        if let Some(serde_json::Value::String(trace_id)) = metadata.get("trace_id") {
-            tracing::info!(target: "task_history", parent: &span.clone(), trace_id = %trace_id);
-        }
-    };
+    override_task_history_with_traceparent(&span.clone(), &headers);
 
     let span_clone = span.clone();
     async move {

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -55,6 +55,11 @@ pub(crate) struct TaskSpan {
     /// An identifier to the [`TaskSpan`] that directly started this [`TaskSpan`].
     pub(crate) parent_span_id: Option<Arc<str>>,
 
+    /// A span id that came from a client-initiated trace. When set, it indicates this span is the child of a trace for a broader, distributed system (i.e. greater than just `spiced` used for distributed tracing).
+    ///
+    /// Only used if `parent_span_id` is `None`.
+    pub(crate) distributed_parent_id: Option<Arc<str>>,
+
     pub(crate) task: Arc<str>,
     pub(crate) input: Arc<str>,
     pub(crate) captured_output: Option<Arc<str>>,
@@ -187,9 +192,10 @@ impl TaskSpan {
                     }
                     "parent_span_id" => {
                         let str_builder = downcast_builder::<StringBuilder>(field_builder)?;
-                        match &span.parent_span_id {
-                            Some(parent_span_id) => str_builder.append_value(parent_span_id),
-                            None => str_builder.append_null(),
+                        match (&span.parent_span_id, &span.distributed_parent_id) {
+                            (Some(parent_span_id), _) => str_builder.append_value(parent_span_id),
+                            (None, Some(parent_id)) => str_builder.append_value(parent_id),
+                            (None, None) => str_builder.append_null(),
                         }
                     }
                     "task" => {

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -44,6 +44,11 @@ pub const DEFAULT_TASK_HISTORY_RETENTION_CHECK_INTERVAL_SECS: u64 = 15 * 60; // 
 pub(crate) struct TaskSpan {
     pub(crate) trace_id: Arc<str>,
 
+    /// A user-defined trace id that can be used to override the default trace id when exported.
+    /// This is useful for when a trace id wants to be known before its eventually written to an exporter.
+    /// If this isn't a valid 16-byte array (in 32 character hexadecimal representation), it will be ignored.
+    pub(crate) trace_id_override: Option<Arc<str>>,
+
     /// An identifier for the top level [`TaskSpan`] that this [`TaskSpan`] occurs in.
     pub(crate) span_id: Arc<str>,
 

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -28,6 +28,18 @@ use crate::datafusion::DataFusion;
 
 use super::TaskSpan;
 
+macro_rules! extract_attr {
+    ($span:expr, $key:expr) => {
+        $span.events.iter().find_map(|event| {
+            let event_attr_idx = event
+                .attributes
+                .iter()
+                .position(|kv| kv.key.as_str() == $key)?;
+            Some(event.attributes[event_attr_idx].value.as_str().into())
+        })
+    };
+}
+
 #[derive(Clone)]
 pub struct TaskHistoryExporter {
     df: Arc<DataFusion>,
@@ -55,6 +67,10 @@ impl TaskHistoryExporter {
         }
     }
 
+    fn is_valid_span_id(span_id: &Arc<str>) -> bool {
+        span_id.len() == 16 && span_id.chars().all(|c| c.is_ascii_hexdigit())
+    }
+
     fn is_valid_traceid(trace_id: &Arc<str>) -> bool {
         trace_id.len() == 32 && trace_id.chars().all(|c| c.is_ascii_hexdigit())
     }
@@ -77,16 +93,7 @@ impl TaskHistoryExporter {
                 |idx| span.attributes[idx].value.as_str().into(),
             );
 
-        let trace_id_override: Option<Arc<str>> = span
-            .events
-            .iter()
-            .find_map(|event| {
-                let event_attr_idx = event
-                    .attributes
-                    .iter()
-                    .position(|kv| kv.key.as_str() == "trace_id")?;
-                Some(event.attributes[event_attr_idx].value.as_str().into())
-            })
+        let trace_id_override: Option<Arc<str>> = extract_attr!(span, "trace_id")
             .and_then(|trace_id| if Self::is_valid_traceid(&trace_id) {
                 Some(trace_id)
             } else {
@@ -94,17 +101,16 @@ impl TaskHistoryExporter {
                 None
             });
 
-        let captured_output: Option<Arc<str>> = span
-            .events
-            .iter()
-            .find_map(|event| {
-                let event_attr_idx = event
-                    .attributes
-                    .iter()
-                    .position(|kv| kv.key.as_str() == "captured_output")?;
-                Some(event.attributes[event_attr_idx].value.as_str().into())
-            })
-            .map(|output| self.process_output(output));
+        let distributed_parent_id: Option<Arc<str>> = extract_attr!(span, "parent_id")
+            .and_then(|parent_id| if Self::is_valid_span_id(&parent_id) {
+                Some(parent_id)
+            } else {
+                tracing::warn!("User provided 'parent_id'='{}' is a invalid span id. Must be a 32 character hex string.", Arc::clone(&trace_id));
+                None
+            });
+
+        let captured_output: Option<Arc<str>> =
+            extract_attr!(span, "captured_output").map(|output| self.process_output(output));
 
         let start_time = span.start_time;
         let end_time = span.end_time;
@@ -156,6 +162,7 @@ impl TaskHistoryExporter {
             trace_id_override,
             span_id,
             parent_span_id,
+            distributed_parent_id,
             task,
             input,
             captured_output,

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -55,6 +55,10 @@ impl TaskHistoryExporter {
         }
     }
 
+    fn is_valid_traceid(trace_id: &Arc<str>) -> bool {
+        trace_id.len() == 32 && trace_id.chars().all(|c| c.is_ascii_hexdigit())
+    }
+
     fn span_to_task_span(&self, span: SpanData) -> TaskSpan {
         let trace_id: Arc<str> = span.span_context.trace_id().to_string().into();
         let span_id: Arc<str> = span.span_context.span_id().to_string().into();
@@ -72,6 +76,24 @@ impl TaskHistoryExporter {
                 || "".into(),
                 |idx| span.attributes[idx].value.as_str().into(),
             );
+
+        let trace_id_override: Option<Arc<str>> = span
+            .events
+            .iter()
+            .find_map(|event| {
+                let event_attr_idx = event
+                    .attributes
+                    .iter()
+                    .position(|kv| kv.key.as_str() == "trace_id")?;
+                Some(event.attributes[event_attr_idx].value.as_str().into())
+            })
+            .and_then(|trace_id| if Self::is_valid_traceid(&trace_id) {
+                Some(trace_id)
+            } else {
+                tracing::warn!("User provided 'trace_id'='{}' is invalid. Must be a 32 character hex string.", Arc::clone(&trace_id));
+                None
+            });
+
         let captured_output: Option<Arc<str>> = span
             .events
             .iter()
@@ -131,6 +153,7 @@ impl TaskHistoryExporter {
 
         TaskSpan {
             trace_id,
+            trace_id_override,
             span_id,
             parent_span_id,
             task,
@@ -147,10 +170,27 @@ impl TaskHistoryExporter {
 
 impl SpanExporter for TaskHistoryExporter {
     fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
-        let spans = batch
+        let mut spans: Vec<TaskSpan> = batch
             .into_iter()
             .map(|span| self.span_to_task_span(span))
             .collect();
+
+        // If any span has defined a [`TaskSpan::trace_id_override`], we must override others.
+        let overrides: HashMap<Arc<str>, Arc<str>> = spans
+            .iter()
+            .filter_map(|span| {
+                span.trace_id_override
+                    .as_ref()
+                    .map(|new_trace| (Arc::clone(&span.trace_id), Arc::clone(new_trace)))
+            })
+            .collect();
+
+        for span in &mut spans {
+            if let Some(new_trace_id) = overrides.get(&span.trace_id) {
+                span.trace_id = Arc::clone(new_trace_id);
+            }
+        }
+
         let df = Arc::clone(&self.df);
         Box::pin(async move {
             TaskSpan::write(df, spans)


### PR DESCRIPTION
# 🗣 Description
 - Enable the ability to override the `trace_id` & `parent_span_id` for any `runtime.task_history` trace. This is useful for when a trace id wants to be known before it's eventually written to an exporter.
 - `parent_span_id` is also overridable so that HTTP endpoints can honour [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header) HTTP header. 

How to do this in code: 
```rust
tracing::info!(target: "task_history", parent: &span.clone(), trace_id = %trace_id, parent_id = %parent_span_id);

// or
let headers: HeaderMap = ...
override_task_history_with_traceparent(&span, &headers);
 ```


 As an example use, in `v1/chat/completion` now supports traceparent Header.
```shell
curlie http://localhost:8090/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" \
  -d '{
    "model": "oai",
    "messages":[
            {
                "content": "Write me a poem",
                "role": "user"
            }
        ],
    "store": true
}'
```

- We also ensure that the override is [w3 compliant](https://www.w3.org/TR/trace-context/#trace-id). 