### PR TITLE
refactor: Remove on zero results from benchmarks, add data consistency workflow

### DIFF
--- a/.github/actions/build-testoperator/action.yml
+++ b/.github/actions/build-testoperator/action.yml
@@ -29,13 +29,13 @@ runs:
     
     - name: Setup Rust
       if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-      uses: ../setup-rust
+      uses: spiceai/spiceai/.github/actions/setup-rust@trunk
       with:
         os: 'linux'
 
     - name: Setup cc
       if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-      uses: ../setup-cc
+      uses: spiceai/spiceai/.github/actions/setup-cc@trunk
 
     - name: Build the testoperator if it wasn't downloaded
       shell: bash

--- a/.github/actions/build-testoperator/action.yml
+++ b/.github/actions/build-testoperator/action.yml
@@ -1,0 +1,52 @@
+name: Setup testoperator
+description: 'composite action'
+
+# Builds the testoperator if it doesn't exist in MinIO
+# Downloads it based on the commit from the HEAD of the current branch
+# Uploads the testoperator binary to MinIO if built
+#
+# Requires the MinIO CLI to be installed and configured to use this action
+runs:
+  using: 'composite'
+  steps:
+    - name: Set testoperator commit
+      shell: bash
+      run: |
+        echo "TESTOPERATOR_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+    - name: Download the testoperator from MinIO if it exists
+      shell: bash
+      run: |
+        sudo mkdir -p /usr/local/bin
+        if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
+          mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator ./testoperator
+          sudo cp ./testoperator /usr/local/bin/testoperator
+          sudo chmod +x /usr/local/bin/testoperator
+          echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
+        else
+          echo "TESTOPERATOR_DOWNLOADED=false" >> $GITHUB_ENV
+        fi
+    
+    - name: Setup Rust
+      if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
+      uses: ../setup-rust
+      with:
+        os: 'linux'
+
+    - name: Setup cc
+      if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
+      uses: ../setup-cc
+
+    - name: Build the testoperator if it wasn't downloaded
+      shell: bash
+      if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
+      run: |
+        cargo build -p testoperator --release
+        sudo cp target/release/testoperator /usr/local/bin/testoperator
+        sudo chmod +x /usr/local/bin/testoperator
+      
+    - name: Upload the testoperator binary
+      shell: bash
+      if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
+      run: |
+        mc cp /usr/local/bin/testoperator spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator

--- a/.github/actions/setup-testoperator-data/action.yml
+++ b/.github/actions/setup-testoperator-data/action.yml
@@ -1,9 +1,6 @@
 name: Setup testoperator
 description: 'composite action'
 inputs:
-  build_testoperator:
-    description: 'whether to build testoperator'
-    type: string
   query_set:
     description: 'Query set'
     required: true
@@ -17,14 +14,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Build the testoperator if it wasn't downloaded
-      shell: bash
-      if: inputs.build_testoperator == 'true'
-      run: |
-        cargo build -p testoperator --release
-        sudo cp target/release/testoperator /usr/local/bin/testoperator
-        sudo chmod +x /usr/local/bin/testoperator
-    
     - name: Prepare file-based data directory
       shell: bash
       run: |

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -64,32 +64,6 @@ jobs:
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
 
-      - name: Set testoperator commit
-        run: |
-          echo "TESTOPERATOR_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
-
-      - name: Download the testoperator from MinIO if it exists
-        run: |
-          sudo mkdir -p /usr/local/bin
-          if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
-            mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator ./testoperator
-            sudo cp ./testoperator /usr/local/bin/testoperator
-            sudo chmod +x /usr/local/bin/testoperator
-            echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
-          else
-            echo "TESTOPERATOR_DOWNLOADED=false" >> $GITHUB_ENV
-          fi
-
-      - name: Setup Rust
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        uses: ./.github/actions/setup-rust
-        with:
-          os: 'linux'
-
-      - name: Setup cc
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        uses: ./.github/actions/setup-cc
-
       - name: Get latest trunk commit
         if: ${{ !github.event.inputs.spiced_commit }}
         run: |
@@ -107,10 +81,12 @@ jobs:
           tar -xzf spiced_models_linux_x86_64.tar.gz
           sudo cp ./spiced /usr/local/bin/spiced
 
+      - name: Build Testoperator
+        uses: ./.github/actions/build-testoperator
+
       - name: Setup Testoperator
-        uses: ./.github/actions/setup-testoperator
+        uses: ./.github/actions/setup-testoperator-data
         with:
-          build_testoperator: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
           query_set: ${{ github.event.inputs.query_set }}
 
       - name: Run the benchmark test
@@ -146,8 +122,3 @@ jobs:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
-
-      - name: Upload the testoperator binary
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        run: |
-          mc cp /usr/local/bin/testoperator spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -93,7 +93,13 @@ jobs:
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
           rm -rf .spice/data
-          testoperator run bench -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
+          testoperator run bench \
+            -s /usr/local/bin/spiced \
+            -p ${{ github.event.inputs.spicepod_path }} \
+            -d /opt/spiced/data \
+            --query-set ${{ github.event.inputs.query_set }} \
+            --ready-wait ${{ github.event.inputs.ready_wait }} \
+            --disable-progress-bars
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}

--- a/.github/workflows/testoperator_run_data_consistency.yml
+++ b/.github/workflows/testoperator_run_data_consistency.yml
@@ -1,4 +1,4 @@
-name: benchmark e2e tests
+name: data consistency tests
 
 on:
   workflow_dispatch:
@@ -54,8 +54,8 @@ on:
           - 'spiceai-large-runners'
 
 jobs:
-  run-bench:
-    name: Run benchmark e2e tests
+  run-data-consistency:
+    name: Run data consistency tests
     runs-on: ${{ github.event.inputs.runner_type }}
     timeout-minutes: 600
     steps:

--- a/.github/workflows/testoperator_run_data_consistency.yml
+++ b/.github/workflows/testoperator_run_data_consistency.yml
@@ -1,4 +1,4 @@
-name: throughput tests
+name: benchmark e2e tests
 
 on:
   workflow_dispatch:
@@ -9,6 +9,10 @@ on:
         type: string
       spicepod_path:
         description: 'The spicepod file to test with'
+        required: true
+        type: string
+      compare_spicepod_path:
+        description: 'The spicepod file to compare against'
         required: true
         type: string
       query_set:
@@ -50,9 +54,10 @@ on:
           - 'spiceai-large-runners'
 
 jobs:
-  run-throughput:
-    name: Run throughput test
+  run-bench:
+    name: Run benchmark e2e tests
     runs-on: ${{ github.event.inputs.runner_type }}
+    timeout-minutes: 600
     steps:
       - uses: actions/checkout@v4
 
@@ -88,49 +93,51 @@ jobs:
         with:
           query_set: ${{ github.event.inputs.query_set }}
 
-      - name: Run the throughput test
+      - name: Run the data consistency test
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
           rm -rf .spice/data
-          testoperator run throughput \
-            -s /usr/local/bin/spiced \
-            -p ${{ github.event.inputs.spicepod_path }} \
-            -d /opt/spiced/data \
-            --query-set ${{ github.event.inputs.query_set }} \
-            --ready-wait ${{ github.event.inputs.ready_wait }} \
-            --disable-progress-bars
-        env:
-          S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
-          S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
-          S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
-          DREMIO_ENDPOINT: ${{ secrets.SPICE_DREMIO_ENDPOINT}}
-          DREMIO_USERNAME: ${{ secrets.SPICE_DREMIO_USERNAME}}
-          DREMIO_PASSWORD: ${{ secrets.SPICE_DREMIO_PASSWORD}}
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-          AWS_DATABRICKS_DELTA_ACCESS_KEY_ID: ${{ secrets.AWS_DATABRICKS_DELTA_ACCESS_KEY_ID }}
-          AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY: ${{ secrets.AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY }}
-
-      - name: Run the throughput test (with overrides)
-        if: ${{ github.event.inputs.query_overrides != '' }}
-        run: |
-          rm -rf .spice/data
-          testoperator run throughput \
+          testoperator run data-consistency \
             -s /usr/local/bin/spiced \
             -p ${{ github.event.inputs.spicepod_path }} \
             -d /opt/spiced/data \
             --query-set ${{ github.event.inputs.query_set }} \
             --ready-wait ${{ github.event.inputs.ready_wait }} \
             --disable-progress-bars \
-            --query-overrides ${{ github.event.inputs.query_overrides }}
+            --compare-spicepod-path ${{ github.event.inputs.compare_spicepod_path }}
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
           S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
-          DREMIO_ENDPOINT: ${{ secrets.SPICE_DREMIO_ENDPOINT}}
-          DREMIO_USERNAME: ${{ secrets.SPICE_DREMIO_USERNAME}}
-          DREMIO_PASSWORD: ${{ secrets.SPICE_DREMIO_PASSWORD}}
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           AWS_DATABRICKS_DELTA_ACCESS_KEY_ID: ${{ secrets.AWS_DATABRICKS_DELTA_ACCESS_KEY_ID }}
           AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY: ${{ secrets.AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
+
+      - name: Run the data consistency test (with overrides)
+        if: ${{ github.event.inputs.query_overrides != '' }}
+        run: |
+          rm -rf .spice/data
+          testoperator run data-consistency \
+            -s /usr/local/bin/spiced \
+            -p ${{ github.event.inputs.spicepod_path }} \
+            -d /opt/spiced/data \
+            --query-set ${{ github.event.inputs.query_set }} \
+            --query-overrides ${{ github.event.inputs.query_overrides }} \
+            --ready-wait ${{ github.event.inputs.ready_wait }} \
+            --disable-progress-bars \
+            --compare-spicepod-path ${{ github.event.inputs.compare_spicepod_path }}
+        env:
+          S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
+          S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
+          S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          AWS_DATABRICKS_DELTA_ACCESS_KEY_ID: ${{ secrets.AWS_DATABRICKS_DELTA_ACCESS_KEY_ID }}
+          AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY: ${{ secrets.AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -69,32 +69,6 @@ jobs:
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
 
-      - name: Set testoperator commit
-        run: |
-          echo "TESTOPERATOR_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
-
-      - name: Download the testoperator from MinIO if it exists
-        run: |
-          sudo mkdir -p /usr/local/bin
-          if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
-            mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator ./testoperator
-            sudo cp ./testoperator /usr/local/bin/testoperator
-            sudo chmod +x /usr/local/bin/testoperator
-            echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
-          else
-            echo "TESTOPERATOR_DOWNLOADED=false" >> $GITHUB_ENV
-          fi
-
-      - name: Setup Rust
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        uses: ./.github/actions/setup-rust
-        with:
-          os: 'linux'
-
-      - name: Setup cc
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        uses: ./.github/actions/setup-cc
-
       - name: Get latest trunk commit
         if: ${{ !github.event.inputs.spiced_commit }}
         run: |
@@ -112,10 +86,12 @@ jobs:
           tar -xzf spiced_models_linux_x86_64.tar.gz
           sudo cp ./spiced /usr/local/bin/spiced
 
+      - name: Build Testoperator
+        uses: ./.github/actions/build-testoperator
+
       - name: Setup Testoperator
-        uses: ./.github/actions/setup-testoperator
+        uses: ./.github/actions/setup-testoperator-data
         with:
-          build_testoperator: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
           query_set: ${{ github.event.inputs.query_set }}
 
       - name: Run the load test
@@ -151,8 +127,3 @@ jobs:
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           AWS_DATABRICKS_DELTA_ACCESS_KEY_ID: ${{ secrets.AWS_DATABRICKS_DELTA_ACCESS_KEY_ID }}
           AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY: ${{ secrets.AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY }}
-
-      - name: Upload the testoperator binary
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        run: |
-          mc cp /usr/local/bin/testoperator spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -98,7 +98,14 @@ jobs:
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
           rm -rf .spice/data
-          testoperator run load -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --duration ${{ github.event.inputs.duration }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
+          testoperator run load \
+            -s /usr/local/bin/spiced \
+            -p ${{ github.event.inputs.spicepod_path }} \
+            -d /opt/spiced/data \
+            --query-set ${{ github.event.inputs.query_set }} \
+            --ready-wait ${{ github.event.inputs.ready_wait }} \
+            --disable-progress-bars \
+            --duration ${{ github.event.inputs.duration }}
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
@@ -115,7 +122,15 @@ jobs:
         if: ${{ github.event.inputs.query_overrides != '' }}
         run: |
           rm -rf .spice/data
-          testoperator run load -s /usr/local/bin/spiced -p ${{ github.event.inputs.spicepod_path }} -d /opt/spiced/data --query-set ${{ github.event.inputs.query_set }} --duration ${{ github.event.inputs.duration }} --query-overrides ${{ github.event.inputs.query_overrides }} --ready-wait ${{ github.event.inputs.ready_wait }} --disable-progress-bars
+          testoperator run load \
+            -s /usr/local/bin/spiced \
+            -p ${{ github.event.inputs.spicepod_path }} \
+            -d /opt/spiced/data \
+            --query-set ${{ github.event.inputs.query_set }} \
+            --ready-wait ${{ github.event.inputs.ready_wait }} \
+            --disable-progress-bars \
+            --duration ${{ github.event.inputs.duration }} \
+            --query-overrides ${{ github.event.inputs.query_overrides }}
         env:
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -63,32 +63,6 @@ jobs:
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
 
-      - name: Set testoperator commit
-        run: |
-          echo "TESTOPERATOR_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
-
-      - name: Download the testoperator from MinIO if it exists
-        run: |
-          sudo mkdir -p /usr/local/bin
-          if mc stat spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator; then
-            mc cp spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator ./testoperator
-            sudo cp ./testoperator /usr/local/bin/testoperator
-            sudo chmod +x /usr/local/bin/testoperator
-            echo "TESTOPERATOR_DOWNLOADED=true" >> $GITHUB_ENV
-          else
-            echo "TESTOPERATOR_DOWNLOADED=false" >> $GITHUB_ENV
-          fi
-
-      - name: Setup Rust
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        uses: ./.github/actions/setup-rust
-        with:
-          os: 'linux'
-
-      - name: Setup cc
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        uses: ./.github/actions/setup-cc
-
       - name: Get latest trunk commit
         if: ${{ !github.event.inputs.spiced_commit }}
         run: |
@@ -106,10 +80,12 @@ jobs:
           tar -xzf spiced_models_linux_x86_64.tar.gz
           sudo cp ./spiced /usr/local/bin/spiced
 
+      - name: Build Testoperator
+        uses: ./.github/actions/build-testoperator
+
       - name: Setup Testoperator
-        uses: ./.github/actions/setup-testoperator
+        uses: ./.github/actions/setup-testoperator-data
         with:
-          build_testoperator: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
           query_set: ${{ github.event.inputs.query_set }}
 
       - name: Run the throughput test
@@ -145,8 +121,3 @@ jobs:
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           AWS_DATABRICKS_DELTA_ACCESS_KEY_ID: ${{ secrets.AWS_DATABRICKS_DELTA_ACCESS_KEY_ID }}
           AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY: ${{ secrets.AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY }}
-
-      - name: Upload the testoperator binary
-        if: ${{ env.TESTOPERATOR_DOWNLOADED != 'true' }}
-        run: |
-          mc cp /usr/local/bin/testoperator spice-minio/artifacts/testoperator/linux-x86_64/$TESTOPERATOR_COMMIT/testoperator

--- a/tools/testoperator/src/tests/load/mod.rs
+++ b/tools/testoperator/src/tests/load/mod.rs
@@ -38,7 +38,7 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         .await?;
 
     let test_duration = Duration::from_secs(args.duration.unwrap_or(60).try_into()?);
-    let test_hours = (test_duration.as_secs() / 60 / 60).min(1);
+    let test_hours = (test_duration.as_secs() / 60 / 60).max(1);
 
     // baseline run
     println!("Running baseline throughput test");
@@ -56,6 +56,8 @@ pub(crate) async fn run(args: &TestArgs) -> anyhow::Result<()> {
         .statistical_set()?
         .percentile(0.99)?;
     let baseline_metrics = test.collect()?;
+    println!("Baseline metrics:");
+    baseline_metrics.show()?;
     let spiced_instance = test.end();
 
     // load test


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Removes the on zero results checks from the benchmarks, because they weren't running properly and are superseded by the testoperator
* Added a workflow to run the `data-consistency` testoperator test in GitHub actions.
* Splits testoperator build and data setup into separate composite actions.
* Fixes an issue with the load test where it was always only running 1 baseline query set