### PR TITLE
Only create tables `eval.runs` and `eval.results` when an eval is defined

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -531,7 +531,13 @@ impl Runtime {
                 #[cfg(feature = "models")]
                 {
                     self_clone.load_eval_scorer().await;
-                    if let Err(err) = self_clone.load_eval_tables().await {
+                    let num_evals = app_lock
+                        .as_ref()
+                        .map(|app| app.evals.len())
+                        .unwrap_or_default();
+                    if num_evals == 0 {
+                        tracing::trace!("No eval spice components defined. Therefore not loading eval tables into database.");
+                    } else if let Err(err) = self_clone.load_eval_tables().await {
                         tracing::warn!("Creating internal eval run table: {err}");
                     }
                 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -531,11 +531,8 @@ impl Runtime {
                 #[cfg(feature = "models")]
                 {
                     self_clone.load_eval_scorer().await;
-                    let num_evals = app_lock
-                        .as_ref()
-                        .map(|app| app.evals.len())
-                        .unwrap_or_default();
-                    if num_evals == 0 {
+                    let an_eval_exists = app_lock.as_ref().is_some_and(|app| !app.evals.is_empty());
+                    if !an_eval_exists {
                         tracing::trace!("No eval spice components defined. Therefore not loading eval tables into database.");
                     } else if let Err(err) = self_clone.load_eval_tables().await {
                         tracing::warn!("Creating internal eval run table: {err}");


### PR DESCRIPTION
# 🗣 Description
 - When a user has a model build, but isn't using evals, the `eval.runs` and `eval.results` tables are still defined. 
 - This is undue complexity on the user.
 - Since evals aren't hot reloaded (e.g. if a user adds one to an active spiced instance), only needs to be checked at init time. 
