### PR TITLE
Use Llama-3.2-3B-Instruct for Hugging Face integration testing

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -98,5 +98,11 @@ jobs:
           chmod +x ./integration_test/ai_integration_test
 
       - name: Run integration test
+        env:
+          SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
         run: |
+          if [ -z "$SPICE_HF_TOKEN" ] ; then
+            echo "Error: Hugging Face API Token is not defined."
+            exit 1
+          fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture huggingface_test

--- a/crates/runtime/tests/models/snapshots/integration_models__models__nsql__hf_with_model_tasks.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__nsql__hf_with_model_tasks.snap
@@ -2,10 +2,10 @@
 source: crates/runtime/tests/models/mod.rs
 expression: response
 ---
-+------------------------+------------------------------------------------------------------+
-| task                   | input                                                            |
-+------------------------+------------------------------------------------------------------+
-| nsql                   | how many records (as 'total_records') are in taxi_trips dataset? |
-| tool_use::table_schema | {"tables":["spice.public.taxi_trips"],"output":"full"}           |
-| sql_query              | SELECT COUNT(*) AS total_records FROM "taxi_trips"               |
-+------------------------+------------------------------------------------------------------+
++------------------------+-------------------------------------------------------------------------------+
+| task                   | input                                                                         |
++------------------------+-------------------------------------------------------------------------------+
+| nsql                   | how many records (as 'total_records') are in spice.public.taxi_trips dataset? |
+| tool_use::table_schema | {"tables":["spice.public.taxi_trips"],"output":"full"}                        |
+| sql_query              | SELECT COUNT(*) AS total_records FROM "spice"."public"."taxi_trips"           |
++------------------------+-------------------------------------------------------------------------------+


### PR DESCRIPTION
# 🗣 Description

Use Llama-3.2-3B-Instruct for Hugging Face integration testing

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3990

## 🤔 Concerns

`hf_with_sample_data_enabled` NSQL test was disabled as it causes model to crash (`model pipeline unexpectedly closed`). This will be addressed separatly