### PR TITLE
Promote Spicepod version to V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ spice add spiceai/quickstart
 The `spicepod.yaml` file will be updated with the `spiceai/quickstart` dependency.
 
 ```yaml
-version: v1beta1
+version: v1
 kind: Spicepod
 name: spice_qs
 dependencies:

--- a/bin/spice/pkg/spec/spicepod_test.go
+++ b/bin/spice/pkg/spec/spicepod_test.go
@@ -57,7 +57,7 @@ func convertMap(i interface{}) interface{} {
 
 func TestSpicepodSpec_UnmarshalYAML_KnownFields(t *testing.T) {
 	yamlText := `
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test-pod
 datasets:
@@ -80,8 +80,8 @@ dependencies:
 	}
 
 	// Verify known fields
-	if spicePod.Version != "v1beta1" {
-		t.Errorf("Expected version v1beta1, got %s", spicePod.Version)
+	if spicePod.Version != "v1" {
+		t.Errorf("Expected version v1, got %s", spicePod.Version)
 	}
 	if spicePod.Kind != "Spicepod" {
 		t.Errorf("Expected kind Spicepod, got %s", spicePod.Kind)
@@ -108,7 +108,7 @@ dependencies:
 
 func TestSpicepodSpec_UnmarshalYAML_UnknownFields(t *testing.T) {
 	yamlText := `
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test-pod
 datasets:
@@ -127,8 +127,8 @@ nested_unknown:
 	}
 
 	// Verify known fields
-	if spicePod.Version != "v1beta1" {
-		t.Errorf("Expected version v1beta1, got %s", spicePod.Version)
+	if spicePod.Version != "v1" {
+		t.Errorf("Expected version v1, got %s", spicePod.Version)
 	}
 
 	// Verify unknown fields are preserved in Node
@@ -168,7 +168,7 @@ nested_unknown:
 func TestSpicepodSpec_MarshalYAML(t *testing.T) {
 	// Create a SpicepodSpec with both known and unknown fields
 	yamlText := `
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test-pod
 datasets:
@@ -204,8 +204,8 @@ nested_unknown:
 	result = convertMap(result).(map[string]interface{})
 
 	// Check known fields
-	if result["version"] != "v1beta1" {
-		t.Errorf("Expected version v1beta1, got %v", result["version"])
+	if result["version"] != "v1" {
+		t.Errorf("Expected version v1, got %v", result["version"])
 	}
 	if result["kind"] != "Spicepod" {
 		t.Errorf("Expected kind Spicepod, got %v", result["kind"])
@@ -270,7 +270,7 @@ func TestSpicepodSpec_UnmarshalYAML_EdgeCases(t *testing.T) {
 		},
 		{
 			name:    "minimal valid document",
-			yaml:    "version: v1beta1\nkind: Spicepod\nname: test",
+			yaml:    "version: v1\nkind: Spicepod\nname: test",
 			wantErr: false,
 		},
 		{
@@ -281,7 +281,7 @@ func TestSpicepodSpec_UnmarshalYAML_EdgeCases(t *testing.T) {
 		{
 			name: "duplicate known and unknown fields",
 			yaml: `
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test-pod
 unknown_kind: different
@@ -335,7 +335,7 @@ unknown_version: v2
 
 func TestSpicepodSpec_EmptyDatasets(t *testing.T) {
 	yamlText := `
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test-pod
 datasets: []
@@ -353,7 +353,7 @@ datasets: []
 
 func TestSpicepodSpec_ComplexDatasets(t *testing.T) {
 	yamlText := `
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test-pod
 datasets:
@@ -448,7 +448,7 @@ datasets:
 
 func TestSpicepodSpec_PreserveYAMLStyle(t *testing.T) {
 	yamlText := `
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test-pod
 datasets:

--- a/bin/spice/pkg/spicepod/spicepod.go
+++ b/bin/spice/pkg/spicepod/spicepod.go
@@ -54,7 +54,7 @@ func CreateManifest(name string, spicepodDir string) (string, error) {
 	skeletonPod := &spec.SpicepodSpec{
 		SpicepodSpecFields: spec.SpicepodSpecFields{
 			Name:    name,
-			Version: "v1beta1",
+			Version: "v1",
 			Kind:    "Spicepod",
 		},
 	}

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -37,6 +37,7 @@ use crate::component::{
 #[serde(rename_all = "lowercase")]
 pub enum SpicepodVersion {
     V1Beta1,
+    V1,
 }
 
 impl Display for SpicepodVersion {

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -25,7 +25,7 @@ monitoring:
 
 spicepod:
   name: app
-  version: v1beta1
+  version: v1
   kind: Spicepod
 
   datasets: []

--- a/test/arrow-types/create_arrow_types_test_data.py
+++ b/test/arrow-types/create_arrow_types_test_data.py
@@ -80,7 +80,7 @@ for field in fields:
     print(conn.execute(f"DESCRIBE arrow_types.{table_name};").fetchall())
 
 # Generate the spicepod.yml that could be used to load the data
-config_content = """version: v1beta1
+config_content = """version: v1
 kind: Spicepod
 name: arrow-data-types
 datasets:

--- a/test/models/spicepod_hf.yml
+++ b/test/models/spicepod_hf.yml
@@ -1,4 +1,4 @@
-version: v1beta1
+version: v1
 kind: Spicepod
 name: ai-test-spicepod
 

--- a/test/models/spicepod_openai.yml
+++ b/test/models/spicepod_openai.yml
@@ -1,4 +1,4 @@
-version: v1beta1
+version: v1
 kind: Spicepod
 name: ai-test-spicepod
 

--- a/test/scripts/clickbench/setup-clickbench-spicepod.bash
+++ b/test/scripts/clickbench/setup-clickbench-spicepod.bash
@@ -98,7 +98,7 @@ if [ -f "spicepod.yaml" ]; then
   exit 1
 fi
 
-echo "version: v1beta1" >> spicepod.yaml
+echo "version: v1" >> spicepod.yaml
 echo "kind: Spicepod" >> spicepod.yaml
 echo "name: $dbname" >> spicepod.yaml
 

--- a/test/scripts/clickbench/setup-file.bash
+++ b/test/scripts/clickbench/setup-file.bash
@@ -17,7 +17,7 @@ if [ -f "spicepod.yaml" ]; then
   exit 1
 fi
 
-echo "version: v1beta1" >> spicepod.yaml
+echo "version: v1" >> spicepod.yaml
 echo "kind: Spicepod" >> spicepod.yaml
 echo "name: FileConnectorClickbench" >> spicepod.yaml
 

--- a/test/scripts/setup-semi-structure-spicepod.bash
+++ b/test/scripts/setup-semi-structure-spicepod.bash
@@ -179,7 +179,7 @@ if [ -f "spicepod.yaml" ]; then
   exit 1
 fi
 
-echo "version: v1beta1" >> spicepod.yaml
+echo "version: v1" >> spicepod.yaml
 echo "kind: Spicepod" >> spicepod.yaml
 echo "name: test" >> spicepod.yaml
 echo "datasets:" >> spicepod.yaml

--- a/test/scripts/setup-tpc-spicepod.bash
+++ b/test/scripts/setup-tpc-spicepod.bash
@@ -118,7 +118,7 @@ if [ -f "spicepod.yaml" ]; then
   exit 1
 fi
 
-echo "version: v1beta1" >> spicepod.yaml
+echo "version: v1" >> spicepod.yaml
 echo "kind: Spicepod" >> spicepod.yaml
 echo "name: $dbname" >> spicepod.yaml
 

--- a/test/tpc-bench/Makefile
+++ b/test/tpc-bench/Makefile
@@ -231,7 +231,7 @@ file-tpch-load:
 		echo "Loading $$table..."; \
 		cp ./tmp/$$table.parquet ./file-tpch-spicepod/$$table.parquet; \
 	done
-	@echo "version: v1beta1" >> ./file-tpch-spicepod/spicepod.yaml
+	@echo "version: v1" >> ./file-tpch-spicepod/spicepod.yaml
 	@echo "kind: Spicepod" >> ./file-tpch-spicepod/spicepod.yaml
 	@echo "name: file" >> ./file-tpch-spicepod/spicepod.yaml
 	@echo "datasets:" >> ./file-tpch-spicepod/spicepod.yaml
@@ -261,7 +261,7 @@ file-tpcds-load:
 		echo "Loading $$table..."; \
 		cp ./tmp/$$table.parquet ./file-tpcds-spicepod/$$table.parquet; \
 	done
-	@echo "version: v1beta1" >> ./file-tpcds-spicepod/spicepod.yaml
+	@echo "version: v1" >> ./file-tpcds-spicepod/spicepod.yaml
 	@echo "kind: Spicepod" >> ./file-tpcds-spicepod/spicepod.yaml
 	@echo "name: file" >> ./file-tpcds-spicepod/spicepod.yaml
 	@echo "datasets:" >> ./file-tpcds-spicepod/spicepod.yaml

--- a/test/tpc-bench/tpch-spicepod/spicepod.yaml
+++ b/test/tpc-bench/tpch-spicepod/spicepod.yaml
@@ -1,4 +1,4 @@
-version: v1beta1
+version: v1
 kind: Spicepod
 name: tpch-spicepod
 

--- a/tools/evalconverter/src/main.rs
+++ b/tools/evalconverter/src/main.rs
@@ -122,7 +122,7 @@ fn yaml_files_from(dir: &Path) -> Result<Vec<PathBuf>> {
 
 fn spicepod_definition(datasets: Vec<Dataset>, evals: Vec<Eval>) -> SpicepodDefinition {
     SpicepodDefinition {
-        version: SpicepodVersion::V1Beta1,
+        version: SpicepodVersion::V1,
         kind: SpicepodKind::Spicepod,
         name: "spicepod".to_string(),
         datasets: datasets


### PR DESCRIPTION
# 🗣 Description

Updates the default version of the Spicepod from `v1beta1` to `v1` in preparation for our 1.0 release.

The previous version `v1beta` is still accepted, but will no longer be referenced in our docs or generated by default.

## 🔨 Related Issues

N/A

## ⛓️‍💥 Breaking Change

* [x] "Breaking Change" label added if this PR is a breaking change

It isn't technically a breaking change - but it is a significant one.

## 📄 Documentation Updates

https://github.com/spiceai/docs/pull/715
https://github.com/spiceai/cookbook/pull/20

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
