### PR TITLE
Fix model name in `xAI`; add to `runtime/llms` tests

### DIFF
--- a/crates/llms/src/embeddings/candle/util.rs
+++ b/crates/llms/src/embeddings/candle/util.rs
@@ -192,14 +192,15 @@ pub(crate) fn max_seq_length_from_st_config(
 ///
 /// ```rust
 /// use std::collections::HashMap;
-/// use std::path::Path;
+/// use std::path::PathBuf;
+/// use llms::embeddings::candle::link_files_into_tmp_dir;
 ///
-/// let files: HashMap<String, &Path> = vec![
-///    ("model.safetensors".to_string(), Path::new("path/to/model.safetensors")),
-///   ("config.json".to_string(), Path::new("path/to/irrelevant_filename.json")),
+/// let files: HashMap<String, PathBuf> = vec![
+///    ("model.safetensors".to_string(), PathBuf::from("path/to/model.safetensors")),
+///   ("config.json".to_string(), PathBuf::from("path/to/irrelevant_filename.json")),
 /// ].into_iter().collect();
 ///
-/// let temp_dir = link_files_into_tmp_dir(files).unwrap();
+/// let temp_dir = link_files_into_tmp_dir(files);
 ///
 /// ```
 ///

--- a/crates/llms/src/xai.rs
+++ b/crates/llms/src/xai.rs
@@ -40,15 +40,15 @@ pub struct Xai {
 
 impl Xai {
     #[must_use]
-    pub fn new(api_base: Option<&str>, api_key: Option<&str>) -> Self {
-        let mut cfg = OpenAIConfig::default().with_api_base(api_base.unwrap_or(DEFAULT_ENDPOINT));
+    pub fn new(model: Option<&str>, api_key: Option<&str>) -> Self {
+        let mut cfg = OpenAIConfig::default().with_api_base(DEFAULT_ENDPOINT);
 
         if let Some(api_key) = api_key {
             cfg = cfg.with_api_key(api_key);
         }
 
         Self {
-            model: DEFAULT_MODEL.to_string(),
+            model: model.unwrap_or(DEFAULT_MODEL).to_string(),
             client: Client::with_config(cfg),
         }
     }

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -22,6 +22,7 @@ use llms::{
     chat::{create_hf_model, create_local_model, Chat, Error as ChatError},
     embeddings::candle::link_files_into_tmp_dir,
     openai::new_openai_client,
+    xai::Xai,
 };
 use secrecy::Secret;
 use std::{
@@ -30,6 +31,11 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+
+pub(crate) fn create_xai(model_id: &str) -> Arc<Box<dyn Chat>> {
+    let api_key = std::env::var("SPICE_XAI_API_KEY").ok();
+    Arc::new(Box::new(Xai::new(Some(model_id), api_key.as_deref())))
+}
 
 pub(crate) fn create_openai(model_id: &str) -> Arc<Box<dyn Chat>> {
     let api_key = std::env::var("SPICE_OPENAI_API_KEY").ok();

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -58,12 +58,13 @@ type ModelFn<'a> = (&'a str, Box<dyn Fn() -> Arc<Box<dyn Chat>>>);
 type ModelDef<'a> = (&'a str, Arc<Box<dyn Chat>>);
 #[allow(clippy::expect_used)]
 static TEST_MODELS: LazyLock<Vec<ModelDef>> = LazyLock::new(|| {
-    let model_creators: [ModelFn; 4] = [
+    let model_creators: [ModelFn; 5] = [
         (
             "anthropic",
             Box::new(|| create::create_anthropic(None).expect("failed to create anthropic model")),
         ),
         ("openai", Box::new(|| create::create_openai("gpt-4o-mini"))),
+        ("xai", Box::new(|| create::create_xai("grok-beta"))),
         (
             "hf_phi3",
             Box::new(|| {

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -265,16 +265,19 @@ macro_rules! generate_model_tests {
 
         test_model_case!(anthropic, basic);
         test_model_case!(openai, basic);
+        test_model_case!(xai, basic);
         test_model_case!(hf_phi3, basic);
         test_model_case!(local_phi3, basic);
 
         test_model_case!(anthropic, system_prompt);
         test_model_case!(openai, system_prompt);
+        test_model_case!(xai, system_prompt);
         test_model_case!(hf_phi3, system_prompt);
         test_model_case!(local_phi3, system_prompt);
 
         test_model_case!(anthropic, tool_use);
         test_model_case!(openai, tool_use);
+        test_model_case!(xai, tool_use);
         test_model_case!(hf_phi3, tool_use);
         test_model_case!(local_phi3, tool_use);
     };

--- a/crates/llms/tests/llms/snapshots/integration__llms__basic_xai_message_keys.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__basic_xai_message_keys.snap
@@ -1,0 +1,10 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  "assistant",
+  null,
+  null
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__basic_xai_replied_appropriately.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__basic_xai_replied_appropriately.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_xai_assistant_response.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_xai_assistant_response.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_xai_replied_appropriately.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__system_prompt_xai_replied_appropriately.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  1
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__tool_use_xai_finish_reason.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__tool_use_xai_finish_reason.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  "tool_calls"
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__tool_use_xai_tool_choice.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__tool_use_xai_tool_choice.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  "get_current_weather"
+]

--- a/crates/llms/tests/llms/snapshots/integration__llms__tool_use_xai_valid_function_args.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__tool_use_xai_valid_function_args.snap
@@ -1,0 +1,8 @@
+---
+source: crates/llms/tests/llms/mod.rs
+expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serialize snapshot\")"
+snapshot_kind: text
+---
+[
+  "{\"location\":\"Boston\",\"unit\":\"celsius\"}"
+]

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -108,7 +108,7 @@ pub async fn construct_model(
         ModelSource::Anthropic => anthropic(model_id.as_deref(), params),
         ModelSource::Azure => azure(model_id, component.name.as_str(), params),
         ModelSource::Xai => Ok(Box::new(Xai::new(
-            extract_secret!(params, "endpoint"),
+            model_id.as_deref(),
             extract_secret!(params, "xai_api_key"),
         )) as Box<dyn Chat>),
         ModelSource::OpenAi => Ok(openai(model_id, params)),


### PR DESCRIPTION
# 🗣 Description
 - xAI was not using the model name from the `from: xai:model_name`. 
 - Add xAI model type to `runtime/llms` tests.
 
 **Note**: Need to add env variable `SPICE_XAI_API_KEY` to GH actions CI. 
