### PR TITLE
Fix integration tests - add missing `format` query parameter in /v1/status requests

### DIFF
--- a/crates/runtime/tests/endpoint_auth/http.rs
+++ b/crates/runtime/tests/endpoint_auth/http.rs
@@ -120,7 +120,7 @@ async fn test_http_auth() -> Result<(), anyhow::Error> {
         tracing::info!("Metrics health check passed");
 
         // v1/status is authenticated
-        let status_url = format!("http://127.0.0.1:{http_port}/v1/status");
+        let status_url = format!("http://127.0.0.1:{http_port}/v1/status?format=json");
         let response = http_client
             .get(&status_url)
             .send()


### PR DESCRIPTION
Fixed failing integration test:

![CleanShot 2024-12-24 at 22 46 08@2x](https://github.com/user-attachments/assets/9853d452-d6c6-4ce0-a642-c99bc653d358)
