### PR TITLE
Add CI configuration for search benchmark dataset access

### DIFF
--- a/.github/workflows/benchmarks_search.yml
+++ b/.github/workflows/benchmarks_search.yml
@@ -89,6 +89,9 @@ jobs:
         run: chmod +x ./spice_bench
 
       - name: Benchmark ${{ matrix.name }}
+        env:
+          SPICE_SPICEAI_API_KEY: ${{ secrets.SPICE_SPICEAI_BENCHMARK_API_KEY }}
+          SEARCH_BENCHMARK_UPLOAD_RESULTS_DATASET: 'spice.benchmarks.oss_search_benchmarks'
         if: github.event.inputs.selected_configuration == matrix.name || github.event.inputs.run_all == 'true' || github.event_name == 'schedule'
         run: ./spice_bench ${{ matrix.cmd }}
 


### PR DESCRIPTION
# 🗣 Description

Add CI configuration to write benchmark results to the dataset

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3012

