### PR TITLE
Fix '/v1/status' default format

### DIFF
--- a/crates/runtime/src/http/v1/status.rs
+++ b/crates/runtime/src/http/v1/status.rs
@@ -36,6 +36,7 @@ use super::Format;
 #[serde(rename_all = "lowercase")]
 pub struct QueryParams {
     /// The format of the response, either "json" or "csv". Defaults to "json".
+    #[serde(default)]
     pub format: Format,
 }
 


### PR DESCRIPTION
# 🗣 Description
 - Fix '/v1/status' default format to JSON, therefore `v1/status` does not require a `?format=`. 

## 🔨 Related Issues
 - Regression from https://github.com/spiceai/spiceai/pull/3927

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
