### PR TITLE
Handle NULL partition columns for Delta Lake tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,6 +3067,7 @@ dependencies = [
  "iceberg",
  "iceberg-catalog-rest",
  "iceberg-datafusion",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "object_store",
  "rdkafka",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ http = "1.1.0"
 iceberg = "0.4.0"
 iceberg-catalog-rest = "0.4.0"
 iceberg-datafusion = "0.4.0"
+indexmap = "2.7.0"
 insta = { version = "1.41.1", features = ["filters"] }
 itertools = "0.13"
 mysql_async = { version = "0.34.1", features = ["native-tls-tls", "chrono"] }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -49,6 +49,7 @@ http = { version = "1.1.0" }
 iceberg-catalog-rest.workspace = true
 iceberg.workspace = true
 iceberg-datafusion.workspace = true
+indexmap.workspace = true
 itertools.workspace = true
 object_store = { workspace = true }
 rdkafka = { version = "0.37.0", features = ["ssl-vendored"], optional = true }

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -371,7 +371,6 @@ impl TableProvider for DeltaTable {
         //
         // In the above example, the partition columns are `user_id` and `day`.
         // The `user_id` column has a NULL value for the first file and a value of `123` for the second file.
-        // The `day` column has a NULL value for both files.
         //
         // The `delta_kernel` library skips returning the partition columns for files that have a NULL value for the partition columns.
         // Which means that the partition columns will not be returned in the `partition_values` field of the `PartitionedFile` object.

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -42,10 +42,9 @@ use delta_kernel::scan::state::{DvInfo, GlobalScanState, Stats};
 use delta_kernel::scan::ScanBuilder;
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::Table;
-use itertools::Itertools;
+use indexmap::IndexMap;
 use secrecy::{ExposeSecret, SecretString};
 use snafu::prelude::*;
-use std::collections::HashSet;
 use std::{collections::HashMap, sync::Arc};
 use url::Url;
 
@@ -311,7 +310,6 @@ impl TableProvider for DeltaTable {
             .map_err(map_delta_error_to_datafusion_err)?;
 
         let df_schema = DFSchema::try_from(Arc::clone(&self.arrow_schema))?;
-
         let filter = conjunction(filters.to_vec()).unwrap_or_else(|| lit(true));
         let physical_expr = state.create_physical_expr(filter, &df_schema)?;
 
@@ -361,20 +359,54 @@ impl TableProvider for DeltaTable {
             return Err(err);
         }
 
+        // In Delta Lake, all files must have the same partition columns,
+        // but Delta allows NULL values for the partition columns, represented in the filesystem as `__HIVE_DEFAULT_PARTITION__`.
+        //
+        // user_id=__HIVE_DEFAULT_PARTITION__/
+        //   day=2024-01-01/
+        //     part-00000.parquet
+        // user_id=123/
+        //   day=2024-01-01/
+        //     part-00001.parquet
+        //
+        // In the above example, the partition columns are `user_id` and `day`.
+        // The `user_id` column has a NULL value for the first file and a value of `123` for the second file.
+        // The `day` column has a NULL value for both files.
+        //
+        // The `delta_kernel` library skips returning the partition columns for files that have a NULL value for the partition columns.
+        // Which means that the partition columns will not be returned in the `partition_values` field of the `PartitionedFile` object.
+        // We handle this by keeping track of all the partition columns we find in the `all_partition_columns` variable and if one
+        // doesn't have a value, we add a NULL value for that field to the `partition_values` field of the `PartitionedFile` object.
         let mut partitioned_files: Vec<PartitionedFile> = vec![];
-        let mut partition_column_counts = HashSet::new();
-        let mut all_partition_columns = HashSet::new();
+        let all_partition_columns = scan_context
+            .files
+            .iter()
+            .flat_map(|file| {
+                file.partition_values.iter().filter_map(|(k, _)| {
+                    let schema = self.schema();
+                    schema.field_with_name(k).ok().cloned()
+                })
+            })
+            // Use an IndexMap to preserve insertion order
+            .fold(IndexMap::new(), |mut acc, field| {
+                acc.insert(field, ());
+                acc
+            });
         for file in scan_context.files {
             let mut partitioned_file = file.partitioned_file;
-            partition_column_counts.insert(file.partition_values.len());
-            partitioned_file.partition_values = file
-                .partition_values
+            partitioned_file.partition_values = all_partition_columns
                 .iter()
-                .map(|(k, v)| {
-                    let schema = self.schema();
-                    let field = schema.field_with_name(k)?;
-                    all_partition_columns.insert(field.clone());
-                    ScalarValue::try_from_string(v.clone(), field.data_type())
+                .map(|(field, ())| {
+                    if let Some((_, value)) = file
+                        .partition_values
+                        .iter()
+                        .find(|(k, _)| *k == field.name())
+                    {
+                        ScalarValue::try_from_string(value.clone(), field.data_type())
+                    } else {
+                        // This will create a null value typed for the field
+                        Ok(ScalarValue::try_from(field.data_type())?)
+                    }
                 })
                 .collect::<Result<Vec<_>, DataFusionError>>()?;
 
@@ -392,21 +424,10 @@ impl TableProvider for DeltaTable {
             partitioned_files.push(partitioned_file);
         }
 
-        if partition_column_counts.len() > 1 {
-            return Err(DataFusionError::Execution(format!(
-                "Inconsistent partitioning detected for Delta table {}: Some files have {} partition columns while others have {}. \
-                All files in a Delta table must use the same partitioning scheme. \
-                Expected partition columns: {}",
-                self.table.location(),
-                partition_column_counts.iter().max().unwrap_or(&0),
-                partition_column_counts.iter().min().unwrap_or(&0),
-                all_partition_columns.iter()
-                    .map(Field::name)
-                    .join(", ")
-            )));
-        }
-
-        let partition_cols = &all_partition_columns.into_iter().collect::<Vec<_>>();
+        let partition_cols = &all_partition_columns
+            .into_iter()
+            .map(|(field, ())| field)
+            .collect::<Vec<_>>();
         let schema = self.arrow_schema.project(
             &self
                 .arrow_schema

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -55,7 +55,7 @@ cudarc = { version = "0.12.2", optional = true, features = [
     "cuda-version-from-build-system",
 ] }
 either = "1.13.0"
-indexmap = "2.7.0"
+indexmap.workspace = true
 tempfile = "3.13.0"
 
 

--- a/crates/runtime/tests/delta_lake/mod.rs
+++ b/crates/runtime/tests/delta_lake/mod.rs
@@ -41,70 +41,85 @@ impl Drop for FileCleanup {
     }
 }
 
+async fn setup_test_data(zip_url: &str, dir_name: &str) -> Result<String, String> {
+    let tmp_dir = std::env::temp_dir();
+    let path = format!("{}/{}", tmp_dir.display(), dir_name);
+    let _ = std::fs::remove_dir_all(&path);
+    let _ = std::fs::create_dir(&path);
+
+    // Download and extract the test data
+    let resp = reqwest::get(zip_url).await.expect("request failed");
+    let mut out = File::create(format!("{path}/{dir_name}.zip")).expect("failed to create file");
+    let _ = out.write_all(&resp.bytes().await.expect("failed to read bytes"));
+    let _ = std::process::Command::new("unzip")
+        .stdin(std::process::Stdio::null())
+        .arg(format!("{path}/{dir_name}.zip"))
+        .arg("-d")
+        .arg(&path)
+        .spawn()
+        .expect("unzip failed")
+        .wait()
+        .expect("unzip failed");
+
+    Ok(path)
+}
+
+async fn run_delta_lake_test(
+    app_name: &str,
+    dataset_path: &str,
+    dataset_name: &str,
+    query: &str,
+    expected_results: &[&str],
+) -> Result<(), String> {
+    let app = AppBuilder::new(app_name)
+        .with_dataset(make_delta_lake_dataset(dataset_path, dataset_name, false))
+        .build();
+
+    let status = runtime::status::RuntimeStatus::new();
+    let df = crate::get_test_datafusion(Arc::clone(&status));
+    let rt = Runtime::builder()
+        .with_app(app)
+        .with_datafusion(df)
+        .build()
+        .await;
+
+    // Set a timeout for the test
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+            return Err("Timed out waiting for datasets to load".to_string());
+        }
+        () = rt.load_components() => {}
+    }
+
+    let query_result = rt
+        .datafusion()
+        .query_builder(query)
+        .build()
+        .run()
+        .await
+        .map_err(|e| format!("query `{query}` to plan: {e}"))?;
+
+    let data = query_result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .map_err(|e| format!("query `{query}` to results: {e}"))?;
+
+    assert_batches_eq!(expected_results, &data);
+    Ok(())
+}
+
 #[tokio::test]
 async fn query_delta_lake_with_partitions() -> Result<(), String> {
     test_request_context().scope(async {
-        let tmp_dir = std::env::temp_dir();
-        let path = format!("{}/nation", tmp_dir.display());
+        let path = setup_test_data(
+            "https://public-data.spiceai.org/delta-lake-nation-with-partitionkey.zip",
+            "nation",
+        )
+        .await?;
         let _hook = FileCleanup { path: path.clone() };
-        let _ = std::fs::remove_dir_all(&path);
-        let _ = std::fs::create_dir(&path);
-
-        let resp =
-            reqwest::get("https://public-data.spiceai.org/delta-lake-nation-with-partitionkey.zip")
-                .await
-                .expect("request failed");
-        let mut out = File::create(format!("{path}/nation.zip")).expect("failed to create file");
-        let _ = out.write_all(&resp.bytes().await.expect("failed to read bytes"));
-        let _ = std::process::Command::new("unzip")
-            .stdin(std::process::Stdio::null())
-            .arg(format!("{path}/nation.zip"))
-            .arg("-d")
-            .arg(&path)
-            .spawn()
-            .expect("unzip failed")
-            .wait()
-            .expect("unzip failed");
-
-        let app = AppBuilder::new("delta_lake_partition_test")
-            .with_dataset(make_delta_lake_dataset(
-                &format!("{path}/nation"),
-                "test",
-                false,
-            ))
-            .build();
-
-        let status = runtime::status::RuntimeStatus::new();
-        let df = crate::get_test_datafusion(Arc::clone(&status));
-        let rt = Runtime::builder()
-            .with_app(app)
-            .with_datafusion(df)
-            .build()
-            .await;
-
-        // Set a timeout for the test
-        tokio::select! {
-            () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
-                return Err("Timed out waiting for datasets to load".to_string());
-            }
-            () = rt.load_components() => {}
-        }
 
         let query = "SELECT * from test order by n_nationkey";
-        let query_result = rt
-            .datafusion()
-            .query_builder(query)
-            .build()
-            .run()
-            .await
-            .map_err(|e| format!("query `{query}` to plan: {e}"))?;
-
-        let data = query_result
-            .data
-            .try_collect::<Vec<RecordBatch>>()
-            .await
-            .map_err(|e| format!("query `{query}` to results: {e}"))?;
-
         let expected_results = [
         "+-------------+----------------+-------------+--------------------------------------------------------------------------------------------------------------------+",
         "| n_nationkey | n_name         | n_regionkey | n_comment                                                                                                          |",
@@ -136,8 +151,68 @@ async fn query_delta_lake_with_partitions() -> Result<(), String> {
         "| 24          | UNITED STATES  | 1           | ly ironic requests along the slyly bold ideas hang after the blithely special notornis; blithely even accounts     |",
         "+-------------+----------------+-------------+--------------------------------------------------------------------------------------------------------------------+",
         ];
-        assert_batches_eq!(expected_results, &data);
 
-        Ok(())
-    }).await
+        run_delta_lake_test(
+            "delta_lake_partition_test",
+            &format!("{path}/nation"),
+            "test",
+            query,
+            &expected_results,
+        )
+        .await
+    })
+    .await
+}
+
+#[tokio::test]
+async fn query_delta_lake_with_null_partitions() -> Result<(), String> {
+    test_request_context()
+        .scope(async {
+            let path = setup_test_data(
+                "https://public-data.spiceai.org/delta-lake-null-partition.zip",
+                "delta_partition",
+            )
+            .await?;
+            let _hook = FileCleanup { path: path.clone() };
+
+            let test_cases = [
+                (
+                    "SELECT tenant_id, day FROM test ORDER BY tenant_id, day",
+                    vec![
+                        "+-----------+------------+",
+                        "| tenant_id | day        |",
+                        "+-----------+------------+",
+                        "| tenant1   | 2024-01-01 |",
+                        "| tenant1   | 2024-01-01 |",
+                        "|           | 2024-01-02 |",
+                        "+-----------+------------+",
+                    ],
+                ),
+                (
+                    "SELECT * FROM test ORDER BY tenant_id, day, document_id",
+                    vec![
+                        "+-----------+------------+-------------+--------------------------+-------------+-------------------+-----------------------------+",
+                        "| tenant_id | day        | document_id | raw_email                | compression | compression_level | ingested_at                 |",
+                        "+-----------+------------+-------------+--------------------------+-------------+-------------------+-----------------------------+",
+                        "| tenant1   | 2024-01-01 | doc1        | 7465737420656d61696c     | gzip        | 6                 | 2025-01-11T03:14:44.193684Z |",
+                        "| tenant1   | 2024-01-01 | doc3        | 7465737420656d61696c2033 | gzip        | 6                 | 2025-01-11T03:14:44.193688Z |",
+                        "|           | 2024-01-02 | doc2        | 7465737420656d61696c2032 | gzip        | 6                 | 2025-01-11T03:14:44.193687Z |",
+                        "+-----------+------------+-------------+--------------------------+-------------+-------------------+-----------------------------+",
+                    ],
+                ),
+            ];
+
+            for (query, expected_results) in test_cases {
+                run_delta_lake_test(
+                    "delta_lake_null_partition_test",
+                    &format!("{path}/delta_partition"),
+                    "test",
+                    query,
+                    &expected_results,
+                )
+                .await?;
+            }
+            Ok(())
+        })
+        .await
 }

--- a/crates/runtime/tests/delta_lake/mod.rs
+++ b/crates/runtime/tests/delta_lake/mod.rs
@@ -41,6 +41,7 @@ impl Drop for FileCleanup {
     }
 }
 
+#[allow(clippy::expect_used)]
 async fn setup_test_data(zip_url: &str, dir_name: &str) -> Result<String, String> {
     let tmp_dir = std::env::temp_dir();
     let path = format!("{}/{}", tmp_dir.display(), dir_name);


### PR DESCRIPTION
# 🗣 Description

Fixes an issue where NULL partition columns for Delta Lake tables (represented as `__HIVE_DEFAULT_PARTITION__`) were not handled correctly, leading to errors like:

```bash
sql> select * from test;
Internal Error: An unexpected internal error occurred. Execute '.error' for details.
sql> .error
An internal error occurred.
Arrow error: Invalid argument error: column types must match schema types, expected Utf8 but found Date32 at column index 0
```

## 🔨 Related Issues

Closes #4260

## 📄 Documentation Updates

N/A

## 🤔 Concerns

N/A
