### PR TITLE
Add TSV format to all `object_store`-based connectors

### DIFF
--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -21,6 +21,8 @@ use super::{
 };
 
 use crate::component::dataset::Dataset;
+use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
+use lazy_static::lazy_static;
 use snafu::prelude::*;
 use std::any::Any;
 use std::clone::Clone;
@@ -70,95 +72,83 @@ impl AzureBlobFSFactory {
     }
 }
 
-const PARAMETERS: &[ParameterSpec] = &[
-    ParameterSpec::connector("account")
-        .description("Azure Storage account name.")
-        .secret(),
-    ParameterSpec::connector("container_name")
-        .description("Azure Storage container name.")
-        .secret(),
-    ParameterSpec::connector("access_key")
-        .description("Azure Storage account access key.")
-        .secret(),
-    ParameterSpec::connector("bearer_token")
-        .description("Bearer token to use in Azure requests.")
-        .secret(),
-    ParameterSpec::connector("client_id")
-        .description("Azure client ID.")
-        .secret(),
-    ParameterSpec::connector("client_secret")
-        .description("Azure client secret.")
-        .secret(),
-    ParameterSpec::connector("tenant_id")
-        .description("Azure tenant ID.")
-        .secret(),
-    ParameterSpec::connector("sas_string")
-        .description("Azure SAS string.")
-        .secret(),
-    ParameterSpec::connector("endpoint")
-        .description("Azure Storage endpoint.")
-        .secret(),
-    ParameterSpec::connector("use_emulator")
-        .description("Use the Azure Storage emulator.")
-        .default("false"),
-    ParameterSpec::connector("use_fabric_endpoint")
-        .description("Use the Azure Storage fabric endpoint.")
-        .default("false"),
-    ParameterSpec::connector("allow_http")
-        .description("Allow insecure HTTP connections.")
-        .default("false"),
-    ParameterSpec::connector("authority_host")
-        .description("Sets an alternative authority host."),
-    ParameterSpec::connector("max_retries")
-        .description("The maximum number of retries.")
-        .default("3"),
-    ParameterSpec::connector("retry_timeout")
-        .description("Retry timeout."),
-    ParameterSpec::connector("backoff_initial_duration")
-        .description("Initial backoff duration."),
-    ParameterSpec::connector("backoff_max_duration")
-        .description("Maximum backoff duration."),
-    ParameterSpec::connector("backoff_base")
-        .description("The base of the exponential to use"),
-    ParameterSpec::connector("proxy_url")
-        .description("Proxy URL to use when connecting"),
-    ParameterSpec::connector("proxy_ca_certificate")
-        .description("CA certificate for the proxy.")
-        .secret(),
-    ParameterSpec::connector("proxy_excludes")
-        .description("Set list of hosts to exclude from proxy connections"),
-    ParameterSpec::connector("msi_endpoint")
-        .description("Sets the endpoint for acquiring managed identity tokens.")
-        .secret(),
-    ParameterSpec::connector("federated_token_file")
-        .description("Sets a file path for acquiring Azure federated identity token in Kubernetes"),
-    ParameterSpec::connector("use_cli")
-        .description("Set if the Azure CLI should be used for acquiring access tokens."),
-    ParameterSpec::connector("skip_signature")
-        .description("Skip fetching credentials and skip signing requests. Used for interacting with public containers."),
-    ParameterSpec::connector("disable_tagging")
-        .description("Ignore any tags provided to put_opts"),
+lazy_static! {
+    static ref PARAMETERS: Vec<ParameterSpec> = {
+        let mut all_parameters = Vec::new();
+        all_parameters.extend_from_slice(&[
+            ParameterSpec::connector("account")
+                .description("Azure Storage account name.")
+                .secret(),
+            ParameterSpec::connector("container_name")
+                .description("Azure Storage container name.")
+                .secret(),
+            ParameterSpec::connector("access_key")
+                .description("Azure Storage account access key.")
+                .secret(),
+            ParameterSpec::connector("bearer_token")
+                .description("Bearer token to use in Azure requests.")
+                .secret(),
+            ParameterSpec::connector("client_id")
+                .description("Azure client ID.")
+                .secret(),
+            ParameterSpec::connector("client_secret")
+                .description("Azure client secret.")
+                .secret(),
+            ParameterSpec::connector("tenant_id")
+                .description("Azure tenant ID.")
+                .secret(),
+            ParameterSpec::connector("sas_string")
+                .description("Azure SAS string.")
+                .secret(),
+            ParameterSpec::connector("endpoint")
+                .description("Azure Storage endpoint.")
+                .secret(),
+            ParameterSpec::connector("use_emulator")
+                .description("Use the Azure Storage emulator.")
+                .default("false"),
+            ParameterSpec::connector("use_fabric_endpoint")
+                .description("Use the Azure Storage fabric endpoint.")
+                .default("false"),
+            ParameterSpec::connector("allow_http")
+                .description("Allow insecure HTTP connections.")
+                .default("false"),
+            ParameterSpec::connector("authority_host")
+                .description("Sets an alternative authority host."),
+            ParameterSpec::connector("max_retries")
+                .description("The maximum number of retries.")
+                .default("3"),
+            ParameterSpec::connector("retry_timeout")
+                .description("Retry timeout."),
+            ParameterSpec::connector("backoff_initial_duration")
+                .description("Initial backoff duration."),
+            ParameterSpec::connector("backoff_max_duration")
+                .description("Maximum backoff duration."),
+            ParameterSpec::connector("backoff_base")
+                .description("The base of the exponential to use"),
+            ParameterSpec::connector("proxy_url")
+                .description("Proxy URL to use when connecting"),
+            ParameterSpec::connector("proxy_ca_certificate")
+                .description("CA certificate for the proxy.")
+                .secret(),
+            ParameterSpec::connector("proxy_excludes")
+                .description("Set list of hosts to exclude from proxy connections"),
+            ParameterSpec::connector("msi_endpoint")
+                .description("Sets the endpoint for acquiring managed identity tokens.")
+                .secret(),
+            ParameterSpec::connector("federated_token_file")
+                .description("Sets a file path for acquiring Azure federated identity token in Kubernetes"),
+            ParameterSpec::connector("use_cli")
+                .description("Set if the Azure CLI should be used for acquiring access tokens."),
+            ParameterSpec::connector("skip_signature")
+                .description("Skip fetching credentials and skip signing requests. Used for interacting with public containers."),
+            ParameterSpec::connector("disable_tagging")
+                .description("Ignore any tags provided to put_opts"),
 
-    // Common listing table parameters
-    ParameterSpec::runtime("file_format"),
-    ParameterSpec::runtime("file_extension"),
-    ParameterSpec::runtime("schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
-    ParameterSpec::runtime("csv_has_header")
-        .description("Set true to indicate that the first line is a header."),
-    ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
-    ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
-    ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema.")
-        .deprecated("use 'schema_infer_max_records' instead"),
-
-    ParameterSpec::runtime("csv_delimiter")
-        .description("The character separating values within a row."),
-    ParameterSpec::runtime("file_compression_type")
-        .description("The type of compression used on the file. Supported types are: gzip, bzip2, xz, zstd, uncompressed"),
-    ParameterSpec::runtime("hive_partitioning_enabled")
-        .description("Enable partitioning using hive-style partitioning from the folder structure. Defaults to false."),
-];
+        ]);
+        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+        all_parameters
+    };
+}
 
 impl DataConnectorFactory for AzureBlobFSFactory {
     fn create(
@@ -221,7 +211,7 @@ impl DataConnectorFactory for AzureBlobFSFactory {
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
-        PARAMETERS
+        &PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -22,14 +22,13 @@ use super::{
 
 use crate::component::dataset::Dataset;
 use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
-use lazy_static::lazy_static;
 use snafu::prelude::*;
 use std::any::Any;
 use std::clone::Clone;
 use std::future::Future;
 use std::pin::Pin;
 use std::string::String;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use url::Url;
 
 #[derive(Debug, Snafu)]
@@ -72,83 +71,81 @@ impl AzureBlobFSFactory {
     }
 }
 
-lazy_static! {
-    static ref PARAMETERS: Vec<ParameterSpec> = {
-        let mut all_parameters = Vec::new();
-        all_parameters.extend_from_slice(&[
-            ParameterSpec::connector("account")
-                .description("Azure Storage account name.")
-                .secret(),
-            ParameterSpec::connector("container_name")
-                .description("Azure Storage container name.")
-                .secret(),
-            ParameterSpec::connector("access_key")
-                .description("Azure Storage account access key.")
-                .secret(),
-            ParameterSpec::connector("bearer_token")
-                .description("Bearer token to use in Azure requests.")
-                .secret(),
-            ParameterSpec::connector("client_id")
-                .description("Azure client ID.")
-                .secret(),
-            ParameterSpec::connector("client_secret")
-                .description("Azure client secret.")
-                .secret(),
-            ParameterSpec::connector("tenant_id")
-                .description("Azure tenant ID.")
-                .secret(),
-            ParameterSpec::connector("sas_string")
-                .description("Azure SAS string.")
-                .secret(),
-            ParameterSpec::connector("endpoint")
-                .description("Azure Storage endpoint.")
-                .secret(),
-            ParameterSpec::connector("use_emulator")
-                .description("Use the Azure Storage emulator.")
-                .default("false"),
-            ParameterSpec::connector("use_fabric_endpoint")
-                .description("Use the Azure Storage fabric endpoint.")
-                .default("false"),
-            ParameterSpec::connector("allow_http")
-                .description("Allow insecure HTTP connections.")
-                .default("false"),
-            ParameterSpec::connector("authority_host")
-                .description("Sets an alternative authority host."),
-            ParameterSpec::connector("max_retries")
-                .description("The maximum number of retries.")
-                .default("3"),
-            ParameterSpec::connector("retry_timeout")
-                .description("Retry timeout."),
-            ParameterSpec::connector("backoff_initial_duration")
-                .description("Initial backoff duration."),
-            ParameterSpec::connector("backoff_max_duration")
-                .description("Maximum backoff duration."),
-            ParameterSpec::connector("backoff_base")
-                .description("The base of the exponential to use"),
-            ParameterSpec::connector("proxy_url")
-                .description("Proxy URL to use when connecting"),
-            ParameterSpec::connector("proxy_ca_certificate")
-                .description("CA certificate for the proxy.")
-                .secret(),
-            ParameterSpec::connector("proxy_excludes")
-                .description("Set list of hosts to exclude from proxy connections"),
-            ParameterSpec::connector("msi_endpoint")
-                .description("Sets the endpoint for acquiring managed identity tokens.")
-                .secret(),
-            ParameterSpec::connector("federated_token_file")
-                .description("Sets a file path for acquiring Azure federated identity token in Kubernetes"),
-            ParameterSpec::connector("use_cli")
-                .description("Set if the Azure CLI should be used for acquiring access tokens."),
-            ParameterSpec::connector("skip_signature")
-                .description("Skip fetching credentials and skip signing requests. Used for interacting with public containers."),
-            ParameterSpec::connector("disable_tagging")
-                .description("Ignore any tags provided to put_opts"),
+static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
+    let mut all_parameters = Vec::new();
+    all_parameters.extend_from_slice(&[
+        ParameterSpec::connector("account")
+            .description("Azure Storage account name.")
+            .secret(),
+        ParameterSpec::connector("container_name")
+            .description("Azure Storage container name.")
+            .secret(),
+        ParameterSpec::connector("access_key")
+            .description("Azure Storage account access key.")
+            .secret(),
+        ParameterSpec::connector("bearer_token")
+            .description("Bearer token to use in Azure requests.")
+            .secret(),
+        ParameterSpec::connector("client_id")
+            .description("Azure client ID.")
+            .secret(),
+        ParameterSpec::connector("client_secret")
+            .description("Azure client secret.")
+            .secret(),
+        ParameterSpec::connector("tenant_id")
+            .description("Azure tenant ID.")
+            .secret(),
+        ParameterSpec::connector("sas_string")
+            .description("Azure SAS string.")
+            .secret(),
+        ParameterSpec::connector("endpoint")
+            .description("Azure Storage endpoint.")
+            .secret(),
+        ParameterSpec::connector("use_emulator")
+            .description("Use the Azure Storage emulator.")
+            .default("false"),
+        ParameterSpec::connector("use_fabric_endpoint")
+            .description("Use the Azure Storage fabric endpoint.")
+            .default("false"),
+        ParameterSpec::connector("allow_http")
+            .description("Allow insecure HTTP connections.")
+            .default("false"),
+        ParameterSpec::connector("authority_host")
+            .description("Sets an alternative authority host."),
+        ParameterSpec::connector("max_retries")
+            .description("The maximum number of retries.")
+            .default("3"),
+        ParameterSpec::connector("retry_timeout")
+            .description("Retry timeout."),
+        ParameterSpec::connector("backoff_initial_duration")
+            .description("Initial backoff duration."),
+        ParameterSpec::connector("backoff_max_duration")
+            .description("Maximum backoff duration."),
+        ParameterSpec::connector("backoff_base")
+            .description("The base of the exponential to use"),
+        ParameterSpec::connector("proxy_url")
+            .description("Proxy URL to use when connecting"),
+        ParameterSpec::connector("proxy_ca_certificate")
+            .description("CA certificate for the proxy.")
+            .secret(),
+        ParameterSpec::connector("proxy_excludes")
+            .description("Set list of hosts to exclude from proxy connections"),
+        ParameterSpec::connector("msi_endpoint")
+            .description("Sets the endpoint for acquiring managed identity tokens.")
+            .secret(),
+        ParameterSpec::connector("federated_token_file")
+            .description("Sets a file path for acquiring Azure federated identity token in Kubernetes"),
+        ParameterSpec::connector("use_cli")
+            .description("Set if the Azure CLI should be used for acquiring access tokens."),
+        ParameterSpec::connector("skip_signature")
+            .description("Skip fetching credentials and skip signing requests. Used for interacting with public containers."),
+        ParameterSpec::connector("disable_tagging")
+            .description("Ignore any tags provided to put_opts"),
 
-        ]);
-        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
-        all_parameters
-    };
-}
+    ]);
+    all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+    all_parameters
+});
 
 impl DataConnectorFactory for AzureBlobFSFactory {
     fn create(

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -16,8 +16,10 @@ limitations under the License.
 
 use crate::accelerated_table::AcceleratedTable;
 use crate::component::dataset::Dataset;
+use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
 use crate::dataconnector::ConnectorComponent;
 use async_trait::async_trait;
+
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use snafu::prelude::*;
 use std::future::Future;
@@ -62,31 +64,6 @@ impl FileFactory {
     }
 }
 
-const PARAMETERS: &[ParameterSpec] = &[
-    // Common listing table parameters
-    ParameterSpec::runtime("file_format"),
-    ParameterSpec::runtime("file_extension"),
-    ParameterSpec::runtime("schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
-    ParameterSpec::runtime("csv_has_header")
-        .description("Set true to indicate that the first line is a header."),
-    ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
-    ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
-    ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema.")
-        .deprecated("use 'schema_infer_max_records' instead"),
-    ParameterSpec::runtime("tsv_has_header")
-        .description("Set true to indicate that the first line is a header."),
-    ParameterSpec::runtime("tsv_quote").description("The quote character in a row."),
-    ParameterSpec::runtime("tsv_escape").description("The escape character in a row."),
-    ParameterSpec::runtime("csv_delimiter")
-        .description("The character separating values within a row."),
-    ParameterSpec::runtime("file_compression_type")
-        .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
-    ParameterSpec::runtime("hive_partitioning_enabled")
-        .description("Enable partitioning using hive-style partitioning from the folder structure. Defaults to false."),
-];
-
 impl DataConnectorFactory for FileFactory {
     fn create(
         &self,
@@ -104,7 +81,7 @@ impl DataConnectorFactory for FileFactory {
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
-        PARAMETERS
+        LISTING_TABLE_PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 use crate::component::dataset::Dataset;
+use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
+use lazy_static::lazy_static;
 use snafu::prelude::*;
 use std::any::Any;
 use std::future::Future;
@@ -53,32 +55,20 @@ impl FTPFactory {
     }
 }
 
-const PARAMETERS: &[ParameterSpec] = &[
-    ParameterSpec::connector("user").secret(),
-    ParameterSpec::connector("pass").secret(),
-    ParameterSpec::connector("port").description("The port to connect to."),
-    ParameterSpec::runtime("client_timeout")
-        .description("The timeout setting for FTP client."),
-
-    // Common listing table parameters
-    ParameterSpec::runtime("file_format"),
-    ParameterSpec::runtime("file_extension"),
-    ParameterSpec::runtime("schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
-    ParameterSpec::runtime("csv_has_header")
-        .description("Set true to indicate that the first line is a header."),
-    ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
-    ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
-    ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema.")
-        .deprecated("use 'schema_infer_max_records' instead"),
-    ParameterSpec::runtime("csv_delimiter")
-        .description("The character separating values within a row."),
-    ParameterSpec::runtime("file_compression_type")
-        .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
-    ParameterSpec::runtime("hive_partitioning_enabled")
-        .description("Enable partitioning using hive-style partitioning from the folder structure. Defaults to false."),
-];
+lazy_static! {
+    static ref PARAMETERS: Vec<ParameterSpec> = {
+        let mut all_parameters = Vec::new();
+        all_parameters.extend_from_slice(&[
+            ParameterSpec::connector("user").secret(),
+            ParameterSpec::connector("pass").secret(),
+            ParameterSpec::connector("port").description("The port to connect to."),
+            ParameterSpec::runtime("client_timeout")
+                .description("The timeout setting for FTP client."),
+        ]);
+        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+        all_parameters
+    };
+}
 
 impl DataConnectorFactory for FTPFactory {
     fn create(
@@ -98,7 +88,7 @@ impl DataConnectorFactory for FTPFactory {
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
-        PARAMETERS
+        &PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -16,12 +16,11 @@ limitations under the License.
 
 use crate::component::dataset::Dataset;
 use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
-use lazy_static::lazy_static;
 use snafu::prelude::*;
 use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use url::Url;
 
 use super::{listing, ConnectorComponent, ConnectorParams};
@@ -55,20 +54,17 @@ impl FTPFactory {
     }
 }
 
-lazy_static! {
-    static ref PARAMETERS: Vec<ParameterSpec> = {
-        let mut all_parameters = Vec::new();
-        all_parameters.extend_from_slice(&[
-            ParameterSpec::connector("user").secret(),
-            ParameterSpec::connector("pass").secret(),
-            ParameterSpec::connector("port").description("The port to connect to."),
-            ParameterSpec::runtime("client_timeout")
-                .description("The timeout setting for FTP client."),
-        ]);
-        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
-        all_parameters
-    };
-}
+static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
+    let mut all_parameters = Vec::new();
+    all_parameters.extend_from_slice(&[
+        ParameterSpec::connector("user").secret(),
+        ParameterSpec::connector("pass").secret(),
+        ParameterSpec::connector("port").description("The port to connect to."),
+        ParameterSpec::runtime("client_timeout").description("The timeout setting for FTP client."),
+    ]);
+    all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+    all_parameters
+});
 
 impl DataConnectorFactory for FTPFactory {
     fn create(

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -15,6 +15,9 @@ limitations under the License.
 */
 
 use crate::component::dataset::Dataset;
+use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
+use lazy_static::lazy_static;
+
 use snafu::prelude::*;
 use std::any::Any;
 use std::future::Future;
@@ -54,30 +57,20 @@ impl HttpsFactory {
     }
 }
 
-const PARAMETERS: &[ParameterSpec] = &[
-    ParameterSpec::connector("username").secret(),
-    ParameterSpec::connector("password").secret(),
-    ParameterSpec::connector("port").description("The port to connect to."),
-    ParameterSpec::runtime("client_timeout")
-        .description("The timeout setting for HTTP(S) client."),
-
-    // Common listing table parameters
-    ParameterSpec::runtime("file_format"),
-    ParameterSpec::runtime("file_extension"),
-    ParameterSpec::runtime("schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
-    ParameterSpec::runtime("csv_has_header")
-        .description("Set true to indicate that the first line is a header."),
-    ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
-    ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
-    ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema.")
-        .deprecated("use 'schema_infer_max_records' instead"),
-    ParameterSpec::runtime("csv_delimiter")
-        .description("The character separating values within a row."),
-    ParameterSpec::runtime("file_compression_type")
-        .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
-];
+lazy_static! {
+    static ref PARAMETERS: Vec<ParameterSpec> = {
+        let mut all_parameters = Vec::new();
+        all_parameters.extend_from_slice(&[
+            ParameterSpec::connector("username").secret(),
+            ParameterSpec::connector("password").secret(),
+            ParameterSpec::connector("port").description("The port to connect to."),
+            ParameterSpec::runtime("client_timeout")
+                .description("The timeout setting for HTTP(S) client."),
+        ]);
+        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+        all_parameters
+    };
+}
 
 impl DataConnectorFactory for HttpsFactory {
     fn create(
@@ -96,7 +89,7 @@ impl DataConnectorFactory for HttpsFactory {
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
-        PARAMETERS
+        &PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -16,13 +16,12 @@ limitations under the License.
 
 use crate::component::dataset::Dataset;
 use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
-use lazy_static::lazy_static;
 
 use snafu::prelude::*;
 use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use url::Url;
 
 use super::{
@@ -57,20 +56,18 @@ impl HttpsFactory {
     }
 }
 
-lazy_static! {
-    static ref PARAMETERS: Vec<ParameterSpec> = {
-        let mut all_parameters = Vec::new();
-        all_parameters.extend_from_slice(&[
-            ParameterSpec::connector("username").secret(),
-            ParameterSpec::connector("password").secret(),
-            ParameterSpec::connector("port").description("The port to connect to."),
-            ParameterSpec::runtime("client_timeout")
-                .description("The timeout setting for HTTP(S) client."),
-        ]);
-        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
-        all_parameters
-    };
-}
+static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
+    let mut all_parameters = Vec::new();
+    all_parameters.extend_from_slice(&[
+        ParameterSpec::connector("username").secret(),
+        ParameterSpec::connector("password").secret(),
+        ParameterSpec::connector("port").description("The port to connect to."),
+        ParameterSpec::runtime("client_timeout")
+            .description("The timeout setting for HTTP(S) client."),
+    ]);
+    all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+    all_parameters
+});
 
 impl DataConnectorFactory for HttpsFactory {
     fn create(

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -52,6 +52,7 @@ use url::Url;
 use crate::object_store_registry::default_runtime_env;
 
 use super::infer::infer_partitions_with_types;
+use super::DelimitedFormat;
 
 #[async_trait]
 pub trait ListingTableConnector: DataConnector {
@@ -148,11 +149,11 @@ pub trait ListingTableConnector: DataConnector {
 
         match (file_format_param, file_extension.as_deref()) {
             (Some("csv"), _) | (None, Some("csv")) => Ok((
-                Some(self.get_csv_format(dataset, params)?),
+                Some(self.delimiter_separated_format(dataset, params, DelimitedFormat::Csv)?),
                 extension.unwrap_or(".csv".to_string()),
             )),
             (Some("tsv"), _) | (None, Some("tsv")) => Ok((
-                Some(self.get_tsv_format(dataset, params)?),
+                Some(self.delimiter_separated_format(dataset, params, DelimitedFormat::Tsv)?),
                 extension.unwrap_or(".tsv".to_string()),
             )),
             (Some("jsonl"), _) | (None, Some("jsonl"))=> Ok((
@@ -217,26 +218,34 @@ pub trait ListingTableConnector: DataConnector {
         Ok(Arc::new(format))
     }
 
-    fn get_csv_format(
+    /// Returns a [`CsvFormat`] based on the provided [`Datasets`] parameters, and choice of delimiter.
+    ///
+    /// Uses the appropriate parameters based on the [`DelimitedFormat`] provided.
+    fn delimiter_separated_format(
         &self,
         dataset: &Dataset,
         params: &Parameters,
+        delimiter: DelimitedFormat,
     ) -> DataConnectorResult<Arc<CsvFormat>>
     where
         Self: Display,
     {
+        let has_header_key = format!("{delimiter}_has_header");
+        let quote_key = format!("{delimiter}_quote");
+        let escape_key = format!("{delimiter}_escape");
+
         let has_header = params
-            .get("csv_has_header")
+            .get(&has_header_key)
             .expose()
             .ok()
             .map_or(true, |f| f.eq_ignore_ascii_case("true"));
         let quote = params
-            .get("csv_quote")
+            .get(&quote_key)
             .expose()
             .ok()
             .map_or(b'"', |f| *f.as_bytes().first().unwrap_or(&b'"'));
         let escape = params
-            .get("csv_escape")
+            .get(&escape_key)
             .expose()
             .ok()
             .and_then(|f| f.as_bytes().first().copied());
@@ -244,13 +253,11 @@ pub trait ListingTableConnector: DataConnector {
             .get("schema_infer_max_records")
             .expose()
             .ok()
-            .or(params.get("csv_schema_infer_max_records").expose().ok()) // For backwards compatibility
-            .map_or_else(|| 1000, |f| usize::from_str(f).map_or(1000, |f| f));
-        let delimiter = params
-            .get("csv_delimiter")
-            .expose()
-            .ok()
-            .map_or(b',', |f| *f.as_bytes().first().unwrap_or(&b','));
+            .or(params
+                .get(&format!("{delimiter}_schema_infer_max_records"))
+                .expose()
+                .ok()) // For backwards compatibility
+            .map_or_else(|| 1000, |f| usize::from_str(f).unwrap_or(1000));
         let compression_type = params
             .get("file_compression_type")
             .expose()
@@ -263,67 +270,16 @@ pub trait ListingTableConnector: DataConnector {
                 .with_quote(quote)
                 .with_escape(escape)
                 .with_schema_infer_max_rec(schema_infer_max_rec)
-                .with_delimiter(delimiter)
+                .with_delimiter(delimiter.separator())
                 .with_file_compression_type(
                     FileCompressionType::from_str(compression_type)
                         .boxed()
                         .context(crate::dataconnector::InvalidConfigurationSnafu {
                             dataconnector: format!("{self}"),
-                            message: format!("Invalid CSV compression_type: {compression_type}, supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
-                            connector_component: ConnectorComponent::from(dataset)
-                        })?,
-                ),
-        ))
-    }
-
-    fn get_tsv_format(
-        &self,
-        dataset: &Dataset,
-        params: &Parameters,
-    ) -> DataConnectorResult<Arc<CsvFormat>>
-    where
-        Self: Display,
-    {
-        let has_header = params
-            .get("tsv_has_header")
-            .expose()
-            .ok()
-            .map_or(true, |f| f.eq_ignore_ascii_case("true"));
-        let quote = params
-            .get("tsv_quote")
-            .expose()
-            .ok()
-            .map_or(b'"', |f| *f.as_bytes().first().unwrap_or(&b'"'));
-        let escape = params
-            .get("tsv_escape")
-            .expose()
-            .ok()
-            .and_then(|f| f.as_bytes().first().copied());
-        let schema_infer_max_rec = params
-            .get("schema_infer_max_records")
-            .expose()
-            .ok()
-            .map_or_else(|| 1000, |f| usize::from_str(f).map_or(1000, |f| f));
-        let compression_type = params
-            .get("file_compression_type")
-            .expose()
-            .ok()
-            .unwrap_or_default();
-
-        Ok(Arc::new(
-            CsvFormat::default()
-                .with_has_header(has_header)
-                .with_quote(quote)
-                .with_escape(escape)
-                .with_schema_infer_max_rec(schema_infer_max_rec)
-                .with_delimiter(b'\t')
-                .with_file_compression_type(
-                    FileCompressionType::from_str(compression_type)
-                        .boxed()
-                        .context(crate::dataconnector::InvalidConfigurationSnafu {
-                            dataconnector: format!("{self}"),
-                            message: format!("Invalid TSV compression_type: {compression_type}, supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
-                            connector_component: ConnectorComponent::from(dataset)
+                            message: format!(
+                                "Invalid {} compression_type: {compression_type}, supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED", delimiter.to_string().to_uppercase()
+                            ),
+                            connector_component: ConnectorComponent::from(dataset),
                         })?,
                 ),
         ))

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -47,7 +47,6 @@ use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
-use tract_core::tract_data::itertools::Itertools;
 use url::Url;
 
 use crate::object_store_registry::default_runtime_env;

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -230,22 +230,18 @@ pub trait ListingTableConnector: DataConnector {
     where
         Self: Display,
     {
-        let has_header_key = format!("{delimiter}_has_header");
-        let quote_key = format!("{delimiter}_quote");
-        let escape_key = format!("{delimiter}_escape");
-
         let has_header = params
-            .get(&has_header_key)
+            .get(&format!("{delimiter}_has_header"))
             .expose()
             .ok()
             .map_or(true, |f| f.eq_ignore_ascii_case("true"));
         let quote = params
-            .get(&quote_key)
+            .get(&format!("{delimiter}_quote"))
             .expose()
             .ok()
             .map_or(b'"', |f| *f.as_bytes().first().unwrap_or(&b'"'));
         let escape = params
-            .get(&escape_key)
+            .get(&format!("{delimiter}_escape"))
             .expose()
             .ok()
             .and_then(|f| f.as_bytes().first().copied());

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -47,6 +47,7 @@ use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
+use tract_core::tract_data::itertools::Itertools;
 use url::Url;
 
 use crate::object_store_registry::default_runtime_env;
@@ -560,6 +561,7 @@ mod tests {
     use std::pin::Pin;
     use url::Url;
 
+    use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
     use crate::dataconnector::{ConnectorParams, DataConnectorFactory};
     use crate::parameters::ParameterSpec;
 
@@ -618,20 +620,7 @@ mod tests {
         }
     }
 
-    const TEST_PARAMETERS: &[ParameterSpec] = &[
-        ParameterSpec::runtime("file_extension"),
-        ParameterSpec::runtime("file_format"),
-        ParameterSpec::runtime("schema_infer_max_records"),
-        ParameterSpec::runtime("csv_has_header"),
-        ParameterSpec::runtime("csv_quote"),
-        ParameterSpec::runtime("csv_escape"),
-        ParameterSpec::runtime("csv_schema_infer_max_records"),
-        ParameterSpec::runtime("csv_delimiter"),
-        ParameterSpec::runtime("tsv_has_header"),
-        ParameterSpec::runtime("tsv_quote"),
-        ParameterSpec::runtime("tsv_escape"),
-        ParameterSpec::runtime("file_compression_type"),
-    ];
+    const TEST_PARAMETERS: &[ParameterSpec] = LISTING_TABLE_PARAMETERS;
 
     fn setup_connector(path: String, params: HashMap<String, String>) -> (TestConnector, Dataset) {
         let connector = TestConnector {

--- a/crates/runtime/src/dataconnector/listing/mod.rs
+++ b/crates/runtime/src/dataconnector/listing/mod.rs
@@ -16,11 +16,59 @@ limitations under the License.
 
 use url::form_urlencoded;
 
-use crate::parameters::Parameters;
+use crate::parameters::{ParameterSpec, Parameters};
 
 mod connector;
 mod infer;
 pub use connector::ListingTableConnector;
+
+/// All [`super::DataConnectorFactory`] that create [`ListingTableConnector`]s should have at least these parameters returned from the associated [`super::DataConnectorFactory::parameters`].
+pub const LISTING_TABLE_PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::runtime("file_format"),
+    ParameterSpec::runtime("file_extension"),
+    ParameterSpec::runtime("schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema."),
+    ParameterSpec::runtime("tsv_has_header")
+        .description("Set true to indicate that the first line is a header."),
+    ParameterSpec::runtime("tsv_quote").description("The quote character in a row."),
+    ParameterSpec::runtime("tsv_escape").description("The escape character in a row."),
+    ParameterSpec::runtime("csv_has_header")
+        .description("Set true to indicate that the first line is a header."),
+    ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
+    ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
+    ParameterSpec::runtime("csv_schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema.")
+        .deprecated("use 'schema_infer_max_records' instead"),
+    ParameterSpec::runtime("csv_delimiter")
+        .description("The character separating values within a row."),
+    ParameterSpec::runtime("file_compression_type")
+        .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
+    ParameterSpec::runtime("hive_partitioning_enabled")
+        .description("Enable partitioning using hive-style partitioning from the folder structure. Defaults to false."),
+];
+
+pub enum DelimitedFormat {
+    Tsv,
+    Csv,
+}
+
+impl std::fmt::Display for DelimitedFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DelimitedFormat::Tsv => write!(f, "tsv"),
+            DelimitedFormat::Csv => write!(f, "csv"),
+        }
+    }
+}
+
+impl DelimitedFormat {
+    fn separator(&self) -> u8 {
+        match self {
+            DelimitedFormat::Tsv => b'\t',
+            DelimitedFormat::Csv => b',',
+        }
+    }
+}
 
 #[must_use]
 pub fn build_fragments(params: &Parameters, keys: Vec<&str>) -> String {

--- a/crates/runtime/src/dataconnector/listing/mod.rs
+++ b/crates/runtime/src/dataconnector/listing/mod.rs
@@ -32,6 +32,9 @@ pub const LISTING_TABLE_PARAMETERS: &[ParameterSpec] = &[
         .description("Set true to indicate that the first line is a header."),
     ParameterSpec::runtime("tsv_quote").description("The quote character in a row."),
     ParameterSpec::runtime("tsv_escape").description("The escape character in a row."),
+    ParameterSpec::runtime("tsv_schema_infer_max_records")
+        .description("Set a limit in terms of records to scan to infer the schema.")
+        .deprecated("use 'schema_infer_max_records' instead"),
     ParameterSpec::runtime("csv_has_header")
         .description("Set true to indicate that the first line is a header."),
     ParameterSpec::runtime("csv_quote").description("The quote character in a row."),

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -20,8 +20,10 @@ use super::{
     DataConnectorResult, ParameterSpec, Parameters,
 };
 
-use crate::component::dataset::Dataset;
 use crate::parameters::ParamLookup;
+use crate::{component::dataset::Dataset, dataconnector::listing::LISTING_TABLE_PARAMETERS};
+
+use lazy_static::lazy_static;
 use snafu::prelude::*;
 use std::any::Any;
 use std::clone::Clone;
@@ -122,37 +124,26 @@ impl S3Factory {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }
 }
-
-const PARAMETERS: &[ParameterSpec] = &[
-    ParameterSpec::connector("region").secret(),
-    ParameterSpec::connector("endpoint").secret(),
-    ParameterSpec::connector("key").secret(),
-    ParameterSpec::connector("secret").secret(),
-    ParameterSpec::connector("auth").description("Configures the authentication method for S3. Supported methods are: public (i.e. no auth), iam_role, key.").secret(),
-    ParameterSpec::runtime("client_timeout")
-        .description("The timeout setting for S3 client."),
-    ParameterSpec::runtime("allow_http")
-        .description("Allow HTTP protocol for S3 endpoint."),
-
-    // Common listing table parameters
-    ParameterSpec::runtime("file_format"),
-    ParameterSpec::runtime("file_extension"),
-    ParameterSpec::runtime("schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
-    ParameterSpec::runtime("csv_has_header")
-        .description("Set true to indicate that the first line is a header."),
-    ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
-    ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
-    ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema.")
-        .deprecated("use 'schema_infer_max_records' instead"),
-    ParameterSpec::runtime("csv_delimiter")
-        .description("The character separating values within a row."),
-    ParameterSpec::runtime("file_compression_type")
-        .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
-    ParameterSpec::runtime("hive_partitioning_enabled")
-        .description("Enable partitioning using hive-style partitioning from the folder structure. Defaults to false."),
-];
+lazy_static! {
+    static ref PARAMETERS: Vec<ParameterSpec> = {
+        let mut all_parameters = Vec::new();
+        all_parameters.extend_from_slice(&[
+            ParameterSpec::connector("region").secret(),
+            ParameterSpec::connector("endpoint").secret(),
+            ParameterSpec::connector("key").secret(),
+            ParameterSpec::connector("secret").secret(),
+            ParameterSpec::connector("auth")
+                .description("Configures the authentication method for S3. Supported methods are: public (i.e. no auth), iam_role, key.")
+                .secret(),
+            ParameterSpec::runtime("client_timeout")
+                .description("The timeout setting for S3 client."),
+            ParameterSpec::runtime("allow_http")
+                .description("Allow HTTP protocol for S3 endpoint."),
+        ]);
+        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+        all_parameters
+    };
+}
 
 impl DataConnectorFactory for S3Factory {
     fn create(
@@ -251,7 +242,7 @@ impl DataConnectorFactory for S3Factory {
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
-        PARAMETERS
+        &PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -23,14 +23,13 @@ use super::{
 use crate::parameters::ParamLookup;
 use crate::{component::dataset::Dataset, dataconnector::listing::LISTING_TABLE_PARAMETERS};
 
-use lazy_static::lazy_static;
 use snafu::prelude::*;
 use std::any::Any;
 use std::clone::Clone;
 use std::future::Future;
 use std::pin::Pin;
 use std::string::String;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use url::Url;
 
 // https://docs.aws.amazon.com/general/latest/gr/rande.html
@@ -124,10 +123,9 @@ impl S3Factory {
         Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
     }
 }
-lazy_static! {
-    static ref PARAMETERS: Vec<ParameterSpec> = {
-        let mut all_parameters = Vec::new();
-        all_parameters.extend_from_slice(&[
+static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
+    let mut all_parameters = Vec::new();
+    all_parameters.extend_from_slice(&[
             ParameterSpec::connector("region").secret(),
             ParameterSpec::connector("endpoint").secret(),
             ParameterSpec::connector("key").secret(),
@@ -140,10 +138,9 @@ lazy_static! {
             ParameterSpec::runtime("allow_http")
                 .description("Allow HTTP protocol for S3 endpoint."),
         ]);
-        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
-        all_parameters
-    };
-}
+    all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+    all_parameters
+});
 
 impl DataConnectorFactory for S3Factory {
     fn create(

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -15,6 +15,9 @@ limitations under the License.
 */
 
 use crate::component::dataset::Dataset;
+use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
+use lazy_static::lazy_static;
+
 use snafu::prelude::*;
 use std::any::Any;
 use std::future::Future;
@@ -62,32 +65,20 @@ impl SFTPFactory {
     }
 }
 
-const PARAMETERS: &[ParameterSpec] = &[
-    ParameterSpec::connector("user").secret(),
-    ParameterSpec::connector("pass").secret(),
-    ParameterSpec::connector("port").description("The port to connect to."),
-    ParameterSpec::runtime("client_timeout")
-        .description("The timeout setting for SFTP client."),
-
-    // Common listing table parameters
-    ParameterSpec::runtime("file_format"),
-    ParameterSpec::runtime("file_extension"),
-    ParameterSpec::runtime("schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema."),
-    ParameterSpec::runtime("csv_has_header")
-        .description("Set true to indicate that the first line is a header."),
-    ParameterSpec::runtime("csv_quote").description("The quote character in a row."),
-    ParameterSpec::runtime("csv_escape").description("The escape character in a row."),
-    ParameterSpec::runtime("csv_schema_infer_max_records")
-        .description("Set a limit in terms of records to scan to infer the schema")
-        .deprecated("use 'schema_infer_max_records' instead"),
-    ParameterSpec::runtime("csv_delimiter")
-        .description("The character separating values within a row."),
-    ParameterSpec::runtime("file_compression_type")
-        .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
-    ParameterSpec::runtime("hive_partitioning_enabled")
-        .description("Enable partitioning using hive-style partitioning from the folder structure. Defaults to false."),
-];
+lazy_static! {
+    static ref PARAMETERS: Vec<ParameterSpec> = {
+        let mut all_parameters = Vec::new();
+        all_parameters.extend_from_slice(&[
+            ParameterSpec::connector("user").secret(),
+            ParameterSpec::connector("pass").secret(),
+            ParameterSpec::connector("port").description("The port to connect to."),
+            ParameterSpec::runtime("client_timeout")
+                .description("The timeout setting for SFTP client."),
+        ]);
+        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+        all_parameters
+    };
+}
 
 impl DataConnectorFactory for SFTPFactory {
     fn create(
@@ -107,7 +98,7 @@ impl DataConnectorFactory for SFTPFactory {
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
-        PARAMETERS
+        &PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -16,13 +16,12 @@ limitations under the License.
 
 use crate::component::dataset::Dataset;
 use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
-use lazy_static::lazy_static;
 
 use snafu::prelude::*;
 use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use url::Url;
 
 use super::{
@@ -65,20 +64,18 @@ impl SFTPFactory {
     }
 }
 
-lazy_static! {
-    static ref PARAMETERS: Vec<ParameterSpec> = {
-        let mut all_parameters = Vec::new();
-        all_parameters.extend_from_slice(&[
-            ParameterSpec::connector("user").secret(),
-            ParameterSpec::connector("pass").secret(),
-            ParameterSpec::connector("port").description("The port to connect to."),
-            ParameterSpec::runtime("client_timeout")
-                .description("The timeout setting for SFTP client."),
-        ]);
-        all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
-        all_parameters
-    };
-}
+static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
+    let mut all_parameters = Vec::new();
+    all_parameters.extend_from_slice(&[
+        ParameterSpec::connector("user").secret(),
+        ParameterSpec::connector("pass").secret(),
+        ParameterSpec::connector("port").description("The port to connect to."),
+        ParameterSpec::runtime("client_timeout")
+            .description("The timeout setting for SFTP client."),
+    ]);
+    all_parameters.extend_from_slice(LISTING_TABLE_PARAMETERS);
+    all_parameters
+});
 
 impl DataConnectorFactory for SFTPFactory {
     fn create(

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -299,7 +299,7 @@ impl<'a> ExposedParamLookup<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParameterSpec {
     pub name: &'static str,
     pub required: bool,


### PR DESCRIPTION
# 🗣 Description
 - Standardise all list table connector parameters across all listing table connectors.
 - This enables TSV file format support for all relevant connectors. 

## 🔨 Related Issues
 - Original TSV implementation: https://github.com/spiceai/spiceai/pull/4098 

## 📄 Documentation Updates
- [ ] Update TSV params