### PR TITLE
Fix windows build

### DIFF
--- a/bin/spice/Makefile
+++ b/bin/spice/Makefile
@@ -21,7 +21,7 @@ LDFLAGS:="-X $(BASE_PACKAGE_NAME)/bin/spice/pkg/version.version=$(SPICE_VERSION)
 .PHONY: all
 all:
 ifeq ($(OS),Windows_NT)
-	go build -v -ldflags=$(LDFLAGS) -o ..\..\target\release\spice.exe
+	go build -v -ldflags=$(LDFLAGS) -o "..\..\target\release\spice.exe"
 else
 	mkdir -p ../../target/release 2> /dev/null || true
 	go build -v -ldflags=$(LDFLAGS) -o ../../target/release/spice $(TAGS)


### PR DESCRIPTION
# 🗣 Description

Fix windows build, without double quote the spice will be "..\..\target\release\spice.exe" instead of "spice.exe" in target/release directory. It's been failing on trunk for a while and causes no binaries uploaded to MinIO

successful run: https://github.com/spiceai/spiceai/actions/runs/13041673403

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
