### PR TITLE
 Data is streamed when reading from the GitHub connector (GraphQL tables)

### DIFF
--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -615,7 +615,7 @@ pub struct GraphQLClient {
 
 #[derive(Clone)]
 pub struct GraphQLQuery {
-    source_query: Arc<str>,
+    _source_query: Arc<str>,
     ast: Document<'static, String>,
     pub json_pointer: Option<Arc<str>>,
     pub pagination_parameters: Option<PaginationParameters>,
@@ -634,7 +634,7 @@ impl TryFrom<Arc<str>> for GraphQLQuery {
         let query_ref: &'static str = unsafe { std::mem::transmute::<&str, &'static str>(&query) };
 
         let ast =
-            parse_query::<String>(&query_ref).map_err(|_| super::Error::InvalidGraphQLQuery {
+            parse_query::<String>(query_ref).map_err(|_| super::Error::InvalidGraphQLQuery {
                 message: "Failed to parse GraphQL query".to_string(),
                 line: 0,
                 column: 0,
@@ -644,7 +644,7 @@ impl TryFrom<Arc<str>> for GraphQLQuery {
         let (pagination_parameters, json_pointer) = PaginationParameters::parse(&ast);
 
         Ok(Self {
-            source_query: query,
+            _source_query: query,
             ast,
             json_pointer: json_pointer.map(Arc::from),
             pagination_parameters,
@@ -672,6 +672,7 @@ impl GraphQLQuery {
         }
     }
 
+    #[must_use]
     pub fn ast(&self) -> &Document<'_, String> {
         // SAFETY: We can safely transmute back to a shorter lifetime
         unsafe {
@@ -679,6 +680,7 @@ impl GraphQLQuery {
         }
     }
 
+    #[must_use]
     pub fn ast_mut(&mut self) -> &mut Document<'_, String> {
         // SAFETY: We can safely transmute back to a shorter lifetime
         unsafe {
@@ -834,6 +836,7 @@ impl GraphQLClient {
         })
     }
 
+    #[must_use]
     pub fn execute_paginated(
         self: Arc<Self>,
         query: GraphQLQuery,

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -844,7 +844,7 @@ impl GraphQLClient {
         limit: Option<usize>,
         error_checker: Option<ErrorChecker>,
     ) -> SendableRecordBatchStream {
-        let mut builder = RecordBatchReceiverStream::builder(schema, 2);
+        let mut builder = RecordBatchReceiverStream::builder(Arc::clone(&schema), 2);
         let tx = builder.tx();
 
         // Spawn the task that will fetch and send the GraphQL record batches
@@ -858,7 +858,7 @@ impl GraphQLClient {
                 match self
                     .execute(
                         &mut query,
-                        None, // Schema already provided to builder
+                        Some(Arc::clone(&schema)),
                         limit,
                         current_cursor,
                         error_checker.clone(),

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -35,6 +35,9 @@ use std::{cmp::min, fmt::Display, io::Cursor, sync::Arc};
 
 use url::Url;
 
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::{error::DataFusionError, physical_plan::stream::RecordBatchReceiverStream};
+
 pub enum Auth {
     Basic(String, Option<String>),
     Bearer(Arc<dyn TokenProvider>),
@@ -611,26 +614,37 @@ pub struct GraphQLClient {
 }
 
 #[derive(Clone)]
-pub struct GraphQLQuery<'a> {
-    pub ast: Document<'a, String>,
+pub struct GraphQLQuery {
+    source_query: Arc<str>,
+    ast: Document<'static, String>,
     pub json_pointer: Option<Arc<str>>,
     pub pagination_parameters: Option<PaginationParameters>,
 }
 
-impl<'a> TryFrom<&'a str> for GraphQLQuery<'a> {
+impl TryFrom<Arc<str>> for GraphQLQuery {
     type Error = super::Error;
 
-    fn try_from(query: &'a str) -> Result<Self, self::Error> {
-        let ast = parse_query::<String>(query).map_err(|_| super::Error::InvalidGraphQLQuery {
-            message: "Failed to parse GraphQL query".to_string(),
-            line: 0,
-            column: 0,
-            query: query.to_string(),
-        })?;
+    fn try_from(query: Arc<str>) -> Result<Self, self::Error> {
+        // SAFETY: We're transmuting the lifetime to 'static and this is safe because:
+        // 1. The reference won't outlive the GraphQLQuery struct and we don't give it out as a static reference
+        // 2. The source Arc is kept alive as long as the GraphQLQuery exists
+        // 3. Arc guarantees the data remains at the same address
+        //
+        // This wouldn't be required if Rust had proper support for self-referencing structs.
+        let query_ref: &'static str = unsafe { std::mem::transmute::<&str, &'static str>(&query) };
+
+        let ast =
+            parse_query::<String>(&query_ref).map_err(|_| super::Error::InvalidGraphQLQuery {
+                message: "Failed to parse GraphQL query".to_string(),
+                line: 0,
+                column: 0,
+                query: query.to_string(),
+            })?;
 
         let (pagination_parameters, json_pointer) = PaginationParameters::parse(&ast);
 
         Ok(Self {
+            source_query: query,
             ast,
             json_pointer: json_pointer.map(Arc::from),
             pagination_parameters,
@@ -638,7 +652,7 @@ impl<'a> TryFrom<&'a str> for GraphQLQuery<'a> {
     }
 }
 
-impl GraphQLQuery<'_> {
+impl GraphQLQuery {
     #[must_use]
     pub fn to_string(&self, limit: Option<usize>, cursor: Option<String>) -> String {
         let query = self.ast.to_string();
@@ -655,6 +669,22 @@ impl GraphQLQuery<'_> {
             record_count >= limit
         } else {
             false
+        }
+    }
+
+    pub fn ast(&self) -> &Document<'_, String> {
+        // SAFETY: We can safely transmute back to a shorter lifetime
+        unsafe {
+            std::mem::transmute::<&Document<'static, String>, &Document<'_, String>>(&self.ast)
+        }
+    }
+
+    pub fn ast_mut(&mut self) -> &mut Document<'_, String> {
+        // SAFETY: We can safely transmute back to a shorter lifetime
+        unsafe {
+            std::mem::transmute::<&mut Document<'static, String>, &mut Document<'_, String>>(
+                &mut self.ast,
+            )
         }
     }
 }
@@ -704,9 +734,9 @@ impl GraphQLClient {
         })
     }
 
-    pub(crate) async fn execute<'a>(
+    pub(crate) async fn execute(
         &self,
-        query: &mut GraphQLQuery<'a>,
+        query: &mut GraphQLQuery,
         schema: Option<SchemaRef>,
         limit: Option<usize>,
         cursor: Option<String>,
@@ -804,53 +834,71 @@ impl GraphQLClient {
         })
     }
 
-    pub(crate) async fn execute_paginated<'a>(
-        &self,
-        query: &mut GraphQLQuery<'a>,
+    pub fn execute_paginated(
+        self: Arc<Self>,
+        query: GraphQLQuery,
         schema: SchemaRef,
         limit: Option<usize>,
         error_checker: Option<ErrorChecker>,
-    ) -> Result<Vec<Vec<RecordBatch>>> {
-        let mut result = self
-            .execute(
-                query,
-                Some(Arc::clone(&schema)),
-                limit,
-                None,
-                error_checker.clone(),
-            )
-            .await?;
-        let mut res = vec![result.records];
-        let mut limit = limit;
+    ) -> SendableRecordBatchStream {
+        let mut builder = RecordBatchReceiverStream::builder(schema, 2);
+        let tx = builder.tx();
 
-        if result.limit_reached {
-            return Ok(res);
-        }
+        // Spawn the task that will fetch and send the GraphQL record batches
+        builder.spawn(async move {
+            let mut current_cursor = None;
+            let mut record_count = 0;
+            let mut query = query;
+            let mut limit = limit;
 
-        while let Some(next_cursor_val) = result.cursor {
-            if let Some(p) = query.pagination_parameters.as_ref() {
-                if limit.is_some() {
-                    limit = Some(p.reduce_limit(result.record_count));
+            loop {
+                match self
+                    .execute(
+                        &mut query,
+                        None, // Schema already provided to builder
+                        limit,
+                        current_cursor,
+                        error_checker.clone(),
+                    )
+                    .await
+                {
+                    Ok(result) => {
+                        // Send each batch through the channel
+                        for batch in result.records {
+                            tx.send(Ok(batch)).await.map_err(|_| {
+                                DataFusionError::Execution(
+                                    "Failed to send record batch".to_string(),
+                                )
+                            })?;
+                        }
+
+                        record_count += result.record_count;
+
+                        // Update cursor and check if we should continue
+                        if result.limit_reached || result.cursor.is_none() {
+                            break;
+                        }
+
+                        // Update cursor and limit for next iteration
+                        current_cursor = result.cursor;
+                        if let Some(p) = query.pagination_parameters.as_ref() {
+                            if limit.is_some() {
+                                limit = Some(p.reduce_limit(record_count));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tx.send(Err(DataFusionError::Execution(e.to_string())))
+                            .await
+                            .ok();
+                        break;
+                    }
                 }
             }
+            Ok(())
+        });
 
-            result = self
-                .execute(
-                    query,
-                    Some(Arc::clone(&schema)),
-                    limit,
-                    Some(next_cursor_val),
-                    error_checker.clone(),
-                )
-                .await?;
-            res.push(result.records);
-
-            if result.limit_reached {
-                break;
-            }
-        }
-
-        Ok(res)
+        builder.build()
     }
 }
 
@@ -982,6 +1030,8 @@ fn format_query_with_context(query: &str, line: usize, column: usize) -> String 
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use reqwest::StatusCode;
     use serde_json::Value;
 
@@ -1132,7 +1182,7 @@ mod tests {
         ];
 
         for case in test_cases {
-            let query = GraphQLQuery::try_from(case.query).expect("Should parse query");
+            let query = GraphQLQuery::try_from(Arc::from(case.query)).expect("Should parse query");
             let result = PaginationParameters::parse(&query.ast);
             assert_eq!(result, case.expected, "Failed test case: {}", case.name);
         }
@@ -1150,7 +1200,7 @@ mod tests {
             }
         }";
 
-        let query = GraphQLQuery::try_from(query).expect("Should parse query");
+        let query = GraphQLQuery::try_from(Arc::from(query)).expect("Should parse query");
         let (pagination_parameters_opt, _) = PaginationParameters::parse(&query.ast);
         pagination_parameters_opt.expect("Should get pagination params");
         let new_query = query.to_string(None, Some("new_cursor".to_string()));
@@ -1176,7 +1226,7 @@ mod tests {
             }
         }"#;
 
-        let query = GraphQLQuery::try_from(query).expect("Should parse query");
+        let query = GraphQLQuery::try_from(Arc::from(query)).expect("Should parse query");
         let (pagination_parameters_opt, _) = PaginationParameters::parse(&query.ast);
         pagination_parameters_opt.expect("Should get pagination params");
         let new_query = query.to_string(None, Some("new_cursor".to_string()));
@@ -1202,7 +1252,7 @@ mod tests {
             }
         }";
 
-        let query = GraphQLQuery::try_from(query).expect("Should parse query");
+        let query = GraphQLQuery::try_from(Arc::from(query)).expect("Should parse query");
         let (pagination_parameters_opt, _) = PaginationParameters::parse(&query.ast);
         pagination_parameters_opt.expect("Should get pagination params");
         let new_query = query.to_string(Some(5), Some("new_cursor".to_string()));
@@ -1232,7 +1282,7 @@ mod tests {
             }
         }";
 
-        let query = GraphQLQuery::try_from(query).expect("Should parse query");
+        let query = GraphQLQuery::try_from(Arc::from(query)).expect("Should parse query");
         let (pagination_parameters_opt, _) = PaginationParameters::parse(&query.ast);
         let pagination_parameters =
             pagination_parameters_opt.expect("Failed to get pagination params");
@@ -1269,7 +1319,7 @@ mod tests {
             }
         }";
 
-        let query = GraphQLQuery::try_from(query).expect("Should parse query");
+        let query = GraphQLQuery::try_from(Arc::from(query)).expect("Should parse query");
         let (pagination_parameters_opt, _) = PaginationParameters::parse(&query.ast);
         let pagination_parameters =
             pagination_parameters_opt.expect("Failed to get pagination params");

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -839,63 +839,65 @@ impl GraphQLClient {
     #[must_use]
     pub fn execute_paginated(
         self: Arc<Self>,
-        query: GraphQLQuery,
-        schema: SchemaRef,
+        mut query: GraphQLQuery,
+        gql_schema: SchemaRef,
+        table_schema: SchemaRef,
         limit: Option<usize>,
         error_checker: Option<ErrorChecker>,
     ) -> SendableRecordBatchStream {
-        let mut builder = RecordBatchReceiverStream::builder(Arc::clone(&schema), 2);
+        let mut builder = RecordBatchReceiverStream::builder(table_schema, 2);
         let tx = builder.tx();
 
         // Spawn the task that will fetch and send the GraphQL record batches
         builder.spawn(async move {
-            let mut current_cursor = None;
-            let mut record_count = 0;
-            let mut query = query;
+            let mut result = self
+                .execute(
+                    &mut query,
+                    Some(Arc::clone(&gql_schema)),
+                    limit,
+                    None,
+                    error_checker.clone(),
+                )
+                .await
+                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
             let mut limit = limit;
 
-            loop {
-                match self
+            for batch in result.records {
+                tx.send(Ok(batch)).await.map_err(|_| {
+                    DataFusionError::Execution("Failed to send record batch".to_string())
+                })?;
+            }
+
+            if result.limit_reached {
+                return Ok(());
+            }
+
+            while let Some(next_cursor_val) = result.cursor {
+                if let Some(p) = query.pagination_parameters.as_ref() {
+                    if limit.is_some() {
+                        limit = Some(p.reduce_limit(result.record_count));
+                    }
+                }
+
+                result = self
                     .execute(
                         &mut query,
-                        Some(Arc::clone(&schema)),
+                        Some(Arc::clone(&gql_schema)),
                         limit,
-                        current_cursor,
+                        Some(next_cursor_val),
                         error_checker.clone(),
                     )
                     .await
-                {
-                    Ok(result) => {
-                        // Send each batch through the channel
-                        for batch in result.records {
-                            tx.send(Ok(batch)).await.map_err(|_| {
-                                DataFusionError::Execution(
-                                    "Failed to send record batch".to_string(),
-                                )
-                            })?;
-                        }
+                    .map_err(|e| DataFusionError::Execution(e.to_string()))?;
 
-                        record_count += result.record_count;
+                for batch in result.records {
+                    tx.send(Ok(batch)).await.map_err(|_| {
+                        DataFusionError::Execution("Failed to send record batch".to_string())
+                    })?;
+                }
 
-                        // Update cursor and check if we should continue
-                        if result.limit_reached || result.cursor.is_none() {
-                            break;
-                        }
-
-                        // Update cursor and limit for next iteration
-                        current_cursor = result.cursor;
-                        if let Some(p) = query.pagination_parameters.as_ref() {
-                            if limit.is_some() {
-                                limit = Some(p.reduce_limit(record_count));
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tx.send(Err(DataFusionError::Execution(e.to_string())))
-                            .await
-                            .ok();
-                        break;
-                    }
+                if result.limit_reached {
+                    break;
                 }
             }
             Ok(())

--- a/crates/data_components/src/graphql/mod.rs
+++ b/crates/data_components/src/graphql/mod.rs
@@ -113,7 +113,7 @@ pub trait GraphQLContext: Send + Sync + std::fmt::Debug {
     fn inject_parameters(
         &self,
         _filters: &[FilterPushdownResult],
-        _query: &mut GraphQLQuery<'_>,
+        _query: &mut GraphQLQuery,
     ) -> Result<(), datafusion::error::DataFusionError> {
         Ok(())
     }

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -13,21 +13,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use async_trait::async_trait;
-use snafu::ResultExt;
 
-use crate::arrow::write::MemTable;
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
+use async_trait::async_trait;
 use datafusion::{
     catalog::Session,
     datasource::{TableProvider, TableType},
-    error::DataFusionError,
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::{SendableRecordBatchStream, TaskContext},
     logical_expr::{Expr, TableProviderFilterPushDown},
-    physical_plan::ExecutionPlan,
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionMode,
+        ExecutionPlan, Partitioning, PlanProperties,
+    },
 };
-use std::{any::Any, sync::Arc};
+use futures::StreamExt;
+use snafu::ResultExt;
+use std::{any::Any, fmt, sync::Arc};
 
-use super::{client::GraphQLClient, GraphQLContext, ResultTransformSnafu};
+use super::{client::GraphQLClient, ErrorChecker, GraphQLContext, ResultTransformSnafu};
 use super::{client::GraphQLQuery, Result};
 
 pub type TransformFn =
@@ -62,7 +67,8 @@ impl GraphQLTableProviderBuilder {
     }
 
     pub async fn build(self, query_string: &str) -> Result<GraphQLTableProvider> {
-        let mut query = GraphQLQuery::try_from(query_string)?;
+        let query_string: Arc<str> = Arc::from(query_string);
+        let mut query = GraphQLQuery::try_from(Arc::clone(&query_string))?;
 
         if self.client.json_pointer.is_none() && query.json_pointer.is_none() {
             return Err(super::Error::NoJsonPointerFound {});
@@ -87,8 +93,8 @@ impl GraphQLTableProviderBuilder {
         };
 
         Ok(GraphQLTableProvider {
-            client: self.client,
-            base_query: query_string.to_string(),
+            client: Arc::new(self.client),
+            base_query: query_string,
             gql_schema: Arc::clone(&result.schema),
             table_schema,
             transform_fn: self.transform_fn,
@@ -98,8 +104,8 @@ impl GraphQLTableProviderBuilder {
 }
 
 pub struct GraphQLTableProvider {
-    client: GraphQLClient,
-    base_query: String,
+    client: Arc<GraphQLClient>,
+    base_query: Arc<str>,
     gql_schema: SchemaRef,
     table_schema: SchemaRef,
     transform_fn: Option<TransformFn>,
@@ -150,12 +156,12 @@ impl TableProvider for GraphQLTableProvider {
 
     async fn scan(
         &self,
-        state: &dyn Session,
-        projection: Option<&Vec<usize>>,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        let mut query = GraphQLQuery::try_from(self.base_query.as_str())
+        let mut query = GraphQLQuery::try_from(Arc::clone(&self.base_query))
             .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
 
         let error_checker = if let Some(context) = &self.context {
@@ -171,32 +177,114 @@ impl TableProvider for GraphQLTableProvider {
             None
         };
 
-        let mut res = self
-            .client
-            .execute_paginated(
-                &mut query,
-                Arc::clone(&self.gql_schema),
-                limit,
-                error_checker,
-            )
-            .await
-            .boxed()
-            .map_err(DataFusionError::External)?;
+        Ok(Arc::new(GraphQLTableProviderExec::new(
+            Arc::clone(&self.client),
+            query,
+            Arc::clone(&self.table_schema),
+            limit,
+            error_checker,
+            self.transform_fn.clone(),
+        )))
+    }
+}
+
+pub struct GraphQLTableProviderExec {
+    client: Arc<GraphQLClient>,
+    query: GraphQLQuery,
+    schema: SchemaRef,
+    limit: Option<usize>,
+    error_checker: Option<ErrorChecker>,
+    transform_fn: Option<TransformFn>,
+    properties: PlanProperties,
+}
+
+impl GraphQLTableProviderExec {
+    pub fn new(
+        client: Arc<GraphQLClient>,
+        query: GraphQLQuery,
+        schema: SchemaRef,
+        limit: Option<usize>,
+        error_checker: Option<ErrorChecker>,
+        transform_fn: Option<TransformFn>,
+    ) -> Self {
+        Self {
+            client,
+            query,
+            schema: Arc::clone(&schema),
+            limit,
+            error_checker,
+            transform_fn,
+            properties: PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(1),
+                ExecutionMode::Bounded,
+            ),
+        }
+    }
+}
+
+impl std::fmt::Debug for GraphQLTableProviderExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "GraphQLTableProviderExec")
+    }
+}
+
+impl DisplayAs for GraphQLTableProviderExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "GraphQLTableProviderExec")
+    }
+}
+
+impl ExecutionPlan for GraphQLTableProviderExec {
+    fn name(&self) -> &'static str {
+        "GraphQLTableProviderExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let mut stream = Arc::clone(&self.client).execute_paginated(
+            self.query.clone(),
+            Arc::clone(&self.schema),
+            self.limit,
+            self.error_checker.clone(),
+        );
 
         if let Some(transform_fn) = &self.transform_fn {
-            res = res
-                .into_iter()
-                .map(|inner_vec| {
-                    inner_vec
-                        .into_iter()
-                        .map(|batch| transform_fn(&batch).map_err(DataFusionError::External))
-                        .collect::<Result<Vec<_>, DataFusionError>>()
-                })
-                .collect::<Result<Vec<Vec<_>>, DataFusionError>>()?;
+            let transform_fn = *transform_fn;
+            let schema = stream.schema();
+            let tx_stream = stream.map(move |batch| {
+                batch.and_then(|b| transform_fn(&b).map_err(DataFusionError::External))
+            });
+
+            stream = Box::pin(RecordBatchStreamAdapter::new(schema, tx_stream));
         }
 
-        let table = MemTable::try_new(Arc::clone(&self.table_schema), res)?;
-
-        table.scan(state, projection, filters, limit).await
+        Ok(stream)
     }
 }

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -181,6 +181,7 @@ impl TableProvider for GraphQLTableProvider {
         let graphql_exec = Arc::new(GraphQLTableProviderExec::new(
             Arc::clone(&self.client),
             query,
+            Arc::clone(&self.gql_schema),
             Arc::clone(&self.table_schema),
             limit,
             error_checker,
@@ -208,7 +209,8 @@ impl TableProvider for GraphQLTableProvider {
 pub struct GraphQLTableProviderExec {
     client: Arc<GraphQLClient>,
     query: GraphQLQuery,
-    schema: SchemaRef,
+    gql_schema: SchemaRef,
+    table_schema: SchemaRef,
     limit: Option<usize>,
     error_checker: Option<ErrorChecker>,
     transform_fn: Option<TransformFn>,
@@ -220,7 +222,8 @@ impl GraphQLTableProviderExec {
     pub fn new(
         client: Arc<GraphQLClient>,
         query: GraphQLQuery,
-        schema: SchemaRef,
+        gql_schema: SchemaRef,
+        table_schema: SchemaRef,
         limit: Option<usize>,
         error_checker: Option<ErrorChecker>,
         transform_fn: Option<TransformFn>,
@@ -228,12 +231,13 @@ impl GraphQLTableProviderExec {
         Self {
             client,
             query,
-            schema: Arc::clone(&schema),
+            gql_schema,
+            table_schema: Arc::clone(&table_schema),
             limit,
             error_checker,
             transform_fn,
             properties: PlanProperties::new(
-                EquivalenceProperties::new(schema),
+                EquivalenceProperties::new(table_schema),
                 Partitioning::UnknownPartitioning(1),
                 ExecutionMode::Bounded,
             ),
@@ -263,7 +267,7 @@ impl ExecutionPlan for GraphQLTableProviderExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
+        Arc::clone(&self.table_schema)
     }
 
     fn properties(&self) -> &PlanProperties {
@@ -288,7 +292,8 @@ impl ExecutionPlan for GraphQLTableProviderExec {
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let mut stream = Arc::clone(&self.client).execute_paginated(
             self.query.clone(),
-            Arc::clone(&self.schema),
+            Arc::clone(&self.gql_schema),
+            Arc::clone(&self.table_schema),
             self.limit,
             self.error_checker.clone(),
         );

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -183,7 +183,7 @@ impl TableProvider for GraphQLTableProvider {
             Arc::clone(&self.table_schema),
             limit,
             error_checker,
-            self.transform_fn.clone(),
+            self.transform_fn,
         )))
     }
 }
@@ -199,6 +199,7 @@ pub struct GraphQLTableProviderExec {
 }
 
 impl GraphQLTableProviderExec {
+    #[must_use]
     pub fn new(
         client: Arc<GraphQLClient>,
         query: GraphQLQuery,

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -24,8 +24,9 @@ use datafusion::{
     logical_expr::{Expr, TableProviderFilterPushDown},
     physical_expr::EquivalenceProperties,
     physical_plan::{
-        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionMode,
-        ExecutionPlan, Partitioning, PlanProperties,
+        expressions::Column, projection::ProjectionExec, stream::RecordBatchStreamAdapter,
+        DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning, PhysicalExpr,
+        PlanProperties,
     },
 };
 use futures::StreamExt;
@@ -157,7 +158,7 @@ impl TableProvider for GraphQLTableProvider {
     async fn scan(
         &self,
         _state: &dyn Session,
-        _projection: Option<&Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
@@ -177,14 +178,30 @@ impl TableProvider for GraphQLTableProvider {
             None
         };
 
-        Ok(Arc::new(GraphQLTableProviderExec::new(
+        let graphql_exec = Arc::new(GraphQLTableProviderExec::new(
             Arc::clone(&self.client),
             query,
             Arc::clone(&self.table_schema),
             limit,
             error_checker,
             self.transform_fn,
-        )))
+        ));
+
+        if let Some(projection) = projection {
+            let mut projection_expr = Vec::with_capacity(projection.len());
+            for idx in projection {
+                let col_name = self.table_schema.field(*idx).name();
+                projection_expr.push((
+                    Arc::new(Column::new(col_name, *idx)) as Arc<dyn PhysicalExpr>,
+                    col_name.to_string(),
+                ));
+            }
+
+            let projection_exec = ProjectionExec::try_new(projection_expr, graphql_exec)?;
+            return Ok(Arc::new(projection_exec));
+        }
+
+        Ok(graphql_exec)
     }
 }
 

--- a/crates/runtime/src/dataconnector/github/commits.rs
+++ b/crates/runtime/src/dataconnector/github/commits.rs
@@ -47,7 +47,7 @@ impl GraphQLContext for CommitsTableArgs {
     fn inject_parameters(
         &self,
         filters: &[FilterPushdownResult],
-        query: &mut GraphQLQuery<'_>,
+        query: &mut GraphQLQuery,
     ) -> Result<(), datafusion::error::DataFusionError> {
         inject_parameters("history", commits_inject_parameters, filters, query)
             .map_err(find_datafusion_root)

--- a/crates/runtime/src/dataconnector/github/issues.rs
+++ b/crates/runtime/src/dataconnector/github/issues.rs
@@ -56,7 +56,7 @@ impl GraphQLContext for IssuesTableArgs {
     fn inject_parameters(
         &self,
         filters: &[FilterPushdownResult],
-        query: &mut GraphQLQuery<'_>,
+        query: &mut GraphQLQuery,
     ) -> Result<(), datafusion::error::DataFusionError> {
         if self.query_mode == GitHubQueryMode::Auto {
             return Ok(());

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -884,7 +884,7 @@ pub(crate) fn inject_parameters<F>(
     target_field_name: &str,
     field_modifier: F,
     filters: &[FilterPushdownResult],
-    query: &mut GraphQLQuery<'_>,
+    query: &mut GraphQLQuery,
 ) -> Result<(), datafusion::error::DataFusionError>
 where
     F: Fn(
@@ -961,7 +961,7 @@ where
     field_modifier(target_field, &filters)?;
 
     // update any change in JSON pointer and pagination parameters
-    let (pagination_parameters, json_pointer) = PaginationParameters::parse(&query.ast());
+    let (pagination_parameters, json_pointer) = PaginationParameters::parse(query.ast());
     query.pagination_parameters = pagination_parameters;
     query.json_pointer = json_pointer.map(Arc::from);
 

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -904,7 +904,7 @@ where
 
     // find the history() field leaf in the AST
     let mut all_selections: Vec<&mut Selection<'_, String>> = Vec::new();
-    for def in &mut query.ast.definitions {
+    for def in &mut query.ast_mut().definitions {
         let selections = match def {
             Definition::Operation(OperationDefinition::Query(Query { selection_set, .. })) => {
                 &mut selection_set.items
@@ -961,7 +961,7 @@ where
     field_modifier(target_field, &filters)?;
 
     // update any change in JSON pointer and pagination parameters
-    let (pagination_parameters, json_pointer) = PaginationParameters::parse(&query.ast);
+    let (pagination_parameters, json_pointer) = PaginationParameters::parse(&query.ast());
     query.pagination_parameters = pagination_parameters;
     query.json_pointer = json_pointer.map(Arc::from);
 

--- a/crates/runtime/src/dataconnector/github/pull_requests.rs
+++ b/crates/runtime/src/dataconnector/github/pull_requests.rs
@@ -56,7 +56,7 @@ impl GraphQLContext for PullRequestTableArgs {
     fn inject_parameters(
         &self,
         filters: &[FilterPushdownResult],
-        query: &mut GraphQLQuery<'_>,
+        query: &mut GraphQLQuery,
     ) -> Result<(), datafusion::error::DataFusionError> {
         if self.query_mode == GitHubQueryMode::Auto {
             return Ok(());

--- a/crates/runtime/tests/snapshots/integration__test_github_commits_auto.snap
+++ b/crates/runtime/tests/snapshots/integration__test_github_commits_auto.snap
@@ -10,6 +10,6 @@ description: "Query: SELECT * FROM spiceai_commits_auto LIMIT 10"
 |               |     TableScan: spiceai_commits_auto projection=[sha, id, author_name, author_email, committed_date, message, message_body, message_head_line, additions, deletions], fetch=10 |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                             |
 |               |   BytesProcessedExec                                                                                                                                                          |
-|               |     MemoryExec: partitions=1, partition_sizes=[10]                                                                                                                            |
+|               |     GraphQLTableProviderExec                                                                                                                                                  |
 |               |                                                                                                                                                                               |
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/runtime/tests/snapshots/integration__test_github_stargazers_auto.snap
+++ b/crates/runtime/tests/snapshots/integration__test_github_stargazers_auto.snap
@@ -10,6 +10,6 @@ description: "Query: SELECT * FROM spiceai_stargazers_auto LIMIT 10"
 |               |     TableScan: spiceai_stargazers_auto projection=[starred_at, login, email, name, company, x_username, location, avatar_url, bio], fetch=10 |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                            |
 |               |   BytesProcessedExec                                                                                                                         |
-|               |     MemoryExec: partitions=1, partition_sizes=[10]                                                                                           |
+|               |     GraphQLTableProviderExec                                                                                                                 |
 |               |                                                                                                                                              |
 +---------------+----------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/runtime/tests/snapshots/integration__test_graphql_pagination_select_all.snap
+++ b/crates/runtime/tests/snapshots/integration__test_graphql_pagination_select_all.snap
@@ -8,6 +8,6 @@ description: "Query: SELECT * FROM test_graphql"
 | logical_plan  | BytesProcessedNode                                     |
 |               |   TableScan: test_graphql projection=[id, name, posts] |
 | physical_plan | BytesProcessedExec                                     |
-|               |   MemoryExec: partitions=2, partition_sizes=[2, 2]     |
+|               |   GraphQLTableProviderExec                             |
 |               |                                                        |
 +---------------+--------------------------------------------------------+

--- a/crates/runtime/tests/snapshots/integration__test_graphql_pagination_select_limit_1_id_4.snap
+++ b/crates/runtime/tests/snapshots/integration__test_graphql_pagination_select_limit_1_id_4.snap
@@ -2,18 +2,19 @@
 source: crates/runtime/tests/integration.rs
 description: "Query: SELECT * FROM test_graphql where id = '4' limit 1"
 ---
-+---------------+------------------------------------------------------------+
-| plan_type     | plan                                                       |
-+---------------+------------------------------------------------------------+
-| logical_plan  | Limit: skip=0, fetch=1                                     |
-|               |   BytesProcessedNode                                       |
-|               |     Filter: test_graphql.id = Utf8("4")                    |
-|               |       TableScan: test_graphql projection=[id, name, posts] |
-| physical_plan | GlobalLimitExec: skip=0, fetch=1                           |
-|               |   CoalescePartitionsExec                                   |
-|               |     BytesProcessedExec                                     |
-|               |       CoalesceBatchesExec: target_batch_size=8192          |
-|               |         FilterExec: id@0 = 4                               |
-|               |           MemoryExec: partitions=2, partition_sizes=[2, 2] |
-|               |                                                            |
-+---------------+------------------------------------------------------------+
++---------------+--------------------------------------------------------------------------------+
+| plan_type     | plan                                                                           |
++---------------+--------------------------------------------------------------------------------+
+| logical_plan  | Limit: skip=0, fetch=1                                                         |
+|               |   BytesProcessedNode                                                           |
+|               |     Filter: test_graphql.id = Utf8("4")                                        |
+|               |       TableScan: test_graphql projection=[id, name, posts]                     |
+| physical_plan | GlobalLimitExec: skip=0, fetch=1                                               |
+|               |   CoalescePartitionsExec                                                       |
+|               |     BytesProcessedExec                                                         |
+|               |       CoalesceBatchesExec: target_batch_size=8192                              |
+|               |         FilterExec: id@0 = 4                                                   |
+|               |           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1 |
+|               |             GraphQLTableProviderExec                                           |
+|               |                                                                                |
++---------------+--------------------------------------------------------------------------------+

--- a/crates/runtime/tests/snapshots/integration__test_graphql_select_all.snap
+++ b/crates/runtime/tests/snapshots/integration__test_graphql_select_all.snap
@@ -8,6 +8,6 @@ description: "Query: SELECT * FROM test_graphql"
 | logical_plan  | BytesProcessedNode                                     |
 |               |   TableScan: test_graphql projection=[id, name, posts] |
 | physical_plan | BytesProcessedExec                                     |
-|               |   MemoryExec: partitions=1, partition_sizes=[4]        |
+|               |   GraphQLTableProviderExec                             |
 |               |                                                        |
 +---------------+--------------------------------------------------------+

--- a/crates/runtime/tests/snapshots/integration__test_graphql_select_posts_title.snap
+++ b/crates/runtime/tests/snapshots/integration__test_graphql_select_posts_title.snap
@@ -11,6 +11,7 @@ description: "Query: SELECT posts[1]['title'] from test_graphql"
 | physical_plan | ProjectionExec: expr=[get_field(array_element(posts@0, 1), title) as test_graphql.posts[Int64(1)][title]] |
 |               |   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1                                    |
 |               |     BytesProcessedExec                                                                                    |
-|               |       MemoryExec: partitions=1, partition_sizes=[4]                                                       |
+|               |       ProjectionExec: expr=[posts@2 as posts]                                                             |
+|               |         GraphQLTableProviderExec                                                                          |
 |               |                                                                                                           |
 +---------------+-----------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
# 🗣 Description

This PR implements proper streaming for the GitHub connector (backed by GraphQL tables). GitHub Files requires another update to properly stream results. That will come in the next PR.

This is part of the effort to move the GitHub Data Connector to Stable for the v1.0 release.

## 🔨 Related Issues

Part of #4039

## 🤔 Concerns

This PR makes use of unsafe Rust to remove lifetime parameters on the `GraphQLQuery` struct. In order to properly stream results, we need to return a stream object which references the query, and might outlive the parent struct. The `GraphQLQuery` node had a lifetime parameter because the parsed AST node referenced the source text it was parsed from. By embedding a smart pointer to the source text (as an Arc<str>) in the same struct, we can guarantee that the source text will live at least as long as the `GraphQLQuery` struct that relies on it. So we can safely mutate the lifetime reference internally to `'static`, as long as we never give out that static reference.

I've added two functions `ast()` and `ast_mut` which will downcast the lifetime reference to the lifetime of the struct, which upholds the safety guarantee.

This was the cleanest way I could think of to achieve what we wanted, without having to fork the graphql AST library to be able to support owned versions of the struct.

Another option would have been to use something like https://crates.io/crates/ouroboros to allow it to be a self-referencing struct - but I felt this was cleaner.