### PR TITLE
chore: Update MacOS test release install to macos-13

### DIFF
--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -24,7 +24,7 @@ jobs:
             target_os: darwin
             target_arch: aarch64
           - name: macOS x64 (Intel)
-            runner: macos-12
+            runner: macos-13
             target_os: darwin
             target_arch: x86_64
           - name: Windows x64


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the MacOS target for test release install to `macos-13`, because `macos-12` has been removed

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->

* If there's other workflows we use with `macos-12` they'll need to be updated. They're not my concern for this PR, as this is to unblock the release testing.