### PR TITLE
feat: Re-enable defaults on test spicepods

### DIFF
--- a/test/spicepods/tpcds/accelerated/file_arrow.yaml
+++ b/test/spicepods/tpcds/accelerated/file_arrow.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: file_tpcds
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/file_duckdb_file.yaml
+++ b/test/spicepods/tpcds/accelerated/file_duckdb_file.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: file_tpcds
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/file_duckdb_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/file_duckdb_memory.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: file_tpcds
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/file.yaml
+++ b/test/spicepods/tpcds/file.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: file_tpcds
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/s3.yaml
+++ b/test/spicepods/tpcds/s3.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: s3_tpch
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpch/accelerated/file_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/file_arrow.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: file_tpch_arrow
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/file_duckdb_file.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: file_tpch_duckdb_file
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/file_duckdb_memory.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: file_tpch_duckdb_memory
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/s3_arrow.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: s3_tpch_arrow
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/s3_duckdb_file.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: s3_tpch_duckdb_file
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/s3_duckdb_memory.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: s3_tpch_duckdb_memory
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/duckdb.yaml
+++ b/test/spicepods/tpch/duckdb.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: duckdb_tpch
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: duckdb:customer
     name: customer

--- a/test/spicepods/tpch/file.yaml
+++ b/test/spicepods/tpch/file.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: file_tpch
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/s3.yaml
+++ b/test/spicepods/tpch/s3.yaml
@@ -1,11 +1,6 @@
 version: v1
 kind: Spicepod
 name: s3_tpch
-runtime:
-  results_cache:
-    enabled: false
-  task_history:
-    enabled: false
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Re-enables defaults for `task_history` and `results_cache` for the testing spicepods, to align with the out-of-the-box Spice experience.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4124 