### PR TITLE
Add federated source information to refresh errors

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -205,6 +205,7 @@ pub struct Builder {
     runtime_status: Arc<status::RuntimeStatus>,
     dataset_name: TableReference,
     federated: Arc<FederatedTable>,
+    federated_source: String,
     accelerator: Arc<dyn TableProvider>,
     refresh: refresh::Refresh,
     retention: Option<Retention>,
@@ -224,6 +225,7 @@ impl Builder {
         runtime_status: Arc<status::RuntimeStatus>,
         dataset_name: TableReference,
         federated: Arc<FederatedTable>,
+        federated_source: String,
         accelerator: Arc<dyn TableProvider>,
         refresh: refresh::Refresh,
     ) -> Self {
@@ -231,6 +233,7 @@ impl Builder {
             runtime_status,
             dataset_name,
             federated,
+            federated_source,
             accelerator,
             refresh,
             retention: None,
@@ -398,6 +401,7 @@ impl Builder {
             Arc::clone(&self.runtime_status),
             self.dataset_name.clone(),
             Arc::clone(&self.federated),
+            Some(self.federated_source),
             Arc::clone(&refresh_params),
             Arc::clone(&self.accelerator),
         );
@@ -458,6 +462,7 @@ impl AcceleratedTable {
         runtime_status: Arc<status::RuntimeStatus>,
         dataset_name: TableReference,
         federated: Arc<FederatedTable>,
+        federated_source: String,
         accelerator: Arc<dyn TableProvider>,
         refresh: refresh::Refresh,
     ) -> Builder {
@@ -465,6 +470,7 @@ impl AcceleratedTable {
             runtime_status,
             dataset_name,
             federated,
+            federated_source,
             accelerator,
             refresh,
         )

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -300,6 +300,7 @@ pub struct Refresher {
     runtime_status: Arc<status::RuntimeStatus>,
     dataset_name: TableReference,
     federated: Arc<FederatedTable>,
+    federated_source: Option<String>,
     refresh: Arc<RwLock<Refresh>>,
     accelerator: Arc<dyn TableProvider>,
     cache_provider: Option<Arc<QueryResultsCacheProvider>>,
@@ -315,6 +316,7 @@ impl Refresher {
         runtime_status: Arc<status::RuntimeStatus>,
         dataset_name: TableReference,
         federated: Arc<FederatedTable>,
+        federated_source: Option<String>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
     ) -> Self {
@@ -322,6 +324,7 @@ impl Refresher {
             runtime_status,
             dataset_name,
             federated,
+            federated_source,
             refresh,
             accelerator,
             cache_provider: None,
@@ -402,6 +405,7 @@ impl Refresher {
             Arc::clone(&self.runtime_status),
             self.dataset_name.clone(),
             Arc::clone(&self.federated),
+            self.federated_source.clone(),
             Arc::clone(&self.refresh),
             Arc::clone(&self.accelerator),
         );
@@ -542,6 +546,7 @@ impl Refresher {
             Arc::clone(&self.runtime_status),
             self.dataset_name.clone(),
             Arc::clone(&self.federated),
+            self.federated_source.clone(),
             Arc::clone(&self.accelerator),
         ));
 
@@ -574,6 +579,7 @@ impl Refresher {
             Arc::clone(&self.runtime_status),
             self.dataset_name.clone(),
             Arc::clone(&self.federated),
+            self.federated_source.clone(),
             Arc::clone(&self.accelerator),
         ));
 
@@ -688,6 +694,7 @@ mod tests {
             status,
             TableReference::bare("test"),
             federated,
+            Some("mem_table".to_string()),
             Arc::new(RwLock::new(refresh)),
             Arc::clone(&accelerator),
         );
@@ -895,6 +902,7 @@ mod tests {
                 status::RuntimeStatus::new(),
                 TableReference::bare("test"),
                 federated,
+                Some("mem_table".to_string()),
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
             );
@@ -1047,6 +1055,7 @@ mod tests {
                 status::RuntimeStatus::new(),
                 TableReference::bare("test"),
                 federated,
+                Some("mem_table".to_string()),
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
             );
@@ -1249,6 +1258,7 @@ mod tests {
                 status::RuntimeStatus::new(),
                 TableReference::bare("test"),
                 federated,
+                Some("mem_table".to_string()),
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
             );

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -386,18 +386,15 @@ impl Refresher {
     ) -> Option<tokio::task::JoinHandle<()>> {
         let time_column = self.refresh.read().await.time_column.clone();
 
-        let mut on_start_refresh_external = match acceleration_refresh_mode {
-            AccelerationRefreshMode::Disabled => return None,
-            AccelerationRefreshMode::Append(receiver) => {
-                if let (Some(receiver), Some(_)) = (receiver, time_column) {
-                    receiver
-                } else {
-                    return Some(self.start_streaming_append(ready_sender));
-                }
+        let mut on_start_refresh_external = match (acceleration_refresh_mode, time_column) {
+            (AccelerationRefreshMode::Disabled, _) => return None,
+            (AccelerationRefreshMode::Append(Some(receiver)), Some(_))
+            | (AccelerationRefreshMode::Full(receiver), _) => receiver,
+            (AccelerationRefreshMode::Append(_), _) => {
+                return Some(self.start_streaming_append(ready_sender))
             }
-            AccelerationRefreshMode::Full(receiver) => receiver,
-            AccelerationRefreshMode::Changes(stream) => {
-                return Some(self.start_changes_stream(stream, ready_sender));
+            (AccelerationRefreshMode::Changes(stream), _) => {
+                return Some(self.start_changes_stream(stream, ready_sender))
             }
         };
 

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -49,6 +49,7 @@ impl RefreshTaskRunner {
         runtime_status: Arc<status::RuntimeStatus>,
         dataset_name: TableReference,
         federated: Arc<FederatedTable>,
+        federated_source: Option<String>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
     ) -> Self {
@@ -56,6 +57,7 @@ impl RefreshTaskRunner {
             runtime_status,
             dataset_name.clone(),
             federated,
+            federated_source,
             accelerator,
         ));
 

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -809,9 +809,11 @@ impl DataFusion {
             Arc::clone(&self.runtime_status),
             dataset.name.clone(),
             Arc::clone(&source_table_provider),
+            dataset.source().to_string(),
             accelerated_table_provider,
             refresh,
         );
+
         accelerated_table_builder.retention(Retention::new(
             dataset.time_column.clone(),
             dataset.time_format,

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -122,6 +122,7 @@ pub async fn create_internal_accelerated_table(
         runtime_status,
         name.clone(),
         federated_table,
+        "internal".to_string(),
         accelerated_table_provider,
         refresh,
     );

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -116,6 +116,7 @@ async fn create_refresh_task(
             rt.status(),
             table_name.into(),
             Arc::clone(&accelerated_table.get_federated_table()),
+            None,
             accelerated_table.get_accelerator(),
         ),
         accelerated_table.refresh_params().read().await.clone(),

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -332,6 +332,7 @@ pub async fn create_synced_internal_accelerated_table(
         runtime_status,
         table_reference.clone(),
         federated_table,
+        "spice.ai".to_string(),
         accelerated_table_provider,
         refresh,
     );


### PR DESCRIPTION
# 🗣 Description

Propagate federated source information to refresh logic and include it to refresh errors:


>2025-01-29T04:05:32.656513Z  WARN runtime::accelerated_table::refresh_task: Failed to load data for dataset taxi_trips (s3): Failed to get data from the connector.
...

## 🔨 Related Issues

Closes  #4552 

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

1. We have federated TableProvider but it does not expose source name information so `federated_source` was added on top of `federated` field.
1. Alternative approach considered was replacing `dataset_name` (`TableReference`) with full `Dataset` instance that can be used to retrieve both name and source but in several places like tests and internal logic we construct Refresh/AcceleratedTable w/o using dataset, passing source parameter only worked better.

