### PR TITLE
feat: Download latest spiced commit for testoperators

### DIFF
--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -5,7 +5,7 @@ description: 'composite action'
 #
 # Requires the MinIO CLI to be installed and configured to use this action
 inputs:
-  spiced_commit: # optionally override the commit find and set a specific commit
+  spiced_commit: # optionally override the commit to download
     description: 'spiced build commit'
     required: false
     type: string

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -6,7 +6,8 @@ description: 'composite action'
 # Requires the MinIO CLI to be installed and configured to use this action
 # Requires the repository to have at least a fetch depth of 10 to collect the commit history
 outputs:
-  SPICED_COMMIT: ${{ steps.find-spiced.outputs.spiced_commit }}
+  spiced_commit:
+    value: ${{ steps.find-spiced.outputs.spiced_commit }}
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -5,14 +5,19 @@ description: 'composite action'
 #
 # Requires the MinIO CLI to be installed and configured to use this action
 # Requires the repository to have at least a fetch depth of 10 to collect the commit history
+inputs:
+  spiced_commit: # optionally override the commit find and set a specific commit
+    description: 'spiced build commit'
+    required: false
+    type: string
 outputs:
   spiced_commit:
-    value: ${{ steps.find-spiced.outputs.spiced_commit }}
+    value: ${{ steps.output_spiced_commit.outputs.spiced_commit }}
 runs:
   using: 'composite'
   steps:
     - name: Find the latest built spiced commit
-      id: find-spiced
+      if: ${{ !inputs.spiced_commit }}
       shell: bash
       run: |
         commit_hashes=($(git log --pretty=format:"%H" -n 10))
@@ -22,13 +27,23 @@ runs:
           if mc stat spice-minio/artifacts/spiced/linux-x86_64/$hash/spiced_models_linux_x86_64.tar.gz; then
             echo "Found $hash in MinIO"
             echo "SPICED_COMMIT=$hash" >> $GITHUB_ENV
-            echo "SPICED_COMMIT=$hash" >> $GITHUB_OUTPUT
             exit 0
           fi
         done
 
         echo "Could not find any recently built spiced commit in MinIO"
         exit 1
+    
+    - name: Set SPICED_COMMIT from workflow input
+      shell: bash
+      if: ${{ inputs.spiced_commit }}
+      run: |
+        echo "SPICED_COMMIT=${{ inputs.spiced_commit }}" >> $GITHUB_ENV
+    
+    - name: Output SPICED_COMMIT
+      id: output_spiced_commit
+      shell: bash
+      run: echo "SPICED_COMMIT=$SPICED_COMMIT" >> $GITHUB_OUTPUT
 
     - name: Download spiced from MinIO
       shell: bash

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -1,0 +1,37 @@
+name: Setup spiced
+description: 'composite action'
+
+# Downloads the most recent spiced build from MinIO, within the last 10 commits
+#
+# Requires the MinIO CLI to be installed and configured to use this action
+# Requires the repository to have at least a fetch depth of 10 to collect the commit history
+outputs:
+  SPICED_COMMIT: ${{ steps.find-spiced.outputs.spiced_commit }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Find the latest built spiced commit
+      id: find-spiced
+      shell: bash
+      run: |
+        commit_hashes=($(git log --pretty=format:"%H" -n 10))
+
+        for hash in "${commit_hashes[@]}"; do
+          echo "Checking $hash in MinIO"
+          if mc stat spice-minio/artifacts/spiced/linux-x86_64/$hash/spiced_models_linux_x86_64.tar.gz; then
+            echo "Found $hash in MinIO"
+            echo "SPICED_COMMIT=$hash" >> $GITHUB_ENV
+            echo "SPICED_COMMIT=$hash" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+        done
+
+        echo "Could not find any recently built spiced commit in MinIO"
+        exit 1
+
+    - name: Download spiced from MinIO
+      shell: bash
+      run: |
+        mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
+        tar -xzf spiced_models_linux_x86_64.tar.gz
+        sudo cp ./spiced /usr/local/bin/spiced

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       run: |
         git fetch --depth=10 origin
-        commit_hashes=($(git log trunk --pretty=format:"%H" -n 10))
+        commit_hashes=($(git log origin/trunk --pretty=format:"%H" -n 10))
 
         for hash in "${commit_hashes[@]}"; do
           echo "Checking $hash in MinIO"

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -4,7 +4,6 @@ description: 'composite action'
 # Downloads the most recent spiced build from MinIO, within the last 10 commits
 #
 # Requires the MinIO CLI to be installed and configured to use this action
-# Requires the repository to have at least a fetch depth of 10 to collect the commit history
 inputs:
   spiced_commit: # optionally override the commit find and set a specific commit
     description: 'spiced build commit'
@@ -20,7 +19,8 @@ runs:
       if: ${{ !inputs.spiced_commit }}
       shell: bash
       run: |
-        commit_hashes=($(git log --pretty=format:"%H" -n 10))
+        git fetch --depth=10 origin trunk
+        commit_hashes=($(git log trunk --pretty=format:"%H" -n 10))
 
         for hash in "${commit_hashes[@]}"; do
           echo "Checking $hash in MinIO"

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -19,7 +19,7 @@ runs:
       if: ${{ !inputs.spiced_commit }}
       shell: bash
       run: |
-        git fetch --depth=10 origin trunk
+        git fetch --depth=10 origin
         commit_hashes=($(git log trunk --pretty=format:"%H" -n 10))
 
         for hash in "${commit_hashes[@]}"; do

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -25,6 +25,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10
+
+      - name: Install MinIO
+        run: |
+          sudo apt update && sudo apt install wget -y
+          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
+          sudo chmod +x /usr/local/bin/mc
+          mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
       
       - name: Setup spiced
         uses: ./.github/actions/setup-spiced

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Find the latest built spiced commit
         run: |
+          git fetch --all
           commit_hashes=($(git log --pretty=format:"%H" -n 10))
 
           for hash in "${commit_hashes[@]}"; do

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: spiceai-runners
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -25,32 +25,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10
-
-      - name: Install MinIO
-        run: |
-          sudo apt update && sudo apt install wget -y
-          sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
-          sudo chmod +x /usr/local/bin/mc
-          mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
-
-      - name: Find the latest built spiced commit
-        run: |
-          commit_hashes=($(git log --pretty=format:"%H" -n 10))
-
-          for hash in "${commit_hashes[@]}"; do
-            echo "Checking $hash in MinIO"
-            if mc stat spice-minio/artifacts/spiced/linux-x86_64/$hash/spiced_models_linux_x86_64.tar.gz; then
-              echo "Found $hash in MinIO"
-              echo "SPICED_COMMIT=$hash" >> $GITHUB_ENV
-              exit 0
-            fi
-          done
-
-          echo "Could not find any recently built spiced commit in MinIO"
-          exit 1
-
-      - name: Download spiced from MinIO
-        run: |
-          mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
-          tar -xzf spiced_models_linux_x86_64.tar.gz
-          sudo cp ./spiced /usr/local/bin/spiced
+      
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        id: setup-spiced
+      
+      - name: Display spiced commit
+        run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: spiceai-runners
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install MinIO
         run: |
@@ -33,7 +35,6 @@ jobs:
 
       - name: Find the latest built spiced commit
         run: |
-          git fetch --all
           commit_hashes=($(git log --pretty=format:"%H" -n 10))
 
           for hash in "${commit_hashes[@]}"; do

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -36,8 +36,6 @@ jobs:
       - name: Setup spiced
         uses: ./.github/actions/setup-spiced
         id: setup-spiced
-        with:
-          spiced_commit: "some override"
       
       - name: Display spiced commit
         run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Setup spiced
         uses: ./.github/actions/setup-spiced
         id: setup-spiced
+        with:
+          spiced_commit: "some override"
       
       - name: Display spiced commit
         run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -63,23 +63,11 @@ jobs:
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
-
-      - name: Get latest trunk commit
-        if: ${{ !github.event.inputs.spiced_commit }}
-        run: |
-          git fetch origin
-          echo "SPICED_COMMIT=$(git rev-parse origin/trunk)" >> $GITHUB_ENV
-
-      - name: Set SPICED_COMMIT from workflow input
-        if: ${{ github.event.inputs.spiced_commit }}
-        run: |
-          echo "SPICED_COMMIT=${{ github.event.inputs.spiced_commit }}" >> $GITHUB_ENV
-
-      - name: Download spiced from MinIO
-        run: |
-          mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
-          tar -xzf spiced_models_linux_x86_64.tar.gz
-          sudo cp ./spiced /usr/local/bin/spiced
+      
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
 
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -56,8 +56,6 @@ jobs:
     timeout-minutes: 600
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -56,6 +56,8 @@ jobs:
     timeout-minutes: 600
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_data_consistency.yml
+++ b/.github/workflows/testoperator_run_data_consistency.yml
@@ -67,23 +67,11 @@ jobs:
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
-
-      - name: Get latest trunk commit
-        if: ${{ !github.event.inputs.spiced_commit }}
-        run: |
-          git fetch origin
-          echo "SPICED_COMMIT=$(git rev-parse origin/trunk)" >> $GITHUB_ENV
-
-      - name: Set SPICED_COMMIT from workflow input
-        if: ${{ github.event.inputs.spiced_commit }}
-        run: |
-          echo "SPICED_COMMIT=${{ github.event.inputs.spiced_commit }}" >> $GITHUB_ENV
-
-      - name: Download spiced from MinIO
-        run: |
-          mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
-          tar -xzf spiced_models_linux_x86_64.tar.gz
-          sudo cp ./spiced /usr/local/bin/spiced
+      
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
 
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator

--- a/.github/workflows/testoperator_run_data_consistency.yml
+++ b/.github/workflows/testoperator_run_data_consistency.yml
@@ -60,6 +60,8 @@ jobs:
     timeout-minutes: 600
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_data_consistency.yml
+++ b/.github/workflows/testoperator_run_data_consistency.yml
@@ -60,8 +60,6 @@ jobs:
     timeout-minutes: 600
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_http_consistency.yml
+++ b/.github/workflows/testoperator_run_http_consistency.yml
@@ -65,23 +65,11 @@ jobs:
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
-
-      - name: Get latest trunk commit
-        if: ${{ !github.event.inputs.spiced_commit }}
-        run: |
-          git fetch origin
-          echo "SPICED_COMMIT=$(git rev-parse origin/trunk)" >> $GITHUB_ENV
-
-      - name: Set SPICED_COMMIT from workflow input
-        if: ${{ github.event.inputs.spiced_commit }}
-        run: |
-          echo "SPICED_COMMIT=${{ github.event.inputs.spiced_commit }}" >> $GITHUB_ENV
-
-      - name: Download spiced from MinIO
-        run: |
-          mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
-          tar -xzf spiced_models_linux_x86_64.tar.gz
-          sudo cp ./spiced /usr/local/bin/spiced
+      
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
 
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator

--- a/.github/workflows/testoperator_run_http_consistency.yml
+++ b/.github/workflows/testoperator_run_http_consistency.yml
@@ -58,8 +58,6 @@ jobs:
           echo "  buckets=${{ github.event.inputs.buckets }}"
 
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_http_consistency.yml
+++ b/.github/workflows/testoperator_run_http_consistency.yml
@@ -58,6 +58,8 @@ jobs:
           echo "  buckets=${{ github.event.inputs.buckets }}"
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_http_overhead.yml
+++ b/.github/workflows/testoperator_run_http_overhead.yml
@@ -74,23 +74,11 @@ jobs:
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
-
-      - name: Get latest trunk commit
-        if: ${{ !github.event.inputs.spiced_commit }}
-        run: |
-          git fetch origin
-          echo "SPICED_COMMIT=$(git rev-parse origin/trunk)" >> $GITHUB_ENV
-
-      - name: Set SPICED_COMMIT from workflow input
-        if: ${{ github.event.inputs.spiced_commit }}
-        run: |
-          echo "SPICED_COMMIT=${{ github.event.inputs.spiced_commit }}" >> $GITHUB_ENV
-
-      - name: Download spiced from MinIO
-        run: |
-          mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
-          tar -xzf spiced_models_linux_x86_64.tar.gz
-          sudo cp ./spiced /usr/local/bin/spiced
+      
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
 
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator

--- a/.github/workflows/testoperator_run_http_overhead.yml
+++ b/.github/workflows/testoperator_run_http_overhead.yml
@@ -67,6 +67,8 @@ jobs:
           echo "  base_component=${{ github.event.inputs.base_component }}"
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_http_overhead.yml
+++ b/.github/workflows/testoperator_run_http_overhead.yml
@@ -67,8 +67,6 @@ jobs:
           echo "  base_component=${{ github.event.inputs.base_component }}"
 
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -68,23 +68,11 @@ jobs:
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
-
-      - name: Get latest trunk commit
-        if: ${{ !github.event.inputs.spiced_commit }}
-        run: |
-          git fetch origin
-          echo "SPICED_COMMIT=$(git rev-parse origin/trunk)" >> $GITHUB_ENV
-
-      - name: Set SPICED_COMMIT from workflow input
-        if: ${{ github.event.inputs.spiced_commit }}
-        run: |
-          echo "SPICED_COMMIT=${{ github.event.inputs.spiced_commit }}" >> $GITHUB_ENV
-
-      - name: Download spiced from MinIO
-        run: |
-          mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
-          tar -xzf spiced_models_linux_x86_64.tar.gz
-          sudo cp ./spiced /usr/local/bin/spiced
+      
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
 
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -61,6 +61,8 @@ jobs:
     timeout-minutes: 600
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -61,8 +61,6 @@ jobs:
     timeout-minutes: 600
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -62,23 +62,11 @@ jobs:
           sudo wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc
           sudo chmod +x /usr/local/bin/mc
           mc alias set spice-minio ${{ secrets.MINIO_ENDPOINT }} ${{ secrets.MINIO_ACCESS_KEY }} ${{ secrets.MINIO_SECRET_KEY }}
-
-      - name: Get latest trunk commit
-        if: ${{ !github.event.inputs.spiced_commit }}
-        run: |
-          git fetch origin
-          echo "SPICED_COMMIT=$(git rev-parse origin/trunk)" >> $GITHUB_ENV
-
-      - name: Set SPICED_COMMIT from workflow input
-        if: ${{ github.event.inputs.spiced_commit }}
-        run: |
-          echo "SPICED_COMMIT=${{ github.event.inputs.spiced_commit }}" >> $GITHUB_ENV
-
-      - name: Download spiced from MinIO
-        run: |
-          mc cp spice-minio/artifacts/spiced/linux-x86_64/$SPICED_COMMIT/spiced_models_linux_x86_64.tar.gz spiced_models_linux_x86_64.tar.gz
-          tar -xzf spiced_models_linux_x86_64.tar.gz
-          sudo cp ./spiced /usr/local/bin/spiced
+      
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
 
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -55,6 +55,8 @@ jobs:
     runs-on: ${{ github.event.inputs.runner_type }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
 
       - name: Install MinIO
         run: |

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -55,8 +55,6 @@ jobs:
     runs-on: ${{ github.event.inputs.runner_type }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 10
 
       - name: Install MinIO
         run: |


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Makes a composite action to detect the latest built `spiced` commit, and downloads it from MinIO
* Optionally, takes a specific commit to override the commit detection and downloads that commit instead
* Updates all of the testoperator actions to use the new `spiced` download method

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4376 