### PR TITLE
Remove 'tools: builtin'

### DIFF
--- a/crates/runtime/src/tools/builtin/catalog.rs
+++ b/crates/runtime/src/tools/builtin/catalog.rs
@@ -114,6 +114,6 @@ impl SpiceToolCatalog for BuiltinToolCatalog {
     }
 
     fn name(&self) -> &'static str {
-        "builtin"
+        "auto"
     }
 }

--- a/crates/runtime/src/tools/options.rs
+++ b/crates/runtime/src/tools/options.rs
@@ -74,7 +74,6 @@ impl SpiceToolsOptions {
                 // Handle nested groupings. e.g: `spiced_tools: nsql, my_other_tool`.
                 .flat_map(|s| match s.parse() {
                     Ok(SpiceToolsOptions::Nsql) => SpiceToolsOptions::Nsql.tools_by_name(),
-                    Ok(SpiceToolsOptions::Auto) => SpiceToolsOptions::Auto.tools_by_name(),
                     _ => vec![s.as_str()],
                 })
                 .unique()


### PR DESCRIPTION
# 🗣 Description
 - Builtin tools, as a group are now called `auto`.
 - Remove edge case where we handled `auto`. 
 - The result of the above is that  'tools: builtin' is no longer valid. 

## ⛓️‍💥 Breaking Change

* [x] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates
 - https://github.com/spiceai/docs/pull/829 