### PR TITLE
fix: Use specific model errors where available

### DIFF
--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -111,6 +111,9 @@ pub enum Error {
 
     #[snafu(display("Failed to find tensors for the model.\nExpected tensors with a file extension of: {extensions}.\nVerify the model is correctly configured, and try again."))]
     ModelMissingTensors { extensions: String },
+
+    #[snafu(display("Failed to load a file specified for the model.\nCould not find the file: {file_url}.\nVerify the `files` parameters for the model, and try again."))]
+    ModelFileMissing { file_url: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -126,6 +129,23 @@ pub fn try_map_boxed_error(e: &(dyn std::error::Error + Send + Sync)) -> Option<
         Some(Error::ModelMissingTensors {
             extensions: TENSOR_EXTENSIONS.join(", "),
         })
+    } else if err_string.contains("hf api error") && err_string.contains("status: 404") {
+        let file_url = err_string
+            .split("url: ")
+            .last()
+            .map(|url| {
+                url.split(' ')
+                    .next()
+                    .unwrap_or_default()
+                    .replace([']', ')'], "")
+            })
+            .unwrap_or_default();
+
+        if file_url.is_empty() {
+            None
+        } else {
+            Some(Error::ModelFileMissing { file_url })
+        }
     } else {
         None
     }

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -49,6 +49,8 @@ use mistralrs::MessageContent;
 
 use crate::embeddings::candle::download_hf_file;
 
+static TENSOR_EXTENSIONS: [&str; 4] = [".safetensors", ".pth", ".pt", ".bin"];
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum LlmRuntime {
@@ -106,9 +108,37 @@ pub enum Error {
 
     #[snafu(display("Runtime does not currently support the {modality} modality"))]
     UnsupportedModalityType { modality: String },
+
+    #[snafu(display("Failed to find tensors for the model.\nExpected tensors with a file extension of: {extensions}.\nVerify the model is correctly configured, and try again."))]
+    ModelMissingTensors { extensions: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Attempts to string match a model error to a known error type.
+/// Returns None if no match is found.
+#[must_use]
+pub fn try_map_boxed_error(e: &(dyn std::error::Error + Send + Sync)) -> Option<Error> {
+    let err_string = e.to_string().to_ascii_lowercase();
+    if err_string.contains("expected file with extension")
+        && TENSOR_EXTENSIONS.iter().any(|ext| err_string.contains(ext))
+    {
+        Some(Error::ModelMissingTensors {
+            extensions: TENSOR_EXTENSIONS.join(", "),
+        })
+    } else {
+        None
+    }
+}
+
+/// Re-writes a boxed error to a known error type, if possible.
+/// Always returns a boxed error. Returns the original error if no match is found.
+#[must_use]
+pub fn try_map_boxed_error_to_box(
+    e: Box<dyn std::error::Error + Send + Sync>,
+) -> Box<dyn std::error::Error + Send + Sync> {
+    try_map_boxed_error(&*e).map_or_else(|| e, std::convert::Into::into)
+}
 
 /// Convert a structured [`ChatCompletionRequestMessage`] to a basic string. Useful for basic
 /// [`Chat::run`] but reduces optional configuration provided by callers.

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -49,7 +49,15 @@ use mistralrs::MessageContent;
 
 use crate::embeddings::candle::download_hf_file;
 
-static TENSOR_EXTENSIONS: [&str; 4] = [".safetensors", ".pth", ".pt", ".bin"];
+static WEIGHTS_EXTENSIONS: [&str; 7] = [
+    ".safetensors",
+    ".pth",
+    ".pt",
+    ".bin",
+    ".onyx",
+    ".gguf",
+    ".ggml",
+];
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
@@ -96,8 +104,8 @@ pub enum Error {
     #[snafu(display("The specified model, '{from}', does not support executing the task '{task}'.\nSelect a different model or task, and try again."))]
     UnsupportedTaskForModel { from: String, task: String },
 
-    #[snafu(display("Failed to find tensors for the model.\nExpected tensors with a file extension of: {extensions}.\nVerify the model is correctly configured, and try again."))]
-    ModelMissingTensors { extensions: String },
+    #[snafu(display("Failed to find weights for the model.\nExpected tensors with a file extension of: {extensions}.\nVerify the model is correctly configured, and try again."))]
+    ModelMissingWeights { extensions: String },
 
     #[snafu(display("Failed to load a file specified for the model.\nCould not find the file: {file_url}.\nVerify the `files` parameters for the model, and try again."))]
     ModelFileMissing { file_url: String },
@@ -111,10 +119,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub fn try_map_boxed_error(e: &(dyn std::error::Error + Send + Sync)) -> Option<Error> {
     let err_string = e.to_string().to_ascii_lowercase();
     if err_string.contains("expected file with extension")
-        && TENSOR_EXTENSIONS.iter().any(|ext| err_string.contains(ext))
+        && WEIGHTS_EXTENSIONS
+            .iter()
+            .any(|ext| err_string.contains(ext))
     {
-        Some(Error::ModelMissingTensors {
-            extensions: TENSOR_EXTENSIONS.join(", "),
+        Some(Error::ModelMissingWeights {
+            extensions: WEIGHTS_EXTENSIONS.join(", "),
         })
     } else if err_string.contains("hf api error") && err_string.contains("status: 404") {
         let file_url = err_string

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{model::try_to_chat_model, Result, Runtime, UnableToInitializeLlmSnafu};
-use llms::chat::Chat;
+use llms::chat::{try_map_boxed_error_to_box, Chat};
 use secrecy::SecretString;
 use snafu::ResultExt;
 use spicepod::component::model::Model as SpicepodModel;
@@ -33,11 +33,13 @@ impl Runtime {
         let l = try_to_chat_model(&m, &params, Arc::new(self.clone()))
             .await
             .boxed()
+            .map_err(try_map_boxed_error_to_box)
             .context(UnableToInitializeLlmSnafu)?;
 
         l.health()
             .await
             .boxed()
+            .map_err(try_map_boxed_error_to_box)
             .context(UnableToInitializeLlmSnafu)?;
         Ok(l)
     }

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -28,21 +28,20 @@ use spicepod::component::model::{Model as SpicepodModel, ModelType};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to load LLM: {}. Verify configuration and try again.\nError: {}\nFor details, visit https://spiceai.org/docs/components/models", name, source))]
+    #[snafu(display("Failed to load LLM: {name}.\n{source}"))]
     FailedToLoadLLM {
         name: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Failed to load runnable model: {}. Verify configuration and try again.\nError: {}\nFor details, visit https://spiceai.org/docs/components/models", name, source))]
+    #[snafu(display("Failed to load runnable model: {name}.\n{source}"))]
     FailedToLoadRunnableModel {
         name: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     #[snafu(display(
-        "Failed to load model {} from spicepod. Unable to determine model type. Verify configuration and try again.\nFor details, visit https://spiceai.org/docs/components/models",
-        name
+        "Failed to load model {name} from spicepod.\nUnable to determine model type. Verify the model source and try again.\nFor details, visit https://spiceai.org/docs/components/models",
     ))]
     UnableToDetermineModelType { name: String },
 }


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds a function to map a boxed error, based on the error as a string, to a known `llms::chat::Error`