### PR TITLE
Mitigate flaky integration test `test_github_pulls`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,7 +1618,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -6228,7 +6228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8543,7 +8543,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -8576,7 +8576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -9506,6 +9506,7 @@ dependencies = [
  "ssh2",
  "suppaftp",
  "telemetry",
+ "test_retry",
  "tiberius",
  "tokio",
  "tokio-rusqlite",
@@ -10903,6 +10904,17 @@ checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test_retry"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532fa61a8207816e2bf329548a15ceed1ab5a1fac0afed6475f95675cba1f412"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -12441,7 +12453,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -145,6 +145,7 @@ jsonpath-rust = "0.7.3"
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio-current-thread"] }
 scopeguard = "1.2.0"
 spice-cloud = { path = "../spice_cloud" }
+test_retry = "0.1.0"
 tokio = { workspace = true, features = ["time", "test-util"] }
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/runtime/tests/github/mod.rs
+++ b/crates/runtime/tests/github/mod.rs
@@ -44,6 +44,7 @@ fn make_github_dataset(owner: &str, repo: &str, query_type: &str, query_mode: &s
 }
 
 #[tokio::test]
+#[test_retry::retry]
 async fn test_github_pulls() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 


### PR DESCRIPTION
# 🗣 Description

The integration test `test_github_pulls` can sometimes fail in CI due to hitting rate limits, see if retrying the test helps.
