### PR TITLE
Allow for a subset of build artifacts to be published to minio

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -415,14 +415,18 @@ jobs:
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ env.MINIO_ENDPOINT }} ${{ env.MINIO_ACCESS_KEY }} ${{ env.MINIO_SECRET_KEY }}
 
-          # If 'spiced_linux_x86_64.tar.gz' exists, assume all other standard artifacts exist.
           if [ -f "${ARTIFACT_DIR}/spiced_linux_x86_64.tar.gz" ]; then
             mc cp ${{ env.ARTIFACT_DIR }}/spiced_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          fi;
+
+          if [ -f "${ARTIFACT_DIR}/spiced_models_linux_x86_64.tar.gz" ]; then
             mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          fi;
+
+          if [ -f "${ARTIFACT_DIR}/spice_linux_x86_64.tar.gz" ]; then
             mc cp ${{ env.ARTIFACT_DIR }}/spice_linux_x86_64.tar.gz spice-minio/artifacts/spice/linux-x86_64/${{ env.COMMIT_SHA }}/
           fi;
 
-          # Upload CUDA models if they exist
           if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_linux_x86_64.tar.gz" ]; then
             mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
           fi

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -377,29 +377,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Don't fail if artifact not found. logic to check expected artifacts is done when
+      # publishing (last step).
       - name: download artifacts - spice_linux_x86_64
-        if: matrix.target.runner != 'ubuntu-gpu-t4-4-core'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: spice_linux_x86_64
           path: ${{ env.ARTIFACT_DIR }}
 
       - name: download artifacts - spiced_linux_x86_64
-        if: matrix.target.runner != 'ubuntu-gpu-t4-4-core'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: spiced_linux_x86_64
           path: ${{ env.ARTIFACT_DIR }}
 
       - name: download artifacts - spiced_models_linux_x86_64
-        if: matrix.target.runner != 'ubuntu-gpu-t4-4-core'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: spiced_models_linux_x86_64
           path: ${{ env.ARTIFACT_DIR }}
 
       - name: download artifacts - spiced_models_linux_x86_64
-        if: matrix.target.runner == 'ubuntu-gpu-t4-4-core'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: spiced_models_cuda_linux_x86_64


### PR DESCRIPTION
# 🗣 Description
- When using `build_and_release`, user can specific to build a subset of the possible artifacts (via `platform_option` input of `workflow_dispatch` action). This means, they might not all be present when publishing to Minio. Therefore we use `continue-on-error: true` when downloading artifacts. 