### PR TITLE
Ensure trace_id is overridden for prior written spans

### DIFF
--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -16,15 +16,17 @@ limitations under the License.
 
 use crate::accelerated_table::refresh::Refresh;
 use crate::datafusion::DataFusion;
-use crate::dataupdate::DataUpdate;
+use crate::dataupdate::{DataUpdate, UpdateType};
 use crate::internal_table::create_internal_accelerated_table;
 use crate::status;
 use crate::{component::dataset::acceleration::Acceleration, datafusion::SPICE_RUNTIME_SCHEMA};
 use crate::{component::dataset::TimeFormat, secrets::Secrets};
-use arrow::array::{ArrayBuilder, MapBuilder, RecordBatch, StringBuilder};
+use arrow::array::{ArrayBuilder, MapBuilder, RecordBatch, StringArray, StringBuilder};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow_schema::ArrowError;
 use data_components::arrow::struct_builder::StructBuilder;
 use datafusion::sql::TableReference;
+use futures::TryStreamExt;
 use snafu::prelude::*;
 use snafu::{ResultExt, Snafu};
 use std::collections::HashMap;
@@ -101,7 +103,7 @@ impl TaskSpan {
             status,
             tbl_reference,
             Arc::new(TaskSpan::table_schema()),
-            None,
+            Some(vec!["span_id".to_string()]),
             Acceleration::default(),
             Refresh::default(),
             retention,
@@ -151,6 +153,15 @@ impl TaskSpan {
     }
 
     pub async fn write(df: Arc<DataFusion>, spans: Vec<TaskSpan>) -> Result<(), Error> {
+        let overrides: Vec<_> = spans
+            .iter()
+            .filter_map(|s| {
+                s.trace_id_override
+                    .as_ref()
+                    .map(|new_trace| (Arc::clone(&s.trace_id), Arc::clone(new_trace)))
+            })
+            .collect();
+
         let data = Self::to_record_batch(spans)
             .boxed()
             .context(UnableToWriteToTableSnafu)?;
@@ -168,6 +179,65 @@ impl TaskSpan {
         .await
         .boxed()
         .context(UnableToWriteToTableSnafu)?;
+
+        // Override trace_ids if necessary. Must be after above write so that it also handles override this batch of spans.
+        for (from, to) in overrides {
+            Self::override_trace_id(Arc::clone(&df), from, to)
+                .await
+                .boxed()
+                .context(UnableToUpdateTracesSnafu)?;
+        }
+
+        Ok(())
+    }
+
+    async fn override_trace_id(
+        df: Arc<DataFusion>,
+        from: Arc<str>,
+        to: Arc<str>,
+    ) -> Result<(), Error> {
+        let overriden: Vec<_> = df
+            .query_builder(
+                format!(
+                    "SELECT * FROM {} where trace_id = '{from}'",
+                    TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE)
+                        .to_quoted_string()
+                )
+                .as_str(),
+            )
+            .build()
+            .run()
+            .await
+            .boxed()
+            .context(UnableToUpdateTracesSnafu)?
+            .data
+            .try_collect::<Vec<RecordBatch>>()
+            .await
+            .boxed()
+            .context(UnableToUpdateTracesSnafu)?
+            .into_iter()
+            .filter_map(|rb| {
+                let (idx, _) = rb.schema().column_with_name("trace_id")?;
+                let mut cols = rb.columns().to_vec();
+
+                cols[idx] = Arc::new(StringArray::from(vec![to.to_string(); rb.num_rows()]));
+                Some(RecordBatch::try_new(rb.schema(), cols))
+            })
+            .collect::<Result<_, ArrowError>>()
+            .boxed()
+            .context(UnableToUpdateTracesSnafu)?;
+
+        df.write_data(
+            &TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE),
+            DataUpdate {
+                schema: Arc::new(Self::table_schema()),
+                data: overriden,
+                update_type: UpdateType::Changes,
+            },
+        )
+        .await
+        .boxed()
+        .context(UnableToUpdateTracesSnafu)?;
 
         Ok(())
     }
@@ -292,6 +362,11 @@ pub enum Error {
 
     #[snafu(display("Error writing to `task_history` table: {source}"))]
     UnableToWriteToTable {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Unable to update `trace_id` column in the `task_history` table: {source}"))]
+    UnableToUpdateTraces {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 

--- a/crates/runtime/src/task_history.rs
+++ b/crates/runtime/src/task_history.rs
@@ -217,6 +217,7 @@ impl TaskSpan {
             .context(UnableToUpdateTracesSnafu)?
             .into_iter()
             .filter_map(|rb| {
+                // Replace the trace id column with the new `to` trace id.
                 let (idx, _) = rb.schema().column_with_name("trace_id")?;
                 let mut cols = rb.columns().to_vec();
 


### PR DESCRIPTION
# 🗣 Description
Limitation in prior implementation of overriding `trace_id` in `runtime.task_history`. Only applies the trace_id override to spans in the same batch being exported. Below is an example of the effect (for large traces). 

```
+----------------------------------+------------------+---------------------+
| trace_id                         | span_id          | task                |
+----------------------------------+------------------+---------------------+
| 4006b51208dbcd4dd9e2711e9370a743 | 6d2dd0bfb1b9d769 | eval_run            |  <- `eval_run` is always
| 31cf86e5572330ac71bc787e10600d81 | 7749fce6f2e00baa | sql_query           |---+   exported last.
| 31cf86e5572330ac71bc787e10600d81 | 8d32124df669bc05 | ai_completion       |   |
| 31cf86e5572330ac71bc787e10600d81 | 568ee8b20203b641 | ai_completion       |   | These are in same trace 
| 31cf86e5572330ac71bc787e10600d81 | 46279bb639ade86d | ai_completion       |   | 
| 31cf86e5572330ac71bc787e10600d81 | 002d92285acca2b5 | ai_completion       |   |
| 31cf86e5572330ac71bc787e10600d81 | 3de9a06e21f4d54b | ai_completion       |---+
| 4006b51208dbcd4dd9e2711e9370a743 | 5aceb0da1846095e | ai_completion       |--+
| 4006b51208dbcd4dd9e2711e9370a743 | 1546f815c2425bff | ai_completion       |  | They should be with these.
| 4006b51208dbcd4dd9e2711e9370a743 | 2865cf8e77fb6915 | ai_completion       |  |
| 4006b51208dbcd4dd9e2711e9370a743 | 53d2883765d9cdd5 | ai_completion       |  |
| 4006b51208dbcd4dd9e2711e9370a743 | 21634592ca92fdb1 | sql_query           |--+
+----------------------------------+------------------+---------------------+
```

- This PR fixes it. 

## 🤔 Concerns
 - Adding a primary key to `runtime.task_history` just for this feature.