### PR TITLE
Disable ident normalization (i.e. `SELECT MyColumn from table` works)

### DIFF
--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -58,6 +58,12 @@ impl DataFusionBuilder {
             .with_information_schema(true)
             .with_create_default_catalog_and_schema(false);
 
+        // Prevents DataFusion from lowercasing identifiers, i.e. "SELECT MyColumn FROM my_table" would be "SELECT mycolumn FROM mytable" without this.
+        // This improves the UX for data sources where column names are case-sensitive, since they no longer need to be quoted.
+        df_config
+            .options_mut()
+            .sql_parser
+            .enable_ident_normalization = false;
         df_config.options_mut().optimizer.expand_views_at_output = true;
         df_config.options_mut().sql_parser.dialect = "PostgreSQL".to_string();
         df_config.options_mut().catalog.default_catalog = SPICE_DEFAULT_CATALOG.to_string();


### PR DESCRIPTION
# 🗣 Description

Disable identifier normalization (i.e. lowercasing all un-quoted identifiers) to improve the UX of working with data sources that have case-sensitive columns.

This was previously raised in #3957, but closed due to a desire to keep as close to PostgreSQL dialect semantics as possible. However, given the variety of data sources that Spice connects to, it materially worses the UX to require quoting identifiers that aren't lowercase. 

Most people using Spice would expect to be able to write `SELECT MyColumn from table` and have it work.

## 🔨 Related Issues

Brings back #3957

## ⛓️‍💥 Breaking Change

* [x] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

TBD
