### PR TITLE
feat: add postgres clickbench accelerator, release postgres accelerator

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -463,6 +463,20 @@ jobs:
     runs-on: spiceai-large-runners
     needs: build-database-bench-binary
 
+    services:
+      postgres_acc:
+        image: ${{( matrix.cmd == '-a postgres' || matrix.cmd == '-a postgres -b clickbench') && 'ghcr.io/cloudnative-pg/postgresql:16-bookworm' || '' }}
+        options: >-
+          --shm-size=2gb
+          --health-cmd="pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -482,6 +496,9 @@ jobs:
             bench: 'clickbench'
           - cmd: '-a sqlite -m file -b clickbench'
             name: 'sqlite accelerator (file mode)'
+            bench: 'clickbench'
+          - cmd: '-a postgres -b clickbench'
+            name: 'postgres accelerator'
             bench: 'clickbench'
 
     steps:
@@ -516,6 +533,11 @@ jobs:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
           S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
+          PG_BENCHMARK_PG_HOST: localhost
+          PG_BENCHMARK_PG_USER: postgres
+          PG_BENCHMARK_PG_PASS: postgres
+          PG_BENCHMARK_PG_SSLMODE: disable
+          PG_BENCHMARK_ACC_PG_DBNAME: postgres
 
   create-pr:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Currently supported data stores for local materialization/acceleration. More com
 | ---------- | ------------------------------- | ----------------- | ---------------- |
 | `arrow`    | In-Memory Arrow Records         | Release Candidate | `memory`         |
 | `duckdb`   | Embedded [DuckDB][duckdb]       | Release Candidate | `memory`, `file` |
+| `postgres` | Attached [PostgreSQL][postgres] | Release Candidate |                  |
 | `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate | `memory`, `file` |
-| `postgres` | Attached [PostgreSQL][postgres] | Beta              |                  |
 
 [duckdb]: https://docs.spiceai.org/data-accelerators/duckdb
 [postgres]: https://github.com/spiceai/cookbook/tree/trunk/postgres/accelerator#postgresql-data-accelerator

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -191,10 +191,12 @@ fn get_accelerator_refresh_sql(
     dataset: &str,
     bench_name: &str,
 ) -> Option<String> {
-    if let Some("sqlite") = engine {
+    if let Some("sqlite" | "postgres") = engine {
         if bench_name == "clickbench" {
             // SQLite has troubles loading the whole ClickBench set with indexes enabled
-            // remove this refresh SQL when we support index creation after table load
+            // remove this refresh SQL when we support index creation after table load.
+            //
+            // Postgres also can't load the full dataset within the 3 hour time limit
             return Some(format!("SELECT * FROM {dataset} LIMIT 10000000"));
         }
     }

--- a/docs/criteria/accelerators/rc.md
+++ b/docs/criteria/accelerators/rc.md
@@ -11,7 +11,7 @@ All criteria must be met for the accelerator to be considered [RC](../definition
 | Arrow       | ✅           | @sgrebnov    |
 | DuckDB      | ✅           | @peasee      |
 | SQLite      | ✅           | @peasee      |
-| PostgreSQL  | ❌           |              |
+| PostgreSQL  | ✅           | @peasee      |
 
 ## RC Release Criteria
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds Postgres Clickbench to the accelerator benchmarks
* Releases Postgres accelerator to RC

Successful ClickBench run: https://github.com/spiceai/spiceai/actions/runs/12577298709/job/35054737823

Postgres ClickBench row count has been limited for RC in benchmarks. Tested locally, it can load the entire set - it just takes a long time (~4-8 hours).

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

Postgres has performance issues with inserts similar to SQLite, and might also benefit from #3954 

Part of #3874 

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

* Docs release update for Postgres is required