### PR TITLE
Run CUDA builds in a separate workflow

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -84,22 +84,7 @@ jobs:
                 target_arch: "x86_64",
                 target_arch_go: "amd64",
                 tags: ["default", "models"],
-              }, {
-                name: "GPU T4 Ubuntu",
-                runner: "ubuntu-gpu-t4-4-core",
-                target_os: "linux",
-                target_arch: "x86_64",
-                target_arch_go: "amd64",
-                tags: ["cuda"]
-              },
-              {
-                name: "GPU T4 Windows",
-                runner: "windows-gpu-t4-4-core",
-                target_os: "windows",
-                target_arch: "x86_64",
-                target_arch_go: "amd64",
-                tags: ["cuda"]
-              },
+              }
             ];
 
             // If running via workflow_dispatch, filter based on input
@@ -113,10 +98,6 @@ jobs:
               return matrix.filter(m => m.name === platform_option);
             }
 
-            // Do not run GPU builds automatically on PRs
-            if (context.eventName === 'push' && context.ref === 'refs/heads/trunk') {
-              return matrix.filter(m => !m.tags.includes("cuda"));
-            }
             return matrix;
 
   build:
@@ -321,52 +302,6 @@ jobs:
           name: spiced_models_metal_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
           path: spiced_models_metal_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz
 
-      ## Models + CUDA flavor: 90, 89, 86, 80, 75 
-      - name: Run Spiced CUDA Build (COMPUTE_CAP=75).
-        uses: ./.github/actions/spiced-cuda-build
-        if: contains(matrix.target.tags, 'cuda')
-        with:
-          cuda-version: "12.4.1"
-          cuda-compute-capability: "75"
-          artifact-tag: ${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          target_os: ${{ matrix.target.target_os }}
-
-      - name: Run Spiced CUDA Build (COMPUTE_CAP=80).
-        uses: ./.github/actions/spiced-cuda-build
-        if: contains(matrix.target.tags, 'cuda')
-        with:
-          cuda-version: "12.4.1"
-          cuda-compute-capability: "80"
-          artifact-tag: ${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          target_os: ${{ matrix.target.target_os }}
-
-      - name: Run Spiced CUDA Build (COMPUTE_CAP=86).
-        uses: ./.github/actions/spiced-cuda-build
-        if: contains(matrix.target.tags, 'cuda')
-        with:
-          cuda-version: "12.4.1"
-          cuda-compute-capability: "86"
-          artifact-tag: ${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          target_os: ${{ matrix.target.target_os }}
-
-      - name: Run Spiced CUDA Build (COMPUTE_CAP=89).
-        uses: ./.github/actions/spiced-cuda-build
-        if: contains(matrix.target.tags, 'cuda')
-        with:
-          cuda-version: "12.4.1"
-          cuda-compute-capability: "89"
-          artifact-tag: ${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          target_os: ${{ matrix.target.target_os }}
-
-      - name: Run Spiced CUDA Build (COMPUTE_CAP=90).
-        uses: ./.github/actions/spiced-cuda-build
-        if: contains(matrix.target.tags, 'cuda')
-        with:
-          cuda-version: "12.4.1"
-          cuda-compute-capability: "90"
-          artifact-tag: ${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          target_os: ${{ matrix.target.target_os }}
-
       ## CLI build
       - name: Build spice
         if: contains(matrix.target.tags, 'default')
@@ -426,10 +361,104 @@ jobs:
             Copy-Item -Recurse -Force target/* C:/spiceai/build/target
           }
 
+  cuda-build:
+    name: Build CUDA ${{ matrix.compute_cap }} binaries
+    runs-on: ${{ matrix.runner }}
+    needs: setup-matrix
+    strategy:
+      matrix:
+        include:
+          - compute_cap: "75"
+            runner: "ubuntu-gpu-t4-4-core"
+            target_os: "linux"
+            target_arch: "x86_64"
+          - compute_cap: "80"
+            runner: "ubuntu-gpu-t4-4-core"
+            target_os: "linux"
+            target_arch: "x86_64"
+          - compute_cap: "86"
+            runner: "ubuntu-gpu-t4-4-core"
+            target_os: "linux"
+            target_arch: "x86_64"
+          - compute_cap: "89"
+            runner: "ubuntu-gpu-t4-4-core"
+            target_os: "linux"
+            target_arch: "x86_64"
+          - compute_cap: "90"
+            runner: "ubuntu-gpu-t4-4-core"
+            target_os: "linux"
+            target_arch: "x86_64"
+          - compute_cap: "75"
+            runner: "windows-gpu-t4-4-core"
+            target_os: "windows"
+            target_arch: "x86_64"
+          - compute_cap: "80"
+            runner: "windows-gpu-t4-4-core"
+            target_os: "windows"
+            target_arch: "x86_64"
+          - compute_cap: "86"
+            runner: "windows-gpu-t4-4-core"
+            target_os: "windows"
+            target_arch: "x86_64"
+          - compute_cap: "89"
+            runner: "windows-gpu-t4-4-core"
+            target_os: "windows"
+            target_arch: "x86_64"
+          - compute_cap: "90"
+            runner: "windows-gpu-t4-4-core"
+            target_os: "windows"
+            target_arch: "x86_64"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The `windows-gpu-t4-4-core` does not have Python installed
+      - name: Set up Python3
+        if: matrix.target_os == 'windows'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Set REL_VERSION from version.txt
+        run: python3 ./.github/scripts/get_release_version.py
+
+      # The `windows-gpu-t4-4-core` does not have modern PowerShell installed
+      - name: Install PowerShell
+        if: matrix.target_os == 'windows'
+        uses: ./.github/actions/install-pwsh
+
+      # The `windows-gpu-t4-4-core` requires Visual Studio Build Tools
+      - name: Install Visual Studio Build Tools
+        if: matrix.target_os == 'windows'
+        uses: ./.github/actions/install-vs-buildtools
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: ${{ matrix.target_os }}
+
+      - name: Set up make
+        if: matrix.target_os == 'linux' || matrix.runner == 'windows-gpu-t4-4-core'
+        uses: ./.github/actions/setup-make
+        with:
+          os: ${{ matrix.target_os }}
+
+      - name: Set up cc
+        if: matrix.target_os == 'linux'
+        uses: ./.github/actions/setup-cc
+
+      - name: Run Spiced CUDA Build
+        uses: ./.github/actions/spiced-cuda-build
+        with:
+          cuda-version: "12.4.1"
+          cuda-compute-capability: ${{ matrix.compute_cap }}
+          artifact-tag: ${{ matrix.target_os }}_${{ matrix.target_arch }}
+          target_os: ${{ matrix.target_os }}
+
   publish-minio:
     name: Publish linux-x86_64 binaries to Minio
     runs-on: spiceai-runners
-    needs: build
+    needs: [build, cuda-build]
     env:
       GOVER: 1.23.4
       ARTIFACT_DIR: ./release
@@ -545,7 +574,7 @@ jobs:
 
   publish:
     name: Publish ${{ matrix.target_os }}-${{ matrix.target_arch }} binaries
-    needs: build
+    needs: [build, cuda-build]
     if: startswith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request'
     env:
       ARTIFACT_DIR: ./release

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -38,8 +38,6 @@ on:
           - "macOS aarch64 (Apple Silicon)"
           - "Windows x64"
           - "macOS x64 (Intel)"
-          - "GPU T4 Ubuntu"
-          - "GPU T4 Windows"
         default: "all"
 
 jobs:
@@ -96,102 +94,6 @@ jobs:
               }
 
               return matrix.filter(m => m.name === platform_option);
-            }
-
-            return matrix;
-
-  setup-cuda-matrix:
-    name: Setup CUDA matrix
-    runs-on: spiceai-runners
-    outputs:
-      matrix: ${{ steps.setup-matrix.outputs.result }}
-
-    steps:
-      - name: Set up matrix
-        uses: actions/github-script@v7
-        id: setup-matrix
-        with:
-          script: |
-            const matrix = [
-              {
-                compute_cap: "75",
-                runner: "ubuntu-gpu-t4-4-core",
-                target_os: "linux",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "80",
-                runner: "ubuntu-gpu-t4-4-core",
-                target_os: "linux",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "86",
-                runner: "ubuntu-gpu-t4-4-core",
-                target_os: "linux",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "89",
-                runner: "ubuntu-gpu-t4-4-core",
-                target_os: "linux",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "90",
-                runner: "ubuntu-gpu-t4-4-core",
-                target_os: "linux",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "75",
-                runner: "windows-gpu-t4-4-core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "80",
-                runner: "windows-gpu-t4-4-core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "86",
-                runner: "windows-gpu-t4-4-core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "89",
-                runner: "windows-gpu-t4-4-core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "90",
-                runner: "windows-gpu-t4-4-core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              }
-            ];
-
-            // If running via workflow_dispatch, filter based on input
-            if (context.eventName === 'workflow_dispatch') {
-              const platform_option = context.payload.inputs.platform_option;
-
-              if (platform_option === 'all') {
-                return matrix;
-              }
-
-              if (platform_option === 'GPU T4 Ubuntu') {
-                return matrix.filter(m => m.target_os === 'linux');
-              }
-
-              if (platform_option === 'GPU T4 Windows') {
-                return matrix.filter(m => m.target_os === 'windows');
-              }
-
-              return [];
             }
 
             return matrix;
@@ -457,64 +359,10 @@ jobs:
             Copy-Item -Recurse -Force target/* C:/spiceai/build/target
           }
 
-  cuda-build:
-    name: Build CUDA ${{ matrix.target.compute_cap }} binaries
-    runs-on: ${{ matrix.target.runner }}
-    needs: setup-cuda-matrix
-    strategy:
-      matrix:
-        target: ${{ fromJson(needs.setup-cuda-matrix.outputs.matrix) }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # The `windows-gpu-t4-4-core` does not have Python installed
-      - name: Set up Python3
-        if: matrix.target.target_os == 'windows'
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Set REL_VERSION from version.txt
-        run: python3 ./.github/scripts/get_release_version.py
-
-      # The `windows-gpu-t4-4-core` does not have modern PowerShell installed
-      - name: Install PowerShell
-        if: matrix.target.target_os == 'windows'
-        uses: ./.github/actions/install-pwsh
-
-      # The `windows-gpu-t4-4-core` requires Visual Studio Build Tools
-      - name: Install Visual Studio Build Tools
-        if: matrix.target.target_os == 'windows'
-        uses: ./.github/actions/install-vs-buildtools
-
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          os: ${{ matrix.target.target_os }}
-
-      - name: Set up make
-        if: matrix.target.target_os == 'linux' || matrix.target.runner == 'windows-gpu-t4-4-core'
-        uses: ./.github/actions/setup-make
-        with:
-          os: ${{ matrix.target.target_os }}
-
-      - name: Set up cc
-        if: matrix.target.target_os == 'linux'
-        uses: ./.github/actions/setup-cc
-
-      - name: Run Spiced CUDA Build
-        uses: ./.github/actions/spiced-cuda-build
-        with:
-          cuda-version: "12.4.1"
-          cuda-compute-capability: ${{ matrix.target.compute_cap }}
-          artifact-tag: ${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          target_os: ${{ matrix.target.target_os }}
-
   publish-minio:
     name: Publish linux-x86_64 binaries to Minio
     runs-on: spiceai-runners
-    needs: [build, cuda-build]
+    needs: build
     env:
       GOVER: 1.23.4
       ARTIFACT_DIR: ./release
@@ -549,43 +397,6 @@ jobs:
           name: spiced_models_linux_x86_64
           path: ${{ env.ARTIFACT_DIR }}
 
-
-      #  CUDA flavors: 90, 89, 86, 80, 75 
-      - name: download artifacts - spiced_models_cuda_75_linux_x86_64
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_75_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_80_linux_x86_64
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_80_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_86_linux_x86_64
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_86_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_89_linux_x86_64
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_89_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_90_linux_x86_64
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_90_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
-
       - name: Upload artifacts to Minio
         run: |
           sudo apt-get update
@@ -606,31 +417,9 @@ jobs:
             mc cp ${{ env.ARTIFACT_DIR }}/spice_linux_x86_64.tar.gz spice-minio/artifacts/spice/linux-x86_64/${{ env.COMMIT_SHA }}/
           fi;
 
-          # CUDA flavors: 90, 89, 86, 80, 75 
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_75_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_75_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_80_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_80_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_86_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_86_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_89_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_89_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_90_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_90_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
   publish:
     name: Publish ${{ matrix.target_os }}-${{ matrix.target_arch }} binaries
-    needs: [build, cuda-build]
+    needs: build
     if: startswith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request'
     env:
       ARTIFACT_DIR: ./release

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -100,6 +100,102 @@ jobs:
 
             return matrix;
 
+  setup-cuda-matrix:
+    name: Setup CUDA matrix
+    runs-on: spiceai-runners
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.result }}
+
+    steps:
+      - name: Set up matrix
+        uses: actions/github-script@v7
+        id: setup-matrix
+        with:
+          script: |
+            const matrix = [
+              {
+                compute_cap: "75",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "80",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "86",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "89",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "90",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "75",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "80",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "86",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "89",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "90",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              }
+            ];
+
+            // If running via workflow_dispatch, filter based on input
+            if (context.eventName === 'workflow_dispatch') {
+              const platform_option = context.payload.inputs.platform_option;
+
+              if (platform_option === 'all') {
+                return matrix;
+              }
+
+              if (platform_option === 'GPU T4 Ubuntu') {
+                return matrix.filter(m => m.target_os === 'linux');
+              }
+
+              if (platform_option === 'GPU T4 Windows') {
+                return matrix.filter(m => m.target_os === 'windows');
+              }
+
+              return [];
+            }
+
+            return matrix;
+
   build:
     name: Build ${{ matrix.target.name }} binaries
     runs-on: ${{ matrix.target.runner }}
@@ -362,59 +458,19 @@ jobs:
           }
 
   cuda-build:
-    name: Build CUDA ${{ matrix.compute_cap }} binaries
-    runs-on: ${{ matrix.runner }}
-    needs: setup-matrix
+    name: Build CUDA ${{ matrix.target.compute_cap }} binaries
+    runs-on: ${{ matrix.target.runner }}
+    needs: setup-cuda-matrix
     strategy:
       matrix:
-        include:
-          - compute_cap: "75"
-            runner: "ubuntu-gpu-t4-4-core"
-            target_os: "linux"
-            target_arch: "x86_64"
-          - compute_cap: "80"
-            runner: "ubuntu-gpu-t4-4-core"
-            target_os: "linux"
-            target_arch: "x86_64"
-          - compute_cap: "86"
-            runner: "ubuntu-gpu-t4-4-core"
-            target_os: "linux"
-            target_arch: "x86_64"
-          - compute_cap: "89"
-            runner: "ubuntu-gpu-t4-4-core"
-            target_os: "linux"
-            target_arch: "x86_64"
-          - compute_cap: "90"
-            runner: "ubuntu-gpu-t4-4-core"
-            target_os: "linux"
-            target_arch: "x86_64"
-          - compute_cap: "75"
-            runner: "windows-gpu-t4-4-core"
-            target_os: "windows"
-            target_arch: "x86_64"
-          - compute_cap: "80"
-            runner: "windows-gpu-t4-4-core"
-            target_os: "windows"
-            target_arch: "x86_64"
-          - compute_cap: "86"
-            runner: "windows-gpu-t4-4-core"
-            target_os: "windows"
-            target_arch: "x86_64"
-          - compute_cap: "89"
-            runner: "windows-gpu-t4-4-core"
-            target_os: "windows"
-            target_arch: "x86_64"
-          - compute_cap: "90"
-            runner: "windows-gpu-t4-4-core"
-            target_os: "windows"
-            target_arch: "x86_64"
+        target: ${{ fromJson(needs.setup-cuda-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
 
       # The `windows-gpu-t4-4-core` does not have Python installed
       - name: Set up Python3
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
@@ -424,36 +480,36 @@ jobs:
 
       # The `windows-gpu-t4-4-core` does not have modern PowerShell installed
       - name: Install PowerShell
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         uses: ./.github/actions/install-pwsh
 
       # The `windows-gpu-t4-4-core` requires Visual Studio Build Tools
       - name: Install Visual Studio Build Tools
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         uses: ./.github/actions/install-vs-buildtools
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:
-          os: ${{ matrix.target_os }}
+          os: ${{ matrix.target.target_os }}
 
       - name: Set up make
-        if: matrix.target_os == 'linux' || matrix.runner == 'windows-gpu-t4-4-core'
+        if: matrix.target.target_os == 'linux' || matrix.target.runner == 'windows-gpu-t4-4-core'
         uses: ./.github/actions/setup-make
         with:
-          os: ${{ matrix.target_os }}
+          os: ${{ matrix.target.target_os }}
 
       - name: Set up cc
-        if: matrix.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         uses: ./.github/actions/setup-cc
 
       - name: Run Spiced CUDA Build
         uses: ./.github/actions/spiced-cuda-build
         with:
           cuda-version: "12.4.1"
-          cuda-compute-capability: ${{ matrix.compute_cap }}
-          artifact-tag: ${{ matrix.target_os }}_${{ matrix.target_arch }}
-          target_os: ${{ matrix.target_os }}
+          cuda-compute-capability: ${{ matrix.target.compute_cap }}
+          artifact-tag: ${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          target_os: ${{ matrix.target.target_os }}
 
   publish-minio:
     name: Publish linux-x86_64 binaries to Minio

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -150,6 +150,7 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     needs: setup-matrix
     strategy:
+      fail-fast: false
       matrix:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
@@ -213,41 +214,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      #  CUDA flavors: 90, 89, 86, 80, 75 
-      - name: download artifacts - spiced_models_cuda_75_linux_x86_64
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_75_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
+      - name: Create artifact directory
+        run: mkdir -p ${{ env.ARTIFACT_DIR }}
 
-      - name: download artifacts - spiced_models_cuda_80_linux_x86_64
-        continue-on-error: true
+      # Download all Linux CUDA artifacts
+      - name: Download Linux CUDA artifacts
         uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_80_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_86_linux_x86_64
         continue-on-error: true
-        uses: actions/download-artifact@v4
         with:
-          name: spiced_models_cuda_86_linux_x86_64
+          pattern: spiced_models_cuda_*_linux_x86_64
           path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_89_linux_x86_64
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_89_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_90_linux_x86_64
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_90_linux_x86_64
-          path: ${{ env.ARTIFACT_DIR }}
+          merge-multiple: true
 
       - name: Upload artifacts to Minio
         run: |
@@ -257,26 +234,13 @@ jobs:
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ env.MINIO_ENDPOINT }} ${{ env.MINIO_ACCESS_KEY }} ${{ env.MINIO_SECRET_KEY }}
 
-          # CUDA flavors: 90, 89, 86, 80, 75 
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_75_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_75_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_80_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_80_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_86_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_86_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_89_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_89_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
-
-          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_90_linux_x86_64.tar.gz" ]; then
-            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_90_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
-          fi
+          # Upload any CUDA artifacts that were successfully built
+          for file in ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_*_linux_x86_64.tar.gz; do
+            if [ -f "$file" ]; then
+              echo "Uploading $file to Minio..."
+              mc cp "$file" spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+            fi
+          done
 
   publish:
     name: Publish CUDA binaries
@@ -297,79 +261,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Create artifact directory
+        run: mkdir -p ${{ env.ARTIFACT_DIR }}
+
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 
-      # CUDA flavors: 90, 89, 86, 80, 75 
-      - name: download artifacts - spiced_models_cuda_75_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os != 'windows'
+      # Download all CUDA artifacts for this platform
+      - name: Download CUDA artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
-          name: spiced_models_cuda_75_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          pattern: |
+            spiced_models_cuda_*_${{ matrix.target_os }}_${{ matrix.target_arch }}
+            spiced.exe_models_cuda_*_${{ matrix.target_os }}_${{ matrix.target_arch }}
           path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_75_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os == 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced.exe_models_cuda_75_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_80_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os != 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_80_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_80_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os == 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced.exe_models_cuda_80_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_86_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os != 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_86_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_86_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os == 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced.exe_models_cuda_86_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_89_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os != 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_89_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_89_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os == 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced.exe_models_cuda_89_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_90_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os != 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced_models_cuda_90_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
-
-      - name: download artifacts - spiced_models_cuda_90_${{ matrix.target_os }}_${{ matrix.target_arch }}
-        if: matrix.target_os == 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: spiced.exe_models_cuda_90_${{ matrix.target_os }}_${{ matrix.target_arch }}
-          path: ${{ env.ARTIFACT_DIR }}
+          merge-multiple: true
 
       - name: lists artifacts
         run: ls -l ${{ env.ARTIFACT_DIR }}

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -34,6 +34,18 @@ on:
           - "Linux x64"
           - "Windows x64"
         default: "all"
+      compute_cap:
+        description: "Which CUDA compute capability to build for? (Default is ALL)"
+        required: false
+        type: choice
+        options:
+          - "all"
+          - "75"
+          - "80"
+          - "86"
+          - "89"
+          - "90"
+        default: "all"
 
 jobs:
   setup-matrix:
@@ -114,20 +126,21 @@ jobs:
             // If running via workflow_dispatch, filter based on input
             if (context.eventName === 'workflow_dispatch') {
               const platform_option = context.payload.inputs.platform_option;
+              const compute_cap = context.payload.inputs.compute_cap;
+              let filtered = matrix;
 
-              if (platform_option === 'all') {
-                return matrix;
+              // Filter by platform if specified
+              if (platform_option !== 'all') {
+                const target_os = platform_option === 'Linux x64' ? 'linux' : 'windows';
+                filtered = filtered.filter(m => m.target_os === target_os);
               }
 
-              if (platform_option === 'Linux x64') {
-                return matrix.filter(m => m.target_os === 'linux');
+              // Filter by compute capability if specified
+              if (compute_cap !== 'all') {
+                filtered = filtered.filter(m => m.compute_cap === compute_cap);
               }
 
-              if (platform_option === 'Windows x64') {
-                return matrix.filter(m => m.target_os === 'windows');
-              }
-
-              return [];
+              return filtered;
             }
 
             return matrix;

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -1,0 +1,389 @@
+name: build_and_release_cuda
+
+on:
+  push:
+    tags:
+      - v*
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'README.md'
+      - 'Makefile'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+      - 'LICENSE'
+      - '.github/**'
+      - 'version.txt'
+      - '.schema/**'
+      - '.vscode/**'
+      - 'deploy/**'
+      - 'install/**'
+      - 'media/**'
+      - 'monitoring/**'
+      - 'acknowledgements.md'
+      - 'Dockerfile*'
+
+  workflow_dispatch:
+    inputs:
+      platform_option:
+        description: "Which platform do you want to run on? (Default is ALL)"
+        required: false
+        type: choice
+        options:
+          - "all"
+          - "Linux x64"
+          - "Windows x64"
+        default: "all"
+
+jobs:
+  setup-matrix:
+    name: Setup CUDA matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.result }}
+
+    steps:
+      - name: Set up matrix
+        uses: actions/github-script@v7
+        id: setup-matrix
+        with:
+          script: |
+            const matrix = [
+              {
+                compute_cap: "75",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "80",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "86",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "89",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "90",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "75",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "80",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "86",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "89",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              },
+              {
+                compute_cap: "90",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64"
+              }
+            ];
+
+            // If running via workflow_dispatch, filter based on input
+            if (context.eventName === 'workflow_dispatch') {
+              const platform_option = context.payload.inputs.platform_option;
+
+              if (platform_option === 'all') {
+                return matrix;
+              }
+
+              if (platform_option === 'Linux x64') {
+                return matrix.filter(m => m.target_os === 'linux');
+              }
+
+              if (platform_option === 'Windows x64') {
+                return matrix.filter(m => m.target_os === 'windows');
+              }
+
+              return [];
+            }
+
+            return matrix;
+
+  build:
+    name: Build CUDA ${{ matrix.target.compute_cap }} binaries
+    runs-on: ${{ matrix.target.runner }}
+    needs: setup-matrix
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The `windows-gpu-t4-4-core` does not have Python installed
+      - name: Set up Python3
+        if: matrix.target.target_os == 'windows'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Set REL_VERSION from version.txt
+        run: python3 ./.github/scripts/get_release_version.py
+
+      # The `windows-gpu-t4-4-core` does not have modern PowerShell installed
+      - name: Install PowerShell
+        if: matrix.target.target_os == 'windows'
+        uses: ./.github/actions/install-pwsh
+
+      # The `windows-gpu-t4-4-core` requires Visual Studio Build Tools
+      - name: Install Visual Studio Build Tools
+        if: matrix.target.target_os == 'windows'
+        uses: ./.github/actions/install-vs-buildtools
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: ${{ matrix.target.target_os }}
+
+      - name: Set up make
+        if: matrix.target.target_os == 'linux' || matrix.target.runner == 'windows-gpu-t4-4-core'
+        uses: ./.github/actions/setup-make
+        with:
+          os: ${{ matrix.target.target_os }}
+
+      - name: Set up cc
+        if: matrix.target.target_os == 'linux'
+        uses: ./.github/actions/setup-cc
+
+      - name: Run Spiced CUDA Build
+        uses: ./.github/actions/spiced-cuda-build
+        with:
+          cuda-version: "12.4.1"
+          cuda-compute-capability: ${{ matrix.target.compute_cap }}
+          artifact-tag: ${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          target_os: ${{ matrix.target.target_os }}
+
+  publish-minio:
+    name: Publish linux-x86_64 CUDA binaries to Minio
+    runs-on: spiceai-runners
+    needs: build
+    env:
+      ARTIFACT_DIR: ./release
+      MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+      MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+      MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+      COMMIT_SHA: ${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      #  CUDA flavors: 90, 89, 86, 80, 75 
+      - name: download artifacts - spiced_models_cuda_75_linux_x86_64
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_75_linux_x86_64
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_80_linux_x86_64
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_80_linux_x86_64
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_86_linux_x86_64
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_86_linux_x86_64
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_89_linux_x86_64
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_89_linux_x86_64
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_90_linux_x86_64
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_90_linux_x86_64
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: Upload artifacts to Minio
+        run: |
+          sudo apt-get update
+          sudo apt-get install wget -y
+          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo chmod +x /usr/local/bin/mc
+          mc alias set spice-minio ${{ env.MINIO_ENDPOINT }} ${{ env.MINIO_ACCESS_KEY }} ${{ env.MINIO_SECRET_KEY }}
+
+          # CUDA flavors: 90, 89, 86, 80, 75 
+          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_75_linux_x86_64.tar.gz" ]; then
+            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_75_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          fi
+
+          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_80_linux_x86_64.tar.gz" ]; then
+            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_80_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          fi
+
+          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_86_linux_x86_64.tar.gz" ]; then
+            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_86_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          fi
+
+          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_89_linux_x86_64.tar.gz" ]; then
+            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_89_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          fi
+
+          if [ -f "${ARTIFACT_DIR}/spiced_models_cuda_90_linux_x86_64.tar.gz" ]; then
+            mc cp ${{ env.ARTIFACT_DIR }}/spiced_models_cuda_90_linux_x86_64.tar.gz spice-minio/artifacts/spiced/linux-x86_64/${{ env.COMMIT_SHA }}/
+          fi
+
+  publish:
+    name: Publish CUDA binaries
+    needs: build
+    if: startswith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request'
+    env:
+      ARTIFACT_DIR: ./release
+
+    strategy:
+      matrix:
+        include:
+          - target_os: linux
+            target_arch: x86_64
+          - target_os: windows
+            target_arch: x86_64
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set REL_VERSION from version.txt
+        run: python3 ./.github/scripts/get_release_version.py
+
+      # CUDA flavors: 90, 89, 86, 80, 75 
+      - name: download artifacts - spiced_models_cuda_75_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os != 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_75_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_75_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os == 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced.exe_models_cuda_75_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_80_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os != 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_80_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_80_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os == 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced.exe_models_cuda_80_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_86_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os != 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_86_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_86_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os == 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced.exe_models_cuda_86_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_89_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os != 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_89_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_89_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os == 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced.exe_models_cuda_89_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_90_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os != 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced_models_cuda_90_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: download artifacts - spiced_models_cuda_90_${{ matrix.target_os }}_${{ matrix.target_arch }}
+        if: matrix.target_os == 'windows'
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced.exe_models_cuda_90_${{ matrix.target_os }}_${{ matrix.target_arch }}
+          path: ${{ env.ARTIFACT_DIR }}
+
+      - name: lists artifacts
+        run: ls -l ${{ env.ARTIFACT_DIR }}
+
+      - name: publish CUDA binaries to github
+        run: |
+          # Parse repository to get owner and repo names
+          OWNER_NAME="${GITHUB_REPOSITORY%%/*}"
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          # Get the list of files
+          RELEASE_ARTIFACT=(${ARTIFACT_DIR}/*)
+          # Delete existing release artifact
+          python ./.github/scripts/github_release.py delete \
+            --owner $OWNER_NAME --repo $REPO_NAME \
+            --tag "v${{ env.REL_VERSION }}" \
+            ${RELEASE_ARTIFACT[*]}
+          if [ "$LATEST_RELEASE" = "true" ]; then
+            export RELEASE_BODY=`cat ./docs/release_notes/v${{ env.REL_VERSION }}.md`
+          else
+            export RELEASE_BODY="This is the release candidate ${{ env.REL_VERSION }}"
+          fi
+          echo "Uploading Spice.ai CUDA Binaries to GitHub Release"
+          python ./.github/scripts/github_release.py upload \
+            --owner $OWNER_NAME --repo $REPO_NAME \
+            --tag "v${{ env.REL_VERSION }}" \
+            --release-name "v${{ env.REL_VERSION }}" \
+            --body "${RELEASE_BODY}" \
+            --prerelease "$PRE_RELEASE" \
+            ${RELEASE_ARTIFACT[*]} 


### PR DESCRIPTION
# 🗣 Description

Reduce the complexity of the main build workflow by separating the CUDA builds into their own dedicated workflow.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

These workflow files can be difficult to debug due to the long cycle times to get feedback. The CUDA builds especially take a very long time to build, so its possible I inadvertently broke something.

However, by splitting the CUDA builds into a separate workflow file, in addition to the maintainability win, we also mitigate the potential issue of CUDA builds blocking the main binaries from being built.
