### PR TITLE
Introduce `supports_transactional_write` DataConnector flag for `read_write` mode

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -400,6 +400,10 @@ pub trait DataConnector: Send + Sync {
         None
     }
 
+    fn supports_transactional_write(&self) -> bool {
+        false
+    }
+
     async fn metadata_provider(
         &self,
         _dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -142,6 +142,10 @@ impl DataConnector for Postgres {
         self
     }
 
+    fn supports_transactional_write(&self) -> bool {
+        true
+    }
+
     #[cfg(feature = "postgres-write")]
     async fn read_write_provider(
         &self,

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -252,6 +252,10 @@ impl DataConnector for SpiceAI {
         }
     }
 
+    fn supports_transactional_write(&self) -> bool {
+        true
+    }
+
     async fn read_write_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -720,6 +720,14 @@ impl DataFusion {
                         .build()
                     })?
                     .context(UnableToResolveTableProviderSnafu)?;
+
+                if !source.supports_transactional_write() {
+                    tracing::warn!(
+                        "Table '{}' added with write capability, but its data connector does not fully support transactional writes or support depends on the target service. Concurrent writes may result in unexpected behavior.",
+                        dataset.name
+                    );
+                }
+
                 Arc::new(FederatedTable::new(read_write_provider))
             }
         };
@@ -1068,16 +1076,27 @@ impl DataFusion {
 
         let source_table_provider = match dataset.mode() {
             Mode::Read => federated_table_provider,
-            Mode::ReadWrite => source
-                .read_write_provider(dataset)
-                .await
-                .ok_or_else(|| {
-                    WriteProviderNotImplementedSnafu {
-                        table_name: dataset.name.to_string(),
-                    }
-                    .build()
-                })?
-                .context(UnableToResolveTableProviderSnafu)?,
+            Mode::ReadWrite => {
+                let read_write_provider = source
+                    .read_write_provider(dataset)
+                    .await
+                    .ok_or_else(|| {
+                        WriteProviderNotImplementedSnafu {
+                            table_name: dataset.name.to_string(),
+                        }
+                        .build()
+                    })?
+                    .context(UnableToResolveTableProviderSnafu)?;
+
+                if !source.supports_transactional_write() {
+                    tracing::warn!(
+                        "Table '{}' added with write capability, but its data connector does not fully support transactional writes or support depends on the target service. Concurrent writes may result in unexpected behavior.",
+                        dataset.name
+                    );
+                }
+
+                read_write_provider
+            }
         };
 
         self.register_metadata_table(dataset, Arc::clone(&source))

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -145,6 +145,10 @@ impl DataConnector for EmbeddingConnector {
             .await
     }
 
+    fn supports_transactional_write(&self) -> bool {
+        self.inner_connector.supports_transactional_write()
+    }
+
     async fn read_write_provider(
         &self,
         dataset: &Dataset,


### PR DESCRIPTION
# 🗣 Description

Introduce `supports_transactional_write` `DataConnector` flag indicating that concurrent writes for `read_write` table provider are safe. Motivation: not all DataConnectors can fully support concurrent/transactional writes that can lead to unpredicted state and unwanted behavior, PR adds warning message if write is configured for a DataConnector w/o explicitly marked transactional write support. 

Marked `spice.ai` and `postgres` as supporting transactional writes. List of other DataConnectors implementing `read_write_provider`:
 - `dremio`: requires additional review before setting `supports_transactional_write`
 - `memory`: based on implementation review write is performed after collecting all records and based on special rw lock which guarantees concurrent writes don't conflict (next write awaits for in-progress one to be fully completed). `supports_transactional_write` will be set via  separate PR after running test to confirm this behavior.

Alternative approach considered was detecting supports_transactional_write capability as part of Flight DoPut handler and rejecting write if DataConnector does  not have `supports_transactional_write` but found the following limitations with such approach:
 - For some DataConnectors (for example Flight) support is based on underlaying server implementation (Flight Server / DoPut handler implementation) so not always could be set for a DataConnector thus warning instead of full rejection is preferred approach IMO.
 - Detecting DataConnector source based on  dyn TableProvider is not always possible for Federated Tables and requires using dataset definition to reconstruct DataConnector which brings additional overhead so it is proposed to use warning message during writable Table creation instead of adding verification into Flight DoPut. 

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
