### PR TITLE
Enable `spice login abfs`

### DIFF
--- a/bin/spice/cmd/login.go
+++ b/bin/spice/cmd/login.go
@@ -274,6 +274,49 @@ var sharepointCmd = &cobra.Command{
 	},
 }
 
+var abfsCmd = &cobra.Command{
+	Use:   "abfs",
+	Short: "Login to a Microsoft 365 abfs account",
+	Example: `
+	spice login abfs --tenant-id <tenant-id> --client-id <client-id>
+
+# See more at: https://docs.spiceai.org/
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		tenant_id, err := cmd.Flags().GetString(m365TenantId)
+		if err != nil {
+			slog.Error("getting tenant_id", "error", err)
+			os.Exit(1)
+		} else if tenant_id == "" {
+			slog.Error("No tenant_id provided, use --tenant-id")
+			os.Exit(1)
+		}
+
+		client_id, err := cmd.Flags().GetString(m365ClientId)
+		if err != nil {
+			slog.Error("getting client_id", "error", err)
+			os.Exit(1)
+		} else if client_id == "" {
+			slog.Error("No client_id provided, use --client-id")
+			os.Exit(1)
+		}
+
+		access_token, err := msal.InteractivelyGetAccessToken(cmd.Context(), tenant_id, client_id, []string{"https://storage.azure.com/.default"})
+		if err != nil {
+			slog.Error("Error getting Microsoft access token", "error", err)
+			os.Exit(1)
+		}
+
+		slog.Info(fmt.Sprintf("%s", aurora.BrightGreen(fmt.Sprintf("Successfully logged into Microsoft 365 abfs with client ID: %s", client_id))))
+
+		mergeAuthConfig(cmd, api.AUTH_TYPE_ABFS, map[string]string{
+			api.AUTH_PARAM_BEARER_TOKEN: access_token,
+			api.AUTH_PARAM_TENANT_ID:    tenant_id,
+			api.AUTH_PARAM_CLIENT_ID:    client_id,
+		})
+	},
+}
+
 var sparkCmd = &cobra.Command{
 	Use:   "spark",
 	Short: "Login to a Spark Connect remote",
@@ -562,6 +605,10 @@ func init() {
 	sharepointCmd.Flags().StringP(m365TenantId, "t", "", "Microsoft organization tenant ID")
 	sharepointCmd.Flags().StringP(m365ClientId, "c", "", "Microsoft Azure AD application client ID")
 	loginCmd.AddCommand(sharepointCmd)
+
+	abfsCmd.Flags().StringP(m365TenantId, "t", "", "Microsoft organization tenant ID")
+	abfsCmd.Flags().StringP(m365ClientId, "c", "", "Microsoft Azure AD application client ID")
+	loginCmd.AddCommand(abfsCmd)
 
 	s3Cmd.Flags().StringP(accessKeyFlag, "k", "", "Access key")
 	s3Cmd.Flags().StringP(accessSecretFlag, "s", "", "Access Secret")

--- a/bin/spice/cmd/login.go
+++ b/bin/spice/cmd/login.go
@@ -276,7 +276,7 @@ var sharepointCmd = &cobra.Command{
 
 var abfsCmd = &cobra.Command{
 	Use:   "abfs",
-	Short: "Login to a Microsoft 365 abfs account",
+	Short: "Login to a Azure Storage Account",
 	Example: `
 	spice login abfs --tenant-id <tenant-id> --client-id <client-id>
 
@@ -307,7 +307,7 @@ var abfsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		slog.Info(fmt.Sprintf("%s", aurora.BrightGreen(fmt.Sprintf("Successfully logged into Microsoft 365 abfs with client ID: %s", client_id))))
+		slog.Info(fmt.Sprintf("%s", aurora.BrightGreen(fmt.Sprintf("Successfully logged into Azure Storage Account with client ID: %s", client_id))))
 
 		mergeAuthConfig(cmd, api.AUTH_TYPE_ABFS, map[string]string{
 			api.AUTH_PARAM_BEARER_TOKEN: access_token,

--- a/bin/spice/pkg/api/auth.go
+++ b/bin/spice/pkg/api/auth.go
@@ -26,6 +26,7 @@ const (
 	AUTH_TYPE_SNOWFLAKE  = "SNOWFLAKE"
 	AUTH_TYPE_SPARK      = "SPARK"
 	AUTH_TYPE_SHAREPOINT = "SHAREPOINT"
+	AUTH_TYPE_ABFS       = "ABFS"
 
 	AUTH_PARAM_API_KEY                = "API_KEY"
 	AUTH_PARAM_KEY                    = "KEY"


### PR DESCRIPTION
# 🗣 Description

Add the login command for ABFS connector `spice login abfs --tenant-id <tenant-id> --client-id <client-id>`. It performs interactive login and get the bearer token for access azure storage account with Microsoft OAuth

## 🔨 Related Issues

- Close: https://github.com/spiceai/spiceai/issues/3845
- Part of: https://github.com/spiceai/spiceai/issues/3082

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, quickstarts/samples or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
