### PR TITLE
Fix bug in Iceberg tables selecting a subset of columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5679,8 +5679,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59608aad36da6061f353bd12efa049bc12ea437032cd4cf67f03696d45557db9"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=557c79ff2c443c089e09d3ad60d382eb7fdba7bf#557c79ff2c443c089e09d3ad60d382eb7fdba7bf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5700,8 +5699,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389127b6db8b815e6f7e87b316c80c80058e361d1e9a514b6bb6c28781f371f0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=557c79ff2c443c089e09d3ad60d382eb7fdba7bf#557c79ff2c443c089e09d3ad60d382eb7fdba7bf"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,3 +172,5 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
 iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "557c79ff2c443c089e09d3ad60d382eb7fdba7bf" }
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "557c79ff2c443c089e09d3ad60d382eb7fdba7bf" }
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "557c79ff2c443c089e09d3ad60d382eb7fdba7bf" }


### PR DESCRIPTION
# 🗣 Description

Fixes a bug in the Iceberg catalog connector where selecting a subset of the columns would return an error. This was a bug in the Iceberg crate that was fixed after the `0.4.0` release, but was included in our existing fork.

The fix is to also override the `iceber-datafusion` and `iceberg-catalog-rest` crates to come from our fork with the fix.

The upstream PR that fixed it: https://github.com/apache/iceberg-rust/pull/829

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
