### PR TITLE
Define S3 connector tpcds overrides for load test

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -35,6 +35,7 @@ on:
           - 'duckdb'
           - 'snowflake'
           - 'iceberg-sf1'
+          - 's3'
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true

--- a/.github/workflows/testoperator_run_data_consistency.yml
+++ b/.github/workflows/testoperator_run_data_consistency.yml
@@ -39,6 +39,7 @@ on:
           - 'duckdb'
           - 'snowflake'
           - 'iceberg-sf1'
+          - 's3'
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -40,6 +40,7 @@ on:
           - 'duckdb'
           - 'snowflake'
           - 'iceberg-sf1'
+          - 's3'
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -35,6 +35,7 @@ on:
           - 'duckdb'
           - 'snowflake'
           - 'iceberg-sf1'
+          - 's3'
       ready_wait:
         description: 'How long (in seconds) to wait for spiced to start'
         required: true

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -46,6 +46,7 @@ pub enum QueryOverrides {
     DuckDB,
     Snowflake,
     IcebergSF1,
+    S3,
 }
 
 impl QueryOverrides {
@@ -59,6 +60,7 @@ impl QueryOverrides {
             "spark" => Some(Self::Spark),
             "odbc_athena" => Some(Self::ODBCAthena),
             "duckdb" => Some(Self::DuckDB),
+            "s3" => Some(Self::S3),
             _ => None,
         }
     }
@@ -272,6 +274,13 @@ pub fn get_tpcds_test_queries(
                 87  // EXCEPT and INTERSECT aren't supported
             );
             add_tpcds_query_overrides!(queries, "postgres", 36, 70, 86)
+        }
+        Some(QueryOverrides::S3) => {
+            let queries: Vec<(&'static str, &'static str)> = remove_tpcds_query!(
+                queries,
+                72 // Query Q72 causes high resource usage by the runtime and affects other concurrent queries during the load test. https://github.com/spiceai/spiceai/issues/4360
+            );
+            queries
         }
         Some(_) | None => queries,
     }

--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -42,7 +42,7 @@ testoperator export [COMMAND] [OPTIONS]
 - `-s, --spiced-path <SPICED_PATH>`: Path to the `spiced` binary.
 - `-d, --data-dir <DATA_DIR>`: An optional data directory to symlink into the `spiced` instance.
 - `--query-set <QUERY_SET>`: The query set to use for the test. Possible values: `tpch`, `tpcds`, `clickbench`.
-- `--query-overrides <QUERY_OVERRIDES>`: Optional query overrides. Possible values: `sqlite`, `postgresql`, `mysql`, `dremio`, `spark`, `odbcathena`, `duckdb`.
+- `--query-overrides <QUERY_OVERRIDES>`: Optional query overrides. Possible values: `sqlite`, `postgresql`, `mysql`, `dremio`, `spark`, `odbcathena`, `duckdb`, `s3`.
 - `--concurrency <CONCURRENCY>`: The concurrency level for the test.
 - `--ready-wait <WAIT TIME>`: How long to wait before spiced is ready.
 - `--disable-progress-bars`: Disable progress bars during the test.

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -93,6 +93,7 @@ pub enum QueryOverridesArg {
     Duckdb,
     Snowflake,
     IcebergSF1,
+    S3,
 }
 
 impl From<QuerySetArg> for QuerySet {
@@ -117,6 +118,7 @@ impl From<QueryOverridesArg> for QueryOverrides {
             QueryOverridesArg::Duckdb => QueryOverrides::DuckDB,
             QueryOverridesArg::Snowflake => QueryOverrides::Snowflake,
             QueryOverridesArg::IcebergSF1 => QueryOverrides::IcebergSF1,
+            QueryOverridesArg::S3 => QueryOverrides::S3,
         }
     }
 }


### PR DESCRIPTION
Allow to override s3 tpcds queries in load tests because of https://github.com/spiceai/spiceai/issues/4360