### PR TITLE
feat: Update load test criteria, testoperator updates

### DIFF
--- a/.github/actions/setup-testoperator/action.yml
+++ b/.github/actions/setup-testoperator/action.yml
@@ -32,6 +32,20 @@ runs:
         sudo mkdir -p /opt/spiced/data
         sudo chown runner:runner -R /opt/spiced/data
 
+    - name: Download DuckDB TPCH Data
+      shell: bash
+      if: inputs.query_set == 'tpch'
+      run: |
+        cd /opt/spiced/data
+        mc cp spice-minio/benchmarks/duckdb/tpch.db ./
+
+    - name: Download DuckDB TPCDS Data
+      shell: bash
+      if: inputs.query_set == 'tpcds'
+      run: |
+        cd /opt/spiced/data
+        mc cp spice-minio/benchmarks/duckdb/tpcds.db ./
+
     - name: Download File Connector TPCH Data
       shell: bash
       if: inputs.query_set == 'tpch'

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -116,7 +116,7 @@ jobs:
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
           rm -rf .spice/data
-          testoperator run bench -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --ready-wait ${{ github.event.inputs.ready_wait }}
+          testoperator run bench -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
@@ -133,7 +133,7 @@ jobs:
         if: ${{ github.event.inputs.query_overrides != '' }}
         run: |
           rm -rf .spice/data
-          testoperator run bench -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --query-overrides ${{ github.event.inputs.query_overrides }} --ready-wait ${{ github.event.inputs.ready_wait }}
+          testoperator run bench -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --query-overrides ${{ github.event.inputs.query_overrides }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -121,7 +121,7 @@ jobs:
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
           rm -rf .spice/data
-          testoperator run load -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --duration ${{ github.event.inputs.duration }} --ready-wait ${{ github.event.inputs.ready_wait }}
+          testoperator run load -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --duration ${{ github.event.inputs.duration }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
@@ -135,7 +135,7 @@ jobs:
         if: ${{ github.event.inputs.query_overrides != '' }}
         run: |
           rm -rf .spice/data
-          testoperator run load -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --duration ${{ github.event.inputs.duration }} --query-overrides ${{ github.event.inputs.query_overrides }} --ready-wait ${{ github.event.inputs.ready_wait }}
+          testoperator run load -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --duration ${{ github.event.inputs.duration }} --query-overrides ${{ github.event.inputs.query_overrides }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -115,7 +115,7 @@ jobs:
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
           rm -rf .spice/data
-          testoperator run throughput -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --ready-wait ${{ github.event.inputs.ready_wait }}
+          testoperator run throughput -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
@@ -129,7 +129,7 @@ jobs:
         if: ${{ github.event.inputs.query_overrides != '' }}
         run: |
           rm -rf .spice/data
-          testoperator run throughput -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --query-overrides ${{ github.event.inputs.query_overrides }} --ready-wait ${{ github.event.inputs.ready_wait }}
+          testoperator run throughput -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --query-overrides ${{ github.event.inputs.query_overrides }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11389,6 +11389,7 @@ dependencies = [
  "clap",
  "flight_client",
  "futures",
+ "indicatif",
  "nix",
  "regex",
  "reqwest 0.12.9",

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -25,6 +25,7 @@ tonic.workspace = true
 rustls.workspace = true
 uuid = { workspace = true, features = ["v4"]}
 sysinfo = "0.33.1"
+indicatif = "0.17.9"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = { version = "0.29", features = ["signal"] }

--- a/crates/test-framework/src/spiced/mod.rs
+++ b/crates/test-framework/src/spiced/mod.rs
@@ -229,6 +229,16 @@ impl SpicedInstance {
 
         Ok(process.memory())
     }
+
+    pub fn show_memory_usage(&self) -> Result<()> {
+        let memory_usage = self.memory_usage()?;
+        // drop memory usage to MB as a u32 before converting to GB as a float
+        // we don't really care about the fractional memory usage of KB/MB
+        let memory_usage_gb = f64::from(u32::try_from(memory_usage / 1024 / 1024)?) / 1024.0;
+        println!("Memory usage: {memory_usage_gb:.2} GB");
+
+        Ok(())
+    }
 }
 
 impl Drop for SpicedInstance {

--- a/crates/test-framework/src/spicetest/mod.rs
+++ b/crates/test-framework/src/spicetest/mod.rs
@@ -123,7 +123,8 @@ impl SpiceTest<NotStarted> {
             EndCondition::Duration(duration) => {
                 // refresh the progress bar every 10 seconds, or every 1/1000th of the duration
                 // for an 8 hour test, this would be every ~28 seconds
-                let pb = ProgressBar::new(duration.as_secs());
+                let pb =
+                    ProgressBar::new(duration.as_secs() / self.state.query_set.len() as u64 * 2); // this isn't 100% representative of the progress bar count, but it's close enough (500ms per query)
                 pb.enable_steady_tick(Duration::from_secs((duration.as_secs() / 1000).max(10)));
 
                 pb

--- a/crates/test-framework/src/spicetest/mod.rs
+++ b/crates/test-framework/src/spicetest/mod.rs
@@ -124,7 +124,7 @@ impl SpiceTest<NotStarted> {
                 // refresh the progress bar every 10 seconds, or every 1/1000th of the duration
                 // for an 8 hour test, this would be every ~28 seconds
                 let pb =
-                    ProgressBar::new(duration.as_secs() / self.state.query_set.len() as u64 * 2); // this isn't 100% representative of the progress bar count, but it's close enough (500ms per query)
+                    ProgressBar::new(duration.as_secs() / self.state.query_set.len() as u64 * 2); // this isn't 100% representative of the progress bar count, but it's close enough (2s per query)
                 pb.enable_steady_tick(Duration::from_secs((duration.as_secs() / 1000).max(10)));
 
                 pb

--- a/crates/test-framework/src/spicetest/mod.rs
+++ b/crates/test-framework/src/spicetest/mod.rs
@@ -57,7 +57,7 @@ pub type SpiceTestQueryWorkers = Vec<JoinHandle<Result<SpiceTestQueryWorkerResul
 pub struct Running {
     start_time: Instant,
     query_workers: SpiceTestQueryWorkers,
-    progress_bar: MultiProgress,
+    progress_bar: Option<MultiProgress>,
 }
 pub struct Completed {
     query_durations: BTreeMap<String, Vec<Duration>>,
@@ -79,6 +79,7 @@ pub struct SpiceTest<S: TestState> {
     query_count: usize,
     parallel_count: usize,
     start_time: SystemTime,
+    use_progress_bars: bool,
 
     state: S,
 }
@@ -92,11 +93,18 @@ impl SpiceTest<NotStarted> {
             query_count: 0,
             parallel_count: 1,
             start_time: SystemTime::now(),
+            use_progress_bars: true,
             state: NotStarted {
                 query_set: vec![],
                 end_condition: EndCondition::QuerySetCompleted(1),
             },
         }
+    }
+
+    #[must_use]
+    pub fn with_progress_bars(mut self, use_progress_bars: bool) -> Self {
+        self.use_progress_bars = use_progress_bars;
+        self
     }
 
     #[must_use]
@@ -147,18 +155,27 @@ impl SpiceTest<NotStarted> {
             return Err(anyhow::anyhow!("Parallel count must be greater than 0"));
         }
 
-        let multi = MultiProgress::new();
+        let multi = if self.use_progress_bars {
+            Some(MultiProgress::new())
+        } else {
+            None
+        };
 
         let flight_client = self.spiced_instance.flight_client().await?;
         let query_workers = (0..self.parallel_count)
             .map(|id| {
-                SpiceTestQueryWorker::new(
+                let worker = SpiceTestQueryWorker::new(
                     id,
                     self.state.query_set.clone(),
                     self.state.end_condition,
                     flight_client.clone(),
-                )
-                .with_progress_bar(multi.add(self.get_new_progress_bar()))
+                );
+
+                if let Some(multi) = &multi {
+                    worker.with_progress_bar(multi.add(self.get_new_progress_bar()))
+                } else {
+                    worker
+                }
             })
             .map(SpiceTestQueryWorker::start)
             .collect();
@@ -169,6 +186,7 @@ impl SpiceTest<NotStarted> {
             query_count: self.query_count,
             parallel_count: self.parallel_count,
             start_time: self.start_time,
+            use_progress_bars: self.use_progress_bars,
             state: Running {
                 start_time: Instant::now(),
                 query_workers,
@@ -197,7 +215,9 @@ impl SpiceTest<Running> {
             }
         }
 
-        self.state.progress_bar.clear()?;
+        if let Some(multi) = self.state.progress_bar {
+            multi.clear()?;
+        }
 
         Ok(SpiceTest {
             name: self.name,
@@ -205,6 +225,7 @@ impl SpiceTest<Running> {
             query_count: self.query_count,
             parallel_count: self.parallel_count,
             start_time: self.start_time,
+            use_progress_bars: self.use_progress_bars,
             state: Completed {
                 query_durations,
                 test_duration: self.state.start_time.elapsed(),

--- a/crates/test-framework/src/spicetest/mod.rs
+++ b/crates/test-framework/src/spicetest/mod.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 use anyhow::Result;
 use futures::future::join_all;
+use indicatif::{MultiProgress, ProgressBar};
 use tokio::task::JoinHandle;
 use worker::{SpiceTestQueryWorker, SpiceTestQueryWorkerResult};
 
@@ -56,6 +57,7 @@ pub type SpiceTestQueryWorkers = Vec<JoinHandle<Result<SpiceTestQueryWorkerResul
 pub struct Running {
     start_time: Instant,
     query_workers: SpiceTestQueryWorkers,
+    progress_bar: MultiProgress,
 }
 pub struct Completed {
     query_durations: BTreeMap<String, Vec<Duration>>,
@@ -116,6 +118,25 @@ impl SpiceTest<NotStarted> {
         self
     }
 
+    fn get_new_progress_bar(&self) -> ProgressBar {
+        match self.state.end_condition {
+            EndCondition::Duration(duration) => {
+                // refresh the progress bar every 10 seconds, or every 1/1000th of the duration
+                // for an 8 hour test, this would be every ~28 seconds
+                let pb = ProgressBar::new(duration.as_secs());
+                pb.enable_steady_tick(Duration::from_secs((duration.as_secs() / 1000).max(10)));
+
+                pb
+            }
+            EndCondition::QuerySetCompleted(count) => {
+                let pb = ProgressBar::new((self.state.query_set.len() * count) as u64);
+                pb.enable_steady_tick(Duration::from_secs(1));
+
+                pb
+            }
+        }
+    }
+
     pub async fn start(self) -> Result<SpiceTest<Running>> {
         if self.state.query_set.is_empty() {
             return Err(anyhow::anyhow!("Query set is empty"));
@@ -124,6 +145,8 @@ impl SpiceTest<NotStarted> {
         if self.parallel_count == 0 {
             return Err(anyhow::anyhow!("Parallel count must be greater than 0"));
         }
+
+        let multi = MultiProgress::new();
 
         let flight_client = self.spiced_instance.flight_client().await?;
         let query_workers = (0..self.parallel_count)
@@ -134,6 +157,7 @@ impl SpiceTest<NotStarted> {
                     self.state.end_condition,
                     flight_client.clone(),
                 )
+                .with_progress_bar(multi.add(self.get_new_progress_bar()))
             })
             .map(SpiceTestQueryWorker::start)
             .collect();
@@ -147,6 +171,7 @@ impl SpiceTest<NotStarted> {
             state: Running {
                 start_time: Instant::now(),
                 query_workers,
+                progress_bar: multi,
             },
         })
     }
@@ -170,6 +195,9 @@ impl SpiceTest<Running> {
                     .extend(duration);
             }
         }
+
+        self.state.progress_bar.clear()?;
+
         Ok(SpiceTest {
             name: self.name,
             spiced_instance: self.spiced_instance,

--- a/crates/test-framework/src/spicetest/worker.rs
+++ b/crates/test-framework/src/spicetest/worker.rs
@@ -22,6 +22,7 @@ use std::{
 use anyhow::Result;
 use flight_client::FlightClient;
 use futures::StreamExt;
+use indicatif::ProgressBar;
 use tokio::task::JoinHandle;
 
 use super::EndCondition;
@@ -31,6 +32,7 @@ pub(crate) struct SpiceTestQueryWorker {
     query_set: Vec<(&'static str, &'static str)>,
     end_condition: EndCondition,
     flight_client: FlightClient,
+    pub progress_bar: Option<ProgressBar>,
 }
 
 pub struct SpiceTestQueryWorkerResult {
@@ -65,7 +67,13 @@ impl SpiceTestQueryWorker {
             query_set,
             end_condition,
             flight_client,
+            progress_bar: None,
         }
+    }
+
+    pub fn with_progress_bar(mut self, progress_bar: ProgressBar) -> Self {
+        self.progress_bar = Some(progress_bar);
+        self
     }
 
     pub fn start(self) -> JoinHandle<Result<SpiceTestQueryWorkerResult>> {
@@ -77,7 +85,6 @@ impl SpiceTestQueryWorker {
 
             while !self.end_condition.is_met(&start, query_set_count) {
                 'query_set: for query in &self.query_set {
-                    eprintln!("Running: Worker {} - Query '{}'", self.id, query.0,);
                     let mut row_count = 0;
                     let query_start = Instant::now();
                     match self.flight_client.query(query.1).await {
@@ -105,6 +112,10 @@ impl SpiceTestQueryWorker {
                                 .push(duration);
 
                             *row_counts.entry(query.0.to_string()).or_default() += row_count;
+
+                            if let Some(pb) = self.progress_bar.as_ref() {
+                                pb.inc(1);
+                            }
                         }
                         Err(e) => match e {
                             flight_client::Error::UnableToConnectToServer { .. }

--- a/crates/test-framework/src/spicetest/worker.rs
+++ b/crates/test-framework/src/spicetest/worker.rs
@@ -84,6 +84,15 @@ impl SpiceTestQueryWorker {
             let start = Instant::now();
 
             while !self.end_condition.is_met(&start, query_set_count) {
+                if self.progress_bar.is_none() && self.id == 0 {
+                    println!(
+                        "Worker {} - Query set count: {} - Elapsed time: {:?}",
+                        self.id,
+                        query_set_count,
+                        start.elapsed()
+                    );
+                }
+
                 'query_set: for query in &self.query_set {
                     let mut row_count = 0;
                     let query_start = Instant::now();

--- a/docs/criteria/accelerators/stable.md
+++ b/docs/criteria/accelerators/stable.md
@@ -40,8 +40,11 @@ Indexes are not required for test coverage, but can be introduced if required fo
   - [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
   - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
   - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric at the required [parallel query count](../definitions.md).
-  - [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. The 99th percentile of load test query [timing measurements](../definitions.md) must be no more than 10% higher than the 99th percentile of the baseline throughput test timing measurements. The service must not become unavailable for the entire duration of the test.
-    - Queries that have a median execution time faster than 500ms are excluded from this check, as they complete so fast that this check is not meaningful.
+  - [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. The 99th percentile of load test query [timing measurements](../definitions.md) must be compared against than the 99th percentile of the baseline throughput test timing measurements.
+    - Three or more [Yellow percentile measurements](../definitions.md#stop-light-percentile-measurements) are considered a test failure.
+    - One or more [Red percentile measurements](../definitions.md#stop-light-percentile-measurements) are considered a test failure.
+    - The service must not become unavailable for the entire duration of the test. A connection failure is considered a test failure.
+    - Queries that have a 99th percentile execution time faster than 1000ms are excluded from this check, as they complete so fast that this check is not meaningful.
   - [ ] Memory usage is collected at the end of the end-to-end test and reported as a metric on the overall connector.
 
 #### TPC-DS
@@ -55,8 +58,11 @@ Indexes are not required for test coverage, but can be introduced if required fo
   - [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
   - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
   - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric at the required [parallel query count](../definitions.md).
-  - [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. The 99th percentile of load test query [timing measurements](../definitions.md) must be no more than 10% higher than the 99th percentile of the baseline throughput test timing measurements. The service must not become unavailable for the entire duration of the test.
-    - Queries that have a median execution time faster than 500ms are excluded from this check, as they complete so fast that this check is not meaningful.
+  - [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. The 99th percentile of load test query [timing measurements](../definitions.md) must be compared against than the 99th percentile of the baseline throughput test timing measurements.
+    - Three or more [Yellow percentile measurements](../definitions.md#stop-light-percentile-measurements) are considered a test failure.
+    - One or more [Red percentile measurements](../definitions.md#stop-light-percentile-measurements) are considered a test failure.
+    - The service must not become unavailable for the entire duration of the test. A connection failure is considered a test failure.
+    - Queries that have a 99th percentile execution time faster than 1000ms are excluded from this check, as they complete so fast that this check is not meaningful.
   - [ ] Memory usage is collected at the end of the end-to-end test and reported as a metric on the overall connector.
 
 #### ClickBench

--- a/docs/criteria/connectors/stable.md
+++ b/docs/criteria/connectors/stable.md
@@ -141,8 +141,11 @@ Indexes are not required for test coverage, but can be introduced if required fo
 - [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
 - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
 - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric at the required [parallel query count](../definitions.md).
-- [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. The 99th percentile of load test query [timing measurements](../definitions.md) must be no more than 10% higher than the 99th percentile of the baseline throughput test timing measurements. The service must not become unavailable for the entire duration of the test.
-  - Queries that have a median execution time faster than 500ms are excluded from this check, as they complete so fast that this check is not meaningful.
+- [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. The 99th percentile of load test query [timing measurements](../definitions.md) must be compared against than the 99th percentile of the baseline throughput test timing measurements.
+  - Three or more [Yellow percentile measurements](../definitions.md#stop-light-percentile-measurements) are considered a test failure.
+  - One or more [Red percentile measurements](../definitions.md#stop-light-percentile-measurements) are considered a test failure.
+  - The service must not become unavailable for the entire duration of the test. A connection failure is considered a test failure.
+  - Queries that have a 99th percentile execution time faster than 1000ms are excluded from this check, as they complete so fast that this check is not meaningful.
 - [ ] Memory usage is collected at the end of the end-to-end test and reported as a metric on the overall connector.
 - [ ] At the scale factor required by the connector criteria:
   - [ ] A test script exists that can load TPC-H data at the [designated scale factor](#stable-release-criteria) into this connector.
@@ -155,8 +158,11 @@ Indexes are not required for test coverage, but can be introduced if required fo
 - [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
 - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
 - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric at the required [parallel query count](../definitions.md).
-- [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. The 99th percentile of load test query [timing measurements](../definitions.md) must be no more than 10% higher than the 99th percentile of the baseline throughput test timing measurements. The service must not become unavailable for the entire duration of the test.
-  - Queries that have a median execution time faster than 500ms are excluded from this check, as they complete so fast that this check is not meaningful.
+- [ ] A [Load Test](../definitions.md) runs for a minimum of 8 hours as part of the end-to-end test. The 99th percentile of load test query [timing measurements](../definitions.md) must be compared against than the 99th percentile of the baseline throughput test timing measurements.
+  - Three or more [Yellow percentile measurements](../definitions.md#stop-light-percentile-measurements) are considered a test failure.
+  - One or more [Red percentile measurements](../definitions.md#stop-light-percentile-measurements) are considered a test failure.
+  - The service must not become unavailable for the entire duration of the test. A connection failure is considered a test failure.
+  - Queries that have a 99th percentile execution time faster than 1000ms are excluded from this check, as they complete so fast that this check is not meaningful.
 - [ ] Memory usage is collected at the end of the end-to-end test and reported as a metric on the overall connector.
 - [ ] At the scale factor required by the connector criteria:
   - [ ] A test script exists that can load TPC-DS data at the [designated scale factor](#stable-release-criteria) into this connector.

--- a/docs/criteria/definitions.md
+++ b/docs/criteria/definitions.md
@@ -106,3 +106,11 @@ The following table defines how many parallel queries are required at a given sc
 A load test refers to an extended duration throughput test. For a given throughput test, a load test is where the throughput test is repeated for a set number of hours.
 
 The system is provided with no delays or pauses between throughput test repetitions, resulting in a sustained high-load test.
+
+### Stop-light percentile measurements
+
+The load test uses a stop-light system to determine severity of timing measurements compared against the baseline:
+
+- 🟢: Green - an increase of the 99th percentile of less than 10% compared to the baseline
+- 🟡: Yellow - an increase of the 99th percentile between 10-20% compared to the baseline
+- 🔴: Red - an increase of the 99th percentile of more then 20% compared to the baseline

--- a/test/spicepods/tpcds/duckdb.yaml
+++ b/test/spicepods/tpcds/duckdb.yaml
@@ -1,0 +1,77 @@
+version: v1
+kind: Spicepod
+name: duckdb_tpch
+datasets:
+  - from: duckdb:catalog_sales
+    name: catalog_sales
+    params: &duckdb_params
+      duckdb_open: ./data/tpcds.db
+  - from: duckdb:catalog_returns
+    name: catalog_returns
+    params: *duckdb_params
+  - from: duckdb:inventory
+    name: inventory
+    params: *duckdb_params
+  - from: duckdb:store_sales
+    name: store_sales
+    params: *duckdb_params
+  - from: duckdb:store_returns
+    name: store_returns
+    params: *duckdb_params
+  - from: duckdb:web_sales
+    name: web_sales
+    params: *duckdb_params
+  - from: duckdb:web_returns
+    name: web_returns
+    params: *duckdb_params
+  - from: duckdb:customer
+    name: customer
+    params: *duckdb_params
+  - from: duckdb:customer_address
+    name: customer_address
+    params: *duckdb_params
+  - from: duckdb:customer_demographics
+    name: customer_demographics
+    params: *duckdb_params
+  - from: duckdb:date_dim
+    name: date_dim
+    params: *duckdb_params
+  - from: duckdb:household_demographics
+    name: household_demographics
+    params: *duckdb_params
+  - from: duckdb:item
+    name: item
+    params: *duckdb_params
+  - from: duckdb:promotion
+    name: promotion
+    params: *duckdb_params
+  - from: duckdb:ship_mode
+    name: ship_mode
+    params: *duckdb_params
+  - from: duckdb:store
+    name: store
+    params: *duckdb_params
+  - from: duckdb:time_dim
+    name: time_dim
+    params: *duckdb_params
+  - from: duckdb:warehouse
+    name: warehouse
+    params: *duckdb_params
+  - from: duckdb:web_page
+    name: web_page
+    params: *duckdb_params
+  - from: duckdb:web_site
+    name: web_site
+    params: *duckdb_params
+  - from: duckdb:reason
+    name: reason
+    params: *duckdb_params
+  - from: duckdb:call_center
+    name: call_center
+    params: *duckdb_params
+  - from: duckdb:income_band
+    name: income_band
+    params: *duckdb_params
+  - from: duckdb:catalog_page
+    name: catalog_page
+    params: *duckdb_params

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -69,6 +69,9 @@ pub struct TestArgs {
 
     #[arg(long)]
     pub(crate) ready_wait: Option<usize>,
+
+    #[arg(long)]
+    pub(crate) disable_progress_bars: bool,
 }
 
 #[derive(Clone, ValueEnum)]

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -38,11 +38,11 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.subcommand {
         Commands::Run(TestCommands::Throughput(args)) => tests::throughput::run(&args).await?,
-        Commands::Export(TestCommands::Throughput(args)) => tests::throughput::export(&args)?,
+        Commands::Export(TestCommands::Throughput(args)) => tests::env_export(&args)?,
         Commands::Run(TestCommands::Load(args)) => tests::load::run(&args).await?,
-        Commands::Export(TestCommands::Load(args)) => tests::load::export(&args)?,
+        Commands::Export(TestCommands::Load(args)) => tests::env_export(&args)?,
         Commands::Run(TestCommands::Bench(args)) => tests::bench::run(&args).await?,
-        Commands::Export(TestCommands::Bench(args)) => tests::bench::export(&args)?,
+        Commands::Export(TestCommands::Bench(args)) => tests::env_export(&args)?,
     }
 
     Ok(())

--- a/tools/testoperator/src/tests/bench/mod.rs
+++ b/tools/testoperator/src/tests/bench/mod.rs
@@ -42,6 +42,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
     let benchmark_test = SpiceTest::new(app.name.clone(), spiced_instance)
         .with_query_set(queries.clone())
         .with_end_condition(EndCondition::QuerySetCompleted(5))
+        .with_progress_bars(!args.disable_progress_bars)
         .start()
         .await?;
 

--- a/tools/testoperator/src/tests/bench/mod.rs
+++ b/tools/testoperator/src/tests/bench/mod.rs
@@ -19,24 +19,11 @@ use crate::commands::TestArgs;
 use std::time::Duration;
 use test_framework::{
     anyhow,
+    metrics::MetricCollector,
     queries::{QueryOverrides, QuerySet},
     spiced::SpicedInstance,
     spicetest::{EndCondition, SpiceTest},
 };
-
-pub(crate) fn export(args: &TestArgs) -> anyhow::Result<()> {
-    let (_, mut start_request) = get_app_and_start_request(args)?;
-
-    start_request.prepare()?;
-    let tempdir_path = start_request.get_tempdir_path();
-
-    println!(
-        "Exported spicepod environment to: {}",
-        tempdir_path.to_string_lossy()
-    );
-
-    Ok(())
-}
 
 pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
     let query_set = QuerySet::from(args.query_set.clone());
@@ -59,8 +46,12 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         .await?;
 
     let test = benchmark_test.wait().await?;
+    let metrics = test.collect()?;
     let mut spiced_instance = test.end();
 
+    metrics.show()?;
+
+    spiced_instance.show_memory_usage()?;
     spiced_instance.stop()?;
     Ok(())
 }

--- a/tools/testoperator/src/tests/load/mod.rs
+++ b/tools/testoperator/src/tests/load/mod.rs
@@ -80,6 +80,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
     spiced_instance.stop()?;
 
     let mut test_passed = true;
+    let mut yellow_measurements = 0;
     for (query, _) in queries {
         let Some(duration) = test_durations.get(query) else {
             return Err(anyhow::anyhow!(
@@ -101,17 +102,34 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         };
 
         let percentile_99th = duration.percentile(0.99)?;
-        let percentile_ratio = percentile_99th.as_secs_f64() / baseline_percentile.as_secs_f64();
+        let percentile_ratio =
+            ((percentile_99th.as_secs_f64() / baseline_percentile.as_secs_f64()) - 1.0) * 100.0;
 
-        if percentile_ratio > 1.1 {
+        // yellow measurements = 10% to 20% increase
+        // red measurements = > 20% increase
+        let (yellow, red) = (
+            percentile_ratio > 10.0 && percentile_ratio <= 20.0,
+            percentile_ratio > 20.0,
+        );
+
+        if red {
             println!(
-                "FAIL - Query {query} has a 99th percentile that is {percentile_ratio}% of the baseline 99th percentile",
+                "FAIL - Query {query} has a 99th percentile that increased {percentile_ratio}% of the baseline 99th percentile",
             );
             test_passed = false;
+        } else if yellow {
+            println!(
+                "WARN - Query {query} has a 99th percentile that increased {percentile_ratio}% of the baseline 99th percentile",
+            );
+            yellow_measurements += 1;
         }
     }
 
-    if !test_passed {
+    if yellow_measurements >= 3 {
+        return Err(anyhow::anyhow!(
+            "Load test failed due to too many yellow measurements"
+        ));
+    } else if !test_passed {
         return Err(anyhow::anyhow!("Load test failed."));
     }
 

--- a/tools/testoperator/src/tests/load/mod.rs
+++ b/tools/testoperator/src/tests/load/mod.rs
@@ -43,6 +43,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         .with_query_set(queries.clone())
         .with_parallel_count(args.concurrency.unwrap_or(8))
         .with_end_condition(EndCondition::QuerySetCompleted(2))
+        .with_progress_bars(!args.disable_progress_bars)
         .start()
         .await?;
 
@@ -62,6 +63,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         .with_end_condition(EndCondition::Duration(Duration::from_secs(
             args.duration.unwrap_or(60).try_into()?,
         )))
+        .with_progress_bars(!args.disable_progress_bars)
         .start()
         .await?;
 

--- a/tools/testoperator/src/tests/load/mod.rs
+++ b/tools/testoperator/src/tests/load/mod.rs
@@ -89,11 +89,6 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
             ));
         };
 
-        let median_duration = duration.median()?;
-        if median_duration.as_millis() < 500 {
-            continue; // skip queries that are too fast for percentile comparisons to be meaningful
-        }
-
         let Some(baseline_percentile) = baseline_percentiles.get(query) else {
             return Err(anyhow::anyhow!(
                 "Query {} not found in baseline percentiles",
@@ -102,6 +97,10 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         };
 
         let percentile_99th = duration.percentile(0.99)?;
+        if percentile_99th.as_millis() < 1000 {
+            continue; // skip queries that are too fast to be meaningful
+        }
+
         let percentile_ratio =
             ((percentile_99th.as_secs_f64() / baseline_percentile.as_secs_f64()) - 1.0) * 100.0;
 

--- a/tools/testoperator/src/tests/load/mod.rs
+++ b/tools/testoperator/src/tests/load/mod.rs
@@ -25,20 +25,6 @@ use test_framework::{
     spicetest::{EndCondition, SpiceTest},
 };
 
-pub(crate) fn export(args: &TestArgs) -> anyhow::Result<()> {
-    let (_, mut start_request) = get_app_and_start_request(args)?;
-
-    start_request.prepare()?;
-    let tempdir_path = start_request.get_tempdir_path();
-
-    println!(
-        "Exported spicepod environment to: {}",
-        tempdir_path.to_string_lossy()
-    );
-
-    Ok(())
-}
-
 pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
     let query_set = QuerySet::from(args.query_set.clone());
     let query_overrides = args.query_overrides.clone().map(QueryOverrides::from);
@@ -90,13 +76,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
     println!("Load test metrics:");
     metrics.show()?;
 
-    // collect memory usage before stopping the instance
-    let memory_usage = spiced_instance.memory_usage()?;
-    // drop memory usage to MB as a u32 before converting to GB as a float
-    // we don't really care about the fractional memory usage of KB/MB
-    let memory_usage_gb = f64::from(u32::try_from(memory_usage / 1024 / 1024)?) / 1024.0;
-    println!("Memory usage: {memory_usage_gb:.2} GB");
-
+    spiced_instance.show_memory_usage()?;
     spiced_instance.stop()?;
 
     let mut test_passed = true;

--- a/tools/testoperator/src/tests/mod.rs
+++ b/tools/testoperator/src/tests/mod.rs
@@ -38,3 +38,17 @@ pub(crate) fn get_app_and_start_request(args: &TestArgs) -> anyhow::Result<(App,
 
     Ok((app, start_request))
 }
+
+pub(crate) fn env_export(args: &TestArgs) -> anyhow::Result<()> {
+    let (_, mut start_request) = get_app_and_start_request(args)?;
+
+    start_request.prepare()?;
+    let tempdir_path = start_request.get_tempdir_path();
+
+    println!(
+        "Exported spicepod environment to: {}",
+        tempdir_path.to_string_lossy()
+    );
+
+    Ok(())
+}

--- a/tools/testoperator/src/tests/throughput/mod.rs
+++ b/tools/testoperator/src/tests/throughput/mod.rs
@@ -43,6 +43,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         .with_query_set(queries.clone())
         .with_parallel_count(1)
         .with_end_condition(EndCondition::QuerySetCompleted(6))
+        .with_progress_bars(!args.disable_progress_bars)
         .start()
         .await?;
 
@@ -55,6 +56,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         .with_query_set(queries.clone())
         .with_parallel_count(args.concurrency.unwrap_or(8))
         .with_end_condition(EndCondition::QuerySetCompleted(2))
+        .with_progress_bars(!args.disable_progress_bars)
         .start()
         .await?;
 

--- a/tools/testoperator/src/tests/throughput/mod.rs
+++ b/tools/testoperator/src/tests/throughput/mod.rs
@@ -25,20 +25,6 @@ use test_framework::{
     spicetest::{EndCondition, SpiceTest},
 };
 
-pub(crate) fn export(args: &TestArgs) -> anyhow::Result<()> {
-    let (_, mut start_request) = get_app_and_start_request(args)?;
-
-    start_request.prepare()?;
-    let tempdir_path = start_request.get_tempdir_path();
-
-    println!(
-        "Exported spicepod environment to: {}",
-        tempdir_path.to_string_lossy()
-    );
-
-    Ok(())
-}
-
 pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
     let query_set = QuerySet::from(args.query_set.clone());
     let query_overrides = args.query_overrides.clone().map(QueryOverrides::from);
@@ -79,6 +65,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
 
     metrics.show()?;
 
+    spiced_instance.show_memory_usage()?;
     spiced_instance.stop()?;
 
     println!(


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the load test criteria to introduce the concept of the stop-light system for timing measurements (green, yellow, red)
* Updates the automatic pass to less than 1000ms of the 99th percentile
* Updates printing output to use progress bars rather than printing a line for each individual query, to limit log spam on outputs
* Print memory usage on every kind of test
* Print metrics on benchmark tests
* Moved common environment export code into a common path