### PR TITLE
Default to AI-enabled runtime for `spice run`/`spice install`

### DIFF
--- a/bin/spice/cmd/install.go
+++ b/bin/spice/cmd/install.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spiceai/spiceai/bin/spice/pkg/constants"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/runtime"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
@@ -45,9 +46,14 @@ spice install ai
 			slog.Error("failed to check for latest CLI release version", "error", err)
 		}
 
-		flavor := ""
+		flavor := constants.FlavorDefault
 		if len(args) > 0 {
-			flavor = args[0]
+			var err error
+			flavor, err = constants.ParseFlavor(args[0])
+			if err != nil {
+				slog.Error("Invalid command specified. Try: `spice install` or `spice install ai`")
+				os.Exit(1)
+			}
 		}
 
 		var installed bool
@@ -63,7 +69,7 @@ spice install ai
 			os.Exit(1)
 		}
 
-		if cpu && flavor != "ai" {
+		if cpu && flavor != constants.FlavorAI {
 			slog.Error("CPU flag is only allowed when installing the 'ai' flavor. Try: `spice install ai --cpu`")
 			os.Exit(1)
 		}

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -127,10 +127,11 @@ spice upgrade
 
 		slog.Info(fmt.Sprintf("Spice.ai CLI upgraded to %s successfully.", release.TagName))
 
-		flavor := ""
+		// For upgrades, default to the flavor that was installed previously.
+		flavor := constants.FlavorCore
 		models, accelerated := rtcontext.ModelsFlavorInstalled()
 		if models {
-			flavor = "ai"
+			flavor = constants.FlavorAI
 		}
 
 		err = rtcontext.InstallOrUpgradeRuntime(flavor, accelerated) // retain the current accelerator setting for upgrades

--- a/bin/spice/pkg/constants/flavor.go
+++ b/bin/spice/pkg/constants/flavor.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+import "fmt"
+
+type Flavor int
+
+const (
+	// The default flavor will install the AI-enabled runtime on new installs.
+	// For upgrades, it will upgrade whatever flavor is currently installed.
+	FlavorDefault Flavor = iota
+	// FlavorCore will install the core runtime that only includes data components.
+	FlavorCore
+	// FlavorAI will install the AI-enabled runtime. This is a superset of the core runtime.
+	FlavorAI
+)
+
+func ParseFlavor(s string) (Flavor, error) {
+	switch s {
+	case "":
+		return FlavorDefault, nil
+	case "ai":
+		return FlavorAI, nil
+	}
+
+	// The core flavor can't be specified by the user - its only used internally when handling upgrades.
+	return FlavorDefault, fmt.Errorf("unknown flavor: %s, valid flavors are: \"\", ai", s)
+}
+
+func (flavor Flavor) IsValid() bool {
+	return flavor == FlavorDefault || flavor == FlavorAI || flavor == FlavorCore
+}

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -173,15 +173,15 @@ func (c *RuntimeContext) RequireModelsFlavor(cmd *cobra.Command) {
 	if models, _ := c.ModelsFlavorInstalled(); models {
 		return
 	}
-	slog.Info("This feature requires a runtime version with models enabled. Install (y/n)? ")
+	slog.Info("This feature requires a runtime version with AI features enabled. Install (y/n)? ")
 	var confirm string
 	_, _ = fmt.Scanf("%s", &confirm)
 	if strings.ToLower(strings.TrimSpace(confirm)) != "y" {
-		slog.Warn("Models runtime not installed, exiting...")
+		slog.Warn("AI-enabled runtime not installed, exiting...")
 		os.Exit(0)
 	}
-	slog.Info("Installing models runtime...")
-	err := c.InstallOrUpgradeRuntime("models", true) // default to using an accelerator for prompted installs
+	slog.Info("Installing AI-enabled runtime...")
+	err := c.InstallOrUpgradeRuntime(constants.FlavorAI, true) // default to using an accelerator for prompted installs
 	if err != nil {
 		slog.Error("installing models runtime", "error", err)
 		os.Exit(1)
@@ -234,7 +234,7 @@ func (c *RuntimeContext) IsRuntimeInstallRequired() bool {
 	return errors.Is(err, os.ErrNotExist)
 }
 
-func (c *RuntimeContext) InstallOrUpgradeRuntime(flavor string, allowAccelerator bool) error {
+func (c *RuntimeContext) InstallOrUpgradeRuntime(flavor constants.Flavor, allowAccelerator bool) error {
 	err := c.prepareInstallDir()
 	if err != nil {
 		return err

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -173,7 +173,7 @@ func (c *RuntimeContext) RequireModelsFlavor(cmd *cobra.Command) {
 	if models, _ := c.ModelsFlavorInstalled(); models {
 		return
 	}
-	slog.Info("This feature requires a runtime version with AI features enabled. Install (y/n)? ")
+	slog.Info("This feature requires a runtime version with AI capabilities enabled. Install (y/n)? ")
 	var confirm string
 	_, _ = fmt.Scanf("%s", &confirm)
 	if strings.ToLower(strings.TrimSpace(confirm)) != "y" {

--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -54,7 +54,7 @@ func GetLatestCliRelease() (*RepoRelease, error) {
 	return release, nil
 }
 
-func DownloadRuntimeAsset(flavor string, release *RepoRelease, downloadPath string, allowAccelerator bool) error {
+func DownloadRuntimeAsset(flavor constants.Flavor, release *RepoRelease, downloadPath string, allowAccelerator bool) error {
 	assetName := GetRuntimeAssetName(flavor, allowAccelerator)
 	slog.Info(fmt.Sprintf("Downloading the Spice runtime..., %s", assetName))
 	return DownloadReleaseAsset(githubClient, release, assetName, downloadPath)
@@ -64,19 +64,17 @@ func DownloadAsset(release *RepoRelease, downloadPath string, assetName string) 
 	return DownloadReleaseAsset(githubClient, release, assetName, downloadPath)
 }
 
-func GetRuntimeAssetName(flavor string, allowAccelerator bool) string {
-	switch {
-	case flavor == "ai":
+func GetRuntimeAssetName(flavor constants.Flavor, allowAccelerator bool) string {
+	var downloadFlavor string
+	if flavor == constants.FlavorAI || flavor == constants.FlavorDefault {
 		if accelerator, exists := get_ai_accelerator(); exists && allowAccelerator {
-			flavor = fmt.Sprintf("_models_%s", accelerator)
+			downloadFlavor = fmt.Sprintf("_models_%s", accelerator)
 		} else {
-			flavor = "_models"
+			downloadFlavor = "_models"
 		}
-	case flavor != "":
-		flavor = fmt.Sprintf("_%s", flavor)
 	}
 
-	assetName := fmt.Sprintf("%s%s_%s_%s.tar.gz", constants.SpiceRuntimeFilename, flavor, runtime.GOOS, getRustArch())
+	assetName := fmt.Sprintf("%s%s_%s_%s.tar.gz", constants.SpiceRuntimeFilename, downloadFlavor, runtime.GOOS, getRustArch())
 
 	return assetName
 }

--- a/bin/spice/pkg/runtime/runtime.go
+++ b/bin/spice/pkg/runtime/runtime.go
@@ -21,14 +21,15 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/spiceai/spiceai/bin/spice/pkg/constants"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
 
 // Ensures the runtime is installed. Returns true if the runtime was installed or upgraded, false if it was already installed.
-func EnsureInstalled(flavor string, autoUpgrade bool, allowAccelerator bool) (bool, error) {
-	if flavor != "ai" && flavor != "" {
-		return false, fmt.Errorf("invalid flavor: %s", flavor)
+func EnsureInstalled(flavor constants.Flavor, autoUpgrade bool, allowAccelerator bool) (bool, error) {
+	if !flavor.IsValid() {
+		return false, fmt.Errorf("invalid flavor")
 	}
 
 	rtcontext := context.NewContext()
@@ -52,7 +53,7 @@ func EnsureInstalled(flavor string, autoUpgrade bool, allowAccelerator bool) (bo
 		}
 	}
 
-	if models, _ := rtcontext.ModelsFlavorInstalled(); !models && flavor == "ai" {
+	if models, _ := rtcontext.ModelsFlavorInstalled(); !models && flavor == constants.FlavorAI {
 		shouldInstall = true
 	}
 
@@ -76,7 +77,7 @@ func Run(args []string) error {
 		os.Exit(1)
 	}
 
-	_, err = EnsureInstalled("", false, false) // base runtime without ai has no need for accelerator
+	_, err = EnsureInstalled(constants.FlavorDefault, false, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# 🗣 Description

Defaults to installing the AI-enabled runtime via the CLI. Will preserve the existing installation flavor on upgrades.

## ⛓️‍💥 Breaking Change

Changes the default behavior of the CLI for installing the runtime.

* [x] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

Will require a corresponding change in the getting started section.

## 🤔 Concerns

I reworked the `flavor` in the CLI as a somewhat type-safe enum to prevent confusing `models`/`ai`
