### PR TITLE
Tweak model loading and missing tool errors messages

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -319,7 +319,7 @@ async fn start_anonymous_telemetry(
     if !explicitly_disabled {
         #[cfg(feature = "anonymous_telemetry")]
         telemetry::anonymous::start(
-            spicepod_name.map_or_else(|| "unknown", String::as_str),
+            spicepod_name.map_or_else(|| "unknown", w),
             telemetry_properties,
         )
         .await;

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -319,7 +319,7 @@ async fn start_anonymous_telemetry(
     if !explicitly_disabled {
         #[cfg(feature = "anonymous_telemetry")]
         telemetry::anonymous::start(
-            spicepod_name.map_or_else(|| "unknown", w),
+            spicepod_name.map_or_else(|| "unknown", String::as_str),
             telemetry_properties,
         )
         .await;

--- a/crates/runtime/src/init/embedding.rs
+++ b/crates/runtime/src/init/embedding.rs
@@ -68,11 +68,7 @@ impl Runtime {
                         metrics::embeddings::LOAD_ERROR.add(1, &[]);
                         self.status
                             .update_embedding(&in_embed.name, status::ComponentStatus::Error);
-                        tracing::warn!(
-                            "Unable to load embedding from spicepod {}, error: {}",
-                            in_embed.name,
-                            e,
-                        );
+                        tracing::warn!("Failed to load embedding {}.\nError: {}\nVerify configuration and try again.\nFor details, visit https://spiceai.org/docs/components/embeddings", in_embed.name, e);
                     }
                 }
             }

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -29,13 +29,13 @@ use spicepod::component::model::{Model as SpicepodModel, ModelType};
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to load LLM: {}. Verify configuration and try again.\nError: {}\nFor details, visit https://spiceai.org/docs/components/models", name, source))]
-    LlmLoadError {
+    FailedToLoadLLM {
         name: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     #[snafu(display("Failed to load runnable model: {}. Verify configuration and try again.\nError: {}\nFor details, visit https://spiceai.org/docs/components/models", name, source))]
-    RunnableModelLoadError {
+    FailedToLoadModelError {
         name: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -108,7 +108,7 @@ impl Runtime {
                     llm_map.insert(m.name.clone(), l);
                     Ok(())
                 }
-                Err(e) => Err(Error::LlmLoadError {
+                Err(e) => Err(Error::FailedToLoadLLM {
                     name: m.name.clone(),
                     source: Box::new(e),
                 }),
@@ -119,7 +119,7 @@ impl Runtime {
                     model_map.insert(m.name.clone(), in_m);
                     Ok(())
                 }
-                Err(e) => Err(Error::RunnableModelLoadError {
+                Err(e) => Err(Error::FailedToLoadModelError {
                     name: m.name.clone(),
                     source: Box::new(e),
                 }),

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -23,7 +23,29 @@ use crate::{
 use app::App;
 use model_components::model::Model;
 use opentelemetry::KeyValue;
+use snafu::prelude::*;
 use spicepod::component::model::{Model as SpicepodModel, ModelType};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to load LLM: {}. Verify configuration and try again.\nError: {}\nFor details, visit https://spiceai.org/docs/components/models", name, source))]
+    LlmLoadError {
+        name: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display("Failed to load runnable model: {}. Verify configuration and try again.\nError: {}\nFor details, visit https://spiceai.org/docs/components/models", name, source))]
+    RunnableModelLoadError {
+        name: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display(
+        "Failed to load model {} from spicepod. Unable to determine model type. Verify configuration and try again.\nFor details, visit https://spiceai.org/docs/components/models",
+        name
+    ))]
+    UnableToDetermineModelType { name: String },
+}
 
 impl Runtime {
     pub(crate) async fn load_models(&self) {
@@ -79,17 +101,17 @@ impl Runtime {
 
         let model_type = m.model_type();
         tracing::trace!("Model type for {} is {:#?}", m.name, model_type.clone());
-        let result: Result<(), String> = match model_type {
+        let result: Result<(), Error> = match model_type {
             Some(ModelType::Llm) => match self.load_llm(m.clone(), params).await {
                 Ok(l) => {
                     let mut llm_map = self.llms.write().await;
                     llm_map.insert(m.name.clone(), l);
                     Ok(())
                 }
-                Err(e) => Err(format!(
-                    "Unable to load LLM from spicepod {}, error: {}",
-                    m.name, e,
-                )),
+                Err(e) => Err(Error::LlmLoadError {
+                    name: m.name.clone(),
+                    source: Box::new(e),
+                }),
             },
             Some(ModelType::Ml) => match Model::load(m.clone(), params).await {
                 Ok(in_m) => {
@@ -97,15 +119,14 @@ impl Runtime {
                     model_map.insert(m.name.clone(), in_m);
                     Ok(())
                 }
-                Err(e) => Err(format!(
-                    "Unable to load runnable model from spicepod {}, error: {}",
-                    m.name, e,
-                )),
+                Err(e) => Err(Error::RunnableModelLoadError {
+                    name: m.name.clone(),
+                    source: Box::new(e),
+                }),
             },
-            None => Err(format!(
-                "Unable to load model {} from spicepod. Unable to determine model type.",
-                m.name,
-            )),
+            None => Err(Error::UnableToDetermineModelType {
+                name: m.name.clone(),
+            }),
         };
         match result {
             Ok(()) => {
@@ -124,7 +145,7 @@ impl Runtime {
                 metrics::models::LOAD_ERROR.add(1, &[]);
                 self.status
                     .update_model(&model.name, status::ComponentStatus::Error);
-                tracing::warn!(e);
+                tracing::warn!("{e}");
             }
         }
     }

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -35,7 +35,7 @@ pub enum Error {
     },
 
     #[snafu(display("Failed to load runnable model: {}. Verify configuration and try again.\nError: {}\nFor details, visit https://spiceai.org/docs/components/models", name, source))]
-    FailedToLoadModelError {
+    FailedToLoadRunnableModel {
         name: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -119,7 +119,7 @@ impl Runtime {
                     model_map.insert(m.name.clone(), in_m);
                     Ok(())
                 }
-                Err(e) => Err(Error::FailedToLoadModelError {
+                Err(e) => Err(Error::FailedToLoadRunnableModel {
                     name: m.name.clone(),
                     source: Box::new(e),
                 }),

--- a/crates/runtime/src/tools/utils.rs
+++ b/crates/runtime/src/tools/utils.rs
@@ -86,12 +86,26 @@ pub async fn get_tools(rt: Arc<Runtime>, opts: &SpiceToolsOptions) -> Vec<Arc<dy
     let all_tools = rt.tools.read().await;
 
     let mut tools = vec![];
+
+    let mut missing_tools = vec![];
+
     for tt in opts.tools_by_name() {
         if let Some(tool) = all_tools.get(tt) {
             tools.extend(tool.tools().await);
         } else {
-            tracing::warn!("Tool {tt} not found in registry");
+            missing_tools.push(tt);
         }
     }
+
+    if !missing_tools.is_empty() {
+        let available_tools = all_tools
+            .keys()
+            .map(|k| k.as_str())
+            .collect::<Vec<&str>>()
+            .join(", ");
+
+        tracing::warn!("The following tools were not found in the registry: {}.\nAvailable tools are: {available_tools}.\nFor details, visit https://docs.spiceai.org/features/large-language-models/tools", missing_tools.join(", "));
+    }
+
     tools
 }

--- a/crates/runtime/src/tools/utils.rs
+++ b/crates/runtime/src/tools/utils.rs
@@ -100,7 +100,7 @@ pub async fn get_tools(rt: Arc<Runtime>, opts: &SpiceToolsOptions) -> Vec<Arc<dy
     if !missing_tools.is_empty() {
         let available_tools = all_tools
             .keys()
-            .map(|k| k.as_str())
+            .map(String::as_str)
             .collect::<Vec<&str>>()
             .join(", ");
 


### PR DESCRIPTION
# 🗣 Description

### Missing tool error message
Displays the missing tools, available tools, and a link to the documentation.

```console
2025-01-20T03:11:21.407911Z  INFO runtime::init::model: Loading model [chat] from openai:gpt-4o-mini...
2025-01-20T03:11:21.409303Z  WARN runtime::tools::utils: The following tools were not found in the registry: invalid_tool_name, test_tool.
Available tools are: store_memory, list_datasets, random_sample, document_similarity, get_readiness, builtin, memory, sample_distinct_columns, top_n_sample, sql, table_schema, load_memory.
For details, visit https://docs.spiceai.org/features/large-language-models/tools
2025-01-20T03:11:21.418773Z  INFO runtime::init::dataset: Dataset cities registered (file:./cities.csv), results cache enabled.
```

### Models and Embeddings loading error messages

```console
2025-01-20T04:42:51.631013Z  WARN runtime::init::model: Failed to load LLM: chat. Verify configuration and try again.
Error: Failed to run LLM health check: invalid_request_error: The model `invalid_model_id` does not exist or you do not have access to it. (code: model_not_found)
For details, visit https://spiceai.org/docs/components/models
```

```console
2025-01-20T04:42:51.261899Z  WARN runtime::init::embedding: Failed to load embedding openai_embeddings.
Error: Failed to run Embedding health check: Failed to create embedding: invalid_request_error: The model `text-embedding-4-small` does not exist or you do not have access to it. (code: model_not_found)
Verify configuration and try again.
For details, visit https://spiceai.org/docs/components/embeddings
```