### PR TITLE
Update spice cli to use `GH_TOKEN` or `GITHUB_TOKEN` env variables when calling releases api

### DIFF
--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -75,9 +75,6 @@ jobs:
 
     - name: start Spice runtime
       if: matrix.target_os != 'windows'
-      env:
-        # pass github token to spice cli
-        SPICE_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         spice init app
         cd app
@@ -85,9 +82,6 @@ jobs:
   
     - name: start Spice runtime (Windows)
       if: matrix.target_os == 'windows'
-      env:
-        # pass github token to spice cli
-        SPICE_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         spice init app
         cd app

--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -75,6 +75,9 @@ jobs:
 
     - name: start Spice runtime
       if: matrix.target_os != 'windows'
+      env:
+        # pass github token to spice cli
+        SPICE_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         spice init app
         cd app
@@ -82,6 +85,9 @@ jobs:
   
     - name: start Spice runtime (Windows)
       if: matrix.target_os == 'windows'
+      env:
+        # pass github token to spice cli
+        SPICE_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         spice init app
         cd app

--- a/bin/spice/pkg/github/github.go
+++ b/bin/spice/pkg/github/github.go
@@ -28,8 +28,9 @@ import (
 )
 
 type GitHubClient struct {
-	Owner string
-	Repo  string
+	Owner       string
+	Repo        string
+	accessToken string
 }
 
 func NewGitHubClientFromPath(path string) (*GitHubClient, error) {
@@ -47,8 +48,9 @@ func NewGitHubClientFromPath(path string) (*GitHubClient, error) {
 
 func NewGitHubClient(owner string, repo string) *GitHubClient {
 	return &GitHubClient{
-		Owner: owner,
-		Repo:  repo,
+		Owner:       owner,
+		Repo:        repo,
+		accessToken: os.Getenv("SPICE_CLI_GITHUB_TOKEN"),
 	}
 }
 
@@ -88,6 +90,11 @@ func (g *GitHubClient) call(method string, url string, payload []byte, accept st
 
 	if accept != "" {
 		req.Header.Add("Accept", accept)
+	}
+
+	// Add Authorization header if GITHUB_TOKEN is present
+	if g.accessToken != "" {
+		req.Header.Add("Authorization", "Bearer "+g.accessToken)
 	}
 
 	response, err := http.DefaultClient.Do(req)

--- a/bin/spice/pkg/github/github.go
+++ b/bin/spice/pkg/github/github.go
@@ -28,9 +28,9 @@ import (
 )
 
 type GitHubClient struct {
-	Owner       string
-	Repo        string
-	accessToken string
+	token string
+	Owner string
+	Repo  string
 }
 
 func NewGitHubClientFromPath(path string) (*GitHubClient, error) {
@@ -47,10 +47,15 @@ func NewGitHubClientFromPath(path string) (*GitHubClient, error) {
 }
 
 func NewGitHubClient(owner string, repo string) *GitHubClient {
+	token := os.Getenv("GH_TOKEN")
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+
 	return &GitHubClient{
-		Owner:       owner,
-		Repo:        repo,
-		accessToken: os.Getenv("SPICE_CLI_GITHUB_TOKEN"),
+		token: token,
+		Owner: owner,
+		Repo:  repo,
 	}
 }
 
@@ -93,8 +98,8 @@ func (g *GitHubClient) call(method string, url string, payload []byte, accept st
 	}
 
 	// Add Authorization header if GITHUB_TOKEN is present
-	if g.accessToken != "" {
-		req.Header.Add("Authorization", "Bearer "+g.accessToken)
+	if g.token != "" {
+		req.Header.Add("Authorization", "Bearer "+g.token)
 	}
 
 	response, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
closes #4086 

When checking for latest available release, Spice CLI will use `GH_TOKEN` or `GITHUB_TOKEN` (in the order of precedence) to authenticate GitHub requests. That is needed to fix E2E Test Release Installation which is gets rate limited.