### PR TITLE
Run CUDA builds on non-GPU instances

### DIFF
--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -60,7 +60,6 @@ runs:
 
     - name: Verify CUDA prerequisites
       run: |
-        nvidia-smi
         nvcc --version
       shell: ${{ env.SHELL }}
 

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -64,37 +64,37 @@ jobs:
             const matrix = [
               {
                 compute_cap: "75",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "80",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "86",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "87",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "89",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "90",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -64,73 +64,73 @@ jobs:
             const matrix = [
               {
                 compute_cap: "75",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "80",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "86",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "87",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "89",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "90",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "75",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "80",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "86",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "87",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "89",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "90",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               }
@@ -170,30 +170,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The `windows-gpu-t4-4-core` does not have Python installed
-      - name: Set up Python3
-        if: matrix.target.target_os == 'windows'
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
-
-      # The `windows-gpu-t4-4-core` does not have modern PowerShell installed
-      - name: Install PowerShell
-        if: matrix.target.target_os == 'windows'
-        uses: ./.github/actions/install-pwsh
-
-      # The `windows-gpu-t4-4-core` requires Visual Studio Build Tools
-      - name: Install Visual Studio Build Tools
-        if: matrix.target.target_os == 'windows'
-        uses: ./.github/actions/install-vs-buildtools
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:
           os: ${{ matrix.target.target_os }}
+
+      - name: Set up wget
+        if: matrix.target.target_os == 'linux'
+        run: sudo apt-get update && sudo apt-get install wget -y
 
       - name: Set up make
         if: matrix.target.target_os == 'linux' || matrix.target.runner == 'windows-gpu-t4-4-core'

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -173,6 +173,10 @@ jobs:
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 
+      - name: Install Visual Studio Build Tools
+        if: matrix.target.target_os == 'windows'
+        uses: ./.github/actions/install-vs-buildtools
+
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:


### PR DESCRIPTION
# 🗣 Description

The CUDA builds don't need to run on an instance with a GPU installed - they just need the CUDA toolkit to be installed.

Successful run: https://github.com/spiceai/spiceai/actions/runs/12946111995
