### PR TITLE
fix: Use MetricsCollector::show() for HTTP testoperator commands

### DIFF
--- a/crates/test-framework/src/lib.rs
+++ b/crates/test-framework/src/lib.rs
@@ -40,7 +40,8 @@ pub enum TestType {
     Throughput,
     Load,
     Benchmark,
-    HTTP,
+    HTTPConsistency,
+    HTTPOverhead,
 }
 
 impl Display for TestType {
@@ -49,7 +50,8 @@ impl Display for TestType {
             TestType::Throughput => write!(f, "throughput"),
             TestType::Load => write!(f, "load"),
             TestType::Benchmark => write!(f, "benchmark"),
-            TestType::HTTP => write!(f, "http"),
+            TestType::HTTPConsistency => write!(f, "http_consistency"),
+            TestType::HTTPOverhead => write!(f, "http_overhead"),
         }
     }
 }

--- a/tools/testoperator/src/tests/http/overhead.rs
+++ b/tools/testoperator/src/tests/http/overhead.rs
@@ -34,6 +34,7 @@ use test_framework::{
         },
         SpiceTest,
     },
+    TestType,
 };
 
 /// Runs a test to ensure the P50 & p90 latencies do not increase by some threshold over the
@@ -73,15 +74,16 @@ pub(crate) async fn overhead_run(args: &HttpOverheadTestArgs) -> anyhow::Result<
 
     println!("{}", with_color!(Color::Blue, "Starting overhead test"));
     let test = test.start()?.wait().await?;
-    let results = test.metrics()?;
+    let results = test.collect(TestType::HTTPOverhead)?;
+    results.show()?;
 
     let mut spiced_instance = test.end();
     spiced_instance.stop()?;
 
-    let Some(baseline) = results.iter().find(|q| q.query_name == "baseline") else {
+    let Some(baseline) = results.metrics.iter().find(|q| q.query_name == "baseline") else {
         return Err(anyhow::anyhow!("Baseline results not found"));
     };
-    let Some(spice) = results.iter().find(|q| q.query_name == "spice") else {
+    let Some(spice) = results.metrics.iter().find(|q| q.query_name == "spice") else {
         return Err(anyhow::anyhow!("Spice results not found"));
     };
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Uses the provided methods from `MetricsCollector` to display data tables, removing the function to print an ascii table