### PR TITLE
Update supported CUDA targets: add 87(cli), remove 75

### DIFF
--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -40,7 +40,6 @@ on:
         type: choice
         options:
           - "all"
-          - "75"
           - "80"
           - "86"
           - "87"
@@ -62,12 +61,6 @@ jobs:
         with:
           script: |
             const matrix = [
-              {
-                compute_cap: "75",
-                runner: "spiceai-large-runners",
-                target_os: "linux",
-                target_arch: "x86_64"
-              },
               {
                 compute_cap: "80",
                 runner: "spiceai-large-runners",
@@ -96,12 +89,6 @@ jobs:
                 compute_cap: "90",
                 runner: "spiceai-large-runners",
                 target_os: "linux",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "75",
-                runner: "windows-latest",
-                target_os: "windows",
                 target_arch: "x86_64"
               },
               {

--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -96,7 +96,7 @@ func getRustArch() string {
 }
 
 // GPU versions that are supported via dedicated CUDA builds
-var supportedCudaVersionsBinaries = []string{"75", "80", "86", "89", "90"}
+var supportedCudaVersionsBinaries = []string{"80", "86", "87", "89", "90"}
 
 func checkCudaVersionSupported(computeCap string) bool {
 	for _, version := range supportedCudaVersionsBinaries {


### PR DESCRIPTION
# 🗣 Description

CUDA target 87 for build binaries was added by 
- https://github.com/spiceai/spiceai/pull/4489


Target 75 has been removed due to 
- https://github.com/spiceai/spiceai/issues/4470

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
