### PR TITLE
Accept `:`, `/` or `://` as the delimiter for the data connector

### DIFF
--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -430,19 +430,19 @@ mod tests {
     fn test_spice_dataset_path() {
         let tests = vec![
             (
-                "spiceai:spice.ai/lukekim/demo/datasets/my_data".to_string(),
+                "spice.ai:spice.ai/lukekim/demo/datasets/my_data".to_string(),
                 "lukekim.demo.my_data",
             ),
             (
-                "spiceai:spice.ai/lukekim/demo/my_data".to_string(),
+                "spice.ai:spice.ai/lukekim/demo/my_data".to_string(),
                 "lukekim.demo.my_data",
             ),
             (
-                "spiceai:lukekim/demo/datasets/my_data".to_string(),
+                "spice.ai:lukekim/demo/datasets/my_data".to_string(),
                 "lukekim.demo.my_data",
             ),
             (
-                "spiceai:lukekim/demo/my_data".to_string(),
+                "spice.ai:lukekim/demo/my_data".to_string(),
                 "lukekim.demo.my_data",
             ),
             (
@@ -453,11 +453,6 @@ mod tests {
                 "spice.ai/lukekim/demo/my_data".to_string(),
                 "lukekim.demo.my_data",
             ),
-            (
-                "lukekim/demo/datasets/my_data".to_string(),
-                "lukekim.demo.my_data",
-            ),
-            ("lukekim/demo/my_data".to_string(), "lukekim.demo.my_data"),
             ("eth.recent_blocks".to_string(), "eth.recent_blocks"),
         ];
 

--- a/crates/runtime/tests/acceleration/file_watcher.rs
+++ b/crates/runtime/tests/acceleration/file_watcher.rs
@@ -39,7 +39,7 @@ fn get_dataset() -> Dataset {
     let path = std::env::current_dir()
         .expect("get current directory")
         .join("test_file_watcher.csv");
-    Dataset::new(format!("file:/{}", path.display()), "names")
+    Dataset::new(format!("file://{}", path.display()), "names")
 }
 
 const NAMES_CSV: &str = include_str!("data/names.csv");

--- a/crates/runtime/tests/snapshots/integration__test_graphql_select_tcgdex.snap
+++ b/crates/runtime/tests/snapshots/integration__test_graphql_select_tcgdex.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/runtime/tests/integration.rs
-assertion_line: 151
 description: "Query: SELECT * FROM tcgdex LIMIT 5"
-snapshot_kind: text
 ---
 +---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                             |
@@ -12,6 +10,6 @@ snapshot_kind: text
 |               |     TableScan: tcgdex projection=[firstEdCards, holoCards, id, name, normalCards, officialCards, releaseDate, reverseCards, totalCards], fetch=5 |
 | physical_plan | GlobalLimitExec: skip=0, fetch=5                                                                                                                 |
 |               |   BytesProcessedExec                                                                                                                             |
-|               |     MemoryExec: partitions=1, partition_sizes=[178]                                                                                              |
+|               |     MemoryExec: partitions=1, partition_sizes=[179]                                                                                              |
 |               |                                                                                                                                                  |
 +---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
# 🗣 Description

Changes the delimiter that chooses the data connector from only `:` to accepting `/` and `://` as well.

i.e. all of these will now work:

```yaml
datasets:
  - from: postgres:my_cool_table
    name: foobar0

  - from: postgres/my_cool_table
    name: foobar1
  
  - from: postgres://my_cool_table
    name: foobar2
```

## ⛓️‍💥 Breaking Change

The `file` data connector previously accepted `file://path_to_file.csv` as an absolute path to `/path_to_file.csv`. This change breaks that behavior and aligns it with what the Url::parse method does - `file://path_to_file.csv` is not a relative path to `path_to_file.csv`

* [x] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

Will need a pass through docs to ensure they are updated.

## 🤔 Concerns

N/A
