### PR TITLE
Fix column quoting for SpiceCloudPlatform dialect

### DIFF
--- a/crates/data_components/src/flight/federation.rs
+++ b/crates/data_components/src/flight/federation.rs
@@ -16,7 +16,7 @@ impl FlightTable {
     fn create_federated_table_source(
         self: Arc<Self>,
     ) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
-        let table_name = self.table_reference.to_string();
+        let table_name = self.table_reference.to_quoted_string();
         tracing::trace!(
             table_name,
             %self.table_reference,

--- a/crates/data_components/src/flightsql/federation.rs
+++ b/crates/data_components/src/flightsql/federation.rs
@@ -19,7 +19,7 @@ impl FlightSQLTable {
     fn create_federated_table_source(
         self: Arc<Self>,
     ) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
-        let table_name = self.table_reference.to_string();
+        let table_name = self.table_reference.to_quoted_string();
         tracing::trace!(
             table_name,
             %self.table_reference,

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -35,9 +35,9 @@ use data_components::flight::FlightTable;
 use data_components::{Read, ReadWrite};
 use datafusion::catalog::CatalogProvider;
 use datafusion::datasource::TableProvider;
-use datafusion::sql::unparser::dialect::DefaultDialect;
 use datafusion::sql::unparser::dialect::Dialect;
 use datafusion::sql::unparser::dialect::IntervalStyle;
+use datafusion::sql::unparser::dialect::PostgreSqlDialect;
 use datafusion::sql::TableReference;
 use datafusion_federation::FederatedTableProviderAdaptor;
 use flight_client::Credentials;
@@ -98,7 +98,7 @@ impl Dialect for SpiceCloudPlatformDialect {
     }
 
     fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
-        DefaultDialect {}.identifier_quote_style(identifier)
+        PostgreSqlDialect {}.identifier_quote_style(identifier)
     }
 }
 


### PR DESCRIPTION
# 🗣 Description

Fixes the quoting of columns for the SpiceCloudPlatformDialect - it was previously using the DefaultDialect which doesn't quote columns by default. Now its switched to the PostgreSQLDialect which does quote columns by default.

This fixes the issue with `spice connect spiceai/quickstart`

## 🔨 Related Issues

Closes #3855
