### PR TITLE
Improvement to delta_lake data component error message

### DIFF
--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -52,7 +52,7 @@ use crate::Read;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Delta Lake Table connection failed.\n{source}\nVerify Delta Lake Connector configuration and try again.\nFor details, visit https://docs.spiceai.org/components/data-connectors/delta-lake#configuration"))]
+    #[snafu(display("Delta Lake Table connection failed.\n{source}\nVerify the Delta Lake Table's validity and try again."))]
     DeltaTableError { source: delta_kernel::Error },
 }
 


### PR DESCRIPTION
# 🗣 Description

Remove the message pointing to `delta_lake_connector` documentation in the `delta_lake` component, since the component is shared by both `delta_lake connector` and `databricks connector`.

Add message to instruct user to verify the table validity. The `source` error message from `delta kernel rs` crate would reveal details about which part of the table is invalid, e.g. _last_checkpoint file missing, etc.

## 🔨 Related Issues

This is relevant to a issue raised by customer regarding the error `Had a _last_checkpoint hint but didn't find any checkpoints`, which indicates the checkpoint file pointed by `_last_checkpoint` in delta log is missing. 

Discussed with Delta Kernel rs maintainer, since this is only happens when the checkpoint from _delta_log is manually deleted, which is out of the normal behavior, they suggest to let end user handle the issue instead of falling back in reading the table in delta kernel rs.

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

We could potentially add a more precise error message by matching the string value of Delta_kernel_error::Generic, for example, matching `Error::generic(
            "Had a _last_checkpoint hint but didn't find any checkpoints",
        )` and add a custom message like `Please check if the checkpoint file referred by _last_checkpoint exist`. However I'm not sure matching string would be a good idea for performance, while the new error message will inform user to check the delta table validity.