### PR TITLE
Make GH workflows with spiceai-macos runners more stable

### DIFF
--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -51,7 +51,6 @@ jobs:
           go-version: ${{ env.GOVER }}
 
       - name: Set up Rust
-        if: matrix.target.target_os == 'linux'
         uses: ./.github/actions/setup-rust
         with:
           os: ${{ matrix.target.target_os }}

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -22,9 +22,14 @@ concurrency:
 jobs:
   build:
     name: Build Test Binary
-    runs-on: [self-hosted, macOS]
+    runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: 'darwin'
 
       # Build the test binary without running tests
       - name: Build AI integration test binary
@@ -44,7 +49,7 @@ jobs:
     name: Test OpenAI Models
     needs: build
     permissions: read-all
-    runs-on: [self-hosted, macOS]
+    runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# 🗣 Description

Make GH workflows with `spiceai-macos` runners  more stable.

This fixes issues when after some successfull runs there is the following error. 

>/opt/github-runner/_work/_temp/8c84e1d6-ab19-4ec8-8675-0947155de9c7.sh: line 1: cargo: command not found

The step does not re-install rust/takes more time if Rust is already installed/available.

