### PR TITLE
Create a `CatalogConnector` abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12536,9 +12536,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514a48569e4e21c86d0b84b5612b5e73c0b2cf09db63260134ba426d4e8ea714"
+checksum = "68e76d357bc95c7d0939c92c04c9269871a8470eea39cb1f0231eeadb0c47d0f"
 dependencies = [
  "indexmap 2.7.0",
  "serde",
@@ -12548,9 +12548,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5629efe65599d0ccd5d493688cbf6e03aa7c1da07fe59ff97cf5977ed0637f66"
+checksum = "564b03f8044ad6806bdc0d635e88be24967e785eef096df6b2636d2cc1e05d4b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -19,7 +19,7 @@ use std::{error::Error, sync::Arc};
 
 use ::arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use datafusion::{datasource::TableProvider, sql::TableReference};
+use datafusion::{catalog::CatalogProvider, datasource::TableProvider, sql::TableReference};
 
 pub mod arrow;
 #[cfg(feature = "clickhouse")]
@@ -85,4 +85,9 @@ pub trait ReadWrite: Send + Sync {
         table_reference: TableReference,
         schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn Error + Send + Sync>>;
+}
+
+#[async_trait]
+pub trait RefreshableCatalogProvider: CatalogProvider {
+    async fn refresh(&self) -> Result<(), Box<dyn Error + Send + Sync>>;
 }

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -57,6 +57,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// An ergonomic wrapper around calling Unity Catalog APIs.
 ///
 /// Could be replaced once <https://crates.io/crates/unitycatalog-client> is available.
+#[derive(Debug)]
 pub struct UnityCatalog {
     endpoint: String,
     token: Option<SecretString>,
@@ -244,7 +245,7 @@ pub struct UCTableEnvelope {
 }
 
 /// Response from `/api/2.1/unity-catalog/tables/{table_name}`
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct UCTable {
     pub name: String,
     pub catalog_name: String,
@@ -259,7 +260,7 @@ pub struct UCTable {
     pub storage_location: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct UCColumn {
     pub name: String,
     pub type_text: String,

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -23,15 +23,19 @@ use datafusion::{
 };
 use globset::GlobSet;
 use snafu::prelude::*;
-use std::{any::Any, collections::HashMap, sync::Arc};
+use std::{
+    any::Any,
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
-use crate::Read;
+use crate::{Read, RefreshableCatalogProvider};
 
 use super::{CatalogId, Result, UCSchema, UCTable, UnityCatalog};
 
 #[derive(Debug)]
 pub struct UnityCatalogProvider {
-    schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+    schemas: HashMap<String, Arc<UnityCatalogSchemaProvider>>,
 }
 
 impl UnityCatalogProvider {
@@ -39,7 +43,7 @@ impl UnityCatalogProvider {
         client: Arc<UnityCatalog>,
         catalog_id: CatalogId,
         table_creator: Arc<dyn Read>,
-        table_reference_creator: fn(UCTable) -> Option<TableReference>,
+        table_reference_creator: fn(&UCTable) -> Option<TableReference>,
         include: Option<GlobSet>,
     ) -> Result<Self> {
         let schemas =
@@ -65,10 +69,7 @@ impl UnityCatalogProvider {
                 include.clone(),
             )
             .await?;
-            schemas_map.insert(
-                schema.name,
-                Arc::new(schema_provider) as Arc<dyn SchemaProvider>,
-            );
+            schemas_map.insert(schema.name, Arc::new(schema_provider));
         }
         Ok(Self {
             schemas: schemas_map,
@@ -90,13 +91,41 @@ impl CatalogProvider for UnityCatalogProvider {
 
     /// Retrieves a specific schema from the catalog by name, provided it exists.
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
-        self.schemas.get(name).cloned()
+        self.schemas
+            .get(name)
+            .cloned()
+            .map(|s| s as Arc<dyn SchemaProvider>)
     }
 }
 
-#[derive(Debug)]
+#[async_trait]
+impl RefreshableCatalogProvider for UnityCatalogProvider {
+    async fn refresh(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let refresh_futures = self.schemas.values().map(|schema| schema.refresh());
+        futures::future::join_all(refresh_futures)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(())
+    }
+}
+
 pub struct UnityCatalogSchemaProvider {
-    tables: HashMap<String, Arc<dyn TableProvider>>,
+    tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
+    client: Arc<UnityCatalog>,
+    schema: UCSchema,
+    table_reference_creator: fn(&UCTable) -> Option<TableReference>,
+    include: Option<Arc<GlobSet>>,
+    table_creator: Arc<dyn Read>,
+}
+
+impl std::fmt::Debug for UnityCatalogSchemaProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnityCatalogSchemaProvider")
+            .field("schema", &self.schema)
+            .field("tables", &self.tables)
+            .finish_non_exhaustive()
+    }
 }
 
 impl UnityCatalogSchemaProvider {
@@ -109,7 +138,7 @@ impl UnityCatalogSchemaProvider {
         client: Arc<UnityCatalog>,
         schema: &UCSchema,
         table_creator: Arc<dyn Read>,
-        table_reference_creator: fn(UCTable) -> Option<TableReference>,
+        table_reference_creator: fn(&UCTable) -> Option<TableReference>,
         include: Option<Arc<GlobSet>>,
     ) -> Result<Self> {
         let tables = client
@@ -123,7 +152,7 @@ impl UnityCatalogSchemaProvider {
         let mut tables_map = HashMap::new();
         for table in tables {
             let table_name = table.name.to_string();
-            let table_reference = table_reference_creator(table);
+            let table_reference = table_reference_creator(&table);
 
             let Some(table_reference) = table_reference else {
                 continue;
@@ -151,7 +180,101 @@ impl UnityCatalogSchemaProvider {
             tables_map.insert(table_name, table_provider);
         }
 
-        Ok(Self { tables: tables_map })
+        Ok(Self {
+            tables: RwLock::new(tables_map),
+            client,
+            schema: schema.clone(),
+            table_reference_creator,
+            include,
+            table_creator,
+        })
+    }
+
+    pub async fn refresh(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let previous_table_names = self.table_names();
+        let current_tables = self
+            .client
+            .list_tables(&self.schema.catalog_name, &self.schema.name)
+            .await?
+            .context(super::SchemaDoesntExistSnafu {
+                schema: self.schema.name.to_string(),
+                catalog_id: self.schema.catalog_name.to_string(),
+            })?;
+
+        let mut new_tables = Vec::new();
+        let mut removed_tables = Vec::new();
+
+        for table_name in &previous_table_names {
+            if !current_tables.iter().any(|t| t.name == *table_name) {
+                removed_tables.push(table_name.clone());
+            }
+        }
+
+        for table in current_tables {
+            if !previous_table_names.contains(&table.name) {
+                new_tables.push(table);
+            }
+        }
+
+        let mut new_table_providers = HashMap::new();
+        for table in new_tables {
+            let Some(provider) = Self::provider_for_uc_table(
+                &self.schema,
+                &table,
+                Arc::clone(&self.table_creator),
+                self.table_reference_creator,
+                self.include.clone(),
+            )
+            .await
+            else {
+                continue;
+            };
+            new_table_providers.insert(table.name.to_string(), provider);
+        }
+
+        let mut guard = match self.tables.write() {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
+        for table_name in removed_tables {
+            guard.remove(&table_name);
+        }
+        for (table_name, provider) in new_table_providers {
+            guard.insert(table_name, provider);
+        }
+        Ok(())
+    }
+
+    async fn provider_for_uc_table(
+        schema: &UCSchema,
+        table: &UCTable,
+        table_creator: Arc<dyn Read>,
+        table_reference_creator: fn(&UCTable) -> Option<TableReference>,
+        include: Option<Arc<GlobSet>>,
+    ) -> Option<Arc<dyn TableProvider>> {
+        let table_name = table.name.to_string();
+        let table_reference = table_reference_creator(table)?;
+
+        let schema_with_table = format!("{}.{}", schema.name, table_name);
+        tracing::debug!("Checking if table {} should be included", schema_with_table);
+        if let Some(include) = &include {
+            if !include.is_match(&schema_with_table) {
+                tracing::debug!("Table {} is not included", schema_with_table);
+                return None;
+            }
+        }
+
+        let table_provider = match table_creator
+            .table_provider(table_reference.clone(), None)
+            .await
+        {
+            Ok(provider) => provider,
+            Err(source) => {
+                tracing::warn!("Couldn't get table provider for {table_reference}: {source}");
+                return None;
+            }
+        };
+        Some(table_provider)
     }
 }
 
@@ -165,13 +288,21 @@ impl SchemaProvider for UnityCatalogSchemaProvider {
 
     /// Retrieves the list of available table names in this schema.
     fn table_names(&self) -> Vec<String> {
-        self.tables.keys().cloned().collect()
+        let guard = match self.tables.read() {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
+        guard.keys().cloned().collect()
     }
 
     /// Retrieves a specific table from the schema by name, if it exists,
     /// otherwise returns `Ok(None)`.
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
-        let Some(table) = self.tables.get(name) else {
+        let guard = match self.tables.read() {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
+        let Some(table) = guard.get(name) else {
             return Ok(None);
         };
 
@@ -180,6 +311,10 @@ impl SchemaProvider for UnityCatalogSchemaProvider {
 
     /// Returns true if table exist in the schema provider, false otherwise.
     fn table_exist(&self, name: &str) -> bool {
-        self.tables.contains_key(name)
+        let guard = match self.tables.read() {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
+        guard.contains_key(name)
     }
 }

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -243,6 +243,30 @@ impl UnityCatalogSchemaProvider {
             Ok(guard) => guard,
             Err(e) => e.into_inner(),
         };
+        if !removed_tables.is_empty() || !new_table_providers.is_empty() {
+            let mut message = format!(
+                "Refreshed schema {}.{}. ",
+                self.schema.catalog_name, self.schema.name
+            );
+            if !removed_tables.is_empty() {
+                message.push_str(&format!("Tables removed: {}.", removed_tables.join(", ")));
+            }
+            if !new_table_providers.is_empty() {
+                if !removed_tables.is_empty() {
+                    message.push(' ');
+                }
+                message.push_str(&format!(
+                    "Tables added: {}.",
+                    new_table_providers
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .as_slice()
+                        .join(", ")
+                ));
+            }
+            tracing::info!("{}", message);
+        }
         for table_name in removed_tables {
             guard.remove(&table_name);
         }

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -21,6 +21,7 @@ use datafusion::{
     error::DataFusionError,
     sql::TableReference,
 };
+use futures::{StreamExt, TryStreamExt};
 use globset::GlobSet;
 use snafu::prelude::*;
 use std::{
@@ -101,11 +102,17 @@ impl CatalogProvider for UnityCatalogProvider {
 #[async_trait]
 impl RefreshableCatalogProvider for UnityCatalogProvider {
     async fn refresh(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let refresh_futures = self.schemas.values().map(|schema| schema.refresh());
-        futures::future::join_all(refresh_futures)
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
+        let max_concurrent = 5;
+        let futures = self
+            .schemas
+            .values()
+            .cloned()
+            .map(|schema| async move { schema.refresh().await });
+
+        futures::stream::iter(futures)
+            .buffer_unordered(max_concurrent)
+            .try_collect::<Vec<_>>()
+            .await?;
         Ok(())
     }
 }

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -20,7 +20,7 @@ use app::App;
 use tokio::sync::RwLock;
 
 use crate::{
-    dataaccelerator, dataconnector,
+    catalogconnector, dataaccelerator, dataconnector,
     datafusion::DataFusion,
     datasets_health_monitor::DatasetsHealthMonitor,
     extension::{Extension, ExtensionFactory},
@@ -124,6 +124,7 @@ impl RuntimeBuilder {
 
     pub async fn build(self) -> Runtime {
         dataconnector::register_all().await;
+        catalogconnector::register_all().await;
         dataaccelerator::register_all().await;
         tools::factory::register_all_factories().await;
         document_parse::register_all().await;

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -1,0 +1,236 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::CatalogConnector;
+use super::ConnectorComponent;
+use super::ParameterSpec;
+use super::Parameters;
+use crate::component::catalog::Catalog;
+use crate::dataconnector::databricks::Databricks as DatabricksDataConnector;
+use crate::dataconnector::ConnectorParams;
+use crate::get_params_with_secrets;
+use crate::Runtime;
+use async_trait::async_trait;
+use data_components::delta_lake::DeltaTableFactory;
+use data_components::unity_catalog::provider::UnityCatalogProvider;
+use data_components::unity_catalog::CatalogId;
+use data_components::unity_catalog::Endpoint;
+use data_components::unity_catalog::UCTable;
+use data_components::unity_catalog::UnityCatalog as UnityCatalogClient;
+use data_components::Read;
+use data_components::RefreshableCatalogProvider;
+use datafusion::sql::TableReference;
+use secrecy::SecretString;
+use snafu::ResultExt;
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct Databricks {
+    params: Parameters,
+}
+
+impl Databricks {
+    #[must_use]
+    pub fn new_connector(params: ConnectorParams) -> Arc<dyn CatalogConnector> {
+        Arc::new(Self {
+            params: params.parameters,
+        })
+    }
+}
+
+pub(crate) const PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::connector("endpoint")
+        .required()
+        .secret()
+        .description("The endpoint of the Databricks instance."),
+    ParameterSpec::connector("token")
+        .required()
+        .secret()
+        .description("The personal access token used to authenticate against the DataBricks API."),
+    ParameterSpec::runtime("mode")
+        .description("The execution mode for querying against Databricks.")
+        .default("spark_connect"),
+    ParameterSpec::runtime("client_timeout")
+        .description("The timeout setting for object store client."),
+    ParameterSpec::connector("cluster_id").description("The ID of the compute cluster in Databricks to use for the query. Only valid when mode is spark_connect."),
+    ParameterSpec::connector("use_ssl").description("Use a TLS connection to connect to the Databricks Spark Connect endpoint.").default("true"),
+
+    // S3 storage options
+    ParameterSpec::connector("aws_region")
+        .description("The AWS region to use for S3 storage.")
+        .secret(),
+    ParameterSpec::connector("aws_access_key_id")
+        .description("The AWS access key ID to use for S3 storage.")
+        .secret(),
+    ParameterSpec::connector("aws_secret_access_key")
+        .description("The AWS secret access key to use for S3 storage.")
+        .secret(),
+    ParameterSpec::connector("aws_endpoint")
+        .description("The AWS endpoint to use for S3 storage.")
+        .secret(),
+
+    // Azure storage options
+    ParameterSpec::connector("azure_storage_account_name")
+        .description("The storage account to use for Azure storage.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_account_key")
+        .description("The storage account key to use for Azure storage.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_client_id")
+        .description("The service principal client id for accessing the storage account.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_client_secret")
+        .description("The service principal client secret for accessing the storage account.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_sas_key")
+        .description("The shared access signature key for accessing the storage account.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_endpoint")
+        .description("The endpoint for the Azure Blob storage account.")
+        .secret(),
+
+    // GCS storage options
+    ParameterSpec::connector("google_service_account")
+        .description("Filesystem path to the Google service account JSON key file.")
+        .secret(),
+];
+
+#[async_trait]
+impl CatalogConnector for Databricks {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn refreshable_catalog_provider(
+        self: Arc<Self>,
+        runtime: &Runtime,
+        catalog: &Catalog,
+    ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
+        let Some(catalog_id) = catalog.catalog_id.clone() else {
+            return Err(super::Error::InvalidConfigurationNoSource {
+                connector: "databricks".into(),
+                message: "A Catalog Name is required for the Databricks Unity Catalog.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#from".into(),
+                connector_component: ConnectorComponent::from(catalog)
+            });
+        };
+
+        let endpoint = self.params.get("endpoint").expose().ok_or_else(|p| {
+            super::Error::InvalidConfigurationNoSource {
+                connector: "databricks".into(),
+                message: format!("A required parameter was missing: {}.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
+                connector_component: ConnectorComponent::from(catalog)
+            }
+        })?;
+        let token = self.params.get("token").ok_or_else(|p| {
+            super::Error::InvalidConfigurationNoSource {
+                connector: "databricks".into(),
+                message: format!("A required parameter was missing: {}.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
+                connector_component: ConnectorComponent::from(catalog)
+            }
+        })?;
+
+        let unity_catalog =
+            UnityCatalogClient::new(Endpoint(endpoint.to_string()), Some(token.clone()));
+        let client = Arc::new(unity_catalog);
+
+        // Copy the catalog params into the dataset params, and allow user to override
+        let mut dataset_params: HashMap<String, SecretString> =
+            get_params_with_secrets(runtime.secrets(), &catalog.params).await;
+
+        let secret_dataset_params =
+            get_params_with_secrets(runtime.secrets(), &catalog.dataset_params).await;
+
+        for (key, value) in secret_dataset_params {
+            dataset_params.insert(key, value);
+        }
+
+        let params = Parameters::try_new(
+            "connector databricks",
+            dataset_params.into_iter().collect(),
+            "databricks",
+            runtime.secrets(),
+            PARAMETERS,
+        )
+        .await
+        .context(super::InternalWithSourceSnafu {
+            connector: "databricks".to_string(),
+            connector_component: ConnectorComponent::from(catalog),
+        })?;
+
+        let mode = self.params.get("mode").expose().ok();
+        let (table_creator, table_reference_creator) = if let Some("delta_lake") = mode {
+            (
+                Arc::new(DeltaTableFactory::new(params.to_secret_map())) as Arc<dyn Read>,
+                table_reference_creator_delta_lake as fn(&UCTable) -> Option<TableReference>,
+            )
+        } else {
+            let dataset_databricks =
+                match DatabricksDataConnector::new(params)
+                    .await
+                    .map_err(|source| super::Error::UnableToGetCatalogProvider {
+                        connector: "databricks".to_string(),
+                        source: source.into(),
+                        connector_component: ConnectorComponent::from(catalog),
+                    }) {
+                    Ok(dataset_databricks) => dataset_databricks,
+                    Err(e) => return Err(e),
+                };
+
+            (
+                dataset_databricks.read_provider(),
+                table_reference_creator_spark as fn(&UCTable) -> Option<TableReference>,
+            )
+        };
+
+        let catalog_provider = match UnityCatalogProvider::try_new(
+            client,
+            CatalogId(catalog_id),
+            table_creator,
+            table_reference_creator,
+            catalog.include.clone(),
+        )
+        .await
+        {
+            Ok(provider) => provider,
+            Err(e) => {
+                return Err(super::Error::UnableToGetCatalogProvider {
+                    connector: "databricks".to_string(),
+                    source: Box::new(e),
+                    connector_component: ConnectorComponent::from(catalog),
+                })
+            }
+        };
+
+        Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>)
+    }
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn table_reference_creator_spark(uc_table: &UCTable) -> Option<TableReference> {
+    let table_reference = TableReference::Full {
+        catalog: uc_table.catalog_name.clone().into(),
+        schema: uc_table.schema_name.clone().into(),
+        table: uc_table.name.clone().into(),
+    };
+    Some(table_reference)
+}
+
+fn table_reference_creator_delta_lake(uc_table: &UCTable) -> Option<TableReference> {
+    let storage_location = uc_table.storage_location.as_deref()?;
+    Some(TableReference::bare(format!("{storage_location}/")))
+}

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -56,10 +56,19 @@ pub enum Error {
         connector_component: ConnectorComponent,
         message: String,
     },
+
+    #[snafu(display("Failed to load the {connector_component} ({connector}).\nAn unknown Catalog Connector Error occurred: {source}\nPlease report a bug on GitHub: https://github.com/spiceai/spiceai/issues"))]
+    InternalWithSource {
+        connector: String,
+        connector_component: ConnectorComponent,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[cfg(feature = "databricks")]
+pub mod databricks;
 #[cfg(feature = "delta_lake")]
 pub mod unity_catalog;
 
@@ -95,6 +104,16 @@ pub async fn register_all() {
             unity_catalog::UnityCatalog::new_connector,
             "unity_catalog",
             unity_catalog::PARAMETERS,
+        ),
+    );
+
+    #[cfg(feature = "databricks")]
+    registry.insert(
+        "databricks".to_string(),
+        CatalogConnectorFactory::new(
+            databricks::Databricks::new_connector,
+            "databricks",
+            databricks::PARAMETERS,
         ),
     );
 }

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -1,0 +1,224 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    any::Any,
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
+use crate::{
+    component::catalog::Catalog,
+    dataconnector::{ConnectorComponent, ConnectorParams},
+    parameters::{ParameterSpec, Parameters},
+    Runtime,
+};
+use async_trait::async_trait;
+use data_components::RefreshableCatalogProvider;
+use datafusion::catalog::CatalogProvider;
+use snafu::prelude::*;
+use tokio::{sync::Mutex, task::JoinHandle};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to setup the {connector_component} ({connector}).\n{source}"))]
+    UnableToGetCatalogProvider {
+        connector: String,
+        connector_component: ConnectorComponent,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Cannot setup the {connector_component} ({connector}) with an invalid configuration.\n{message}"))]
+    InvalidConfiguration {
+        connector: String,
+        connector_component: ConnectorComponent,
+        message: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Cannot setup the {connector_component} ({connector}) with an invalid configuration.\n{message}"))]
+    InvalidConfigurationNoSource {
+        connector: String,
+        connector_component: ConnectorComponent,
+        message: String,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[cfg(feature = "delta_lake")]
+pub mod unity_catalog;
+
+pub(crate) static CATALOG_CONNECTOR_FACTORY_REGISTRY: LazyLock<
+    Mutex<HashMap<String, CatalogConnectorFactory>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Create a new `CatalogConnector` by name.
+///
+/// # Returns
+///
+/// `None` if the connector for `name` is not registered, otherwise a `Result` containing the result of calling the constructor to create a `CatalogConnector`.
+pub async fn create_new_connector(
+    name: &str,
+    params: ConnectorParams,
+) -> Option<Arc<dyn CatalogConnector>> {
+    let guard = CATALOG_CONNECTOR_FACTORY_REGISTRY.lock().await;
+
+    let connector_factory = guard.get(name);
+
+    let factory = connector_factory?;
+
+    Some(factory.connector(params))
+}
+
+pub async fn register_all() {
+    let mut registry = CATALOG_CONNECTOR_FACTORY_REGISTRY.lock().await;
+
+    #[cfg(feature = "delta_lake")]
+    registry.insert(
+        "unity_catalog".to_string(),
+        CatalogConnectorFactory::new(
+            unity_catalog::UnityCatalog::new_connector,
+            "unity_catalog",
+            unity_catalog::PARAMETERS,
+        ),
+    );
+}
+
+pub(crate) struct CatalogConnectorFactory {
+    connector_factory: fn(ConnectorParams) -> Arc<dyn CatalogConnector>,
+    prefix: &'static str,
+    parameters: &'static [ParameterSpec],
+}
+
+impl CatalogConnectorFactory {
+    pub fn new(
+        connector_factory: fn(ConnectorParams) -> Arc<dyn CatalogConnector>,
+        prefix: &'static str,
+        parameters: &'static [ParameterSpec],
+    ) -> Self {
+        Self {
+            connector_factory,
+            prefix,
+            parameters,
+        }
+    }
+
+    pub fn connector(&self, params: ConnectorParams) -> Arc<dyn CatalogConnector> {
+        (self.connector_factory)(params)
+    }
+
+    pub fn prefix(&self) -> &'static str {
+        self.prefix
+    }
+
+    pub fn parameters(&self) -> &'static [ParameterSpec] {
+        self.parameters
+    }
+}
+
+/// A `CatalogConnector` knows how to connect to a remote catalog and create a DataFusion `CatalogProvider`.
+#[async_trait]
+pub trait CatalogConnector: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+
+    /// Returns a DataFusion `CatalogProvider` which can automatically populate tables from a remote catalog.
+    /// The returned provider must implement RefreshableCatalogProvider which will be used to refresh the catalog.
+    async fn refreshable_catalog_provider(
+        self: Arc<Self>,
+        _runtime: &Runtime,
+        _catalog: &Catalog,
+    ) -> Result<Arc<dyn RefreshableCatalogProvider>>;
+}
+
+pub async fn get_catalog_provider(
+    connector: Arc<dyn CatalogConnector>,
+    runtime: &Runtime,
+    catalog: &Catalog,
+    refresh_interval: Option<Duration>,
+) -> Result<Arc<dyn CatalogProvider>> {
+    let provider = RefreshingCatalogProvider::new(
+        connector
+            .refreshable_catalog_provider(runtime, catalog)
+            .await?,
+    )
+    .start_refresh(refresh_interval);
+    Ok(Arc::new(provider))
+}
+
+/// A `CatalogProvider` that periodically refreshes its contents from a remote catalog.
+#[derive(Debug)]
+pub struct RefreshingCatalogProvider {
+    inner: Arc<dyn RefreshableCatalogProvider>,
+    refresh_task: Option<JoinHandle<Result<()>>>,
+}
+
+impl RefreshingCatalogProvider {
+    pub fn new_with_refresh(
+        inner: Arc<dyn RefreshableCatalogProvider>,
+        refresh_interval: Duration,
+    ) -> Self {
+        Self::new(inner).start_refresh(Some(refresh_interval))
+    }
+
+    fn new(inner: Arc<dyn RefreshableCatalogProvider>) -> Self {
+        Self {
+            inner,
+            refresh_task: None,
+        }
+    }
+
+    fn start_refresh(mut self, interval: Option<Duration>) -> Self {
+        assert!(self.refresh_task.is_none(), "Refresh task already running");
+        let interval = interval.unwrap_or(Duration::from_secs(60));
+        let inner = Arc::clone(&self.inner);
+        self.refresh_task = Some(tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+                match inner.refresh().await {
+                    Ok(()) => (),
+                    Err(e) => {
+                        tracing::error!("Failed to refresh catalog: {}", e);
+                    }
+                }
+            }
+        }));
+        self
+    }
+}
+
+impl CatalogProvider for RefreshingCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self.inner.as_any()
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        self.inner.schema_names()
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn datafusion::catalog::SchemaProvider>> {
+        self.inner.schema(name)
+    }
+}
+
+impl Drop for RefreshingCatalogProvider {
+    fn drop(&mut self) {
+        if let Some(task) = self.refresh_task.take() {
+            task.abort();
+        }
+    }
+}

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -14,14 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use super::CatalogConnector;
 use super::ConnectorComponent;
-use super::DataConnector;
-use super::DataConnectorFactory;
-use super::DataConnectorParams;
 use super::ParameterSpec;
 use super::Parameters;
 use crate::component::catalog::Catalog;
-use crate::component::dataset::Dataset;
+use crate::dataconnector::ConnectorParams;
 use crate::get_params_with_secrets;
 use crate::Runtime;
 use async_trait::async_trait;
@@ -30,15 +28,13 @@ use data_components::unity_catalog::provider::UnityCatalogProvider;
 use data_components::unity_catalog::UCTable;
 use data_components::unity_catalog::UnityCatalog as UnityCatalogClient;
 use data_components::Read;
-use datafusion::catalog::CatalogProvider;
-use datafusion::datasource::TableProvider;
+use data_components::RefreshableCatalogProvider;
 use datafusion::sql::TableReference;
 use secrecy::SecretString;
 use snafu::prelude::*;
 use std::any::Any;
-use std::pin::Pin;
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::{collections::HashMap, future::Future};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -68,22 +64,16 @@ pub struct UnityCatalog {
     params: Parameters,
 }
 
-#[derive(Default, Copy, Clone)]
-pub struct UnityCatalogFactory {}
-
-impl UnityCatalogFactory {
+impl UnityCatalog {
     #[must_use]
-    pub fn new() -> Self {
-        Self {}
-    }
-
-    #[must_use]
-    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
-        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
+    pub fn new_connector(params: ConnectorParams) -> Arc<dyn CatalogConnector> {
+        Arc::new(Self {
+            params: params.parameters,
+        })
     }
 }
 
-const PARAMETERS: &[ParameterSpec] = &[
+pub(crate) const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::connector("token").secret().description(
         "The personal access token used to authenticate against the Unity Catalog API.",
     ),
@@ -125,70 +115,38 @@ const PARAMETERS: &[ParameterSpec] = &[
         .secret(),
 ];
 
-impl DataConnectorFactory for UnityCatalogFactory {
-    fn create(
-        &self,
-        params: DataConnectorParams,
-    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        Box::pin(async move {
-            Ok(Arc::new(UnityCatalog {
-                params: params.parameters,
-            }) as Arc<dyn DataConnector>)
-        })
-    }
-
-    fn prefix(&self) -> &'static str {
-        "unity_catalog"
-    }
-
-    fn parameters(&self) -> &'static [ParameterSpec] {
-        PARAMETERS
-    }
-}
-
 #[async_trait]
-impl DataConnector for UnityCatalog {
+impl CatalogConnector for UnityCatalog {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
-    async fn read_provider(
-        &self,
-        dataset: &Dataset,
-    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
-        Err(super::DataConnectorError::UnableToGetReadProvider {
-            dataconnector: "unity_catalog".to_string(),
-            source: "The Unity Catalog only supports catalogs, not individual datasets.\nSetup a Unity Catalog instead: https://docs.spiceai.org/components/catalogs/unity-catalog".into(),
-            connector_component: ConnectorComponent::from(dataset)
-        })
-    }
-
-    async fn catalog_provider(
+    async fn refreshable_catalog_provider(
         self: Arc<Self>,
         runtime: &Runtime,
         catalog: &Catalog,
-    ) -> Option<super::DataConnectorResult<Arc<dyn CatalogProvider>>> {
+    ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
         let Some(catalog_id) = catalog.catalog_id.clone() else {
-            return Some(Err(
-                super::DataConnectorError::InvalidConfigurationNoSource {
-                    dataconnector: "unity_catalog".into(),
+            return Err(
+                super::Error::InvalidConfigurationNoSource {
+                    connector: "unity_catalog".into(),
                     message: "A Catalog Path is required for Unity Catalog.\nFor details, visit: https://docs.spiceai.org/components/catalogs/unity-catalog#from".into(),
                     connector_component: ConnectorComponent::from(catalog),
                 },
-            ));
+            );
         };
 
         // The catalog_id for the unity_catalog provider is the full URL to the catalog like:
         // https://<host>/api/2.1/unity-catalog/catalogs/<catalog_id>
         let (endpoint, catalog_id) = match UnityCatalogClient::parse_catalog_url(&catalog_id)
-            .map_err(|e| super::DataConnectorError::InvalidConfiguration {
-                dataconnector: "unity_catalog".to_string(),
+            .map_err(|e| super::Error::InvalidConfiguration {
+                connector: "unity_catalog".to_string(),
                 connector_component: ConnectorComponent::from(catalog),
                 message: e.to_string(),
                 source: Box::new(e),
             }) {
             Ok((endpoint, catalog_id)) => (endpoint, catalog_id),
-            Err(e) => return Some(Err(e)),
+            Err(e) => return Err(e),
         };
 
         let client = Arc::new(UnityCatalogClient::new(
@@ -220,19 +178,19 @@ impl DataConnector for UnityCatalog {
         {
             Ok(provider) => provider,
             Err(e) => {
-                return Some(Err(super::DataConnectorError::UnableToGetCatalogProvider {
-                    dataconnector: "unity_catalog".to_string(),
+                return Err(super::Error::UnableToGetCatalogProvider {
+                    connector: "unity_catalog".to_string(),
                     connector_component: ConnectorComponent::from(catalog),
                     source: Box::new(e),
-                }))
+                })
             }
         };
 
-        Some(Ok(Arc::new(catalog_provider) as Arc<dyn CatalogProvider>))
+        Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>)
     }
 }
 
-fn table_reference_creator(uc_table: UCTable) -> Option<TableReference> {
-    let storage_location = uc_table.storage_location?;
+fn table_reference_creator(uc_table: &UCTable) -> Option<TableReference> {
+    let storage_location = uc_table.storage_location.as_deref()?;
     Some(TableReference::bare(format!("{storage_location}/")))
 }

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -31,33 +31,9 @@ use data_components::Read;
 use data_components::RefreshableCatalogProvider;
 use datafusion::sql::TableReference;
 use secrecy::SecretString;
-use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
-
-#[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(display("Unable to parse SpiceAI dataset path: {dataset_path}"))]
-    UnableToParseDatasetPath { dataset_path: String },
-
-    #[snafu(display("Unable to publish data to SpiceAI: {source}"))]
-    UnableToPublishData { source: flight_client::Error },
-
-    #[snafu(display("Missing required secrets"))]
-    MissingRequiredSecrets,
-
-    #[snafu(display(r#"Unable to connect to endpoint "{endpoint}": {source}"#))]
-    UnableToVerifyEndpointConnection {
-        source: ns_lookup::Error,
-        endpoint: String,
-    },
-
-    #[snafu(display("Unable to create flight client: {source}"))]
-    UnableToCreateFlightClient { source: flight_client::Error },
-}
-
-pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Clone)]
 pub struct UnityCatalog {

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use crate::accelerated_table::AcceleratedTable;
+use crate::catalogconnector::CATALOG_CONNECTOR_FACTORY_REGISTRY;
 use crate::component::catalog::Catalog;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
@@ -93,8 +94,6 @@ pub mod snowflake;
 #[cfg(feature = "spark")]
 pub mod spark;
 pub mod spiceai;
-#[cfg(feature = "delta_lake")]
-pub mod unity_catalog;
 
 #[derive(Debug, Snafu)]
 pub enum DataConnectorError {
@@ -267,7 +266,7 @@ pub async fn register_connector_factory(
 /// `None` if the connector for `name` is not registered, otherwise a `Result` containing the result of calling the constructor to create a `DataConnector`.
 pub async fn create_new_connector(
     name: &str,
-    params: DataConnectorParams,
+    params: ConnectorParams,
 ) -> Option<AnyErrorResult<Arc<dyn DataConnector>>> {
     let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
 
@@ -330,19 +329,13 @@ pub async fn register_all() {
     register_connector_factory("snowflake", snowflake::SnowflakeFactory::new_arc()).await;
     #[cfg(feature = "debezium")]
     register_connector_factory("debezium", debezium::DebeziumFactory::new_arc()).await;
-    #[cfg(feature = "delta_lake")]
-    register_connector_factory(
-        "unity_catalog",
-        unity_catalog::UnityCatalogFactory::new_arc(),
-    )
-    .await;
     register_connector_factory("localpod", localpod::LocalPodFactory::new_arc()).await;
 }
 
 pub trait DataConnectorFactory: Send + Sync {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>>;
 
     fn supports_invalid_type_action(&self) -> bool {
@@ -505,18 +498,18 @@ impl std::fmt::Display for ConnectorComponent {
     }
 }
 
-pub struct DataConnectorParams {
+pub struct ConnectorParams {
     pub(crate) parameters: Parameters,
     pub(crate) invalid_type_action: Option<InvalidTypeAction>,
     pub(crate) component: ConnectorComponent,
 }
 
-pub struct DataConnectorParamsBuilder {
+pub struct ConnectorParamsBuilder {
     connector: Arc<str>,
     component: ConnectorComponent,
 }
 
-impl DataConnectorParamsBuilder {
+impl ConnectorParamsBuilder {
     #[must_use]
     pub fn new(connector: Arc<str>, component: ConnectorComponent) -> Self {
         Self {
@@ -528,46 +521,58 @@ impl DataConnectorParamsBuilder {
     pub async fn build(
         &self,
         secrets: Arc<RwLock<Secrets>>,
-    ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
-        let params = match &self.component {
+    ) -> Result<ConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
+        let name = self.connector.to_string();
+        let (params, prefix, parameters) = match &self.component {
             ConnectorComponent::Catalog(catalog) => {
-                get_params_with_secrets(Arc::clone(&secrets), &catalog.params).await
+                let guard = CATALOG_CONNECTOR_FACTORY_REGISTRY.lock().await;
+                let connector_factory = guard.get(&name);
+
+                let factory =
+                    connector_factory.ok_or_else(|| DataConnectorError::InvalidConnectorType {
+                        dataconnector: name.clone(),
+                        connector_component: self.component.clone(),
+                    })?;
+
+                (
+                    get_params_with_secrets(Arc::clone(&secrets), &catalog.params).await,
+                    factory.prefix(),
+                    factory.parameters(),
+                )
             }
             ConnectorComponent::Dataset(dataset) => {
-                get_params_with_secrets(Arc::clone(&secrets), &dataset.params).await
+                let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
+                let connector_factory = guard.get(&name);
+
+                let factory = connector_factory.ok_or_else(|| {
+                    if name == ODBC_DATACONNECTOR {
+                        DataConnectorError::OdbcNotInstalled {
+                            connector_component: self.component.clone(),
+                        }
+                    } else {
+                        DataConnectorError::InvalidConnectorType {
+                            dataconnector: name.clone(),
+                            connector_component: self.component.clone(),
+                        }
+                    }
+                })?;
+
+                let params = get_params_with_secrets(Arc::clone(&secrets), &dataset.params).await;
+
+                (params, factory.prefix(), factory.parameters())
             }
         };
-
-        let name = self.connector.to_string();
-        let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
-
-        let connector_factory = guard.get(&name);
-
-        let factory = connector_factory.ok_or_else(|| {
-            if name == ODBC_DATACONNECTOR {
-                DataConnectorError::OdbcNotInstalled {
-                    connector_component: self.component.clone(),
-                }
-            } else {
-                DataConnectorError::InvalidConnectorType {
-                    dataconnector: name.clone(),
-                    connector_component: self.component.clone(),
-                }
-            }
-        });
-
-        let factory = factory?;
 
         let parameters = Parameters::try_new(
             &format!("connector {name}"),
             params.into_iter().collect(),
-            factory.prefix(),
+            prefix,
             secrets,
-            factory.parameters(),
+            parameters,
         )
         .await?;
 
-        Ok(DataConnectorParams {
+        Ok(ConnectorParams {
             parameters,
             invalid_type_action: None,
             component: self.component.clone(),

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -20,6 +20,7 @@ use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
 use crate::datafusion::error::find_datafusion_root;
 use crate::federated_table::FederatedTable;
+use crate::get_params_with_secrets;
 use crate::parameters::ParameterSpec;
 use crate::parameters::Parameters;
 use crate::secrets::Secrets;
@@ -36,7 +37,6 @@ use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::unparser::Unparser;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::InvalidTypeAction;
-use secrecy::SecretString;
 use snafu::prelude::*;
 use std::any::Any;
 use std::collections::HashMap;
@@ -507,7 +507,6 @@ impl std::fmt::Display for ConnectorComponent {
 
 pub struct DataConnectorParams {
     pub(crate) parameters: Parameters,
-    pub(crate) metadata: HashMap<String, String>,
     pub(crate) invalid_type_action: Option<InvalidTypeAction>,
     pub(crate) component: ConnectorComponent,
 }
@@ -526,35 +525,19 @@ impl DataConnectorParamsBuilder {
         }
     }
 
-    pub async fn with_runtime(
+    pub async fn build(
         &self,
-        runtime: &Runtime,
-    ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
-        match &self.component {
-            ConnectorComponent::Catalog(catalog) => {
-                let secrets = runtime.secrets();
-                let params = runtime.get_params_with_secrets(&catalog.params).await;
-                let params = self.without_runtime(params, secrets).await?;
-
-                Ok(params)
-            }
-            ConnectorComponent::Dataset(dataset) => {
-                let secrets = runtime.secrets();
-                let params = runtime.get_params_with_secrets(&dataset.params).await;
-                let mut params = self.without_runtime(params, secrets).await?;
-                params.metadata.clone_from(&dataset.metadata);
-                params.invalid_type_action = dataset.invalid_type_action.map(Into::into);
-
-                Ok(params)
-            }
-        }
-    }
-
-    pub async fn without_runtime(
-        &self,
-        params: HashMap<String, SecretString>,
         secrets: Arc<RwLock<Secrets>>,
     ) -> Result<DataConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
+        let params = match &self.component {
+            ConnectorComponent::Catalog(catalog) => {
+                get_params_with_secrets(Arc::clone(&secrets), &catalog.params).await
+            }
+            ConnectorComponent::Dataset(dataset) => {
+                get_params_with_secrets(Arc::clone(&secrets), &dataset.params).await
+            }
+        };
+
         let name = self.connector.to_string();
         let guard = DATA_CONNECTOR_FACTORY_REGISTRY.lock().await;
 
@@ -586,7 +569,6 @@ impl DataConnectorParamsBuilder {
 
         Ok(DataConnectorParams {
             parameters,
-            metadata: HashMap::new(),
             invalid_type_action: None,
             component: self.component.clone(),
         })

--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 use super::listing::{build_fragments, ListingTableConnector};
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams,
-    DataConnectorResult, ParameterSpec, Parameters,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, DataConnectorResult,
+    ParameterSpec, Parameters,
 };
 
 use crate::component::dataset::Dataset;
@@ -163,7 +163,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for AzureBlobFSFactory {
     fn create(
         &self,
-        mut params: DataConnectorParams,
+        mut params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         if let Some(sas_token) = params.parameters.get("sas_string").expose().ok() {
             if let Some(sas_token) = sas_token.strip_prefix('?') {

--- a/crates/runtime/src/dataconnector/clickhouse.rs
+++ b/crates/runtime/src/dataconnector/clickhouse.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 use url::Url;
 
 use super::ConnectorComponent;
-use super::DataConnectorParams;
+use super::ConnectorParams;
 use super::{DataConnector, DataConnectorError, DataConnectorFactory, Parameters};
 use crate::parameters::{ParamLookup, ParameterSpec};
 
@@ -133,7 +133,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for ClickhouseFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             match get_config_from_params(params.parameters).await {

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
-use crate::Runtime;
+use crate::{get_params_with_secrets, Runtime};
 use async_trait::async_trait;
 use data_components::databricks_delta::DatabricksDelta;
 use data_components::databricks_spark::DatabricksSparkConnect;
@@ -146,11 +146,10 @@ impl Databricks {
 
         // Copy the catalog params into the dataset params, and allow user to override
         let mut dataset_params: HashMap<String, SecretString> =
-            runtime.get_params_with_secrets(&catalog.params).await;
+            get_params_with_secrets(runtime.secrets(), &catalog.params).await;
 
-        let secret_dataset_params = runtime
-            .get_params_with_secrets(&catalog.dataset_params)
-            .await;
+        let secret_dataset_params =
+            get_params_with_secrets(runtime.secrets(), &catalog.dataset_params).await;
 
         for (key, value) in secret_dataset_params {
             dataset_params.insert(key, value);

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -14,25 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
-use crate::{get_params_with_secrets, Runtime};
 use async_trait::async_trait;
 use data_components::databricks_delta::DatabricksDelta;
 use data_components::databricks_spark::DatabricksSparkConnect;
-use data_components::delta_lake::DeltaTableFactory;
-use data_components::unity_catalog::provider::UnityCatalogProvider;
-use data_components::unity_catalog::{CatalogId, Endpoint, UCTable, UnityCatalog};
+use data_components::unity_catalog::Endpoint;
 use data_components::Read;
 use datafusion::catalog::CatalogProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::any::Any;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::{collections::HashMap, future::Future};
 
 use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec,
@@ -113,107 +109,8 @@ impl Databricks {
         }
     }
 
-    async fn catalog_provider(
-        self: Arc<Self>,
-        runtime: &Runtime,
-        catalog: &Catalog,
-    ) -> super::DataConnectorResult<Arc<dyn CatalogProvider>> {
-        let Some(catalog_id) = catalog.catalog_id.clone() else {
-            return Err(super::DataConnectorError::InvalidConfigurationNoSource {
-                dataconnector: "databricks".into(),
-                message: "A Catalog Name is required for the Databricks Unity Catalog.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#from".into(),
-                connector_component: ConnectorComponent::from(catalog)
-            });
-        };
-
-        let endpoint = self.params.get("endpoint").expose().ok_or_else(|p| {
-            super::DataConnectorError::InvalidConfigurationNoSource {
-                dataconnector: "databricks".into(),
-                message: format!("A required parameter was missing: {}.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
-                connector_component: ConnectorComponent::from(catalog)
-            }
-        })?;
-        let token = self.params.get("token").ok_or_else(|p| {
-            super::DataConnectorError::InvalidConfigurationNoSource {
-                dataconnector: "databricks".into(),
-                message: format!("A required parameter was missing: {}.\nFor details, visit: https://docs.spiceai.org/components/catalogs/databricks#params", p.0),
-                connector_component: ConnectorComponent::from(catalog)
-            }
-        })?;
-
-        let unity_catalog = UnityCatalog::new(Endpoint(endpoint.to_string()), Some(token.clone()));
-        let client = Arc::new(unity_catalog);
-
-        // Copy the catalog params into the dataset params, and allow user to override
-        let mut dataset_params: HashMap<String, SecretString> =
-            get_params_with_secrets(runtime.secrets(), &catalog.params).await;
-
-        let secret_dataset_params =
-            get_params_with_secrets(runtime.secrets(), &catalog.dataset_params).await;
-
-        for (key, value) in secret_dataset_params {
-            dataset_params.insert(key, value);
-        }
-
-        let factory = DatabricksFactory::new();
-
-        let params = Parameters::try_new(
-            "connector databricks",
-            dataset_params.into_iter().collect(),
-            factory.prefix(),
-            runtime.secrets(),
-            factory.parameters(),
-        )
-        .await
-        .context(super::InternalWithSourceSnafu {
-            dataconnector: "databricks".to_string(),
-            connector_component: ConnectorComponent::from(catalog),
-        })?;
-
-        let mode = self.params.get("mode").expose().ok();
-        let (table_creator, table_reference_creator) = if let Some("delta_lake") = mode {
-            (
-                Arc::new(DeltaTableFactory::new(params.to_secret_map())) as Arc<dyn Read>,
-                table_reference_creator_delta_lake as fn(&UCTable) -> Option<TableReference>,
-            )
-        } else {
-            let dataset_databricks = match Databricks::new(params).await.map_err(|source| {
-                super::DataConnectorError::UnableToGetCatalogProvider {
-                    dataconnector: "databricks".to_string(),
-                    source: source.into(),
-                    connector_component: ConnectorComponent::from(catalog),
-                }
-            }) {
-                Ok(dataset_databricks) => dataset_databricks,
-                Err(e) => return Err(e),
-            };
-
-            (
-                dataset_databricks.read_provider,
-                table_reference_creator_spark as fn(&UCTable) -> Option<TableReference>,
-            )
-        };
-
-        let catalog_provider = match UnityCatalogProvider::try_new(
-            client,
-            CatalogId(catalog_id),
-            table_creator,
-            table_reference_creator,
-            catalog.include.clone(),
-        )
-        .await
-        {
-            Ok(provider) => provider,
-            Err(e) => {
-                return Err(super::DataConnectorError::UnableToGetCatalogProvider {
-                    dataconnector: "databricks".to_string(),
-                    source: Box::new(e),
-                    connector_component: ConnectorComponent::from(catalog),
-                })
-            }
-        };
-
-        Ok(Arc::new(catalog_provider) as Arc<dyn CatalogProvider>)
+    pub(crate) fn read_provider(&self) -> Arc<dyn Read> {
+        Arc::clone(&self.read_provider)
     }
 }
 
@@ -329,27 +226,4 @@ impl DataConnector for Databricks {
                 connector_component: ConnectorComponent::from(dataset),
             })?)
     }
-
-    async fn catalog_provider(
-        self: Arc<Self>,
-        runtime: &Runtime,
-        catalog: &Catalog,
-    ) -> Option<super::DataConnectorResult<Arc<dyn CatalogProvider>>> {
-        Some(Databricks::catalog_provider(self, runtime, catalog).await)
-    }
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn table_reference_creator_spark(uc_table: &UCTable) -> Option<TableReference> {
-    let table_reference = TableReference::Full {
-        catalog: uc_table.catalog_name.clone().into(),
-        schema: uc_table.schema_name.clone().into(),
-        table: uc_table.name.clone().into(),
-    };
-    Some(table_reference)
-}
-
-fn table_reference_creator_delta_lake(uc_table: &UCTable) -> Option<TableReference> {
-    let storage_location = uc_table.storage_location.as_deref()?;
-    Some(TableReference::bare(format!("{storage_location}/")))
 }

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -20,7 +20,6 @@ use data_components::databricks_delta::DatabricksDelta;
 use data_components::databricks_spark::DatabricksSparkConnect;
 use data_components::unity_catalog::Endpoint;
 use data_components::Read;
-use datafusion::catalog::CatalogProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
 use secrecy::ExposeSecret;
@@ -53,7 +52,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct Databricks {
     read_provider: Arc<dyn Read>,
-    params: Parameters,
 }
 
 impl Databricks {
@@ -75,7 +73,6 @@ impl Databricks {
             );
             Ok(Self {
                 read_provider: Arc::new(databricks_delta.clone()),
-                params,
             })
         } else {
             let mut databricks_use_ssl = true;
@@ -104,7 +101,6 @@ impl Databricks {
             .context(UnableToConstructDatabricksSparkSnafu)?;
             Ok(Self {
                 read_provider: Arc::new(databricks_spark.clone()),
-                params,
             })
         }
     }

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use std::{collections::HashMap, future::Future};
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec,
     Parameters,
 };
 
@@ -174,7 +174,7 @@ impl Databricks {
         let (table_creator, table_reference_creator) = if let Some("delta_lake") = mode {
             (
                 Arc::new(DeltaTableFactory::new(params.to_secret_map())) as Arc<dyn Read>,
-                table_reference_creator_delta_lake as fn(UCTable) -> Option<TableReference>,
+                table_reference_creator_delta_lake as fn(&UCTable) -> Option<TableReference>,
             )
         } else {
             let dataset_databricks = match Databricks::new(params).await.map_err(|source| {
@@ -190,7 +190,7 @@ impl Databricks {
 
             (
                 dataset_databricks.read_provider,
-                table_reference_creator_spark as fn(UCTable) -> Option<TableReference>,
+                table_reference_creator_spark as fn(&UCTable) -> Option<TableReference>,
             )
         };
 
@@ -292,7 +292,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for DatabricksFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let databricks = Databricks::new(params.parameters).await?;
@@ -340,16 +340,16 @@ impl DataConnector for Databricks {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn table_reference_creator_spark(uc_table: UCTable) -> Option<TableReference> {
+fn table_reference_creator_spark(uc_table: &UCTable) -> Option<TableReference> {
     let table_reference = TableReference::Full {
-        catalog: uc_table.catalog_name.into(),
-        schema: uc_table.schema_name.into(),
-        table: uc_table.name.into(),
+        catalog: uc_table.catalog_name.clone().into(),
+        schema: uc_table.schema_name.clone().into(),
+        table: uc_table.name.clone().into(),
     };
     Some(table_reference)
 }
 
-fn table_reference_creator_delta_lake(uc_table: UCTable) -> Option<TableReference> {
-    let storage_location = uc_table.storage_location?;
+fn table_reference_creator_delta_lake(uc_table: &UCTable) -> Option<TableReference> {
+    let storage_location = uc_table.storage_location.as_deref()?;
     Some(TableReference::bare(format!("{storage_location}/")))
 }

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -37,7 +37,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use super::{DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec, Parameters};
+use super::{ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec, Parameters};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -193,7 +193,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for DebeziumFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let debezium = Debezium::new(params.parameters)?;

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -26,7 +26,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec,
     Parameters,
 };
 
@@ -103,7 +103,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for DeltaLakeFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let delta = DeltaLake::new(params.parameters);

--- a/crates/runtime/src/dataconnector/dremio.rs
+++ b/crates/runtime/src/dataconnector/dremio.rs
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 use super::ConnectorComponent;
+use super::ConnectorParams;
 use super::DataConnector;
 use super::DataConnectorFactory;
-use super::DataConnectorParams;
 use super::ParameterSpec;
 use crate::component::dataset::Dataset;
 use crate::dataconnector::DataConnectorError;
@@ -108,7 +108,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for DremioFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let endpoint: Arc<str> = params

--- a/crates/runtime/src/dataconnector/duckdb.rs
+++ b/crates/runtime/src/dataconnector/duckdb.rs
@@ -31,8 +31,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    AnyErrorResult, ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
-    DataConnectorParams, ParameterSpec,
+    AnyErrorResult, ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError,
+    DataConnectorFactory, ParameterSpec,
 };
 
 #[derive(Debug, Snafu)]
@@ -50,9 +50,7 @@ pub struct DuckDB {
 }
 
 impl DuckDB {
-    pub(crate) fn create_in_memory(
-        params: &DataConnectorParams,
-    ) -> AnyErrorResult<DuckDBTableFactory> {
+    pub(crate) fn create_in_memory(params: &ConnectorParams) -> AnyErrorResult<DuckDBTableFactory> {
         let pool = Arc::new(
             DuckDbConnectionPool::new_memory()
                 .map_err(|source| DataConnectorError::UnableToConnectInternal {
@@ -72,7 +70,7 @@ impl DuckDB {
 
     pub(crate) fn create_file(
         path: &str,
-        params: &DataConnectorParams,
+        params: &ConnectorParams,
     ) -> AnyErrorResult<DuckDBTableFactory> {
         let pool = Arc::new(
             DuckDbConnectionPool::new_file(path, &AccessMode::ReadOnly)
@@ -112,7 +110,7 @@ const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::connector("open")];
 impl DataConnectorFactory for DuckDBFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let duckdb_factory =

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -31,7 +31,7 @@ use std::{any::Any, env};
 use tokio::sync::mpsc;
 use url::Url;
 
-use super::DataConnectorParams;
+use super::ConnectorParams;
 use super::{
     listing::ListingTableConnector, DataConnector, DataConnectorFactory, DataConnectorResult,
     InvalidConfigurationSnafu, ParameterSpec, Parameters,
@@ -86,7 +86,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for FileFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             Ok(Arc::new(File {

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec,
 };
 use crate::component::dataset::Dataset;
 use arrow_flight::sql::client::FlightSqlServiceClient;
@@ -72,7 +72,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for FlightSQLFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let endpoint: String = params

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -22,7 +22,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use url::Url;
 
-use super::{listing, ConnectorComponent, DataConnectorParams};
+use super::{listing, ConnectorComponent, ConnectorParams};
 use super::{
     listing::ListingTableConnector, DataConnector, DataConnectorFactory, DataConnectorResult,
     ParameterSpec, Parameters,
@@ -83,7 +83,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for FTPFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let ftp = FTP {

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -56,8 +56,8 @@ use std::{any::Any, future::Future, pin::Pin, str::FromStr, sync::Arc};
 use url::Url;
 
 use super::{
-    graphql::default_spice_client, ConnectorComponent, DataConnector, DataConnectorError,
-    DataConnectorFactory, DataConnectorParams, ParameterSpec, Parameters,
+    graphql::default_spice_client, ConnectorComponent, ConnectorParams, DataConnector,
+    DataConnectorError, DataConnectorFactory, ParameterSpec, Parameters,
 };
 
 mod commits;
@@ -325,7 +325,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for GithubFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         let token = params.parameters.get("token").expose().ok();
         let client_id = params.parameters.get("client_id").expose().ok();

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -27,8 +27,8 @@ use std::{any::Any, future::Future, pin::Pin, sync::Arc};
 use url::Url;
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
-    DataConnectorParams, InvalidConfigurationSnafu, ParameterSpec, Parameters,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
+    InvalidConfigurationSnafu, ParameterSpec, Parameters,
 };
 
 pub struct GraphQL {
@@ -75,7 +75,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for GraphQLFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let graphql = GraphQL {

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -27,7 +27,7 @@ use super::{
     DataConnector, DataConnectorError, DataConnectorFactory, DataConnectorResult, ParameterSpec,
     Parameters,
 };
-use super::{ConnectorComponent, DataConnectorParams};
+use super::{ConnectorComponent, ConnectorParams};
 
 pub struct Https {
     params: Parameters,
@@ -82,7 +82,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for HttpsFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             Ok(Arc::new(Https {

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -551,7 +551,7 @@ mod tests {
     use std::pin::Pin;
     use url::Url;
 
-    use crate::dataconnector::{DataConnectorFactory, DataConnectorParams};
+    use crate::dataconnector::{ConnectorParams, DataConnectorFactory};
     use crate::parameters::ParameterSpec;
 
     use super::*;
@@ -569,7 +569,7 @@ mod tests {
     impl DataConnectorFactory for TestConnector {
         fn create(
             &self,
-            params: DataConnectorParams,
+            params: ConnectorParams,
         ) -> Pin<Box<dyn Future<Output = crate::dataconnector::NewDataConnectorResult> + Send>>
         {
             Box::pin(async move {

--- a/crates/runtime/src/dataconnector/localpod.rs
+++ b/crates/runtime/src/dataconnector/localpod.rs
@@ -29,7 +29,7 @@ use crate::datafusion::DataFusion;
 use crate::DataConnector;
 use crate::{component::dataset::Dataset, parameters::ParameterSpec};
 
-use super::{ConnectorComponent, DataConnectorFactory, DataConnectorParams};
+use super::{ConnectorComponent, ConnectorParams, DataConnectorFactory};
 
 pub const LOCALPOD_DATACONNECTOR: &str = "localpod";
 
@@ -51,7 +51,7 @@ impl LocalPodFactory {
 impl DataConnectorFactory for LocalPodFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             Err(Box::new(super::DataConnectorError::Internal {

--- a/crates/runtime/src/dataconnector/memory.rs
+++ b/crates/runtime/src/dataconnector/memory.rs
@@ -26,8 +26,8 @@ use datafusion::datasource::TableProvider;
 use futures::Future;
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
-    DataConnectorParams, ParameterSpec,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
+    ParameterSpec,
 };
 
 /// A connector that wraps a [`MemTable`] initialised without data, that can be
@@ -62,7 +62,7 @@ impl MemoryConnectorFactory {
 impl DataConnectorFactory for MemoryConnectorFactory {
     fn create(
         &self,
-        _params: DataConnectorParams,
+        _params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move { Ok(Arc::new(MemoryConnector::default()) as Arc<dyn DataConnector>) })
     }

--- a/crates/runtime/src/dataconnector/mssql.rs
+++ b/crates/runtime/src/dataconnector/mssql.rs
@@ -28,8 +28,8 @@ use std::{any::Any, future::Future};
 use tiberius::{Config, EncryptionLevel};
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams,
-    DataConnectorResult, ParameterSpec, Parameters, UnableToGetReadProviderSnafu,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, DataConnectorResult,
+    ParameterSpec, Parameters, UnableToGetReadProviderSnafu,
 };
 
 #[derive(Debug, Snafu)]
@@ -167,7 +167,7 @@ impl SqlServerFactory {
 impl DataConnectorFactory for SqlServerFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             Ok(Arc::new(SqlServer::new(&params.parameters).await?) as Arc<dyn DataConnector>)

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -33,8 +33,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
-    DataConnectorParams, ParameterSpec,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
+    ParameterSpec,
 };
 
 #[derive(Debug, Snafu)]
@@ -78,7 +78,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for MySQLFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let pool: Arc<

--- a/crates/runtime/src/dataconnector/odbc.rs
+++ b/crates/runtime/src/dataconnector/odbc.rs
@@ -33,7 +33,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec,
 };
 
 #[derive(Debug, Snafu)]
@@ -200,7 +200,7 @@ fn parameter_is_integer(parameters: &Parameters, param: &str) -> Result<()> {
 impl DataConnectorFactory for ODBCFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             parameter_is_integer(&params.parameters, "max_binary_size")?;

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -31,8 +31,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
-    DataConnectorParams, ParameterSpec,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
+    ParameterSpec,
 };
 
 #[derive(Debug, Snafu)]
@@ -77,7 +77,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for PostgresFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             match PostgresConnectionPool::new(params.parameters.to_secret_map()).await {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 use super::{
     listing::{self, ListingTableConnector},
-    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
-    DataConnectorParams, DataConnectorResult, ParameterSpec, Parameters,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
+    DataConnectorResult, ParameterSpec, Parameters,
 };
 
 use crate::component::dataset::Dataset;
@@ -157,7 +157,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for S3Factory {
     fn create(
         &self,
-        mut params: DataConnectorParams,
+        mut params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         if let Some(endpoint) = params.parameters.get("endpoint").expose().ok() {
             if endpoint.ends_with('/') {

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -26,7 +26,7 @@ use super::{
     listing::{self, ListingTableConnector},
     DataConnector, DataConnectorFactory, DataConnectorResult, ParameterSpec, Parameters,
 };
-use super::{ConnectorComponent, DataConnectorParams};
+use super::{ConnectorComponent, ConnectorParams};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -92,7 +92,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for SFTPFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let sftp = SFTP {

--- a/crates/runtime/src/dataconnector/sharepoint.rs
+++ b/crates/runtime/src/dataconnector/sharepoint.rs
@@ -27,8 +27,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorFactory, DataConnectorParams,
-    DataConnectorResult, ParameterSpec, Parameters, UnableToGetReadProviderSnafu,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, DataConnectorResult,
+    ParameterSpec, Parameters, UnableToGetReadProviderSnafu,
 };
 
 #[derive(Debug, Snafu)]
@@ -130,7 +130,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for SharepointFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             Ok(Arc::new(Sharepoint::new(&params.parameters)?) as Arc<dyn DataConnector>)

--- a/crates/runtime/src/dataconnector/sink.rs
+++ b/crates/runtime/src/dataconnector/sink.rs
@@ -35,7 +35,7 @@ use datafusion::{
 };
 use futures::Future;
 
-use super::{DataConnector, DataConnectorFactory, DataConnectorParams, ParameterSpec};
+use super::{ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec};
 
 /// A no-op connector that allows for Spice to act as a "sink" for data.
 ///
@@ -87,7 +87,7 @@ impl SinkConnectorFactory {
 impl DataConnectorFactory for SinkConnectorFactory {
     fn create(
         &self,
-        _params: DataConnectorParams,
+        _params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let schema = Schema::new(vec![Field::new("placeholder", DataType::Utf8, false)]);

--- a/crates/runtime/src/dataconnector/snowflake.rs
+++ b/crates/runtime/src/dataconnector/snowflake.rs
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 use super::ConnectorComponent;
+use super::ConnectorParams;
 use super::DataConnector;
 use super::DataConnectorFactory;
-use super::DataConnectorParams;
 use super::ParameterSpec;
 use async_trait::async_trait;
 use data_components::snowflake::SnowflakeTableFactory;
@@ -78,7 +78,7 @@ const PARAMETERS: &[ParameterSpec] = &[
 impl DataConnectorFactory for SnowflakeFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let pool: Arc<

--- a/crates/runtime/src/dataconnector/spark.rs
+++ b/crates/runtime/src/dataconnector/spark.rs
@@ -28,8 +28,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use super::{
-    ConnectorComponent, DataConnector, DataConnectorError, DataConnectorFactory,
-    DataConnectorParams, ParameterSpec, Parameters,
+    ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
+    ParameterSpec, Parameters,
 };
 
 #[derive(Debug, Snafu)]
@@ -94,7 +94,7 @@ const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::connector("remote").secret
 impl DataConnectorFactory for SparkFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             match Spark::new(params.parameters).await {

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 use super::ConnectorComponent;
+use super::ConnectorParams;
 use super::DataConnector;
 use super::DataConnectorError;
 use super::DataConnectorFactory;
-use super::DataConnectorParams;
 use super::ParameterSpec;
 use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
@@ -129,7 +129,7 @@ const HEADER_APP: &str = "spiceai-app";
 impl DataConnectorFactory for SpiceAIFactory {
     fn create(
         &self,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         let default_flight_url: Arc<str> = if cfg!(feature = "dev") {
             "https://dev-flight.spiceai.io".into()

--- a/crates/runtime/src/dataconnector/unity_catalog.rs
+++ b/crates/runtime/src/dataconnector/unity_catalog.rs
@@ -22,6 +22,7 @@ use super::ParameterSpec;
 use super::Parameters;
 use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
+use crate::get_params_with_secrets;
 use crate::Runtime;
 use async_trait::async_trait;
 use data_components::delta_lake::DeltaTableFactory;
@@ -197,11 +198,10 @@ impl DataConnector for UnityCatalog {
 
         // Copy the catalog params into the dataset params, and allow user to override
         let mut dataset_params: HashMap<String, SecretString> =
-            runtime.get_params_with_secrets(&catalog.params).await;
+            get_params_with_secrets(runtime.secrets(), &catalog.params).await;
 
-        let secret_dataset_params = runtime
-            .get_params_with_secrets(&catalog.dataset_params)
-            .await;
+        let secret_dataset_params =
+            get_params_with_secrets(runtime.secrets(), &catalog.dataset_params).await;
 
         for (key, value) in secret_dataset_params {
             dataset_params.insert(key, value);

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -82,7 +82,7 @@ impl Runtime {
 
         let source = catalog.provider.clone();
         let params = DataConnectorParamsBuilder::new(source.clone().into(), (&catalog).into())
-            .with_runtime(self)
+            .build(self.secrets())
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
 

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -17,10 +17,11 @@ limitations under the License.
 use std::sync::Arc;
 
 use crate::{
+    catalogconnector::{self, get_catalog_provider, CatalogConnector},
     component::catalog::Catalog,
-    dataconnector::{DataConnector, DataConnectorParamsBuilder},
-    metrics, status, warn_spaced, DataConnectorDoesntSupportCatalogsSnafu, LogErrors, Result,
-    Runtime, UnableToInitializeDataConnectorSnafu, UnableToLoadCatalogConnectorSnafu,
+    dataconnector::ConnectorParamsBuilder,
+    metrics, status, warn_spaced, LogErrors, Result, Runtime,
+    UnableToInitializeCatalogConnectorSnafu, UnableToLoadCatalogConnectorSnafu,
 };
 use app::App;
 use futures::future::join_all;
@@ -76,32 +77,30 @@ impl Runtime {
         .await;
     }
 
-    async fn load_catalog_connector(&self, catalog: &Catalog) -> Result<Arc<dyn DataConnector>> {
+    async fn load_catalog_connector(&self, catalog: &Catalog) -> Result<Arc<dyn CatalogConnector>> {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
         let catalog = catalog.clone();
 
         let source = catalog.provider.clone();
-        let params = DataConnectorParamsBuilder::new(source.clone().into(), (&catalog).into())
+        let params = ConnectorParamsBuilder::new(source.clone().into(), (&catalog).into())
             .build(self.secrets())
             .await
-            .context(UnableToInitializeDataConnectorSnafu)?;
+            .context(UnableToInitializeCatalogConnectorSnafu)?;
 
-        let data_connector: Arc<dyn DataConnector> = match self
-            .get_dataconnector_from_source(&source, params)
-            .await
-        {
-            Ok(data_connector) => data_connector,
-            Err(err) => {
-                let catalog_name = &catalog.name;
-                self.status
-                    .update_catalog(catalog_name, status::ComponentStatus::Error);
-                metrics::catalogs::LOAD_ERROR.add(1, &[]);
-                warn_spaced!(spaced_tracer, "{} {err}", catalog_name);
-                return Err(crate::Error::UnableToInitializeDataConnector { source: err.into() });
-            }
+        let Some(catalog_connector) = catalogconnector::create_new_connector(&source, params).await
+        else {
+            let catalog_name = &catalog.name;
+            self.status
+                .update_catalog(catalog_name, status::ComponentStatus::Error);
+            metrics::catalogs::LOAD_ERROR.add(1, &[]);
+            let err = crate::Error::UnknownCatalogConnector {
+                catalog_connector: source,
+            };
+            warn_spaced!(spaced_tracer, "{} {err}", catalog_name);
+            return Err(err);
         };
 
-        Ok(data_connector)
+        Ok(catalog_connector)
     }
 
     fn catalogs_iter<'a>(app: &Arc<App>) -> impl Iterator<Item = Result<Catalog>> + 'a {
@@ -128,21 +127,17 @@ impl Runtime {
     async fn register_catalog(
         &self,
         catalog: &Catalog,
-        data_connector: Arc<dyn DataConnector>,
+        catalog_connector: Arc<dyn CatalogConnector>,
     ) -> Result<()> {
         tracing::info!(
             "Registering catalog '{}' for {}",
             &catalog.name,
             &catalog.provider
         );
-        let catalog_provider = data_connector
-            .catalog_provider(self, catalog)
+        let catalog_provider = get_catalog_provider(catalog_connector, self, catalog, None)
             .await
-            .context(DataConnectorDoesntSupportCatalogsSnafu {
-                dataconnector: catalog.provider.clone(),
-            })?
             .boxed()
-            .context(UnableToInitializeDataConnectorSnafu)?;
+            .context(UnableToInitializeCatalogConnectorSnafu)?;
         let num_schemas = catalog_provider
             .schema_names()
             .iter()

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -23,8 +23,8 @@ use crate::{
     dataconnector::{
         self,
         localpod::{LocalPodConnector, LOCALPOD_DATACONNECTOR},
-        ConnectorComponent, DataConnector, DataConnectorError, DataConnectorParams,
-        DataConnectorParamsBuilder, ODBC_DATACONNECTOR,
+        ConnectorComponent, ConnectorParams, ConnectorParamsBuilder, DataConnector,
+        DataConnectorError, ODBC_DATACONNECTOR,
     },
     embeddings::connector::EmbeddingConnector,
     error_spaced,
@@ -178,7 +178,7 @@ impl Runtime {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
 
         let source = ds.source();
-        let params = DataConnectorParamsBuilder::new(source.into(), (&ds).into())
+        let params = ConnectorParamsBuilder::new(source.into(), (&ds).into())
             .build(self.secrets())
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
@@ -491,7 +491,7 @@ impl Runtime {
     pub(crate) async fn get_dataconnector_from_source(
         &self,
         source: &str,
-        params: DataConnectorParams,
+        params: ConnectorParams,
     ) -> Result<Arc<dyn DataConnector>> {
         // Unlike most other data connectors, the localpod connector needs a reference to the current DataFusion instance.
         if source == LOCALPOD_DATACONNECTOR {

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -179,7 +179,7 @@ impl Runtime {
 
         let source = ds.source();
         let params = DataConnectorParamsBuilder::new(source.into(), (&ds).into())
-            .with_runtime(self)
+            .build(self.secrets())
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
 

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -17,7 +17,8 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
-    metrics, model::ENABLE_MODEL_SUPPORT_MESSAGE, status, timing::TimeMeasurement, Runtime,
+    get_params_with_secrets, metrics, model::ENABLE_MODEL_SUPPORT_MESSAGE, status,
+    timing::TimeMeasurement, Runtime,
 };
 use app::App;
 use model_components::model::Model;
@@ -74,7 +75,7 @@ impl Runtime {
                 }
             })
             .collect::<HashMap<_, _>>();
-        let params = self.get_params_with_secrets(&p).await;
+        let params = get_params_with_secrets(self.secrets(), &p).await;
 
         let model_type = m.model_type();
         tracing::trace!("Model type for {} is {:#?}", m.name, model_type.clone());

--- a/crates/runtime/src/init/tool.rs
+++ b/crates/runtime/src/init/tool.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
-    metrics, status,
+    get_params_with_secrets, metrics, status,
     tools::{self, factory::default_available_catalogs},
     Runtime, SpiceModelTool, SpiceToolCatalog, UnableToInitializeLlmToolSnafu,
 };
@@ -74,7 +74,7 @@ impl Runtime {
         self.status
             .update_tool(&tool.name, status::ComponentStatus::Initializing);
         let params_with_secrets: HashMap<String, SecretString> =
-            self.get_params_with_secrets(&tool.params).await;
+            get_params_with_secrets(self.secrets(), &tool.params).await;
 
         match tools::factory::forge(tool, params_with_secrets)
             .await

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -51,6 +51,7 @@ use crate::extension::Extension;
 pub mod accelerated_table;
 pub mod auth;
 mod builder;
+pub mod catalogconnector;
 pub mod component;
 pub mod config;
 pub mod dataaccelerator;
@@ -122,6 +123,11 @@ pub enum Error {
     },
 
     #[snafu(display("{source}"))]
+    UnableToInitializeCatalogConnector {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("{source}"))]
     UnableToInitializeLlm {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -136,8 +142,11 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Unknown data connector: {data_connector}"))]
+    #[snafu(display("Unknown data connector: {data_connector}.\nSpecify a valid data connector and retry. For details, visit: https://docs.spiceai.org/components/data-connectors"))]
     UnknownDataConnector { data_connector: String },
+
+    #[snafu(display("Unknown catalog connector: {catalog_connector}.\nSpecify a valid catalog connector and retry. For details, visit: https://docs.spiceai.org/components/catalogs"))]
+    UnknownCatalogConnector { catalog_connector: String },
 
     #[snafu(display("The runtime is built without ODBC support.\nBuild Spice.ai OSS with the `odbc` feature enabled or use the Docker image that includes ODBC support.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/odbc"))]
     OdbcNotInstalled,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -543,14 +543,6 @@ impl Runtime {
             tracing::error!("Could not start the Spice runtime: {err}");
         }
     }
-
-    pub async fn get_params_with_secrets(
-        &self,
-        params: &HashMap<String, String>,
-    ) -> HashMap<String, SecretString> {
-        let shared_secrets = Arc::clone(&self.secrets);
-        get_params_with_secrets(shared_secrets, params).await
-    }
 }
 
 #[allow(clippy::implicit_hasher)]

--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -19,7 +19,7 @@ use async_openai::types::EmbeddingInput;
 use futures::TryStreamExt;
 use rand::Rng;
 use reqwest::{header::HeaderMap, Client};
-use runtime::{config::Config, Runtime};
+use runtime::{config::Config, get_params_with_secrets, Runtime};
 use secrecy::SecretString;
 use snafu::ResultExt;
 use spicepod::component::{
@@ -445,7 +445,7 @@ async fn sql_to_display(
     pretty_format_batches(&data).map(|d| format!("{d}")).boxed()
 }
 
-async fn get_params_with_secrets(
+async fn get_params_with_secrets_value(
     params: &HashMap<String, Value>,
     rt: &Runtime,
 ) -> HashMap<String, SecretString> {
@@ -461,5 +461,5 @@ async fn get_params_with_secrets(
         })
         .collect::<HashMap<_, _>>();
 
-    rt.get_params_with_secrets(&params).await
+    get_params_with_secrets(rt.secrets(), &params).await
 }

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -20,7 +20,7 @@ use crate::models::sql_to_display;
 use crate::{
     init_tracing, init_tracing_with_task_history,
     models::{
-        create_api_bindings_config, get_params_with_secrets, get_taxi_trips_dataset,
+        create_api_bindings_config, get_params_with_secrets_value, get_taxi_trips_dataset,
         get_tpcds_dataset, normalize_chat_completion_response, normalize_embeddings_response,
         send_chat_completions_request,
     },
@@ -607,7 +607,7 @@ async fn get_openai_chat_model(
         .params
         .insert("tools".to_string(), tools.into().into());
 
-    let model_secrets = get_params_with_secrets(&model_with_tools.params, &rt).await;
+    let model_secrets = get_params_with_secrets_value(&model_with_tools.params, &rt).await;
     try_to_chat_model(&model_with_tools, &model_secrets, rt)
         .await
         .map_err(anyhow::Error::from)

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use catalog::SpiceAICatalogProvider;
@@ -319,7 +319,7 @@ async fn get_spiceai_table_provider(
     dataset.replication = Some(Replication { enabled: true });
 
     let params = DataConnectorParamsBuilder::new(name.into(), (&dataset).into())
-        .without_runtime(HashMap::new(), secrets)
+        .build(secrets)
         .await
         .context(UnableToCreateDataConnectorSnafu)?;
 

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -35,7 +35,7 @@ use runtime::{
     },
     dataaccelerator::{self, create_accelerator_table},
     dataconnector::{
-        create_new_connector, DataConnector, DataConnectorError, DataConnectorParamsBuilder,
+        create_new_connector, ConnectorParamsBuilder, DataConnector, DataConnectorError,
     },
     extension::{Error as ExtensionError, Extension, ExtensionFactory, ExtensionManifest, Result},
     federated_table::FederatedTable,
@@ -318,7 +318,7 @@ async fn get_spiceai_table_provider(
     dataset.mode = Mode::ReadWrite;
     dataset.replication = Some(Replication { enabled: true });
 
-    let params = DataConnectorParamsBuilder::new(name.into(), (&dataset).into())
+    let params = ConnectorParamsBuilder::new(name.into(), (&dataset).into())
         .build(secrets)
         .await
         .context(UnableToCreateDataConnectorSnafu)?;


### PR DESCRIPTION
# 🗣 Description

This large refactoring PR adds the concept of a `CatalogConnector` that is separate from a `DataConnector` and moves over two existing CatalogConnectors (UnityCatalog/Databricks) over to this new abstraction.

This is work necessary to prepare for #3872 to ensure that the right catalog abstractions are in place.

Additionally, we need catalogs to be able to periodically refresh their included tables to reflect changes from the upstream catalog provider. This PR defines the `RefreshableCatalogProvider` trait with a single method `refresh` that all catalog providers supported in Spice must support. Currently this is hard-coded to refresh every 60 seconds.

## 🔨 Related Issues

Ground work preparing for #3872

## 📄 Documentation Updates

N/A

## 🤔 Concerns

Hard-coding the refresh interval for now
