### PR TITLE
fix: Testoperator git fetch depth

### DIFF
--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -19,7 +19,7 @@ runs:
       if: ${{ !inputs.spiced_commit }}
       shell: bash
       run: |
-        git fetch --depth=10 origin/trunk
+        git fetch --depth=10 origin trunk
         commit_hashes=($(git log origin/trunk --pretty=format:"%H" -n 10))
 
         for hash in "${commit_hashes[@]}"; do

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -19,7 +19,7 @@ runs:
       if: ${{ !inputs.spiced_commit }}
       shell: bash
       run: |
-        git fetch --depth=10 origin
+        git fetch --depth=10 origin/trunk
         commit_hashes=($(git log origin/trunk --pretty=format:"%H" -n 10))
 
         for hash in "${commit_hashes[@]}"; do


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Forces `git fetch --depth=10 origin trunk` instead of leaving the ref empty