### PR TITLE
Verify `search` and `chat` on Windows as part of AI installation tests

### DIFF
--- a/.github/workflows/e2e_test_release_install_ai.yml
+++ b/.github/workflows/e2e_test_release_install_ai.yml
@@ -241,7 +241,7 @@ jobs:
         run: |
           brew install expect
 
-      - name: Test vector search)
+      - name: Test vector search
         if: matrix.target.target_os != 'windows'
         run: |
           ./test/models/search_01.exp

--- a/.github/workflows/e2e_test_release_install_ai.yml
+++ b/.github/workflows/e2e_test_release_install_ai.yml
@@ -1,48 +1,100 @@
 name: E2E Test Release Installation(AI)
 on:
   workflow_dispatch:
+    inputs:
+        platform_option:
+          description: "Which platform do you want to run on? (Default is ALL)"
+          required: false
+          type: choice
+          options:
+            - "all"
+            - "Linux x64 (GPU T4)"
+            - "macOS aarch64 (GPU M4)"
+            - "Windows x64 (GPU T4)"
+            - "Linux aarch64"
+            - "macOS aarch64"
+            - "Windows x64"
+          default: "all"
 
 jobs:
+  setup-matrix:
+    name: Setup matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.result }}
+
+    steps:
+      - name: Set up matrix
+        uses: actions/github-script@v7
+        id: setup-matrix
+        with:
+          script: |
+            const matrix = [
+              {
+                name: "Linux x64 (GPU T4)",
+                runner: "ubuntu-gpu-t4-4-core",
+                target_os: "linux",
+                target_arch: "x86_64",
+                tags: ["cuda"]
+              },
+              {
+                name: "macOS aarch64 (GPU M4)",
+                runner: "spiceai-macos",
+                target_os: "darwin",
+                target_arch: "aarch64",
+                tags: ["metal"]
+              },
+              {
+                name: "Windows x64 (GPU T4)",
+                runner: "windows-gpu-t4-4-core",
+                target_os: "windows",
+                target_arch: "x86_64",
+                tags: ["cuda"]
+              },
+              {
+                name: "Linux aarch64",
+                runner: "hosted-linux-arm-runner",
+                target_os: "linux",
+                target_arch: "aarch64",
+                tags: []
+              },
+              {
+                name: "macOS aarch64",
+                runner: "macos-14",
+                target_os: "darwin",
+                target_arch: "aarch64",
+                tags: []
+              },
+              {
+                name: "Windows x64",
+                runner: "windows-latest",
+                target_os: "windows",
+                target_arch: "x86_64",
+                tags: []
+              }
+            ];
+
+            const platform_option = context.payload.inputs.platform_option;
+            let filtered = matrix;
+
+            if (platform_option !== 'all') {
+              filtered = filtered.filter(m => m.name === platform_option);
+            }
+
+            return filtered;
+
   test-install:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.target.name }}
+    runs-on: ${{ matrix.target.runner }}
+    needs: setup-matrix
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: Linux x64 (GPU T4)
-            runner: ubuntu-gpu-t4-4-core
-            target_os: linux
-            target_arch: x86_64
-            tags: ['cuda']
-          - name: macOS aarch64 (GPU M4)
-            runner: spiceai-macos
-            target_os: darwin
-            target_arch: aarch64
-            tags: ['metal']
-          - name: Windows x64 (GPU T4)
-            runner: windows-gpu-t4-4-core
-            target_os: windows
-            target_arch: x86_64,
-            tags: ['cuda']
-          - name: 'Linux aarch64'
-            runner: 'hosted-linux-arm-runner'
-            target_os: 'linux'
-            target_arch: 'aarch64'
-            tags: []
-          - name: 'macOS aarch64'
-            runner: 'macos-14'
-            target_os: 'darwin'
-            target_arch: 'aarch64'
-            tags: []
-          - name: 'Windows x64'
-            runner: 'windows-latest'
-            target_os: 'windows'
-            target_arch: 'x86_64'
-            tags: []
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+
     steps:
       - name: system info
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: uname -m
 
       - name: checkout code
@@ -50,19 +102,19 @@ jobs:
 
       # The aarch64 Linux runner does not have tools pre-installed
       - name: Install missing tools
-        if: matrix.target_os == 'linux' && matrix.target_arch == 'aarch64'
+        if: matrix.target.target_os == 'linux' && matrix.target.target_arch == 'aarch64'
         run: |
           sudo apt-get update
           sudo apt install jq -y
 
       # The `windows-gpu-t4-4-core` does not have PowerShell installed
       - name: Install PowerShell
-        if: matrix.runner == 'windows-gpu-t4-4-core'
+        if: matrix.target.runner == 'windows-gpu-t4-4-core'
         uses: ./.github/actions/install-pwsh
 
       # nvidia-smi is not available on windows-gpu-t4-4-core, installing CUDA Toolkit
       - name: Install CUDA Toolkit (Windows)
-        if: matrix.runner == 'windows-gpu-t4-4-core'
+        if: matrix.target.runner == 'windows-gpu-t4-4-core'
         uses: Jimver/cuda-toolkit@v0.2.19
         id: cuda-toolkit
         with:
@@ -73,32 +125,32 @@ jobs:
           use-local-cache: false
 
       - name: CUDA version
-        if: contains(matrix.tags, 'cuda')
+        if: contains(matrix.target.tags, 'cuda')
         run: |
           nvidia-smi
           nvidia-smi --query-gpu=compute_cap --format=csv
 
       - name: install Spice (https://install.spiceai.org)
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl https://install.spiceai.org | /bin/bash
 
       - name: install Spice (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -L "https://install.spiceai.org/Install.ps1" -o Install.ps1 && PowerShell -ExecutionPolicy Bypass -File ./Install.ps1
 
       - name: add Spice bin to PATH
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         run: |
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
 
       - name: add Spice bin to PATH (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         run: |
           Add-Content $env:GITHUB_PATH (Join-Path $HOME ".spice\bin")
         shell: pwsh
@@ -112,20 +164,20 @@ jobs:
           spice version
 
       - name: Init Spice app (OpenAI model)
-        if: "!contains(matrix.tags, 'metal')"
+        if: "!contains(matrix.target.tags, 'metal')"
         run: |
           cp ./test/models/spicepod_openai.yml ./spicepod.yaml
           cat ./spicepod.yaml
 
       # acceleration is currently supported for metal target only
       - name: Init Spice app (Huggingface model)
-        if: contains(matrix.tags, 'metal')
+        if: contains(matrix.target.tags, 'metal')
         run: |
           cp ./test/models/spicepod_hf.yml ./spicepod.yaml
           cat ./spicepod.yaml
 
       - name: Start Spice runtime
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICE_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -133,13 +185,13 @@ jobs:
           spice run &> spice.log &
 
       - name: Wait for Spice runtime is ready
-        if: matrix.target_os != 'windows'
+        if: matrix.target.target_os != 'windows'
         timeout-minutes: 3
         run: |
           while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
 
       - name: start Spice runtime (Windows)
-        if: matrix.target_os == 'windows'
+        if: matrix.target.target_os == 'windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICE_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -158,38 +210,55 @@ jobs:
               Write-Host "Failed to reach /health endpoint. Error: $($_.Exception.Message)"
             }
           } while ($res -ne "ready")
+
+          echo "Verifying embedding and vector search"
+          $url = "http://127.0.0.1:8090/v1/search"
+          $body = @{ text = "Spice runtime error" } | ConvertTo-Json
+          $response = Invoke-RestMethod -Uri $url -Headers @{ "Content-Type" = "application/json" } -Method POST -Body $body -ErrorAction Stop
+          echo ($response | ConvertTo-Json -Depth 10)
+          if (-not $response.matches) { exit 1 }
+          echo "Passed"
+          
+          echo "Verifying chat functionality"
+          $url = "http://127.0.0.1:8090/v1/chat/completions"
+          $body = @{ messages = @(@{ role = "user"; content = "What datasets you have access to?" }); model = "openai-gpt"; stream = $false } | ConvertTo-Json
+          $response = Invoke-RestMethod -Uri $url -Headers @{ "Content-Type" = "application/json" } -Method POST -Body $body -ErrorAction Stop
+          echo ($response | ConvertTo-Json -Depth 10)
+          if (-not $response.choices) { exit 1 }
+          echo "Passed"
+
         shell: pwsh
         timeout-minutes: 3
 
       - name: Install expect (linux)
-        if: matrix.target_os == 'linux'
+        if: matrix.target.target_os == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y expect
 
       - name: Install expect (macOS)
-        if: matrix.target_os == 'darwin'
+        if: matrix.target.target_os == 'darwin'
         run: |
           brew install expect
 
-      - name: Test vector search
-        if: matrix.target_os != 'windows' # pending `expect`` tool installation on Windows
+      - name: Test vector search)
+        if: matrix.target.target_os != 'windows'
         run: |
           ./test/models/search_01.exp
 
       - name: Test chat
-        if: matrix.target_os != 'windows' # pending `expect` tool installation on Windows
+        if: matrix.target.target_os != 'windows'
         run: |
           ./test/models/chat_01_simple.exp
 
       - name: Stop spice and check logs
-        if: always() && matrix.target_os != 'windows'
+        if: always() && matrix.target.target_os != 'windows'
         run: |
           killall spice || true
           cat spice.log
 
       - name: Stop spice and check logs (Windows)
-        if: always() && matrix.target_os == 'windows'
+        if: always() && matrix.target.target_os == 'windows'
         run: |
           Get-Process spice -ErrorAction SilentlyContinue | Stop-Process -Force
           if (Test-Path stdout.log) {


### PR DESCRIPTION
# 🗣 Description

Verify models (embeddings + LLM) and search functionality as part of installation tests on Windows.

`Setup matrix` step added to simplify development and maintenance - it is not required for the release installation testing where we want to test all platforms.

Example test run: https://github.com/spiceai/spiceai/actions/runs/12923869821/job/36041883076

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

I tried to get tests via separate GH Action steps but was always getting `No connection could be made because the target machine actively refused it.` so added verification directly to `start Spice runtime (Windows)` step
