### PR TITLE
Upgrade cuda-toolkit to v0.2.21 (ARM runners compatibility improvements)

### DIFF
--- a/.github/actions/spiced-cuda-build/action.yaml
+++ b/.github/actions/spiced-cuda-build/action.yaml
@@ -41,7 +41,7 @@ runs:
 
     - name: Install CUDA Toolkit (Linux)
       if: ${{ inputs.target_os != 'windows'}}
-      uses: Jimver/cuda-toolkit@v0.2.19
+      uses: Jimver/cuda-toolkit@v0.2.21
       id: cuda-toolkit-linux
       with:
         cuda: ${{ inputs.cuda-version }}
@@ -52,7 +52,7 @@ runs:
 
     - name: Install CUDA Toolkit (Windows)
       if: ${{ inputs.target_os == 'windows'}}
-      uses: Jimver/cuda-toolkit@v0.2.19
+      uses: Jimver/cuda-toolkit@v0.2.21
       id: cuda-toolkit-windows
       with:
         cuda: ${{ inputs.cuda-version }}

--- a/.github/workflows/e2e_test_release_install_ai.yml
+++ b/.github/workflows/e2e_test_release_install_ai.yml
@@ -115,7 +115,7 @@ jobs:
       # nvidia-smi is not available on windows-gpu-t4-4-core, installing CUDA Toolkit
       - name: Install CUDA Toolkit (Windows)
         if: matrix.target.runner == 'windows-gpu-t4-4-core'
-        uses: Jimver/cuda-toolkit@v0.2.19
+        uses: Jimver/cuda-toolkit@v0.2.21
         id: cuda-toolkit
         with:
           method: network


### PR DESCRIPTION
Arm runners is available on github runners

Windows arm runners are coming in the following weeks.

Nvidia is merging together ARM64 and SBSA cuda and drivers.

Also Windows cuda arm is coming.