### PR TITLE
Fix Bug: No field named body_embedding when do vector search with refresh sql containing subset of columns

### DIFF
--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -136,3 +136,63 @@ pub fn schema_meta_get_computed_columns(
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    fn create_test_schema_with_embeddings() -> Schema {
+        Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, true),
+            Field::new(
+                "name_embedding",
+                DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::FixedSizeList(
+                        Arc::new(Field::new("item", DataType::Float32, false)),
+                        1536,
+                    ),
+                    false,
+                ))),
+                false,
+            ),
+            Field::new(
+                "name_offset",
+                DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::FixedSizeList(
+                        Arc::new(Field::new("item", DataType::Int32, false)),
+                        2,
+                    ),
+                    false,
+                ))),
+                false,
+            ),
+        ])
+    }
+
+    #[test]
+    fn test_computed_columns_meta() {
+        let mut schema = create_test_schema_with_embeddings();
+
+        let mut computed_columns_meta = HashMap::new();
+        computed_columns_meta.insert(
+            "name".to_string(),
+            vec!["name_embedding".to_string(), "name_offset".to_string()],
+        );
+
+        // Set metadata
+        set_computed_columns_meta(&mut schema, &computed_columns_meta);
+
+        // Retrieve computed columns metadata
+        let computed_columns = schema_meta_get_computed_columns(&schema, "name")
+            .expect("should return computed columns");
+
+        assert_eq!(computed_columns.len(), 2);
+        assert_eq!(computed_columns[0].name(), "name_embedding");
+        assert_eq!(computed_columns[1].name(), "name_offset");
+    }
+}

--- a/crates/arrow_tools/src/schema.rs
+++ b/crates/arrow_tools/src/schema.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::{collections::HashMap, sync::Arc};
+
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::common::DFSchema;
 use snafu::prelude::*;
@@ -90,4 +92,47 @@ pub fn expand_views_schema(schema: &Schema) -> Schema {
         .collect();
 
     Schema::new(transformed_fields)
+}
+
+pub fn set_computed_columns_meta<S: ::std::hash::BuildHasher>(
+    schema: &mut Schema,
+    computed_columns_meta: &HashMap<String, Vec<String>, S>,
+) {
+    for (base_column, computed_columns) in computed_columns_meta {
+        set_computed_columns_meta_for_base_column(schema, base_column, computed_columns);
+    }
+}
+
+pub fn set_computed_columns_meta_for_base_column(
+    schema: &mut Schema,
+    base_column: &str,
+    computed_columns: &[String],
+) {
+    schema.metadata.insert(
+        format!("{base_column}_computed_columns"),
+        computed_columns.join(","),
+    );
+}
+
+#[must_use]
+pub fn schema_meta_get_computed_columns(
+    schema: &Schema,
+    base_column: &str,
+) -> Option<Vec<Arc<Field>>> {
+    let key = format!("{base_column}_computed_columns");
+
+    if let Some(computed_columns_str) = schema.metadata.get(&key) {
+        let computed_column_names: Vec<&str> = computed_columns_str.split(',').collect();
+
+        Some(
+            schema
+                .fields()
+                .iter()
+                .filter(|field| computed_column_names.contains(&field.name().as_str()))
+                .cloned()
+                .collect(),
+        )
+    } else {
+        None
+    }
 }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -20,6 +20,8 @@ use crate::component::catalog::Catalog;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
 use crate::datafusion::error::find_datafusion_root;
+use crate::embeddings::table::include_embeddings_internal_columns;
+use crate::embeddings::table::EmbeddingTable;
 use crate::federated_table::FederatedTable;
 use crate::get_params_with_secrets;
 use crate::parameters::ParameterSpec;
@@ -444,7 +446,22 @@ pub async fn get_data(
 
             DataFrame::new(ctx.state(), logical_plan)
         }
-        Some(sql) => ctx.sql(&sql).await.map_err(find_datafusion_root)?,
+        Some(sql) => {
+            let session = ctx.state();
+            let mut plan = session
+                .create_logical_plan(&sql)
+                .await
+                .map_err(find_datafusion_root)?;
+
+            // If the refresh SQL defines a subset of columns to fetch, the internal embedding columns
+            // are not included automatically so we verify their presence and add them manually.
+            if let Some(embedding_table) = table_provider.as_any().downcast_ref::<EmbeddingTable>()
+            {
+                plan = include_embeddings_internal_columns(plan, embedding_table)?;
+            };
+
+            DataFrame::new(session, plan)
+        }
     };
 
     for filter in filters {

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -20,20 +20,25 @@ use crate::component::catalog::Catalog;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::Dataset;
 use crate::datafusion::error::find_datafusion_root;
-use crate::embeddings::table::include_embeddings_internal_columns;
-use crate::embeddings::table::EmbeddingTable;
 use crate::federated_table::FederatedTable;
 use crate::get_params_with_secrets;
 use crate::parameters::ParameterSpec;
 use crate::parameters::Parameters;
 use crate::secrets::Secrets;
+use arrow_schema::SchemaRef;
+use arrow_tools::schema::schema_meta_get_computed_columns;
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
+use datafusion::common::tree_node::Transformed;
+use datafusion::common::tree_node::TreeNode;
+use datafusion::common::Column;
 use datafusion::dataframe::DataFrame;
 use datafusion::datasource::{DefaultTableSource, TableProvider};
 use datafusion::error::DataFusionError;
+use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::SendableRecordBatchStream;
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::logical_expr::{Expr, LogicalPlanBuilder};
 use datafusion::sql::unparser::Unparser;
 use datafusion::sql::TableReference;
@@ -453,12 +458,9 @@ pub async fn get_data(
                 .await
                 .map_err(find_datafusion_root)?;
 
-            // If the refresh SQL defines a subset of columns to fetch, the internal embedding columns
-            // are not included automatically so we verify their presence and add them manually.
-            if let Some(embedding_table) = table_provider.as_any().downcast_ref::<EmbeddingTable>()
-            {
-                plan = include_embeddings_internal_columns(plan, embedding_table)?;
-            };
+            // If the refresh SQL defines a subset of columns to fetch, computed columns such as embeddings
+            // are not included automatically, so we verify their presence and add them manually if needed.
+            plan = include_computed_columns(plan, &table_provider.schema())?;
 
             DataFrame::new(session, plan)
         }
@@ -593,6 +595,46 @@ impl ConnectorParamsBuilder {
             component: self.component.clone(),
         })
     }
+}
+
+/// Ensures that the associated computed columns (e.g., embeddings) are included
+/// in the `LogicalPlan::Projection` node.
+/// If any required computed columns are missing, they are automatically added to the projection.
+fn include_computed_columns(
+    plan: LogicalPlan,
+    source_table_schema: &SchemaRef,
+) -> DataFusionResult<LogicalPlan> {
+    let plan = plan
+        .transform_down(|plan| {
+            match plan {
+                LogicalPlan::Projection(mut proj) => {
+                    for (idx, col) in proj.schema.columns().iter().enumerate() {
+                        if let Some(computed_columns) = schema_meta_get_computed_columns(
+                            source_table_schema.as_ref(),
+                            col.name(),
+                        ) {
+                            for computed_column in computed_columns {
+                                if !proj
+                                    .schema
+                                    .has_column_with_unqualified_name(computed_column.name())
+                                {
+                                    proj.expr.push(Expr::Column(Column::new(
+                                        proj.schema.qualified_field(idx).0.cloned(),
+                                        computed_column.name().to_string(),
+                                    )));
+                                }
+                            }
+                        }
+                    }
+                    // The Transformed flag is not used, so we always specify it as transformed for simplicity.
+                    Ok(Transformed::yes(LogicalPlan::Projection(proj)))
+                }
+                _ => Ok(Transformed::no(plan)),
+            }
+        })?
+        .data;
+
+    Ok(plan)
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -281,7 +281,7 @@ mod tests {
     }
 
     fn create_test_schema_with_enmbeddings() -> Arc<Schema> {
-        Arc::new(Schema::new(vec![
+        let mut schema = Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("name", DataType::Utf8, false),
             Field::new("value", DataType::Float64, true),
@@ -309,7 +309,17 @@ mod tests {
                 ))),
                 false,
             ),
-        ]))
+        ]);
+
+        // mark `name_embedding` and `name_offset` as computed columns for `name`
+        let mut computed_columns_meta = std::collections::HashMap::new();
+        computed_columns_meta.insert(
+            "name".to_string(),
+            vec!["name_embedding".to_string(), "name_offset".to_string()],
+        );
+        arrow_tools::schema::set_computed_columns_meta(&mut schema, &computed_columns_meta);
+
+        Arc::new(schema)
     }
 
     #[test]

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use std::sync::Arc;
 
 use arrow_schema::SchemaRef;
+use arrow_tools::schema::schema_meta_get_computed_columns;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::sql::parser::{DFParser, Statement};
 use datafusion::sql::sqlparser::ast::{Expr, GroupByExpr, SelectItem, SetExpr};
@@ -25,8 +26,6 @@ use datafusion::sql::{sqlparser, TableReference};
 use itertools::Itertools;
 use snafu::prelude::*;
 use sqlparser::ast::Statement as SQLStatement;
-
-use crate::{embedding_col, offset_col};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -237,27 +236,29 @@ fn validate_select_columns(
         }
     }
 
-    // If the refresh SQL defines a subset of columns to fetch, the internal embedding columns
-    // are not included automatically. We check their presence in the source schema and add them manually.
-    fields = include_embeddings_columns(&fields, &source_schema);
+    // If the refresh SQL defines a subset of columns to fetch, computed columns (e.g., embeddings)
+    // are not included automatically. We verify their presence in the source schema and add them manually if needed.
+    fields = include_computed_columns(&fields, &source_schema);
 
     Ok(Arc::new(Schema::new(fields)))
 }
 
-/// Checks the source schema for internal embedding columns corresponding to the
-/// provided fields. Adds any missing embedding-related fields to the schema if they are found.
-fn include_embeddings_columns(
+/// Checks the source schema for associated computed columns (e.g., embeddings)
+/// and adds any missing computed fields to the target schema if they are found.
+fn include_computed_columns(
     fields: &[arrow_schema::Field],
     source_schema: &SchemaRef,
 ) -> Vec<arrow_schema::Field> {
     let mut extended_fields = fields.to_owned();
     for field in fields {
-        let field_name = field.name();
-        for internal_col in [embedding_col!(field_name), offset_col!(field_name)] {
-            // Add the field if it's found in the source schema and does not exist in target schema
-            if let Ok(field) = source_schema.field_with_name(&internal_col) {
-                if !extended_fields.iter().any(|f| f.name() == &internal_col) {
-                    extended_fields.push(field.clone());
+        if let Some(computed_cols) = schema_meta_get_computed_columns(source_schema, field.name()) {
+            for computed_col in computed_cols {
+                // Add field only if it does not exist in target schema
+                if !extended_fields
+                    .iter()
+                    .any(|f| f.name() == computed_col.name())
+                {
+                    extended_fields.push((*computed_col).clone());
                 }
             }
         }

--- a/crates/runtime/src/datafusion/refresh_sql.rs
+++ b/crates/runtime/src/datafusion/refresh_sql.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use arrow_schema::SchemaRef;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::sql::parser::{DFParser, Statement};
 use datafusion::sql::sqlparser::ast::{Expr, GroupByExpr, SelectItem, SetExpr};
@@ -24,6 +25,8 @@ use datafusion::sql::{sqlparser, TableReference};
 use itertools::Itertools;
 use snafu::prelude::*;
 use sqlparser::ast::Statement as SQLStatement;
+
+use crate::{embedding_col, offset_col};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -234,7 +237,33 @@ fn validate_select_columns(
         }
     }
 
+    // If the refresh SQL defines a subset of columns to fetch, the internal embedding columns
+    // are not included automatically. We check their presence in the source schema and add them manually.
+    fields = include_embeddings_columns(&fields, &source_schema);
+
     Ok(Arc::new(Schema::new(fields)))
+}
+
+/// Checks the source schema for internal embedding columns corresponding to the
+/// provided fields. Adds any missing embedding-related fields to the schema if they are found.
+fn include_embeddings_columns(
+    fields: &[arrow_schema::Field],
+    source_schema: &SchemaRef,
+) -> Vec<arrow_schema::Field> {
+    let mut extended_fields = fields.to_owned();
+    for field in fields {
+        let field_name = field.name();
+        for internal_col in [embedding_col!(field_name), offset_col!(field_name)] {
+            // Add the field if it's found in the source schema and does not exist in target schema
+            if let Ok(field) = source_schema.field_with_name(&internal_col) {
+                if !extended_fields.iter().any(|f| f.name() == &internal_col) {
+                    extended_fields.push(field.clone());
+                }
+            }
+        }
+    }
+
+    extended_fields
 }
 
 #[cfg(test)]
@@ -247,6 +276,38 @@ mod tests {
             Field::new("id", DataType::Int64, false),
             Field::new("name", DataType::Utf8, false),
             Field::new("value", DataType::Float64, true),
+        ]))
+    }
+
+    fn create_test_schema_with_enmbeddings() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, true),
+            Field::new(
+                "name_embedding",
+                DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::FixedSizeList(
+                        Arc::new(Field::new("item", DataType::Float32, false)),
+                        1536,
+                    ),
+                    false,
+                ))),
+                false,
+            ),
+            Field::new(
+                "name_offset",
+                DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::FixedSizeList(
+                        Arc::new(Field::new("item", DataType::Int32, false)),
+                        2,
+                    ),
+                    false,
+                ))),
+                false,
+            ),
         ]))
     }
 
@@ -335,5 +396,20 @@ mod tests {
             result,
             Err(Error::ExpectedSingleSqlStatement { .. })
         ));
+    }
+
+    #[test]
+    fn test_valid_select_columns_with_embeddings() -> Result<()> {
+        let schema = create_test_schema_with_enmbeddings();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT id, name FROM test_table";
+
+        let result = validate_refresh_sql(table, sql, Arc::clone(&schema))?;
+        assert_eq!(result.fields().len(), 4);
+        assert_eq!(result.field(0).name(), "id");
+        assert_eq!(result.field(1).name(), "name");
+        assert_eq!(result.field(2).name(), "name_embedding");
+        assert_eq!(result.field(3).name(), "name_offset");
+        Ok(())
     }
 }

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -19,13 +19,13 @@ use std::{any::Any, sync::Arc};
 
 use arrow::datatypes::{DataType, Schema, SchemaRef};
 use arrow_schema::Field;
+use arrow_tools::schema;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::common::tree_node::{Transformed, TreeNode};
-use datafusion::common::{project_schema, Column, Constraints, Statistics};
+use datafusion::common::{project_schema, Constraints, Statistics};
 use datafusion::error::Result as DataFusionResult;
 use datafusion::logical_expr::dml::InsertOp;
-use datafusion::logical_expr::{LogicalPlan, TableProviderFilterPushDown};
+use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::{
     datasource::{TableProvider, TableType},
@@ -446,21 +446,37 @@ impl TableProvider for EmbeddingTable {
             .filter_map(|i| base_schema.fields.get(i).cloned())
             .collect();
 
+        let mut computed_columns_meta: HashMap<String, Vec<String>> = HashMap::new();
+
         // Important to be kept alphabetical for fast lookup in [`EmbeddingTable::columns_to_embed`]
         let mut embedding_fields: Vec<_> = self
             .get_additional_embedding_columns_sorted()
             .iter()
-            .filter_map(|k| {
+            .filter_map(|base_column_name| {
                 base_schema
-                    .column_with_name(k)
-                    .map(|(_, field)| self.embedding_fields(field))
+                    .column_with_name(base_column_name)
+                    .map(|(_, field)| {
+                        let embedding_fields = self.embedding_fields(field);
+                        computed_columns_meta.insert(
+                            base_column_name.clone(),
+                            embedding_fields
+                                .iter()
+                                .map(|f| f.name().to_string())
+                                .collect(),
+                        );
+                        embedding_fields
+                    })
             })
             .flatten()
             .collect();
 
         base_fields.append(&mut embedding_fields);
 
-        Arc::new(Schema::new(base_fields))
+        let mut schema = Schema::new(base_fields);
+
+        schema::set_computed_columns_meta(&mut schema, &computed_columns_meta);
+
+        Arc::new(schema)
     }
 
     async fn scan(
@@ -591,54 +607,6 @@ impl TableProvider for EmbeddingTable {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.base_table.insert_into(state, input, overwrite).await
     }
-}
-
-/// Ensures that for each column with embeddings (`col_name`), the `LogicalPlan::Projection` node
-/// includes the associated Spice internal columns (`col_name_embeddings`, `col_name_offset`).
-/// If any required columns are missing, they are automatically added to the projection.
-pub(crate) fn include_embeddings_internal_columns(
-    plan: LogicalPlan,
-    table: &EmbeddingTable,
-) -> DataFusionResult<LogicalPlan> {
-    let plan = plan
-        .transform_down(|plan| {
-            match plan {
-                LogicalPlan::Projection(mut proj) => {
-                    for col_with_embeddings in table.get_embedding_columns() {
-                        // Ensure that for each included column with embeddings, the associated Spice internal
-                        // embedding columns are present in the projection.
-                        if let Some(idx) = proj
-                            .schema
-                            .index_of_column_by_name(None, &col_with_embeddings)
-                        {
-                            let mut spice_embedding_columns =
-                                vec![embedding_col!(col_with_embeddings)];
-                            if table.is_chunked(&col_with_embeddings) {
-                                spice_embedding_columns.push(offset_col!(col_with_embeddings));
-                            }
-
-                            for spice_embedding_column in spice_embedding_columns {
-                                if !proj
-                                    .schema
-                                    .has_column_with_unqualified_name(&spice_embedding_column)
-                                {
-                                    proj.expr.push(Expr::Column(Column::new(
-                                        proj.schema.qualified_field(idx).0.cloned(),
-                                        spice_embedding_column,
-                                    )));
-                                }
-                            }
-                        }
-                    }
-                    // The Transformed flag is not used, so we always specify it as transformed for simplicity.
-                    Ok(Transformed::yes(LogicalPlan::Projection(proj)))
-                }
-                _ => Ok(Transformed::no(plan)),
-            }
-        })?
-        .data;
-
-    Ok(plan)
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -21,10 +21,11 @@ use arrow::datatypes::{DataType, Schema, SchemaRef};
 use arrow_schema::Field;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::common::{project_schema, Constraints, Statistics};
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::{project_schema, Column, Constraints, Statistics};
 use datafusion::error::Result as DataFusionResult;
 use datafusion::logical_expr::dml::InsertOp;
-use datafusion::logical_expr::TableProviderFilterPushDown;
+use datafusion::logical_expr::{LogicalPlan, TableProviderFilterPushDown};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::{
     datasource::{TableProvider, TableType},
@@ -590,6 +591,54 @@ impl TableProvider for EmbeddingTable {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         self.base_table.insert_into(state, input, overwrite).await
     }
+}
+
+/// Ensures that for each column with embeddings (`col_name`), the `LogicalPlan::Projection` node
+/// includes the associated Spice internal columns (`col_name_embeddings`, `col_name_offset`).
+/// If any required columns are missing, they are automatically added to the projection.
+pub fn include_embeddings_internal_columns(
+    plan: LogicalPlan,
+    table: &EmbeddingTable,
+) -> DataFusionResult<LogicalPlan> {
+    let plan = plan
+        .transform_down(|plan| {
+            match plan {
+                LogicalPlan::Projection(mut proj) => {
+                    for col_with_embeddings in table.get_embedding_columns() {
+                        // Ensure that for each included column with embeddings, the associated Spice internal
+                        // embedding columns are present in the projection.
+                        if let Some(idx) = proj
+                            .schema
+                            .index_of_column_by_name(None, &col_with_embeddings)
+                        {
+                            let mut spice_embedding_columns =
+                                vec![embedding_col!(col_with_embeddings)];
+                            if table.is_chunked(&col_with_embeddings) {
+                                spice_embedding_columns.push(offset_col!(col_with_embeddings));
+                            }
+
+                            for spice_embedding_column in spice_embedding_columns {
+                                if !proj
+                                    .schema
+                                    .has_column_with_unqualified_name(&spice_embedding_column)
+                                {
+                                    proj.expr.push(Expr::Column(Column::new(
+                                        proj.schema.qualified_field(idx).0.cloned(),
+                                        spice_embedding_column,
+                                    )));
+                                }
+                            }
+                        }
+                    }
+                    // The Transformed flag is not used, so we always specify it as transformed for simplicity.
+                    Ok(Transformed::yes(LogicalPlan::Projection(proj)))
+                }
+                _ => Ok(Transformed::no(plan)),
+            }
+        })?
+        .data;
+
+    Ok(plan)
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -596,7 +596,7 @@ impl TableProvider for EmbeddingTable {
 /// Ensures that for each column with embeddings (`col_name`), the `LogicalPlan::Projection` node
 /// includes the associated Spice internal columns (`col_name_embeddings`, `col_name_offset`).
 /// If any required columns are missing, they are automatically added to the projection.
-pub fn include_embeddings_internal_columns(
+pub(crate) fn include_embeddings_internal_columns(
     plan: LogicalPlan,
     table: &EmbeddingTable,
 ) -> DataFusionResult<LogicalPlan> {

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -188,7 +188,7 @@ mod search {
 
         test_request_context()
             .scope(async {
-                let mut ds_tpcds_item = get_tpcds_dataset("item", None);
+                let mut ds_tpcds_item = get_tpcds_dataset("item", None, None);
                 ds_tpcds_item.embeddings = vec![ColumnEmbeddingConfig {
                     column: "i_item_desc".to_string(),
                     model: "hf_minilm".to_string(),
@@ -197,7 +197,7 @@ mod search {
                 }];
 
                 let mut ds_tpcds_cp_with_chunking =
-                    get_tpcds_dataset("catalog_page", Some("catalog_page_with_chunking"));
+                    get_tpcds_dataset("catalog_page", Some("catalog_page_with_chunking"), Some("select cp_description, cp_catalog_page_sk from catalog_page_with_chunking limit 20"));
                 ds_tpcds_cp_with_chunking.embeddings = vec![ColumnEmbeddingConfig {
                     column: "cp_description".to_string(),
                     model: "hf_minilm".to_string(),

--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -188,7 +188,11 @@ fn get_taxi_trips_dataset() -> Dataset {
     dataset
 }
 
-fn get_tpcds_dataset(ds_name: &str, spice_name: Option<&str>) -> Dataset {
+fn get_tpcds_dataset(
+    ds_name: &str,
+    spice_name: Option<&str>,
+    refresh_sql: Option<&str>,
+) -> Dataset {
     let mut dataset = Dataset::new(
         format!("s3://spiceai-public-datasets/tpcds/{ds_name}/"),
         spice_name.unwrap_or(ds_name),
@@ -203,10 +207,14 @@ fn get_tpcds_dataset(ds_name: &str, spice_name: Option<&str>) -> Dataset {
     ));
     dataset.acceleration = Some(Acceleration {
         enabled: true,
-        refresh_sql: Some(format!(
-            "SELECT * FROM {} LIMIT 20",
-            spice_name.unwrap_or(ds_name)
-        )),
+        refresh_sql: Some(
+            refresh_sql
+                .unwrap_or(&format!(
+                    "SELECT * FROM {} LIMIT 20",
+                    spice_name.unwrap_or(ds_name)
+                ))
+                .to_string(),
+        ),
         ..Default::default()
     });
     dataset

--- a/crates/runtime/tests/models/openai.rs
+++ b/crates/runtime/tests/models/openai.rs
@@ -152,7 +152,7 @@ mod search {
                     .await
                     .map_err(anyhow::Error::msg)?;
 
-                let mut ds_tpcds_item = get_tpcds_dataset("item", None);
+                let mut ds_tpcds_item = get_tpcds_dataset("item", None, None);
                 ds_tpcds_item.embeddings = vec![ColumnEmbeddingConfig {
                     column: "i_item_desc".to_string(),
                     model: "openai_embeddings".to_string(),
@@ -161,7 +161,7 @@ mod search {
                 }];
 
                 let mut ds_tpcds_cp_with_chunking =
-                    get_tpcds_dataset("catalog_page", Some("catalog_page_with_chunking"));
+                    get_tpcds_dataset("catalog_page", Some("catalog_page_with_chunking"), Some("select cp_description, cp_catalog_page_sk from catalog_page_with_chunking limit 20"));
                 ds_tpcds_cp_with_chunking.embeddings = vec![ColumnEmbeddingConfig {
                     column: "cp_description".to_string(),
                     model: "openai_embeddings".to_string(),
@@ -419,7 +419,7 @@ async fn openai_test_chat_messages() -> Result<(), anyhow::Error> {
                 .await
                 .map_err(anyhow::Error::msg)?;
 
-            let mut ds_tpcds_item = get_tpcds_dataset("item", None);
+            let mut ds_tpcds_item = get_tpcds_dataset("item", None, None);
             ds_tpcds_item.embeddings = vec![ColumnEmbeddingConfig {
                 column: "i_item_desc".to_string(),
                 model: "openai_embeddings".to_string(),


### PR DESCRIPTION
# 🗣 Description

When `refresh_sql` contains a subset of columns with embeddings, Spice internal embedding fields are not included automatically in the dataset schema and are not fetched/calculated during the refresh from the `EmbeddingTable` resulting in broken vector similarity search functionality. This PR implements the logic to:

1. Detect when the source schema contains automatically created embedding fields for a column included in `refresh_sql` and add them.
2. When getting refresh data automatically include Spice internal embedding columns in the logical plan.

Note: The `Projection` node is updated/mutated in-place without additional copies. The logic is applied for data refresh only.

Other Alternatives Considered

1. **Warn user if `refresh_sql` contains a subset of columns with embeddings**: This would require users to manually include Spice internal columns in the refresh SQL. This was rejected as it does not provide the best DX; embedding columns are Spice internal and should be added automatically.
  
2. **Inject Spice internal columns directly into `refresh_sql`**: This alternative involved injecting additional Spice internal columns directly into `refresh_sql` so that data refresh works out of the box, without injecting Spice internal columns into the plan. The preferred original approach was chosen to preserve the original `refresh_sql` in traces, logs, and telemetry, as updating the `refresh_sql` could cause confusion.

## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/4258

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

