### PR TITLE
Handle `LargeStringArray` in `v1/search`.

### DIFF
--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -42,7 +42,7 @@ use std::fmt;
 use tokio::sync::RwLock;
 
 use crate::model::EmbeddingModelStore;
-use crate::{convert_to_iterator, embedding_col, offset_col};
+use crate::{convert_string_arrow_to_iterator, embedding_col, offset_col};
 
 use super::table::EmbeddingColumnConfig;
 
@@ -270,7 +270,7 @@ pub(crate) async fn compute_additional_embedding_columns(
             continue;
         };
 
-        let Some(arr_iter) = convert_to_iterator!(raw_data) else {
+        let Some(arr_iter) = convert_string_arrow_to_iterator!(raw_data) else {
             tracing::warn!(
                     "Expected 'StringArray', 'StringViewArray' or 'LargeStringArray' for column '{}', but got {}",
                     col,

--- a/crates/runtime/src/embeddings/execution_plan.rs
+++ b/crates/runtime/src/embeddings/execution_plan.rs
@@ -42,7 +42,7 @@ use std::fmt;
 use tokio::sync::RwLock;
 
 use crate::model::EmbeddingModelStore;
-use crate::{embedding_col, offset_col};
+use crate::{convert_to_iterator, embedding_col, offset_col};
 
 use super::table::EmbeddingColumnConfig;
 
@@ -270,15 +270,7 @@ pub(crate) async fn compute_additional_embedding_columns(
             continue;
         };
 
-        let arr_iter: Box<dyn Iterator<Item = Option<&str>> + Send> = if let Some(arr) =
-            raw_data.as_any().downcast_ref::<StringArray>()
-        {
-            Box::new(arr.iter())
-        } else if let Some(arr) = raw_data.as_any().downcast_ref::<StringViewArray>() {
-            Box::new(arr.iter())
-        } else if let Some(arr) = raw_data.as_any().downcast_ref::<LargeStringArray>() {
-            Box::new(arr.iter())
-        } else {
+        let Some(arr_iter) = convert_to_iterator!(raw_data) else {
             tracing::warn!(
                     "Expected 'StringArray', 'StringViewArray' or 'LargeStringArray' for column '{}', but got {}",
                     col,

--- a/crates/runtime/src/embeddings/mod.rs
+++ b/crates/runtime/src/embeddings/mod.rs
@@ -24,7 +24,7 @@ pub mod vector_search;
 /// Converts string-like Arrow types into an iterator [`Option<Box<dyn Iterator<Item = Option<&str>>>>`]. If the downcast conversion
 /// fails, returns `None`.
 #[macro_export]
-macro_rules! convert_to_iterator {
+macro_rules! convert_string_arrow_to_iterator {
     ($data:expr) => {{
         None.or($data
             .as_any()

--- a/crates/runtime/src/embeddings/mod.rs
+++ b/crates/runtime/src/embeddings/mod.rs
@@ -20,3 +20,23 @@ pub mod execution_plan;
 pub mod table;
 pub mod task;
 pub mod vector_search;
+
+/// Converts string-like Arrow types into an iterator [`Option<Box<dyn Iterator<Item = Option<&str>>>>`]. If the downcast conversion
+/// fails, returns `None`.
+#[macro_export]
+macro_rules! convert_to_iterator {
+    ($data:expr) => {{
+        None.or($data
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .map(|arr| Box::new(arr.iter()) as Box<dyn Iterator<Item = Option<&str>> + Send>))
+            .or($data
+                .as_any()
+                .downcast_ref::<StringViewArray>()
+                .map(|arr| Box::new(arr.iter()) as Box<dyn Iterator<Item = Option<&str>> + Send>))
+            .or($data
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .map(|arr| Box::new(arr.iter()) as Box<dyn Iterator<Item = Option<&str>> + Send>))
+    }};
+}

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use app::App;
-use arrow::array::{RecordBatch, StringArray, StringViewArray};
+use arrow::array::{LargeStringArray, RecordBatch, StringArray, StringViewArray};
 use arrow::error::ArrowError;
 use arrow::util::pretty::pretty_format_batches;
 use arrow_schema::{Schema, SchemaRef};
@@ -40,8 +40,8 @@ use tracing::{Instrument, Span};
 use crate::accelerated_table::AcceleratedTable;
 use crate::datafusion::query::write_to_json_string;
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
+use crate::{convert_to_iterator, embedding_col, offset_col};
 use crate::{datafusion::DataFusion, model::EmbeddingModelStore};
-use crate::{embedding_col, offset_col};
 
 use super::table::EmbeddingTable;
 use snafu::prelude::*;
@@ -352,19 +352,9 @@ impl VectorSearchTableResult {
         let result = embedding_records
             .iter()
             .flat_map(|v| {
-                let embedded_column = v.column(0);
-                if let Some(col) = embedded_column.as_any().downcast_ref::<StringArray>() {
-                    col.iter()
-                        .map(|v| v.unwrap_or_default().to_string())
-                        .collect::<Vec<String>>()
-                } else if let Some(col) = embedded_column.as_any().downcast_ref::<StringViewArray>()
-                {
-                    col.iter()
-                        .map(|v| v.unwrap_or_default().to_string())
-                        .collect::<Vec<String>>()
-                } else {
-                    vec![]
-                }
+                convert_to_iterator!(v.column(0))
+                    .map(|v| v.map(|vv| vv.unwrap_or_default().to_string()).collect_vec())
+                    .unwrap_or_default()
             })
             .collect();
 
@@ -383,7 +373,6 @@ impl VectorSearchTableResult {
         if self.data.first().is_none_or(|d| d.num_rows() == 0) {
             return Ok(vec![]);
         }
-
         let primary_keys_json = self.primary_keys_json()?;
         let additional_columns_json = self.addition_columns_json()?;
         let values = self.embedding_columns_list()?;
@@ -476,7 +465,6 @@ pub fn to_matches_sorted(result: &VectorSearchResult, limit: usize) -> Result<Ve
     });
 
     matches.truncate(limit);
-
     Ok(matches)
 }
 

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -40,7 +40,7 @@ use tracing::{Instrument, Span};
 use crate::accelerated_table::AcceleratedTable;
 use crate::datafusion::query::write_to_json_string;
 use crate::datafusion::{SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA};
-use crate::{convert_to_iterator, embedding_col, offset_col};
+use crate::{convert_string_arrow_to_iterator, embedding_col, offset_col};
 use crate::{datafusion::DataFusion, model::EmbeddingModelStore};
 
 use super::table::EmbeddingTable;
@@ -352,7 +352,7 @@ impl VectorSearchTableResult {
         let result = embedding_records
             .iter()
             .flat_map(|v| {
-                convert_to_iterator!(v.column(0))
+                convert_string_arrow_to_iterator!(v.column(0))
                     .map(|v| v.map(|vv| vv.unwrap_or_default().to_string()).collect_vec())
                     .unwrap_or_default()
             })


### PR DESCRIPTION
# 🗣 Description
 - Handle `LargeStringArray` parsing when converting arrow from SQL to response json for `v1/search`.
 - Also standardise the string types we handle parsing from via macro `convert_string_arrow_to_iterator!(...`. 

## 🔨 Related Issues
 - https://github.com/spiceai/spiceai/pull/4263 