### PR TITLE
feat: Add CPU models install escape hatch

### DIFF
--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -128,11 +128,12 @@ spice upgrade
 		slog.Info(fmt.Sprintf("Spice.ai CLI upgraded to %s successfully.", release.TagName))
 
 		flavor := ""
-		if rtcontext.ModelsFlavorInstalled() {
+		models, accelerated := rtcontext.ModelsFlavorInstalled()
+		if models {
 			flavor = "ai"
 		}
 
-		err = rtcontext.InstallOrUpgradeRuntime(flavor)
+		err = rtcontext.InstallOrUpgradeRuntime(flavor, accelerated) // retain the current accelerator setting for upgrades
 		if err != nil {
 			slog.Error("installing runtime", "error", err)
 			os.Exit(1)

--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -54,8 +54,8 @@ func GetLatestCliRelease() (*RepoRelease, error) {
 	return release, nil
 }
 
-func DownloadRuntimeAsset(flavor string, release *RepoRelease, downloadPath string) error {
-	assetName := GetRuntimeAssetName(flavor)
+func DownloadRuntimeAsset(flavor string, release *RepoRelease, downloadPath string, allowAccelerator bool) error {
+	assetName := GetRuntimeAssetName(flavor, allowAccelerator)
 	slog.Info(fmt.Sprintf("Downloading the Spice runtime..., %s", assetName))
 	return DownloadReleaseAsset(githubClient, release, assetName, downloadPath)
 }
@@ -64,10 +64,10 @@ func DownloadAsset(release *RepoRelease, downloadPath string, assetName string) 
 	return DownloadReleaseAsset(githubClient, release, assetName, downloadPath)
 }
 
-func GetRuntimeAssetName(flavor string) string {
+func GetRuntimeAssetName(flavor string, allowAccelerator bool) string {
 	switch {
 	case flavor == "ai":
-		if accelerator, exists := get_ai_accelerator(); exists {
+		if accelerator, exists := get_ai_accelerator(); exists && allowAccelerator {
 			flavor = fmt.Sprintf("_models_%s", accelerator)
 		} else {
 			flavor = "_models"

--- a/bin/spice/pkg/runtime/runtime.go
+++ b/bin/spice/pkg/runtime/runtime.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Ensures the runtime is installed. Returns true if the runtime was installed or upgraded, false if it was already installed.
-func EnsureInstalled(flavor string, autoUpgrade bool) (bool, error) {
+func EnsureInstalled(flavor string, autoUpgrade bool, allowAccelerator bool) (bool, error) {
 	if flavor != "ai" && flavor != "" {
 		return false, fmt.Errorf("invalid flavor: %s", flavor)
 	}
@@ -52,12 +52,12 @@ func EnsureInstalled(flavor string, autoUpgrade bool) (bool, error) {
 		}
 	}
 
-	if flavor == "ai" && !rtcontext.ModelsFlavorInstalled() {
+	if models, _ := rtcontext.ModelsFlavorInstalled(); !models && flavor == "ai" {
 		shouldInstall = true
 	}
 
 	if shouldInstall {
-		err = rtcontext.InstallOrUpgradeRuntime(flavor)
+		err = rtcontext.InstallOrUpgradeRuntime(flavor, allowAccelerator)
 		if err != nil {
 			return shouldInstall, err
 		}
@@ -76,7 +76,7 @@ func Run(args []string) error {
 		os.Exit(1)
 	}
 
-	_, err = EnsureInstalled("", false)
+	_, err = EnsureInstalled("", false, false) // base runtime without ai has no need for accelerator
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds a `--cpu` flag to `spice install` for the `ai` flavor, as an escape hatch to install a non-accelerated models image

Examples:

```bash
╰─± spice install ai
2025/01/20 18:57:12 INFO Checking for latest Spice runtime release...
2025/01/20 18:57:13 INFO Downloading and installing Spice.ai Runtime v1.0.0-rc.5 ...
2025/01/20 18:57:13 INFO Downloading the Spice runtime..., spiced_models_cuda_86_linux_x86_64.tar.gz
╰─± spice install ai --cpu
2025/01/20 18:57:16 INFO Checking for latest Spice runtime release...
2025/01/20 18:57:16 INFO Downloading and installing Spice.ai Runtime v1.0.0-rc.5 ...
2025/01/20 18:57:16 INFO Downloading the Spice runtime..., spiced_models_linux_x86_64.tar.gz
╰─± spice install ai --force
2025/01/20 18:57:19 INFO Checking for latest Spice runtime release...
2025/01/20 18:57:19 INFO Downloading and installing Spice.ai Runtime v1.0.0-rc.5 ...
2025/01/20 18:57:19 INFO Downloading the Spice runtime..., spiced_models_cuda_86_linux_x86_64.tar.gz
╰─± spice install ai --cpu --force
2025/01/20 18:57:22 INFO Checking for latest Spice runtime release...
2025/01/20 18:57:22 INFO Downloading and installing Spice.ai Runtime v1.0.0-rc.5 ...
2025/01/20 18:57:22 INFO Downloading the Spice runtime..., spiced_models_linux_x86_64.tar.gz
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #3925