### PR TITLE
Fixes for the Debezium connector

### DIFF
--- a/crates/data_components/src/debezium/arrow.rs
+++ b/crates/data_components/src/debezium/arrow.rs
@@ -19,10 +19,10 @@ use crate::arrow::struct_builder::StructBuilder;
 use super::change_event::Field as ChangeEventField;
 use arrow::{
     array::{
-        ArrayBuilder, BooleanBuilder, Decimal128Builder, Float32Builder, Float64Builder,
-        Int16Builder, Int32Builder, Int64Builder, ListBuilder, PrimitiveBuilder, RecordBatch,
-        StringBuilder, StructArray, Time64MicrosecondBuilder, TimestampMicrosecondBuilder,
-        TimestampMillisecondBuilder,
+        ArrayBuilder, BinaryBuilder, BooleanBuilder, Decimal128Builder, Float32Builder,
+        Float64Builder, Int16Builder, Int32Builder, Int64Builder, ListBuilder, PrimitiveBuilder,
+        RecordBatch, StringBuilder, StructArray, Time64MicrosecondBuilder,
+        TimestampMicrosecondBuilder, TimestampMillisecondBuilder,
     },
     datatypes::{
         ArrowPrimitiveType, DataType, Date32Type, Field, Int16Type, Int32Type, Int64Type, Schema,
@@ -335,6 +335,15 @@ fn append_field_value_to_builder(
                     .fail()?;
                 }
             }
+        }
+        DataType::Binary => {
+            let binary_builder = downcast_builder::<BinaryBuilder>(builder)?;
+            let base64_decoded = field_value
+                .as_str()
+                .map(|v| BASE64_STANDARD.decode(v))
+                .transpose()
+                .context(UnableToDecodeBase64Snafu)?;
+            binary_builder.append_option(base64_decoded);
         }
         _ => {
             DataTypeNotSupportedSnafu {

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -59,7 +59,34 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Clone)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum SslIdentification {
+    None,
+    #[default]
+    Https,
+}
+
+impl TryFrom<&str> for SslIdentification {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(match value {
+            "none" => SslIdentification::None,
+            "https" => SslIdentification::Https,
+            _ => return Err(()),
+        })
+    }
+}
+
+impl std::fmt::Display for SslIdentification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SslIdentification::None => write!(f, "none"),
+            SslIdentification::Https => write!(f, "https"),
+        }
+    }
+}
+
 pub struct KafkaConfig {
     pub brokers: String,
     pub security_protocol: String,
@@ -68,6 +95,7 @@ pub struct KafkaConfig {
     pub sasl_password: Option<String>,
     pub ssl_ca_location: Option<String>,
     pub enable_ssl_certificate_verification: bool,
+    pub ssl_endpoint_identification_algorithm: SslIdentification,
 }
 
 pub struct KafkaConsumer {
@@ -219,7 +247,15 @@ impl KafkaConsumer {
         }
         if kafka_config.enable_ssl_certificate_verification {
             config.set("enable.ssl.certificate.verification", "true");
+        } else {
+            config.set("enable.ssl.certificate.verification", "false");
         }
+        config.set(
+            "ssl.endpoint.identification.algorithm",
+            kafka_config
+                .ssl_endpoint_identification_algorithm
+                .to_string(),
+        );
 
         let consumer: StreamConsumer = config
             .set_log_level(RDKafkaLogLevel::Debug)

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -87,6 +87,7 @@ impl std::fmt::Display for SslIdentification {
     }
 }
 
+#[derive(Clone)]
 pub struct KafkaConfig {
     pub brokers: String,
     pub security_protocol: String,

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -18,6 +18,7 @@ use crate::component::dataset::acceleration::{Engine, RefreshMode};
 use crate::component::dataset::Dataset;
 use crate::dataaccelerator::spice_sys::debezium_kafka::DebeziumKafkaSys;
 use crate::dataconnector::ConnectorComponent;
+use crate::datafusion::refresh_sql;
 use crate::federated_table::FederatedTable;
 use arrow::datatypes::SchemaRef;
 use async_stream::stream;
@@ -48,6 +49,9 @@ pub enum Error {
 
     #[snafu(display("Missing required parameter: 'debezium_kafka_bootstrap_servers'. Specify a value.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/debezium#parameters"))]
     MissingKafkaBootstrapServers,
+
+    #[snafu(display("{source}"))]
+    RefreshSql { source: refresh_sql::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -124,7 +128,7 @@ impl Debezium {
                 .ok()
                 .unwrap_or("https")
                 .try_into()
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|()| {
                     tracing::warn!("Invalid value for 'kafka_ssl_endpoint_identification_algorithm'. Supported values: 'none', 'https'. Defaulting to 'https'.");
                     data_components::kafka::SslIdentification::Https
                 }),
@@ -302,8 +306,22 @@ impl DataConnector for Debezium {
             None => get_metadata_from_kafka(dataset, &topic, self.kafka_config.clone()).await?,
         };
 
+        let refresh_sql = dataset.refresh_sql();
+        let refresh_schema = if let Some(refresh_sql) = &refresh_sql {
+            refresh_sql::validate_refresh_sql(dataset.name.clone(), refresh_sql.as_str(), schema)
+                .boxed()
+                .map_err(|e| super::DataConnectorError::InvalidConfiguration {
+                    dataconnector: "debezium".to_string(),
+                    message: format!("The refresh SQL is invalid: {e}"),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: e,
+                })?
+        } else {
+            schema
+        };
+
         let debezium_kafka = Arc::new(DebeziumKafka::new(
-            schema,
+            refresh_schema,
             metadata.primary_keys,
             kafka_consumer,
         ));

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -118,6 +118,16 @@ impl Debezium {
                 .to_string()
                 .parse()
                 .unwrap_or(true),
+            ssl_endpoint_identification_algorithm: params
+                .get("kafka_ssl_endpoint_identification_algorithm")
+                .expose()
+                .ok()
+                .unwrap_or("https")
+                .try_into()
+                .unwrap_or_else(|_| {
+                    tracing::warn!("Invalid value for 'kafka_ssl_endpoint_identification_algorithm'. Supported values: 'none', 'https'. Defaulting to 'https'.");
+                    data_components::kafka::SslIdentification::Https
+                }),
         };
 
         Ok(Self { kafka_config })
@@ -171,6 +181,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("kafka_enable_ssl_certificate_verification")
         .default("true")
         .description("Enable SSL/TLS certificate verification. Default: 'true'."),
+    ParameterSpec::runtime("kafka_ssl_endpoint_identification_algorithm")
+        .default("https")
+        .description("SSL/TLS endpoint identification algorithm. Default: 'https'. Options: 'none', 'https'."),
 ];
 
 impl DataConnectorFactory for DebeziumFactory {


### PR DESCRIPTION
# 🗣 Description

This PR includes several fixes for the Debezium connector to add another parameter (`kafka_ssl_endpoint_identification_algorithm`), support another data type (Binary), properly disable `kafka_enable_ssl_certificate_verification` when it is set to false, and support column filtering via the `refresh_sql` parameter.

`kafka_ssl_endpoint_identification_algorithm` - Default: `https`. Options: `none`, `https`. When working with Kafka systems configured with TLS/SSL, this parameter controls how the identity of the Kafka broker is validated against the certificate it presents. If the DNS name of the broker doesn't exactly match one of the subjectAlternativeNames in the certificate, the connection will fail (wildcards aren't allowed). Setting this option to `none` allows bypassing this identity check, but still validates the certificate itself.

## 📄 Documentation Updates

Requires a docs update for the new parameter

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
