### PR TITLE
Use `gpt-4o-mini` as a default model for openai provider

### DIFF
--- a/crates/llms/src/openai/chat.rs
+++ b/crates/llms/src/openai/chat.rs
@@ -31,12 +31,6 @@ use tracing_futures::Instrument;
 
 use super::Openai;
 
-pub const MAX_COMPLETION_TOKENS: u16 = 1024_u16; // Avoid accidentally using infinite tokens. Should think about this more.
-
-pub(crate) const GPT3_5_TURBO_INSTRUCT: &str = "gpt-3.5-turbo";
-
-pub const DEFAULT_LLM_MODEL: &str = GPT3_5_TURBO_INSTRUCT;
-
 #[async_trait]
 impl<C: Config + Send + Sync> Chat for Openai<C> {
     fn as_sql(&self) -> Option<&dyn SqlGeneration> {

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -23,10 +23,10 @@ pub mod embed;
 
 pub const MAX_COMPLETION_TOKENS: u16 = 1024_u16; // Avoid accidentally using infinite tokens. Should think about this more.
 
-pub(crate) const GPT3_5_TURBO_INSTRUCT: &str = "gpt-3.5-turbo";
+pub(crate) const GPT_4O_MINI: &str = "gpt-4o-mini";
 pub(crate) const TEXT_EMBED_3_SMALL: &str = "text-embedding-3-small";
 
-pub const DEFAULT_LLM_MODEL: &str = GPT3_5_TURBO_INSTRUCT;
+pub const DEFAULT_LLM_MODEL: &str = GPT_4O_MINI;
 pub const DEFAULT_EMBEDDING_MODEL: &str = TEXT_EMBED_3_SMALL;
 
 pub struct Openai<C: Config> {


### PR DESCRIPTION
# 🗣 Description

[OpenAI docs recommends](https://platform.openai.com/docs/models#gpt-3-5-turbo) to use gpt-4o-mini as a default instead of gpt-3.5-turbo

> As of July 2024, gpt-4o-mini should be used in place of gpt-3.5-turbo, as it is cheaper, more capable, multimodal, and just as fast. gpt-3.5-turbo is still available for use in the API.