### PR TITLE
Add xAI key to llm integration tests

### DIFF
--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -75,12 +75,14 @@ jobs:
         run: |
           echo 'SPICE_OPENAI_API_KEY="${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}"' > .env
           echo 'SPICE_ANTHROPIC_API_KEY="${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}"' >> .env
+          echo 'SPICE_XAI_API_KEY="${{ secrets.SPICE_SECRET_XAI_API_KEY }}"' >> .env
 
         # Don't run local models in the integration test yet.
       - name: Run integration test
         env:
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
           SPICE_SECRET_ANTHROPIC_API_KEY: ${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}
+          SPICE_SECRET_XAI_API_KEY: ${{ secrets.SPICE_SECRET_XAI_API_KEY }}
         run: |
           if [ -z "$SPICE_SECRET_OPENAI_API_KEY" ] ; then
             echo "Error: OpenAI API key is not defined."
@@ -90,5 +92,9 @@ jobs:
             echo "Error: Anthropic API key is not defined."
             exit 1
           fi
-          export MODEL_SKIPLIST="hf/phi3,local/phi3"
+          if [ -z "$SPICE_SECRET_XAI_API_KEY" ] ; then
+            echo "Error: xAI API key is not defined."
+            exit 1
+          fi
+          export MODEL_SKIPLIST="hf_phi3,local_phi3"
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/llms_integration_test --nocapture


### PR DESCRIPTION
> Requires `SPICE_SECRET_XAI_API_KEY` to be added to repo secrets. 

# 🗣 Description
 - Add xAI api key for integration tests running in CI.
 - Fix denylist for local models. 
