### PR TITLE
Fix federation bug for correlated subqueries of deeply nested Dremio tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=d8697414cd59b4d6fce64a9899d7bcc6b26f27c9#d8697414cd59b4d6fce64a9899d7bcc6b26f27c9"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=a889f4bd47cba6b96d24a63a03891c64dadb6e15#a889f4bd47cba6b96d24a63a03891c64dadb6e15"
 dependencies = [
  "arrow-json 53.3.0",
  "async-stream",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation-sql"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=d8697414cd59b4d6fce64a9899d7bcc6b26f27c9#d8697414cd59b4d6fce64a9899d7bcc6b26f27c9"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=a889f4bd47cba6b96d24a63a03891c64dadb6e15#a889f4bd47cba6b96d24a63a03891c64dadb6e15"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -3517,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=5567f09f8154e484c6e73336e32875bd25a9a1fa#5567f09f8154e484c6e73336e32875bd25a9a1fa"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=47f096b1551ccd4a21adf51084fa03b0bc518288#47f096b1551ccd4a21adf51084fa03b0bc518288"
 dependencies = [
  "arrow",
  "arrow-json 53.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ datafusion-common = "43"
 datafusion-execution = "43"
 datafusion-expr = "43"
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "d8697414cd59b4d6fce64a9899d7bcc6b26f27c9" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
 datafusion-functions-json = "0.43"
 datafusion-table-providers = "0.1"
 dotenvy = "0.15"
@@ -160,8 +160,8 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "4e
 
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4" }
 
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "d8697414cd59b4d6fce64a9899d7bcc6b26f27c9" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "5567f09f8154e484c6e73336e32875bd25a9a1fa" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "47f096b1551ccd4a21adf51084fa03b0bc518288" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae" }
 


### PR DESCRIPTION
# 🗣 Description

Brings in https://github.com/spiceai/datafusion-federation/pull/40 to fix an issue where table name rewrites were not being performed for deeply nested Dremio tables in correlated subqueries.

## 🔨 Related Issues

Closes #4384

## 📄 Documentation Updates

N/A

## 🤔 Concerns

N/A
