### PR TITLE
feat: Add more test spicepods

### DIFF
--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Download the testoperator from MinIO if it exists
         run: |
           if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
-            mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator /usr/local/bin/testoperator
-            chmod +x /usr/local/bin/testoperator
+            sudo mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator /usr/local/bin/testoperator
+            sudo chmod +x /usr/local/bin/testoperator
             echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
           else
             echo "TESTOPERATOR_DOWNLOADED=false" >> $GITHUB_ENV

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -116,8 +116,8 @@ jobs:
         if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
         run: |
           cargo build -p testoperator --release
-          cp target/release/testoperator /usr/local/bin/testoperator
-          chmod +x /usr/local/bin/testoperator
+          sudo cp target/release/testoperator /usr/local/bin/testoperator
+          sudo chmod +x /usr/local/bin/testoperator
 
       - name: Run the throughput test
         run: |

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -28,12 +28,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install MinIO
+        run: |
+          sudo apt update && sudo apt install wget -y
+          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo chmod +x /usr/local/bin/mc
+          mc alias set spice-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }}
+
+      - name: Set testoperator commit
+        run: |
+          echo "TESTOPERATOR_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Download the testoperator from MinIO if it exists
+        run: |
+          if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
+            mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator /usr/local/bin/testoperator
+            chmod +x /usr/local/bin/testoperator
+            echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
+          else
+            echo "TESTOPERATOR_DOWNLOADED=false" >> $GITHUB_ENV
+          fi
+
       - name: Setup Rust
+        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
         uses: ./.github/actions/setup-rust
         with:
           os: 'linux'
       
       - name: Setup cc
+        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
         uses: ./.github/actions/setup-cc
 
       - name: Get latest trunk commit
@@ -49,14 +72,17 @@ jobs:
       
       - name: Download spiced from MinIO
         run: |
-          sudo apt update && sudo apt install wget -y
-          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
-          sudo chmod +x /usr/local/bin/mc
-          mc alias set spice-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }}
           mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
           tar -xzf spiced_models_linux_x86_64.tar.gz
           sudo mkdir -p /usr/local/bin
           sudo cp ./spiced /usr/local/bin/spiced
+
+      - name: Build the testoperator if it wasn't downloaded
+        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
+        run: |
+          cargo build -p testoperator --release
+          sudo cp target/release/testoperator /usr/local/bin/testoperator
+          sudo chmod +x /usr/local/bin/testoperator
       
       - name: Prepare file-based data directory
         run: |
@@ -98,27 +124,6 @@ jobs:
           mc cp spice-minio/benchmarks/tpcds_sf1/store/ ./ --recursive
           mc cp spice-minio/benchmarks/tpcds_sf1/time_dim/ ./ --recursive
       
-      - name: Set testoperator commit
-        run: |
-          echo "TESTOPERATOR_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
-
-      - name: Download the testoperator from MinIO if it exists
-        run: |
-          if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
-            mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator /usr/local/bin/testoperator
-            chmod +x /usr/local/bin/testoperator
-            echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
-          else
-            echo "TESTOPERATOR_DOWNLOADED=false" >> $GITHUB_ENV
-          fi
-      
-      - name: Build the testoperator if it wasn't downloaded
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        run: |
-          cargo build -p testoperator --release
-          sudo cp target/release/testoperator /usr/local/bin/testoperator
-          sudo chmod +x /usr/local/bin/testoperator
-
       - name: Run the throughput test
         run: |
           testoperator run throughput -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }}

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -41,8 +41,10 @@ jobs:
 
       - name: Download the testoperator from MinIO if it exists
         run: |
+          sudo mkdir -p /usr/local/bin
           if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
-            sudo mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator /usr/local/bin/testoperator
+            mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator ./testoperator
+            sudo cp ./testoperator /usr/local/bin/testoperator
             sudo chmod +x /usr/local/bin/testoperator
             echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
           else
@@ -74,7 +76,6 @@ jobs:
         run: |
           mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
           tar -xzf spiced_models_linux_x86_64.tar.gz
-          sudo mkdir -p /usr/local/bin
           sudo cp ./spiced /usr/local/bin/spiced
 
       - name: Build the testoperator if it wasn't downloaded

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -60,8 +60,9 @@ jobs:
       
       - name: Prepare file-based data directory
         run: |
-          rm -rf /opt/spiced/data
-          mkdir -p /opt/spiced/data
+          sudo rm -rf /opt/spiced/data
+          sudo mkdir -p /opt/spiced/data
+          sudo chown runner:runner -R /opt/spiced/data
 
       - name: Download File Connector TPCH Data
         if: ${{ github.event.inputs.query_set == 'tpch' }}

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt update && sudo apt install wget -y
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
-          mc alias set spice-minio ${{ secrets.CLICKBENCH_S3_ENDPOINT }} ${{ secrets.CLICKBENCH_S3_KEY }} ${{ secrets.CLICKBENCH_S3_SECRET }}
+          mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
 
       - name: Set testoperator commit
         run: |

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -20,10 +20,6 @@ on:
           - 'tpch'
           - 'tpcds'
           - 'clickbench'
-      data_dir:
-        description: 'The data directory to use'
-        required: false
-        type: string
 
 jobs:
   run-throughput:
@@ -62,20 +58,75 @@ jobs:
           sudo mkdir -p /usr/local/bin
           sudo cp ./spiced /usr/local/bin/spiced
       
-      - name: Run the throughput test (no data directory)
-        if: ${{ !github.event.inputs.data_dir }}
+      - name: Prepare file-based data directory
         run: |
-          cargo run -p testoperator -- run throughput -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} --query-set ${{ github.event.inputs.query_set }}
+          rm -rf /opt/spiced/data
+          mkdir -p /opt/spiced/data
+
+      - name: Download File Connector TPCH Data
+        if: ${{ github.event.inputs.query_set == 'tpch' }}
+        run: |
+          cd /opt/spiced/data
+          mc cp spice-minio/benchmarks/tpch_sf1/customer/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpch_sf1/lineitem/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpch_sf1/nation/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpch_sf1/orders/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpch_sf1/part/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpch_sf1/partsupp/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpch_sf1/region/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpch_sf1/supplier/ ./ --recursive
+      
+      - name: Download File Connector TPCDS Data
+        if: ${{ github.event.inputs.query_set == 'tpcds' }}
+        run: |
+          cd /opt/spiced/data
+          mc cp spice-minio/benchmarks/tpcds_sf1/catalog_sales/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/catalog_returns/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/inventory/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/store_sales/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/store_returns/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/web_sales/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/web_returns/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/customer/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/customer_address/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/customer_demographics/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/date_dim/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/household_demographics/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/item/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/promotion/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/store/ ./ --recursive
+          mc cp spice-minio/benchmarks/tpcds_sf1/time_dim/ ./ --recursive
+      
+      - name: Set testoperator commit
+        run: |
+          echo "TESTOPERATOR_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Download the testoperator from MinIO if it exists
+        run: |
+          if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
+            mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator /usr/local/bin/testoperator
+            chmod +x /usr/local/bin/testoperator
+            echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
+          else
+            echo "TESTOPERATOR_DOWNLOADED=false" >> $GITHUB_ENV
+          fi
+      
+      - name: Build the testoperator if it wasn't downloaded
+        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
+        run: |
+          cargo build -p testoperator --release
+          cp target/release/testoperator /usr/local/bin/testoperator
+          chmod +x /usr/local/bin/testoperator
+
+      - name: Run the throughput test
+        run: |
+          testoperator run throughput -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }}
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
           S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
-        
-      - name: Run the throughput test (data directory)
-        if: ${{ github.event.inputs.data_dir }}
+      
+      - name: Upload the testoperator binary
+        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
         run: |
-          cargo run -p testoperator -- run throughput -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d ${{ github.event.inputs.data_dir }} --query-set ${{ github.event.inputs.query_set }}
-        env:
-          S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
-          S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
-          S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
+          mc cp /usr/local/bin/testoperator spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator

--- a/test/spicepods/tpcds/file.yaml
+++ b/test/spicepods/tpcds/file.yaml
@@ -1,0 +1,49 @@
+version: v1
+kind: Spicepod
+name: file_tpcds
+runtime:
+  results_cache:
+    enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: file:./data/catalog_sales.parquet
+    name: catalog_sales
+  - from: file:./data/catalog_returns.parquet
+    name: catalog_returns
+  - from: file:./data/inventory.parquet
+    name: inventory
+  - from: file:./data/store_sales.parquet
+    name: store_sales
+  - from: file:./data/store_returns.parquet
+    name: store_returns
+  - from: file:./data/web_sales.parquet
+    name: web_sales
+  - from: file:./data/web_returns.parquet
+    name: web_returns
+  - from: file:./data/customer.parquet
+    name: customer
+  - from: file:./data/customer_address.parquet
+    name: customer_address
+  - from: file:./data/customer_demographics.parquet
+    name: customer_demographics
+  - from: file:./data/date_dim.parquet
+    name: date_dim
+  - from: file:./data/household_demographics.parquet
+    name: household_demographics
+  - from: file:./data/item.parquet
+    name: item
+  - from: file:./data/promotion.parquet
+    name: promotion
+  - from: file:./data/ship_mode.parquet
+    name: ship_mode
+  - from: file:./data/store.parquet
+    name: store
+  - from: file:./data/time_dim.parquet
+    name: time_dim
+  - from: file:./data/warehouse.parquet
+    name: warehouse
+  - from: file:./data/web_page.parquet
+    name: web_page
+  - from: file:./data/web_site.parquet
+    name: web_site

--- a/test/spicepods/tpcds/s3.yaml
+++ b/test/spicepods/tpcds/s3.yaml
@@ -1,0 +1,72 @@
+version: v1
+kind: Spicepod
+name: s3_tpch
+runtime:
+  results_cache:
+    enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: s3://benchmarks/tpcds_sf1/catalog_sales/
+    name: catalog_sales
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+  - from: s3://benchmarks/tpcds_sf1/catalog_returns/
+    name: catalog_returns
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/inventory/
+    name: inventory
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/store_sales/
+    name: store_sales
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/store_returns/
+    name: store_returns
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/web_sales/
+    name: web_sales
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/web_returns/
+    name: web_returns
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/customer/
+    name: customer
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/customer_address/
+    name: customer_address
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/customer_demographics/
+    name: customer_demographics
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/date_dim/
+    name: date_dim
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/household_demographics/
+    name: household_demographics
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/item/
+    name: item
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/promotion/
+    name: promotion
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/store/
+    name: store
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/time_dim/
+    name: time_dim
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/warehouse/
+    name: warehouse
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/web_page/
+    name: web_page
+    params: *s3_params
+  - from: s3://benchmarks/tpcds_sf1/web_site/
+    name: web_site
+    params: *s3_params

--- a/test/spicepods/tpch/accelerated/file_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/file_arrow.yaml
@@ -1,0 +1,35 @@
+version: v1
+kind: Spicepod
+name: file_tpch_arrow
+runtime:
+  results_cache:
+    enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: file:./data/customer.parquet
+    name: customer
+    acceleration: &acceleration
+      enabled: true
+      engine: arrow
+  - from: file:./data/lineitem.parquet
+    name: lineitem
+    acceleration: *acceleration
+  - from: file:./data/nation.parquet
+    name: nation
+    acceleration: *acceleration
+  - from: file:./data/orders.parquet
+    name: orders
+    acceleration: *acceleration
+  - from: file:./data/part.parquet
+    name: part
+    acceleration: *acceleration
+  - from: file:./data/partsupp.parquet
+    name: partsupp
+    acceleration: *acceleration
+  - from: file:./data/region.parquet
+    name: region
+    acceleration: *acceleration
+  - from: file:./data/supplier.parquet
+    name: supplier
+    acceleration: *acceleration

--- a/test/spicepods/tpch/accelerated/file_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/file_duckdb_file.yaml
@@ -1,0 +1,36 @@
+version: v1
+kind: Spicepod
+name: file_tpch_duckdb_file
+runtime:
+  results_cache:
+    enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: file:./data/customer.parquet
+    name: customer
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: file:./data/lineitem.parquet
+    name: lineitem
+    acceleration: *acceleration
+  - from: file:./data/nation.parquet
+    name: nation
+    acceleration: *acceleration
+  - from: file:./data/orders.parquet
+    name: orders
+    acceleration: *acceleration
+  - from: file:./data/part.parquet
+    name: part
+    acceleration: *acceleration
+  - from: file:./data/partsupp.parquet
+    name: partsupp
+    acceleration: *acceleration
+  - from: file:./data/region.parquet
+    name: region
+    acceleration: *acceleration
+  - from: file:./data/supplier.parquet
+    name: supplier
+    acceleration: *acceleration

--- a/test/spicepods/tpch/accelerated/file_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/file_duckdb_memory.yaml
@@ -1,0 +1,36 @@
+version: v1
+kind: Spicepod
+name: file_tpch_duckdb_memory
+runtime:
+  results_cache:
+    enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: file:./data/customer.parquet
+    name: customer
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: memory
+  - from: file:./data/lineitem.parquet
+    name: lineitem
+    acceleration: *acceleration
+  - from: file:./data/nation.parquet
+    name: nation
+    acceleration: *acceleration
+  - from: file:./data/orders.parquet
+    name: orders
+    acceleration: *acceleration
+  - from: file:./data/part.parquet
+    name: part
+    acceleration: *acceleration
+  - from: file:./data/partsupp.parquet
+    name: partsupp
+    acceleration: *acceleration
+  - from: file:./data/region.parquet
+    name: region
+    acceleration: *acceleration
+  - from: file:./data/supplier.parquet
+    name: supplier
+    acceleration: *acceleration

--- a/test/spicepods/tpch/accelerated/s3_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/s3_arrow.yaml
@@ -1,0 +1,49 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: s3://benchmarks/tpch_sf1/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: arrow
+  - from: s3://benchmarks/tpch_sf1/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/accelerated/s3_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/s3_duckdb_file.yaml
@@ -1,0 +1,50 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_duckdb_file
+runtime:
+  results_cache:
+    enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: s3://benchmarks/tpch_sf1/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: s3://benchmarks/tpch_sf1/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/accelerated/s3_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/s3_duckdb_memory.yaml
@@ -1,0 +1,50 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_duckdb_memory
+runtime:
+  results_cache:
+    enabled: false
+  task_history:
+    enabled: false
+datasets:
+  - from: s3://benchmarks/tpch_sf1/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: memory
+  - from: s3://benchmarks/tpch_sf1/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf1/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/duckdb.yaml
+++ b/test/spicepods/tpch/duckdb.yaml
@@ -4,6 +4,8 @@ name: duckdb_tpch
 runtime:
   results_cache:
     enabled: false
+  task_history:
+    enabled: false
 datasets:
   - from: duckdb:customer
     name: customer

--- a/test/spicepods/tpch/file.yaml
+++ b/test/spicepods/tpch/file.yaml
@@ -4,6 +4,8 @@ name: file_tpch
 runtime:
   results_cache:
     enabled: false
+  task_history:
+    enabled: false
 datasets:
   - from: file:./data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/s3.yaml
+++ b/test/spicepods/tpch/s3.yaml
@@ -4,6 +4,8 @@ name: s3_tpch
 runtime:
   results_cache:
     enabled: false
+  task_history:
+    enabled: false
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds more test spicepods
* Splits test spicepods in directories by query set, and adds sub-directories for accelerated spicepods
* Updates the throughput test workflow to cache the `testoperator` binary in MinIO, based on the commit from the branch the test is running
* Downloads file-based data from MinIO as part of the workflow setup

Workflow run without a cached `testoperator` - 3m 36s: https://github.com/spiceai/spiceai/actions/runs/12683510383
Workflow run with a cached `testoperator` - 17s 🏎️🔥🔥  : https://github.com/spiceai/spiceai/actions/runs/12683544972/job/35350795961

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4124 