### PR TITLE
Disable spice.ai connector integration test

### DIFF
--- a/crates/runtime/tests/spiceai/mod.rs
+++ b/crates/runtime/tests/spiceai/mod.rs
@@ -45,6 +45,7 @@ fn make_spiceai_dataset(path: &str, name: &str) -> Dataset {
 }
 
 #[tokio::test]
+#[ignore]
 async fn spiceai_federation() -> Result<(), anyhow::Error> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _tracing = init_tracing(Some("integration=debug,info"));


### PR DESCRIPTION
The query used for testing returns non-deterministic results, test needs to be reworked.