### PR TITLE
Handle failed query in load test

### DIFF
--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -169,6 +169,9 @@ impl StatisticsCollector<BTreeMap<String, Duration>, BTreeMap<String, Vec<Durati
     fn percentile(&self, percentile: f64) -> Result<BTreeMap<String, Duration>> {
         let mut percentiles = BTreeMap::new();
         for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
             percentiles.insert(query.clone(), durations.percentile(percentile)?);
         }
         Ok(percentiles)
@@ -177,6 +180,9 @@ impl StatisticsCollector<BTreeMap<String, Duration>, BTreeMap<String, Vec<Durati
     fn median(&self) -> Result<BTreeMap<String, Duration>> {
         let mut medians = BTreeMap::new();
         for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
             medians.insert(query.clone(), durations.median()?);
         }
         Ok(medians)
@@ -185,6 +191,9 @@ impl StatisticsCollector<BTreeMap<String, Duration>, BTreeMap<String, Vec<Durati
     fn average(&self) -> Result<BTreeMap<String, Duration>> {
         let mut averages = BTreeMap::new();
         for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
             averages.insert(query.clone(), durations.average()?);
         }
         Ok(averages)
@@ -193,6 +202,9 @@ impl StatisticsCollector<BTreeMap<String, Duration>, BTreeMap<String, Vec<Durati
     fn statistical_set(&self) -> Result<BTreeMap<String, Vec<Duration>>> {
         let mut statistical_sets = BTreeMap::new();
         for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
             statistical_sets.insert(query.clone(), durations.statistical_set()?);
         }
         Ok(statistical_sets)

--- a/tools/testoperator/src/tests/load/mod.rs
+++ b/tools/testoperator/src/tests/load/mod.rs
@@ -84,16 +84,14 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
     let mut test_passed = true;
     let mut yellow_measurements = 0;
     for (query, _) in queries {
+        let Some(baseline_percentile) = baseline_percentiles.get(query) else {
+            // Query Failed, no percentile statistics recorded
+            continue;
+        };
+
         let Some(duration) = test_durations.get(query) else {
             return Err(anyhow::anyhow!(
                 "Query {} not found in test durations",
-                query
-            ));
-        };
-
-        let Some(baseline_percentile) = baseline_percentiles.get(query) else {
-            return Err(anyhow::anyhow!(
-                "Query {} not found in baseline percentiles",
                 query
             ));
         };


### PR DESCRIPTION
# 🗣 Description

The current load test would panic when encountering query failure. This PR solves the issue by properly skip failed query in percentile metrics counting when performing load test.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
