### PR TITLE
feat: Load table schemas through REST for Spice Cloud Catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,6 +5678,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a80b3807a5082662fa608d85dedb1a5341ae395c#a80b3807a5082662fa608d85dedb1a5341ae395c"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -5726,6 +5727,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a80b3807a5082662fa608d85dedb1a5341ae395c#a80b3807a5082662fa608d85dedb1a5341ae395c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5750,6 +5752,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.4.0"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a80b3807a5082662fa608d85dedb1a5341ae395c#a80b3807a5082662fa608d85dedb1a5341ae395c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,7 +5678,6 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -5727,7 +5726,6 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5752,7 +5750,6 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,12 +172,8 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-#iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
-#iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
-#iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
-
-iceberg = { path = "../iceberg-rust/crates/iceberg" }
-iceberg-catalog-rest = { path = "../iceberg-rust/crates/catalog/rest" }
-iceberg-datafusion = { path = "../iceberg-rust/crates/integrations/datafusion" }
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a80b3807a5082662fa608d85dedb1a5341ae395c" }
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a80b3807a5082662fa608d85dedb1a5341ae395c" }
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a80b3807a5082662fa608d85dedb1a5341ae395c" }
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,8 +172,12 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
+#iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
+#iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
+#iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
+
+iceberg = { path = "../iceberg-rust/crates/iceberg" }
+iceberg-catalog-rest = { path = "../iceberg-rust/crates/catalog/rest" }
+iceberg-datafusion = { path = "../iceberg-rust/crates/integrations/datafusion" }
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -117,12 +117,6 @@ impl FlightFactory {
         table_reference: impl Into<MultiPartTableReference>,
         schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
-        if schema.is_some() {
-            println!("FlightSQL schema is some");
-        } else {
-            println!("FlightSQL schema is none");
-        }
-
         let table_provider = match schema {
             Some(schema) => Arc::new(FlightTable::create_with_schema(
                 self.name,

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -117,6 +117,12 @@ impl FlightFactory {
         table_reference: impl Into<MultiPartTableReference>,
         schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
+        if schema.is_some() {
+            println!("FlightSQL schema is some");
+        } else {
+            println!("FlightSQL schema is none");
+        }
+
         let table_provider = match schema {
             Some(schema) => Arc::new(FlightTable::create_with_schema(
                 self.name,

--- a/crates/data_components/src/iceberg/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog.rs
@@ -23,11 +23,12 @@ use iceberg::{
     table::Table, Catalog, Error as IcebergError, ErrorKind, Namespace, NamespaceIdent,
     Result as IcebergResult, TableCommit, TableCreation, TableIdent,
 };
-use iceberg_catalog_rest::{RestCatalog as IcebergRestCatalog, RestCatalogConfig};
+use iceberg_catalog_rest::{HttpClient, RestCatalog as IcebergRestCatalog, RestCatalogConfig};
 
 #[derive(Debug)]
 pub struct RestCatalog {
     inner: IcebergRestCatalog,
+    pub(crate) catalog_config: RestCatalogConfig,
 }
 
 impl RestCatalog {
@@ -35,8 +36,13 @@ impl RestCatalog {
     #[allow(clippy::missing_panics_doc)]
     pub fn new(catalog_config: RestCatalogConfig) -> Self {
         Self {
-            inner: IcebergRestCatalog::new(catalog_config),
+            inner: IcebergRestCatalog::new(catalog_config.clone()),
+            catalog_config,
         }
+    }
+
+    pub fn http_client(&self) -> IcebergResult<HttpClient> {
+        HttpClient::new(&self.catalog_config)
     }
 }
 

--- a/crates/data_components/src/spice_cloud/catalog.rs
+++ b/crates/data_components/src/spice_cloud/catalog.rs
@@ -1,0 +1,79 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use super::provider::Error;
+use arrow::datatypes::SchemaRef as ArrowSchemaRef;
+use http::Method;
+use iceberg::{arrow::schema_to_arrow_schema, spec::SchemaRef, TableIdent};
+use iceberg_catalog_rest::{ErrorResponse, OK};
+use serde::Deserialize;
+
+use crate::iceberg::catalog::RestCatalog;
+
+#[derive(Debug, Deserialize)]
+struct LoadTableResponse {
+    metadata: TableMetadata,
+}
+
+#[derive(Debug, Deserialize)]
+struct TableMetadata {
+    schemas: Vec<SchemaRef>,
+}
+
+pub struct SpiceCatalog {
+    inner: Arc<RestCatalog>,
+}
+
+impl SpiceCatalog {
+    #[must_use]
+    pub fn new(inner: Arc<RestCatalog>) -> Self {
+        Self { inner }
+    }
+
+    pub async fn get_table_schema(&self, table: &TableIdent) -> Result<ArrowSchemaRef, Error> {
+        let client = self
+            .inner
+            .http_client()
+            .map_err(|err| Error::LoadTable { source: err })?;
+
+        let request = client
+            .request(Method::GET, self.inner.catalog_config.table_endpoint(table))
+            .build()
+            .map_err(|err| Error::LoadTable { source: err.into() })?;
+
+        let resp = client
+            .query::<LoadTableResponse, ErrorResponse, OK>(request)
+            .await
+            .map_err(|err| Error::LoadTable { source: err })?;
+
+        let schema = resp.metadata.schemas.first();
+        if let Some(schema) = schema {
+            Ok(Arc::new(
+                schema_to_arrow_schema(schema).map_err(|err| Error::LoadTable { source: err })?,
+            ))
+        } else {
+            Err(Error::NoSchemaFound {})
+        }
+    }
+}
+
+impl From<Arc<RestCatalog>> for SpiceCatalog {
+    fn from(inner: Arc<RestCatalog>) -> Self {
+        Self::new(inner)
+    }
+}

--- a/crates/data_components/src/spice_cloud/mod.rs
+++ b/crates/data_components/src/spice_cloud/mod.rs
@@ -14,4 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+pub mod catalog;
 pub mod provider;

--- a/crates/data_components/src/spice_cloud/provider.rs
+++ b/crates/data_components/src/spice_cloud/provider.rs
@@ -25,8 +25,10 @@ use datafusion::catalog::{CatalogProvider, SchemaProvider, TableProvider};
 use datafusion::error::Result as DFResult;
 use datafusion::sql::TableReference;
 use futures::future::try_join_all;
+use futures::TryFutureExt;
 use globset::GlobSet;
-use iceberg::{Catalog, NamespaceIdent};
+use iceberg::arrow::schema_to_arrow_schema;
+use iceberg::{Catalog, NamespaceIdent, TableIdent};
 use snafu::prelude::*;
 
 use crate::{Read, RefreshableCatalogProvider};
@@ -45,6 +47,9 @@ pub enum Error {
 
     #[snafu(display("Failed to list tables: {source}"))]
     ListTables { source: iceberg::Error },
+
+    #[snafu(display("Failed to load table: {source}"))]
+    LoadTable { source: iceberg::Error },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -186,7 +191,7 @@ impl SpiceCloudPlatformSchemaProvider {
             .await
             .context(ListTablesSnafu)?;
 
-        let included_table_names: Vec<TableReference> = table_names
+        let included_table_names: Vec<(TableReference, TableIdent)> = table_names
             .clone()
             .into_iter()
             .filter_map(|ref table_name| {
@@ -218,24 +223,38 @@ impl SpiceCloudPlatformSchemaProvider {
                         return None;
                     }
                 }
-                Some(table_reference)
+                Some((table_reference, table_name.clone()))
             })
             .collect();
 
-        let table_providers: Vec<_> = try_join_all(
-            included_table_names
-                .clone()
-                .into_iter()
-                .map(|ref table_name| connector.table_provider(table_name.clone(), None))
-                .collect::<Vec<_>>(),
-        )
-        .await
-        .context(TableProviderCreationSnafu)?;
+        // let iceberg_tables = try_join_all(
+        //     included_table_names
+        //         .iter()
+        //         .map(|(_, name)| client.load_table(name))
+        //         .collect::<Vec<_>>(),
+        // )
+        // .await
+        // .map_err(|err| Error::LoadTable { source: err })?;
+
+        // let table_providers: Vec<_> = try_join_all(
+        //     iceberg_tables
+        //         .into_iter()
+        //         .zip(included_table_names.iter().cloned())
+        //         .map(|(table, (name, _))| {
+        //             let schema = Arc::new(
+        //                 schema_to_arrow_schema(table.metadata().current_schema()).unwrap(),
+        //             );
+        //             connector.table_provider(name, Some(schema))
+        //         })
+        //         .collect::<Vec<_>>(),
+        // )
+        // .await
+        // .map_err(|err| Error::TableProviderCreation { source: err })?;
 
         let tables: HashMap<String, Arc<dyn TableProvider>> = included_table_names
             .into_iter()
             .zip(table_providers.into_iter())
-            .map(|(name, provider)| (name.table().to_string(), provider))
+            .map(|((name, _), provider)| (name.table().to_string(), provider))
             .collect();
 
         Ok(SpiceCloudPlatformSchemaProvider { tables })

--- a/crates/data_components/src/spice_cloud/provider.rs
+++ b/crates/data_components/src/spice_cloud/provider.rs
@@ -25,15 +25,15 @@ use datafusion::catalog::{CatalogProvider, SchemaProvider, TableProvider};
 use datafusion::error::Result as DFResult;
 use datafusion::sql::TableReference;
 use futures::future::try_join_all;
-use futures::TryFutureExt;
 use globset::GlobSet;
-use iceberg::arrow::schema_to_arrow_schema;
 use iceberg::{Catalog, NamespaceIdent, TableIdent};
 use snafu::prelude::*;
 
 use crate::{Read, RefreshableCatalogProvider};
 
 use crate::iceberg::catalog::RestCatalog;
+
+use super::catalog::SpiceCatalog;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -50,6 +50,9 @@ pub enum Error {
 
     #[snafu(display("Failed to load table: {source}"))]
     LoadTable { source: iceberg::Error },
+
+    #[snafu(display("No schema found for table"))]
+    NoSchemaFound,
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -227,29 +230,24 @@ impl SpiceCloudPlatformSchemaProvider {
             })
             .collect();
 
-        // let iceberg_tables = try_join_all(
-        //     included_table_names
-        //         .iter()
-        //         .map(|(_, name)| client.load_table(name))
-        //         .collect::<Vec<_>>(),
-        // )
-        // .await
-        // .map_err(|err| Error::LoadTable { source: err })?;
+        let client = SpiceCatalog::from(client);
+        let iceberg_schemas = try_join_all(
+            included_table_names
+                .iter()
+                .map(|(_, ident)| client.get_table_schema(ident))
+                .collect::<Vec<_>>(),
+        )
+        .await?;
 
-        // let table_providers: Vec<_> = try_join_all(
-        //     iceberg_tables
-        //         .into_iter()
-        //         .zip(included_table_names.iter().cloned())
-        //         .map(|(table, (name, _))| {
-        //             let schema = Arc::new(
-        //                 schema_to_arrow_schema(table.metadata().current_schema()).unwrap(),
-        //             );
-        //             connector.table_provider(name, Some(schema))
-        //         })
-        //         .collect::<Vec<_>>(),
-        // )
-        // .await
-        // .map_err(|err| Error::TableProviderCreation { source: err })?;
+        let table_providers: Vec<_> = try_join_all(
+            iceberg_schemas
+                .into_iter()
+                .zip(included_table_names.iter().cloned())
+                .map(|(schema, (name, _))| connector.table_provider(name, Some(schema)))
+                .collect::<Vec<_>>(),
+        )
+        .await
+        .map_err(|err| Error::TableProviderCreation { source: err })?;
 
         let tables: HashMap<String, Arc<dyn TableProvider>> = included_table_names
             .into_iter()


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Uses the Iceberg REST catalog integration to load the table schemas for Spice Cloud Catalog without performing a data query

Depends on https://github.com/spiceai/iceberg-rust/pull/2, then needs an update to `Cargo.toml` to point to the correct dependency.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4033 