### PR TITLE
Set unified max encoding and decoding message size for all flight client configurations across runtime

### DIFF
--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -21,13 +21,16 @@ use arrow::{
 use async_stream::stream;
 use async_trait::async_trait;
 use datafusion_table_providers::sql::sql_provider_datafusion::expr;
-use flight_client::tls::new_tls_flight_channel;
+use flight_client::{
+    tls::new_tls_flight_channel, MAX_DECODING_MESSAGE_SIZE, MAX_ENCODING_MESSAGE_SIZE,
+};
 use futures::{Stream, StreamExt, TryStreamExt};
 use snafu::prelude::*;
 use std::{any::Any, fmt, sync::Arc, vec};
 
 use arrow_flight::{
     error::FlightError,
+    flight_service_client::FlightServiceClient,
     sql::{client::FlightSqlServiceClient, CommandGetTables},
     FlightEndpoint, IpcMessage,
 };
@@ -189,10 +192,15 @@ impl FlightSQLTable {
             .connect()
             .await
             .context(UnableToConnectToServerSnafu)?;
+
+        let flight_client = FlightServiceClient::new(channel)
+            .max_encoding_message_size(MAX_ENCODING_MESSAGE_SIZE)
+            .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
+
         Self::create(
             "flightsql",
             s,
-            FlightSqlServiceClient::new(channel),
+            FlightSqlServiceClient::new_from_inner(flight_client),
             table_reference.into(),
         )
         .await
@@ -516,6 +524,8 @@ fn query_to_stream(
     mut client: FlightSqlServiceClient<Channel>,
     sql: &str,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> {
+    println!("[flightsq] query_to_stream: {}", sql);
+
     let sql = sql.to_string();
 
     stream! {
@@ -532,7 +542,10 @@ fn query_to_stream(
                         Ok(mut flight_stream) => {
                             while let Some(batch) = flight_stream.next().await {
                                 match batch {
-                                    Ok(batch) => yield Ok(batch),
+                                    Ok(batch) => {
+                                        println!("[flightsq] query_to_stream: batch: {:?}", batch);
+                                        yield Ok(batch)
+                                    },
                                     Err(error) => yield Err(to_execution_error(Error::UnableToQueryArrowFlight { source: error }))
                                 }
                             }

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -524,7 +524,6 @@ fn query_to_stream(
     mut client: FlightSqlServiceClient<Channel>,
     sql: &str,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> {
-
     let sql = sql.to_string();
 
     stream! {

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -542,10 +542,7 @@ fn query_to_stream(
                         Ok(mut flight_stream) => {
                             while let Some(batch) = flight_stream.next().await {
                                 match batch {
-                                    Ok(batch) => {
-                                        println!("[flightsq] query_to_stream: batch: {:?}", batch);
-                                        yield Ok(batch)
-                                    },
+                                    Ok(batch) => yield Ok(batch),
                                     Err(error) => yield Err(to_execution_error(Error::UnableToQueryArrowFlight { source: error }))
                                 }
                             }

--- a/crates/data_components/src/flightsql.rs
+++ b/crates/data_components/src/flightsql.rs
@@ -524,7 +524,6 @@ fn query_to_stream(
     mut client: FlightSqlServiceClient<Channel>,
     sql: &str,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> {
-    println!("[flightsq] query_to_stream: {}", sql);
 
     let sql = sql.to_string();
 

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -41,6 +41,9 @@ use tonic::IntoStreamingRequest;
 
 pub mod tls;
 
+pub const MAX_ENCODING_MESSAGE_SIZE: usize = 100 * 1024 * 1024;
+pub const MAX_DECODING_MESSAGE_SIZE: usize = 100 * 1024 * 1024;
+
 #[derive(Debug)]
 pub struct TonicStatusError(tonic::Status);
 
@@ -221,8 +224,8 @@ impl FlightClient {
 
         Ok(FlightClient {
             flight_client: FlightServiceClient::new(flight_channel)
-                .max_encoding_message_size(100 * 1024 * 1024)
-                .max_decoding_message_size(100 * 1024 * 1024),
+                .max_encoding_message_size(MAX_ENCODING_MESSAGE_SIZE)
+                .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
             credentials,
             url,
             metadata,

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -33,7 +33,7 @@ use datafusion::dataframe::DataFrame;
 use datafusion::datasource::{provider_as_source, MemTable};
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::{LogicalPlanBuilder, UNNAMED_TABLE};
-use flight_client::TonicStatusError;
+use flight_client::{TonicStatusError, MAX_DECODING_MESSAGE_SIZE, MAX_ENCODING_MESSAGE_SIZE};
 use futures::{StreamExt, TryStreamExt};
 use llms::chat::LlmRuntime;
 use prost::Message;
@@ -175,8 +175,8 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
 
     // The encoder/decoder size is limited to 500MB.
     let client = FlightServiceClient::new(channel)
-        .max_decoding_message_size(500 * 1024 * 1024)
-        .max_encoding_message_size(500 * 1024 * 1024);
+        .max_encoding_message_size(MAX_ENCODING_MESSAGE_SIZE)
+        .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
 
     let mut rl: Editor<(), FileHistory> = Editor::new()?;
     let key_handler = Box::new(KeyEventHandler {});


### PR DESCRIPTION
Use a single encode/decode message size of 100 MiB for all flight client and server configurations