### PR TITLE
Improve UX of downloading GGUF from HF

### DIFF
--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -304,38 +304,38 @@ impl MistralLlama {
     ) -> Result<Self> {
         let model_parts: Vec<&str> = model_id.split(':').collect();
 
-        let loader: Result<Box<dyn Loader>> = match gguf_filename {
-            // Loading the GGUF directly (as if it is a quantized model, although it need not be quantized).
-            Some(gguf) => Ok(GGUFLoaderBuilder::new(
+        // Loading the GGUF directly (as if it is a quantized model, although it need not be quantized).
+        let loader: Result<Box<dyn Loader>> = if let Some(gguf) = gguf_filename {
+            Ok(GGUFLoaderBuilder::new(
                 None,
                 None,
                 model_parts[0].to_string(),
                 vec![gguf.to_string_lossy().to_string()],
                 GGUFSpecificConfig::default(),
             )
-            .build()),
-            None => {
-                // Hardcoded model architecture can ensure correct loading type.
-                // If not provided, it will be inferred (generally from `.model_type` in a downloaded `config.json`)
-                let loader_type = arch
-                    .map(|a| {
-                        mistralrs::NormalLoaderType::from_str(a)
-                            .map_err(|e| ChatError::UnsupportedModelType { source: e.into() })
-                    })
-                    .transpose()?;
+            .build())
+        } else {
+            // Hardcoded model architecture can ensure correct loading type.
+            // If not provided, it will be inferred (generally from `.model_type` in a downloaded `config.json`)
+            let loader_type = arch
+                .map(|a| {
+                    mistralrs::NormalLoaderType::from_str(a)
+                        .map_err(|e| ChatError::UnsupportedModelType { source: e.into() })
+                })
+                .transpose()?;
 
-                let builder = NormalLoaderBuilder::new(
-                    mistralrs::NormalSpecificConfig::default(),
-                    None,
-                    None,
-                    Some(model_parts[0].to_string()),
-                );
+            let builder = NormalLoaderBuilder::new(
+                mistralrs::NormalSpecificConfig::default(),
+                None,
+                None,
+                Some(model_parts[0].to_string()),
+            );
 
-                builder
-                    .build(loader_type)
-                    .map_err(|e| ChatError::FailedToLoadModel { source: e.into() })
-            }
+            builder
+                .build(loader_type)
+                .map_err(|e| ChatError::FailedToLoadModel { source: e.into() })
         };
+
         let device = Self::get_device();
         let token_source = hf_token_literal.map_or(TokenSource::CacheToken, |secret| {
             tracing::info!("Explicitly given a Huggingface token. Using instead of any system defaults (if any).");

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -300,11 +300,11 @@ impl MistralLlama {
         model_id: &str,
         arch: Option<&str>,
         hf_token_literal: Option<&Secret<String>>,
-        quantized_gguf_filename: Option<PathBuf>,
+        gguf_filename: Option<PathBuf>,
     ) -> Result<Self> {
         let model_parts: Vec<&str> = model_id.split(':').collect();
 
-        let loader: Result<Box<dyn Loader>> = match quantized_gguf_filename {
+        let loader: Result<Box<dyn Loader>> = match gguf_filename {
             // Loading the GGUF directly (as if it is a quantized model, although it need not be quantized).
             Some(gguf) => Ok(GGUFLoaderBuilder::new(
                 None,

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -34,7 +34,7 @@ use futures::{Stream, TryStreamExt};
 use mistralrs::{
     AutoDeviceMapParams, ChatCompletionChunkResponse, ChatCompletionResponse, ChunkChoice,
     Constraint, Device, DeviceMapSetting, Function, GGMLLoaderBuilder, GGMLSpecificConfig,
-    GGUFLoaderBuilder, GGUFSpecificConfig, LocalModelPaths, MistralRs, MistralRsBuilder,
+    GGUFLoaderBuilder, GGUFSpecificConfig, Loader, LocalModelPaths, MistralRs, MistralRsBuilder,
     ModelDType, ModelPaths, NormalLoaderBuilder, NormalRequest, Pipeline,
     Request as MistralRequest, RequestMessage, Response as MistralResponse, SamplingParams,
     TokenSource, Tool, ToolCallResponse, ToolChoice, ToolType,
@@ -300,32 +300,49 @@ impl MistralLlama {
         model_id: &str,
         arch: Option<&str>,
         hf_token_literal: Option<&Secret<String>>,
+        quantized_gguf_filename: Option<PathBuf>,
     ) -> Result<Self> {
         let model_parts: Vec<&str> = model_id.split(':').collect();
 
-        // Hardcoded model architecture can ensure correct loading type.
-        // If not provided, it will be inferred (generally from `.model_type` in a downloaded `config.json`)
-        let loader_type = arch
-            .map(|a| {
-                mistralrs::NormalLoaderType::from_str(a)
-                    .map_err(|e| ChatError::UnsupportedModelType { source: e.into() })
-            })
-            .transpose()?;
+        let loader: Result<Box<dyn Loader>> = match quantized_gguf_filename {
+            // Loading the GGUF directly (as if it is a quantized model, although it need not be quantized).
+            Some(gguf) => Ok(GGUFLoaderBuilder::new(
+                None,
+                None,
+                model_parts[0].to_string(),
+                vec![gguf.to_string_lossy().to_string()],
+                GGUFSpecificConfig::default(),
+            )
+            .build()),
+            None => {
+                // Hardcoded model architecture can ensure correct loading type.
+                // If not provided, it will be inferred (generally from `.model_type` in a downloaded `config.json`)
+                let loader_type = arch
+                    .map(|a| {
+                        mistralrs::NormalLoaderType::from_str(a)
+                            .map_err(|e| ChatError::UnsupportedModelType { source: e.into() })
+                    })
+                    .transpose()?;
 
-        let builder = NormalLoaderBuilder::new(
-            mistralrs::NormalSpecificConfig::default(),
-            None,
-            None,
-            Some(model_parts[0].to_string()),
-        );
+                let builder = NormalLoaderBuilder::new(
+                    mistralrs::NormalSpecificConfig::default(),
+                    None,
+                    None,
+                    Some(model_parts[0].to_string()),
+                );
+
+                builder
+                    .build(loader_type)
+                    .map_err(|e| ChatError::FailedToLoadModel { source: e.into() })
+            }
+        };
         let device = Self::get_device();
         let token_source = hf_token_literal.map_or(TokenSource::CacheToken, |secret| {
+            tracing::info!("Explicitly given a Huggingface token. Using instead of any system defaults (if any).");
             TokenSource::Literal(secret.expose_secret().clone())
         });
 
-        let pipeline = builder
-            .build(loader_type)
-            .map_err(|e| ChatError::FailedToLoadModel { source: e.into() })?
+        let pipeline = loader?
             .load_model_from_hf(
                 model_parts.get(1).map(|&x| x.to_string()),
                 token_source,

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -338,7 +338,7 @@ impl MistralLlama {
 
         let device = Self::get_device();
         let token_source = hf_token_literal.map_or(TokenSource::CacheToken, |secret| {
-            tracing::info!("Explicitly given a Huggingface token. Using instead of any system defaults (if any).");
+            tracing::debug!("A HuggingFace token was specified in parameters. The specified token will be used instead of any system/environment defaults.");
             TokenSource::Literal(secret.expose_secret().clone())
         });
 

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -66,6 +66,7 @@ pub(crate) fn create_hf(model_id: &str) -> Result<Arc<Box<dyn Chat>>, ChatError>
     Ok(Arc::new(create_hf_model(
         model_id,
         None,
+        None,
         std::env::var("HF_TOKEN").ok().map(Secret::new).as_ref(),
     )?))
 }

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -61,7 +61,7 @@ pub async fn try_to_chat_model(
     params: &HashMap<String, SecretString>,
     rt: Arc<Runtime>,
 ) -> Result<Box<dyn Chat>, LlmError> {
-    let model = construct_model(component, params).await?;
+    let model = construct_model(component, params)?;
 
     // Handle tool usage
     let spice_tool_opt: Option<SpiceToolsOptions> = extract_secret!(params, "tools")
@@ -93,7 +93,7 @@ pub async fn try_to_chat_model(
     Ok(tool_model)
 }
 
-pub async fn construct_model(
+pub fn construct_model(
     component: &spicepod::component::model::Model,
     params: &HashMap<String, SecretString>,
 ) -> Result<Box<dyn Chat>, LlmError> {
@@ -103,7 +103,7 @@ pub async fn construct_model(
     })?;
 
     let model = match prefix {
-        ModelSource::HuggingFace => huggingface(model_id, component, params).await,
+        ModelSource::HuggingFace => huggingface(model_id, component, params),
         ModelSource::File => file(component, params),
         ModelSource::Anthropic => anthropic(model_id.as_deref(), params),
         ModelSource::Azure => azure(model_id, component.name.as_str(), params),
@@ -168,7 +168,7 @@ fn anthropic(
     Ok(Box::new(anthropic) as Box<dyn Chat>)
 }
 
-async fn huggingface(
+fn huggingface(
     model_id: Option<String>,
     component: &spicepod::component::model::Model,
     params: &HashMap<String, SecretString>,

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -195,16 +195,14 @@ async fn huggingface(
             None
         });
 
-    if let Some(path) = gguf_path {
+    if let Some(ref path) = gguf_path {
         tracing::debug!(
             "For Huggingface model {}, the GGUF model {} will be downloaded and used.",
             component.name,
             path.display()
         );
-        return llms::chat::create_hf_w_gguf(id.as_str(), path.as_path(), hf_token).await;
-    }
-
-    llms::chat::create_hf_model(&id, model_type, hf_token)
+    };
+    llms::chat::create_hf_model(&id, model_type, gguf_path, hf_token)
 }
 
 fn openai(

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -425,6 +425,7 @@ async fn huggingface_test_chat_messages() -> Result<(), anyhow::Error> {
         let model = Arc::new(create_hf_model(
             HF_TEST_MODEL,
         Some(HF_TEST_MODEL_TYPE),
+        None,
             None,
         )?);
 


### PR DESCRIPTION
# 🗣 Description
 - Add progress bar to `spiced` output when downloading GGUF model from HF. This requires loading GGUF HF models in the similar manner as other HF models (currently we load in a entirely separate function). 
 - Also add log for when we have an explicit HF token provided by user.