### PR TITLE
fix xAI; don't use openai defaults

### DIFF
--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -75,7 +75,8 @@ pub fn new_openai_client(
     org_id: Option<&str>,
     project_id: Option<&str>,
 ) -> Openai<OpenAIConfig> {
-    let mut cfg = OpenAIConfig::new();
+    // Default to empty API key to avoid picking up ENV variable in downstream library.
+    let mut cfg = OpenAIConfig::new().with_api_key("");
 
     if let Some(org_id) = org_id {
         cfg = cfg.with_org_id(org_id);
@@ -85,7 +86,6 @@ pub fn new_openai_client(
         cfg = cfg.with_project_id(project_id);
     }
 
-    // If an API key is provided, use it. Otherwise use default from env variables.
     if let Some(api_key) = api_key {
         cfg = cfg.with_api_key(api_key);
     }

--- a/crates/llms/src/xai.rs
+++ b/crates/llms/src/xai.rs
@@ -40,12 +40,10 @@ pub struct Xai {
 
 impl Xai {
     #[must_use]
-    pub fn new(model: Option<&str>, api_key: Option<&str>) -> Self {
-        let mut cfg = OpenAIConfig::default().with_api_base(DEFAULT_ENDPOINT);
-
-        if let Some(api_key) = api_key {
-            cfg = cfg.with_api_key(api_key);
-        }
+    pub fn new(model: Option<&str>, api_key: &str) -> Self {
+        let cfg = OpenAIConfig::default()
+            .with_api_base(DEFAULT_ENDPOINT)
+            .with_api_key(api_key);
 
         Self {
             model: model.unwrap_or(DEFAULT_MODEL).to_string(),

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -32,9 +32,14 @@ use std::{
     sync::Arc,
 };
 
-pub(crate) fn create_xai(model_id: &str) -> Arc<Box<dyn Chat>> {
-    let api_key = std::env::var("SPICE_XAI_API_KEY").ok();
-    Arc::new(Box::new(Xai::new(Some(model_id), api_key.as_deref())))
+pub(crate) fn create_xai(model_id: &str) -> Result<Arc<Box<dyn Chat>>, anyhow::Error> {
+    let Ok(api_key) = std::env::var("SPICE_XAI_API_KEY") else {
+        return Err(anyhow::anyhow!("SPICE_XAI_API_KEY not set"));
+    };
+    Ok(Arc::new(Box::new(Xai::new(
+        Some(model_id),
+        api_key.as_str(),
+    ))))
 }
 
 pub(crate) fn create_openai(model_id: &str) -> Arc<Box<dyn Chat>> {

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -68,7 +68,12 @@ static TEST_MODELS: LazyLock<Vec<ModelDef>> = LazyLock::new(|| {
             Box::new(|| create::create_anthropic(None).expect("failed to create anthropic model")),
         ),
         ("openai", Box::new(|| create::create_openai("gpt-4o-mini"))),
-        ("xai", Box::new(|| create::create_xai("grok-beta"))),
+        (
+            "xai",
+            Box::new(|| {
+                create::create_xai("grok-beta").expect("failed to create 'grok-beta' from xAI")
+            }),
+        ),
         (
             "hf_phi3",
             Box::new(|| {

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -139,7 +139,7 @@ fn xai(
 ) -> Result<Box<dyn Chat>, LlmError> {
     let Some(api_key) = extract_secret!(params, "xai_api_key") else {
         return Err(LlmError::FailedToLoadModel {
-            source: ""Missing required paramter 'xai_api_key'. Specify a value.\nFor details, visit: https://spiceai.org/docs/components/models/xai"".into(),
+            source: "No `xai_api_key` provided for xAI model.".into(),
         });
     };
     Ok(Box::new(Xai::new(model_id, api_key)) as Box<dyn Chat>)

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -110,10 +110,7 @@ pub async fn construct_model(
         ModelSource::File => file(component, params),
         ModelSource::Anthropic => anthropic(model_id.as_deref(), params),
         ModelSource::Azure => azure(model_id, component.name.as_str(), params),
-        ModelSource::Xai => Ok(Box::new(Xai::new(
-            model_id.as_deref(),
-            extract_secret!(params, "xai_api_key"),
-        )) as Box<dyn Chat>),
+        ModelSource::Xai => xai(model_id.as_deref(), params),
         ModelSource::OpenAi => Ok(openai(model_id, params)),
         ModelSource::SpiceAI => Err(LlmError::UnsupportedTaskForModel {
             from: "spiceai".into(),
@@ -134,6 +131,18 @@ pub async fn construct_model(
         component.get_openai_request_overrides(),
     );
     Ok(Box::new(wrapper))
+}
+
+fn xai(
+    model_id: Option<&str>,
+    params: &HashMap<String, SecretString>,
+) -> Result<Box<dyn Chat>, LlmError> {
+    let Some(api_key) = extract_secret!(params, "xai_api_key") else {
+        return Err(LlmError::FailedToLoadModel {
+            source: "No `xai_api_key` provided for xAI model.".into(),
+        });
+    };
+    Ok(Box::new(Xai::new(model_id, api_key)) as Box<dyn Chat>)
 }
 
 fn anthropic(

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -139,7 +139,7 @@ fn xai(
 ) -> Result<Box<dyn Chat>, LlmError> {
     let Some(api_key) = extract_secret!(params, "xai_api_key") else {
         return Err(LlmError::FailedToLoadModel {
-            source: "No `xai_api_key` provided for xAI model.".into(),
+            source: ""Missing required paramter 'xai_api_key'. Specify a value.\nFor details, visit: https://spiceai.org/docs/components/models/xai"".into(),
         });
     };
     Ok(Box::new(Xai::new(model_id, api_key)) as Box<dyn Chat>)


### PR DESCRIPTION
# 🗣 Description
 - Stop Openai, xAI from using env variable `$OPENAI_API_KEY` as default API key.
 - Ensure xAI has an API key. 
