### PR TITLE
In spiced_docker, propagate setup to publish-cuda

### DIFF
--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -324,7 +324,7 @@ jobs:
 
   publish-cuda:
     if: ${{ github.event_name == 'push' || inputs.target == 'cuda' || inputs.target == 'all' }}
-    needs: build-cuda
+    needs: [setup, build-cuda]
     runs-on: "ubuntu-gpu-t4-4-core"
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
# 🗣 Description
 - Github action will not give `needs.setup.outputs.rel_version` to `publish-cuda` unless it explicitly depends on the `setup` job. Without it, this causes `$REL_VERSION` to not be set, and image names to be invalid.

## 🔨 Related Issues
 See failed build: https://github.com/spiceai/spiceai/actions/runs/13002933383/job/36267141312#step:8:79
