### PR TITLE
Extend flight compute context for spice.ai connector with org and app names, to fix federated queries from different spice.ai data sources

### DIFF
--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -107,8 +107,8 @@ impl FlightFactory {
     }
 
     #[must_use]
-    pub fn with_compute_context(mut self, compute_context: String) -> Self {
-        self.compute_context = Some(Arc::from(compute_context.as_str()));
+    pub fn with_compute_context(mut self, compute_context: &str) -> Self {
+        self.compute_context = Some(Arc::from(compute_context));
         self
     }
 
@@ -338,7 +338,7 @@ impl FlightTable {
 
     fn get_extended_context(base_context: &str, compute_context: Option<Arc<str>>) -> String {
         if let Some(compute_context) = compute_context {
-            format!("{},{}", base_context, compute_context)
+            format!("{base_context},{compute_context}")
         } else {
             base_context.to_string()
         }

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -75,6 +75,7 @@ pub struct FlightFactory {
     client: FlightClient,
     dialect: Arc<dyn Dialect>,
     subquery_use_partial_path: bool,
+    compute_context: Option<Arc<str>>,
 }
 
 impl FlightFactory {
@@ -90,6 +91,7 @@ impl FlightFactory {
             client,
             dialect,
             subquery_use_partial_path,
+            compute_context: None,
         }
     }
 
@@ -101,6 +103,12 @@ impl FlightFactory {
     #[must_use]
     pub fn with_metadata(mut self, metadata: MetadataMap) -> Self {
         self.client = self.client.with_metadata(metadata);
+        self
+    }
+
+    #[must_use]
+    pub fn with_compute_context(mut self, compute_context: String) -> Self {
+        self.compute_context = Some(Arc::from(compute_context.as_str()));
         self
     }
 
@@ -117,6 +125,7 @@ impl FlightFactory {
                 schema,
                 Arc::clone(&self.dialect),
                 self.subquery_use_partial_path,
+                self.compute_context.as_ref().map(Arc::clone),
             )),
             None => Arc::new(
                 FlightTable::create(
@@ -125,6 +134,7 @@ impl FlightFactory {
                     table_reference,
                     Arc::clone(&self.dialect),
                     self.subquery_use_partial_path,
+                    self.compute_context.as_ref().map(Arc::clone),
                 )
                 .await?,
             ),
@@ -198,6 +208,7 @@ impl FlightTable {
         table_reference: impl Into<MultiPartTableReference>,
         dialect: Arc<dyn Dialect>,
         subquery_use_partial_path: bool,
+        compute_context: Option<Arc<str>>,
     ) -> Result<Self> {
         let table_reference = table_reference.into();
         let schema = Self::get_query_schema(
@@ -208,17 +219,17 @@ impl FlightTable {
             ),
         )
         .await?;
+
+        let base_context = Self::get_base_context(&client);
+        let join_push_down_context = Self::get_extended_context(&base_context, compute_context);
+
         Ok(Self {
             name,
             client: client.clone(),
             schema,
             table_reference,
             dialect,
-            join_push_down_context: format!(
-                "url={},username={}",
-                client.url(),
-                client.username().unwrap_or_default()
-            ),
+            join_push_down_context,
             subquery_use_partial_path,
         })
     }
@@ -230,20 +241,21 @@ impl FlightTable {
         schema: SchemaRef,
         dialect: Arc<dyn Dialect>,
         subquery_use_partial_path: bool,
+        compute_context: Option<Arc<str>>,
     ) -> Self {
         let table_reference = table_reference.into();
         tracing::debug!("table_reference={:?}", table_reference);
+
+        let base_context = Self::get_base_context(&client);
+        let join_push_down_context = Self::get_extended_context(&base_context, compute_context);
+
         Self {
             name,
             client: client.clone(),
             schema,
             table_reference,
             dialect,
-            join_push_down_context: format!(
-                "url={},username={:?}",
-                client.url(),
-                client.username().unwrap_or_default()
-            ),
+            join_push_down_context,
             subquery_use_partial_path,
         }
     }
@@ -314,6 +326,22 @@ impl FlightTable {
 
     pub fn get_table_reference(&self) -> String {
         self.table_reference.to_string()
+    }
+
+    fn get_base_context(client: &FlightClient) -> String {
+        format!(
+            "url={},username={}",
+            client.url(),
+            client.username().unwrap_or_default()
+        )
+    }
+
+    fn get_extended_context(base_context: &str, compute_context: Option<Arc<str>>) -> String {
+        if let Some(compute_context) = compute_context {
+            format!("{},{}", base_context, compute_context)
+        } else {
+            base_context.to_string()
+        }
     }
 }
 

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -75,7 +75,7 @@ pub struct FlightFactory {
     client: FlightClient,
     dialect: Arc<dyn Dialect>,
     subquery_use_partial_path: bool,
-    compute_context: Option<Arc<str>>,
+    extra_compute_context: Option<Arc<str>>,
 }
 
 impl FlightFactory {
@@ -91,7 +91,7 @@ impl FlightFactory {
             client,
             dialect,
             subquery_use_partial_path,
-            compute_context: None,
+            extra_compute_context: None,
         }
     }
 
@@ -107,8 +107,8 @@ impl FlightFactory {
     }
 
     #[must_use]
-    pub fn with_compute_context(mut self, compute_context: &str) -> Self {
-        self.compute_context = Some(Arc::from(compute_context));
+    pub fn with_extra_compute_context(mut self, compute_context: &str) -> Self {
+        self.extra_compute_context = Some(Arc::from(compute_context));
         self
     }
 
@@ -125,7 +125,7 @@ impl FlightFactory {
                 schema,
                 Arc::clone(&self.dialect),
                 self.subquery_use_partial_path,
-                self.compute_context.as_ref().map(Arc::clone),
+                self.extra_compute_context.as_ref().map(Arc::clone),
             )),
             None => Arc::new(
                 FlightTable::create(
@@ -134,7 +134,7 @@ impl FlightFactory {
                     table_reference,
                     Arc::clone(&self.dialect),
                     self.subquery_use_partial_path,
-                    self.compute_context.as_ref().map(Arc::clone),
+                    self.extra_compute_context.as_ref().map(Arc::clone),
                 )
                 .await?,
             ),
@@ -208,7 +208,7 @@ impl FlightTable {
         table_reference: impl Into<MultiPartTableReference>,
         dialect: Arc<dyn Dialect>,
         subquery_use_partial_path: bool,
-        compute_context: Option<Arc<str>>,
+        extra_compute_context: Option<Arc<str>>,
     ) -> Result<Self> {
         let table_reference = table_reference.into();
         let schema = Self::get_query_schema(
@@ -221,7 +221,8 @@ impl FlightTable {
         .await?;
 
         let base_context = Self::get_base_context(&client);
-        let join_push_down_context = Self::get_extended_context(&base_context, compute_context);
+        let join_push_down_context =
+            Self::get_extended_context(&base_context, extra_compute_context);
 
         Ok(Self {
             name,
@@ -241,13 +242,14 @@ impl FlightTable {
         schema: SchemaRef,
         dialect: Arc<dyn Dialect>,
         subquery_use_partial_path: bool,
-        compute_context: Option<Arc<str>>,
+        extra_compute_context: Option<Arc<str>>,
     ) -> Self {
         let table_reference = table_reference.into();
         tracing::debug!("table_reference={:?}", table_reference);
 
         let base_context = Self::get_base_context(&client);
-        let join_push_down_context = Self::get_extended_context(&base_context, compute_context);
+        let join_push_down_context =
+            Self::get_extended_context(&base_context, extra_compute_context);
 
         Self {
             name,

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -208,7 +208,7 @@ impl DataConnector for SpiceAI {
             SpiceAIDatasetPath::OrgAppPath { org, app, path } => {
                 let mut map = MetadataMap::new();
 
-                let compute_context = format!(
+                let spiceai_context = format!(
                     "org={},app={}",
                     org.to_str().unwrap_or_default(),
                     app.to_str().unwrap_or_default()
@@ -220,7 +220,7 @@ impl DataConnector for SpiceAI {
                     self.flight_factory
                         .clone()
                         .with_metadata(map)
-                        .with_compute_context(compute_context.as_str()),
+                        .with_extra_compute_context(spiceai_context.as_str()),
                     path,
                 )
             }

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -207,9 +207,22 @@ impl DataConnector for SpiceAI {
         let (flight_factory, table_reference) = match dataset_path {
             SpiceAIDatasetPath::OrgAppPath { org, app, path } => {
                 let mut map = MetadataMap::new();
+
+                let compute_context = format!(
+                    "org={},app={}",
+                    org.to_str().unwrap_or_default(),
+                    app.to_str().unwrap_or_default()
+                );
+
                 map.insert(HEADER_ORG, org);
                 map.insert(HEADER_APP, app);
-                (self.flight_factory.clone().with_metadata(map), path)
+                (
+                    self.flight_factory
+                        .clone()
+                        .with_metadata(map)
+                        .with_compute_context(compute_context),
+                    path,
+                )
             }
             SpiceAIDatasetPath::Path(path) => (self.flight_factory.clone(), path),
         };

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -220,7 +220,7 @@ impl DataConnector for SpiceAI {
                     self.flight_factory
                         .clone()
                         .with_metadata(map)
-                        .with_compute_context(compute_context),
+                        .with_compute_context(compute_context.as_str()),
                     path,
                 )
             }


### PR DESCRIPTION
part of #3350 

Fixes federated queries from different spice.ai data sources by extending the flight compute context for the spice.ai connector with org and app names.

---

Sample spicepod:

```yaml
version: v1beta1
kind: Spicepod
name: sample

datasets:
  - from: spice.ai/spiceai/tpch/datasets/tpch.customer
    name: customer1

  - from: spice.ai/ewgenius/tpch/datasets/customer
    name: customer2
```

**Before**:

```console
sql> select customer1.c_name as name1, customer2.c_name as name2 from customer1, customer2 limit 2;
Query Error: table 'spice.public.customer' not found
```

execution plan:
```
+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | BytesProcessedNode                                                                                                                                                                                                                                                                                                                                             |
|               |   Federated                                                                                                                                                                                                                                                                                                                                                    |
|               |  Limit: skip=0, fetch=2                                                                                                                                                                                                                                                                                                                                        |
|               |   Projection: customer1.c_name AS name1, customer2.c_name AS name2                                                                                                                                                                                                                                                                                             |
|               |     Cross Join:                                                                                                                                                                                                                                                                                                                                                |
|               |       TableScan: customer1 projection=[c_name]                                                                                                                                                                                                                                                                                                                 |
|               |       TableScan: customer2 projection=[c_name]                                                                                                                                                                                                                                                                                                                 |
| physical_plan | BytesProcessedExec                                                                                                                                                                                                                                                                                                                                             |
|               |   SchemaCastScanExec                                                                                                                                                                                                                                                                                                                                           |
|               |     VirtualExecutionPlan name=spice.ai compute_context=url=https://flight.spiceai.io,username= sql=SELECT customer1.c_name AS name1, customer2.c_name AS name2 FROM customer1 JOIN customer2 ON true LIMIT 2 rewritten_sql=SELECT "tpch"."customer"."c_name" AS "name1", "customer"."c_name" AS "name2" FROM "tpch"."customer" JOIN "customer" ON true LIMIT 2 |
|               |                                                                                                                                                                                                                                                                                                                                                                |
+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

**After**:

```console
sql> select customer1.c_name as name1, customer2.c_name as name2 from customer1, customer2 limit 2;
+--------------------+--------------------+
| name1              | name2              |
+--------------------+--------------------+
| Customer#000098305 | Customer#000000001 |
| Customer#000098305 | Customer#000000002 |
+--------------------+--------------------+

Time: 44.072072041 seconds. 2 rows.
```

execution plan:
```
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                          |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: customer1.c_name AS name1, customer2.c_name AS name2                                                                                                                                                                              |
|               |   Limit: skip=0, fetch=2                                                                                                                                                                                                                      |
|               |     Cross Join:                                                                                                                                                                                                                               |
|               |       Limit: skip=0, fetch=2                                                                                                                                                                                                                  |
|               |         BytesProcessedNode                                                                                                                                                                                                                    |
|               |           Federated                                                                                                                                                                                                                           |
|               |  Projection: customer1.c_name                                                                                                                                                                                                                 |
|               |   TableScan: customer1 projection=[c_name]                                                                                                                                                                                                    |
|               |       Limit: skip=0, fetch=2                                                                                                                                                                                                                  |
|               |         BytesProcessedNode                                                                                                                                                                                                                    |
|               |           Federated                                                                                                                                                                                                                           |
|               |  Projection: customer2.c_name                                                                                                                                                                                                                 |
|               |   TableScan: customer2 projection=[c_name]                                                                                                                                                                                                    |
| physical_plan | ProjectionExec: expr=[c_name@0 as name1, c_name@1 as name2]                                                                                                                                                                                   |
|               |   GlobalLimitExec: skip=0, fetch=2                                                                                                                                                                                                            |
|               |     CoalescePartitionsExec                                                                                                                                                                                                                    |
|               |       CrossJoinExec                                                                                                                                                                                                                           |
|               |         BytesProcessedExec                                                                                                                                                                                                                    |
|               |           SchemaCastScanExec                                                                                                                                                                                                                  |
|               |             VirtualExecutionPlan name=spice.ai compute_context=url=https://flight.spiceai.io,username=,org=spiceai,app=tpch sql=SELECT customer1.c_name FROM customer1 rewritten_sql=SELECT "tpch"."customer"."c_name" FROM "tpch"."customer" |
|               |         RepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=1                                                                                                                                                                 |
|               |           BytesProcessedExec                                                                                                                                                                                                                  |
|               |             SchemaCastScanExec                                                                                                                                                                                                                |
|               |               VirtualExecutionPlan name=spice.ai compute_context=url=https://flight.spiceai.io,username=,org=ewgenius,app=tpch sql=SELECT customer2.c_name FROM customer2 rewritten_sql=SELECT "customer"."c_name" FROM "customer"            |
|               |                                                                                                                                                                                                                                               |
+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
