### PR TITLE
fix: Disable ident normalization in datafusion config

### DIFF
--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -58,6 +58,10 @@ impl DataFusionBuilder {
             .with_information_schema(true)
             .with_create_default_catalog_and_schema(false);
 
+        df_config
+            .options_mut()
+            .sql_parser
+            .enable_ident_normalization = false;
         df_config.options_mut().sql_parser.dialect = "PostgreSQL".to_string();
         df_config.options_mut().catalog.default_catalog = SPICE_DEFAULT_CATALOG.to_string();
         df_config.options_mut().catalog.default_schema = SPICE_DEFAULT_SCHEMA.to_string();


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Disabled identifier normalization in DataFusion, which forces all column identifiers to lowercase by default. This requires that any mixed-case columns be wrapped with quotes like `"` to prevent normalization from applying to them.

See the DataFusion user guide: https://datafusion.apache.org/user-guide/configs.html

### Before:
```sql
select UserID from hits limit 1;
```

```bash
No field named userid. Valid fields are hits."WatchID", hits."JavaEnable", ...
```

### After:
```sql
select UserID from hits limit 1;
```

```bash
+----------------------+
| UserID               |
+----------------------+
| -2461439046089301801 |
+----------------------+
```

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

Out of an abundance of caution, I am marking this as a breaking change as it will break any behavior where queries relied on an uppercase column being normalized to a lowercase one.

Queries that relied on this behavior will now need to use the correct specific case for the target column.

* [x] "Breaking Change" label added if this PR is a breaking change