### PR TITLE
Package CUDA runtime libraries into artifact for Windows

### DIFF
--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -60,7 +60,6 @@ runs:
 
     - name: Verify CUDA prerequisites
       run: |
-        nvidia-smi
         nvcc --version
       shell: ${{ env.SHELL }}
 

--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -59,13 +59,18 @@ runs:
       run: |
         echo "SHELL=bash" >> $GITHUB_ENV
         echo "BUILD_CMD=make -C bin/spiced SPICED_NON_DEFAULT_FEATURES='models,cuda'" >> $GITHUB_ENV
-        echo 'PACKAGE_CMD=mv target/release/spiced spiced && \
-          chmod +x spiced && \
-          cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcudart.so* . && \
-          cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublas.so* . && \
-          cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublasLt.so* . && \
-          cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcurand.so* . && \
-          tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced lib*.so*' >> $GITHUB_ENV
+        {
+          echo "PACKAGE_CMD=$(cat <<'EOF'
+            mv target/release/spiced spiced &&
+            chmod +x spiced &&
+            cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcudart.so* . &&
+            cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublas.so* . &&
+            cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublasLt.so* . &&
+            cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcurand.so* . &&
+            tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced lib*.so*
+          EOF
+          )" | tr '\n' ' '
+        } >> $GITHUB_ENV
       shell: bash
 
     - name: Install CUDA Toolkit (Linux)

--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -68,7 +68,7 @@ runs:
           "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcurand.so* ."
           "tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced lib*.so*"
         )
-        echo "PACKAGE_CMD=${commands[*]}" >> $GITHUB_ENV
+        echo "PACKAGE_CMD=$(IFS=" && "; echo "${commands[*]}")" >> $GITHUB_ENV
       shell: bash
 
     - name: Install CUDA Toolkit (Linux)

--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -68,7 +68,15 @@ runs:
           "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcurand.so* ."
           "tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced lib*.so*"
         )
-        echo "PACKAGE_CMD=$(IFS=" && "; echo "${commands[*]}")" >> $GITHUB_ENV
+        joined_commands=""
+        for cmd in "${commands[@]}"; do
+          if [ -z "$joined_commands" ]; then
+            joined_commands="$cmd"
+          else
+            joined_commands="$joined_commands && $cmd"
+          fi
+        done
+        echo "PACKAGE_CMD=$joined_commands" >> $GITHUB_ENV
       shell: bash
 
     - name: Install CUDA Toolkit (Linux)

--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -31,14 +31,6 @@ runs:
         echo "CUDA_VERSION_MM=$majorMinor" >> $env:GITHUB_ENV
       shell: pwsh
 
-    - name: Set CUDA version (Linux)
-      if: ${{ inputs.target_os != 'windows'}}
-      run: |
-        cuda_version="${{ inputs.cuda-version }}"
-        major_minor=$(echo $cuda_version | cut -d'.' -f1,2)
-        echo "CUDA_VERSION_MM=$major_minor" >> $GITHUB_ENV
-      shell: bash
-
     - name: Define Shell and Commands (windows)
       if: ${{ inputs.target_os == 'windows'}}
       run: |
@@ -59,24 +51,7 @@ runs:
       run: |
         echo "SHELL=bash" >> $GITHUB_ENV
         echo "BUILD_CMD=make -C bin/spiced SPICED_NON_DEFAULT_FEATURES='models,cuda'" >> $GITHUB_ENV
-        commands=(
-          "mv target/release/spiced spiced"
-          "chmod +x spiced"
-          "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcudart.so* ."
-          "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublas.so* ."
-          "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublasLt.so* ."
-          "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcurand.so* ."
-          "tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced lib*.so*"
-        )
-        joined_commands=""
-        for cmd in "${commands[@]}"; do
-          if [ -z "$joined_commands" ]; then
-            joined_commands="$cmd"
-          else
-            joined_commands="$joined_commands && $cmd"
-          fi
-        done
-        echo "PACKAGE_CMD=$joined_commands" >> $GITHUB_ENV
+        echo "PACKAGE_CMD=mv target/release/spiced spiced && chmod +x spiced && tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced" >> $GITHUB_ENV
       shell: bash
 
     - name: Install CUDA Toolkit (Linux)

--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -23,12 +23,35 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Set CUDA version (Windows)
+      if: ${{ inputs.target_os == 'windows'}}
+      run: |
+        $version = "${{ inputs.cuda-version }}"
+        $majorMinor = $version.Split('.')[0..1] -join '.'
+        echo "CUDA_VERSION_MM=$majorMinor" >> $env:GITHUB_ENV
+      shell: pwsh
+
+    - name: Set CUDA version (Linux)
+      if: ${{ inputs.target_os != 'windows'}}
+      run: |
+        cuda_version="${{ inputs.cuda-version }}"
+        major_minor=$(echo $cuda_version | cut -d'.' -f1,2)
+        echo "CUDA_VERSION_MM=$major_minor" >> $GITHUB_ENV
+      shell: bash
+
     - name: Define Shell and Commands (windows)
       if: ${{ inputs.target_os == 'windows'}}
       run: |
         echo "SHELL=pwsh" >> $env:GITHUB_ENV
         echo "BUILD_CMD=cd bin\\spiced && cargo build --release --features models,cuda --target-dir ../../target" >> $env:GITHUB_ENV
-        echo "PACKAGE_CMD=move target\\release\\spiced.exe spiced.exe -Force && tar -czf spiced.exe_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced.exe" >> $env:GITHUB_ENV
+        @(
+            "PACKAGE_CMD=move target\release\spiced.exe spiced.exe -Force; ",
+            "copy 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA_VERSION_MM }}\bin\cudart64_*.dll' .; ",
+            "copy 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA_VERSION_MM }}\bin\cublas64_*.dll' .; ",
+            "copy 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA_VERSION_MM }}\bin\cublasLt64_*.dll' .; ",
+            "copy 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${{ env.CUDA_VERSION_MM }}\bin\curand64_*.dll' .; ",
+            "tar -czf spiced.exe_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced.exe *.dll"
+        ) -join '' | echo >> $env:GITHUB_ENV
       shell: pwsh
 
     - name: Define Shell and Commands
@@ -36,7 +59,13 @@ runs:
       run: |
         echo "SHELL=bash" >> $GITHUB_ENV
         echo "BUILD_CMD=make -C bin/spiced SPICED_NON_DEFAULT_FEATURES='models,cuda'" >> $GITHUB_ENV
-        echo "PACKAGE_CMD=mv target/release/spiced spiced && chmod +x spiced && tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced" >> $GITHUB_ENV
+        echo 'PACKAGE_CMD=mv target/release/spiced spiced && \
+          chmod +x spiced && \
+          cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcudart.so* . && \
+          cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublas.so* . && \
+          cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublasLt.so* . && \
+          cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcurand.so* . && \
+          tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced lib*.so*' >> $GITHUB_ENV
       shell: bash
 
     - name: Install CUDA Toolkit (Linux)

--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -59,18 +59,16 @@ runs:
       run: |
         echo "SHELL=bash" >> $GITHUB_ENV
         echo "BUILD_CMD=make -C bin/spiced SPICED_NON_DEFAULT_FEATURES='models,cuda'" >> $GITHUB_ENV
-        {
-          echo "PACKAGE_CMD=$(cat <<'EOF'
-            mv target/release/spiced spiced &&
-            chmod +x spiced &&
-            cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcudart.so* . &&
-            cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublas.so* . &&
-            cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublasLt.so* . &&
-            cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcurand.so* . &&
-            tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced lib*.so*
-          EOF
-          )" | tr '\n' ' '
-        } >> $GITHUB_ENV
+        commands=(
+          "mv target/release/spiced spiced"
+          "chmod +x spiced"
+          "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcudart.so* ."
+          "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublas.so* ."
+          "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcublasLt.so* ."
+          "cp /usr/local/cuda-${{ env.CUDA_VERSION_MM }}/lib64/libcurand.so* ."
+          "tar czf spiced_models_cuda_${{ inputs.cuda-compute-capability }}_${{ inputs.artifact-tag }}.tar.gz spiced lib*.so*"
+        )
+        echo "PACKAGE_CMD=${commands[*]}" >> $GITHUB_ENV
       shell: bash
 
     - name: Install CUDA Toolkit (Linux)

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -64,37 +64,37 @@ jobs:
             const matrix = [
               {
                 compute_cap: "75",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "80",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "86",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "87",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "89",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "90",
-                runner: "spiceai-runners",
+                runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -64,73 +64,73 @@ jobs:
             const matrix = [
               {
                 compute_cap: "75",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "80",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "86",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "87",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "89",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "90",
-                runner: "ubuntu-gpu-t4-4-core",
+                runner: "spiceai-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "75",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "80",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "86",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "87",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "89",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "90",
-                runner: "windows-gpu-t4-4-core",
+                runner: "windows-latest",
                 target_os: "windows",
                 target_arch: "x86_64"
               }
@@ -170,30 +170,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The `windows-gpu-t4-4-core` does not have Python installed
-      - name: Set up Python3
-        if: matrix.target.target_os == 'windows'
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
-
-      # The `windows-gpu-t4-4-core` does not have modern PowerShell installed
-      - name: Install PowerShell
-        if: matrix.target.target_os == 'windows'
-        uses: ./.github/actions/install-pwsh
-
-      # The `windows-gpu-t4-4-core` requires Visual Studio Build Tools
-      - name: Install Visual Studio Build Tools
-        if: matrix.target.target_os == 'windows'
-        uses: ./.github/actions/install-vs-buildtools
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:
           os: ${{ matrix.target.target_os }}
+
+      - name: Set up wget
+        if: matrix.target.target_os == 'linux'
+        run: sudo apt-get update && sudo apt-get install wget -y
 
       - name: Set up make
         if: matrix.target.target_os == 'linux' || matrix.target.runner == 'windows-gpu-t4-4-core'

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -173,6 +173,10 @@ jobs:
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 
+      - name: Install Visual Studio Build Tools
+        if: matrix.target.target_os == 'windows'
+        uses: ./.github/actions/install-vs-buildtools
+
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:


### PR DESCRIPTION
# 🗣 Description

Package the CUDA runtime library dependencies into the built artifact. The Spice CLI will automatically place these next to the binary when downloaded them from GitHub releases.

This solves the issue of missing CUDA dependencies if the user hasn't installed the CUDA toolkit.

## 🔨 Related Issues

https://github.com/spiceai/spiceai/issues/4471

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
