### PR TITLE
Fix `build_cuda` in Update spiced_docker.yml

### DIFF
--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -216,7 +216,7 @@ jobs:
           cache-to: type=gha,scope=build-cuda,mode=max
           build-args: |
             REL_VERSION=${{ needs.setup.outputs.rel_version }}
-            CARGO_FEATURES=release,cuda
+            CARGO_FEATURES=release,models,cuda
 
       - name: Upload CUDA artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
```diff
- CARGO_FEATURES=release,cuda
+ CARGO_FEATURES=release,cuda,models
```
Prior artifact that did not have models enabled: https://github.com/spiceai/spiceai/actions/runs/12684576470 
