### PR TITLE
For local models, use 'content=""' instead of None

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "mistralrs"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
 dependencies = [
  "anyhow",
  "candle-core 0.8.0",
@@ -7175,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
 dependencies = [
  "akin",
  "anyhow",
@@ -7251,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.6",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
 dependencies = [
  "bindgen_cuda 0.1.5",
  "byteorder",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-vision"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
 dependencies = [
  "candle-core 0.8.0",
  "image 0.25.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "mistralrs"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
+source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
 dependencies = [
  "anyhow",
  "candle-core 0.8.0",
@@ -7175,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
+source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
 dependencies = [
  "akin",
  "anyhow",
@@ -7251,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
+source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.6",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
+source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
 dependencies = [
  "bindgen_cuda 0.1.5",
  "byteorder",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-vision"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=a17f391e1eeeea58340006f7e005f4559ba1fd14#a17f391e1eeeea58340006f7e005f4559ba1fd14"
+source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
 dependencies = [
  "candle-core 0.8.0",
  "image 0.25.5",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,8 +41,8 @@ text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "5
 pulldown-cmark = "0.12.1"
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "dc0807771716d7d9aeb65c9b2e2abced8a4a18b5" }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "dc0807771716d7d9aeb65c9b2e2abced8a4a18b5", package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "a17f391e1eeeea58340006f7e005f4559ba1fd14" }
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "a17f391e1eeeea58340006f7e005f4559ba1fd14", package = "mistralrs-core" }
 rand = "0.8.5"
 tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
     "candle",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,8 +41,8 @@ text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "5
 pulldown-cmark = "0.12.1"
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "a17f391e1eeeea58340006f7e005f4559ba1fd14" }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "a17f391e1eeeea58340006f7e005f4559ba1fd14", package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "b8f7eab30b7ef54ec30d24b8de14b1583a277039" }
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "b8f7eab30b7ef54ec30d24b8de14b1583a277039", package = "mistralrs-core" }
 rand = "0.8.5"
 tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
     "candle",

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -467,11 +467,6 @@ impl MistralLlama {
                     if c.finish_reason == "stop" && !c.message.tool_calls.is_empty() {
                         c.finish_reason = "tool_calls".to_string();
                     }
-
-                    if c.message.content.is_none() && !c.message.tool_calls.is_empty() {
-                        // Use Some(""), not None as it is more compatible with many open source `chat_template`s.
-                        c.message.content = Some("".to_string());
-                    }
                 });
 
                 Ok(resp)
@@ -712,8 +707,7 @@ fn chunk_choices_to_openai(choice: &ChunkChoice) -> Result<ChatChoiceStream, Ope
     Ok(ChatChoiceStream {
         index: *index as u32,
         delta: ChatCompletionStreamResponseDelta {
-            // Use Some(""), not None as it is more compatible with many open source `chat_template`s.
-            content: Some(delta.content.clone().unwrap_or_default()),
+            content: delta.content.clone(),
             function_call: None,
             tool_calls: delta.tool_calls.as_ref().map(|t| {
                 t.iter()

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -713,7 +713,7 @@ fn chunk_choices_to_openai(choice: &ChunkChoice) -> Result<ChatChoiceStream, Ope
         index: *index as u32,
         delta: ChatCompletionStreamResponseDelta {
             // Use Some(""), not None as it is more compatible with many open source `chat_template`s.
-            content: Some(delta.content.unwrap_or_default()),
+            content: Some(delta.content.clone().unwrap_or_default()),
             function_call: None,
             tool_calls: delta.tool_calls.as_ref().map(|t| {
                 t.iter()

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -467,7 +467,13 @@ impl MistralLlama {
                     if c.finish_reason == "stop" && !c.message.tool_calls.is_empty() {
                         c.finish_reason = "tool_calls".to_string();
                     }
+
+                    if c.message.content.is_none() && !c.message.tool_calls.is_empty() {
+                        // Use Some(""), not None as it is more compatible with many open source `chat_template`s.
+                        c.message.content = Some("".to_string());
+                    }
                 });
+
                 Ok(resp)
             }
             MistralResponse::ModelError(e, _) => Err(OpenAIError::ApiError(ApiError {
@@ -706,7 +712,8 @@ fn chunk_choices_to_openai(choice: &ChunkChoice) -> Result<ChatChoiceStream, Ope
     Ok(ChatChoiceStream {
         index: *index as u32,
         delta: ChatCompletionStreamResponseDelta {
-            content: delta.content.clone(),
+            // Use Some(""), not None as it is more compatible with many open source `chat_template`s.
+            content: Some(delta.content.unwrap_or_default()),
             function_call: None,
             tool_calls: delta.tool_calls.as_ref().map(|t| {
                 t.iter()

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -387,7 +387,10 @@ pub fn message_to_mistral(
                         Either::Left(json!(content_json).to_string()),
                     );
                 }
-                None => {}
+                None => {
+                    // Use Some(""), not None as it is more compatible with many open source `chat_template`s.
+                    map.insert("content".to_string(), Either::Left(String::new()));
+                }
             };
             if let Some(name) = name {
                 map.insert("name".to_string(), Either::Left(name.clone()));


### PR DESCRIPTION
# 🗣 Description
 - For local/HF models, pass an empty `content` string instead of None.
 - Log warning if user uses tools with a model (actually chat_template) that does not support them.

#### Example difference in payload sent to local/HF models
Current
```json
{
    "role": "assistant",
    "content": null,
    "tool_calls": [{
        "id": "call_u1oRSNIIV3B7hNwm7Od8qwQ9",
        "type": "function",
        "function": {
          "name": "get_current_weather",
          "arguments": "{\"location\":\"Boston, MA\"}"
        }
      }],
    "refusal": null
}
```

Now
```json
{
    "role": "assistant",
    "content": "",
    "tool_calls": [{
        "id": "call_u1oRSNIIV3B7hNwm7Od8qwQ9",
        "type": "function",
        "function": {
          "name": "get_current_weather",
          "arguments": "{\"location\":\"Boston, MA\"}"
        }
      }],
    "refusal": null
}
```
## 🔨 Related Issues
 - Found in this issue: https://github.com/spiceai/spiceai/issues/3936.

## Related PRs
 - https://github.com/spiceai/mistral.rs/pull/21
