### PR TITLE
Add analyzer rule to override Spice internal UDFs (`cosine_distance`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2953,8 +2953,8 @@ dependencies = [
  "chrono",
  "clickhouse-rs",
  "datafusion",
- "datafusion-federation",
- "datafusion-federation-sql",
+ "datafusion-federation 0.1.6 (git+https://github.com/spiceai/datafusion-federation.git?rev=bc20c8cd89ca046613a685d935c5088e42324a83)",
+ "datafusion-federation-sql 0.1.6 (git+https://github.com/spiceai/datafusion-federation.git?rev=bc20c8cd89ca046613a685d935c5088e42324a83)",
  "datafusion-table-providers",
  "db_connection_pool",
  "delta_kernel",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -3061,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "log",
  "tokio",
@@ -3094,7 +3094,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "arrow",
  "chrono",
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3137,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3158,13 +3158,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-federation"
+version = "0.1.6"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=bc20c8cd89ca046613a685d935c5088e42324a83#bc20c8cd89ca046613a685d935c5088e42324a83"
+dependencies = [
+ "arrow-json 53.3.0",
+ "async-stream",
+ "async-trait",
+ "datafusion",
+ "futures",
+]
+
+[[package]]
 name = "datafusion-federation-sql"
 version = "0.1.6"
 source = "git+https://github.com/spiceai/datafusion-federation.git?rev=5af0df83c2cd1d3f82f293b066b401a4dfd4064b#5af0df83c2cd1d3f82f293b066b401a4dfd4064b"
 dependencies = [
  "async-trait",
  "datafusion",
- "datafusion-federation",
+ "datafusion-federation 0.1.6 (git+https://github.com/spiceai/datafusion-federation.git?rev=5af0df83c2cd1d3f82f293b066b401a4dfd4064b)",
+ "futures",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "datafusion-federation-sql"
+version = "0.1.6"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=bc20c8cd89ca046613a685d935c5088e42324a83#bc20c8cd89ca046613a685d935c5088e42324a83"
+dependencies = [
+ "async-trait",
+ "datafusion",
+ "datafusion-federation 0.1.6 (git+https://github.com/spiceai/datafusion-federation.git?rev=bc20c8cd89ca046613a685d935c5088e42324a83)",
  "futures",
  "tokio",
  "tracing",
@@ -3173,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3199,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3219,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3244,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3266,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "datafusion-common",
  "datafusion-expr",
@@ -3280,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3289,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3308,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3335,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3348,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3363,7 +3388,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3397,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "43.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=2b93a308f65df1ae0cd8f3f8194b9b60201a500f#2b93a308f65df1ae0cd8f3f8194b9b60201a500f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=2663a7f6366f2e86575769293a0ab4cd21ad16d9#2663a7f6366f2e86575769293a0ab4cd21ad16d9"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3427,8 +3452,8 @@ dependencies = [
  "byteorder",
  "chrono",
  "datafusion",
- "datafusion-federation",
- "datafusion-federation-sql",
+ "datafusion-federation 0.1.6 (git+https://github.com/spiceai/datafusion-federation.git?rev=bc20c8cd89ca046613a685d935c5088e42324a83)",
+ "datafusion-federation-sql 0.1.6 (git+https://github.com/spiceai/datafusion-federation.git?rev=5af0df83c2cd1d3f82f293b066b401a4dfd4064b)",
  "duckdb",
  "dyn-clone",
  "fallible-iterator 0.3.0",
@@ -6228,7 +6253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8543,7 +8568,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -8576,7 +8601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -9439,8 +9464,8 @@ dependencies = [
  "dashmap",
  "data_components",
  "datafusion",
- "datafusion-federation",
- "datafusion-federation-sql",
+ "datafusion-federation 0.1.6 (git+https://github.com/spiceai/datafusion-federation.git?rev=bc20c8cd89ca046613a685d935c5088e42324a83)",
+ "datafusion-federation-sql 0.1.6 (git+https://github.com/spiceai/datafusion-federation.git?rev=bc20c8cd89ca046613a685d935c5088e42324a83)",
  "datafusion-functions-json",
  "datafusion-table-providers",
  "db_connection_pool",
@@ -12441,7 +12466,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,8 @@ datafusion-common = "43"
 datafusion-execution = "43"
 datafusion-expr = "43"
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "bc20c8cd89ca046613a685d935c5088e42324a83" }
+# datafusion-federation-sql = { path = "../other/datafusion-federation/sources/sql"}
 datafusion-functions-json = "0.43"
 datafusion-table-providers = "0.1"
 dotenvy = "0.15"
@@ -144,16 +145,22 @@ uuid = "1.9.1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "2b93a308f65df1ae0cd8f3f8194b9b60201a500f" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "2b93a308f65df1ae0cd8f3f8194b9b60201a500f" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "2b93a308f65df1ae0cd8f3f8194b9b60201a500f" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "2b93a308f65df1ae0cd8f3f8194b9b60201a500f" }
-
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "2663a7f6366f2e86575769293a0ab4cd21ad16d9" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "2663a7f6366f2e86575769293a0ab4cd21ad16d9" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "2663a7f6366f2e86575769293a0ab4cd21ad16d9" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "2663a7f6366f2e86575769293a0ab4cd21ad16d9" }
+# datafusion = { path = "../other/datafusion/datafusion/core" }
+# datafusion-common = { path = "../other/datafusion/datafusion/common" }
+# datafusion-expr = { path = "../other/datafusion/datafusion/expr" }
+# datafusion-execution = { path = "../other/datafusion/datafusion/execution" }
 
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4" }
 
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "bc20c8cd89ca046613a685d935c5088e42324a83" }
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b64bbf0393f8a49ab7cba97e2f3cbb1b06a3e695" }
+
+# datafusion-federation = { path = "../other/datafusion-federation/datafusion-federation"}
+# datafusion-table-providers = { path = "../other/datafusion-table-providers"}
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "1034c325aee35eb704e741f56ed942ae22ff4e19" }
 

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -68,6 +68,9 @@ impl DeletionTableProvider for PolyTableProvider {
 }
 
 impl FederationProvider for PolyTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
     fn name(&self) -> &str {
         "FederationProviderForPolyTableProvider"
     }

--- a/crates/data_components/src/poly.rs
+++ b/crates/data_components/src/poly.rs
@@ -49,6 +49,11 @@ impl PolyTableProvider {
 
         adaptor.map(|f| Arc::clone(&f.source))
     }
+
+    #[must_use]
+    pub fn get_write_table_provider(&self) -> Arc<dyn TableProvider> {
+        Arc::clone(&self.write)
+    }
 }
 
 #[async_trait]

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -86,6 +86,10 @@ impl FederationAdaptor {
 }
 
 impl FederationProvider for FederationAdaptor {
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
     fn name(&self) -> &str {
         "FederationProviderForAcceleratedDataset"
     }

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -63,6 +63,10 @@ pub struct Dremio {
 pub struct DremioDialect {}
 
 impl Dialect for DremioDialect {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn use_timestamp_for_date64(&self) -> bool {
         true
     }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -89,6 +89,10 @@ pub struct SpiceAI {
 pub struct SpiceCloudPlatformDialect {}
 
 impl Dialect for SpiceCloudPlatformDialect {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
     fn use_timestamp_for_date64(&self) -> bool {
         true
     }

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -68,6 +68,7 @@ mod extension;
 pub mod filter_converter;
 pub mod refresh_sql;
 pub mod schema;
+mod spice_udf_override;
 pub mod udf;
 
 pub const SPICE_DEFAULT_CATALOG: &str = "spice";

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -36,7 +36,10 @@ use datafusion::{
 use datafusion_federation::FederationAnalyzerRule;
 use tokio::sync::RwLock as TokioRwLock;
 
-use crate::{embeddings, object_store_registry::default_runtime_env, status};
+use crate::{
+    datafusion::spice_udf_override::SpiceUDFsOverride, embeddings,
+    object_store_registry::default_runtime_env, status,
+};
 
 use super::{
     extension::{bytes_processed::BytesProcessedOptimizerRule, SpiceQueryPlanner},
@@ -170,6 +173,7 @@ fn get_analyzer_rules() -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
     vec![
         Arc::new(InlineTableScan::new()),
         Arc::new(ExpandWildcardRule::new()),
+        Arc::new(SpiceUDFsOverride::new()),
         Arc::new(FederationAnalyzerRule::new()),
         // The rest of these rules are run after the federation analyzer since they only affect internal DataFusion execution.
         Arc::new(ResolveGroupingFunction::new()),

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -103,6 +103,7 @@ impl DataFusionBuilder {
             .with_query_planner(Arc::new(SpiceQueryPlanner::new()))
             .with_runtime_env(default_runtime_env())
             .with_analyzer_rules(get_analyzer_rules())
+            .with_optimizer_rule(Arc::new(SpiceUDFsOverride::new()))
             .build();
 
         if let Err(e) = datafusion_functions_json::register_all(&mut state) {
@@ -173,7 +174,6 @@ fn get_analyzer_rules() -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
     vec![
         Arc::new(InlineTableScan::new()),
         Arc::new(ExpandWildcardRule::new()),
-        Arc::new(SpiceUDFsOverride::new()),
         Arc::new(FederationAnalyzerRule::new()),
         // The rest of these rules are run after the federation analyzer since they only affect internal DataFusion execution.
         Arc::new(ResolveGroupingFunction::new()),

--- a/crates/runtime/src/datafusion/spice_udf_override.rs
+++ b/crates/runtime/src/datafusion/spice_udf_override.rs
@@ -1,0 +1,273 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use arrow_schema::DataType;
+use data_components::poly::PolyTableProvider;
+use datafusion::{
+    catalog::TableProvider,
+    common::tree_node::{Transformed, TransformedResult, TreeNode},
+    config::ConfigOptions,
+    datasource::source_as_provider,
+    error::Result as DataFusionResult,
+    logical_expr::{
+        expr::ScalarFunction, ColumnarValue, LogicalPlan, Projection, ScalarUDF, ScalarUDFImpl, Signature, TableScan, TableSource
+    },
+    optimizer::AnalyzerRule,
+    prelude::Expr,
+};
+use datafusion_federation::FederatedTableProviderAdaptor;
+use datafusion_table_providers::duckdb::write::DuckDBTableWriter;
+
+use crate::accelerated_table::AcceleratedTable;
+
+/// Implements `DataFusion` `AnalyzerRule` to replace `SpiceAI` internal UDFs with definitions that match
+/// the signature of the target execution engine
+#[derive(Default, Debug)]
+pub struct SpiceUDFsOverride {}
+
+impl SpiceUDFsOverride {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl AnalyzerRule for SpiceUDFsOverride {
+    fn analyze(&self, plan: LogicalPlan, _: &ConfigOptions) -> DataFusionResult<LogicalPlan> {
+        plan.transform_up_with_subqueries(override_spice_udf).data()
+    }
+
+    fn name(&self) -> &str {
+        "spiceai_udf_override_rule"
+    }
+}
+
+/// Replaces `SpiceAI` UDFs with target execution engine-specific UDFs within the logical plan.
+/// The transformation applies only to UDFs that are part of `Projection` nodes.
+fn override_spice_udf(plan: LogicalPlan) -> DataFusionResult<Transformed<LogicalPlan>> {
+    match plan {
+        LogicalPlan::Projection(Projection { expr, input, .. }) => {
+            // Note: while there is currently no in-place mutation API that uses `&mut TreeNode`,
+            // the transforming APIs are efficient and optimized to avoid cloning.
+            match override_spice_udf_in_exprs(&input, expr)? {
+                (new_expr, true) => {
+                    Ok(Transformed::yes(
+                        Projection::try_new(new_expr, Arc::clone(&input))
+                            .map(LogicalPlan::Projection)?,
+                    ))
+                }
+                (new_expr, false) => {
+                    Ok(Transformed::no(
+                        Projection::try_new(new_expr, Arc::clone(&input))
+                            .map(LogicalPlan::Projection)?,
+                    ))
+                }
+            }
+        }
+        _ => Ok(Transformed::no(plan)),
+    }
+}
+
+fn override_spice_udf_in_exprs(
+    input: &LogicalPlan,
+    exprs: Vec<Expr>,
+) -> DataFusionResult<(Vec<Expr>, bool)> {
+    let mut modified = false;
+    let exprs: Vec<Expr> = exprs
+        .into_iter()
+        .map(|expr| {
+            // recursive `transform` is required as UDF can be nested in the expression tree
+            expr.transform(|expr| {
+                if let Expr::ScalarFunction(scalar_fn) = expr {
+                    let udf_fn_name = scalar_fn.name();
+                    match udf_fn_name {
+                        "cosine_distance" if is_duckdb_accelerator_provider(input)? => {
+                            let rewritten_expr =
+                                rewrite_cosine_distance_udf_duckdb(scalar_fn.func, scalar_fn.args)?;
+                            modified = true;
+                            return Ok(Transformed::yes(rewritten_expr));
+                        }
+                        _ => (),
+                    }
+                    return Ok(Transformed::no(Expr::ScalarFunction(scalar_fn)));
+                }
+                Ok(Transformed::no(expr))
+            })
+            .map(|x| x.data)
+        })
+        .collect::<DataFusionResult<Vec<_>>>()?;
+
+    Ok((exprs, modified))
+}
+
+/// Converts the `cosine_distance` UDF into `DuckDB` `array_cosine_distance` function:
+/// `https://duckdb.org/docs/sql/functions/array.html#array_cosine_distancearray1-array2`
+///
+///  Replaces `make_array` function with `DuckDB` `array_value` function to convert list to `DuckDB` Array (`FixedSizeList`),
+///  otherwise `DuckDB` will throw an error:
+///
+/// SQL Error: java.sql.SQLException: Binder Error: No function matches the given name and argument types `array_cosine_distance(FLOAT[384], DOUBLE[])`. You might need to add explicit type casts.
+///  Candidate functions:
+///  `array_cosine_distance(FLOAT[ANY], FLOAT[ANY])` -> FLOAT
+///  `array_cosine_distance(DOUBLE[ANY], DOUBLE[ANY])` -> DOUBLE
+///
+fn rewrite_cosine_distance_udf_duckdb(
+    func: Arc<ScalarUDF>,
+    args: Vec<Expr>,
+) -> DataFusionResult<Expr> {
+    tracing::debug!("Rewriting `cosine_distance` UDF for DuckDB");
+    let args: Vec<Expr> = args
+        .into_iter()
+        .map(|expr| {
+            expr.transform(|expr| match expr {
+                Expr::ScalarFunction(scalar_func)
+                    if scalar_func.name().to_lowercase() == "make_array" =>
+                {
+                    // replace `make_array` with DuckDB `array_value`
+                    let expr = Expr::ScalarFunction(ScalarFunction::new_udf(
+                        Arc::new(ScalarUDF::new_from_impl(RenameFunctionUDF::new(
+                            "array_value",
+                            scalar_func.func,
+                        ))),
+                        scalar_func.args,
+                    ));
+                    Ok(Transformed::yes(expr))
+                }
+                _ => Ok(Transformed::no(expr)),
+            })
+            .map(|x| x.data)
+        })
+        .collect::<DataFusionResult<Vec<_>>>()?;
+
+    // Rename `cosine_distance` into `array_cosine_distance`
+    let expr = Expr::ScalarFunction(ScalarFunction::new_udf(
+        Arc::new(ScalarUDF::new_from_impl(RenameFunctionUDF::new(
+            "array_cosine_distance",
+            func,
+        ))),
+        args,
+    ));
+
+   Ok(expr)
+}
+
+/// Recursively searches children of `LogicalPlan` to `TableScan` node and checks if the target execution engine is `DuckDB`
+pub(crate) fn is_duckdb_accelerator_provider(plan: &LogicalPlan) -> DataFusionResult<bool> {
+    let federated_table_exists = plan.exists(|x: &LogicalPlan| {
+       if let LogicalPlan::TableScan(TableScan { ref source, .. }) = x {
+            let Some(provider) = get_accelerator_write_table_provider(source)? else {
+                return Ok(false);
+            };
+
+            return Ok(provider
+                .as_any()
+                .downcast_ref::<DuckDBTableWriter>()
+                .is_some());
+        }
+
+        Ok(false)
+    })?;
+
+    Ok(federated_table_exists)
+}
+
+pub fn get_accelerator_write_table_provider(
+    source: &Arc<dyn TableSource>,
+) -> DataFusionResult<Option<Arc<dyn TableProvider>>> {
+    let source = source_as_provider(source)?;
+
+    let Some(wrapper) = source
+        .as_any()
+        .downcast_ref::<FederatedTableProviderAdaptor>()
+    else {
+        return Ok(None);
+    };
+
+    let Some(federated_table_provider) = &wrapper.table_provider else {
+        return Ok(None);
+    };
+
+    let Some(accelerated_table) = federated_table_provider
+        .as_any()
+        .downcast_ref::<AcceleratedTable>()
+    else {
+        return Ok(None);
+    };
+
+    let accelerator = accelerated_table.get_accelerator();
+
+    let Some(poly_provider) = accelerator.as_any().downcast_ref::<PolyTableProvider>() else {
+        return Ok(None);
+    };
+
+    Ok(Some(poly_provider.get_write_table_provider()))
+}
+
+#[derive(Debug)]
+struct RenameFunctionUDF {
+    name: String,
+    inner: Arc<ScalarUDF>,
+}
+
+/// UDF function wrapper to rename it during unparsing
+/// Implementation is requried as analyzer rules use them for coercion and type checking
+impl RenameFunctionUDF {
+    fn new(name: &str, inner: Arc<ScalarUDF>) -> Self {
+        Self {
+            name: name.to_string(),
+            inner,
+        }
+    }
+}
+
+impl ScalarUDFImpl for RenameFunctionUDF {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    fn signature(&self) -> &Signature {
+        self.inner.signature()
+    }
+
+    fn return_type_from_exprs(
+        &self,
+        args: &[Expr],
+        schema: &dyn datafusion::common::ExprSchema,
+        arg_types: &[DataType],
+    ) -> DataFusionResult<DataType> {
+        self.inner.return_type_from_exprs(args, schema, arg_types)
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        // this method should not be called as `return_type_from_exprs` is implemented
+        unreachable!("RenameFunctionUDF return_type should not be called")
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> DataFusionResult<Vec<DataType>> {
+        // used by other rules to coerce types
+        self.inner.coerce_types(arg_types)
+    }
+
+    fn invoke(&self, _args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
+        // UDF should be used for unparsing purpose only
+        unreachable!("RenameFunctionUDF should not be invoked")
+    }
+}

--- a/crates/runtime/src/datafusion/spice_udf_override.rs
+++ b/crates/runtime/src/datafusion/spice_udf_override.rs
@@ -217,14 +217,14 @@ pub fn get_accelerator_write_table_provider(
     Ok(Some(poly_provider.get_write_table_provider()))
 }
 
+/// UDF function wrapper to provide different function name during unparsing
+/// Implementation is requried as analyzer rules use them for coercion and type checking
 #[derive(Debug)]
 struct RenameFunctionUDF {
     name: String,
     inner: Arc<ScalarUDF>,
 }
 
-/// UDF function wrapper to rename it during unparsing
-/// Implementation is requried as analyzer rules use them for coercion and type checking
 impl RenameFunctionUDF {
     fn new(name: &str, inner: Arc<ScalarUDF>) -> Self {
         Self {

--- a/crates/runtime/src/datafusion/spice_udf_override.rs
+++ b/crates/runtime/src/datafusion/spice_udf_override.rs
@@ -17,26 +17,23 @@ limitations under the License.
 use std::sync::Arc;
 
 use arrow_schema::DataType;
-use data_components::poly::PolyTableProvider;
 use datafusion::{
-    catalog::TableProvider,
-    common::tree_node::{Transformed, TransformedResult, TreeNode},
-    config::ConfigOptions,
-    datasource::source_as_provider,
-    error::Result as DataFusionResult,
+    common::tree_node::{Transformed, TreeNode, TreeNodeRecursion},
+    error::{DataFusionError, Result as DataFusionResult},
     logical_expr::{
-        expr::ScalarFunction, ColumnarValue, LogicalPlan, Projection, ScalarUDF, ScalarUDFImpl, Signature, TableScan, TableSource
+        expr::ScalarFunction, ColumnarValue, Extension, LogicalPlan, Projection, ScalarUDF,
+        ScalarUDFImpl, Signature, TableScan,
     },
-    optimizer::AnalyzerRule,
+    optimizer::{optimizer::ApplyOrder, OptimizerConfig, OptimizerRule},
     prelude::Expr,
+    sql::unparser::dialect::{Dialect, DuckDBDialect},
 };
-use datafusion_federation::FederatedTableProviderAdaptor;
-use datafusion_table_providers::duckdb::write::DuckDBTableWriter;
-
-use crate::accelerated_table::AcceleratedTable;
+use datafusion_federation::{get_table_source, FederatedPlanNode};
+use datafusion_federation_sql::SQLFederationProvider;
 
 /// Implements `DataFusion` `AnalyzerRule` to replace `SpiceAI` internal UDFs with definitions that match
-/// the signature of the target execution engine
+/// the signature of the target execution engine.
+/// The rule is applied to `Projection` nodes of federated logical plans.
 #[derive(Default, Debug)]
 pub struct SpiceUDFsOverride {}
 
@@ -46,9 +43,44 @@ impl SpiceUDFsOverride {
     }
 }
 
-impl AnalyzerRule for SpiceUDFsOverride {
-    fn analyze(&self, plan: LogicalPlan, _: &ConfigOptions) -> DataFusionResult<LogicalPlan> {
-        plan.transform_up_with_subqueries(override_spice_udf).data()
+impl OptimizerRule for SpiceUDFsOverride {
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn supports_rewrite(&self) -> bool {
+        true
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>, DataFusionError> {
+        if let LogicalPlan::Extension(extension_node) = plan {
+            if let Some(node) = extension_node
+                .node
+                .as_any()
+                .downcast_ref::<FederatedPlanNode>()
+            {
+                // extension plan node and logical plan are immutable references
+                // so we need to clone the plan and reconstruct the extension node
+                let updated_plan = node.plan().clone().transform(override_spice_udf)?;
+                let planner = node.planner();
+
+                let updated_extension_node = Extension {
+                    node: Arc::new(FederatedPlanNode::new(updated_plan.data, planner)),
+                };
+
+                if updated_plan.transformed {
+                    return Ok(Transformed::yes(LogicalPlan::Extension(updated_extension_node)));
+                }
+                return Ok(Transformed::no(LogicalPlan::Extension(updated_extension_node)));
+            }
+            return Ok(Transformed::no(LogicalPlan::Extension(extension_node)));
+        }
+
+        Ok(Transformed::no(plan))
     }
 
     fn name(&self) -> &str {
@@ -64,18 +96,14 @@ fn override_spice_udf(plan: LogicalPlan) -> DataFusionResult<Transformed<Logical
             // Note: while there is currently no in-place mutation API that uses `&mut TreeNode`,
             // the transforming APIs are efficient and optimized to avoid cloning.
             match override_spice_udf_in_exprs(&input, expr)? {
-                (new_expr, true) => {
-                    Ok(Transformed::yes(
-                        Projection::try_new(new_expr, Arc::clone(&input))
-                            .map(LogicalPlan::Projection)?,
-                    ))
-                }
-                (new_expr, false) => {
-                    Ok(Transformed::no(
-                        Projection::try_new(new_expr, Arc::clone(&input))
-                            .map(LogicalPlan::Projection)?,
-                    ))
-                }
+                (new_expr, true) => Ok(Transformed::yes(
+                    Projection::try_new(new_expr, Arc::clone(&input))
+                        .map(LogicalPlan::Projection)?,
+                )),
+                (new_expr, false) => Ok(Transformed::no(
+                    Projection::try_new(new_expr, Arc::clone(&input))
+                        .map(LogicalPlan::Projection)?,
+                )),
             }
         }
         _ => Ok(Transformed::no(plan)),
@@ -93,9 +121,10 @@ fn override_spice_udf_in_exprs(
             // recursive `transform` is required as UDF can be nested in the expression tree
             expr.transform(|expr| {
                 if let Expr::ScalarFunction(scalar_fn) = expr {
-                    let udf_fn_name = scalar_fn.name();
-                    match udf_fn_name {
-                        "cosine_distance" if is_duckdb_accelerator_provider(input)? => {
+                    match scalar_fn.name() {
+                        "cosine_distance"
+                            if is_duckdb_dialect(retrieve_dialect(input)?.as_ref()) =>
+                        {
                             let rewritten_expr =
                                 rewrite_cosine_distance_udf_duckdb(scalar_fn.func, scalar_fn.args)?;
                             modified = true;
@@ -112,6 +141,10 @@ fn override_spice_udf_in_exprs(
         .collect::<DataFusionResult<Vec<_>>>()?;
 
     Ok((exprs, modified))
+}
+
+fn is_duckdb_dialect(dialect: Option<&Arc<dyn Dialect>>) -> bool {
+    dialect.is_some_and(|dialect| dialect.as_any().is::<DuckDBDialect>())
 }
 
 /// Converts the `cosine_distance` UDF into `DuckDB` `array_cosine_distance` function:
@@ -162,59 +195,43 @@ fn rewrite_cosine_distance_udf_duckdb(
         args,
     ));
 
-   Ok(expr)
+    Ok(expr)
 }
 
 /// Recursively searches children of `LogicalPlan` to `TableScan` node and checks if the target execution engine is `DuckDB`
-pub(crate) fn is_duckdb_accelerator_provider(plan: &LogicalPlan) -> DataFusionResult<bool> {
-    let federated_table_exists = plan.exists(|x: &LogicalPlan| {
-       if let LogicalPlan::TableScan(TableScan { ref source, .. }) = x {
-            let Some(provider) = get_accelerator_write_table_provider(source)? else {
-                return Ok(false);
-            };
+pub(crate) fn retrieve_dialect(plan: &LogicalPlan) -> DataFusionResult<Option<Arc<dyn Dialect>>> {
+    let mut dialect: Option<Arc<dyn Dialect>> = None;
 
-            return Ok(provider
-                .as_any()
-                .downcast_ref::<DuckDBTableWriter>()
-                .is_some());
+    plan.apply(|x| {
+        if let Some(x) = retrieve_federated_node_dialect(x)? {
+            dialect = Some(x);
+            return Ok(TreeNodeRecursion::Stop);
         }
-
-        Ok(false)
+        Ok(TreeNodeRecursion::Continue)
     })?;
-
-    Ok(federated_table_exists)
+    Ok(dialect)
 }
 
-pub fn get_accelerator_write_table_provider(
-    source: &Arc<dyn TableSource>,
-) -> DataFusionResult<Option<Arc<dyn TableProvider>>> {
-    let source = source_as_provider(source)?;
+fn retrieve_federated_node_dialect(
+    plan: &LogicalPlan,
+) -> DataFusionResult<Option<Arc<dyn Dialect>>> {
+    match plan {
+        LogicalPlan::TableScan(TableScan { ref source, .. }) => {
+            let Some(federated_source) = get_table_source(source)? else {
+                return Ok(None);
+            };
 
-    let Some(wrapper) = source
-        .as_any()
-        .downcast_ref::<FederatedTableProviderAdaptor>()
-    else {
-        return Ok(None);
-    };
+            let provider = federated_source.federation_provider();
 
-    let Some(federated_table_provider) = &wrapper.table_provider else {
-        return Ok(None);
-    };
+            let Some(sql_provider) = provider.as_any().downcast_ref::<SQLFederationProvider>()
+            else {
+                return Ok(None);
+            };
 
-    let Some(accelerated_table) = federated_table_provider
-        .as_any()
-        .downcast_ref::<AcceleratedTable>()
-    else {
-        return Ok(None);
-    };
-
-    let accelerator = accelerated_table.get_accelerator();
-
-    let Some(poly_provider) = accelerator.as_any().downcast_ref::<PolyTableProvider>() else {
-        return Ok(None);
-    };
-
-    Ok(Some(poly_provider.get_write_table_provider()))
+            Ok(Some(sql_provider.dialect()))
+        }
+        _ => Ok(None),
+    }
 }
 
 /// UDF function wrapper to provide different function name during unparsing


### PR DESCRIPTION
# 🗣 Description

Add `spiceai_udf_override_rule` analyzer rule to override Spice internal UDFs to match the signature of the target execution engine. Currently supports overriding `cosine_distance` for DuckDB only.

Pending the following PRs:
 - datafusion: [Enable downcasting support for Dialect trait](https://github.com/spiceai/datafusion/pull/67)
 - datafusion-federation: [Enable downcasting for FederationProvider and expose Dialect information ](https://github.com/spiceai/datafusion-federation/pull/27)
 - datafusion-table-providers: to be updated after datafusion-federation is merged

## 🔨 Related Issues

Fixes https://github.com/spiceai/spiceai/issues/3796

## ⛓️‍💥 Breaking Change


## 📄 Documentation Updates


## 🤔 Concerns

 - Need to add tests

