### PR TITLE
Improve the UX of using huggingface models & embeddings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11136,6 +11136,7 @@ name = "spicepod"
 version = "1.1.0"
 dependencies = [
  "fundu",
+ "regex",
  "schemars",
  "serde",
  "serde-value",

--- a/crates/model_components/src/modelsource/huggingface.rs
+++ b/crates/model_components/src/modelsource/huggingface.rs
@@ -17,39 +17,12 @@ limitations under the License.
 use super::Error;
 use super::ModelSource;
 use async_trait::async_trait;
-use regex::Regex;
 use secrecy::{ExposeSecret, Secret, SecretString};
 use snafu::prelude::*;
+use spicepod::component::model::HUGGINGFACE_PATH_REGEX;
 use std::collections::HashMap;
 use std::io::Cursor;
-use std::sync::{Arc, LazyLock};
-
-// Matches model paths in these formats:
-// - organization/model-name
-// - organization/model-name:revision
-// - huggingface:organization/model-name
-// - hf:organization/model-name
-// - huggingface:organization/model-name:revision
-// - hf:organization/model-name:revision
-// - huggingface.co/organization/model-name
-// - huggingface.co/organization/model-name:revision
-// - huggingface:huggingface.co/organization/model-name
-// - hf:huggingface.co/organization/model-name
-//
-// Captures three named groups:
-// - org: Organization name (allows word chars and hyphens)
-// - model: Model name (allows word chars, hyphens, and dots)
-// - revision: Optional revision/version (allows word chars, digits, hyphens, and dots)
-static HUGGINGFACE_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    match Regex::new(
-        r"\A(?:(?:huggingface|hf):)?(huggingface\.co\/)?(?<org>[\w\-]+)\/(?<model>[\w\-\.]+)(:(?<revision>[\w\d\-\.]+))?\z",
-    ) {
-        Ok(regex) => regex,
-        Err(e) => {
-            panic!("Regex is invalid: {e}");
-        }
-    }
-});
+use std::sync::Arc;
 
 pub struct Huggingface {}
 
@@ -168,138 +141,5 @@ impl ModelSource for Huggingface {
         }
 
         Ok(onnx_file_name)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_huggingface_path_regex() {
-        let test_cases = vec![
-            // Basic format
-            (
-                "organization/model-name",
-                ("organization", "model-name", ""),
-            ),
-            // With revision
-            (
-                "organization/model-name:v1.0",
-                ("organization", "model-name", "v1.0"),
-            ),
-            // With huggingface: prefix
-            (
-                "huggingface:organization/model-name",
-                ("organization", "model-name", ""),
-            ),
-            // With hf: prefix
-            (
-                "hf:organization/model-name",
-                ("organization", "model-name", ""),
-            ),
-            // With huggingface: prefix and revision
-            (
-                "huggingface:organization/model-name:v1.0",
-                ("organization", "model-name", "v1.0"),
-            ),
-            // With hf: prefix and revision
-            (
-                "hf:organization/model-name:v1.0",
-                ("organization", "model-name", "v1.0"),
-            ),
-            // With huggingface.co domain
-            (
-                "huggingface.co/organization/model-name",
-                ("organization", "model-name", ""),
-            ),
-            // With huggingface.co domain and revision
-            (
-                "huggingface.co/organization/model-name:v1.0",
-                ("organization", "model-name", "v1.0"),
-            ),
-            // With huggingface: prefix and huggingface.co domain
-            (
-                "huggingface:huggingface.co/organization/model-name",
-                ("organization", "model-name", ""),
-            ),
-            // With hf: prefix and huggingface.co domain
-            (
-                "hf:huggingface.co/organization/model-name",
-                ("organization", "model-name", ""),
-            ),
-            // With huggingface: prefix, huggingface.co domain, and revision
-            (
-                "huggingface:huggingface.co/organization/model-name:v1.0",
-                ("organization", "model-name", "v1.0"),
-            ),
-            // With hf: prefix, huggingface.co domain, and revision
-            (
-                "hf:huggingface.co/organization/model-name:v1.0",
-                ("organization", "model-name", "v1.0"),
-            ),
-            // Test hyphens in organization name
-            ("my-org/model-name", ("my-org", "model-name", "")),
-            // Test hyphens and dots in model name
-            (
-                "organization/my-model.v2",
-                ("organization", "my-model.v2", ""),
-            ),
-            // Test complex revision with hyphens, dots, and numbers
-            (
-                "organization/model-name:v1.2-beta.3",
-                ("organization", "model-name", "v1.2-beta.3"),
-            ),
-            // Test 'latest' revision (handled in code)
-            (
-                "organization/model-name:latest",
-                ("organization", "model-name", "latest"),
-            ),
-        ];
-
-        for (input, expected) in test_cases {
-            let caps = HUGGINGFACE_PATH_REGEX
-                .captures(input)
-                .unwrap_or_else(|| panic!("Failed to match valid input: {input}"));
-
-            assert_eq!(&caps["org"], expected.0, "org mismatch for input: {input}");
-            assert_eq!(
-                &caps["model"], expected.1,
-                "model mismatch for input: {input}"
-            );
-
-            let revision = caps.name("revision").map_or("", |m| m.as_str());
-            assert_eq!(revision, expected.2, "revision mismatch for input: {input}");
-        }
-    }
-
-    #[test]
-    fn test_invalid_huggingface_paths() {
-        let invalid_paths = vec![
-            "",                   // Empty string
-            "invalid",            // No slash
-            "/",                  // Just a slash
-            "org/",               // Missing model name
-            "/model",             // Missing organization
-            "org/model:",         // Empty revision
-            "org/model::",        // Double colon
-            "huggingface:",       // Missing path
-            "hf:",                // Missing path
-            "huggingface:/",      // Invalid path
-            "hf:/",               // Invalid path
-            "huggingface.co",     // Missing path
-            "huggingface.co/",    // Missing org and model
-            "org/model/extra",    // Extra path component
-            "@org/model",         // Invalid character in org
-            "org/@model",         // Invalid character in model
-            "org/model:@version", // Invalid character in revision
-        ];
-
-        for path in invalid_paths {
-            assert!(
-                HUGGINGFACE_PATH_REGEX.captures(path).is_none(),
-                "Should not match invalid path: {path}"
-            );
-        }
     }
 }

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -9,6 +9,7 @@ version.workspace = true
 
 [dependencies]
 fundu.workspace = true
+regex.workspace = true
 schemars = { version = "0.8.19", optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde-value = "0.7.0"

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, fmt::Display, path::Path, sync::LazyLock};
 use regex::Regex;
+use std::{collections::HashMap, fmt::Display, path::Path, sync::LazyLock};
 
 use super::{Nameable, WithDependsOn};
 #[cfg(feature = "schemars")]
@@ -492,7 +492,6 @@ pub(crate) fn is_llm_file(p: &Path) -> bool {
         || extension == "safetensors"
         || filename == "pytorch_model.bin"
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, fmt::Display, path::Path};
+use std::{collections::HashMap, fmt::Display, path::Path, sync::LazyLock};
+use regex::Regex;
 
 use super::{Nameable, WithDependsOn};
 #[cfg(feature = "schemars")]
@@ -83,12 +84,39 @@ pub enum ModelSource {
     File,
 }
 
+// Matches model paths in these formats:
+// - organization/model-name
+// - organization/model-name:revision
+// - huggingface:organization/model-name
+// - hf:organization/model-name
+// - huggingface:organization/model-name:revision
+// - hf:organization/model-name:revision
+// - huggingface.co/organization/model-name
+// - huggingface.co/organization/model-name:revision
+// - huggingface:huggingface.co/organization/model-name
+// - hf:huggingface.co/organization/model-name
+//
+// Captures three named groups:
+// - org: Organization name (allows word chars and hyphens)
+// - model: Model name (allows word chars, hyphens, and dots)
+// - revision: Optional revision/version (allows word chars, digits, hyphens, and dots)
+pub static HUGGINGFACE_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    match Regex::new(
+        r"\A(?:(?:huggingface|hf):)?(huggingface\.co\/)?(?<org>[\w\-]+)\/(?<model>[\w\-\.]+)(:(?<revision>[\w\d\-\.]+))?\z",
+    ) {
+        Ok(regex) => regex,
+        Err(_) => {
+            unreachable!("Regex is checked at compile time");
+        }
+    }
+});
+
 /// Implement the [`TryFrom<&str>`] trait for [`ModelSource`]. Should be the inverse of [`ModelSource`]'s [`Display`].
 impl TryFrom<&str> for ModelSource {
     type Error = &'static str;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        if value.starts_with("huggingface:huggingface.co") {
+        if value.starts_with("huggingface") || value.starts_with("hf") {
             Ok(ModelSource::HuggingFace)
         } else if value.starts_with("file") {
             Ok(ModelSource::File)
@@ -116,7 +144,7 @@ impl Display for ModelSource {
             ModelSource::Azure => write!(f, "azure"),
             ModelSource::Xai => write!(f, "xai"),
             ModelSource::Anthropic => write!(f, "anthropic"),
-            ModelSource::HuggingFace => write!(f, "huggingface:huggingface.co"),
+            ModelSource::HuggingFace => write!(f, "huggingface"),
             ModelSource::File => write!(f, "file"),
             ModelSource::SpiceAI => write!(f, "spiceai"),
         }
@@ -129,6 +157,7 @@ pub enum ModelType {
     Llm,
     Ml,
 }
+
 impl Display for ModelType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -256,6 +285,16 @@ impl Model {
     #[must_use]
     pub fn get_model_id(&self) -> Option<String> {
         match self.get_source() {
+            Some(ModelSource::HuggingFace) => {
+                HUGGINGFACE_PATH_REGEX.captures(&self.from).map(|caps| {
+                    let model = format!("{}/{}", &caps["org"], &caps["model"]);
+                    if let Some(revision) = caps.name("revision") {
+                        format!("{}:{}", model, revision.as_str())
+                    } else {
+                        model
+                    }
+                })
+            }
             Some(p) => {
                 let from = &self.from;
                 if let Some(stripped) = from.strip_prefix(&format!("{p}:")) {
@@ -452,4 +491,138 @@ pub(crate) fn is_llm_file(p: &Path) -> bool {
         || extension == "ggml"
         || extension == "safetensors"
         || filename == "pytorch_model.bin"
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_huggingface_path_regex() {
+        let test_cases = vec![
+            // Basic format
+            (
+                "organization/model-name",
+                ("organization", "model-name", ""),
+            ),
+            // With revision
+            (
+                "organization/model-name:v1.0",
+                ("organization", "model-name", "v1.0"),
+            ),
+            // With huggingface: prefix
+            (
+                "huggingface:organization/model-name",
+                ("organization", "model-name", ""),
+            ),
+            // With hf: prefix
+            (
+                "hf:organization/model-name",
+                ("organization", "model-name", ""),
+            ),
+            // With huggingface: prefix and revision
+            (
+                "huggingface:organization/model-name:v1.0",
+                ("organization", "model-name", "v1.0"),
+            ),
+            // With hf: prefix and revision
+            (
+                "hf:organization/model-name:v1.0",
+                ("organization", "model-name", "v1.0"),
+            ),
+            // With huggingface.co domain
+            (
+                "huggingface.co/organization/model-name",
+                ("organization", "model-name", ""),
+            ),
+            // With huggingface.co domain and revision
+            (
+                "huggingface.co/organization/model-name:v1.0",
+                ("organization", "model-name", "v1.0"),
+            ),
+            // With huggingface: prefix and huggingface.co domain
+            (
+                "huggingface:huggingface.co/organization/model-name",
+                ("organization", "model-name", ""),
+            ),
+            // With hf: prefix and huggingface.co domain
+            (
+                "hf:huggingface.co/organization/model-name",
+                ("organization", "model-name", ""),
+            ),
+            // With huggingface: prefix, huggingface.co domain, and revision
+            (
+                "huggingface:huggingface.co/organization/model-name:v1.0",
+                ("organization", "model-name", "v1.0"),
+            ),
+            // With hf: prefix, huggingface.co domain, and revision
+            (
+                "hf:huggingface.co/organization/model-name:v1.0",
+                ("organization", "model-name", "v1.0"),
+            ),
+            // Test hyphens in organization name
+            ("my-org/model-name", ("my-org", "model-name", "")),
+            // Test hyphens and dots in model name
+            (
+                "organization/my-model.v2",
+                ("organization", "my-model.v2", ""),
+            ),
+            // Test complex revision with hyphens, dots, and numbers
+            (
+                "organization/model-name:v1.2-beta.3",
+                ("organization", "model-name", "v1.2-beta.3"),
+            ),
+            // Test 'latest' revision (handled in code)
+            (
+                "organization/model-name:latest",
+                ("organization", "model-name", "latest"),
+            ),
+        ];
+
+        for (input, expected) in test_cases {
+            let caps = HUGGINGFACE_PATH_REGEX
+                .captures(input)
+                .unwrap_or_else(|| panic!("Failed to match valid input: {input}"));
+
+            assert_eq!(&caps["org"], expected.0, "org mismatch for input: {input}");
+            assert_eq!(
+                &caps["model"], expected.1,
+                "model mismatch for input: {input}"
+            );
+
+            let revision = caps.name("revision").map_or("", |m| m.as_str());
+            assert_eq!(revision, expected.2, "revision mismatch for input: {input}");
+        }
+    }
+
+    #[test]
+    fn test_invalid_huggingface_paths() {
+        let invalid_paths = vec![
+            "",                   // Empty string
+            "invalid",            // No slash
+            "/",                  // Just a slash
+            "org/",               // Missing model name
+            "/model",             // Missing organization
+            "org/model:",         // Empty revision
+            "org/model::",        // Double colon
+            "huggingface:",       // Missing path
+            "hf:",                // Missing path
+            "huggingface:/",      // Invalid path
+            "hf:/",               // Invalid path
+            "huggingface.co",     // Missing path
+            "huggingface.co/",    // Missing org and model
+            "org/model/extra",    // Extra path component
+            "@org/model",         // Invalid character in org
+            "org/@model",         // Invalid character in model
+            "org/model:@version", // Invalid character in revision
+        ];
+
+        for path in invalid_paths {
+            assert!(
+                HUGGINGFACE_PATH_REGEX.captures(path).is_none(),
+                "Should not match invalid path: {path}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
# 🗣 Description

This is a follow-on PR to #4451 that actually applies the correct regex to allow the expanded huggingface identifiers. The previous PR only applied it to traditional ML models, not LLMs or embeddings. This PR consolidates the regex in the `spicepod` crate and reuses it in all of the places it needs to be.

