### PR TITLE
Update release branch naming

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,7 +11,7 @@ The `trunk` branch serves as the primary development branch containing the lates
 ### Major and Minor Releases
 
 1. Create the release branch from trunk one day before the scheduled release (or use an existing branch from a pre-release)
-2. Name the branch `release-X.Y` (excluding patch version)
+2. Name the branch `release/X.Y` (excluding patch version)
 3. Execute all testing procedures on this branch
 4. Apply fixes/changes:
    - First commit to `trunk`
@@ -21,7 +21,7 @@ The `trunk` branch serves as the primary development branch containing the lates
 
 Pre-releases follow the format `vX.Y.0-rc.N` where `N` is the RC number (e.g., `v1.0.0-rc.1`).
 
-1. Create/use the corresponding minor release branch (e.g., `release-1.0` for `v1.0.0-rc.1`)
+1. Create/use the corresponding minor release branch (e.g., `release/1.0` for `v1.0.0-rc.1`)
 2. The latest release branch should always be fast-forwarded from `trunk`.
 3. Older release branches should have changes cherry-picked from `trunk` as needed.
 4. Update version number in `version.txt` and `Cargo.toml` to include the new RC version (e.g., `v1.0.0-rc.1`). For the latest release branch, this is done in trunk and fast-forwarded to the release branch. Older release branches should have the version number updated directly.
@@ -29,14 +29,14 @@ Pre-releases follow the format `vX.Y.0-rc.N` where `N` is the RC number (e.g., `
 
 Example:
 
-- RC releases for `v1.0.0` (e.g., `v1.0.0-rc.1`, `v1.0.0-rc.2`, etc.) → `release-1.0` branch.
-- If `release-1.1` exists, changes to `release-1.0` must be cherry-picked from `trunk`.
+- RC releases for `v1.0.0` (e.g., `v1.0.0-rc.1`, `v1.0.0-rc.2`, etc.) → `release/1.0` branch.
+- If `release/1.1` exists, changes to `release/1.0` must be cherry-picked from `trunk`.
 
 ### Patch Releases
 
 For version `vX.Y.Z`:
 
-1. Use existing minor release branch (`release-X.Y`)
+1. Use existing minor release branch (`release/X.Y`)
 2. Cherry-pick required fixes from `trunk`. No new features are allowed in patch releases, only bug/security fixes.
 3. Update patch version number.
 


### PR DESCRIPTION
# 🗣 Description

Release branches should have a `/` in them going forward, i.e. `release/1.1`, not `release-1.1`
