### PR TITLE
Remove macOS Intel build

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -60,12 +60,6 @@ jobs:
                 target_os: "windows",
                 target_arch: "x86_64",
                 target_arch_go: "amd64"
-              }, {
-                name: "macOS x64 (Intel)",
-                runner: "macos-14-large",
-                target_os: "darwin",
-                target_arch: "x86_64",
-                target_arch_go: "amd64"
               }
             ];
 
@@ -78,11 +72,6 @@ jobs:
               }
 
               return matrix.filter(m => m.name === platform_option);
-            }
-
-            // Filter out macos-14-large runner for trunk pushes
-            if (context.eventName === 'push' && context.ref === 'refs/heads/trunk') {
-              return matrix.filter(target => target.runner !== 'macos-14-large');
             }
 
             return matrix;
@@ -384,8 +373,6 @@ jobs:
             target_arch: aarch64
           - target_os: darwin
             target_arch: aarch64
-          - target_os: darwin
-            target_arch: x86_64
           - target_os: windows
             target_arch: x86_64
 

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -50,13 +50,6 @@ jobs:
                 target_os: "darwin",
                 target_arch: "aarch64",
                 target_arch_go: "arm64"
-              }, {
-                name: "macOS x64 (Intel)",
-                builder: "macos-14-large",
-                runner: "macos-14-large",
-                target_os: "darwin",
-                target_arch: "x86_64",
-                target_arch_go: "amd64"
               }
             ];
 

--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -23,10 +23,6 @@ jobs:
             runner: macos-14
             target_os: darwin
             target_arch: aarch64
-          - name: macOS x64 (Intel)
-            runner: macos-13
-            target_os: darwin
-            target_arch: x86_64
           - name: Windows x64
             runner: windows-latest
             target_os: windows

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -41,7 +41,7 @@ getSystemInfo() {
 }
 
 verifySupported() {
-    local supported=(linux-x86_64 linux-aarch64 darwin-aarch64 darwin-x86_64)
+    local supported=(linux-x86_64 linux-aarch64 darwin-aarch64)
     local current_osarch="${OS}-${ARCH}"
 
     for osarch in "${supported[@]}"; do

--- a/install/install.sh
+++ b/install/install.sh
@@ -43,7 +43,7 @@ getSystemInfo() {
 }
 
 verifySupported() {
-    local supported=(linux-x86_64 linux-aarch64 darwin-aarch64 darwin-x86_64)
+    local supported=(linux-x86_64 linux-aarch64 darwin-aarch64)
     local current_osarch="${OS}-${ARCH}"
 
     for osarch in "${supported[@]}"; do


### PR DESCRIPTION
# 🗣 Description

Removes the macOS Intel binaries from our build, test and publish workflows. Apple is 4 generations into their M-series chips, and it doesn't make sense to keep building and supporting this legacy platform.
