### PR TITLE
Fix streaming for Openai and Anthropic

### DIFF
--- a/crates/llms/src/anthropic/types_stream.rs
+++ b/crates/llms/src/anthropic/types_stream.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(deprecated)] // `function_call` argument is deprecated but no builder pattern alternative is available.
+use super::types::{MessageRole, StopReason, Usage};
 use async_openai::{
     error::{ApiError, OpenAIError},
     types::{
@@ -23,12 +24,11 @@ use async_openai::{
     },
 };
 use futures::{Stream, StreamExt};
+use reqwest_eventsource::Error as SseError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, fmt, pin::Pin, sync::Arc, time::SystemTime};
 use tokio::sync::Mutex;
-
-use super::types::{MessageRole, StopReason, Usage};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
@@ -299,12 +299,12 @@ pub fn transform_stream(
                             completion_tokens_details: None,
                         });
                         state.model = Some(model);
-                        create_stream_response(
+                        Some(create_stream_response(
                             &state.id.clone().unwrap_or_default(),
                             &state.model.clone().unwrap_or_default(),
                             None,
                             None,
-                        )
+                        ))
                     }
                     Ok(MessageCreateStreamResponse::ContentBlockStart {
                         index,
@@ -314,7 +314,7 @@ pub fn transform_stream(
                             state.tool_id_to_content_block.insert(index, t.clone());
                             state.tool_id_to_tool_delta_idx.insert(index, 0);
                         };
-                        create_stream_response(
+                        Some(create_stream_response(
                             &state.id.clone().unwrap_or_default(),
                             &state.model.clone().unwrap_or_default(),
                             None,
@@ -324,13 +324,13 @@ pub fn transform_stream(
                                 finish_reason: None,
                                 logprobs: None,
                             }),
-                        )
+                        ))
                     }
                     Ok(MessageCreateStreamResponse::ContentBlockDelta { index, delta }) => {
                         let tool_idx = *state.tool_id_to_tool_delta_idx.get(&index).unwrap_or(&0);
                         state.tool_id_to_tool_delta_idx.insert(index, tool_idx + 1);
 
-                        create_stream_response(
+                        Some(create_stream_response(
                             &state.id.clone().unwrap_or_default(),
                             &state.model.clone().unwrap_or_default(),
                             None,
@@ -343,7 +343,7 @@ pub fn transform_stream(
                                     state.tool_id_to_content_block.get(&index),
                                 ),
                             }),
-                        )
+                        ))
                     }
                     Ok(MessageCreateStreamResponse::MessageDelta {
                         delta: MessageDelta { stop_reason, .. },
@@ -355,7 +355,7 @@ pub fn transform_stream(
                             u.completion_tokens += inner_usage.output_tokens;
                             u.total_tokens += inner_usage.input_tokens + inner_usage.output_tokens;
                         }
-                        create_stream_response(
+                        Some(create_stream_response(
                             &state.id.clone().unwrap_or_default(),
                             &state.model.clone().unwrap_or_default(),
                             state.usage.clone(),
@@ -378,7 +378,7 @@ pub fn transform_stream(
                                     refusal: None,
                                 },
                             }),
-                        )
+                        ))
                     }
                     Ok(
                         MessageCreateStreamResponse::Ping
@@ -399,7 +399,7 @@ pub fn transform_stream(
         })
         // Because we don't early exit on [`MessageCreateStreamResponse::MessageStop`], we need to handle stream end explicitly, otherwise we will infinite loop on the stream.
         .take_while(|item| {
-            let keep_going = !matches!(item, Err(OpenAIError::ApiError(ApiError { message, .. })) if message == "Stream ended");
+            let keep_going = !matches!(item, Err(OpenAIError::ApiError(ApiError { message, .. })) if SseError::StreamEnded{}.to_string().eq(message));
             futures::future::ready(keep_going)
         });
 
@@ -413,26 +413,25 @@ fn create_stream_response(
     model: &str,
     usage: Option<CompletionUsage>,
     choice: Option<ChatChoiceStream>,
-) -> Option<Result<CreateChatCompletionStreamResponse, OpenAIError>> {
+) -> Result<CreateChatCompletionStreamResponse, OpenAIError> {
     let choices = match choice {
         Some(c) => vec![c],
         None => vec![],
     };
 
-    let Ok(created_time) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) else {
-        return Some(Err(OpenAIError::InvalidArgument(
-            "Failed to get current time".to_string(),
-        )));
-    };
+    let created = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?
+        .as_secs() as u32;
 
-    Some(Ok(CreateChatCompletionStreamResponse {
+    Ok(CreateChatCompletionStreamResponse {
         id: id.to_string(),
-        created: created_time.as_secs() as u32,
+        created,
         model: model.to_string(),
         service_tier: None,
         system_fingerprint: None,
         object: "chat.completion.chunk".to_string(),
         usage,
         choices,
-    }))
+    })
 }

--- a/crates/llms/src/anthropic/types_stream.rs
+++ b/crates/llms/src/anthropic/types_stream.rs
@@ -22,7 +22,7 @@ use async_openai::{
         CreateChatCompletionStreamResponse, FinishReason, FunctionCallStream, Role,
     },
 };
-use futures::{future, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{collections::HashMap, fmt, pin::Pin, sync::Arc, time::SystemTime};
@@ -142,7 +142,9 @@ impl Delta {
             },
             (
                 Delta::InputJsonDelta { partial_json },
-                Some(ContentBlockToolUse { id, name, .. }),
+                Some(ContentBlockToolUse {
+                    id, name: _name, ..
+                }),
             ) => ChatCompletionStreamResponseDelta {
                 content: None,
                 function_call: None,
@@ -151,7 +153,7 @@ impl Delta {
                     id: Some(id.clone()),
                     r#type: Some(ChatCompletionToolType::Function),
                     function: Some(FunctionCallStream {
-                        name: Some(name.clone()),
+                        name: None, // Intentially leave empty to match OpenAI's format.
                         arguments: Some(partial_json),
                     }),
                 }]),
@@ -272,21 +274,10 @@ pub fn transform_stream(
     let state = Arc::new(Mutex::new(StreamState::default()));
 
     let transformed_stream = stream
-        // Must filter out unneeded messages early to avoid the below [`Stream::scan`] returning early
-        .filter(|m| {
-            future::ready(!matches!(
-                m,
-                Ok(MessageCreateStreamResponse::Ping
-                    | MessageCreateStreamResponse::ContentBlockStop { .. }
-                    | MessageCreateStreamResponse::MessageStop)
-            ))
-        })
-        .then(move |item| {
+        .filter_map(move |item| {
             let inner_state = Arc::clone(&state);
-
             async move {
                 let mut state = inner_state.lock().await;
-
                 match item {
                     Ok(MessageCreateStreamResponse::MessageStart {
                         message:
@@ -393,18 +384,23 @@ pub fn transform_stream(
                         MessageCreateStreamResponse::Ping
                         | MessageCreateStreamResponse::ContentBlockStop { .. }
                         | MessageCreateStreamResponse::MessageStop,
-                    ) => unreachable!("Filtered out"),
+                    ) => None,
                     Err(e) => {
                         tracing::debug!("Received an anthropic error stream packet: {:?}", e);
-                        Err(OpenAIError::ApiError(ApiError {
-                            message: e.to_string(),
+                        Some(Err(OpenAIError::ApiError(ApiError {
+                            message: e.error.message,
                             r#type: Some("AnthropicStreamError".to_string()),
                             param: None,
                             code: None,
-                        }))
+                        })))
                     }
                 }
             }
+        })
+        // Because we don't early exit on [`MessageCreateStreamResponse::MessageStop`], we need to handle stream end explicitly, otherwise we will infinite loop on the stream.
+        .take_while(|item| {
+            let keep_going = !matches!(item, Err(OpenAIError::ApiError(ApiError { message, .. })) if message == "Stream ended");
+            futures::future::ready(keep_going)
         });
 
     Box::pin(transformed_stream)
@@ -417,24 +413,26 @@ fn create_stream_response(
     model: &str,
     usage: Option<CompletionUsage>,
     choice: Option<ChatChoiceStream>,
-) -> Result<CreateChatCompletionStreamResponse, OpenAIError> {
+) -> Option<Result<CreateChatCompletionStreamResponse, OpenAIError>> {
     let choices = match choice {
         Some(c) => vec![c],
         None => vec![],
     };
-    let created = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?
-        .as_secs() as u32;
 
-    Ok(CreateChatCompletionStreamResponse {
+    let Ok(created_time) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) else {
+        return Some(Err(OpenAIError::InvalidArgument(
+            "Failed to get current time".to_string(),
+        )));
+    };
+
+    Some(Ok(CreateChatCompletionStreamResponse {
         id: id.to_string(),
-        created,
+        created: created_time.as_secs() as u32,
         model: model.to_string(),
         service_tier: None,
         system_fingerprint: None,
         object: "chat.completion.chunk".to_string(),
         usage,
         choices,
-    })
+    }))
 }

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -406,9 +406,9 @@ macro_rules! generate_model_tests {
         test_model_case!(anthropic, basic);
         test_model_case!(anthropic, system_prompt);
         test_model_case!(anthropic, supports_basic_message_roles);
-        // test_model_case!(anthropic, basic, true);
-        // test_model_case!(anthropic, system_prompt, true);
-        // test_model_case!(anthropic, supports_basic_message_roles, true);
+        test_model_case!(anthropic, basic, true);
+        test_model_case!(anthropic, system_prompt, true);
+        test_model_case!(anthropic, supports_basic_message_roles, true);
 
         test_model_case!(openai, basic);
         test_model_case!(openai, system_prompt);
@@ -442,9 +442,9 @@ macro_rules! generate_model_tests {
         test_model_case!(anthropic, tool_use);
         test_model_case!(anthropic, usage);
         test_model_case!(anthropic, supports_all_message_roles);
-        // test_model_case!(anthropic, tool_use, true);
-        // test_model_case!(anthropic, usage, true);
-        // test_model_case!(anthropic, supports_all_message_roles, true);
+        test_model_case!(anthropic, tool_use, true);
+        test_model_case!(anthropic, usage, true);
+        test_model_case!(anthropic, supports_all_message_roles, true);
 
         test_model_case!(openai, tool_use);
         test_model_case!(openai, tool_use, true);

--- a/crates/llms/tests/llms/snapshots/integration__llms__tool_use_anthropic_valid_function_args.snap
+++ b/crates/llms/tests/llms/snapshots/integration__llms__tool_use_anthropic_valid_function_args.snap
@@ -4,5 +4,5 @@ expression: "serde_json::to_string_pretty(&resp_ptr).expect(\"Failed to serializ
 snapshot_kind: text
 ---
 [
-  "{\"location\":\"Boston\",\"unit\":\"celsius\"}"
+  "{\"location\": \"Boston\", \"unit\": \"celsius\"}"
 ]

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -680,6 +680,15 @@ fn make_a_stream(
                             }
                         }
                     }
+
+                    // When there are no [`ChatChoiceStream`]s, but the model has usage, send the response (with not choices).
+                    if response.choices.is_empty() && response.usage.is_some() {
+                        if let Err(e) = sender_clone.send(Ok(response)).await {
+                            if !sender_clone.is_closed() {
+                                tracing::error!("Error sending error: {}", e);
+                            }
+                        }
+                    }
                 }
 
                 tracing::info!(target: "task_history", captured_output = %chat_output);

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -681,7 +681,7 @@ fn make_a_stream(
                         }
                     }
 
-                    // When there are no [`ChatChoiceStream`]s, but the model has usage, send the response (with not choices).
+                    // When there are no [`ChatChoiceStream`]s, but the model has usage, send the response (with no choices).
                     if response.choices.is_empty() && response.usage.is_some() {
                         if let Err(e) = sender_clone.send(Ok(response)).await {
                             if !sender_clone.is_closed() {


### PR DESCRIPTION
# 🗣 Description

## Issue with OpenAI
Now, usage isn't added to the last non-empty stream chunk that has the `finish_reason: stop`. Rather, its returned in an empty payload (i.e. `.choices.length() ==0`) at the end. 
```jsonl
{"id":"chatcmpl-ArZlM3uuEuwDzGvGjaetc4GeaWDca","choices":[{"index":0,"delta":{"content":null,"refusal":null},"finish_reason":"stop","logprobs":null}],"created":1737332220,"model":"openai-with-spice","service_tier":"default","system_fingerprint":"fp_50cad350e4","object":"chat.completion.chunk"}

{"id":"chatcmpl-ArZlM3uuEuwDzGvGjaetc4GeaWDca","choices":[],"created":1737332220,"model":"openai-with-spice","service_tier":"default","system_fingerprint":"fp_50cad350e4","object":"chat.completion.chunk","usage":{"prompt_tokens":9,"completion_tokens":9,"total_tokens":18,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0}}}
```
For tool using models, we would not process the last stream packet. Now we handle it explicitly. 

## Issue with Anthropic
We were not closing the stream gracefully on an SSE event with type `message_stop`. Anthropic started returning an error in the SSE when this happened. We now gracefully handle this by returning early when we receive this stream end SSE.

