### PR TITLE
Clarify release check error message if it is caused by wrong GH token

### DIFF
--- a/bin/spice/pkg/github/github.go
+++ b/bin/spice/pkg/github/github.go
@@ -115,7 +115,7 @@ func (g *GitHubClient) call(method string, url string, payload []byte, accept st
 	}
 
 	if response.StatusCode == 401 {
-		return nil, NewGitHubCallError("Detected GitHub token from GH_TOKEN or GITHUB_TOKEN environment variable is invalid. Please check the token and try again.", response.StatusCode)
+		return nil, NewGitHubCallError("Detected GitHub token from GH_TOKEN or GITHUB_TOKEN environment variable is invalid. Check the token and try again.", response.StatusCode)
 	}
 
 	if response.StatusCode != 200 {

--- a/bin/spice/pkg/github/github.go
+++ b/bin/spice/pkg/github/github.go
@@ -115,7 +115,7 @@ func (g *GitHubClient) call(method string, url string, payload []byte, accept st
 	}
 
 	if response.StatusCode == 401 {
-		return nil, NewGitHubCallError("Detected GitHub token from GH_TOKEN or GITHUB_TOKEN environment variable is invalid. Please check your token and try again.", response.StatusCode)
+		return nil, NewGitHubCallError("Detected GitHub token from GH_TOKEN or GITHUB_TOKEN environment variable is invalid. Please check the token and try again.", response.StatusCode)
 	}
 
 	if response.StatusCode != 200 {

--- a/bin/spice/pkg/github/github.go
+++ b/bin/spice/pkg/github/github.go
@@ -114,6 +114,10 @@ func (g *GitHubClient) call(method string, url string, payload []byte, accept st
 		return nil, err
 	}
 
+	if response.StatusCode == 401 {
+		return nil, NewGitHubCallError("Detected GitHub token from GH_TOKEN or GITHUB_TOKEN environment variable is invalid. Please check your token and try again.", response.StatusCode)
+	}
+
 	if response.StatusCode != 200 {
 		return nil, NewGitHubCallError(fmt.Sprintf("Error calling GitHub: %s", string(body)), response.StatusCode)
 	}


### PR DESCRIPTION
Before:
```
➜ GH_TOKEN="invalid_token" spice run
2025/01/21 15:24:45 INFO Checking for latest Spice runtime release...
2025/01/21 15:24:45 WARN error checking for runtime upgrade error="Error calling GitHub: {\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/rest\",\"status\":\"401\"}"
2025/01/21 15:24:45 INFO Spice.ai runtime starting...
2025-01-21T06:24:46.588707Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
2025-01-21T06:24:46.599759Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
```

After:
```
➜ GH_TOKEN="invalid_token" spice run
2025/01/21 15:22:51 INFO Checking for latest Spice runtime release...
2025/01/21 15:22:51 WARN error checking for runtime upgrade error="Detected GitHub token from GH_TOKEN or GITHUB_TOKEN environment variable is invalid. Please check your token and try again."
2025/01/21 15:22:51 INFO Spice.ai runtime starting...
2025-01-21T06:22:53.055291Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
2025-01-21T06:22:53.075585Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
```