### PR TITLE
feat: add testoperator data consistency

### DIFF
--- a/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
+++ b/crates/runtime/src/execution_plan/fallback_on_zero_results.rs
@@ -191,7 +191,7 @@ impl ExecutionPlan for FallbackOnZeroResultsScanExec {
                 Box::pin(stream_adapter) as SendableRecordBatchStream
             } else {
                 tracing::trace!("FallbackOnZeroResultsScanExec input_stream.next() returned None");
-                tracing::info!("{fallback_msg}");
+                tracing::debug!("{fallback_msg}");
                 metrics::FEDERATED_FALLBACK.add(1, &[KeyValue::new("dataset_name", table_name.to_string())]);
                 let federated_provider = fallback_provider.table_provider().await;
                 let fallback_plan = match federated_provider

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -18,7 +18,7 @@ limitations under the License.
 pub enum QuerySet {
     Tpch,
     Tpcds,
-    ClickBench,
+    Clickbench,
 }
 
 impl QuerySet {
@@ -30,7 +30,7 @@ impl QuerySet {
         match self {
             QuerySet::Tpch => get_tpch_test_queries(overrides),
             QuerySet::Tpcds => get_tpcds_test_queries(overrides),
-            QuerySet::ClickBench => get_clickbench_test_queries(overrides),
+            QuerySet::Clickbench => get_clickbench_test_queries(overrides),
         }
     }
 }

--- a/crates/test-framework/src/spicetest/worker.rs
+++ b/crates/test-framework/src/spicetest/worker.rs
@@ -38,14 +38,14 @@ pub(crate) struct SpiceTestQueryWorker {
 pub struct SpiceTestQueryWorkerResult {
     pub query_durations: BTreeMap<String, Vec<Duration>>,
     pub connection_failed: bool,
-    pub row_counts: BTreeMap<String, usize>,
+    pub row_counts: BTreeMap<String, Vec<usize>>,
 }
 
 impl SpiceTestQueryWorkerResult {
     pub fn new(
         query_durations: BTreeMap<String, Vec<Duration>>,
         connection_failed: bool,
-        row_counts: BTreeMap<String, usize>,
+        row_counts: BTreeMap<String, Vec<usize>>,
     ) -> Self {
         Self {
             query_durations,
@@ -79,7 +79,7 @@ impl SpiceTestQueryWorker {
     pub fn start(self) -> JoinHandle<Result<SpiceTestQueryWorkerResult>> {
         tokio::spawn(async move {
             let mut query_durations: BTreeMap<String, Vec<Duration>> = BTreeMap::new();
-            let mut row_counts: BTreeMap<String, usize> = BTreeMap::new();
+            let mut row_counts: BTreeMap<String, Vec<usize>> = BTreeMap::new();
             let mut query_set_count = 0;
             let start = Instant::now();
 
@@ -120,7 +120,10 @@ impl SpiceTestQueryWorker {
                                 .or_default()
                                 .push(duration);
 
-                            *row_counts.entry(query.0.to_string()).or_default() += row_count;
+                            row_counts
+                                .entry(query.0.to_string())
+                                .or_default()
+                                .push(row_count);
 
                             if let Some(pb) = self.progress_bar.as_ref() {
                                 pb.inc(1);

--- a/test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_file.yaml
+++ b/test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_file.yaml
@@ -1,0 +1,12 @@
+version: v1
+kind: Spicepod
+name: file_clickbench_duckdb_file_on_zero_results
+datasets:
+  - from: file:data/hits_0.parquet
+    name: hits
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM hits LIMIT 0"
+      on_zero_results: use_source

--- a/test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_memory.yaml
+++ b/test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_memory.yaml
@@ -1,0 +1,12 @@
+version: v1
+kind: Spicepod
+name: file_clickbench_duckdb_file_on_zero_results
+datasets:
+  - from: file:data/hits_0.parquet
+    name: hits
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM hits LIMIT 0"
+      on_zero_results: use_source

--- a/test/spicepods/clickbench/file_small.yaml
+++ b/test/spicepods/clickbench/file_small.yaml
@@ -1,0 +1,6 @@
+version: v1
+kind: Spicepod
+name: file_clickbench_small
+datasets:
+  - from: file:data/hits_0.parquet
+    name: hits

--- a/test/spicepods/tpcds/accelerated/on_zero_results/file_duckdb_file.yaml
+++ b/test/spicepods/tpcds/accelerated/on_zero_results/file_duckdb_file.yaml
@@ -1,0 +1,196 @@
+version: v1
+kind: Spicepod
+name: file_tpcds_duckdb_file_on_zero_results
+datasets:
+  - from: file:data/catalog_sales.parquet
+    name: catalog_sales
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM catalog_sales LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/catalog_returns.parquet
+    name: catalog_returns
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM catalog_returns LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/inventory.parquet
+    name: inventory
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM inventory LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/store_sales.parquet
+    name: store_sales
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM store_sales LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/store_returns.parquet
+    name: store_returns
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM store_returns LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/web_sales.parquet
+    name: web_sales
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM web_sales LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/web_returns.parquet
+    name: web_returns
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM web_returns LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/customer.parquet
+    name: customer
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM customer LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/customer_address.parquet
+    name: customer_address
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM customer_address LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/customer_demographics.parquet
+    name: customer_demographics
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM customer_demographics LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/date_dim.parquet
+    name: date_dim
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM date_dim LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/household_demographics.parquet
+    name: household_demographics
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM household_demographics LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/item.parquet
+    name: item
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM item LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/promotion.parquet
+    name: promotion
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM promotion LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/ship_mode.parquet
+    name: ship_mode
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM ship_mode LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/store.parquet
+    name: store
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM store LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/time_dim.parquet
+    name: time_dim
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM time_dim LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/warehouse.parquet
+    name: warehouse
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM warehouse LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/web_page.parquet
+    name: web_page
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM web_page LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/web_site.parquet
+    name: web_site
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM web_site LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/reason.parquet
+    name: reason
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM reason LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/call_center.parquet
+    name: call_center
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM call_center LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/income_band.parquet
+    name: income_band
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM income_band LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/catalog_page.parquet
+    name: catalog_page
+    acceleration:
+      engine: duckdb
+      mode: file
+      enabled: true
+      refresh_sql: "SELECT * FROM catalog_page LIMIT 0"
+      on_zero_results: use_source

--- a/test/spicepods/tpcds/accelerated/on_zero_results/file_duckdb_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/on_zero_results/file_duckdb_memory.yaml
@@ -1,0 +1,196 @@
+version: v1
+kind: Spicepod
+name: file_tpcds_duckdb_file_on_zero_results
+datasets:
+  - from: file:data/catalog_sales.parquet
+    name: catalog_sales
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM catalog_sales LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/catalog_returns.parquet
+    name: catalog_returns
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM catalog_returns LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/inventory.parquet
+    name: inventory
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM inventory LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/store_sales.parquet
+    name: store_sales
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM store_sales LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/store_returns.parquet
+    name: store_returns
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM store_returns LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/web_sales.parquet
+    name: web_sales
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM web_sales LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/web_returns.parquet
+    name: web_returns
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM web_returns LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/customer.parquet
+    name: customer
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM customer LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/customer_address.parquet
+    name: customer_address
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM customer_address LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/customer_demographics.parquet
+    name: customer_demographics
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM customer_demographics LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/date_dim.parquet
+    name: date_dim
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM date_dim LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/household_demographics.parquet
+    name: household_demographics
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM household_demographics LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/item.parquet
+    name: item
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM item LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/promotion.parquet
+    name: promotion
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM promotion LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/ship_mode.parquet
+    name: ship_mode
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM ship_mode LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/store.parquet
+    name: store
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM store LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/time_dim.parquet
+    name: time_dim
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM time_dim LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/warehouse.parquet
+    name: warehouse
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM warehouse LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/web_page.parquet
+    name: web_page
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM web_page LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/web_site.parquet
+    name: web_site
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM web_site LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/reason.parquet
+    name: reason
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM reason LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/call_center.parquet
+    name: call_center
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM call_center LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/income_band.parquet
+    name: income_band
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM income_band LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/catalog_page.parquet
+    name: catalog_page
+    acceleration:
+      engine: duckdb
+      mode: memory
+      enabled: true
+      refresh_sql: "SELECT * FROM catalog_page LIMIT 0"
+      on_zero_results: use_source

--- a/test/spicepods/tpch/accelerated/on_zero_results/file_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/on_zero_results/file_duckdb_file.yaml
@@ -1,0 +1,68 @@
+version: v1
+kind: Spicepod
+name: file_tpch_duckdb_file_on_zero_results
+datasets:
+  - from: file:data/customer.parquet
+    name: customer
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM customer LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/lineitem.parquet
+    name: lineitem
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM lineitem LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/nation.parquet
+    name: nation
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM nation LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/orders.parquet
+    name: orders
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM orders LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/part.parquet
+    name: part
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM part LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/partsupp.parquet
+    name: partsupp
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM partsupp LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/region.parquet
+    name: region
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM region LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/supplier.parquet
+    name: supplier
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_sql: "SELECT * FROM supplier LIMIT 0"
+      on_zero_results: use_source

--- a/test/spicepods/tpch/accelerated/on_zero_results/file_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/on_zero_results/file_duckdb_memory.yaml
@@ -1,0 +1,68 @@
+version: v1
+kind: Spicepod
+name: file_tpch_duckdb_memory_on_zero_results
+datasets:
+  - from: file:data/customer.parquet
+    name: customer
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: memory
+      refresh_sql: "SELECT * FROM customer LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/lineitem.parquet
+    name: lineitem
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: memory
+      refresh_sql: "SELECT * FROM lineitem LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/nation.parquet
+    name: nation
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: memory
+      refresh_sql: "SELECT * FROM nation LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/orders.parquet
+    name: orders
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: memory
+      refresh_sql: "SELECT * FROM orders LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/part.parquet
+    name: part
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: memory
+      refresh_sql: "SELECT * FROM part LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/partsupp.parquet
+    name: partsupp
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: memory
+      refresh_sql: "SELECT * FROM partsupp LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/region.parquet
+    name: region
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: memory
+      refresh_sql: "SELECT * FROM region LIMIT 0"
+      on_zero_results: use_source
+  - from: file:data/supplier.parquet
+    name: supplier
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: memory
+      refresh_sql: "SELECT * FROM supplier LIMIT 0"
+      on_zero_results: use_source

--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -8,59 +8,71 @@
 
 ### Run
 
-Run a throughput test using the specified Spicepod.
+Run a test using the specified Spicepod.
 
 ```sh
-testoperator run [OPTIONS]
+testoperator run [COMMAND] [OPTIONS]
 ```
 
-#### Options
+#### Commands
 
-- `-p, --spicepod-path <SPICEPOD_PATH>`: Path to the `spicepod.yaml` file.
-- `-s, --spiced-path <SPICED_PATH>`: Path to the `spiced` binary.
-- `-d, --data-dir <DATA_DIR>`: An optional data directory to symlink into the `spiced` instance.
-- `--scale-factor <SCALE_FACTOR>`: The expected scale factor for the test, used in metrics calculation.
-- `--duration <DURATION>`: The duration of the test in seconds.
-- `--query-set <QUERY_SET>`: The query set to use for the test. Possible values: `tpch`, `tpcds`, `clickbench`.
-- `--query-overrides <QUERY_OVERRIDES>`: Optional query overrides. Possible values: `sqlite`, `postgresql`, `mysql`, `dremio`, `spark`, `odbcathena`, `duckdb`.
-- `--concurrency <CONCURRENCY>`: The concurrency level for the test.
-- `--ready-wait <WAIT TIME>`: How long to wait before spiced is ready.
+- `throughput`: Run a throughput test.
+- `load`: Run a load test.
+- `bench`: Run a benchmark test.
+- `data-consistency`: Run a data consistency test.
 
 ### Export
 
 Export the Spicepod environment that would run for a test.
 
 ```sh
-testoperator export [OPTIONS]
+testoperator export [COMMAND] [OPTIONS]
 ```
 
-#### Options
+#### Commands
+
+- `throughput`: Export the environment for a throughput test.
+- `load`: Export the environment for a load test.
+- `bench`: Export the environment for a benchmark test.
+- `data-consistency`: Export the environment for a data consistency test.
+
+### Common Options
 
 - `-p, --spicepod-path <SPICEPOD_PATH>`: Path to the `spicepod.yaml` file.
 - `-s, --spiced-path <SPICED_PATH>`: Path to the `spiced` binary.
 - `-d, --data-dir <DATA_DIR>`: An optional data directory to symlink into the `spiced` instance.
-- `--scale-factor <SCALE_FACTOR>`: The expected scale factor for the test, used in metrics calculation.
-- `--duration <DURATION>`: The duration of the test in seconds.
 - `--query-set <QUERY_SET>`: The query set to use for the test. Possible values: `tpch`, `tpcds`, `clickbench`.
 - `--query-overrides <QUERY_OVERRIDES>`: Optional query overrides. Possible values: `sqlite`, `postgresql`, `mysql`, `dremio`, `spark`, `odbcathena`, `duckdb`.
 - `--concurrency <CONCURRENCY>`: The concurrency level for the test.
 - `--ready-wait <WAIT TIME>`: How long to wait before spiced is ready.
+- `--disable-progress-bars`: Disable progress bars during the test.
 
-## Examples
+### Specific Options
 
-### Running a TPCH Throughput Test on the File Connector
+#### Throughput and Load Tests
+
+- `--scale-factor <SCALE_FACTOR>`: The expected scale factor for the test, used in metrics calculation.
+- `--duration <DURATION>`: The duration of the test in seconds (only for load tests).
+
+#### Data Consistency Test
+
+- `--compare-spicepod <SPICEPOD_PATH>`: Path to a `spicepod.yaml` file to compare in a data consistency test.
+
+### Examples
+
+#### Running a TPCH Throughput Test on the File Connector
 
 ```sh
 testoperator run throughput -p ./benchmarks/file_tpch.yaml -s spiced -d ./.data --query-set tpch
 ```
 
-### Exporting the Spicepod Environment for the File Connector TPCH test
+#### Exporting the Spicepod Environment for the File Connector TPCH Test
 
 ```sh
 testoperator export throughput -p ./benchmarks/file_tpch.yaml -s spiced -d ./.data --query-set tpch
 ```
 
-### Using a non-system wide spiced binary path
+#### Using a Non-System Wide Spiced Binary Path
 
 ```sh
 testoperator run throughput -p spicepod.yaml -s ./target/debug/spiced --query-set tpch

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -33,9 +33,10 @@ pub enum TestCommands {
     Throughput(TestArgs),
     Load(TestArgs),
     Bench(TestArgs),
+    DataConsistency(DataConsistencyArgs),
 }
 
-#[derive(Parser)]
+#[derive(Parser, Debug, Clone)]
 pub struct TestArgs {
     /// Path to the spicepod.yaml file
     #[arg(short('p'), long)]
@@ -74,14 +75,14 @@ pub struct TestArgs {
     pub(crate) disable_progress_bars: bool,
 }
 
-#[derive(Clone, ValueEnum)]
+#[derive(Clone, ValueEnum, Debug)]
 pub enum QuerySetArg {
     Tpch,
     Tpcds,
-    ClickBench,
+    Clickbench,
 }
 
-#[derive(Clone, ValueEnum)]
+#[derive(Clone, ValueEnum, Debug)]
 pub enum QueryOverridesArg {
     Sqlite,
     Postgresql,
@@ -98,7 +99,7 @@ impl From<QuerySetArg> for QuerySet {
         match arg {
             QuerySetArg::Tpch => QuerySet::Tpch,
             QuerySetArg::Tpcds => QuerySet::Tpcds,
-            QuerySetArg::ClickBench => QuerySet::ClickBench,
+            QuerySetArg::Clickbench => QuerySet::ClickBench,
         }
     }
 }
@@ -116,4 +117,13 @@ impl From<QueryOverridesArg> for QueryOverrides {
             QueryOverridesArg::Snowflake => QueryOverrides::Snowflake,
         }
     }
+}
+
+#[derive(Parser, Debug)]
+pub struct DataConsistencyArgs {
+    #[command(flatten)]
+    pub(crate) test_args: TestArgs,
+
+    #[arg(long)]
+    pub(crate) compare_spicepod: PathBuf,
 }

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -99,7 +99,7 @@ impl From<QuerySetArg> for QuerySet {
         match arg {
             QuerySetArg::Tpch => QuerySet::Tpch,
             QuerySetArg::Tpcds => QuerySet::Tpcds,
-            QuerySetArg::Clickbench => QuerySet::ClickBench,
+            QuerySetArg::Clickbench => QuerySet::Clickbench,
         }
     }
 }

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -48,8 +48,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::Run(TestCommands::DataConsistency(args)) => {
             tests::data_consistency::run(&args).await?;
         }
-        Commands::Export(TestCommands::DataConsistency(_)) => {
-            unimplemented!("Export not implemented for data consistency")
+        Commands::Export(TestCommands::DataConsistency(args)) => {
+            tests::env_export(&args.test_args)?;
         }
     }
 

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -41,8 +41,16 @@ async fn main() -> anyhow::Result<()> {
         Commands::Export(TestCommands::Throughput(args)) => tests::env_export(&args)?,
         Commands::Run(TestCommands::Load(args)) => tests::load::run(&args).await?,
         Commands::Export(TestCommands::Load(args)) => tests::env_export(&args)?,
-        Commands::Run(TestCommands::Bench(args)) => tests::bench::run(&args).await?,
+        Commands::Run(TestCommands::Bench(args)) => {
+            tests::bench::run(&args).await?;
+        }
         Commands::Export(TestCommands::Bench(args)) => tests::env_export(&args)?,
+        Commands::Run(TestCommands::DataConsistency(args)) => {
+            tests::data_consistency::run(&args).await?;
+        }
+        Commands::Export(TestCommands::DataConsistency(_)) => {
+            unimplemented!("Export not implemented for data consistency")
+        }
     }
 
     Ok(())

--- a/tools/testoperator/src/tests/bench/mod.rs
+++ b/tools/testoperator/src/tests/bench/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::get_app_and_start_request;
+use super::{get_app_and_start_request, RowCounts};
 use crate::commands::TestArgs;
 use std::time::Duration;
 use test_framework::{
@@ -25,7 +25,7 @@ use test_framework::{
     spicetest::{EndCondition, SpiceTest},
 };
 
-pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
+pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<RowCounts> {
     let query_set = QuerySet::from(args.query_set.clone());
     let query_overrides = args.query_overrides.clone().map(QueryOverrides::from);
     let queries = query_set.get_queries(query_overrides);
@@ -47,6 +47,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         .await?;
 
     let test = benchmark_test.wait().await?;
+    let row_counts = test.validate_returned_row_counts()?;
     let metrics = test.collect()?;
     let mut spiced_instance = test.end();
 
@@ -54,5 +55,5 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
 
     spiced_instance.show_memory_usage()?;
     spiced_instance.stop()?;
-    Ok(())
+    Ok(row_counts)
 }

--- a/tools/testoperator/src/tests/data_consistency/mod.rs
+++ b/tools/testoperator/src/tests/data_consistency/mod.rs
@@ -1,0 +1,61 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::bench;
+use crate::commands::DataConsistencyArgs;
+use test_framework::anyhow;
+
+pub(crate) async fn run(args: &DataConsistencyArgs) -> anyhow::Result<()> {
+    // first benchmark run using the first spicepod
+    let mut test_args = args.test_args.clone();
+    let first_row_counts = bench::run(&test_args).await?;
+
+    // second benchmark run using the second spicepod
+    test_args.spicepod_path.clone_from(&args.compare_spicepod);
+    let second_row_counts = bench::run(&test_args).await?;
+
+    // compare the results
+    let mut test_failed = false;
+    for (query, count) in &first_row_counts {
+        let second_count = second_row_counts.get(query).unwrap_or(&0);
+        if count != second_count {
+            println!(
+                "FAIL - Data consistency check failed for query '{query}': {count} != {second_count}",
+            );
+            test_failed = true;
+        }
+
+        if *count == 0 {
+            println!(
+                "WARN - No data returned for query '{query}' for {:#?}",
+                args.test_args.spicepod_path
+            );
+        }
+
+        if *second_count == 0 {
+            println!(
+                "WARN - No data returned for query '{query}' for {:#?}",
+                args.compare_spicepod
+            );
+        }
+    }
+
+    if test_failed {
+        return Err(anyhow::anyhow!("Data consistency check failed"));
+    }
+
+    Ok(())
+}

--- a/tools/testoperator/src/tests/mod.rs
+++ b/tools/testoperator/src/tests/mod.rs
@@ -14,14 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::BTreeMap;
+
 use crate::commands::TestArgs;
 use test_framework::{
     anyhow, app::App, spiced::StartRequest, spicepod::Spicepod, spicepod_utils::from_app,
 };
 
 pub(crate) mod bench;
+pub(crate) mod data_consistency;
 pub(crate) mod load;
 pub(crate) mod throughput;
+
+pub(crate) type RowCounts = BTreeMap<String, usize>;
 
 pub(crate) fn get_app_and_start_request(args: &TestArgs) -> anyhow::Result<(App, StartRequest)> {
     let spicepod = Spicepod::load_exact(args.spicepod_path.clone())?;


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Changes the log level for on zero results fallback to `DEBUG`
* Adds a new test operator command, `data-consistency`, and associated test framework changes.
    * A data consistency run operates over 2 supplied spicepods. Both spicepods are created in separate apps, one after the other, with a benchmark test run on each. Row counts for each query are then compared, with a test failure for non-matching row counts.
    * The test also fails if query executions within the same app run don't match - e.g. the 2 workers in a single test got different query results.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4027 