### PR TITLE
Preserve schema metadata

### DIFF
--- a/crates/runtime/src/execution_plan/schema_cast.rs
+++ b/crates/runtime/src/execution_plan/schema_cast.rs
@@ -86,19 +86,22 @@ impl ExecutionPlan for SchemaCastScanExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::new(Schema::new(
-            self.input
-                .schema()
-                .fields()
-                .into_iter()
-                .map(|field| {
-                    self.schema
-                        .field_with_name(field.name())
-                        .ok()
-                        .map_or(field.deref().clone(), Clone::clone)
-                })
-                .collect::<Vec<Field>>(),
-        ))
+        Arc::new(
+            Schema::new(
+                self.input
+                    .schema()
+                    .fields()
+                    .into_iter()
+                    .map(|field| {
+                        self.schema
+                            .field_with_name(field.name())
+                            .ok()
+                            .map_or(field.deref().clone(), Clone::clone)
+                    })
+                    .collect::<Vec<Field>>(),
+            )
+            .with_metadata(self.input.schema().metadata().clone()),
+        )
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {


### PR DESCRIPTION
# 🗣 Description

Preserve schema metadata in the `SchemaCastScanExec` implementation

## 🔨 Related Issues

closes #4396 
closes #4401 