### PR TITLE
Fix Spark benchmark credentials, add back overrides

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -202,6 +202,9 @@ jobs:
           - cmd: '-c spark'
             name: 'spark connector'
             bench: 'tpch'
+          - cmd: '-c spark -b tpcds'
+            name: 'spark connector'
+            bench: 'tpcds'
           - cmd: '-c postgres'
             name: 'postgres connector'
             bench: 'tpch'
@@ -307,12 +310,6 @@ jobs:
           - cmd: '-a duckdb -m file -b clickbench --zero-results use_source'
             name: 'duckdb accelerator on_zero_results (file mode)'
             bench: 'clickbench'
-          - cmd: '-c spark'
-            name: 'spark connector'
-            bench: 'tpch'
-          - cmd: '-c spark -b tpcds'
-            name: 'spark connector'
-            bench: 'tpcds'
 
     steps:
       - name: Checkout repository

--- a/crates/runtime/benches/bench_spark/mod.rs
+++ b/crates/runtime/benches/bench_spark/mod.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use app::AppBuilder;
 use runtime::Runtime;
 use spicepod::component::{dataset::Dataset, params::Params};
-use test_framework::queries::{get_tpcds_test_queries, get_tpch_test_queries};
+use test_framework::queries::{get_tpcds_test_queries, get_tpch_test_queries, QueryOverrides};
 
 use crate::results::BenchmarkResultsBuilder;
 
@@ -27,8 +27,8 @@ pub(crate) async fn run(
     bench_name: &str,
 ) -> Result<(), String> {
     let test_queries = match bench_name {
-        "tpch" => get_tpch_test_queries(None),
-        "tpcds" => get_tpcds_test_queries(None),
+        "tpch" => get_tpch_test_queries(Some(QueryOverrides::Spark)),
+        "tpcds" => get_tpcds_test_queries(Some(QueryOverrides::Spark)),
         _ => return Err(format!("Invalid benchmark to run {bench_name}")),
     };
 
@@ -183,10 +183,10 @@ fn make_spark_dataset(path: &str, name: &str) -> Dataset {
             "spark_remote".to_string(),
             format!(
                 "sc://{}:443/;use_ssl=true;user_id=spice.ai;session_id={};token={};x-databricks-cluster-id={}",
-                std::env::var("SPICE_DATABRICKS_ENDPOINT").unwrap_or_default(),
+                std::env::var("DATABRICKS_HOST").unwrap_or_default(),
                 uuid::Uuid::new_v4(),
-                std::env::var("SPICE_DATABRICKS_TOKEN").unwrap_or_default(),
-                std::env::var("SPICE_DATABRICKS_CLUSTER_ID").unwrap_or_default(),
+                std::env::var("DATABRICKS_TOKEN").unwrap_or_default(),
+                std::env::var("DATABRICKS_CLUSTER_ID").unwrap_or_default(),
             ),
         )]
             .into_iter()


### PR DESCRIPTION
# 🗣 Description

- Used correct env variables for Spark benchmark tests.
- Enabled back overrides (was removed by mistake): tpch_q2 and tpchq17 skipped, because Spark doesn't support correlated subqueries:
https://spark.apache.org/docs/latest/sql-error-conditions-unsupported-subquery-expression-category-error-class.html