### PR TITLE
Use MinIO instead of S3 for benchmark tests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -311,24 +311,33 @@ jobs:
       - name: Download DuckDB Connector Data
         if: matrix.cmd == '-c duckdb' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/duckdb/tpch.db
+          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          chmod +x /usr/local/bin/mc
+          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
+          mc cp spice-bench-minio/benchmarks/duckdb/tpch.db ./
 
       - name: Download DuckDB Connector Data
         if: matrix.cmd == '-c duckdb -b tpcds' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/duckdb/tpcds.db
+          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          chmod +x /usr/local/bin/mc
+          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
+          mc cp spice-bench-minio/benchmarks/duckdb/tpcds.db ./
 
       - name: Download File Connector Data
         if: matrix.cmd == '-c file' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/customer/customer.parquet
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/lineitem/lineitem.parquet
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/nation/nation.parquet
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/orders/orders.parquet
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/part/part.parquet
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/partsupp/partsupp.parquet
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/region/region.parquet
-          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/supplier/supplier.parquet
+          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          chmod +x /usr/local/bin/mc
+          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
+          mc cp spice-bench-minio/benchmarks/tpch_sf1/customer/ ./ --recursive
+          mc cp spice-bench-minio/benchmarks/tpch_sf1/lineitem/ ./ --recursive
+          mc cp spice-bench-minio/benchmarks/tpch_sf1/nation/ ./ --recursive
+          mc cp spice-bench-minio/benchmarks/tpch_sf1/orders/ ./ --recursive
+          mc cp spice-bench-minio/benchmarks/tpch_sf1/part/ ./ --recursive
+          mc cp spice-bench-minio/benchmarks/tpch_sf1/partsupp/ ./ --recursive
+          mc cp spice-bench-minio/benchmarks/tpch_sf1/region/ ./ --recursive
+          mc cp spice-bench-minio/benchmarks/tpch_sf1/supplier/ ./ --recursive
 
       - name: Run benchmark with ${{ matrix.name }}
         if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -311,24 +311,24 @@ jobs:
       - name: Download DuckDB Connector Data
         if: matrix.cmd == '-c duckdb' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/duckdb/tpch.db
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/duckdb/tpch.db
 
       - name: Download DuckDB Connector Data
         if: matrix.cmd == '-c duckdb -b tpcds' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/duckdb/tpcds.db
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/duckdb/tpcds.db
 
       - name: Download File Connector Data
         if: matrix.cmd == '-c file' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/tpch/customer/customer.parquet
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/tpch/lineitem/lineitem.parquet
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/tpch/nation/nation.parquet
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/tpch/orders/orders.parquet
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/tpch/part/part.parquet
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/tpch/partsupp/partsupp.parquet
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/tpch/region/region.parquet
-          wget https://spiceai-public-datasets.s3.us-east-1.amazonaws.com/tpch/supplier/supplier.parquet
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/customer/customer.parquet
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/lineitem/lineitem.parquet
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/nation/nation.parquet
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/orders/orders.parquet
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/part/part.parquet
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/partsupp/partsupp.parquet
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/region/region.parquet
+          wget ${{ secrets.CLICKBENCH_S3_ENDPOINT }}/tpch/supplier/supplier.parquet
 
       - name: Run benchmark with ${{ matrix.name }}
         if: (github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
@@ -349,6 +349,9 @@ jobs:
           MYSQL_BENCHMARK_MYSQL_PASS: root
           MYSQL_TPCH_BENCHMARK_MYSQL_DB: tpch_sf1
           MYSQL_TPCDS_BENCHMARK_MYSQL_DB: tpcds_sf1
+          S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
+          S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
+          S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_ODBC_PATH: ${{ secrets.DATABRICKS_ODBC_PATH }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
@@ -429,9 +432,9 @@ jobs:
         continue-on-error: true
         env:
           UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
-          CLICKBENCH_S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
-          CLICKBENCH_S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
-          CLICKBENCH_S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
+          S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
+          S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
+          S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
 
   create-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -311,24 +311,24 @@ jobs:
       - name: Download DuckDB Connector Data
         if: matrix.cmd == '-c duckdb' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
-          chmod +x /usr/local/bin/mc
+          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo chmod +x /usr/local/bin/mc
           mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
           mc cp spice-bench-minio/benchmarks/duckdb/tpch.db ./
 
       - name: Download DuckDB Connector Data
         if: matrix.cmd == '-c duckdb -b tpcds' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
-          chmod +x /usr/local/bin/mc
+          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo chmod +x /usr/local/bin/mc
           mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
           mc cp spice-bench-minio/benchmarks/duckdb/tpcds.db ./
 
       - name: Download File Connector Data
         if: matrix.cmd == '-c file' && ((github.event.inputs.selected_benchmark == matrix.name && (github.event.inputs.bench_name == matrix.bench || github.event.inputs.bench_name == 'all')) || github.event.inputs.run_all == 'true' || github.event_name == 'schedule')
         run: |
-          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
-          chmod +x /usr/local/bin/mc
+          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo chmod +x /usr/local/bin/mc
           mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
           mc cp spice-bench-minio/benchmarks/tpch_sf1/customer/ ./ --recursive
           mc cp spice-bench-minio/benchmarks/tpch_sf1/lineitem/ ./ --recursive

--- a/crates/runtime/benches/bench_object_store/s3.rs
+++ b/crates/runtime/benches/bench_object_store/s3.rs
@@ -23,151 +23,163 @@ pub fn build_app(app_builder: AppBuilder, bench_name: &str) -> Result<AppBuilder
     match bench_name {
         "tpch" => Ok(app_builder
             .with_dataset(make_dataset(
-                "benchmarks/tpch/customer/",
+                "benchmarks/tpch_sf1/customer/",
                 "customer",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpch/lineitem/",
+                "benchmarks/tpch_sf1/lineitem/",
                 "lineitem",
                 bench_name,
             ))
-            .with_dataset(make_dataset("benchmarks/tpch/part/", "part", bench_name))
             .with_dataset(make_dataset(
-                "benchmarks/tpch/partsupp/",
+                "benchmarks/tpch_sf1/part/",
+                "part",
+                bench_name,
+            ))
+            .with_dataset(make_dataset(
+                "benchmarks/tpch_sf1/partsupp/",
                 "partsupp",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpch/orders/",
+                "benchmarks/tpch_sf1/orders/",
                 "orders",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpch/nation/",
+                "benchmarks/tpch_sf1/nation/",
                 "nation",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpch/region/",
+                "benchmarks/tpch_sf1/region/",
                 "region",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpch/supplier/",
+                "benchmarks/tpch_sf1/supplier/",
                 "supplier",
                 bench_name,
             ))),
         "tpcds" => Ok(app_builder
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/call_center/",
+                "benchmarks/tpcds_sf1/call_center/",
                 "call_center",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/catalog_page/",
+                "benchmarks/tpcds_sf1/catalog_page/",
                 "catalog_page",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/catalog_sales/",
+                "benchmarks/tpcds_sf1/catalog_sales/",
                 "catalog_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/catalog_returns/",
+                "benchmarks/tpcds_sf1/catalog_returns/",
                 "catalog_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/income_band/",
+                "benchmarks/tpcds_sf1/income_band/",
                 "income_band",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/inventory/",
+                "benchmarks/tpcds_sf1/inventory/",
                 "inventory",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/store_sales/",
+                "benchmarks/tpcds_sf1/store_sales/",
                 "store_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/store_returns/",
+                "benchmarks/tpcds_sf1/store_returns/",
                 "store_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/web_sales/",
+                "benchmarks/tpcds_sf1/web_sales/",
                 "web_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/web_returns/",
+                "benchmarks/tpcds_sf1/web_returns/",
                 "web_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/customer/",
+                "benchmarks/tpcds_sf1/customer/",
                 "customer",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/customer_address/",
+                "benchmarks/tpcds_sf1/customer_address/",
                 "customer_address",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/customer_demographics/",
+                "benchmarks/tpcds_sf1/customer_demographics/",
                 "customer_demographics",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/date_dim/",
+                "benchmarks/tpcds_sf1/date_dim/",
                 "date_dim",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/household_demographics/",
+                "benchmarks/tpcds_sf1/household_demographics/",
                 "household_demographics",
                 bench_name,
             ))
-            .with_dataset(make_dataset("benchmarks/tpcds/item/", "item", bench_name))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/promotion/",
+                "benchmarks/tpcds_sf1/item/",
+                "item",
+                bench_name,
+            ))
+            .with_dataset(make_dataset(
+                "benchmarks/tpcds_sf1/promotion/",
                 "promotion",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/reason/",
+                "benchmarks/tpcds_sf1/reason/",
                 "reason",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/ship_mode/",
+                "benchmarks/tpcds_sf1/ship_mode/",
                 "ship_mode",
                 bench_name,
             ))
-            .with_dataset(make_dataset("benchmarks/tpcds/store/", "store", bench_name))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/time_dim/",
+                "benchmarks/tpcds_sf1/store/",
+                "store",
+                bench_name,
+            ))
+            .with_dataset(make_dataset(
+                "benchmarks/tpcds_sf1/time_dim/",
                 "time_dim",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/warehouse/",
+                "benchmarks/tpcds_sf1/warehouse/",
                 "warehouse",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/web_page/",
+                "benchmarks/tpcds_sf1/web_page/",
                 "web_page",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "benchmarks/tpcds/web_site/",
+                "benchmarks/tpcds_sf1/web_site/",
                 "web_site",
                 bench_name,
             ))),

--- a/crates/runtime/benches/bench_object_store/s3.rs
+++ b/crates/runtime/benches/bench_object_store/s3.rs
@@ -23,284 +23,272 @@ pub fn build_app(app_builder: AppBuilder, bench_name: &str) -> Result<AppBuilder
     match bench_name {
         "tpch" => Ok(app_builder
             .with_dataset(make_dataset(
-                "spiceai-demo-datasets/tpch/customer/",
+                "benchmarks/tpch/customer/",
                 "customer",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-demo-datasets/tpch/lineitem/",
+                "benchmarks/tpch/lineitem/",
                 "lineitem",
                 bench_name,
             ))
+            .with_dataset(make_dataset("benchmarks/tpch/part/", "part", bench_name))
             .with_dataset(make_dataset(
-                "spiceai-demo-datasets/tpch/part/",
-                "part",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "spiceai-demo-datasets/tpch/partsupp/",
+                "benchmarks/tpch/partsupp/",
                 "partsupp",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-demo-datasets/tpch/orders/",
+                "benchmarks/tpch/orders/",
                 "orders",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-demo-datasets/tpch/nation/",
+                "benchmarks/tpch/nation/",
                 "nation",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-demo-datasets/tpch/region/",
+                "benchmarks/tpch/region/",
                 "region",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-demo-datasets/tpch/supplier/",
+                "benchmarks/tpch/supplier/",
                 "supplier",
                 bench_name,
             ))),
         "tpcds" => Ok(app_builder
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/call_center/",
+                "benchmarks/tpcds/call_center/",
                 "call_center",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/catalog_page/",
+                "benchmarks/tpcds/catalog_page/",
                 "catalog_page",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/catalog_sales/",
+                "benchmarks/tpcds/catalog_sales/",
                 "catalog_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/catalog_returns/",
+                "benchmarks/tpcds/catalog_returns/",
                 "catalog_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/income_band/",
+                "benchmarks/tpcds/income_band/",
                 "income_band",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/inventory/",
+                "benchmarks/tpcds/inventory/",
                 "inventory",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/store_sales/",
+                "benchmarks/tpcds/store_sales/",
                 "store_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/store_returns/",
+                "benchmarks/tpcds/store_returns/",
                 "store_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/web_sales/",
+                "benchmarks/tpcds/web_sales/",
                 "web_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/web_returns/",
+                "benchmarks/tpcds/web_returns/",
                 "web_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/customer/",
+                "benchmarks/tpcds/customer/",
                 "customer",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/customer_address/",
+                "benchmarks/tpcds/customer_address/",
                 "customer_address",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/customer_demographics/",
+                "benchmarks/tpcds/customer_demographics/",
                 "customer_demographics",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/date_dim/",
+                "benchmarks/tpcds/date_dim/",
                 "date_dim",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/household_demographics/",
+                "benchmarks/tpcds/household_demographics/",
                 "household_demographics",
                 bench_name,
             ))
+            .with_dataset(make_dataset("benchmarks/tpcds/item/", "item", bench_name))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/item/",
-                "item",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/promotion/",
+                "benchmarks/tpcds/promotion/",
                 "promotion",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/reason/",
+                "benchmarks/tpcds/reason/",
                 "reason",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/ship_mode/",
+                "benchmarks/tpcds/ship_mode/",
                 "ship_mode",
                 bench_name,
             ))
+            .with_dataset(make_dataset("benchmarks/tpcds/store/", "store", bench_name))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/store/",
-                "store",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/time_dim/",
+                "benchmarks/tpcds/time_dim/",
                 "time_dim",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/warehouse/",
+                "benchmarks/tpcds/warehouse/",
                 "warehouse",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/web_page/",
+                "benchmarks/tpcds/web_page/",
                 "web_page",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds/web_site/",
+                "benchmarks/tpcds/web_site/",
                 "web_site",
                 bench_name,
             ))),
         "tpcds_sf0_01" => Ok(app_builder
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/call_center.parquet",
+                "benchmarks/tpcds_sf0_01/call_center.parquet",
                 "call_center",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/catalog_page.parquet",
+                "benchmarks/tpcds_sf0_01/catalog_page.parquet",
                 "catalog_page",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/catalog_sales.parquet",
+                "benchmarks/tpcds_sf0_01/catalog_sales.parquet",
                 "catalog_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/catalog_returns.parquet",
+                "benchmarks/tpcds_sf0_01/catalog_returns.parquet",
                 "catalog_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/income_band.parquet",
+                "benchmarks/tpcds_sf0_01/income_band.parquet",
                 "income_band",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/inventory.parquet",
+                "benchmarks/tpcds_sf0_01/inventory.parquet",
                 "inventory",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/store_sales.parquet",
+                "benchmarks/tpcds_sf0_01/store_sales.parquet",
                 "store_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/store_returns.parquet",
+                "benchmarks/tpcds_sf0_01/store_returns.parquet",
                 "store_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/web_sales.parquet",
+                "benchmarks/tpcds_sf0_01/web_sales.parquet",
                 "web_sales",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/web_returns.parquet",
+                "benchmarks/tpcds_sf0_01/web_returns.parquet",
                 "web_returns",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/customer.parquet",
+                "benchmarks/tpcds_sf0_01/customer.parquet",
                 "customer",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/customer_address.parquet",
+                "benchmarks/tpcds_sf0_01/customer_address.parquet",
                 "customer_address",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/customer_demographics.parquet",
+                "benchmarks/tpcds_sf0_01/customer_demographics.parquet",
                 "customer_demographics",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/date_dim.parquet",
+                "benchmarks/tpcds_sf0_01/date_dim.parquet",
                 "date_dim",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/household_demographics.parquet",
+                "benchmarks/tpcds_sf0_01/household_demographics.parquet",
                 "household_demographics",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/item.parquet",
+                "benchmarks/tpcds_sf0_01/item.parquet",
                 "item",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/promotion.parquet",
+                "benchmarks/tpcds_sf0_01/promotion.parquet",
                 "promotion",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/reason.parquet",
+                "benchmarks/tpcds_sf0_01/reason.parquet",
                 "reason",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/ship_mode.parquet",
+                "benchmarks/tpcds_sf0_01/ship_mode.parquet",
                 "ship_mode",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/store.parquet",
+                "benchmarks/tpcds_sf0_01/store.parquet",
                 "store",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/time_dim.parquet",
+                "benchmarks/tpcds_sf0_01/time_dim.parquet",
                 "time_dim",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/warehouse.parquet",
+                "benchmarks/tpcds_sf0_01/warehouse.parquet",
                 "warehouse",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/web_page.parquet",
+                "benchmarks/tpcds_sf0_01/web_page.parquet",
                 "web_page",
                 bench_name,
             ))
             .with_dataset(make_dataset(
-                "spiceai-public-datasets/tpcds_sf0_01/web_site.parquet",
+                "benchmarks/tpcds_sf0_01/web_site.parquet",
                 "web_site",
                 bench_name,
             ))),
@@ -317,30 +305,24 @@ pub fn build_app(app_builder: AppBuilder, bench_name: &str) -> Result<AppBuilder
 fn make_dataset(path: &str, name: &str, bench_name: &str) -> Dataset {
     let mut dataset = Dataset::new(format!("s3://{path}"), name.to_string());
 
-    let params: Vec<(String, String)> = match bench_name {
-        "clickbench" => vec![
-            ("file_format".to_string(), "parquet".to_string()),
-            ("client_timeout".to_string(), "3h".to_string()),
-            ("allow_http".to_string(), "true".to_string()),
-            ("s3_auth".to_string(), "key".to_string()),
-            (
-                "s3_endpoint".to_string(),
-                std::env::var("CLICKBENCH_S3_ENDPOINT").unwrap_or_default(),
-            ),
-            (
-                "s3_key".to_string(),
-                std::env::var("CLICKBENCH_S3_KEY").unwrap_or_default(),
-            ),
-            (
-                "s3_secret".to_string(),
-                std::env::var("CLICKBENCH_S3_SECRET").unwrap_or_default(),
-            ),
-        ],
-        _ => vec![
-            ("file_format".to_string(), "parquet".to_string()),
-            ("client_timeout".to_string(), "2m".to_string()),
-        ],
-    };
+    let params: Vec<(String, String)> = vec![
+        ("file_format".to_string(), "parquet".to_string()),
+        ("client_timeout".to_string(), "3h".to_string()),
+        ("allow_http".to_string(), "true".to_string()),
+        ("s3_auth".to_string(), "key".to_string()),
+        (
+            "s3_endpoint".to_string(),
+            std::env::var("S3_ENDPOINT").unwrap_or_default(),
+        ),
+        (
+            "s3_key".to_string(),
+            std::env::var("S3_KEY").unwrap_or_default(),
+        ),
+        (
+            "s3_secret".to_string(),
+            std::env::var("S3_SECRET").unwrap_or_default(),
+        ),
+    ];
 
     dataset.params = Some(Params::from_string_map(params.into_iter().collect()));
     dataset

--- a/crates/runtime/benches/bench_object_store/s3.rs
+++ b/crates/runtime/benches/bench_object_store/s3.rs
@@ -22,299 +22,175 @@ use spicepod::component::{dataset::Dataset, params::Params};
 pub fn build_app(app_builder: AppBuilder, bench_name: &str) -> Result<AppBuilder, String> {
     match bench_name {
         "tpch" => Ok(app_builder
-            .with_dataset(make_dataset(
-                "benchmarks/tpch_sf1/customer/",
-                "customer",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpch_sf1/lineitem/",
-                "lineitem",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpch_sf1/part/",
-                "part",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpch_sf1/partsupp/",
-                "partsupp",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpch_sf1/orders/",
-                "orders",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpch_sf1/nation/",
-                "nation",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpch_sf1/region/",
-                "region",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpch_sf1/supplier/",
-                "supplier",
-                bench_name,
-            ))),
+            .with_dataset(make_dataset("benchmarks/tpch_sf1/customer/", "customer"))
+            .with_dataset(make_dataset("benchmarks/tpch_sf1/lineitem/", "lineitem"))
+            .with_dataset(make_dataset("benchmarks/tpch_sf1/part/", "part"))
+            .with_dataset(make_dataset("benchmarks/tpch_sf1/partsupp/", "partsupp"))
+            .with_dataset(make_dataset("benchmarks/tpch_sf1/orders/", "orders"))
+            .with_dataset(make_dataset("benchmarks/tpch_sf1/nation/", "nation"))
+            .with_dataset(make_dataset("benchmarks/tpch_sf1/region/", "region"))
+            .with_dataset(make_dataset("benchmarks/tpch_sf1/supplier/", "supplier"))),
         "tpcds" => Ok(app_builder
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/call_center/",
                 "call_center",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/catalog_page/",
                 "catalog_page",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/catalog_sales/",
                 "catalog_sales",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/catalog_returns/",
                 "catalog_returns",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/income_band/",
                 "income_band",
-                bench_name,
             ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/inventory/",
-                "inventory",
-                bench_name,
-            ))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/inventory/", "inventory"))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/store_sales/",
                 "store_sales",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/store_returns/",
                 "store_returns",
-                bench_name,
             ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/web_sales/",
-                "web_sales",
-                bench_name,
-            ))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/web_sales/", "web_sales"))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/web_returns/",
                 "web_returns",
-                bench_name,
             ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/customer/",
-                "customer",
-                bench_name,
-            ))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/customer/", "customer"))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/customer_address/",
                 "customer_address",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/customer_demographics/",
                 "customer_demographics",
-                bench_name,
             ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/date_dim/",
-                "date_dim",
-                bench_name,
-            ))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/date_dim/", "date_dim"))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf1/household_demographics/",
                 "household_demographics",
-                bench_name,
             ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/item/",
-                "item",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/promotion/",
-                "promotion",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/reason/",
-                "reason",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/ship_mode/",
-                "ship_mode",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/store/",
-                "store",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/time_dim/",
-                "time_dim",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/warehouse/",
-                "warehouse",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/web_page/",
-                "web_page",
-                bench_name,
-            ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf1/web_site/",
-                "web_site",
-                bench_name,
-            ))),
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/item/", "item"))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/promotion/", "promotion"))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/reason/", "reason"))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/ship_mode/", "ship_mode"))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/store/", "store"))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/time_dim/", "time_dim"))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/warehouse/", "warehouse"))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/web_page/", "web_page"))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf1/web_site/", "web_site"))),
         "tpcds_sf0_01" => Ok(app_builder
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/call_center.parquet",
                 "call_center",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/catalog_page.parquet",
                 "catalog_page",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/catalog_sales.parquet",
                 "catalog_sales",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/catalog_returns.parquet",
                 "catalog_returns",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/income_band.parquet",
                 "income_band",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/inventory.parquet",
                 "inventory",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/store_sales.parquet",
                 "store_sales",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/store_returns.parquet",
                 "store_returns",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/web_sales.parquet",
                 "web_sales",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/web_returns.parquet",
                 "web_returns",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/customer.parquet",
                 "customer",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/customer_address.parquet",
                 "customer_address",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/customer_demographics.parquet",
                 "customer_demographics",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/date_dim.parquet",
                 "date_dim",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/household_demographics.parquet",
                 "household_demographics",
-                bench_name,
             ))
-            .with_dataset(make_dataset(
-                "benchmarks/tpcds_sf0_01/item.parquet",
-                "item",
-                bench_name,
-            ))
+            .with_dataset(make_dataset("benchmarks/tpcds_sf0_01/item.parquet", "item"))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/promotion.parquet",
                 "promotion",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/reason.parquet",
                 "reason",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/ship_mode.parquet",
                 "ship_mode",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/store.parquet",
                 "store",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/time_dim.parquet",
                 "time_dim",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/warehouse.parquet",
                 "warehouse",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/web_page.parquet",
                 "web_page",
-                bench_name,
             ))
             .with_dataset(make_dataset(
                 "benchmarks/tpcds_sf0_01/web_site.parquet",
                 "web_site",
-                bench_name,
             ))),
 
-        "clickbench" => Ok(app_builder.with_dataset(make_dataset(
-            "benchmarks/clickbench/hits/",
-            "hits",
-            bench_name,
-        ))),
+        "clickbench" => {
+            Ok(app_builder.with_dataset(make_dataset("benchmarks/clickbench/hits/", "hits")))
+        }
         _ => Err("Only tpcds or tpch benchmark suites are supported".to_string()),
     }
 }
 
-fn make_dataset(path: &str, name: &str, bench_name: &str) -> Dataset {
+fn make_dataset(path: &str, name: &str) -> Dataset {
     let mut dataset = Dataset::new(format!("s3://{path}"), name.to_string());
 
     let params: Vec<(String, String)> = vec![


### PR DESCRIPTION
# 🗣 Description

Use MinIO as source for the following tests in benchmark:
* S3 Tests
* All accelerator tests
* File connector
* DuckDB tests

This will help lower the s3 cost, and potentially decrease network latency by using the s3 endpoint hosted inside spice infrastructure.

Successful benchmark run: 

**Note:** There will be slight query plan changes due to the parquet file path change and results change for file connector due to the data source change (using parquet data originally in `spice-demo-dataset` bucket instead of the ones in `spice-public-dataset`). The snapshots updates will be addressed in another PR.

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/3608

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
