### PR TITLE
Fix pre-release check to look for `build` string

### DIFF
--- a/bin/spice/cmd/version.go
+++ b/bin/spice/cmd/version.go
@@ -107,7 +107,7 @@ func checkLatestCliReleaseVersion() error {
 
 	cliVersion := version.Version()
 
-	cliIsPreRelease := strings.HasPrefix(cliVersion, "local") || strings.Contains(cliVersion, "rc")
+	cliIsPreRelease := strings.HasPrefix(cliVersion, "local") || strings.Contains(cliVersion, "build")
 
 	if !cliIsPreRelease && semver.Compare(cliVersion, latestReleaseVersion) < 0 {
 		slog.Info(fmt.Sprintf("\nCLI version %s is now available!\nTo upgrade, run \"spice upgrade\".\n", aurora.BrightGreen(latestReleaseVersion)))


### PR DESCRIPTION
# 🗣 Description

Fixes an issue where the CLI was not properly skipping the upgrade check when using a Spice binary built from trunk.

