### PR TITLE
Fix nsql sampling for tables with embeddings

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -1155,6 +1155,7 @@ impl DataFusion {
     /// Specifically filters out:
     ///  - `spice.runtime`
     ///  - `spice.metadata`
+    ///  - `spice.eval`
     pub fn get_user_table_names(&self) -> Vec<TableReference> {
         self.ctx
             .catalog_names()
@@ -1173,7 +1174,8 @@ impl DataFusion {
                             .iter()
                             .filter(|schema| {
                                 !(ctlg == SPICE_DEFAULT_CATALOG && *schema == SPICE_RUNTIME_SCHEMA
-                                    || *schema == SPICE_METADATA_SCHEMA)
+                                    || *schema == SPICE_METADATA_SCHEMA
+                                    || *schema == SPICE_EVAL_SCHEMA)
                             })
                             .flat_map(|schema| {
                                 c.schema(schema)

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -71,8 +71,21 @@ mod nsql {
 
         test_request_context()
             .scope(async {
+
+                let mut taxi_trips_with_embeddings = get_taxi_trips_dataset();
+                taxi_trips_with_embeddings.embeddings = vec![ColumnEmbeddingConfig {
+                    column: "store_and_fwd_flag".to_string(),
+                    model: "hf_minilm".to_string(),
+                    primary_keys: None,
+                    chunking: None,
+                }];
+
                 let app = AppBuilder::new("text-to-sql")
-                    .with_dataset(get_taxi_trips_dataset())
+                    .with_dataset(taxi_trips_with_embeddings)
+                    .with_embedding(get_huggingface_embeddings(
+                        "sentence-transformers/all-MiniLM-L6-v2",
+                        "hf_minilm",
+                    ))
                     .with_model(get_huggingface_model(
                         HF_TEST_MODEL,
                         HF_TEST_MODEL_TYPE,

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -60,10 +60,22 @@ mod nsql {
                 .await
                 .map_err(anyhow::Error::msg)?;
 
+            let mut taxi_trips_with_embeddings = get_taxi_trips_dataset();
+                taxi_trips_with_embeddings.embeddings = vec![ColumnEmbeddingConfig {
+                    column: "store_and_fwd_flag".to_string(),
+                    model: "openai_embeddings".to_string(),
+                    primary_keys: None,
+                    chunking: None,
+                }];
+
             let app = AppBuilder::new("text-to-sql")
-                .with_dataset(get_taxi_trips_dataset())
+                .with_dataset(taxi_trips_with_embeddings)
                 .with_model(get_openai_model("gpt-4o-mini", "nql"))
                 .with_model(get_openai_model("gpt-4o-mini", "nql-2"))
+                .with_embedding(get_openai_embeddings(
+                    Some("text-embedding-3-small"),
+                    "openai_embeddings",
+                ))
                 .build();
 
             let api_config = create_api_bindings_config();

--- a/crates/runtime/tests/models/snapshots/integration_models__models__nsql__hf_with_sample_data_enabled_tasks.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__nsql__hf_with_sample_data_enabled_tasks.snap
@@ -179,6 +179,7 @@ expression: response
 |                        |             ) combined                                                                    |
 |                        |             ORDER BY priority, "Airport_fee"                                              |
 |                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT store_and_fwd_flag_embedding FROM spice.public.taxi_trips LIMIT 3                  |
 | tool_use::sample_data  | RandomSample({"dataset":"spice.public.taxi_trips","limit":3})                             |
 | sql_query              | SELECT * FROM spice.public.taxi_trips LIMIT 3                                             |
 | sql_query              | SELECT COUNT(*) AS total_records FROM "taxi_trips"                                        |

--- a/crates/runtime/tests/models/snapshots/integration_models__models__nsql__openai_with_sample_data_enabled_tasks.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__nsql__openai_with_sample_data_enabled_tasks.snap
@@ -1,7 +1,6 @@
 ---
-source: crates/runtime/tests/models/openai.rs
-expression: "http_post(format!(\"{base_url}/v1/sql\").as_str(),\nformat!(r#\"SELECT task, replace(input, '\\n', ' ') as input\n                            FROM runtime.task_history\n                            WHERE task NOT IN ('ai_completion', 'health', 'accelerated_refresh')\n                            AND start_time > '{}'\n                            ORDER BY start_time, task;\n                        \"#,\nInto::<DateTime<Utc>>::into(task_start_time).to_rfc3339()).as_str(),\nheaders).await.expect(\"Failed to execute HTTP SQL query\")"
-snapshot_kind: text
+source: crates/runtime/tests/models/mod.rs
+expression: response
 ---
 +------------------------+-------------------------------------------------------------------------------------------+
 | task                   | input                                                                                     |
@@ -180,6 +179,7 @@ snapshot_kind: text
 |                        |             ) combined                                                                    |
 |                        |             ORDER BY priority, "Airport_fee"                                              |
 |                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT store_and_fwd_flag_embedding FROM spice.public.taxi_trips LIMIT 3                  |
 | tool_use::sample_data  | RandomSample({"dataset":"spice.public.taxi_trips","limit":3})                             |
 | sql_query              | SELECT * FROM spice.public.taxi_trips LIMIT 3                                             |
 | sql_query              | SELECT COUNT(*) AS "total_records" FROM "spice"."public"."taxi_trips"                     |


### PR DESCRIPTION
# 🗣 Description

Updates sampling to perform `sample_distinct_from_column` only if the underlying column supports the ordering required for distinct sampling; otherwise, falls back to general sampling

## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/3854

## 🤔 Concerns

1. Sampling should be further improved to skip internal columns. This improvement is still necessary/valid to avoid nsql failures for datasets with complex data types.
