### PR TITLE
Implement Iceberg Catalog Connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,6 +3045,9 @@ dependencies = [
  "graph-rs-sdk",
  "graphql-parser",
  "http 1.2.0",
+ "iceberg",
+ "iceberg-catalog-rest",
+ "iceberg-datafusion",
  "object_store",
  "rdkafka",
  "regex",
@@ -5671,6 +5674,41 @@ dependencies = [
  "url",
  "uuid 1.11.0",
  "zstd",
+]
+
+[[package]]
+name = "iceberg-catalog-rest"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59608aad36da6061f353bd12efa049bc12ea437032cd4cf67f03696d45557db9"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "http 1.2.0",
+ "iceberg",
+ "itertools 0.13.0",
+ "log",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tokio",
+ "typed-builder 0.20.0",
+ "uuid 1.11.0",
+]
+
+[[package]]
+name = "iceberg-datafusion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389127b6db8b815e6f7e87b316c80c80058e361d1e9a514b6bb6c28781f371f0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "datafusion",
+ "futures",
+ "iceberg",
+ "tokio",
 ]
 
 [[package]]
@@ -9735,6 +9773,7 @@ dependencies = [
  "hyper 1.5.1",
  "hyper-util",
  "iceberg",
+ "iceberg-catalog-rest",
  "indexmap 2.7.0",
  "insta",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ graphql-parser = "0.4.0"
 hf-hub = { version = "0.3.0", features = ["tokio"] }
 http = "1.1.0"
 iceberg = "0.4.0"
+iceberg-datafusion = "0.4.0"
+iceberg-catalog-rest = "0.4.0"
 insta = { version = "1.41.1", features = ["filters"] }
 itertools = "0.13"
 lazy_static = "1.5.0"

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -44,6 +44,9 @@ globset.workspace = true
 graph-rs-sdk = { workspace = true, optional = true }
 graphql-parser.workspace = true
 http = { version = "1.1.0" }
+iceberg-catalog-rest.workspace = true
+iceberg.workspace = true
+iceberg-datafusion.workspace = true
 object_store = { workspace = true }
 rdkafka = { version = "0.37.0", features = ["ssl-vendored"], optional = true }
 regex = "1.10.4"
@@ -92,7 +95,6 @@ postgres = [
     "datafusion-table-providers/postgres-federation",
 ]
 sharepoint = ["dep:graph-rs-sdk"]
-#, "dep:http"]
 snowflake = ["dep:snowflake-api"]
 spark_connect = ["dep:spark-connect-rs"]
 sqlite = [

--- a/crates/data_components/src/iceberg/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog.rs
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Implementation of an Iceberg REST API Catalog client that knows how to load Spice.ai and/or Iceberg tables.

--- a/crates/data_components/src/iceberg/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog.rs
@@ -30,12 +30,37 @@ pub struct RestCatalog {
     inner: IcebergRestCatalog,
 }
 
+/// The kinds of tables that can be returned from the `RestCatalog`.
+#[derive(Debug, Clone, Copy)]
+pub enum IcebergTableKind {
+    Iceberg,
+    Spice,
+}
+
+/// The table type that can be returned from the `RestCatalog`.
+#[derive(Debug)]
+pub enum IcebergTable {
+    Iceberg(Table),
+    Spice(String),
+}
+
 impl RestCatalog {
     #[must_use]
-    pub fn new(catalog_config: RestCatalogConfig) -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(catalog_config: RestCatalogConfig, table_kind: IcebergTableKind) -> Self {
+        // This will be removed in the next PR.
+        assert!(
+            matches!(table_kind, IcebergTableKind::Iceberg),
+            "RestCatalog currently only supports Iceberg tables"
+        );
         Self {
             inner: IcebergRestCatalog::new(catalog_config),
         }
+    }
+
+    pub async fn load_table(&self, table: &TableIdent) -> IcebergResult<IcebergTable> {
+        let table = self.inner.load_table(table).await?;
+        Ok(IcebergTable::Iceberg(table))
     }
 }
 
@@ -113,8 +138,12 @@ impl Catalog for RestCatalog {
     }
 
     /// Load table from the catalog.
-    async fn load_table(&self, table: &TableIdent) -> IcebergResult<Table> {
-        self.inner.load_table(table).await
+    async fn load_table(&self, _table: &TableIdent) -> IcebergResult<Table> {
+        // We use the load table implementation from our RestCatalog, not this trait's version.
+        return Err(IcebergError::new(
+            ErrorKind::FeatureUnsupported,
+            "Not implemented",
+        ));
     }
 
     /// Drop a table from the catalog.
@@ -177,6 +206,7 @@ mod tests {
                     ("s3.region".to_string(), "us-east-1".to_string()),
                 ]))
                 .build(),
+            IcebergTableKind::Iceberg,
         );
 
         let namespaces = catalog.list_namespaces(None).await;
@@ -200,6 +230,10 @@ mod tests {
             .await
             .expect("Failed to load table");
         println!("{table:?}");
+
+        let IcebergTable::Iceberg(table) = table else {
+            panic!("Expected Iceberg table");
+        };
 
         let df_table_provider = IcebergTableProvider::try_new_from_table(table)
             .await

--- a/crates/data_components/src/iceberg/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog.rs
@@ -15,3 +15,204 @@ limitations under the License.
 */
 
 //! Implementation of an Iceberg REST API Catalog client that knows how to load Spice.ai and/or Iceberg tables.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use iceberg::{
+    table::Table, Catalog, Error as IcebergError, ErrorKind, Namespace, NamespaceIdent,
+    Result as IcebergResult, TableCommit, TableCreation, TableIdent,
+};
+use iceberg_catalog_rest::{RestCatalog as IcebergRestCatalog, RestCatalogConfig};
+
+#[derive(Debug)]
+pub struct RestCatalog {
+    inner: IcebergRestCatalog,
+}
+
+impl RestCatalog {
+    #[must_use]
+    pub fn new(catalog_config: RestCatalogConfig) -> Self {
+        Self {
+            inner: IcebergRestCatalog::new(catalog_config),
+        }
+    }
+}
+
+#[async_trait]
+impl Catalog for RestCatalog {
+    /// List namespaces inside the catalog.
+    async fn list_namespaces(
+        &self,
+        parent: Option<&NamespaceIdent>,
+    ) -> IcebergResult<Vec<NamespaceIdent>> {
+        self.inner.list_namespaces(parent).await
+    }
+
+    /// Create a new namespace inside the catalog.
+    async fn create_namespace(
+        &self,
+        _namespace: &NamespaceIdent,
+        _properties: HashMap<String, String>,
+    ) -> IcebergResult<Namespace> {
+        return Err(IcebergError::new(
+            ErrorKind::FeatureUnsupported,
+            "Not implemented",
+        ));
+    }
+
+    /// Get a namespace information from the catalog.
+    async fn get_namespace(&self, namespace: &NamespaceIdent) -> IcebergResult<Namespace> {
+        self.inner.get_namespace(namespace).await
+    }
+
+    /// Check if namespace exists in catalog.
+    async fn namespace_exists(&self, namespace: &NamespaceIdent) -> IcebergResult<bool> {
+        self.inner.namespace_exists(namespace).await
+    }
+
+    /// Update a namespace inside the catalog.
+    ///
+    /// # Behavior
+    ///
+    /// The properties must be the full set of namespace.
+    async fn update_namespace(
+        &self,
+        _namespace: &NamespaceIdent,
+        _properties: HashMap<String, String>,
+    ) -> IcebergResult<()> {
+        return Err(IcebergError::new(
+            ErrorKind::FeatureUnsupported,
+            "Not implemented",
+        ));
+    }
+
+    /// Drop a namespace from the catalog.
+    async fn drop_namespace(&self, _namespace: &NamespaceIdent) -> IcebergResult<()> {
+        return Err(IcebergError::new(
+            ErrorKind::FeatureUnsupported,
+            "Not implemented",
+        ));
+    }
+
+    /// List tables from namespace.
+    async fn list_tables(&self, namespace: &NamespaceIdent) -> IcebergResult<Vec<TableIdent>> {
+        self.inner.list_tables(namespace).await
+    }
+
+    /// Create a new table inside the namespace.
+    async fn create_table(
+        &self,
+        _namespace: &NamespaceIdent,
+        _creation: TableCreation,
+    ) -> IcebergResult<Table> {
+        return Err(IcebergError::new(
+            ErrorKind::FeatureUnsupported,
+            "Not implemented",
+        ));
+    }
+
+    /// Load table from the catalog.
+    async fn load_table(&self, table: &TableIdent) -> IcebergResult<Table> {
+        self.inner.load_table(table).await
+    }
+
+    /// Drop a table from the catalog.
+    async fn drop_table(&self, _table: &TableIdent) -> IcebergResult<()> {
+        return Err(IcebergError::new(
+            ErrorKind::FeatureUnsupported,
+            "Not implemented",
+        ));
+    }
+
+    /// Check if a table exists in the catalog.
+    async fn table_exists(&self, table: &TableIdent) -> IcebergResult<bool> {
+        self.inner.table_exists(table).await
+    }
+
+    /// Rename a table in the catalog.
+    async fn rename_table(&self, _src: &TableIdent, _dest: &TableIdent) -> IcebergResult<()> {
+        return Err(IcebergError::new(
+            ErrorKind::FeatureUnsupported,
+            "Not implemented",
+        ));
+    }
+
+    /// Update a table to the catalog.
+    async fn update_table(&self, _commit: TableCommit) -> IcebergResult<Table> {
+        return Err(IcebergError::new(
+            ErrorKind::FeatureUnsupported,
+            "Not implemented",
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::prelude::SessionContext;
+    use iceberg_datafusion::IcebergTableProvider;
+    use std::sync::Arc;
+
+    use super::*;
+
+    /// Comment the `#[ignore]` and run this test with `cargo test -p data_components --lib -- iceberg::catalog --nocapture`.
+    ///
+    /// Pre-requisites:
+    /// Follow the guide at https://iceberg.apache.org/spark-quickstart/ to spin up a local Iceberg catalog/Minio & Spark cluster.
+    /// In the Python notebook that gets started at http://localhost:8888, load the `Iceberg - Getting Started.ipynb` notebook.
+    /// Run the first 5 cells to create the `nyc.taxis` table.
+    #[tokio::test]
+    #[ignore]
+    async fn test_rest_catalog() {
+        let catalog = RestCatalog::new(
+            RestCatalogConfig::builder()
+                .uri("http://localhost:8181".to_string())
+                .props(HashMap::from([
+                    (
+                        "s3.endpoint".to_string(),
+                        "http://localhost:9000".to_string(),
+                    ),
+                    ("s3.access-key-id".to_string(), "admin".to_string()),
+                    ("s3.secret-access-key".to_string(), "password".to_string()),
+                    ("s3.region".to_string(), "us-east-1".to_string()),
+                ]))
+                .build(),
+        );
+
+        let namespaces = catalog.list_namespaces(None).await;
+        println!("{namespaces:?}");
+
+        let namespace = catalog
+            .get_namespace(&NamespaceIdent::new("nyc".to_string()))
+            .await;
+        println!("{namespace:?}");
+
+        let tables = catalog
+            .list_tables(&NamespaceIdent::new("nyc".to_string()))
+            .await;
+        println!("{tables:?}");
+
+        let table = catalog
+            .load_table(&TableIdent::new(
+                NamespaceIdent::new("nyc".to_string()),
+                "taxis".to_string(),
+            ))
+            .await
+            .expect("Failed to load table");
+        println!("{table:?}");
+
+        let df_table_provider = IcebergTableProvider::try_new_from_table(table)
+            .await
+            .expect("Failed to create table provider");
+
+        let ctx = SessionContext::new();
+        ctx.register_table("ice_ice_baby", Arc::new(df_table_provider))
+            .expect("Failed to register table");
+
+        let df = ctx
+            .sql("SELECT * FROM ice_ice_baby LIMIT 10")
+            .await
+            .expect("Failed to execute query");
+        df.show().await.expect("Failed to show");
+    }
+}

--- a/crates/data_components/src/iceberg/mod.rs
+++ b/crates/data_components/src/iceberg/mod.rs
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+pub mod catalog;
+pub mod provider;

--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -15,3 +15,173 @@ limitations under the License.
 */
 
 //! Implementation of the `DataFusion` Catalog/Schema providers for Iceberg.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::catalog::{CatalogProvider, SchemaProvider, TableProvider};
+use datafusion::error::Result as DFResult;
+use futures::future::try_join_all;
+use iceberg::{Catalog, NamespaceIdent, Result};
+use iceberg_datafusion::IcebergTableProvider;
+
+use crate::RefreshableCatalogProvider;
+
+use super::catalog::{IcebergTable, RestCatalog};
+
+/// Provides an interface to manage and access multiple schemas
+/// within an Iceberg [`Catalog`].
+///
+/// Acts as a centralized catalog provider that aggregates
+/// multiple [`SchemaProvider`], each associated with distinct namespaces.
+#[derive(Debug)]
+pub struct IcebergCatalogProvider {
+    /// A `HashMap` where keys are namespace names
+    /// and values are dynamic references to objects implementing the
+    /// [`SchemaProvider`] trait.
+    schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+}
+
+impl IcebergCatalogProvider {
+    /// Asynchronously tries to construct a new [`IcebergCatalogProvider`]
+    /// using the given client to fetch and initialize schema providers for
+    /// each namespace in the Iceberg [`Catalog`].
+    ///
+    /// This method retrieves the list of namespace names
+    /// attempts to create a schema provider for each namespace, and
+    /// collects these providers into a `HashMap`.
+    pub async fn try_new(
+        client: Arc<RestCatalog>,
+        root_namespace: Option<NamespaceIdent>,
+    ) -> Result<Self> {
+        let schema_names: Vec<_> = client
+            .list_namespaces(root_namespace.as_ref())
+            .await?
+            .iter()
+            .flat_map(|ns| ns.as_ref().clone())
+            .collect();
+
+        let providers = try_join_all(
+            schema_names
+                .iter()
+                .map(|name| {
+                    IcebergSchemaProvider::try_new(
+                        Arc::clone(&client),
+                        NamespaceIdent::new(name.clone()),
+                    )
+                })
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+
+        let schemas: HashMap<String, Arc<dyn SchemaProvider>> = schema_names
+            .into_iter()
+            .zip(providers.into_iter())
+            .map(|(name, provider)| {
+                let provider = Arc::new(provider) as Arc<dyn SchemaProvider>;
+                (name, provider)
+            })
+            .collect();
+
+        Ok(IcebergCatalogProvider { schemas })
+    }
+}
+
+impl CatalogProvider for IcebergCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        self.schemas.keys().cloned().collect()
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        self.schemas.get(name).cloned()
+    }
+}
+
+#[async_trait]
+impl RefreshableCatalogProvider for IcebergCatalogProvider {
+    async fn refresh(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Will be implemented in a future enhancement.
+        Ok(())
+    }
+}
+
+/// Represents a [`SchemaProvider`] for the Iceberg [`Catalog`], managing
+/// access to table providers within a specific namespace.
+#[derive(Debug)]
+pub(crate) struct IcebergSchemaProvider {
+    /// A `HashMap` where keys are table names
+    /// and values are dynamic references to objects implementing the
+    /// [`TableProvider`] trait.
+    tables: HashMap<String, Arc<dyn TableProvider>>,
+}
+
+impl IcebergSchemaProvider {
+    /// Asynchronously tries to construct a new [`IcebergSchemaProvider`]
+    /// using the given client to fetch and initialize table providers for
+    /// the provided namespace in the Iceberg [`Catalog`].
+    ///
+    /// This method retrieves a list of table names
+    /// attempts to create a table provider for each table name, and
+    /// collects these providers into a `HashMap`.
+    pub(crate) async fn try_new(
+        client: Arc<RestCatalog>,
+        namespace: NamespaceIdent,
+    ) -> Result<Self> {
+        let table_names: Vec<_> = client.list_tables(&namespace).await?;
+
+        let iceberg_tables = try_join_all(
+            table_names
+                .iter()
+                .map(|name| client.load_table(name))
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+
+        let table_providers: Vec<_> = try_join_all(
+            iceberg_tables
+                .into_iter()
+                .map(|iceberg_table| match iceberg_table {
+                    IcebergTable::Iceberg(table) => IcebergTableProvider::try_new_from_table(table),
+                    IcebergTable::Spice(_) => todo!(),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+
+        let tables: HashMap<String, Arc<dyn TableProvider>> = table_names
+            .into_iter()
+            .zip(table_providers.into_iter())
+            .map(|(name, provider)| {
+                let provider = Arc::new(provider) as Arc<dyn TableProvider>;
+                (name.name().to_string(), provider)
+            })
+            .collect();
+
+        Ok(IcebergSchemaProvider { tables })
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for IcebergSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        self.tables.keys().cloned().collect()
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables.contains_key(name)
+    }
+
+    async fn table(&self, name: &str) -> DFResult<Option<Arc<dyn TableProvider>>> {
+        Ok(self.tables.get(name).cloned())
+    }
+}

--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Implementation of the `DataFusion` Catalog/Schema providers for Iceberg.

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -39,6 +39,7 @@ pub mod duckdb;
 pub mod flight;
 #[cfg(feature = "flightsql")]
 pub mod flightsql;
+pub mod iceberg;
 #[cfg(feature = "debezium")]
 pub mod kafka;
 #[cfg(feature = "mssql")]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -61,6 +61,7 @@ http-body-util = "0.1.2"
 hyper = "1.5.1"
 hyper-util = { version = "0.1.6", features = ["service"] }
 iceberg.workspace = true
+iceberg-catalog-rest.workspace = true
 indexmap = "2"
 itertools.workspace = true
 jsonwebtoken = "9.3.0"

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -14,14 +14,44 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::{CatalogConnector, ConnectorComponent, ParameterSpec, Parameters, Result};
+use super::{CatalogConnector, ConnectorComponent, ParameterSpec, Parameters};
 use crate::{
-    component::catalog::Catalog, dataconnector::ConnectorParams, get_params_with_secrets, Runtime,
+    component::catalog::Catalog, dataconnector::ConnectorParams,
+    http::v1::iceberg::namespace::Namespace as HttpNamespace, Runtime,
 };
 use async_trait::async_trait;
 use data_components::RefreshableCatalogProvider;
-use secrecy::SecretString;
+use iceberg::{Namespace, NamespaceIdent};
+use iceberg_catalog_rest::RestCatalogConfig;
+use snafu::prelude::*;
 use std::{any::Any, collections::HashMap, sync::Arc};
+use url::Url;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Invalid URL scheme '{}'. Must be http or https", scheme))]
+    InvalidScheme { scheme: String },
+
+    #[snafu(display("URL is missing a host"))]
+    MissingHost,
+
+    #[snafu(display("Path must contain 'v1' segment"))]
+    MissingV1Segment,
+
+    #[snafu(display("Path must contain 'namespaces' segment"))]
+    MissingNamespacesSegment,
+
+    #[snafu(display("The 'namespaces' segment must come after 'v1'"))]
+    InvalidSegmentOrder,
+
+    #[snafu(display("Missing namespace name after 'namespaces'"))]
+    MissingNamespace,
+
+    #[snafu(display("Failed to parse URL: {}", source))]
+    UrlParse { source: url::ParseError },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Clone)]
 pub struct IcebergCatalog {
@@ -90,8 +120,206 @@ impl CatalogConnector for IcebergCatalog {
         runtime: &Runtime,
         catalog: &Catalog,
     ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
+        let Some(catalog_id) = catalog.catalog_id.clone() else {
+            return Err(
+                super::Error::InvalidConfigurationNoSource {
+                    connector: "iceberg".into(),
+                    message: "A Catalog Path is required for Iceberg in the format of: http://<host_and_port>/v1/namespaces/<namespace>.\nFor details, visit: https://docs.spiceai.org/components/catalogs/iceberg#from".into(),
+                    connector_component: ConnectorComponent::from(catalog),
+                },
+            );
+        };
+
+        let (catalog_config, namespace) = match parse_catalog_url(catalog_id.as_str()) {
+            Ok(result) => result,
+            Err(e) => {
+                return Err(super::Error::InvalidConfiguration {
+                    connector: "iceberg".into(),
+                    message: format!("A Catalog Path is required for Iceberg in the format of: http://<host_and_port>/v1/namespaces/<namespace>.\nFor details, visit: https://docs.spiceai.org/components/catalogs/iceberg#from\n{e}"),
+                    connector_component: ConnectorComponent::from(catalog),
+                    source: Box::new(e),
+                });
+            }
+        };
+
         todo!();
 
         //Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>)
+    }
+}
+
+/// Parses a catalog URL into an Iceberg `RestCatalogConfig` (catalog URI + optional properties)
+/// and the `Namespace` (namespace name + optional properties).
+///
+/// For example:
+///
+/// `https://my.iceberg.com/v1/namespaces/spiceai_sandbox`
+///
+/// Returns:
+/// ```rust
+/// (
+///   RestCatalogConfig { uri: "https://my.iceberg.com", props: {} },
+///   Namespace { name: "spiceai_sandbox", properties: {} }
+/// )
+/// ```
+///
+/// Example with prefix:
+///
+/// `https://my.iceberg.com/v1/my_prefix/namespaces/spiceai_sandbox`
+///
+/// Returns:
+/// ```rust
+/// (
+///   RestCatalogConfig { uri: "https://my.iceberg.com", props: {"prefix": "my_prefix"} },
+///   Namespace { name: "spiceai_sandbox", properties: {} }
+/// )
+/// ```
+pub fn parse_catalog_url(url: &str) -> Result<(RestCatalogConfig, Option<Namespace>)> {
+    // Parse the URL
+    let parsed = Url::parse(url).context(UrlParseSnafu)?;
+
+    // Validate scheme
+    match parsed.scheme() {
+        "http" | "https" => {} // OK
+        other => {
+            return InvalidSchemeSnafu {
+                scheme: other.to_string(),
+            }
+            .fail()
+        }
+    }
+
+    // Build the base URI (scheme://host[:port])
+    let host = parsed.host_str().context(MissingHostSnafu)?;
+
+    let port_part = match parsed.port() {
+        Some(port) => format!(":{port}"),
+        None => String::new(),
+    };
+    let base_uri = format!("{}://{}{}", parsed.scheme(), host, port_part);
+
+    // Extract path segments
+    let segments: Vec<_> = parsed
+        .path_segments()
+        .map(|s| s.filter(|seg| !seg.is_empty()).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    // Find the "v1" segment
+    let v1_idx = segments
+        .iter()
+        .position(|seg| *seg == "v1")
+        .context(MissingV1SegmentSnafu)?;
+
+    // Find the "namespaces" segment
+    let namespaces_idx = segments
+        .iter()
+        .position(|seg| *seg == "namespaces")
+        .context(MissingNamespacesSegmentSnafu)?;
+
+    if namespaces_idx <= v1_idx {
+        return InvalidSegmentOrderSnafu.fail();
+    }
+
+    let mut namespace: Option<Namespace> = None;
+    if namespaces_idx + 1 < segments.len() {
+        // The namespace name is the segment immediately after "namespaces"
+        let namespace_name = HttpNamespace::from_encoded(segments[namespaces_idx + 1]);
+        let Ok(namespace_name) = NamespaceIdent::from_vec(namespace_name.parts) else {
+            unreachable!(
+        "NamespaceIdent::from_vec never fails if namespace_name.parts has at least one part"
+    )
+        };
+        namespace = Some(Namespace::new(namespace_name));
+    }
+
+    // Everything between "v1" and "namespaces" is considered the prefix
+    let prefix_segments = &segments[v1_idx + 1..namespaces_idx];
+    let prefix = prefix_segments.join("/");
+
+    // Build up the catalog properties
+    let mut props = HashMap::new();
+    if !prefix.is_empty() {
+        props.insert("prefix".to_string(), prefix);
+    }
+
+    // Return the RestCatalogConfig + Namespace
+    Ok((
+        RestCatalogConfig::builder()
+            .uri(base_uri)
+            .props(props)
+            .build(),
+        namespace,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_catalog_url_no_prefix() {
+        let url = "https://my.iceberg.com/v1/namespaces/spiceai_sandbox";
+        let (_, namespace) = parse_catalog_url(url).expect("Failed to parse catalog URL");
+        assert_eq!(
+            namespace
+                .clone()
+                .expect("Namespace is None")
+                .name()
+                .to_url_string()
+                .as_str(),
+            "spiceai_sandbox"
+        );
+        assert!(namespace
+            .expect("Namespace is None")
+            .properties()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_parse_catalog_url_with_prefix() {
+        let url = "https://my.iceberg.com/v1/my_prefix/namespaces/spiceai_sandbox";
+        let (_, namespace) = parse_catalog_url(url).expect("Failed to parse catalog URL");
+        assert_eq!(
+            namespace
+                .clone()
+                .expect("Namespace is None")
+                .name()
+                .to_url_string()
+                .as_str(),
+            "spiceai_sandbox"
+        );
+        assert!(namespace
+            .expect("Namespace is None")
+            .properties()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_invalid_scheme() {
+        let url = "ftp://my.iceberg.com/v1/namespaces/spiceai_sandbox";
+        let result = parse_catalog_url(url);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_no_host() {
+        let url = "https:///v1/namespaces/spiceai_sandbox";
+        let result = parse_catalog_url(url);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_namespace_segment() {
+        let url = "https://my.iceberg.com/v1/";
+        let result = parse_catalog_url(url);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_namespace_segment() {
+        let url = "https://my.iceberg.com/v1/namespaces";
+        let result = parse_catalog_url(url);
+        assert!(result.is_ok());
+        assert!(result.expect("Failed to parse catalog URL").1.is_none());
     }
 }

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -90,8 +90,8 @@ pub(crate) const PARAMETERS: &[ParameterSpec] = &[
             "The scope to use for OAuth2 token endpoint (default: catalog).",
         )
         .default("catalog"),
-    ParameterSpec::connector("oauth2_server_uri")
-        .description("The URL to use for OAuth2 server tokens endpoint (default: catalog base URI + 'v1/oauth/tokens')."),
+    ParameterSpec::connector("oauth2_server_url")
+        .description("URL of the OAuth2 server tokens endpoint."),
     // S3 storage options
     ParameterSpec::connector("s3_endpoint")
         .description(
@@ -123,6 +123,10 @@ pub(crate) const PARAMETERS: &[ParameterSpec] = &[
 /// Maps a Spice parameter name to an Iceberg property name.
 fn map_param_name_to_iceberg_prop(param_name: &str) -> Option<String> {
     match param_name {
+        "token" => Some("token".to_string()),
+        "oauth2_credential" => Some("credential".to_string()),
+        "oauth2_server_url" => Some("oauth2-server-uri".to_string()),
+        "oauth2_scope" => Some("scope".to_string()),
         "s3_endpoint" => Some("s3.endpoint".to_string()),
         "s3_access_key_id" => Some("s3.access-key-id".to_string()),
         "s3_secret_access_key" => Some("s3.secret-access-key".to_string()),

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::{CatalogConnector, ConnectorComponent, ParameterSpec, Parameters, Result};
+use crate::{
+    component::catalog::Catalog, dataconnector::ConnectorParams, get_params_with_secrets, Runtime,
+};
+use async_trait::async_trait;
+use data_components::RefreshableCatalogProvider;
+use secrecy::SecretString;
+use std::{any::Any, collections::HashMap, sync::Arc};
+
+#[derive(Clone)]
+pub struct IcebergCatalog {
+    params: Parameters,
+}
+
+impl IcebergCatalog {
+    #[must_use]
+    pub fn new_connector(params: ConnectorParams) -> Arc<dyn CatalogConnector> {
+        Arc::new(Self {
+            params: params.parameters,
+        })
+    }
+}
+
+pub(crate) const PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::connector("token").secret().description(
+        "The personal access token used to authenticate against the Iceberg REST Catalog API.",
+    ),
+    // S3 storage options
+    ParameterSpec::connector("aws_region")
+        .description("The AWS region to use for S3 storage.")
+        .secret(),
+    ParameterSpec::connector("aws_access_key_id")
+        .description("The AWS access key ID to use for S3 storage.")
+        .secret(),
+    ParameterSpec::connector("aws_secret_access_key")
+        .description("The AWS secret access key to use for S3 storage.")
+        .secret(),
+    ParameterSpec::connector("aws_endpoint")
+        .description("The AWS endpoint to use for S3 storage.")
+        .secret(),
+    // Azure storage options
+    ParameterSpec::connector("azure_storage_account_name")
+        .description("The storage account to use for Azure storage.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_account_key")
+        .description("The storage account key to use for Azure storage.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_client_id")
+        .description("The service principal client id for accessing the storage account.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_client_secret")
+        .description("The service principal client secret for accessing the storage account.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_sas_key")
+        .description("The shared access signature key for accessing the storage account.")
+        .secret(),
+    ParameterSpec::connector("azure_storage_endpoint")
+        .description("The endpoint for the Azure Blob storage account.")
+        .secret(),
+    // GCS storage options
+    ParameterSpec::connector("google_service_account")
+        .description("Filesystem path to the Google service account JSON key file.")
+        .secret(),
+];
+
+#[async_trait]
+impl CatalogConnector for IcebergCatalog {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn refreshable_catalog_provider(
+        self: Arc<Self>,
+        runtime: &Runtime,
+        catalog: &Catalog,
+    ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
+        todo!();
+
+        //Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>)
+    }
+}

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -20,9 +20,16 @@ use crate::{
     http::v1::iceberg::namespace::Namespace as HttpNamespace, Runtime,
 };
 use async_trait::async_trait;
-use data_components::RefreshableCatalogProvider;
+use data_components::{
+    iceberg::{
+        catalog::{IcebergTableKind, RestCatalog},
+        provider::IcebergCatalogProvider,
+    },
+    RefreshableCatalogProvider,
+};
 use iceberg::{Namespace, NamespaceIdent};
 use iceberg_catalog_rest::RestCatalogConfig;
+use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::{any::Any, collections::HashMap, sync::Arc};
 use url::Url;
@@ -68,46 +75,64 @@ impl IcebergCatalog {
 }
 
 pub(crate) const PARAMETERS: &[ParameterSpec] = &[
-    ParameterSpec::connector("token").secret().description(
-        "The personal access token used to authenticate against the Iceberg REST Catalog API.",
-    ),
+    ParameterSpec::connector("token")
+        .secret()
+        .description("Bearer token value to use for Authorization header."),
+    ParameterSpec::connector("oauth2_credential")
+        .secret()
+        .description(
+            "Credential to use for OAuth2 client credential flow when initializing the catalog. Separated by a colon as <client_id>:<client_secret>.",
+        ),
+    ParameterSpec::connector("oauth2_token_url")
+        .description("The URL to use for OAuth2 token endpoint."),
+    ParameterSpec::connector("oauth2_scope")
+        .description(
+            "The scope to use for OAuth2 token endpoint (default: catalog).",
+        )
+        .default("catalog"),
+    ParameterSpec::connector("oauth2_server_uri")
+        .description("The URL to use for OAuth2 server tokens endpoint (default: catalog base URI + 'v1/oauth/tokens')."),
     // S3 storage options
-    ParameterSpec::connector("aws_region")
-        .description("The AWS region to use for S3 storage.")
+    ParameterSpec::connector("s3_endpoint")
+        .description(
+            "Configure an alternative endpoint for the S3 service. This can be any s3-compatible object storage service. i.e. Minio, Cloudflare R2, etc.",
+        )
         .secret(),
-    ParameterSpec::connector("aws_access_key_id")
+    ParameterSpec::connector("s3_access_key_id")
         .description("The AWS access key ID to use for S3 storage.")
         .secret(),
-    ParameterSpec::connector("aws_secret_access_key")
+    ParameterSpec::connector("s3_secret_access_key")
         .description("The AWS secret access key to use for S3 storage.")
         .secret(),
-    ParameterSpec::connector("aws_endpoint")
-        .description("The AWS endpoint to use for S3 storage.")
+    ParameterSpec::connector("s3_session_token")
+        .description("Configure the static session token used for S3 storage.")
         .secret(),
-    // Azure storage options
-    ParameterSpec::connector("azure_storage_account_name")
-        .description("The storage account to use for Azure storage.")
+    ParameterSpec::connector("s3_region")
+        .description("The AWS S3 region to use.")
         .secret(),
-    ParameterSpec::connector("azure_storage_account_key")
-        .description("The storage account key to use for Azure storage.")
+    ParameterSpec::connector("s3_role_session_name")
+        .description("An optional identifier for the assumed role session for auditing purposes.")
         .secret(),
-    ParameterSpec::connector("azure_storage_client_id")
-        .description("The service principal client id for accessing the storage account.")
+    ParameterSpec::connector("s3_role_arn")
+        .description("The Amazon Resource Name (ARN) of the role to assume. If provided instead of s3_access_key_id and s3_secret_access_key, temporary credentials will be fetched by assuming this role")
         .secret(),
-    ParameterSpec::connector("azure_storage_client_secret")
-        .description("The service principal client secret for accessing the storage account.")
-        .secret(),
-    ParameterSpec::connector("azure_storage_sas_key")
-        .description("The shared access signature key for accessing the storage account.")
-        .secret(),
-    ParameterSpec::connector("azure_storage_endpoint")
-        .description("The endpoint for the Azure Blob storage account.")
-        .secret(),
-    // GCS storage options
-    ParameterSpec::connector("google_service_account")
-        .description("Filesystem path to the Google service account JSON key file.")
-        .secret(),
+    ParameterSpec::connector("s3_connect_timeout")
+        .description("Configure socket connection timeout, in seconds (default: 60).")
 ];
+
+/// Maps a Spice parameter name to an Iceberg property name.
+fn map_param_name_to_iceberg_prop(param_name: &str) -> Option<String> {
+    match param_name {
+        "s3_endpoint" => Some("s3.endpoint".to_string()),
+        "s3_access_key_id" => Some("s3.access-key-id".to_string()),
+        "s3_secret_access_key" => Some("s3.secret-access-key".to_string()),
+        "s3_session_token" => Some("s3.session-token".to_string()),
+        "s3_region" => Some("s3.region".to_string()),
+        "s3_role_session_name" => Some("client.assume-role.session-name".to_string()),
+        "s3_role_arn" => Some("client.assume-role.arn".to_string()),
+        _ => None,
+    }
+}
 
 #[async_trait]
 impl CatalogConnector for IcebergCatalog {
@@ -117,7 +142,7 @@ impl CatalogConnector for IcebergCatalog {
 
     async fn refreshable_catalog_provider(
         self: Arc<Self>,
-        runtime: &Runtime,
+        _runtime: &Runtime,
         catalog: &Catalog,
     ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
         let Some(catalog_id) = catalog.catalog_id.clone() else {
@@ -130,7 +155,7 @@ impl CatalogConnector for IcebergCatalog {
             );
         };
 
-        let (catalog_config, namespace) = match parse_catalog_url(catalog_id.as_str()) {
+        let (base_uri, mut props, namespace) = match parse_catalog_url(catalog_id.as_str()) {
             Ok(result) => result,
             Err(e) => {
                 return Err(super::Error::InvalidConfiguration {
@@ -142,9 +167,31 @@ impl CatalogConnector for IcebergCatalog {
             }
         };
 
-        todo!();
+        for (key, value) in &self.params {
+            if let Some(prop) = map_param_name_to_iceberg_prop(key.as_str()) {
+                props.insert(prop, value.expose_secret().to_string());
+            }
+        }
 
-        //Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>)
+        let catalog_config = RestCatalogConfig::builder()
+            .uri(base_uri)
+            .props(props)
+            .build();
+
+        let catalog_client = RestCatalog::new(catalog_config, IcebergTableKind::Iceberg);
+
+        let catalog_provider = IcebergCatalogProvider::try_new(
+            Arc::new(catalog_client),
+            namespace.map(|n| n.name().clone()),
+        )
+        .await
+        .map_err(|e| super::Error::UnableToGetCatalogProvider {
+            connector: "iceberg".into(),
+            connector_component: ConnectorComponent::from(catalog),
+            source: Box::new(e),
+        })?;
+
+        Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>)
     }
 }
 
@@ -158,7 +205,8 @@ impl CatalogConnector for IcebergCatalog {
 /// Returns:
 /// ```rust
 /// (
-///   RestCatalogConfig { uri: "https://my.iceberg.com", props: {} },
+///   "https://my.iceberg.com",
+///   {},
 ///   Namespace { name: "spiceai_sandbox", properties: {} }
 /// )
 /// ```
@@ -170,11 +218,14 @@ impl CatalogConnector for IcebergCatalog {
 /// Returns:
 /// ```rust
 /// (
-///   RestCatalogConfig { uri: "https://my.iceberg.com", props: {"prefix": "my_prefix"} },
+///   "https://my.iceberg.com",
+///   {"prefix": "my_prefix"},
 ///   Namespace { name: "spiceai_sandbox", properties: {} }
 /// )
 /// ```
-pub fn parse_catalog_url(url: &str) -> Result<(RestCatalogConfig, Option<Namespace>)> {
+pub fn parse_catalog_url(
+    url: &str,
+) -> Result<(String, HashMap<String, String>, Option<Namespace>)> {
     // Parse the URL
     let parsed = Url::parse(url).context(UrlParseSnafu)?;
 
@@ -242,14 +293,8 @@ pub fn parse_catalog_url(url: &str) -> Result<(RestCatalogConfig, Option<Namespa
         props.insert("prefix".to_string(), prefix);
     }
 
-    // Return the RestCatalogConfig + Namespace
-    Ok((
-        RestCatalogConfig::builder()
-            .uri(base_uri)
-            .props(props)
-            .build(),
-        namespace,
-    ))
+    // Return the Base URI + Properties + Namespace
+    Ok((base_uri, props, namespace))
 }
 
 #[cfg(test)]
@@ -259,7 +304,10 @@ mod tests {
     #[test]
     fn test_parse_catalog_url_no_prefix() {
         let url = "https://my.iceberg.com/v1/namespaces/spiceai_sandbox";
-        let (_, namespace) = parse_catalog_url(url).expect("Failed to parse catalog URL");
+        let (base_uri, props, namespace) =
+            parse_catalog_url(url).expect("Failed to parse catalog URL");
+        assert_eq!(base_uri, "https://my.iceberg.com");
+        assert!(props.is_empty());
         assert_eq!(
             namespace
                 .clone()
@@ -278,7 +326,10 @@ mod tests {
     #[test]
     fn test_parse_catalog_url_with_prefix() {
         let url = "https://my.iceberg.com/v1/my_prefix/namespaces/spiceai_sandbox";
-        let (_, namespace) = parse_catalog_url(url).expect("Failed to parse catalog URL");
+        let (base_uri, props, namespace) =
+            parse_catalog_url(url).expect("Failed to parse catalog URL");
+        assert_eq!(base_uri, "https://my.iceberg.com");
+        assert_eq!(props.get("prefix"), Some(&"my_prefix".to_string()));
         assert_eq!(
             namespace
                 .clone()
@@ -320,6 +371,6 @@ mod tests {
         let url = "https://my.iceberg.com/v1/namespaces";
         let result = parse_catalog_url(url);
         assert!(result.is_ok());
-        assert!(result.expect("Failed to parse catalog URL").1.is_none());
+        assert!(result.expect("Failed to parse catalog URL").2.is_none());
     }
 }

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -69,6 +69,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[cfg(feature = "databricks")]
 pub mod databricks;
+pub mod iceberg;
 #[cfg(feature = "delta_lake")]
 pub mod unity_catalog;
 
@@ -114,6 +115,15 @@ pub async fn register_all() {
             databricks::Databricks::new_connector,
             "databricks",
             databricks::PARAMETERS,
+        ),
+    );
+
+    registry.insert(
+        "iceberg".to_string(),
+        CatalogConnectorFactory::new(
+            iceberg::IcebergCatalog::new_connector,
+            "iceberg",
+            iceberg::PARAMETERS,
         ),
     );
 }

--- a/crates/runtime/src/http.rs
+++ b/crates/runtime/src/http.rs
@@ -42,7 +42,7 @@ mod metrics;
 mod routes;
 mod traceparent;
 
-mod v1;
+pub mod v1;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime/src/http/v1/iceberg/mod.rs
+++ b/crates/runtime/src/http/v1/iceberg/mod.rs
@@ -28,7 +28,7 @@ use namespace::{Namespace, NamespacePath};
 use serde::{self, Deserialize, Serialize};
 
 mod error;
-mod namespace;
+pub mod namespace;
 pub mod tables;
 
 /// Get Iceberg API config

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -199,6 +199,11 @@ impl Parameters {
             self.params.push((key, value));
         }
     }
+
+    /// Returns an iterator over the parameter key-value pairs
+    pub fn iter(&self) -> std::slice::Iter<'_, (String, SecretString)> {
+        self.params.iter()
+    }
 }
 
 #[derive(Clone)]
@@ -206,6 +211,15 @@ pub struct Parameters {
     params: Vec<(String, SecretString)>,
     prefix: &'static str,
     all_params: &'static [ParameterSpec],
+}
+
+impl<'a> IntoIterator for &'a Parameters {
+    type Item = &'a (String, SecretString);
+    type IntoIter = std::slice::Iter<'a, (String, SecretString)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.params.iter()
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
# 🗣 Description

Implements the Iceberg Catalog Connector for connecting to Iceberg tables in Spice.

## 🔨 Related Issues

Closes #3872

## 📄 Documentation Updates

Docs: https://github.com/spiceai/docs/pull/701
Cookbook: https://github.com/spiceai/cookbook/pull/7

## 🤔 Concerns

This PR doesn't implement the support for Spice.ai tables via the catalog connector - that will come in a separate PR. This PR as is fully implements the Iceberg catalog support itself.
