### PR TITLE
Improve refresh error tracing

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -208,6 +208,16 @@ impl RefreshTask {
             refresh.sql.as_deref(),
         )
         .await
+        .inspect_err(|e| {
+            tracing::warn!(
+                "Failed to load data for dataset {}: {}",
+                include_source_to_dataset_name(
+                    &self.dataset_name,
+                    self.federated_source.as_deref()
+                ),
+                inner_err_from_retry_ref(e)
+            );
+        })
     }
 
     async fn write_streaming_data_update(


### PR DESCRIPTION
# 🗣 Description

Add tracing for errors that occur during data writing/processing during refresh, similar to the data stream retrieval step.

>2025-01-29T23:54:14.713275Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset data
2025-01-29T23:55:34.449254Z  WARN runtime::accelerated_table::refresh_task: Failed to load data for dataset data (file): Failed to get data from the connector.
External error: Execution error: External error: Error parsing document Users/sg/spice/spiceai/_pdfs/AMERICANWATERWORKS_2021_10K.pdf: Internal parsing PDF document. Error: ToUnicodeCMap(Parse(Error))
Ensure the dataset configuration is valid, and try again.

## 🔨 Related Issues

Fixes https://github.com/spiceai/spiceai/issues/4569
Part of https://github.com/spiceai/spiceai/issues/4573 

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
