### PR TITLE
Catch when an insecure (http) S3 and ABFS data connectors endpoint is used without specifying the `allow_http` parameter

### DIFF
--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -51,7 +51,7 @@ pub enum Error {
     ))]
     InvalidEndpoint { endpoint: String },
 
-    #[snafu(display("The '{endpoint}' is an insecure HTTP URL, but `allow_http` is not enabled.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/abfs#params"))]
+    #[snafu(display("The '{endpoint}' is a HTTP URL, but `allow_http` is not enabled. Set the parameter `allow_http: true` and retry.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/abfs#params"))]
     InsecureEndpointWithoutAllowHTTP { endpoint: String },
 }
 

--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -50,6 +50,9 @@ pub enum Error {
         "The 'abfs_endpoint' parameter must be a HTTP/S URL, but '{endpoint}' was provided.\nSpecify a valid HTTP/S URL."
     ))]
     InvalidEndpoint { endpoint: String },
+
+    #[snafu(display("The '{endpoint}' is an insecure HTTP URL, but `allow_http` is not enabled.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/abfs#params"))]
+    InsecureEndpointWithoutAllowHTTP { endpoint: String },
 }
 
 pub struct AzureBlobFS {
@@ -107,7 +110,7 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
         ParameterSpec::connector("use_fabric_endpoint")
             .description("Use the Azure Storage fabric endpoint.")
             .default("false"),
-        ParameterSpec::connector("allow_http")
+        ParameterSpec::runtime("allow_http")
             .description("Allow insecure HTTP connections.")
             .default("false"),
         ParameterSpec::connector("authority_host")
@@ -168,6 +171,15 @@ impl DataConnectorFactory for AzureBlobFSFactory {
             if let Some(endpoint) = params.parameters.get("endpoint").expose().ok() {
                 if !(endpoint.starts_with("https://") || endpoint.starts_with("http://")) {
                     return Err(Box::new(Error::InvalidEndpoint {
+                        endpoint: endpoint.to_string(),
+                    })
+                        as Box<dyn std::error::Error + Send + Sync>);
+                }
+
+                if endpoint.starts_with("http://")
+                    && params.parameters.get("allow_http").expose().ok() != Some("true")
+                {
+                    return Err(Box::new(Error::InsecureEndpointWithoutAllowHTTP {
                         endpoint: endpoint.to_string(),
                     })
                         as Box<dyn std::error::Error + Send + Sync>);

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -104,7 +104,7 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("The '{endpoint}' is an insecure HTTP URL, but `allow_http` is not enabled.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"))]
+    #[snafu(display("The '{endpoint}' is a HTTP URL, but `allow_http` is not enabled. Set the parameter `allow_http: true` and retry.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/abfs#params"))]
     InsecureEndpointWithoutAllowHTTP { endpoint: String },
 }
 

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -103,6 +103,9 @@ pub enum Error {
     InvalidIAMRoleAuthentication {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[snafu(display("The '{endpoint}' is an insecure HTTP URL, but `allow_http` is not enabled.\nFor details, visit: https://docs.spiceai.org/components/data-connectors/s3#params"))]
+    InsecureEndpointWithoutAllowHTTP { endpoint: String },
 }
 
 pub struct S3 {
@@ -165,6 +168,15 @@ impl DataConnectorFactory for S3Factory {
             if let Some(endpoint) = params.parameters.get("endpoint").expose().ok() {
                 if !(endpoint.starts_with("https://") || endpoint.starts_with("http://")) {
                     return Err(Box::new(Error::InvalidEndpoint {
+                        endpoint: endpoint.to_string(),
+                    })
+                        as Box<dyn std::error::Error + Send + Sync>);
+                }
+
+                if endpoint.starts_with("http://")
+                    && params.parameters.get("allow_http").expose().ok() != Some("true")
+                {
+                    return Err(Box::new(Error::InsecureEndpointWithoutAllowHTTP {
                         endpoint: endpoint.to_string(),
                     })
                         as Box<dyn std::error::Error + Send + Sync>);


### PR DESCRIPTION
# 🗣 Description

[breaking change] Rename `abfs_allow_http` to `allow_http` in ABFS connector.

Throw an error if http endpoint is used without `allow_http` parameter in S3 and ABFS data connectors

**Before**:

```
2025-01-16T06:08:43.619129Z  WARN runtime::init::dataset: Cannot connect to the dataset call_center (s3).
Object Store error: Generic S3 error: Error after 0 retries in 8.792µs, max_retries:10, retry_timeout:180s, source:builder error for url (http://localhost:9000/tpcds-sf5/call_center.parquet)
```

**After**:

```
2025-01-16T06:37:53.562020Z  WARN runtime::init::dataset: Error initializing dataset call_center. The 'http://localhost:9000' is an insecure HTTP URL, but `allow_http` is not enabled.
For details, visit: https://docs.spiceai.org/components/data-connectors/s3#params
```

## 🔨 Related Issues

closes #4358

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [x] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

- https://github.com/spiceai/docs/pull/766