### PR TITLE
Enable spice.ai tpcds bench workflow. Comment failing tpch queries.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -173,6 +173,9 @@ jobs:
           - cmd: '-c spice.ai'
             name: 'spice.ai connector'
             bench: 'tpch'
+          - cmd: '-c spice.ai -b tpcds'
+            name: 'spice.ai connector'
+            bench: 'tpcds'
           - cmd: '-c s3'
             name: 's3 connector'
             bench: 'tpch'
@@ -330,7 +333,7 @@ jobs:
         run: |
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
-          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
+          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }}
           mc cp spice-bench-minio/benchmarks/duckdb/tpch.db ./
 
       - name: Download DuckDB Connector Data
@@ -338,7 +341,7 @@ jobs:
         run: |
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
-          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
+          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }}
           mc cp spice-bench-minio/benchmarks/duckdb/tpcds.db ./
 
       - name: Download File Connector TPCH Data
@@ -346,7 +349,7 @@ jobs:
         run: |
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
-          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
+          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }}
           mc cp spice-bench-minio/benchmarks/tpch_sf1/customer/ ./ --recursive
           mc cp spice-bench-minio/benchmarks/tpch_sf1/lineitem/ ./ --recursive
           mc cp spice-bench-minio/benchmarks/tpch_sf1/nation/ ./ --recursive
@@ -361,7 +364,7 @@ jobs:
         run: |
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
-          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }} 
+          mc alias set spice-bench-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }}
           mc cp spice-bench-minio/benchmarks/tpcds_sf1/call_center/ ./ --recursive
           mc cp spice-bench-minio/benchmarks/tpcds_sf1/catalog_page/ ./ --recursive
           mc cp spice-bench-minio/benchmarks/tpcds_sf1/catalog_returns/ ./ --recursive

--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -143,6 +143,7 @@ fn get_tpch_test_queries() -> Vec<(&'static str, &'static str)> {
         ("tpch_q14", include_str!("../queries/tpch/q14.sql")),
         // tpch_q15 has a view creation which we don't support by design
         ("tpch_q16", include_str!("../queries/tpch/q16.sql")),
+        // See: https://github.com/spiceai/spiceai/issues/3980
         // DoGet recv error: rpc error: code = InvalidArgument desc = Correlated scalar subquery can only be used in Projection, Filter, Aggregate plan nodes
         // ("tpch_q17", include_str!("../queries/tpch/q17.sql")),
         ("tpch_q18", include_str!("../queries/tpch/q18.sql")),

--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -127,7 +127,7 @@ fn get_params(bench_name: &str) -> Params {
 fn get_tpch_test_queries() -> Vec<(&'static str, &'static str)> {
     vec![
         ("tpch_q1", include_str!("../queries/tpch/q1.sql")),
-        // DoGet recv error: rpc error: code = InvalidArgument desc = Correlated scalar subquery can only be used in Projection, Filter, Aggregate plan nodes
+        // Spice.ai Data Platform doesn't support correlated subqueries yet https://github.com/spiceai/spiceai/issues/4024
         // ("tpch_q2", include_str!("../queries/tpch/q2.sql")),
         ("tpch_q3", include_str!("../queries/tpch/q3.sql")),
         ("tpch_q4", include_str!("../queries/tpch/q4.sql")),
@@ -143,13 +143,12 @@ fn get_tpch_test_queries() -> Vec<(&'static str, &'static str)> {
         ("tpch_q14", include_str!("../queries/tpch/q14.sql")),
         // tpch_q15 has a view creation which we don't support by design
         ("tpch_q16", include_str!("../queries/tpch/q16.sql")),
-        // See: https://github.com/spiceai/spiceai/issues/3980
-        // DoGet recv error: rpc error: code = InvalidArgument desc = Correlated scalar subquery can only be used in Projection, Filter, Aggregate plan nodes
+        // Spice.ai Data Platform doesn't support correlated subqueries yet https://github.com/spiceai/spiceai/issues/4024
         // ("tpch_q17", include_str!("../queries/tpch/q17.sql")),
         ("tpch_q18", include_str!("../queries/tpch/q18.sql")),
         ("tpch_q19", include_str!("../queries/tpch/q19.sql")),
         ("tpch_q20", include_str!("../queries/tpch/q20.sql")),
-        // DoGet recv error: rpc error: code = InvalidArgument desc = No field named l1.l_orderkey. Valid fields are __correlated_sq_1.l_orderkey, __correlated_sq_1.l_suppkey.
+        // Spice.ai Data Platform doesn't support correlated subqueries yet https://github.com/spiceai/spiceai/issues/4024
         // ("tpch_q21", include_str!("../queries/tpch/q21.sql")),
         ("tpch_q22", include_str!("../queries/tpch/q22.sql")),
         (

--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -159,6 +159,7 @@ fn get_tpch_test_queries() -> Vec<(&'static str, &'static str)> {
             "tpch_simple_q2",
             include_str!("../queries/tpch/simple_q2.sql"),
         ),
+        // See: https://github.com/spiceai/spiceai/issues/3980
         // Tonic error: status: ResourceExhausted, message: "DoGet recv error: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (1646208435 vs. 104857600)", details: [], metadata: MetadataMap { headers: {} }
         // (
         //     "tpch_simple_q3",

--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -143,11 +143,13 @@ fn get_tpch_test_queries() -> Vec<(&'static str, &'static str)> {
         ("tpch_q14", include_str!("../queries/tpch/q14.sql")),
         // tpch_q15 has a view creation which we don't support by design
         ("tpch_q16", include_str!("../queries/tpch/q16.sql")),
-        ("tpch_q17", include_str!("../queries/tpch/q17.sql")),
+        // DoGet recv error: rpc error: code = InvalidArgument desc = Correlated scalar subquery can only be used in Projection, Filter, Aggregate plan nodes
+        // ("tpch_q17", include_str!("../queries/tpch/q17.sql")),
         ("tpch_q18", include_str!("../queries/tpch/q18.sql")),
         ("tpch_q19", include_str!("../queries/tpch/q19.sql")),
         ("tpch_q20", include_str!("../queries/tpch/q20.sql")),
-        ("tpch_q21", include_str!("../queries/tpch/q21.sql")),
+        // DoGet recv error: rpc error: code = InvalidArgument desc = No field named l1.l_orderkey. Valid fields are __correlated_sq_1.l_orderkey, __correlated_sq_1.l_suppkey.
+        // ("tpch_q21", include_str!("../queries/tpch/q21.sql")),
         ("tpch_q22", include_str!("../queries/tpch/q22.sql")),
         (
             "tpch_simple_q1",
@@ -157,10 +159,11 @@ fn get_tpch_test_queries() -> Vec<(&'static str, &'static str)> {
             "tpch_simple_q2",
             include_str!("../queries/tpch/simple_q2.sql"),
         ),
-        (
-            "tpch_simple_q3",
-            include_str!("../queries/tpch/simple_q3.sql"),
-        ),
+        // DoGet recv error: rpc error: code = InvalidArgument desc = No field named l1.l_orderkey. Valid fields are __correlated_sq_1.l_orderkey, __correlated_sq_1.l_suppkey.
+        // (
+        //     "tpch_simple_q3",
+        //     include_str!("../queries/tpch/simple_q3.sql"),
+        // ),
         (
             "tpch_simple_q4",
             include_str!("../queries/tpch/simple_q4.sql"),

--- a/crates/runtime/benches/bench_spicecloud/mod.rs
+++ b/crates/runtime/benches/bench_spicecloud/mod.rs
@@ -159,7 +159,7 @@ fn get_tpch_test_queries() -> Vec<(&'static str, &'static str)> {
             "tpch_simple_q2",
             include_str!("../queries/tpch/simple_q2.sql"),
         ),
-        // DoGet recv error: rpc error: code = InvalidArgument desc = No field named l1.l_orderkey. Valid fields are __correlated_sq_1.l_orderkey, __correlated_sq_1.l_suppkey.
+        // Tonic error: status: ResourceExhausted, message: "DoGet recv error: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (1646208435 vs. 104857600)", details: [], metadata: MetadataMap { headers: {} }
         // (
         //     "tpch_simple_q3",
         //     include_str!("../queries/tpch/simple_q3.sql"),


### PR DESCRIPTION
Enabled tpcds workflow for spice.ai connector

## TPCH

| query_name     | status | min_duration_ms | max_duration_ms | iterations |
|----------------|--------|-----------------|-----------------|------------|
| tpch_q1        | passed | 773             | 1804            | 5          |
| tpch_q3        | passed | 929             | 3173            | 5          |
| tpch_q4        | passed | 695             | 1298            | 5          |
| tpch_q5        | passed | 681             | 2120            | 5          |
| tpch_q6        | passed | 659             | 830             | 5          |
| tpch_q7        | passed | 693             | 2800            | 5          |
| tpch_q8        | passed | 721             | 2372            | 5          |
| tpch_q9        | passed | 671             | 2825            | 5          |
| tpch_q10       | passed | 5178            | 5410            | 5          |
| tpch_q11       | passed | 728             | 1876            | 5          |
| tpch_q12       | passed | 731             | 1212            | 5          |
| tpch_q13       | passed | 669             | 1105            | 5          |
| tpch_q14       | passed | 690             | 804             | 5          |
| tpch_q16       | passed | 738             | 3167            | 5          |
| tpch_q18       | passed | 669             | 2340            | 5          |
| tpch_q19       | passed | 678             | 945             | 5          |
| tpch_q20       | passed | 670             | 1291            | 5          |
| tpch_q22       | passed | 660             | 990             | 5          |
| tpch_simple_q1 | passed | 665             | 775             | 5          |
| tpch_simple_q2 | passed | 791             | 1882            | 5          |
| tpch_simple_q4 | passed | 681             | 918             | 5          |
| tpch_simple_q5 | passed | 676             | 2378            | 5          |
| tpch_simple_q6 | passed | 672             | 784             | 5          |
| tpch_simple_q7 | passed | 660             | 1182            | 5          |

## TPCDS

| query_name | status | min_duration_ms | max_duration_ms | iterations | connector_name |
|------------|--------|-----------------|-----------------|------------|----------------|
| tpcds_q1   | passed | 2944            | 4812            | 5          | spice.ai       |
| tpcds_q2   | passed | 2097            | 2697            | 5          | spice.ai       |
| tpcds_q3   | passed | 683             | 1600            | 5          | spice.ai       |
| tpcds_q4   | passed | 11510           | 12112           | 5          | spice.ai       |
| tpcds_q7   | passed | 2189            | 3939            | 5          | spice.ai       |
| tpcds_q9   | passed | 682             | 913             | 5          | spice.ai       |
| tpcds_q11  | passed | 6086            | 7695            | 5          | spice.ai       |
| tpcds_q13  | passed | 731             | 1906            | 5          | spice.ai       |
| tpcds_q15  | passed | 700             | 1567            | 5          | spice.ai       |
| tpcds_q17  | passed | 695             | 2031            | 5          | spice.ai       |
| tpcds_q18  | passed | 3136            | 5018            | 5          | spice.ai       |
| tpcds_q19  | passed | 701             | 1705            | 5          | spice.ai       |
| tpcds_q25  | passed | 703             | 2226            | 5          | spice.ai       |
| tpcds_q26  | passed | 727             | 2731            | 5          | spice.ai       |
| tpcds_q27  | passed | 2622            | 4026            | 5          | spice.ai       |
| tpcds_q28  | passed | 672             | 793             | 5          | spice.ai       |
| tpcds_q29  | passed | 671             | 2583            | 5          | spice.ai       |
| tpcds_q30  | passed | 1193            | 2457            | 5          | spice.ai       |
| tpcds_q31  | passed | 735             | 3839            | 5          | spice.ai       |
| tpcds_q33  | passed | 700             | 2151            | 5          | spice.ai       |
| tpcds_q34  | passed | 711             | 1765            | 5          | spice.ai       |
| tpcds_q36  | passed | 672             | 1758            | 5          | spice.ai       |
| tpcds_q41  | passed | 683             | 801             | 5          | spice.ai       |
| tpcds_q42  | passed | 692             | 1198            | 5          | spice.ai       |
| tpcds_q43  | passed | 697             | 1242            | 5          | spice.ai       |
| tpcds_q44  | passed | 658             | 1238            | 5          | spice.ai       |
| tpcds_q45  | passed | 673             | 1525            | 5          | spice.ai       |
| tpcds_q46  | passed | 2589            | 3259            | 5          | spice.ai       |
| tpcds_q47  | passed | 10326           | 12603           | 5          | spice.ai       |
| tpcds_q48  | passed | 759             | 1238            | 5          | spice.ai       |
| tpcds_q49  | passed | 719             | 3073            | 5          | spice.ai       |
| tpcds_q50  | passed | 684             | 2626            | 5          | spice.ai       |
| tpcds_q51  | passed | 727             | 3420            | 5          | spice.ai       |
| tpcds_q52  | passed | 736             | 1943            | 5          | spice.ai       |
| tpcds_q53  | passed | 687             | 1396            | 5          | spice.ai       |
| tpcds_q54  | passed | 728             | 2353            | 5          | spice.ai       |
| tpcds_q55  | passed | 699             | 1195            | 5          | spice.ai       |
| tpcds_q56  | passed | 2381            | 2516            | 5          | spice.ai       |
| tpcds_q57  | passed | 5575            | 6299            | 5          | spice.ai       |
| tpcds_q58  | passed | 700             | 3324            | 5          | spice.ai       |
| tpcds_q59  | passed | 3512            | 4665            | 5          | spice.ai       |
| tpcds_q60  | passed | 1519            | 3156            | 5          | spice.ai       |
| tpcds_q61  | passed | 713             | 1621            | 5          | spice.ai       |
| tpcds_q62  | passed | 701             | 6421            | 5          | spice.ai       |
| tpcds_q63  | passed | 695             | 1454            | 5          | spice.ai       |
| tpcds_q64  | passed | 8766            | 10953           | 5          | spice.ai       |
| tpcds_q65  | passed | 2538            | 3541            | 5          | spice.ai       |
| tpcds_q66  | passed | 1146            | 4970            | 5          | spice.ai       |
| tpcds_q67  | passed | 3765            | 4257            | 5          | spice.ai       |
| tpcds_q68  | passed | 2223            | 2785            | 5          | spice.ai       |
| tpcds_q70  | passed | 661             | 1958            | 5          | spice.ai       |
| tpcds_q71  | passed | 1990            | 2210            | 5          | spice.ai       |
| tpcds_q73  | passed | 674             | 1432            | 5          | spice.ai       |
| tpcds_q74  | passed | 5104            | 6246            | 5          | spice.ai       |
| tpcds_q75  | passed | 842             | 5589            | 5          | spice.ai       |
| tpcds_q76  | passed | 656             | 1524            | 5          | spice.ai       |
| tpcds_q78  | passed | 783             | 4197            | 5          | spice.ai       |
| tpcds_q79  | passed | 841             | 1747            | 5          | spice.ai       |
| tpcds_q81  | passed | 1409            | 2722            | 5          | spice.ai       |
| tpcds_q83  | passed | 820             | 2668            | 5          | spice.ai       |
| tpcds_q84  | passed | 685             | 1240            | 5          | spice.ai       |
| tpcds_q85  | passed | 826             | 2398            | 5          | spice.ai       |
| tpcds_q86  | passed | 725             | 1119            | 5          | spice.ai       |
| tpcds_q88  | passed | 895             | 5451            | 5          | spice.ai       |
| tpcds_q89  | passed | 739             | 1703            | 5          | spice.ai       |
| tpcds_q90  | passed | 699             | 1307            | 5          | spice.ai       |
| tpcds_q93  | passed | 730             | 1627            | 5          | spice.ai       |
| tpcds_q96  | passed | 648             | 1224            | 5          | spice.ai       |
| tpcds_q97  | passed | 651             | 1582            | 5          | spice.ai       |
| tpcds_q99  | passed | 719             | 2817            | 5          | spice.ai       |