### PR TITLE
Local models can stream tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "mistralrs"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
+source = "git+https://github.com/spiceai/mistral.rs?rev=758443d0d18e8a994b5fdc9cffb162fed5c964bc#758443d0d18e8a994b5fdc9cffb162fed5c964bc"
 dependencies = [
  "anyhow",
  "candle-core 0.8.0",
@@ -7068,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
+source = "git+https://github.com/spiceai/mistral.rs?rev=758443d0d18e8a994b5fdc9cffb162fed5c964bc#758443d0d18e8a994b5fdc9cffb162fed5c964bc"
 dependencies = [
  "akin",
  "anyhow",
@@ -7141,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
+source = "git+https://github.com/spiceai/mistral.rs?rev=758443d0d18e8a994b5fdc9cffb162fed5c964bc#758443d0d18e8a994b5fdc9cffb162fed5c964bc"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.6",
@@ -7153,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
+source = "git+https://github.com/spiceai/mistral.rs?rev=758443d0d18e8a994b5fdc9cffb162fed5c964bc#758443d0d18e8a994b5fdc9cffb162fed5c964bc"
 dependencies = [
  "bindgen_cuda 0.1.5",
  "byteorder",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-vision"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
+source = "git+https://github.com/spiceai/mistral.rs?rev=758443d0d18e8a994b5fdc9cffb162fed5c964bc#758443d0d18e8a994b5fdc9cffb162fed5c964bc"
 dependencies = [
  "candle-core 0.8.0",
  "image 0.25.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "mistralrs"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
+source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
 dependencies = [
  "anyhow",
  "candle-core 0.8.0",
@@ -7068,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
+source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
 dependencies = [
  "akin",
  "anyhow",
@@ -7141,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
+source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.6",
@@ -7153,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
+source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
 dependencies = [
  "bindgen_cuda 0.1.5",
  "byteorder",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-vision"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
+source = "git+https://github.com/spiceai/mistral.rs?rev=5ce6ff5f762b6d2dbeacbc31eff7355d535a4451#5ce6ff5f762b6d2dbeacbc31eff7355d535a4451"
 dependencies = [
  "candle-core 0.8.0",
  "image 0.25.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "mistralrs"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=533c2e9c3d30e3694024cf1d30c921ed95101579#533c2e9c3d30e3694024cf1d30c921ed95101579"
+source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
 dependencies = [
  "anyhow",
  "candle-core 0.8.0",
@@ -7068,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=533c2e9c3d30e3694024cf1d30c921ed95101579#533c2e9c3d30e3694024cf1d30c921ed95101579"
+source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
 dependencies = [
  "akin",
  "anyhow",
@@ -7141,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=533c2e9c3d30e3694024cf1d30c921ed95101579#533c2e9c3d30e3694024cf1d30c921ed95101579"
+source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.6",
@@ -7153,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=533c2e9c3d30e3694024cf1d30c921ed95101579#533c2e9c3d30e3694024cf1d30c921ed95101579"
+source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
 dependencies = [
  "bindgen_cuda 0.1.5",
  "byteorder",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-vision"
 version = "0.3.4"
-source = "git+https://github.com/spiceai/mistral.rs?rev=533c2e9c3d30e3694024cf1d30c921ed95101579#533c2e9c3d30e3694024cf1d30c921ed95101579"
+source = "git+https://github.com/spiceai/mistral.rs?rev=340dd6de56eeb17c625bc2d316a6d4577345629c#340dd6de56eeb17c625bc2d316a6d4577345629c"
 dependencies = [
  "candle-core 0.8.0",
  "image 0.25.5",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,8 +41,8 @@ text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "5
 pulldown-cmark = "0.12.1"
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "5ce6ff5f762b6d2dbeacbc31eff7355d535a4451" }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "5ce6ff5f762b6d2dbeacbc31eff7355d535a4451", package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "758443d0d18e8a994b5fdc9cffb162fed5c964bc" }
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "758443d0d18e8a994b5fdc9cffb162fed5c964bc", package = "mistralrs-core" }
 rand = "0.8.5"
 tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
     "candle",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,8 +41,8 @@ text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "5
 pulldown-cmark = "0.12.1"
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "533c2e9c3d30e3694024cf1d30c921ed95101579" }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "533c2e9c3d30e3694024cf1d30c921ed95101579", package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "340dd6de56eeb17c625bc2d316a6d4577345629c" }
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "340dd6de56eeb17c625bc2d316a6d4577345629c", package = "mistralrs-core" }
 rand = "0.8.5"
 tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
     "candle",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,8 +41,8 @@ text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "5
 pulldown-cmark = "0.12.1"
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "340dd6de56eeb17c625bc2d316a6d4577345629c" }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "340dd6de56eeb17c625bc2d316a6d4577345629c", package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "5ce6ff5f762b6d2dbeacbc31eff7355d535a4451" }
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "5ce6ff5f762b6d2dbeacbc31eff7355d535a4451", package = "mistralrs-core" }
 rand = "0.8.5"
 tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
     "candle",

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -20,11 +20,12 @@ use super::{nsql::SqlGeneration, Chat, Error as ChatError, FailedToRunModelSnafu
 use async_openai::{
     error::{ApiError, OpenAIError},
     types::{
-        ChatChoiceStream, ChatCompletionNamedToolChoice, ChatCompletionRequestUserMessageArgs,
-        ChatCompletionResponseStream, ChatCompletionStreamResponseDelta, ChatCompletionTool,
-        ChatCompletionToolChoiceOption, CompletionUsage, CreateChatCompletionRequest,
+        ChatChoiceStream, ChatCompletionMessageToolCallChunk, ChatCompletionNamedToolChoice,
+        ChatCompletionRequestUserMessageArgs, ChatCompletionResponseStream,
+        ChatCompletionStreamResponseDelta, ChatCompletionTool, ChatCompletionToolChoiceOption,
+        ChatCompletionToolType, CompletionUsage, CreateChatCompletionRequest,
         CreateChatCompletionRequestArgs, CreateChatCompletionResponse,
-        CreateChatCompletionStreamResponse, FinishReason, Role, Stop,
+        CreateChatCompletionStreamResponse, FinishReason, FunctionCallStream, Role, Stop,
     },
 };
 use async_stream::stream;
@@ -35,7 +36,8 @@ use mistralrs::{
     DeviceMapMetadata, Function, GGMLLoaderBuilder, GGMLSpecificConfig, GGUFLoaderBuilder,
     GGUFSpecificConfig, LocalModelPaths, MistralRs, MistralRsBuilder, ModelDType, ModelPaths,
     NormalLoaderBuilder, NormalRequest, Pipeline, Request as MistralRequest, RequestMessage,
-    Response as MistralResponse, SamplingParams, TokenSource, Tool, ToolChoice, ToolType,
+    Response as MistralResponse, SamplingParams, TokenSource, Tool, ToolCallResponse, ToolChoice,
+    ToolType,
 };
 
 use secrecy::{ExposeSecret, Secret};
@@ -658,22 +660,31 @@ fn chunk_to_openai_stream(
 
 #[allow(deprecated, clippy::cast_possible_truncation)]
 fn chunk_choices_to_openai(choice: &ChunkChoice) -> Result<ChatChoiceStream, OpenAIError> {
-    let role: Role = serde_json::from_str(&format!("\"{}\"", &choice.delta.role))
+    let ChunkChoice {
+        index,
+        delta,
+        finish_reason,
+        ..
+    } = choice;
+    let role: Role = serde_json::from_str(&format!("\"{}\"", delta.role))
         .map_err(OpenAIError::JSONDeserialize)?;
 
-    let finish_reason: Option<FinishReason> = choice
-        .finish_reason
+    let finish_reason: Option<FinishReason> = finish_reason
         .as_ref()
         .map(|f| serde_json::from_str(&format!("\"{f}\"")))
         .transpose()
         .map_err(OpenAIError::JSONDeserialize)?;
 
     Ok(ChatChoiceStream {
-        index: choice.index as u32,
+        index: *index as u32,
         delta: ChatCompletionStreamResponseDelta {
-            content: Some(choice.delta.content.clone()),
+            content: delta.content.clone(),
             function_call: None,
-            tool_calls: None,
+            tool_calls: delta.tool_calls.as_ref().map(|t| {
+                t.iter()
+                    .map(|x| parse_tool_call_response(*index as i32, x))
+                    .collect()
+            }),
             role: Some(role),
             refusal: None,
         },
@@ -718,5 +729,20 @@ fn convert_tool(x: &ChatCompletionTool) -> Tool {
                 .clone()
                 .and_then(|p| p.as_object().map(|p| HashMap::from_iter(p.clone()))),
         },
+    }
+}
+
+fn parse_tool_call_response(
+    index: i32,
+    r: &ToolCallResponse,
+) -> ChatCompletionMessageToolCallChunk {
+    ChatCompletionMessageToolCallChunk {
+        id: Some(r.id.clone()),
+        index,
+        r#type: Some(ChatCompletionToolType::Function),
+        function: Some(FunctionCallStream {
+            name: Some(r.function.name.clone()),
+            arguments: Some(r.function.arguments.clone()),
+        }),
     }
 }

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -658,7 +658,11 @@ fn chunk_to_openai_stream(
     })
 }
 
-#[allow(deprecated, clippy::cast_possible_truncation)]
+#[allow(
+    deprecated,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap
+)]
 fn chunk_choices_to_openai(choice: &ChunkChoice) -> Result<ChatChoiceStream, OpenAIError> {
     let ChunkChoice {
         index,


### PR DESCRIPTION
# 🗣 Description
- Local and Huggingface models can use tools when streaming a response back. 
- This works by waiting off sending the stream data until it invalidates itself as being impossible to use for a tool request (when explicitly disabled, we can stream immediately). 

## 🔨 Related Issues
 - PR in mistral.rs: https://github.com/spiceai/mistral.rs/pull/14 

## 📄 Documentation Updates
- [ ] Remove limitations from docs. 
