### PR TITLE
handle `max_completion_tokens` vs `max_tokens` for openai vs azure

### DIFF
--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -105,4 +105,11 @@ impl<C: Config> Openai<C> {
     fn supports_structured_output(&self) -> bool {
         self.client.config().api_base() == OPENAI_API_BASE && self.model.starts_with("gpt-4o")
     }
+
+    /// Returns true if the `OpenAI` compatible model supports `max_completion_tokens` in [`CreateChatCompletionRequest`].
+    ///
+    /// This is useful for limiting the number of tokens used in health checks.
+    fn supports_max_completion_tokens(&self) -> bool {
+        self.client.config().api_base() == OPENAI_API_BASE
+    }
 }


### PR DESCRIPTION
# 🗣 Description
 - Azure OpenAI models do not support `max_completion_tokens`, only `max_tokens` (even  though `max_tokens` is deprecated). When introducing azure models, we reverted to `max_tokens`, however newer o1 models do not accept `max_tokens`. 
 - This PR uses `max_completion_tokens` for all OpenAI-endpoint models, and `max_token` elsewhere.