### PR TITLE
Update datafusion-federation to fix LIMIT with OFFSET handling in logical plan rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=4c0ff795deeddcd728b4f973c27f002468e5dd9f#4c0ff795deeddcd728b4f973c27f002468e5dd9f"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=d0eeb2df72f03db0a94a5bb1ff9b0d5eaf134b1f#d0eeb2df72f03db0a94a5bb1ff9b0d5eaf134b1f"
 dependencies = [
  "arrow-json 53.3.0",
  "async-stream",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation-sql"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=4c0ff795deeddcd728b4f973c27f002468e5dd9f#4c0ff795deeddcd728b4f973c27f002468e5dd9f"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=d0eeb2df72f03db0a94a5bb1ff9b0d5eaf134b1f#d0eeb2df72f03db0a94a5bb1ff9b0d5eaf134b1f"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -3496,7 +3496,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=dc0625178fd7af219b246bd33acc21b68f5a6f4d#dc0625178fd7af219b246bd33acc21b68f5a6f4d"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=05f5776cfd92cae58a90c256335a1efaf9ecabc6#05f5776cfd92cae58a90c256335a1efaf9ecabc6"
 dependencies = [
  "arrow",
  "arrow-json 53.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ datafusion-common = "43"
 datafusion-execution = "43"
 datafusion-expr = "43"
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "4c0ff795deeddcd728b4f973c27f002468e5dd9f" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "d0eeb2df72f03db0a94a5bb1ff9b0d5eaf134b1f" }
 datafusion-functions-json = "0.43"
 datafusion-table-providers = "0.1"
 dotenvy = "0.15"
@@ -158,8 +158,8 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "4e
 
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4" }
 
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "4c0ff795deeddcd728b4f973c27f002468e5dd9f" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "dc0625178fd7af219b246bd33acc21b68f5a6f4d" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "d0eeb2df72f03db0a94a5bb1ff9b0d5eaf134b1f" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "05f5776cfd92cae58a90c256335a1efaf9ecabc6" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae" }
 


### PR DESCRIPTION
closes #4062 

update datafusion-federation with the [fix: handle LogicalPlan::Limit separately to preserve skip and offset in rewrite_table_scans](https://github.com/spiceai/datafusion-federation/pull/34)

fixed limit + offset behavior:

![CleanShot 2025-01-02 at 22 24 52@2x](https://github.com/user-attachments/assets/bf63da26-dd18-4e7f-8251-acc097d4290b)
