### PR TITLE
Upload artifacts to Minio on build_and_release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -324,6 +324,47 @@ jobs:
             Copy-Item -Recurse -Force target/* C:/spiceai/build/target
           }
 
+  publish-minio:
+    name: Publish linux-x86_64 binaries to Minio
+    runs-on: spiceai-runners
+    env:
+      GOVER: 1.23.4
+      ARTIFACT_DIR: ./release
+      MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+      MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+      MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+      COMMIT_SHA: ${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: download artifacts - spice_linux_x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: spice_linux_x86_64
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_linux_x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_linux_x86_64
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_linux_x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_linux_x86_64
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: Upload artifacts to Minio
+        run: |
+          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo chmod +x /usr/local/bin/mc
+          mc alias set spice-minio ${{ env.MINIO_ENDPOINT }} ${{ env.MINIO_ACCESS_KEY }} ${{ env.MINIO_SECRET_KEY }}
+          mc cp ${{ env.ARTIFACT_DIR }}/spiced_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          mc cp ${{ env.ARTIFACT_DIR }}/spice_linux_x86_64.tar.gz spice-minio/artifacts/spice/linux-x86_64/${{ env.COMMIT_SHA }}/
+
   publish:
     name: Publish ${{ matrix.target_os }}-${{ matrix.target_arch }} binaries
     needs: build

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -327,6 +327,7 @@ jobs:
   publish-minio:
     name: Publish linux-x86_64 binaries to Minio
     runs-on: spiceai-runners
+    needs: build
     env:
       GOVER: 1.23.4
       ARTIFACT_DIR: ./release

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -358,6 +358,8 @@ jobs:
 
       - name: Upload artifacts to Minio
         run: |
+          sudo apt-get update
+          sudo apt-get install wget -y
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ env.MINIO_ENDPOINT }} ${{ env.MINIO_ACCESS_KEY }} ${{ env.MINIO_SECRET_KEY }}

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -14,6 +14,7 @@ on:
         required: false
         type: choice
         options:
+          - "all"
           - "Linux x64"
           - "Linux aarch64"
           - "macOS aarch64 (Apple Silicon)"


### PR DESCRIPTION
# 🗣 Description

Upload the linux binaries of `spice` and `spiced` on every trunk `build_and_release` so that we can re-use them for the throughput tests without needing to rebuild them.

## 🔨 Related Issues

N/A
