### PR TITLE
Revert "Promote databricks catalog connector (mode: delta_lake) to beta (#4301)"

### DIFF
--- a/docs/criteria/catalogs/alpha.md
+++ b/docs/criteria/catalogs/alpha.md
@@ -6,13 +6,12 @@ All criteria must be met for the Catalog to be considered Alpha. As Alpha signif
 
 ## Alpha Quality Catalogs
 
-| Catalog                          | Alpha Quality | DRI Sign-off |
-| -------------------------------- | ------------- | ------------ |
-| Databricks (mode: delta_lake)    | ✅            | @Sevenannn   |
-| Databricks (mode: spark_connect) | ➖            |              |
-| Iceberg                          | ➖            |              |
-| Spice.ai                         | ➖            |              |
-| Unity Catalog                    | ➖            |              |
+| Catalog       | Alpha Quality | DRI Sign-off |
+| ------------- | ------------- | ------------ |
+| Databricks    | ➖            |              |
+| Iceberg       | ➖            |              |
+| Spice.ai      | ➖            |              |
+| Unity Catalog | ➖            |              |
 
 ## Alpha Release Criteria
 

--- a/docs/criteria/catalogs/beta.md
+++ b/docs/criteria/catalogs/beta.md
@@ -6,13 +6,12 @@ All criteria must be met for the Catalog to be considered Beta, with exceptions 
 
 ## Beta Quality Catalogs
 
-| Catalog                          | Beta Quality | DRI Sign-off |
-| -------------------------------- | ------------ | ------------ |
-| Databricks (mode: delta_lake)    | ✅           | @Sevenannn   |
-| Databricks (mode: spark_connect) | ➖           |              |
-| Iceberg                          | ➖           |              |
-| Spice.ai                         | ➖           |              |
-| Unity Catalog                    | ➖           |              |
+| Catalog       | Beta Quality | DRI Sign-off |
+| ------------- | ------------ | ------------ |
+| Databricks    | ➖           |              |
+| Iceberg       | ➖           |              |
+| Spice.ai      | ➖           |              |
+| Unity Catalog | ➖           |              |
 
 ## Beta Release Criteria
 

--- a/docs/criteria/catalogs/rc.md
+++ b/docs/criteria/catalogs/rc.md
@@ -6,13 +6,12 @@ All criteria must be met for the Catalog to be considered [RC](../definitions.md
 
 ## RC Quality Catalogs
 
-| Catalog                          | RC Quality | DRI Sign-off |
-| -------------------------------- | ---------- | ------------ |
-| Databricks (mode: delta_lake)    | ➖         |              |
-| Databricks (mode: spark_connect) | ➖         |              |
-| Iceberg                          | ➖         |              |
-| Spice.ai                         | ➖         |              |
-| Unity Catalog                    | ➖         |              |
+| Catalog       | RC Quality | DRI Sign-off |
+| ------------- | ------------ | ------------ |
+| Databricks    | ➖           |              |
+| Iceberg       | ➖           |              |
+| Spice.ai      | ➖           |              |
+| Unity Catalog | ➖           |              |
 
 ## RC Criteria
 


### PR DESCRIPTION
This reverts commit aefd46179f62e72a96a8692da2fa4e62c692f20d.

# 🗣 Description

Revert the promotion to databricks catalog connector since we want to promote mode `delta_lake` and `spark_connect` together

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
