### PR TITLE
Change /v1/models to be OpenAI compatible

### DIFF
--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -135,21 +135,21 @@ spice chat --model <model> --cloud
 			os.Exit(1)
 		}
 		if model == "" {
-			models, err := api.GetData[api.Model](rtcontext, "/v1/models?status=true")
+			models, err := api.GetDataSingle[api.ModelResponse](rtcontext, "/v1/models?status=true")
 			if err != nil {
 				slog.Error("could not list models", "error", err)
 				os.Exit(1)
 			}
 
-			if len(models) == 0 {
+			if len(models.Data) == 0 {
 				slog.Error("No models found")
 				os.Exit(1)
 			}
 
 			availableModels := []string{}
-			for _, model := range models {
+			for _, model := range models.Data {
 				if model.Status == "Ready" {
-					availableModels = append(availableModels, model.Name)
+					availableModels = append(availableModels, model.Id)
 				}
 			}
 

--- a/bin/spice/cmd/models.go
+++ b/bin/spice/cmd/models.go
@@ -47,14 +47,14 @@ spice models
 			slog.Error("getting component statuses", "error", err)
 		}
 
-		models, err := api.GetData[api.Model](rtcontext, "/v1/models?status=true")
+		models, err := api.GetDataSingle[api.ModelResponse](rtcontext, "/v1/models?status=true")
 		if err != nil {
 			slog.Error("listing spiced models", "error", err)
 		}
 
-		table := make([]interface{}, len(models))
-		for i, model := range models {
-			statusEnum, exists := model_statuses[model.Name]
+		table := make([]interface{}, len(models.Data))
+		for i, model := range models.Data {
+			statusEnum, exists := model_statuses[model.Id]
 			if exists {
 				model.Status = statusEnum.String()
 			}

--- a/bin/spice/cmd/nsql.go
+++ b/bin/spice/cmd/nsql.go
@@ -93,21 +93,21 @@ nsql> How much money have I made in each country?
 			os.Exit(1)
 		}
 		if model == "" {
-			models, err := api.GetData[api.Model](rtcontext, "/v1/models?status=true")
+			models, err := api.GetDataSingle[api.ModelResponse](rtcontext, "/v1/models?status=true")
 			if err != nil {
 				slog.Error("listing spiced models", "error", err)
 				os.Exit(1)
 			}
-			if len(models) == 0 {
+			if len(models.Data) == 0 {
 				slog.Error("no models found")
 				os.Exit(1)
 			}
 
 			modelsSelection := []string{}
-			selectedModel := models[0].Name
-			if len(models) > 1 {
-				for _, model := range models {
-					modelsSelection = append(modelsSelection, model.Name)
+			selectedModel := models.Data[0].Id
+			if len(models.Data) > 1 {
+				for _, model := range models.Data {
+					modelsSelection = append(modelsSelection, model.Id)
 				}
 
 				prompt := promptui.Select{

--- a/bin/spice/pkg/api/model.go
+++ b/bin/spice/pkg/api/model.go
@@ -17,7 +17,13 @@ limitations under the License.
 package api
 
 type Model struct {
-	Name   string `json:"name,omitempty" csv:"name" yaml:"name,omitempty"`
-	From   string `json:"from,omitempty" csv:"from" yaml:"from,omitempty"`
-	Status string `json:"status,omitempty" csv:"status,omitempty" yaml:"status,omitempty"`
+	Id      string `json:"id,omitempty" csv:"id" yaml:"id,omitempty"`
+	Object  string `json:"object,omitempty" csv:"object" yaml:"object,omitempty"`
+	OwnedBy string `json:"owned_by,omitempty" csv:"owned_by" yaml:"owned_by,omitempty"`
+	Status  string `json:"status,omitempty" csv:"status,omitempty" yaml:"status,omitempty"`
+}
+
+type ModelResponse struct {
+	Object string  `json:"object,omitempty" csv:"object" yaml:"object,omitempty"`
+	Data   []Model `json:"data,omitempty" csv:"data" yaml:"data,omitempty"`
 }

--- a/bin/spice/pkg/api/util.go
+++ b/bin/spice/pkg/api/util.go
@@ -97,6 +97,14 @@ func GetData[T interface{}](rtcontext *context.RuntimeContext, path string) ([]T
 	return result, nil
 }
 
+func GetDataSingle[T interface{}](rtcontext *context.RuntimeContext, path string) (T, error) {
+	result, err := doRuntimeApiRequest[T](rtcontext, GET, path, nil)
+	if err != nil {
+		return *new(T), err
+	}
+	return result, nil
+}
+
 func PostRuntime[T interface{}](rtcontext *context.RuntimeContext, path string, body *string) (T, error) {
 	return doRuntimeApiRequest[T](rtcontext, POST, path, body)
 }


### PR DESCRIPTION
# 🗣 Description

Changes the response of the `/v1/models` endpoint to be OpenAI compatible.

Previous:

`curl http://localhost:8090/v1/models`
```json
[
  {
    "name": "llama",
    "from": "huggingface:huggingface.co/lmstudio-community/Llama-3-Groq-8B-Tool-Use-GGUF",
    "datasets": null,
    "status": null
  }
]
```

Current:

```json
{
  "object": "list",
  "data": [
    {
      "id": "llama",
      "object": "model",
      "owned_by": "huggingface:huggingface.co/lmstudio-community/Llama-3-Groq-8B-Tool-Use-GGUF",
      "datasets": null,
      "status": null
    }
  ]
}
```

## 🔨 Related Issues

Closes #4506

## ⛓️‍💥 Breaking Change

This changes the response of `/v1/models` as described above, to match the OpenAI specification.

* [x] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

The OpenAPI will need to be updated.

## 🤔 Concerns

N/A
