### PR TITLE
docs: Clarify connector release criteria

### DIFF
--- a/docs/criteria/connectors/rc.md
+++ b/docs/criteria/connectors/rc.md
@@ -158,7 +158,7 @@ Indexes are not required for test coverage, but can be introduced if required fo
 
 ##### ClickBench
 
-- [ ] A test script exists that can load ClickBench data into this connector at the [designated scale factor](#rc-release-criteria).
+- [ ] A test script exists that can load ClickBench data into this connector.
 - [ ] All queries are attempted on this connector. No bug fixes are required for ClickBench.
 - [ ] All ClickBench bugs are raised as issues.
 

--- a/docs/criteria/connectors/stable.md
+++ b/docs/criteria/connectors/stable.md
@@ -138,33 +138,32 @@ Indexes are not required for test coverage, but can be introduced if required fo
 
 ##### TPC-H
 
-- [ ] End-to-end test to cover connecting to TPC-H SF1 for the connector type and benchmarking TPC-H queries (official and simple).
-  - [ ] Connectors should run all queries with no [Major or Minor Bugs](../definitions.md).
-  - [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
-  - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
-  - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric at the required [parallel query count](../definitions.md).
-  - [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. At least 99% of the time, query [timing measurements](../definitions.md) during the load test must remain below the 1% highest [timing measurements](../definitions.md) of the first throughput test, and the service must not become unavailable for the entire duration of the test.
-  - [ ] Memory usage is collected at the end of the end-to-end test and reported as a metric on the overall connector.
-- [ ] A test script exists that can load TPC-H data at the [designated scale factor](#stable-release-criteria) into this connector.
-- [ ] The connector can load TPC-H at the [designated scale factor](#stable-release-criteria), and can run all queries with no [Major or Minor Bugs](../definitions.md).
-- [ ] TPC-H queries that execute successfully on Datafusion, should execute successfully on the connector.
+- [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
+- [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
+- [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric at the required [parallel query count](../definitions.md).
+- [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. At least 99% of the time, query [timing measurements](../definitions.md) during the load test must remain below the 1% highest [timing measurements](../definitions.md) of the first throughput test, and the service must not become unavailable for the entire duration of the test.
+- [ ] Memory usage is collected at the end of the end-to-end test and reported as a metric on the overall connector.
+- [ ] At the scale factor required by the connector criteria:
+  - [ ] A test script exists that can load TPC-DS data at the [designated scale factor](#stable-release-criteria) into this connector.
+  - [ ] The connector can load TPC-DS at the [designated scale factor](#stable-release-criteria), and can run all queries with no [Major or Minor Bugs](../definitions.md).
+  - [ ] TPC-DS queries that execute successfully on Datafusion, should execute successfully on the connector.
 
 ##### TPC-DS
 
-- [ ] End-to-end test to cover connecting to TPC-H SF1 for the connector type and benchmarking TPC-DS queries (official and simple).
-  - [ ] Connectors should run all queries with no [Major or Minor Bugs](../definitions.md).
-  - [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
-  - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
-  - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric at the required [parallel query count](../definitions.md).
-  - [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. At least 99% of the time, query [timing measurements](../definitions.md) during the load test must remain below the 1% highest [timing measurements](../definitions.md) of the first throughput test, and the service must not become unavailable for the entire duration of the test.
-  - [ ] Memory usage is collected at the end of the end-to-end test and reported as a metric on the overall connector.
-- [ ] A test script exists that can load TPC-DS data at the [designated scale factor](#stable-release-criteria) into this connector.
-- [ ] The connector can load TPC-DS at the [designated scale factor](#stable-release-criteria), and can run all queries with no [Major or Minor Bugs](../definitions.md).
-- [ ] TPC-DS queries that execute successfully on Datafusion, should execute successfully on the connector.
+- [ ] Connectors should run all queries with no [Major or Minor Bugs](../definitions.md).
+- [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
+- [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
+- [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric at the required [parallel query count](../definitions.md).
+- [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. At least 99% of the time, query [timing measurements](../definitions.md) during the load test must remain below the 1% highest [timing measurements](../definitions.md) of the first throughput test, and the service must not become unavailable for the entire duration of the test.
+- [ ] Memory usage is collected at the end of the end-to-end test and reported as a metric on the overall connector.
+- [ ] At the scale factor required by the connector criteria:
+  - [ ] A test script exists that can load TPC-DS data at the [designated scale factor](#stable-release-criteria) into this connector.
+  - [ ] The connector can load TPC-DS at the [designated scale factor](#stable-release-criteria), and can run all queries with no [Major or Minor Bugs](../definitions.md).
+  - [ ] TPC-DS queries that execute successfully on Datafusion, should execute successfully on the connector.
 
 ##### ClickBench
 
-- [ ] A test script exists that can load ClickBench data into this connector at the [designated scale factor](#stable-release-criteria).
+- [ ] A test script exists that can load ClickBench data into this connector.
 - [ ] Connectors should run all ClickBench queries with no [Major Bugs](../definitions.md)
 
 #### Data Correctness


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Clarifies what is actually required for stable by removing duplicate points
* Removes the wording of `at the designated scale` for ClickBench, because it is not used as a scaled dataset (it is the size it is).