### PR TITLE
`spice trace chat` support in CLI. 

### DIFF
--- a/bin/spice/cmd/catalogs.go
+++ b/bin/spice/cmd/catalogs.go
@@ -56,6 +56,5 @@ spice catalogs
 
 func init() {
 	catalogsCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
-	catalogsCmd.Flags().String("api-key", "", "The API key to use for authentication")
 	RootCmd.AddCommand(catalogsCmd)
 }

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -376,7 +376,6 @@ func init() {
 	chatCmd.Flags().String(modelKeyFlag, "", "Model to chat with")
 	chatCmd.Flags().String(httpEndpointKeyFlag, "", "HTTP endpoint for chat (default: http://localhost:8090)")
 	chatCmd.Flags().String(userAgentKeyFlag, "", "User agent to use in all requests")
-	chatCmd.Flags().String("api-key", "", "The API key to use for authentication")
 
 	RootCmd.AddCommand(chatCmd)
 }

--- a/bin/spice/cmd/datasets.go
+++ b/bin/spice/cmd/datasets.go
@@ -58,6 +58,5 @@ spice datasets
 
 func init() {
 	datasetsCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
-	datasetsCmd.Flags().String("api-key", "", "The API key to use for authentication")
 	RootCmd.AddCommand(datasetsCmd)
 }

--- a/bin/spice/cmd/models.go
+++ b/bin/spice/cmd/models.go
@@ -66,6 +66,5 @@ spice models
 
 func init() {
 	modelsCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
-	modelsCmd.Flags().String("api-key", "", "The API key to use for authentication")
 	RootCmd.AddCommand(modelsCmd)
 }

--- a/bin/spice/cmd/nsql.go
+++ b/bin/spice/cmd/nsql.go
@@ -240,7 +240,6 @@ func init() {
 	nsqlCmd.Flags().String(modelKeyFlag, "", "Model to use for nsql")
 	nsqlCmd.Flags().String(httpEndpointKeyFlag, "", "HTTP endpoint for nsql (default: http://localhost:8090)")
 	nsqlCmd.Flags().String("user-agent", "", "User agent to use in all requests")
-	nsqlCmd.Flags().String("api-key", "", "The API key to use for authentication")
 
 	RootCmd.AddCommand(nsqlCmd)
 }

--- a/bin/spice/cmd/pods.go
+++ b/bin/spice/cmd/pods.go
@@ -63,6 +63,5 @@ spice pods
 
 func init() {
 	podsCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
-	podsCmd.Flags().String("api-key", "", "The API key to use for authentication")
 	RootCmd.AddCommand(podsCmd)
 }

--- a/bin/spice/cmd/refresh.go
+++ b/bin/spice/cmd/refresh.go
@@ -116,7 +116,6 @@ spice refresh taxi_trips
 
 func init() {
 	refreshCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
-	refreshCmd.Flags().String("api-key", "", "The API key to use for authentication")
 	refreshCmd.Flags().String(refreshSqlFlag, "", "'refresh_sql' to refresh a dataset.")
 	refreshCmd.Flags().String(refreshModeFlag, "", "'refresh_mode', one of: full, append")
 	refreshCmd.Flags().String(maxJitterFlag, "", "'refresh_jitter_max', a duration string (e.g. '1m') to specify the maximum jitter allowed for the refresh operation")

--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -223,7 +223,6 @@ func init() {
 	searchCmd.Flags().String(modelKeyFlag, "", "Model to use for search")
 	searchCmd.Flags().String(httpEndpointKeyFlag, "", "HTTP endpoint for search (default: http://localhost:8090)")
 	searchCmd.Flags().Uint(limitKeyFlag, 10, "Limit number of search results")
-	searchCmd.Flags().String("api-key", "", "The API key to use for authentication")
 
 	RootCmd.AddCommand(searchCmd)
 }

--- a/bin/spice/cmd/spice.go
+++ b/bin/spice/cmd/spice.go
@@ -47,7 +47,7 @@ func init() {
 	RootCmd.PersistentFlags().CountVarP(&verbosity.VerbosityCount, "verbose", "v", "Verbose logging")
 	RootCmd.PersistentFlags().BoolVar(&verbosity.VeryVerbose, "very-verbose", false, "Very verbose logging")
 	RootCmd.PersistentFlags().BoolP("help", "h", false, "Print this help message")
-
+	RootCmd.PersistentFlags().String("api-key", "", "The API key to use for authentication")
 }
 
 func initConfig() {

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -84,7 +84,6 @@ sql> show tables
 
 func init() {
 	sqlCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
-	sqlCmd.Flags().String("api-key", "", "The API key to use for authentication")
 	sqlCmd.Flags().String("user-agent", "", "The user agent to use for all requests")
 	RootCmd.AddCommand(sqlCmd)
 }

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -17,38 +17,33 @@ limitations under the License.
 package cmd
 
 import (
-	"log/slog"
-
 	"github.com/spf13/cobra"
-	"github.com/spiceai/spiceai/bin/spice/pkg/api"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 )
 
-var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Spice runtime status",
+var traceCmd = &cobra.Command{
+	Use:   "trace",
+	Short: "Return a user friendly trace into an operation that occurred in Spice",
 	Example: `
-spice status
+$ spice trace chat --id chatcmpl-At6ZmDE8iAYRPeuQLA0FLlWxGKNnM
+
+$ spice trace chat --last
 `,
+	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
-		if rootCertPath, err := cmd.Flags().GetString("tls-root-certificate-file"); err == nil && rootCertPath != "" {
-			rtcontext = context.NewHttpsContext(rootCertPath)
-		}
-
 		apiKey, _ := cmd.Flags().GetString("api-key")
 		if apiKey != "" {
 			rtcontext.SetApiKey(apiKey)
+			cmd.Print("API key set %s", apiKey)
 		}
-
-		err := api.WriteDataTable(rtcontext, "/v1/status", api.Service{})
-		if err != nil {
-			slog.Error("getting spiced status", "error", err)
-		}
+		cmd.Print(args)
 	},
 }
 
 func init() {
-	statusCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
-	RootCmd.AddCommand(statusCmd)
+	RootCmd.AddCommand(traceCmd)
 }
+
+//  select * from runtime.task_history where trace_id=(select trace_id from runtime.task_history where labels.id='chatcmpl-At6XgMxYOI7KB9oeJJCUu4UINbX9F')
+// select * from runtime.task_history where trace_id=(select trace_id from runtime.task_history where task='ai_chat' order by start_time desc limit 1);

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
@@ -66,7 +67,12 @@ $ spice trace chat --last
 
 		traces, err := taskhistory.SqlRequestToTraces(rtcontext, fmt.Sprintf("SELECT * FROM runtime.task_history WHERE %s ORDER BY start_time asc", filter))
 		if err != nil {
-			cmd.Println(err)
+			slog.Error("SQL query to 'task_history' failed", "error", err)
+			cmd.PrintErrln("Error: failed to retrieve events from runtime.")
+			return
+		}
+		if len(traces) == 0 {
+			cmd.PrintErrln("Error: No events found")
 			return
 		}
 		taskhistory.PrintTreeFromTraces(cmd.OutOrStdout(), traces, Display)

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -17,8 +17,22 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
+	"github.com/spiceai/spiceai/bin/spice/pkg/taskhistory"
+)
+
+var (
+	// If `--last` was requested
+	isLast bool
+
+	// The id of the trace to provide
+	id string
+
+	// The trace_id of the trace to provide
+	trace_id string
 )
 
 var traceCmd = &cobra.Command{
@@ -29,21 +43,56 @@ $ spice trace chat --id chatcmpl-At6ZmDE8iAYRPeuQLA0FLlWxGKNnM
 
 $ spice trace chat --last
 `,
-	Args: cobra.ArbitraryArgs,
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
 		apiKey, _ := cmd.Flags().GetString("api-key")
 		if apiKey != "" {
 			rtcontext.SetApiKey(apiKey)
-			cmd.Print("API key set %s", apiKey)
 		}
-		cmd.Print(args)
+
+		var filter string
+		var err error
+		switch args[0] {
+		case "chat":
+			filter, err = getTraceFilterForChat(id, trace_id, &isLast)
+		default:
+			err = fmt.Errorf("invalid trace type %s", args[0])
+		}
+		if err != nil {
+			cmd.Println(err)
+			return
+		}
+
+		traces, err := taskhistory.SqlRequestToTraces(rtcontext, fmt.Sprintf("SELECT * FROM runtime.task_history WHERE %s ORDER BY start_time asc", filter))
+		if err != nil {
+			cmd.Println(err)
+			return
+		}
+		taskhistory.PrintTreeFromTraces(cmd.OutOrStdout(), traces, Display)
 	},
+}
+
+func Display(t *taskhistory.TaskHistory) string {
+	return fmt.Sprintf("(%8.2fms) %s ", t.ExecutionDurationMs, t.Task)
 }
 
 func init() {
 	RootCmd.AddCommand(traceCmd)
+	traceCmd.Flags().BoolVar(&isLast, "last", false, "Return the last trace")
+	traceCmd.Flags().StringVar(&id, "id", "", "Return the trace with the given id")
+	traceCmd.Flags().StringVar(&trace_id, "trace-id", "", "Return the trace with the given trace id")
 }
 
-//  select * from runtime.task_history where trace_id=(select trace_id from runtime.task_history where labels.id='chatcmpl-At6XgMxYOI7KB9oeJJCUu4UINbX9F')
-// select * from runtime.task_history where trace_id=(select trace_id from runtime.task_history where task='ai_chat' order by start_time desc limit 1);
+func getTraceFilterForChat(id string, trace_id string, last *bool) (string, error) {
+	if last != nil && *last {
+		return "trace_id=(SELECT trace_id from runtime.task_history where task='ai_chat' order by start_time desc limit 1)", nil
+	}
+	if id != "" {
+		return fmt.Sprintf("trace_id=(SELECT trace_id from runtime.task_history where labels.id='%s')", id), nil
+	}
+	if trace_id != "" {
+		return fmt.Sprintf("trace_id='%s'", trace_id), nil
+	}
+	return "", fmt.Errorf("One of --last, --trace-id or --id must be provided")
+}

--- a/bin/spice/pkg/taskhistory/format.go
+++ b/bin/spice/pkg/taskhistory/format.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskhistory
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// PrintTreeFromTraces prints a hierarchical tree of TaskHistory entries to the provided writer.
+// Expects all `traces` to be from the same trace (i.e. same `TraceId`).
+// The `fn` function is used to format details to display on each task history line.
+func PrintTreeFromTraces(w io.Writer, traces []TaskHistory, fn func(t *TaskHistory) string) {
+	printTree(w, buildTraceTree(traces), "", true, fn)
+}
+
+func ConvertLabelsToString(labels map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString("{")
+
+	i := 0
+	for key, value := range labels {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+
+		switch {
+		case isBool(value):
+			sb.WriteString(fmt.Sprintf("%s: %t", key, mustParseBool(value)))
+		case isInt(value):
+			sb.WriteString(fmt.Sprintf("%s: %d", key, mustParseInt(value)))
+		default:
+			sb.WriteString(fmt.Sprintf("%s: %s", key, value))
+		}
+		i++
+	}
+
+	sb.WriteString("}")
+	return sb.String()
+}
+
+// printTree prints the tree in ASCII format.
+func printTree(w io.Writer, node *TreeNode, indent string, isLast bool, fn func(t *TaskHistory) string) {
+	if node == nil {
+		return
+	}
+
+	connector := "├── "
+	if isLast {
+		connector = "└── "
+	}
+	if indent == "" {
+		connector = ""
+	}
+	fmt.Fprintf(w, "%s%s[%s] %s\n", indent, connector, node.TaskHistory.SpanID, fn(&node.TaskHistory))
+
+	// Recurse for children
+	newIndent := indent + "│ "
+	if isLast {
+		newIndent = indent + "  "
+	}
+
+	for i, child := range node.Children {
+		printTree(w, child, newIndent, i == len(node.Children)-1, fn)
+	}
+}
+
+func isBool(s string) bool {
+	_, err := strconv.ParseBool(s)
+	return err == nil
+}
+
+func mustParseBool(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
+}
+
+func isInt(s string) bool {
+	_, err := strconv.Atoi(s)
+	return err == nil
+}
+
+func mustParseInt(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}

--- a/bin/spice/pkg/taskhistory/format.go
+++ b/bin/spice/pkg/taskhistory/format.go
@@ -68,6 +68,7 @@ func printTree(w io.Writer, node *TreeNode, indent string, isLast bool, fn func(
 	if indent == "" {
 		connector = ""
 	}
+
 	fmt.Fprintf(w, "%s%s[%s] %s\n", indent, connector, node.TaskHistory.SpanID, fn(&node.TaskHistory))
 
 	// Recurse for children

--- a/bin/spice/pkg/taskhistory/taskhistory.go
+++ b/bin/spice/pkg/taskhistory/taskhistory.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskhistory
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spiceai/spiceai/bin/spice/pkg/context"
+)
+
+func SqlRequestToTraces(rtcontext *context.RuntimeContext, sql string) ([]TaskHistory, error) {
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s/v1/sql", rtcontext.HttpEndpoint()), strings.NewReader(sql))
+	if err != nil {
+		return nil, fmt.Errorf("error creating SQL request: %w", err)
+	}
+
+	headers := rtcontext.GetHeaders()
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+	request.Header.Set("Content-Type", "text/plain")
+	request.Header.Set("Accept", "Application/json")
+
+	response, err := rtcontext.Client().Do(request)
+
+	if err != nil {
+		return nil, fmt.Errorf("error sending SQL request: %w", err)
+	}
+	raw, err := io.ReadAll(response.Body)
+	if err != nil {
+		return []TaskHistory{}, fmt.Errorf("error reading response from spiced: %w", err)
+	}
+	if len(raw) == 0 {
+		return []TaskHistory{}, nil
+	}
+
+	traces := make([]TaskHistory, 0)
+
+	if err := json.Unmarshal([]byte(raw), &traces); err != nil {
+		return []TaskHistory{}, fmt.Errorf("error parsing response from spiced: %w", err)
+	}
+	return traces, nil
+}
+
+// TaskHistory represents a record in the `runtime.task_history` table.
+type TaskHistory struct {
+	TraceID        string  `json:"trace_id"`
+	SpanID         string  `json:"span_id"`
+	ParentSpanID   *string `json:"parent_span_id,omitempty"`
+	Task           string  `json:"task"`
+	Input          string  `json:"input"`
+	CapturedOutput *string `json:"captured_output,omitempty"`
+	// StartTime           time.Time         `json:"start_time"`
+	// EndTime             time.Time         `json:"end_time"`
+	ExecutionDurationMs float64           `json:"execution_duration_ms"`
+	ErrorMessage        *string           `json:"error_message,omitempty"`
+	Labels              map[string]string `json:"labels"`
+}

--- a/bin/spice/pkg/taskhistory/taskhistory.go
+++ b/bin/spice/pkg/taskhistory/taskhistory.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 )
@@ -62,15 +63,36 @@ func SqlRequestToTraces(rtcontext *context.RuntimeContext, sql string) ([]TaskHi
 
 // TaskHistory represents a record in the `runtime.task_history` table.
 type TaskHistory struct {
-	TraceID        string  `json:"trace_id"`
-	SpanID         string  `json:"span_id"`
-	ParentSpanID   *string `json:"parent_span_id,omitempty"`
-	Task           string  `json:"task"`
-	Input          string  `json:"input"`
-	CapturedOutput *string `json:"captured_output,omitempty"`
-	// StartTime           time.Time         `json:"start_time"`
-	// EndTime             time.Time         `json:"end_time"`
-	ExecutionDurationMs float64           `json:"execution_duration_ms"`
-	ErrorMessage        *string           `json:"error_message,omitempty"`
-	Labels              map[string]string `json:"labels"`
+	TraceID             string               `json:"trace_id"`
+	SpanID              string               `json:"span_id"`
+	ParentSpanID        *string              `json:"parent_span_id,omitempty"`
+	Task                string               `json:"task"`
+	Input               string               `json:"input"`
+	CapturedOutput      *string              `json:"captured_output,omitempty"`
+	StartTime           TimeWithMilliSeconds `json:"start_time"`
+	EndTime             TimeWithMilliSeconds `json:"end_time"`
+	ExecutionDurationMs float64              `json:"execution_duration_ms"`
+	ErrorMessage        *string              `json:"error_message,omitempty"`
+	Labels              map[string]string    `json:"labels"`
+}
+
+type TimeWithMilliSeconds time.Time
+
+func (tMs *TimeWithMilliSeconds) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	s = s[1 : len(s)-1]
+
+	layout := "2006-01-02T15:04:05.999999"
+
+	t, err := time.Parse(layout, s)
+	if err != nil {
+		return err
+	}
+
+	*tMs = TimeWithMilliSeconds(t)
+	return nil
+}
+
+func (tMs TimeWithMilliSeconds) asTime() time.Time {
+	return time.Time(tMs)
 }

--- a/bin/spice/pkg/taskhistory/tree.go
+++ b/bin/spice/pkg/taskhistory/tree.go
@@ -61,7 +61,7 @@ func sortTree(node *TreeNode) {
 		return
 	}
 	sort.Slice(node.Children, func(i, j int) bool {
-		return node.Children[i].TaskHistory.SpanID < node.Children[j].TaskHistory.SpanID
+		return node.Children[i].TaskHistory.StartTime.asTime().Before(node.Children[j].TaskHistory.StartTime.asTime())
 	})
 	for _, child := range node.Children {
 		sortTree(child)

--- a/bin/spice/pkg/taskhistory/tree.go
+++ b/bin/spice/pkg/taskhistory/tree.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskhistory
+
+import (
+	"sort"
+)
+
+// TreeNode represents a node in the trace tree.
+type TreeNode struct {
+	TaskHistory TaskHistory
+	Children    []*TreeNode
+}
+
+// buildTraceTree constructs a hierarchical tree from a list of TaskHistory entries.
+func buildTraceTree(tasks []TaskHistory) *TreeNode {
+	// Create a lookup map for SpanID -> Node
+	nodeMap := make(map[string]*TreeNode)
+
+	// Populate the node map
+	for _, task := range tasks {
+		nodeMap[task.SpanID] = &TreeNode{TaskHistory: task}
+	}
+
+	// Identify the root and assign children
+	var root *TreeNode
+	for _, node := range nodeMap {
+		if node.TaskHistory.ParentSpanID != nil {
+			// Find the parent node and attach as a child
+			if parent, exists := nodeMap[*node.TaskHistory.ParentSpanID]; exists {
+				parent.Children = append(parent.Children, node)
+			}
+		} else {
+			// Root node (no parent)
+			root = node
+		}
+	}
+
+	// Sort children by SpanID for a consistent order
+	sortTree(root)
+	return root
+}
+
+// sortTree sorts the tree nodes recursively by SpanID
+func sortTree(node *TreeNode) {
+	if node == nil {
+		return
+	}
+	sort.Slice(node.Children, func(i, j int) bool {
+		return node.Children[i].TaskHistory.SpanID < node.Children[j].TaskHistory.SpanID
+	})
+	for _, child := range node.Children {
+		sortTree(child)
+	}
+}


### PR DESCRIPTION
# 🗣 Description
- New CLI command
```shell
>> spice trace chat --last
[61cc6bd0e571c783] ( 2593.77ms) ai_chat
  ├── [69362c30f238076f] (    0.36ms) tool_use::get_readiness
  ├── [b6b17f1a9a6b86dc] (  982.21ms) ai_completion
  ├── [c30d692c6c41c5ee] (    0.06ms) tool_use::list_datasets
  └── [ce18756d5fef0df0] ( 1605.12ms) ai_completion

>> spice trace chat --trace-id 61cc6bd0e571c783 

>> spice trace chat --id chatcmpl-AvXwmPSV1PMyGBi9dLfkEQTZPjhqz
```

- Add an `id` label to `ai_chat` task (from the `.id` in the response).

## 📄 Documentation Updates
 - [ ] Update https://spiceai.org/docs/cli/reference.