### PR TITLE
Update E2E installation tests to match model runtime version

### DIFF
--- a/.github/workflows/e2e_test_release_install.yml
+++ b/.github/workflows/e2e_test_release_install.yml
@@ -132,7 +132,8 @@ jobs:
         echo "CLI Version: $cli_version"
         echo "Runtime Version: $runtime_version"
 
-        if [ "$cli_version" != "$release_version" ]; then
+        # Release version contains '+models' suffix, so we need to add it to the cli_version for comparison
+        if [ "$cli_version+models" != "$release_version" ]; then
           echo "CLI version $cli_version does not match the latest release version $release_version."
           exit 1
         fi
@@ -163,9 +164,12 @@ jobs:
 
         $response = Invoke-WebRequest -Uri "https://api.github.com/repos/spiceai/spiceai/releases/latest" -UseBasicParsing -Headers $headers
         $releaseVersion = ($response.Content | ConvertFrom-Json).tag_name
+        # Append "+models" to the release version to match default runtime
+        $releaseVersion = "$releaseVersion+models"
         Write-Host "Release Version: $releaseVersion"
 
-        if ($cliVersion -ne $releaseVersion) {
+        # Release version contains '+models' suffix, so we need to add it to the cliVersion for comparison
+        if ("$cliVersion+models" -ne $releaseVersion) {
           Write-Host "CLI version $cliVersion does not match the latest release version $releaseVersion."
           exit 1
         }


### PR DESCRIPTION
# 🗣 Description

Release version contains additional `+models` suffix we need to add to CLI as well for comparison

```
release_version="$(curl -s "https://api.github.com/repos/spiceai/spiceai/releases/latest" -H "Authorization: token $GITHUB_TOKEN" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')+models"
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
