### PR TITLE
feat: Add the file connector as an appendable benchmark connector

### DIFF
--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -27,6 +27,7 @@ limitations under the License.
 
 use std::panic;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[cfg(feature = "postgres")]
 use crate::bench_postgres::get_postgres_params;
@@ -40,8 +41,9 @@ use futures::TryStreamExt;
 use results::BenchmarkResultsBuilder;
 use runtime::request::{Protocol, RequestContext, UserAgent};
 use runtime::{dataupdate::DataUpdate, Runtime};
-use spicepod::component::dataset::acceleration::{self, Acceleration, Mode};
+use spicepod::component::dataset::acceleration::{self, Acceleration, Mode, RefreshMode};
 use spicepod::component::params::Params;
+use tract_core::num_traits::ToPrimitive;
 
 mod results;
 mod setup;
@@ -88,6 +90,9 @@ struct BenchArgs {
     /// Set the acceleration mode for accelerator
     #[arg(short, long)]
     mode: Option<String>,
+
+    #[arg(long)]
+    append_mode: Option<bool>,
 
     /// Set the benchmark to run: TPCH / TPCDS
     #[arg(short, long, default_value = "tpch")]
@@ -150,21 +155,21 @@ async fn bench_main() -> Result<(), String> {
                 run_connector_bench(connector, upload_results_dataset.as_ref(), args.bench_name.as_ref()).await?;
             }
             let accelerators: Vec<Acceleration> = vec![
-                create_acceleration("arrow", acceleration::Mode::Memory, args.bench_name.as_ref()),
+                create_acceleration("arrow", acceleration::Mode::Memory, args.bench_name.as_ref(), false),
                 #[cfg(feature = "duckdb")]
-                create_acceleration("duckdb", acceleration::Mode::Memory, args.bench_name.as_ref()),
+                create_acceleration("duckdb", acceleration::Mode::Memory, args.bench_name.as_ref(), false),
                 #[cfg(feature = "duckdb")]
-                create_acceleration("duckdb", acceleration::Mode::File, args.bench_name.as_ref()),
+                create_acceleration("duckdb", acceleration::Mode::File, args.bench_name.as_ref(), false),
                 #[cfg(feature = "sqlite")]
-                create_acceleration("sqlite", acceleration::Mode::Memory, args.bench_name.as_ref()),
+                create_acceleration("sqlite", acceleration::Mode::Memory, args.bench_name.as_ref(), false),
                 #[cfg(feature = "sqlite")]
-                create_acceleration("sqlite", acceleration::Mode::File, args.bench_name.as_ref()),
+                create_acceleration("sqlite", acceleration::Mode::File, args.bench_name.as_ref(), false),
                 #[cfg(feature = "postgres")]
-                create_acceleration("postgres", acceleration::Mode::Memory, args.bench_name.as_ref()),
+                create_acceleration("postgres", acceleration::Mode::Memory, args.bench_name.as_ref(), false),
             ];
             for accelerator in accelerators {
-                run_accelerator_bench(accelerator.clone(), upload_results_dataset.as_ref(), "tpch").await?;
-                run_accelerator_bench(accelerator, upload_results_dataset.as_ref(), "tpcds").await?;
+                run_accelerator_bench("s3", accelerator.clone(), upload_results_dataset.as_ref(), "tpch").await?;
+                run_accelerator_bench("s3", accelerator.clone(), upload_results_dataset.as_ref(), "tpcds").await?;
             }
         },
         (Some(connector), None, None) => {
@@ -179,17 +184,21 @@ async fn bench_main() -> Result<(), String> {
                 _ => return Err(format!("Invalid mode parameter for {accelerator} accelerator")),
             };
 
-            let acceleration = create_acceleration(accelerator, mode, args.bench_name.as_ref());
+            let append_mode = args.append_mode.unwrap_or(false);
+            let acceleration = create_acceleration(accelerator, mode, args.bench_name.as_ref(), append_mode);
 
-            match args.bench_name.as_ref() {
-                "tpch" => {
-                    run_accelerator_bench(acceleration, upload_results_dataset.as_ref(), "tpch").await?;
+            match (append_mode, args.bench_name.as_ref()) {
+                (true, "tpch") => {
+                    run_accelerator_bench("duckdb", acceleration, upload_results_dataset.as_ref(), "tpch").await?;
                 }
-                "tpcds" => {
-                    run_accelerator_bench(acceleration, upload_results_dataset.as_ref(), "tpcds").await?;
+                (false, "tpch") => {
+                    run_accelerator_bench("s3", acceleration, upload_results_dataset.as_ref(), "tpch").await?;
                 }
-                "clickbench" => {
-                    run_accelerator_bench(acceleration, upload_results_dataset.as_ref(), "clickbench").await?;
+                (false, "tpcds") => {
+                    run_accelerator_bench("s3", acceleration, upload_results_dataset.as_ref(), "tpcds").await?;
+                }
+                (false, "clickbench") => {
+                    run_accelerator_bench("s3", acceleration, upload_results_dataset.as_ref(), "clickbench").await?;
                 }
                 _ => return Err(format!("Invalid mode bench_name parameter {}", args.bench_name)),
             }
@@ -239,7 +248,7 @@ async fn run_connector_bench(
         }
         #[cfg(feature = "duckdb")]
         "duckdb" => {
-            bench_duckdb::run(&mut rt, &mut benchmark_results, bench_name).await?;
+            bench_duckdb::run(&mut rt, &mut benchmark_results, bench_name, None).await?;
         }
         #[cfg(feature = "odbc")]
         "odbc-databricks" => {
@@ -278,6 +287,7 @@ async fn run_connector_bench(
 }
 
 async fn run_accelerator_bench(
+    connector: &str,
     accelerator: Acceleration,
     upload_results_dataset: Option<&String>,
     bench_name: &str,
@@ -287,18 +297,90 @@ async fn run_accelerator_bench(
     let engine = accelerator.engine.clone();
     let mode = accelerator.mode.clone();
 
-    let (mut benchmark_results, mut rt) =
-        setup::setup_benchmark(upload_results_dataset, "s3", Some(accelerator), bench_name).await?;
+    let (benchmark_results, rt) = match (accelerator.refresh_mode.clone(), connector) {
+        (Some(RefreshMode::Append), "duckdb") => {
+            let scale_factor = 1.0;
+            let handle = bench_duckdb::delayed_source_load(
+                bench_name,
+                10,
+                Duration::from_secs(60),
+                scale_factor,
+            );
 
-    bench_object_store::run(
-        "s3",
-        &mut rt,
-        &mut benchmark_results,
-        engine,
-        Some(mode),
-        bench_name,
-    )
-    .await?;
+            // tracing doesn't initialize until setup_benchmark, but I don't want to call it until data is ready to avoid missing table errors in spiced log
+            println!("Waiting for delayed source load to start...");
+
+            let mut append_startup_timer: usize = 0;
+            loop {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                append_startup_timer += 5;
+                if handle.is_finished() {
+                    if let Ok(Err(e)) = handle.await {
+                        return Err(format!("Error in delayed source load: {e}"));
+                    }
+
+                    return Err("Delayed source load failed - exited with no error".to_string());
+                }
+
+                if append_startup_timer >= 120 {
+                    break;
+                }
+            }
+
+            let (mut benchmark_results, mut rt) = setup::setup_benchmark(
+                upload_results_dataset,
+                connector,
+                Some(accelerator.clone()),
+                bench_name,
+            )
+            .await?;
+
+            bench_duckdb::run(
+                &mut rt,
+                &mut benchmark_results,
+                bench_name,
+                Some(accelerator),
+            )
+            .await?;
+
+            if let Ok(Err(e)) = handle.await {
+                return Err(format!("Error in delayed source load: {e}"));
+            }
+
+            (benchmark_results, rt)
+        }
+        (Some(RefreshMode::Append), _) => {
+            return Err(format!(
+                "Append mode benchmark is not implemented for connector source {connector}"
+            ));
+        }
+        (None, "s3" | "abfs" | "file") => {
+            let (mut benchmark_results, mut rt) = setup::setup_benchmark(
+                upload_results_dataset,
+                connector,
+                Some(accelerator.clone()),
+                bench_name,
+            )
+            .await?;
+
+            bench_object_store::run(
+                connector,
+                &mut rt,
+                &mut benchmark_results,
+                engine,
+                Some(mode),
+                bench_name,
+            )
+            .await?;
+
+            (benchmark_results, rt)
+        }
+        _ => {
+            return Err(format!(
+                "Connector {connector} is not supported for accelerator benchmark"
+            ));
+        }
+    };
 
     let data_update: DataUpdate = benchmark_results.into();
 
@@ -314,18 +396,35 @@ async fn run_accelerator_bench(
     Ok(())
 }
 
-fn create_acceleration(engine: &str, mode: acceleration::Mode, bench_name: &str) -> Acceleration {
-    let params: Option<Params> = match engine {
+fn create_acceleration(
+    engine: &str,
+    mode: acceleration::Mode,
+    bench_name: &str,
+    append: bool,
+) -> Acceleration {
+    match (engine, append) {
         #[cfg(feature = "postgres")]
-        "postgres" => Some(get_postgres_params(true, bench_name)),
-        _ => None,
-    };
-
-    Acceleration {
-        engine: Some(engine.to_string()),
-        mode,
-        params,
-        ..Default::default()
+        ("postgres", false) => Acceleration {
+            engine: Some(engine.to_string()),
+            mode,
+            params: Some(get_postgres_params(true, bench_name)),
+            ..Default::default()
+        },
+        ("duckdb", true) => Acceleration {
+            engine: Some(engine.to_string()),
+            mode,
+            params: None,
+            refresh_mode: Some(acceleration::RefreshMode::Append),
+            refresh_check_interval: Some("2m".to_string()),
+            ..Default::default()
+        },
+        (_, false) => Acceleration {
+            engine: Some(engine.to_string()),
+            mode,
+            params: None,
+            ..Default::default()
+        },
+        (_, true) => panic!("Append mode benchmark is not implemented for {engine}"),
     }
 }
 
@@ -367,6 +466,11 @@ async fn run_query_and_record_result(
 
         let start_iter_time = get_current_unix_ms();
 
+        tracing::debug!(
+            "Running iteration {} of {} for query `{connector}` `{query_name}`...",
+            idx + 1,
+            benchmark_results.iterations()
+        );
         let res = run_query(rt, connector, query_name, query).await;
         let end_iter_time = get_current_unix_ms();
 
@@ -389,7 +493,13 @@ async fn run_query_and_record_result(
                     let limited_records: Vec<_> = records
                         .iter()
                         .flat_map(|batch: &RecordBatch| {
-                            (0..batch.num_rows()).map(move |i| batch.slice(i, 1))
+                            let end = if batch.num_rows() > 10 {
+                                10
+                            } else {
+                                batch.num_rows()
+                            };
+
+                            (0..end).map(move |i| batch.slice(i, 1))
                         })
                         .take(10)
                         .collect();
@@ -416,6 +526,10 @@ async fn run_query_and_record_result(
                         }
                     }
                 }
+
+                tracing::debug!(
+                    "Query `{connector}` `{query_name}` iteration {idx} completed in {iter_duration_ms}ms",
+                );
             }
             Err(e) => {
                 tracing::error!(
@@ -426,6 +540,7 @@ async fn run_query_and_record_result(
             }
         }
     }
+
     let end_time = get_current_unix_ms();
     // Both query failure and snapshot test failure will cause the result to be written as Status::Failed
     benchmark_results.record_result(

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -210,7 +210,7 @@ async fn bench_main() -> Result<(), String> {
                 Some("memory") | None => Mode::Memory,
                 _ => return Err(format!("Invalid mode parameter for {accelerator} accelerator")),
             };
-            
+
             let refresh_mode = RefreshMode::from(args.refresh_mode);
             let acceleration = create_acceleration(accelerator, mode, args.bench_name.as_ref(), refresh_mode.clone());
 

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -493,6 +493,7 @@ pub(crate) async fn run_query_and_record_result(
                     let limited_records: Vec<_> = records
                         .iter()
                         .flat_map(|batch: &RecordBatch| {
+                            // We only take up to 10 records anyway, so avoid iterating over large row results
                             let end = if batch.num_rows() > 10 {
                                 10
                             } else {

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -42,8 +42,6 @@ use results::BenchmarkResultsBuilder;
 use runtime::request::{Protocol, RequestContext, UserAgent};
 use runtime::{dataupdate::DataUpdate, Runtime};
 use spicepod::component::dataset::acceleration::{self, Acceleration, Mode, RefreshMode};
-use spicepod::component::params::Params;
-use tract_core::num_traits::ToPrimitive;
 
 mod results;
 mod setup;
@@ -189,7 +187,7 @@ async fn bench_main() -> Result<(), String> {
 
             match (append_mode, args.bench_name.as_ref()) {
                 (true, "tpch") => {
-                    run_accelerator_bench("duckdb", acceleration, upload_results_dataset.as_ref(), "tpch").await?;
+                    run_accelerator_bench("file", acceleration, upload_results_dataset.as_ref(), "tpch").await?;
                 }
                 (false, "tpch") => {
                     run_accelerator_bench("s3", acceleration, upload_results_dataset.as_ref(), "tpch").await?;
@@ -200,7 +198,8 @@ async fn bench_main() -> Result<(), String> {
                 (false, "clickbench") => {
                     run_accelerator_bench("s3", acceleration, upload_results_dataset.as_ref(), "clickbench").await?;
                 }
-                _ => return Err(format!("Invalid mode bench_name parameter {}", args.bench_name)),
+                (true, benchmark) => return Err(format!("Append mode benchmark is not implemented for {benchmark}")),
+                (false, benchmark) => return Err(format!("Invalid benchmark parameter for accelerator benchmark: {benchmark}")),
             }
         },
         _ => return Err("Invalid command line input: accelerator or mode parameter supplied for connector benchmark".to_string()),
@@ -248,7 +247,7 @@ async fn run_connector_bench(
         }
         #[cfg(feature = "duckdb")]
         "duckdb" => {
-            bench_duckdb::run(&mut rt, &mut benchmark_results, bench_name, None).await?;
+            bench_duckdb::run(&mut rt, &mut benchmark_results, bench_name).await?;
         }
         #[cfg(feature = "odbc")]
         "odbc-databricks" => {
@@ -298,12 +297,13 @@ async fn run_accelerator_bench(
     let mode = accelerator.mode.clone();
 
     let (benchmark_results, rt) = match (accelerator.refresh_mode.clone(), connector) {
-        (Some(RefreshMode::Append), "duckdb") => {
-            let scale_factor = 1.0;
-            let handle = bench_duckdb::delayed_source_load(
+        #[cfg(feature = "duckdb")]
+        (Some(RefreshMode::Append), "file") => {
+            let scale_factor = 10.0; // TODO: parameterize this
+            let handle = bench_duckdb::delayed_source_load_to_parquet(
                 bench_name,
-                10,
-                Duration::from_secs(60),
+                10,                       // TODO: parameterize this
+                Duration::from_secs(120), // 2 minutes * 10 = loading over 20 minutes + overhead for data generation
                 scale_factor,
             );
 
@@ -335,7 +335,7 @@ async fn run_accelerator_bench(
             )
             .await?;
 
-            bench_duckdb::run(
+            bench_object_store::file::run_file_append(
                 &mut rt,
                 &mut benchmark_results,
                 bench_name,
@@ -354,7 +354,7 @@ async fn run_accelerator_bench(
                 "Append mode benchmark is not implemented for connector source {connector}"
             ));
         }
-        (None, "s3" | "abfs" | "file") => {
+        (None, "s3" | "abfs") => {
             let (mut benchmark_results, mut rt) = setup::setup_benchmark(
                 upload_results_dataset,
                 connector,
@@ -415,7 +415,7 @@ fn create_acceleration(
             mode,
             params: None,
             refresh_mode: Some(acceleration::RefreshMode::Append),
-            refresh_check_interval: Some("2m".to_string()),
+            refresh_check_interval: Some("3m".to_string()),
             ..Default::default()
         },
         (_, false) => Acceleration {
@@ -436,7 +436,7 @@ fn get_current_unix_ms() -> i64 {
 }
 
 #[allow(clippy::too_many_lines)]
-async fn run_query_and_record_result(
+pub(crate) async fn run_query_and_record_result(
     rt: &mut Runtime,
     benchmark_results: &mut BenchmarkResultsBuilder,
     connector: &str,

--- a/crates/runtime/benches/bench.rs
+++ b/crates/runtime/benches/bench.rs
@@ -26,6 +26,7 @@ limitations under the License.
 // run_id, started_at, finished_at, connector_name, query_name, status, min_duration, max_duration, iterations, commit_sha
 
 use std::panic;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -69,6 +70,34 @@ mod bench_postgres;
 #[cfg(feature = "spark")]
 mod bench_spark;
 
+#[derive(Debug, Default, Clone, Copy)]
+enum AcceleratorRefreshMode {
+    Append,
+    #[default]
+    Full,
+}
+
+impl FromStr for AcceleratorRefreshMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "append" => Ok(AcceleratorRefreshMode::Append),
+            "full" => Ok(AcceleratorRefreshMode::Full),
+            _ => Err(format!("Unsupported accelerator refresh mode: {s}")),
+        }
+    }
+}
+
+impl From<AcceleratorRefreshMode> for acceleration::RefreshMode {
+    fn from(mode: AcceleratorRefreshMode) -> Self {
+        match mode {
+            AcceleratorRefreshMode::Append => acceleration::RefreshMode::Append,
+            AcceleratorRefreshMode::Full => acceleration::RefreshMode::Full,
+        }
+    }
+}
+
 // Define command line arguments for running benchmark test
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -90,7 +119,7 @@ struct BenchArgs {
     mode: Option<String>,
 
     #[arg(long)]
-    append_mode: Option<bool>,
+    refresh_mode: AcceleratorRefreshMode,
 
     /// Set the benchmark to run: TPCH / TPCDS
     #[arg(short, long, default_value = "tpch")]
@@ -153,17 +182,17 @@ async fn bench_main() -> Result<(), String> {
                 run_connector_bench(connector, upload_results_dataset.as_ref(), args.bench_name.as_ref()).await?;
             }
             let accelerators: Vec<Acceleration> = vec![
-                create_acceleration("arrow", acceleration::Mode::Memory, args.bench_name.as_ref(), false),
+                create_acceleration("arrow", acceleration::Mode::Memory, args.bench_name.as_ref(), RefreshMode::Full),
                 #[cfg(feature = "duckdb")]
-                create_acceleration("duckdb", acceleration::Mode::Memory, args.bench_name.as_ref(), false),
+                create_acceleration("duckdb", acceleration::Mode::Memory, args.bench_name.as_ref(), RefreshMode::Full),
                 #[cfg(feature = "duckdb")]
-                create_acceleration("duckdb", acceleration::Mode::File, args.bench_name.as_ref(), false),
+                create_acceleration("duckdb", acceleration::Mode::File, args.bench_name.as_ref(), RefreshMode::Full),
                 #[cfg(feature = "sqlite")]
-                create_acceleration("sqlite", acceleration::Mode::Memory, args.bench_name.as_ref(), false),
+                create_acceleration("sqlite", acceleration::Mode::Memory, args.bench_name.as_ref(), RefreshMode::Full),
                 #[cfg(feature = "sqlite")]
-                create_acceleration("sqlite", acceleration::Mode::File, args.bench_name.as_ref(), false),
+                create_acceleration("sqlite", acceleration::Mode::File, args.bench_name.as_ref(), RefreshMode::Full),
                 #[cfg(feature = "postgres")]
-                create_acceleration("postgres", acceleration::Mode::Memory, args.bench_name.as_ref(), false),
+                create_acceleration("postgres", acceleration::Mode::Memory, args.bench_name.as_ref(), RefreshMode::Full),
             ];
             for accelerator in accelerators {
                 run_accelerator_bench("s3", accelerator.clone(), upload_results_dataset.as_ref(), "tpch").await?;
@@ -181,25 +210,26 @@ async fn bench_main() -> Result<(), String> {
                 Some("memory") | None => Mode::Memory,
                 _ => return Err(format!("Invalid mode parameter for {accelerator} accelerator")),
             };
+            
+            let refresh_mode = RefreshMode::from(args.refresh_mode);
+            let acceleration = create_acceleration(accelerator, mode, args.bench_name.as_ref(), refresh_mode.clone());
 
-            let append_mode = args.append_mode.unwrap_or(false);
-            let acceleration = create_acceleration(accelerator, mode, args.bench_name.as_ref(), append_mode);
-
-            match (append_mode, args.bench_name.as_ref()) {
-                (true, "tpch") => {
+            match (refresh_mode, args.bench_name.as_ref()) {
+                (RefreshMode::Append, "tpch") => {
                     run_accelerator_bench("file", acceleration, upload_results_dataset.as_ref(), "tpch").await?;
                 }
-                (false, "tpch") => {
+                (RefreshMode::Full, "tpch") => {
                     run_accelerator_bench("s3", acceleration, upload_results_dataset.as_ref(), "tpch").await?;
                 }
-                (false, "tpcds") => {
+                (RefreshMode::Full, "tpcds") => {
                     run_accelerator_bench("s3", acceleration, upload_results_dataset.as_ref(), "tpcds").await?;
                 }
-                (false, "clickbench") => {
+                (RefreshMode::Full, "clickbench") => {
                     run_accelerator_bench("s3", acceleration, upload_results_dataset.as_ref(), "clickbench").await?;
                 }
-                (true, benchmark) => return Err(format!("Append mode benchmark is not implemented for {benchmark}")),
-                (false, benchmark) => return Err(format!("Invalid benchmark parameter for accelerator benchmark: {benchmark}")),
+                (RefreshMode::Append, benchmark) => return Err(format!("Append mode benchmark is not implemented for {benchmark}")),
+                (RefreshMode::Changes, benchmark) => return Err(format!("CDC mode benchmark is not implemented for {benchmark}")),
+                (RefreshMode::Full, benchmark) => return Err(format!("Invalid benchmark parameter for accelerator benchmark: {benchmark}")),
             }
         },
         _ => return Err("Invalid command line input: accelerator or mode parameter supplied for connector benchmark".to_string()),
@@ -400,31 +430,33 @@ fn create_acceleration(
     engine: &str,
     mode: acceleration::Mode,
     bench_name: &str,
-    append: bool,
+    append: acceleration::RefreshMode,
 ) -> Acceleration {
     match (engine, append) {
         #[cfg(feature = "postgres")]
-        ("postgres", false) => Acceleration {
+        ("postgres", RefreshMode::Full) => Acceleration {
             engine: Some(engine.to_string()),
             mode,
             params: Some(get_postgres_params(true, bench_name)),
             ..Default::default()
         },
-        ("duckdb", true) => Acceleration {
+        ("duckdb", RefreshMode::Append) => Acceleration {
             engine: Some(engine.to_string()),
             mode,
             params: None,
-            refresh_mode: Some(acceleration::RefreshMode::Append),
+            refresh_mode: Some(RefreshMode::Append),
             refresh_check_interval: Some("3m".to_string()),
             ..Default::default()
         },
-        (_, false) => Acceleration {
+        (_, RefreshMode::Full) => Acceleration {
             engine: Some(engine.to_string()),
             mode,
             params: None,
             ..Default::default()
         },
-        (_, true) => panic!("Append mode benchmark is not implemented for {engine}"),
+        (_, refresh_mode) => {
+            panic!("Refresh mode {refresh_mode:?} is not implemented for {engine}")
+        }
     }
 }
 

--- a/crates/runtime/benches/bench_duckdb/mod.rs
+++ b/crates/runtime/benches/bench_duckdb/mod.rs
@@ -15,15 +15,27 @@ limitations under the License.
 */
 
 use app::AppBuilder;
+use arrow::array::AsArray;
 use runtime::Runtime;
 
-use crate::results::BenchmarkResultsBuilder;
-use spicepod::component::{dataset::Dataset, params::Params};
+use crate::{results::BenchmarkResultsBuilder, run_query};
+use spicepod::component::{
+    dataset::{
+        acceleration::{Acceleration, RefreshMode},
+        Dataset,
+    },
+    params::Params,
+};
+
+use duckdb::Connection;
+use std::time::Duration;
+use tokio::{task::JoinHandle, time::sleep};
 
 pub(crate) async fn run(
     rt: &mut Runtime,
     benchmark_results: &mut BenchmarkResultsBuilder,
     bench_name: &str,
+    accelerator: Option<Acceleration>,
 ) -> Result<(), String> {
     let test_queries = match bench_name {
         "tpch" => get_tpch_test_queries(),
@@ -32,14 +44,79 @@ pub(crate) async fn run(
     };
 
     let mut errors = Vec::new();
+    let is_append = accelerator
+        .clone()
+        .and_then(|a| a.refresh_mode)
+        .is_some_and(|m| m == RefreshMode::Append);
+
+    if is_append {
+        let start_time = std::time::Instant::now();
+
+        loop {
+            sleep(Duration::from_secs(60 * 3)).await; // refresh interval is 5 minutes - check every 6 minutes
+
+            // check if the data has finished loading
+            let res = run_query(
+                rt,
+                "duckdb",
+                "table_count",
+                "SELECT COUNT(*) as l_count FROM lineitem",
+            )
+            .await;
+
+            if let Err(e) = res {
+                return Err(format!(
+                    "Append mode data load failed. Failed to count rows in lineitem table: {e}"
+                ));
+            }
+
+            let count = res
+                .map_err(|e| e.to_string())?
+                .first()
+                .ok_or("No rows returned from count query")?
+                .column_by_name("l_count")
+                .ok_or("No column named l_count")?
+                .as_primitive::<arrow::datatypes::Int64Type>()
+                .value(0);
+            if count < 6_000_000 {
+                if start_time.elapsed() > Duration::from_secs(60 * 60) {
+                    tracing::error!("Append mode data load failed. Expected over 6 million rows in lineitem table, got {count}");
+                    return Err(format!("Append mode data load failed. Expected over 6 million rows in lineitem table, got {count}"));
+                }
+
+                tracing::info!("Append mode data load in progress. Expected over 6 million rows in lineitem table, got {count}");
+            } else {
+                tracing::info!(
+                    "Append mode data load complete. Loaded {count} rows in lineitem table"
+                );
+                break;
+            }
+        }
+    }
+
+    let bench_name = match (accelerator, is_append) {
+        (Some(accelerator), true) => {
+            format!(
+                "{bench_name}_{}_append",
+                accelerator.engine.unwrap_or("arrow".to_string())
+            )
+        }
+        (Some(accelerator), false) => {
+            format!(
+                "{bench_name}_{}",
+                accelerator.engine.unwrap_or("arrow".to_string())
+            )
+        }
+        (None, _) => bench_name.to_string(),
+    };
 
     for (query_name, query) in test_queries {
         let verify_query_results =
-            query_name.starts_with("tpch_q") || query_name.starts_with("tpcds_q");
+            (query_name.starts_with("tpch_q") || query_name.starts_with("tpcds_q")) && !is_append;
         if let Err(e) = super::run_query_and_record_result(
             rt,
             benchmark_results,
-            "duckdb",
+            &bench_name,
             query_name,
             query,
             verify_query_results,
@@ -57,64 +134,142 @@ pub(crate) async fn run(
     Ok(())
 }
 
-pub fn build_app(app_builder: AppBuilder, bench_name: &str) -> Result<AppBuilder, String> {
+#[allow(clippy::too_many_lines)]
+pub fn build_app(
+    app_builder: AppBuilder,
+    bench_name: &str,
+    acceleration: Option<Acceleration>,
+) -> Result<AppBuilder, String> {
+    let is_append = acceleration
+        .and_then(|a| a.refresh_mode)
+        .is_some_and(|m| m == RefreshMode::Append);
+
+    if is_append {
+        tracing::info!(
+            "Running DuckDB connector in append mode - data will be loaded incrementally"
+        );
+    }
+
     match bench_name {
         "tpch" => Ok(app_builder
-            .with_dataset(make_dataset("customer", "customer", bench_name))
-            .with_dataset(make_dataset("lineitem", "lineitem", bench_name))
-            .with_dataset(make_dataset("part", "part", bench_name))
-            .with_dataset(make_dataset("partsupp", "partsupp", bench_name))
-            .with_dataset(make_dataset("orders", "orders", bench_name))
-            .with_dataset(make_dataset("nation", "nation", bench_name))
-            .with_dataset(make_dataset("region", "region", bench_name))
-            .with_dataset(make_dataset("supplier", "supplier", bench_name))),
+            .with_dataset(make_dataset(
+                "customer",
+                "customer",
+                bench_name,
+                is_append.then_some("c_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "lineitem",
+                "lineitem",
+                bench_name,
+                is_append.then_some("l_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "part",
+                "part",
+                bench_name,
+                is_append.then_some("p_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "partsupp",
+                "partsupp",
+                bench_name,
+                is_append.then_some("ps_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "orders",
+                "orders",
+                bench_name,
+                is_append.then_some("o_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "nation",
+                "nation",
+                bench_name,
+                is_append.then_some("n_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "region",
+                "region",
+                bench_name,
+                is_append.then_some("r_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "supplier",
+                "supplier",
+                bench_name,
+                is_append.then_some("s_created_at"),
+            ))),
         "tpcds" => Ok(app_builder
-            .with_dataset(make_dataset("call_center", "call_center", bench_name))
-            .with_dataset(make_dataset("catalog_page", "catalog_page", bench_name))
-            .with_dataset(make_dataset("catalog_sales", "catalog_sales", bench_name))
+            .with_dataset(make_dataset("call_center", "call_center", bench_name, None))
             .with_dataset(make_dataset(
-                "catalog_returns",
-                "catalog_returns",
+                "catalog_page",
+                "catalog_page",
                 bench_name,
+                None,
             ))
-            .with_dataset(make_dataset("income_band", "income_band", bench_name))
-            .with_dataset(make_dataset("inventory", "inventory", bench_name))
-            .with_dataset(make_dataset("store_sales", "store_sales", bench_name))
-            .with_dataset(make_dataset("store_returns", "store_returns", bench_name))
-            .with_dataset(make_dataset("web_sales", "web_sales", bench_name))
-            .with_dataset(make_dataset("web_returns", "web_returns", bench_name))
-            .with_dataset(make_dataset("customer", "customer", bench_name))
+            .with_dataset(make_dataset(
+                "catalog_sales",
+                "catalog_sales",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset(
+                "catalog_returns",
+                "catalog_returns",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset("income_band", "income_band", bench_name, None))
+            .with_dataset(make_dataset("inventory", "inventory", bench_name, None))
+            .with_dataset(make_dataset("store_sales", "store_sales", bench_name, None))
+            .with_dataset(make_dataset(
+                "store_returns",
+                "store_returns",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset("web_sales", "web_sales", bench_name, None))
+            .with_dataset(make_dataset("web_returns", "web_returns", bench_name, None))
+            .with_dataset(make_dataset("customer", "customer", bench_name, None))
             .with_dataset(make_dataset(
                 "customer_address",
                 "customer_address",
                 bench_name,
+                None,
             ))
             .with_dataset(make_dataset(
                 "customer_demographics",
                 "customer_demographics",
                 bench_name,
+                None,
             ))
-            .with_dataset(make_dataset("date_dim", "date_dim", bench_name))
+            .with_dataset(make_dataset("date_dim", "date_dim", bench_name, None))
             .with_dataset(make_dataset(
                 "household_demographics",
                 "household_demographics",
                 bench_name,
+                None,
             ))
-            .with_dataset(make_dataset("item", "item", bench_name))
-            .with_dataset(make_dataset("promotion", "promotion", bench_name))
-            .with_dataset(make_dataset("reason", "reason", bench_name))
-            .with_dataset(make_dataset("ship_mode", "ship_mode", bench_name))
-            .with_dataset(make_dataset("store", "store", bench_name))
-            .with_dataset(make_dataset("time_dim", "time_dim", bench_name))
-            .with_dataset(make_dataset("warehouse", "warehouse", bench_name))
-            .with_dataset(make_dataset("web_page", "web_page", bench_name))
-            .with_dataset(make_dataset("web_site", "web_site", bench_name))),
+            .with_dataset(make_dataset("item", "item", bench_name, None))
+            .with_dataset(make_dataset("promotion", "promotion", bench_name, None))
+            .with_dataset(make_dataset("reason", "reason", bench_name, None))
+            .with_dataset(make_dataset("ship_mode", "ship_mode", bench_name, None))
+            .with_dataset(make_dataset("store", "store", bench_name, None))
+            .with_dataset(make_dataset("time_dim", "time_dim", bench_name, None))
+            .with_dataset(make_dataset("warehouse", "warehouse", bench_name, None))
+            .with_dataset(make_dataset("web_page", "web_page", bench_name, None))
+            .with_dataset(make_dataset("web_site", "web_site", bench_name, None))),
         _ => Err("Only tpcds or tpch benchmark suites are supported".to_string()),
     }
 }
 
-fn make_dataset(path: &str, name: &str, bench_name: &str) -> Dataset {
+fn make_dataset(path: &str, name: &str, bench_name: &str, time_column: Option<&str>) -> Dataset {
     let mut dataset = Dataset::new(format!("duckdb:{path}"), name.to_string());
+    if let Some(time_column) = time_column {
+        dataset.time_column = Some(time_column.to_string());
+    };
+
     dataset.params = Some(get_params(bench_name));
     dataset
 }
@@ -280,3 +435,123 @@ fn get_tpcds_test_queries() -> Vec<(&'static str, &'static str)> {
         ("tpcds_q99", include_str!("../queries/tpcds/q99.sql")),
     ]
 }
+
+/// Spawn a new thread to load data into the database over a period of time
+/// This is useful for benchmarks that require data changes over time, like append-mode acceleration
+#[allow(clippy::too_many_lines)]
+pub(crate) fn delayed_source_load(
+    bench_name: &str,
+    load_count: usize,
+    load_interval: Duration,
+    scale_factor: f64,
+) -> JoinHandle<Result<(), String>> {
+    let bench_name = bench_name.to_string();
+
+    tokio::spawn(async move {
+        let dest_db_file = format!("./{bench_name}.db");
+        let dest_conn = Connection::open(&dest_db_file).map_err(|e| e.to_string())?;
+
+        for i in 0..load_count {
+            println!("Loading data for {bench_name} benchmark suite, iteration {i}");
+            match bench_name.as_str() {
+                "tpch" => {
+                    let batch_sql = if i == 0 {
+                        format!("
+                        INSTALL tpch;
+                        LOAD tpch;
+                        BEGIN;
+                        CALL dbgen(sf={scale_factor}, children={load_count}, step={i});
+                        ALTER TABLE customer ADD COLUMN c_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE lineitem ADD COLUMN l_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE nation ADD COLUMN n_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE orders ADD COLUMN o_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE part ADD COLUMN p_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE partsupp ADD COLUMN ps_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE region ADD COLUMN r_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE supplier ADD COLUMN s_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        COMMIT;
+                        ")
+                    } else {
+                        // nation and region get excluded from subsequent loads
+                        format!(
+                            "
+                        INSTALL tpch;
+                        LOAD tpch;
+                        BEGIN;
+                        CALL dbgen(sf={scale_factor}, suffix='_new', children={load_count}, step={i});
+                        ALTER TABLE customer_new ADD COLUMN c_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE lineitem_new ADD COLUMN l_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE nation_new ADD COLUMN n_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE orders_new ADD COLUMN o_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE part_new ADD COLUMN p_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE partsupp_new ADD COLUMN ps_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE region_new ADD COLUMN r_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        ALTER TABLE supplier_new ADD COLUMN s_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+                        INSERT INTO customer SELECT * FROM customer_new;
+                        INSERT INTO lineitem SELECT * FROM lineitem_new;
+                        INSERT INTO orders SELECT * FROM orders_new;
+                        INSERT INTO part SELECT * FROM part_new;
+                        INSERT INTO partsupp SELECT * FROM partsupp_new;
+                        INSERT INTO supplier SELECT * FROM supplier_new;
+                        DROP TABLE customer_new;
+                        DROP TABLE lineitem_new;
+                        DROP TABLE nation_new;
+                        DROP TABLE orders_new;
+                        DROP TABLE part_new;
+                        DROP TABLE partsupp_new;
+                        DROP TABLE region_new;
+                        DROP TABLE supplier_new;
+                        COMMIT;
+                        "
+                        )
+                    };
+
+                    dest_conn
+                        .execute_batch(&batch_sql)
+                        .map_err(|e| e.to_string())?;
+                }
+                _ => {
+                    return Err("Only tpch benchmark suites are supported".to_string());
+                }
+            }
+
+            sleep(load_interval).await;
+        }
+
+        Ok::<(), String>(())
+    })
+}
+
+// #[cfg(test)]
+// mod test {
+//     #[tokio::test]
+//     async fn test_delayed_source_load() {
+//         // run the delayed source load
+//         delayed_source_load("tpch", "destination", 3, Duration::from_secs(10), 0.1);
+
+//         // check the destination database has it's first load after a small delay
+//         sleep(Duration::from_secs(3)).await;
+
+//         let conn = Connection::open("./destination.db").unwrap();
+//         let count: i64 = conn
+//             .query_row("SELECT COUNT(*) FROM supplier", [], |row| row.get(0))
+//             .unwrap();
+//         assert_eq!(count, 10_000);
+
+//         // check the destination database has it's second load after a small delay
+//         sleep(Duration::from_secs(10)).await;
+
+//         let count: i64 = conn
+//             .query_row("SELECT COUNT(*) FROM supplier", [], |row| row.get(0))
+//             .unwrap();
+//         assert_eq!(count, 20_000);
+
+//         // check the destination database has it's third load after a small delay
+//         sleep(Duration::from_secs(10)).await;
+
+//         let count: i64 = conn
+//             .query_row("SELECT COUNT(*) FROM supplier", [], |row| row.get(0))
+//             .unwrap();
+//         assert_eq!(count, 30_000);
+//     }
+// }

--- a/crates/runtime/benches/bench_duckdb/mod.rs
+++ b/crates/runtime/benches/bench_duckdb/mod.rs
@@ -15,17 +15,10 @@ limitations under the License.
 */
 
 use app::AppBuilder;
-use arrow::array::AsArray;
 use runtime::Runtime;
 
-use crate::{results::BenchmarkResultsBuilder, run_query};
-use spicepod::component::{
-    dataset::{
-        acceleration::{Acceleration, RefreshMode},
-        Dataset,
-    },
-    params::Params,
-};
+use crate::results::BenchmarkResultsBuilder;
+use spicepod::component::{dataset::Dataset, params::Params};
 
 use duckdb::Connection;
 use std::time::Duration;
@@ -35,7 +28,6 @@ pub(crate) async fn run(
     rt: &mut Runtime,
     benchmark_results: &mut BenchmarkResultsBuilder,
     bench_name: &str,
-    accelerator: Option<Acceleration>,
 ) -> Result<(), String> {
     let test_queries = match bench_name {
         "tpch" => get_tpch_test_queries(),
@@ -44,79 +36,14 @@ pub(crate) async fn run(
     };
 
     let mut errors = Vec::new();
-    let is_append = accelerator
-        .clone()
-        .and_then(|a| a.refresh_mode)
-        .is_some_and(|m| m == RefreshMode::Append);
-
-    if is_append {
-        let start_time = std::time::Instant::now();
-
-        loop {
-            sleep(Duration::from_secs(60 * 3)).await; // refresh interval is 5 minutes - check every 6 minutes
-
-            // check if the data has finished loading
-            let res = run_query(
-                rt,
-                "duckdb",
-                "table_count",
-                "SELECT COUNT(*) as l_count FROM lineitem",
-            )
-            .await;
-
-            if let Err(e) = res {
-                return Err(format!(
-                    "Append mode data load failed. Failed to count rows in lineitem table: {e}"
-                ));
-            }
-
-            let count = res
-                .map_err(|e| e.to_string())?
-                .first()
-                .ok_or("No rows returned from count query")?
-                .column_by_name("l_count")
-                .ok_or("No column named l_count")?
-                .as_primitive::<arrow::datatypes::Int64Type>()
-                .value(0);
-            if count < 6_000_000 {
-                if start_time.elapsed() > Duration::from_secs(60 * 60) {
-                    tracing::error!("Append mode data load failed. Expected over 6 million rows in lineitem table, got {count}");
-                    return Err(format!("Append mode data load failed. Expected over 6 million rows in lineitem table, got {count}"));
-                }
-
-                tracing::info!("Append mode data load in progress. Expected over 6 million rows in lineitem table, got {count}");
-            } else {
-                tracing::info!(
-                    "Append mode data load complete. Loaded {count} rows in lineitem table"
-                );
-                break;
-            }
-        }
-    }
-
-    let bench_name = match (accelerator, is_append) {
-        (Some(accelerator), true) => {
-            format!(
-                "{bench_name}_{}_append",
-                accelerator.engine.unwrap_or("arrow".to_string())
-            )
-        }
-        (Some(accelerator), false) => {
-            format!(
-                "{bench_name}_{}",
-                accelerator.engine.unwrap_or("arrow".to_string())
-            )
-        }
-        (None, _) => bench_name.to_string(),
-    };
 
     for (query_name, query) in test_queries {
         let verify_query_results =
-            (query_name.starts_with("tpch_q") || query_name.starts_with("tpcds_q")) && !is_append;
+            query_name.starts_with("tpch_q") || query_name.starts_with("tpcds_q");
         if let Err(e) = super::run_query_and_record_result(
             rt,
             benchmark_results,
-            &bench_name,
+            "duckdb",
             query_name,
             query,
             verify_query_results,
@@ -135,141 +62,64 @@ pub(crate) async fn run(
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn build_app(
-    app_builder: AppBuilder,
-    bench_name: &str,
-    acceleration: Option<Acceleration>,
-) -> Result<AppBuilder, String> {
-    let is_append = acceleration
-        .and_then(|a| a.refresh_mode)
-        .is_some_and(|m| m == RefreshMode::Append);
-
-    if is_append {
-        tracing::info!(
-            "Running DuckDB connector in append mode - data will be loaded incrementally"
-        );
-    }
-
+pub fn build_app(app_builder: AppBuilder, bench_name: &str) -> Result<AppBuilder, String> {
     match bench_name {
         "tpch" => Ok(app_builder
-            .with_dataset(make_dataset(
-                "customer",
-                "customer",
-                bench_name,
-                is_append.then_some("c_created_at"),
-            ))
-            .with_dataset(make_dataset(
-                "lineitem",
-                "lineitem",
-                bench_name,
-                is_append.then_some("l_created_at"),
-            ))
-            .with_dataset(make_dataset(
-                "part",
-                "part",
-                bench_name,
-                is_append.then_some("p_created_at"),
-            ))
-            .with_dataset(make_dataset(
-                "partsupp",
-                "partsupp",
-                bench_name,
-                is_append.then_some("ps_created_at"),
-            ))
-            .with_dataset(make_dataset(
-                "orders",
-                "orders",
-                bench_name,
-                is_append.then_some("o_created_at"),
-            ))
-            .with_dataset(make_dataset(
-                "nation",
-                "nation",
-                bench_name,
-                is_append.then_some("n_created_at"),
-            ))
-            .with_dataset(make_dataset(
-                "region",
-                "region",
-                bench_name,
-                is_append.then_some("r_created_at"),
-            ))
-            .with_dataset(make_dataset(
-                "supplier",
-                "supplier",
-                bench_name,
-                is_append.then_some("s_created_at"),
-            ))),
+            .with_dataset(make_dataset("customer", "customer", bench_name))
+            .with_dataset(make_dataset("lineitem", "lineitem", bench_name))
+            .with_dataset(make_dataset("part", "part", bench_name))
+            .with_dataset(make_dataset("partsupp", "partsupp", bench_name))
+            .with_dataset(make_dataset("orders", "orders", bench_name))
+            .with_dataset(make_dataset("nation", "nation", bench_name))
+            .with_dataset(make_dataset("region", "region", bench_name))
+            .with_dataset(make_dataset("supplier", "supplier", bench_name))),
         "tpcds" => Ok(app_builder
-            .with_dataset(make_dataset("call_center", "call_center", bench_name, None))
-            .with_dataset(make_dataset(
-                "catalog_page",
-                "catalog_page",
-                bench_name,
-                None,
-            ))
-            .with_dataset(make_dataset(
-                "catalog_sales",
-                "catalog_sales",
-                bench_name,
-                None,
-            ))
+            .with_dataset(make_dataset("call_center", "call_center", bench_name))
+            .with_dataset(make_dataset("catalog_page", "catalog_page", bench_name))
+            .with_dataset(make_dataset("catalog_sales", "catalog_sales", bench_name))
             .with_dataset(make_dataset(
                 "catalog_returns",
                 "catalog_returns",
                 bench_name,
-                None,
             ))
-            .with_dataset(make_dataset("income_band", "income_band", bench_name, None))
-            .with_dataset(make_dataset("inventory", "inventory", bench_name, None))
-            .with_dataset(make_dataset("store_sales", "store_sales", bench_name, None))
-            .with_dataset(make_dataset(
-                "store_returns",
-                "store_returns",
-                bench_name,
-                None,
-            ))
-            .with_dataset(make_dataset("web_sales", "web_sales", bench_name, None))
-            .with_dataset(make_dataset("web_returns", "web_returns", bench_name, None))
-            .with_dataset(make_dataset("customer", "customer", bench_name, None))
+            .with_dataset(make_dataset("income_band", "income_band", bench_name))
+            .with_dataset(make_dataset("inventory", "inventory", bench_name))
+            .with_dataset(make_dataset("store_sales", "store_sales", bench_name))
+            .with_dataset(make_dataset("store_returns", "store_returns", bench_name))
+            .with_dataset(make_dataset("web_sales", "web_sales", bench_name))
+            .with_dataset(make_dataset("web_returns", "web_returns", bench_name))
+            .with_dataset(make_dataset("customer", "customer", bench_name))
             .with_dataset(make_dataset(
                 "customer_address",
                 "customer_address",
                 bench_name,
-                None,
             ))
             .with_dataset(make_dataset(
                 "customer_demographics",
                 "customer_demographics",
                 bench_name,
-                None,
             ))
-            .with_dataset(make_dataset("date_dim", "date_dim", bench_name, None))
+            .with_dataset(make_dataset("date_dim", "date_dim", bench_name))
             .with_dataset(make_dataset(
                 "household_demographics",
                 "household_demographics",
                 bench_name,
-                None,
             ))
-            .with_dataset(make_dataset("item", "item", bench_name, None))
-            .with_dataset(make_dataset("promotion", "promotion", bench_name, None))
-            .with_dataset(make_dataset("reason", "reason", bench_name, None))
-            .with_dataset(make_dataset("ship_mode", "ship_mode", bench_name, None))
-            .with_dataset(make_dataset("store", "store", bench_name, None))
-            .with_dataset(make_dataset("time_dim", "time_dim", bench_name, None))
-            .with_dataset(make_dataset("warehouse", "warehouse", bench_name, None))
-            .with_dataset(make_dataset("web_page", "web_page", bench_name, None))
-            .with_dataset(make_dataset("web_site", "web_site", bench_name, None))),
+            .with_dataset(make_dataset("item", "item", bench_name))
+            .with_dataset(make_dataset("promotion", "promotion", bench_name))
+            .with_dataset(make_dataset("reason", "reason", bench_name))
+            .with_dataset(make_dataset("ship_mode", "ship_mode", bench_name))
+            .with_dataset(make_dataset("store", "store", bench_name))
+            .with_dataset(make_dataset("time_dim", "time_dim", bench_name))
+            .with_dataset(make_dataset("warehouse", "warehouse", bench_name))
+            .with_dataset(make_dataset("web_page", "web_page", bench_name))
+            .with_dataset(make_dataset("web_site", "web_site", bench_name))),
         _ => Err("Only tpcds or tpch benchmark suites are supported".to_string()),
     }
 }
 
-fn make_dataset(path: &str, name: &str, bench_name: &str, time_column: Option<&str>) -> Dataset {
+fn make_dataset(path: &str, name: &str, bench_name: &str) -> Dataset {
     let mut dataset = Dataset::new(format!("duckdb:{path}"), name.to_string());
-    if let Some(time_column) = time_column {
-        dataset.time_column = Some(time_column.to_string());
-    };
-
     dataset.params = Some(get_params(bench_name));
     dataset
 }
@@ -439,7 +289,7 @@ fn get_tpcds_test_queries() -> Vec<(&'static str, &'static str)> {
 /// Spawn a new thread to load data into the database over a period of time
 /// This is useful for benchmarks that require data changes over time, like append-mode acceleration
 #[allow(clippy::too_many_lines)]
-pub(crate) fn delayed_source_load(
+pub(crate) fn delayed_source_load_to_parquet(
     bench_name: &str,
     load_count: usize,
     load_interval: Duration,
@@ -470,6 +320,14 @@ pub(crate) fn delayed_source_load(
                         ALTER TABLE region ADD COLUMN r_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
                         ALTER TABLE supplier ADD COLUMN s_created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
                         COMMIT;
+                        COPY customer TO 'customer.parquet' (FORMAT 'parquet');
+                        COPY lineitem TO 'lineitem.parquet' (FORMAT 'parquet');
+                        COPY nation TO 'nation.parquet' (FORMAT 'parquet');
+                        COPY orders TO 'orders.parquet' (FORMAT 'parquet');
+                        COPY part TO 'part.parquet' (FORMAT 'parquet');
+                        COPY partsupp TO 'partsupp.parquet' (FORMAT 'parquet');
+                        COPY region TO 'region.parquet' (FORMAT 'parquet');
+                        COPY supplier TO 'supplier.parquet' (FORMAT 'parquet');
                         ")
                     } else {
                         // nation and region get excluded from subsequent loads
@@ -502,6 +360,14 @@ pub(crate) fn delayed_source_load(
                         DROP TABLE region_new;
                         DROP TABLE supplier_new;
                         COMMIT;
+                        COPY customer TO 'customer.parquet' (FORMAT 'parquet');
+                        COPY lineitem TO 'lineitem.parquet' (FORMAT 'parquet');
+                        COPY nation TO 'nation.parquet' (FORMAT 'parquet');
+                        COPY orders TO 'orders.parquet' (FORMAT 'parquet');
+                        COPY part TO 'part.parquet' (FORMAT 'parquet');
+                        COPY partsupp TO 'partsupp.parquet' (FORMAT 'parquet');
+                        COPY region TO 'region.parquet' (FORMAT 'parquet');
+                        COPY supplier TO 'supplier.parquet' (FORMAT 'parquet');
                         "
                         )
                     };
@@ -521,37 +387,3 @@ pub(crate) fn delayed_source_load(
         Ok::<(), String>(())
     })
 }
-
-// #[cfg(test)]
-// mod test {
-//     #[tokio::test]
-//     async fn test_delayed_source_load() {
-//         // run the delayed source load
-//         delayed_source_load("tpch", "destination", 3, Duration::from_secs(10), 0.1);
-
-//         // check the destination database has it's first load after a small delay
-//         sleep(Duration::from_secs(3)).await;
-
-//         let conn = Connection::open("./destination.db").unwrap();
-//         let count: i64 = conn
-//             .query_row("SELECT COUNT(*) FROM supplier", [], |row| row.get(0))
-//             .unwrap();
-//         assert_eq!(count, 10_000);
-
-//         // check the destination database has it's second load after a small delay
-//         sleep(Duration::from_secs(10)).await;
-
-//         let count: i64 = conn
-//             .query_row("SELECT COUNT(*) FROM supplier", [], |row| row.get(0))
-//             .unwrap();
-//         assert_eq!(count, 20_000);
-
-//         // check the destination database has it's third load after a small delay
-//         sleep(Duration::from_secs(10)).await;
-
-//         let count: i64 = conn
-//             .query_row("SELECT COUNT(*) FROM supplier", [], |row| row.get(0))
-//             .unwrap();
-//         assert_eq!(count, 30_000);
-//     }
-// }

--- a/crates/runtime/benches/bench_duckdb/mod.rs
+++ b/crates/runtime/benches/bench_duckdb/mod.rs
@@ -61,7 +61,6 @@ pub(crate) async fn run(
     Ok(())
 }
 
-#[allow(clippy::too_many_lines)]
 pub fn build_app(app_builder: AppBuilder, bench_name: &str) -> Result<AppBuilder, String> {
     match bench_name {
         "tpch" => Ok(app_builder

--- a/crates/runtime/benches/bench_object_store/file.rs
+++ b/crates/runtime/benches/bench_object_store/file.rs
@@ -14,97 +14,338 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use arrow::array::AsArray;
+use runtime::Runtime;
+use std::time::Duration;
+use tokio::time::sleep;
+
 use app::AppBuilder;
 
-use spicepod::component::dataset::Dataset;
+use spicepod::component::dataset::{
+    acceleration::{Acceleration, RefreshMode},
+    Dataset,
+};
+
+use crate::run_query;
+
+use super::{get_tpcds_test_queries, get_tpch_test_queries, BenchmarkResultsBuilder};
+
+pub(crate) async fn run_file_append(
+    rt: &mut Runtime,
+    benchmark_results: &mut BenchmarkResultsBuilder,
+    bench_name: &str,
+    accelerator: Option<Acceleration>,
+) -> Result<(), String> {
+    let test_queries = match bench_name {
+        "tpch" => get_tpch_test_queries(),
+        "tpcds" => match accelerator.clone() {
+            Some(Acceleration { engine, .. }) => get_tpcds_test_queries(engine.as_deref()),
+            None => get_tpcds_test_queries(None),
+        },
+        _ => return Err(format!("Invalid benchmark to run {bench_name}")),
+    };
+
+    let mut errors = Vec::new();
+    let is_append = accelerator
+        .clone()
+        .and_then(|a| a.refresh_mode)
+        .is_some_and(|m| m == RefreshMode::Append);
+
+    if is_append {
+        let start_time = std::time::Instant::now();
+
+        loop {
+            sleep(Duration::from_secs(60 * 4)).await; // refresh interval is 3 minutes - check every 4 minutes
+
+            // check if the data has finished loading
+            let res = run_query(
+                rt,
+                "duckdb",
+                "table_count",
+                "SELECT COUNT(*) as l_count FROM lineitem",
+            )
+            .await;
+
+            if let Err(e) = res {
+                return Err(format!(
+                    "Append mode data load failed. Failed to count rows in lineitem table: {e}"
+                ));
+            }
+
+            let count = res
+                .map_err(|e| e.to_string())?
+                .first()
+                .ok_or("No rows returned from count query")?
+                .column_by_name("l_count")
+                .ok_or("No column named l_count")?
+                .as_primitive::<arrow::datatypes::Int64Type>()
+                .value(0);
+            if count < 59_900_000 {
+                // DuckDB dbgen at scale 10 generates 59.9, not 60, million rows for lineitem when using partitioned generation
+                if start_time.elapsed() > Duration::from_secs(60 * 60) {
+                    // if more than 1 hour has passed, the test has failed
+                    tracing::error!("Append mode data load failed. Expected over 59.9 million rows in lineitem table, got {count}");
+                    return Err(format!("Append mode data load failed. Expected over 59.9 million rows in lineitem table, got {count}"));
+                }
+
+                tracing::info!("Append mode data load in progress. Expected over 59.9 million rows in lineitem table, got {count}");
+            } else {
+                tracing::info!(
+                    "Append mode data load complete. Loaded {count} rows in lineitem table"
+                );
+                break;
+            }
+        }
+    }
+
+    let bench_name = match (accelerator, is_append) {
+        (Some(accelerator), true) => {
+            format!(
+                "file_{}_{}_append",
+                accelerator.engine.unwrap_or("arrow".to_string()),
+                accelerator.mode
+            )
+        }
+        (Some(accelerator), false) => {
+            format!(
+                "file_{}_{}",
+                accelerator.engine.unwrap_or("arrow".to_string()),
+                accelerator.mode
+            )
+        }
+        (None, _) => bench_name.to_string(),
+    };
+
+    for (query_name, query) in test_queries {
+        if let Err(e) = crate::run_query_and_record_result(
+            rt,
+            benchmark_results,
+            &bench_name,
+            query_name,
+            query,
+            false,
+        )
+        .await
+        {
+            errors.push(format!("Query {query_name} failed with error: {e}"));
+        };
+    }
+
+    if !errors.is_empty() {
+        tracing::error!("There are failed queries:\n{}", errors.join("\n"));
+    }
+
+    Ok(())
+}
 
 #[allow(clippy::too_many_lines)]
-pub fn build_app(app_builder: AppBuilder, bench_name: &str) -> Result<AppBuilder, String> {
+pub fn build_app(
+    app_builder: AppBuilder,
+    bench_name: &str,
+    acceleration: Option<Acceleration>,
+) -> Result<AppBuilder, String> {
+    let is_append = acceleration
+        .and_then(|a| a.refresh_mode)
+        .is_some_and(|m| m == RefreshMode::Append);
+
+    if is_append {
+        tracing::info!(
+            "Running DuckDB connector in append mode - data will be loaded incrementally"
+        );
+    }
+
     match bench_name {
         "tpch" => Ok(app_builder
-            .with_dataset(make_dataset("customer.parquet", "customer", bench_name))
-            .with_dataset(make_dataset("lineitem.parquet", "lineitem", bench_name))
-            .with_dataset(make_dataset("orders.parquet", "orders", bench_name))
-            .with_dataset(make_dataset("part.parquet", "part", bench_name))
-            .with_dataset(make_dataset("partsupp.parquet", "partsupp", bench_name))
-            .with_dataset(make_dataset("region.parquet", "region", bench_name))
-            .with_dataset(make_dataset("nation.parquet", "nation", bench_name))
-            .with_dataset(make_dataset("supplier.parquet", "supplier", bench_name))),
+            .with_dataset(make_dataset(
+                "customer.parquet",
+                "customer",
+                bench_name,
+                is_append.then_some("c_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "lineitem.parquet",
+                "lineitem",
+                bench_name,
+                is_append.then_some("l_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "orders.parquet",
+                "orders",
+                bench_name,
+                is_append.then_some("o_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "part.parquet",
+                "part",
+                bench_name,
+                is_append.then_some("p_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "partsupp.parquet",
+                "partsupp",
+                bench_name,
+                is_append.then_some("ps_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "region.parquet",
+                "region",
+                bench_name,
+                is_append.then_some("r_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "nation.parquet",
+                "nation",
+                bench_name,
+                is_append.then_some("n_created_at"),
+            ))
+            .with_dataset(make_dataset(
+                "supplier.parquet",
+                "supplier",
+                bench_name,
+                is_append.then_some("s_created_at"),
+            ))),
         "tpcds" => Ok(app_builder
             .with_dataset(make_dataset(
                 "call_center.parquet",
                 "call_center",
                 bench_name,
+                None,
             ))
             .with_dataset(make_dataset(
                 "catalog_page.parquet",
                 "catalog_page",
                 bench_name,
+                None,
             ))
             .with_dataset(make_dataset(
                 "catalog_returns.parquet",
                 "catalog_returns",
                 bench_name,
+                None,
             ))
             .with_dataset(make_dataset(
                 "catalog_sales.parquet",
                 "catalog_sales",
                 bench_name,
+                None,
             ))
-            .with_dataset(make_dataset("customer.parquet", "customer", bench_name))
+            .with_dataset(make_dataset(
+                "customer.parquet",
+                "customer",
+                bench_name,
+                None,
+            ))
             .with_dataset(make_dataset(
                 "customer_address.parquet",
                 "customer_address",
                 bench_name,
+                None,
             ))
             .with_dataset(make_dataset(
                 "customer_demographics.parquet",
                 "customer_demographics",
                 bench_name,
+                None,
             ))
-            .with_dataset(make_dataset("date_dim.parquet", "date_dim", bench_name))
+            .with_dataset(make_dataset(
+                "date_dim.parquet",
+                "date_dim",
+                bench_name,
+                None,
+            ))
             .with_dataset(make_dataset(
                 "household_demographics.parquet",
                 "household_demographics",
                 bench_name,
+                None,
             ))
             .with_dataset(make_dataset(
                 "income_band.parquet",
                 "income_band",
                 bench_name,
+                None,
             ))
-            .with_dataset(make_dataset("inventory.parquet", "inventory", bench_name))
-            .with_dataset(make_dataset("item.parquet", "item", bench_name))
-            .with_dataset(make_dataset("promotion.parquet", "promotion", bench_name))
-            .with_dataset(make_dataset("reason.parquet", "reason", bench_name))
-            .with_dataset(make_dataset("ship_mode.parquet", "ship_mode", bench_name))
-            .with_dataset(make_dataset("store.parquet", "store", bench_name))
+            .with_dataset(make_dataset(
+                "inventory.parquet",
+                "inventory",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset("item.parquet", "item", bench_name, None))
+            .with_dataset(make_dataset(
+                "promotion.parquet",
+                "promotion",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset("reason.parquet", "reason", bench_name, None))
+            .with_dataset(make_dataset(
+                "ship_mode.parquet",
+                "ship_mode",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset("store.parquet", "store", bench_name, None))
             .with_dataset(make_dataset(
                 "store_returns.parquet",
                 "store_returns",
                 bench_name,
+                None,
             ))
             .with_dataset(make_dataset(
                 "store_sales.parquet",
                 "store_sales",
                 bench_name,
+                None,
             ))
-            .with_dataset(make_dataset("time_dim.parquet", "time_dim", bench_name))
-            .with_dataset(make_dataset("warehouse.parquet", "warehouse", bench_name))
-            .with_dataset(make_dataset("web_page.parquet", "web_page", bench_name))
+            .with_dataset(make_dataset(
+                "time_dim.parquet",
+                "time_dim",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset(
+                "warehouse.parquet",
+                "warehouse",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset(
+                "web_page.parquet",
+                "web_page",
+                bench_name,
+                None,
+            ))
             .with_dataset(make_dataset(
                 "web_returns.parquet",
                 "web_returns",
                 bench_name,
+                None,
             ))
-            .with_dataset(make_dataset("web_sales.parquet", "web_sales", bench_name))
-            .with_dataset(make_dataset("web_site.parquet", "web_site", bench_name))),
+            .with_dataset(make_dataset(
+                "web_sales.parquet",
+                "web_sales",
+                bench_name,
+                None,
+            ))
+            .with_dataset(make_dataset(
+                "web_site.parquet",
+                "web_site",
+                bench_name,
+                None,
+            ))),
         _ => Err(
             "Only tpch and tpcds benchmark suites are supported for the file connector".to_string(),
         ),
     }
 }
 
-fn make_dataset(path: &str, name: &str, _bench_name: &str) -> Dataset {
-    Dataset::new(format!("file:./{path}"), name.to_string())
+fn make_dataset(path: &str, name: &str, _bench_name: &str, time_column: Option<&str>) -> Dataset {
+    let mut dataset = Dataset::new(format!("file:./{path}"), name.to_string());
+
+    if let Some(time_column) = time_column {
+        dataset.time_column = Some(time_column.to_string());
+    };
+
+    dataset
 }

--- a/crates/runtime/benches/bench_object_store/file.rs
+++ b/crates/runtime/benches/bench_object_store/file.rs
@@ -106,14 +106,7 @@ pub(crate) async fn run_file_append(
                 accelerator.mode
             )
         }
-        (Some(accelerator), false) => {
-            format!(
-                "file_{}_{}",
-                accelerator.engine.unwrap_or("arrow".to_string()),
-                accelerator.mode
-            )
-        }
-        (None, _) => bench_name.to_string(),
+        _ => "file".to_string(),
     };
 
     for (query_name, query) in test_queries {

--- a/crates/runtime/benches/bench_object_store/mod.rs
+++ b/crates/runtime/benches/bench_object_store/mod.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use crate::results::BenchmarkResultsBuilder;
 use app::AppBuilder;
 use runtime::Runtime;
-use spicepod::component::dataset::acceleration::Mode;
+use spicepod::component::dataset::acceleration::{Acceleration, Mode};
 
 pub(crate) mod abfs;
 pub(crate) mod file;
@@ -29,11 +29,12 @@ pub(crate) fn build_app(
     connector: &str,
     app_builder: AppBuilder,
     bench_name: &str,
+    acceleration: Option<Acceleration>,
 ) -> Result<AppBuilder, String> {
     match connector {
         "s3" => s3::build_app(app_builder, bench_name),
         "abfs" => Ok(abfs::build_app(app_builder, bench_name)),
-        "file" => file::build_app(app_builder, bench_name),
+        "file" => file::build_app(app_builder, bench_name, acceleration),
         _ => Err(format!("Unsupported connector {connector}")),
     }
 }

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -145,7 +145,7 @@ fn build_app(
         #[cfg(feature = "mysql")]
         "mysql" => crate::bench_mysql::build_app(app_builder, bench_name),
         #[cfg(feature = "duckdb")]
-        "duckdb" => crate::bench_duckdb::build_app(app_builder, bench_name),
+        "duckdb" => crate::bench_duckdb::build_app(app_builder, bench_name, acceleration.clone()),
         #[cfg(feature = "odbc")]
         "odbc-databricks" => crate::bench_odbc_databricks::build_app(app_builder, bench_name),
         #[cfg(feature = "odbc")]

--- a/crates/runtime/benches/setup/mod.rs
+++ b/crates/runtime/benches/setup/mod.rs
@@ -133,9 +133,19 @@ fn build_app(
                     .as_ref()
                     .is_some_and(|a| a.engine == Some("sqlite".to_string()))
             {
-                crate::bench_object_store::build_app(connector, app_builder, "tpcds_sf0_01")
+                crate::bench_object_store::build_app(
+                    connector,
+                    app_builder,
+                    "tpcds_sf0_01",
+                    acceleration.clone(),
+                )
             } else {
-                crate::bench_object_store::build_app(connector, app_builder, bench_name)
+                crate::bench_object_store::build_app(
+                    connector,
+                    app_builder,
+                    bench_name,
+                    acceleration.clone(),
+                )
             }
         }
         #[cfg(feature = "spark")]
@@ -145,7 +155,7 @@ fn build_app(
         #[cfg(feature = "mysql")]
         "mysql" => crate::bench_mysql::build_app(app_builder, bench_name),
         #[cfg(feature = "duckdb")]
-        "duckdb" => crate::bench_duckdb::build_app(app_builder, bench_name, acceleration.clone()),
+        "duckdb" => crate::bench_duckdb::build_app(app_builder, bench_name),
         #[cfg(feature = "odbc")]
         "odbc-databricks" => crate::bench_odbc_databricks::build_app(app_builder, bench_name),
         #[cfg(feature = "odbc")]

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -190,7 +190,7 @@ pub mod acceleration {
     #[cfg(feature = "schemars")]
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
-    use std::{collections::HashMap, fmt::Display, str::FromStr};
+    use std::{collections::HashMap, fmt::Display};
 
     use crate::component::params::Params;
 

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -190,7 +190,7 @@ pub mod acceleration {
     #[cfg(feature = "schemars")]
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
-    use std::{collections::HashMap, fmt::Display};
+    use std::{collections::HashMap, fmt::Display, str::FromStr};
 
     use crate::component::params::Params;
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds support to use the `file` connector as an appendable connector source - loading data into the connector (parquet file) over a period of time. Loads the connector source over 30 minutes at scale factor 10 with a static scale factor/load count/load interval.

Uses DuckDB as the generator for simplicity - it has the functions we need to easily generate datasets, add a timestamp column, and export the tables as parquet.

* Adds support for using `duckdb` in an append-mode accelerator benchmark. Validates that the accelerator finishes loading within 1 hour, to test the performance of the accelerator over time.

The benchmark can be run like `bench --bench -a duckdb -m file -b tpch --append-mode true`.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #4101 

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->

* I've avoided making sweeping changes to the structure of the benchmark runners to support these benchmarks. We should focus effort instead on superseding them with #4114 in future.
* Currently does not run as part of the benchmark workflow - will add in future PRs as part of #4102 