### PR TITLE
fix: Retry flaky tests

### DIFF
--- a/crates/runtime/tests/acceleration/single_instance_duckdb.rs
+++ b/crates/runtime/tests/acceleration/single_instance_duckdb.rs
@@ -94,7 +94,7 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
             drop(rt);
             runtime::dataaccelerator::clear_registry().await;
             runtime::dataaccelerator::register_all().await;
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
             let pool = DuckDbConnectionPool::new_file(expected_path, &AccessMode::ReadWrite)
                 .expect("valid path");

--- a/crates/runtime/tests/acceleration/single_instance_duckdb.rs
+++ b/crates/runtime/tests/acceleration/single_instance_duckdb.rs
@@ -54,7 +54,7 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
     let _guard = super::ACCELERATION_MUTEX.lock().await;
 
     test_request_context()
-        .scope(async {
+        .scope_retry(3, || async {
             let status = status::RuntimeStatus::new();
             let df = get_test_datafusion(Arc::clone(&status));
 

--- a/crates/runtime/tests/mysql/federation.rs
+++ b/crates/runtime/tests/mysql/federation.rs
@@ -211,7 +211,7 @@ async fn mysql_federation_inner_join_with_acc() -> Result<(), String> {
             .await;
         // Set a timeout for the test
         tokio::select! {
-            () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+            () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
                 return Err("Timed out waiting for datasets to load".to_string());
             }
             () = rt.load_components() => {}

--- a/crates/runtime/tests/mysql/federation.rs
+++ b/crates/runtime/tests/mysql/federation.rs
@@ -173,7 +173,7 @@ async fn mysql_federation_inner_join_with_acc() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
     let mysql_port = 13308;
 
-    test_request_context().scope(async {
+    test_request_context().scope_retry(3, || async {
         let running_container = start_mysql_docker_container(
             "runtime-integration-test-federation-inner-join-mysql",
             mysql_port,


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds a `.scope_retry` to `RequestContext`, to retry the provided function a certain number of times until completion or failure
* Applies it to the flaky DuckDB and MySQL federation integration tests.