### PR TITLE
Enhance AI tools sampling logic for robust handling of large fields

### DIFF
--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -143,7 +143,7 @@ pub fn to_primitive_type_list(
 /// # Errors
 ///
 /// This function will return an error if arrow conversion fails.
-pub fn truncate_record_batch_data(
+pub fn truncate_string_columns(
     record_batch: &RecordBatch,
     max_characters: usize,
 ) -> Result<RecordBatch, ArrowError> {
@@ -397,7 +397,7 @@ mod test {
 
         let input_batch = parse_json_to_batch(input_batch_json_data, Arc::clone(&schema));
 
-        let processed_batch = truncate_record_batch_data(&input_batch, 5)
+        let processed_batch = truncate_string_columns(&input_batch, 5)
             .expect("truncate_record_batch_data should succeed");
 
         let expected_batch_json_data = r#"

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -140,6 +140,7 @@ pub fn to_primitive_type_list(
 
 /// Recursively truncates the data in a record batch to the specified maximum number of characters.
 /// The truncation is applied to `Utf8` and `Utf8View` data.
+///
 /// # Errors
 ///
 /// This function will return an error if arrow conversion fails.

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -242,7 +242,6 @@ fn trancate_str(str: Option<&str>, max_characters: usize) -> Option<&str> {
     match str {
         Some(value) => {
             if value.len() > max_characters {
-                // Some(String::from(&value[..max_characters]))
                 Some(&value[..max_characters])
             } else {
                 Some(value)

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -138,6 +138,119 @@ pub fn to_primitive_type_list(
     Err(ArrowError::CastError("Invalid column type".into()))
 }
 
+/// Recursively truncates the data in a record batch to the specified maximum number of characters.
+/// The truncation is applied to `Utf8` and `Utf8View` data.
+/// # Errors
+///
+/// This function will return an error if arrow conversion fails.
+pub fn truncate_record_batch_data(
+    record_batch: &RecordBatch,
+    max_characters: usize,
+) -> Result<RecordBatch, ArrowError> {
+    let schema = record_batch.schema();
+    let columns = record_batch
+        .columns()
+        .iter()
+        .zip(schema.fields())
+        .map(|(column, field)| truncate_column_data(Arc::clone(column), field, max_characters))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    RecordBatch::try_new(schema, columns)
+}
+
+fn truncate_column_data(
+    column: ArrayRef,
+    field: &Arc<Field>,
+    max_characters: usize,
+) -> Result<ArrayRef, ArrowError> {
+    match field.data_type() {
+        DataType::Utf8View => {
+            let string_array = column
+                .as_any()
+                .downcast_ref::<arrow::array::StringViewArray>()
+                .ok_or(ArrowError::CastError(
+                    "Failed to downcast to StringViewArray".into(),
+                ))?;
+
+            let truncated = string_array
+                .iter()
+                .map(|x| trancate_str(x, max_characters))
+                .collect::<arrow::array::StringViewArray>();
+
+            Ok(Arc::new(truncated) as ArrayRef)
+        }
+        DataType::Utf8 => {
+            let string_array = column
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .ok_or(ArrowError::CastError(
+                    "Failed to downcast to ListArray".into(),
+                ))?;
+
+            let truncated = string_array
+                .iter()
+                .map(|x| trancate_str(x, max_characters))
+                .collect::<arrow::array::StringArray>();
+
+            Ok(Arc::new(truncated) as ArrayRef)
+        }
+        DataType::List(field) => {
+            let list_array = column
+                .as_any()
+                .downcast_ref::<arrow::array::ListArray>()
+                .ok_or_else(|| ArrowError::CastError("Failed to downcast to ListArray".into()))?;
+
+            let truncated_values =
+                truncate_column_data(Arc::clone(list_array.values()), field, max_characters)?;
+
+            let list = ListArray::new(
+                Arc::clone(field),
+                arrow::buffer::OffsetBuffer::new(
+                    arrow::buffer::Buffer::from_slice_ref(list_array.value_offsets()).into(),
+                ),
+                truncated_values,
+                list_array.logical_nulls(),
+            );
+
+            Ok(Arc::new(list) as ArrayRef)
+        }
+        DataType::Struct(fields) => {
+            let struct_array = column
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .ok_or_else(|| ArrowError::CastError("Failed to downcast to StructArray".into()))?;
+
+            let columns = fields
+                .iter()
+                .enumerate()
+                .map(|(i, field)| {
+                    let field_data = struct_array.column(i);
+                    truncate_column_data(Arc::clone(field_data), field, max_characters)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let truncated_struct =
+                StructArray::from(fields.iter().cloned().zip(columns).collect::<Vec<_>>());
+            Ok(Arc::new(truncated_struct) as ArrayRef)
+        }
+        _ => Ok(column),
+    }
+}
+
+fn trancate_str(str: Option<&str>, max_characters: usize) -> Option<&str> {
+    match str {
+        Some(value) => {
+            if value.len() > max_characters {
+                // Some(String::from(&value[..max_characters]))
+                Some(&value[..max_characters])
+            } else {
+                Some(value)
+            }
+        }
+        None => None,
+    }
+}
+
 #[cfg(test)]
 mod test {
 
@@ -256,5 +369,45 @@ mod test {
         .expect("should create new record batch");
 
         assert_eq!(expected_list_batch, processed_batch);
+    }
+
+    #[test]
+    fn test_truncate_record_batch_data_complex_data() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "labels",
+            DataType::List(Arc::new(Field::new(
+                "struct",
+                DataType::Struct(
+                    vec![
+                        Field::new("id", DataType::Int32, true),
+                        Field::new("name", DataType::Utf8, true),
+                    ]
+                    .into(),
+                ),
+                true,
+            ))),
+            true,
+        )]));
+
+        let input_batch_json_data = r#"
+            {"labels": [{"id": 1, "name": "123"}, {"id": 2, "name": "12345"}, {"id": 1, "name": "123456789"}]}
+            {"labels": null}
+            {"labels": [{"id": 4,"name":"test12345"}, {"id": null,"name":null}]}
+            "#;
+
+        let input_batch = parse_json_to_batch(input_batch_json_data, Arc::clone(&schema));
+
+        let processed_batch = truncate_record_batch_data(&input_batch, 5)
+            .expect("truncate_record_batch_data should succeed");
+
+        let expected_batch_json_data = r#"
+            {"labels": [{"id": 1, "name": "123"}, {"id": 2, "name": "12345"}, {"id": 1, "name": "12345"}]}
+            {"labels": null}
+            {"labels": [{"id": 4,"name":"test1"}, {"id": null,"name":null}]}
+            "#;
+
+        let expected_batch = parse_json_to_batch(expected_batch_json_data, schema);
+
+        assert_eq!(processed_batch, expected_batch);
     }
 }

--- a/crates/runtime/src/tools/builtin/sample/tool.rs
+++ b/crates/runtime/src/tools/builtin/sample/tool.rs
@@ -18,6 +18,7 @@ use crate::{
     Runtime,
 };
 use arrow::util::pretty::pretty_format_batches;
+use arrow_tools::record_batch::truncate_record_batch_data;
 use async_trait::async_trait;
 use serde_json::Value;
 use snafu::ResultExt;
@@ -91,7 +92,11 @@ impl SpiceModelTool for SampleDataTool {
         let span: Span = tracing::span!(target: "task_history", tracing::Level::INFO, "tool_use::sample_data", tool = self.name(), input = format!("{params}"), sample_method = self.method.name());
 
         async {
-            let batch = params.sample(rt.datafusion()).await?;
+            let mut batch = params.sample(rt.datafusion()).await?;
+
+            // truncate large text fields
+            batch = truncate_record_batch_data(&batch, 512)?;
+
             let serial = pretty_format_batches(&[batch]).boxed()?;
 
             Ok(Value::String(format!("{serial}")))

--- a/crates/runtime/src/tools/builtin/sample/tool.rs
+++ b/crates/runtime/src/tools/builtin/sample/tool.rs
@@ -18,7 +18,7 @@ use crate::{
     Runtime,
 };
 use arrow::util::pretty::pretty_format_batches;
-use arrow_tools::record_batch::truncate_record_batch_data;
+use arrow_tools::record_batch::truncate_string_columns;
 use async_trait::async_trait;
 use serde_json::Value;
 use snafu::ResultExt;
@@ -95,7 +95,7 @@ impl SpiceModelTool for SampleDataTool {
             let mut batch = params.sample(rt.datafusion()).await?;
 
             // truncate large text fields
-            batch = truncate_record_batch_data(&batch, 512)?;
+            batch = truncate_string_columns(&batch, 512)?;
 
             let serial = pretty_format_batches(&[batch]).boxed()?;
 


### PR DESCRIPTION
# 🗣 Description

Current sampling logic can return very large data that could not be handled by AI models, plus expensive. PR adds logic to truncate large text fields

## 🔨 Related Issues

Fixes NSQL bug: string too long. Expected a string with maximum length 1048576, but got a string with length 1065155 instead. https://github.com/spiceai/spiceai/issues/3946

## 🤔 Concerns

We might need to make size parameters configurable 
