### PR TITLE
Fix cuda::ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "mistralrs"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=80b548a61b103212d91fdfb6096ca5cd99a9c951#80b548a61b103212d91fdfb6096ca5cd99a9c951"
 dependencies = [
  "anyhow",
  "candle-core 0.8.0",
@@ -7175,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=80b548a61b103212d91fdfb6096ca5cd99a9c951#80b548a61b103212d91fdfb6096ca5cd99a9c951"
 dependencies = [
  "akin",
  "anyhow",
@@ -7251,7 +7251,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=80b548a61b103212d91fdfb6096ca5cd99a9c951#80b548a61b103212d91fdfb6096ca5cd99a9c951"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.6",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=80b548a61b103212d91fdfb6096ca5cd99a9c951#80b548a61b103212d91fdfb6096ca5cd99a9c951"
 dependencies = [
  "bindgen_cuda 0.1.5",
  "byteorder",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-vision"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=dc0807771716d7d9aeb65c9b2e2abced8a4a18b5#dc0807771716d7d9aeb65c9b2e2abced8a4a18b5"
+source = "git+https://github.com/spiceai/mistral.rs?rev=80b548a61b103212d91fdfb6096ca5cd99a9c951#80b548a61b103212d91fdfb6096ca5cd99a9c951"
 dependencies = [
  "candle-core 0.8.0",
  "image 0.25.5",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,8 +41,8 @@ text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "5
 pulldown-cmark = "0.12.1"
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "dc0807771716d7d9aeb65c9b2e2abced8a4a18b5" }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "dc0807771716d7d9aeb65c9b2e2abced8a4a18b5", package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "80b548a61b103212d91fdfb6096ca5cd99a9c951" }
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "80b548a61b103212d91fdfb6096ca5cd99a9c951", package = "mistralrs-core" }
 rand = "0.8.5"
 tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
     "candle",


### PR DESCRIPTION
# 🗣 Description
Fixes [CUDA build issue](https://github.com/spiceai/spiceai/actions/runs/13127107411/job/36625402042). 

```
error[E0432]: unresolved import `crate::cuda::ffi`
  --> /home/runner/.cargo/git/checkouts/mistral.rs-730c94e965981f8c/dc08077/mistralrs-core/src/ops.rs:12:5
   |
12 | use crate::cuda::ffi;
   |     ^^^^^^^^^^^^^^^^ no `ffi` in `cuda`
   |
help: consider importing one of these modules instead
   |
12 | use crate::llguidance::ffi;
   |     ~~~~~~~~~~~~~~~~~~~~~~
12 | use std::ffi;
   |     ~~~~~~~~
12 | use std::os::unix::ffi;
   |     ~~~~~~~~~~~~~~~~~~
12 | use core::ffi;
   |     ~~~~~~~~~
     and 1 other candidate

For more information about this error, try `rustc --explain E0432`.
error: could not compile `mistralrs-core` (lib) due to 1 previous error
```
## 🔨 Related Issues
 - https://github.com/spiceai/spiceai/actions/runs/13127698905/job/36627052528

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
