### PR TITLE
Change no spicepod.yaml log to warning

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -169,22 +169,20 @@ pub async fn run(args: Args) -> Result<()> {
     let prometheus_registry = args.metrics.map(|_| prometheus::Registry::new());
 
     let current_dir = env::current_dir().unwrap_or(PathBuf::from("."));
-    let app: Option<Arc<App>> = match AppBuilder::build_from_filesystem_path(current_dir.clone())
-        .context(UnableToConstructSpiceAppSnafu)
+    let app: Option<Arc<App>> = if let Ok(mut app) =
+        AppBuilder::build_from_filesystem_path(current_dir.clone())
+            .context(UnableToConstructSpiceAppSnafu)
     {
-        Ok(mut app) => {
-            app.runtime = apply_overrides(app.runtime, &args.set_runtime)?;
-            Some(Arc::new(app))
-        }
-        Err(e) => {
-            in_tracing_context(|| {
-                tracing::warn!(
-                    "No spicepod.yaml detected in the current directory: {}\nRun `spice init <name>` to initialize spicepod.yaml and restart the runtime.",
-                    current_dir.display()
-                );
-            });
-            None
-        }
+        app.runtime = apply_overrides(app.runtime, &args.set_runtime)?;
+        Some(Arc::new(app))
+    } else {
+        in_tracing_context(|| {
+            tracing::warn!(
+    "No spicepod.yaml detected in the current directory: {}\nRun `spice init <name>` to initialize spicepod.yaml and restart the runtime.",
+    current_dir.display()
+    );
+        });
+        None
     };
 
     let mut extension_factories: Vec<Box<dyn ExtensionFactory>> = vec![];

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -178,7 +178,10 @@ pub async fn run(args: Args) -> Result<()> {
         }
         Err(e) => {
             in_tracing_context(|| {
-                tracing::error!("{e}");
+                tracing::warn!(
+                    "No spicepod.yaml detected in the current directory: {}\nRun `spice init <name>` to initialize spicepod.yaml and restart the runtime.",
+                    current_dir.display()
+                );
             });
             None
         }


### PR DESCRIPTION
# 🗣 Description

Changes the startup log when no spicepod.yaml is present to:

<img width="798" alt="Screenshot 2025-01-21 at 10 37 18 AM" src="https://github.com/user-attachments/assets/10e4f6df-1440-49a7-8a0a-75fff4657670" />

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
