### PR TITLE
fix: Don't snapshot clickbench benchmarks

### DIFF
--- a/crates/runtime/benches/bench_object_store/mod.rs
+++ b/crates/runtime/benches/bench_object_store/mod.rs
@@ -97,8 +97,7 @@ pub(crate) async fn run(
                 | "s3_arrow_memory_use_source"
                 | "s3_duckdb_memory_use_source"
                 | "s3_duckdb_file_use_source"
-        ) && (query_name.starts_with("clickbench_q")
-            || query_name.starts_with("tpch_q")
+        ) && (query_name.starts_with("tpch_q")
             || query_name.starts_with("tpcds_q"));
 
         match super::run_query_and_return_result(


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Don't snapshot ClickBench benchmarks, because ClickBench queries are un-ordered and return inconsistent results.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #4476