### PR TITLE
Automatically install supported CUDA binary on Windows

### DIFF
--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -121,7 +121,7 @@ func get_ai_accelerator() (string, bool) {
 		}
 	}
 
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
 		version, err := get_cuda_version()
 		if err != nil {
 			slog.Error("checking for CUDA device", "error", err)
@@ -159,11 +159,11 @@ func has_metal_device() (bool, error) {
 }
 
 func get_cuda_version() (*string, error) {
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
 		return nil, nil
 	}
 
-	slog.Debug("On Linux, running `nvidia-smi --query-gpu=compute_cap --format=csv,noheader` to determine hardware")
+	slog.Debug("Running `nvidia-smi --query-gpu=compute_cap --format=csv,noheader` to determine hardware")
 	cmd := exec.Command("nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
# 🗣 Description

Automatically install supported CUDA binary on Windows

```bash
c:\test>spice install ai
2025/01/20 09:22:19 INFO Checking for latest Spice runtime release...
2025/01/20 09:22:19 INFO Spice runtime installation required
2025/01/20 09:22:20 INFO Downloading and installing Spice.ai Runtime v1.0.0-rc.5 ...
2025/01/20 09:22:20 INFO Downloading the Spice runtime..., spiced.exe_models_cuda_86_windows_x86_64.tar.gz
2025/01/20 09:22:23 INFO Spice runtime installed into C:\Users\Administrator\.spice\bin successfully.

c:\test>spiced --version
v1.0.0+models.cuda
```

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3925

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
