### PR TITLE
DuckDB: add support for nested types in Lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3899,7 +3899,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "duckdb"
 version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=1034c325aee35eb704e741f56ed942ae22ff4e19#1034c325aee35eb704e741f56ed942ae22ff4e19"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae#c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae"
 dependencies = [
  "arrow",
  "cast",
@@ -6351,7 +6351,7 @@ checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 [[package]]
 name = "libduckdb-sys"
 version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=1034c325aee35eb704e741f56ed942ae22ff4e19#1034c325aee35eb704e741f56ed942ae22ff4e19"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae#c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "cee50b7
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5af0df83c2cd1d3f82f293b066b401a4dfd4064b" }
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "1f2631473b2b4ed779d797a94d4ac2bca0bd1efd" }
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "1034c325aee35eb704e741f56ed942ae22ff4e19" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae" }
 
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "dfb1e03a5f0702c1a318db5abf40e762d6b2bcc2" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }


### PR DESCRIPTION
# 🗣 Description

Update duckdb-rs version to include [DuckDB: Add support for nested types in Lists (Struct, List, FixedSizeList)](https://github.com/spiceai/duckdb-rs/pull/11)

There is companion PR to `datafusion-table-providers` with duckdb update and tests: https://github.com/datafusion-contrib/datafusion-table-providers/pull/203. This could be applied separately, `datafusion-table-providers` upgrade is not required as spice overrides DuckDB version used by `datafusion-table-providers`.

## 📄 Documentation Updates

DuckDB Limitation (docs) section must be updated to include the new support for nested types in Lists
