### PR TITLE
fix: Postgres LargeUtf8 is equal to Utf8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=47f096b1551ccd4a21adf51084fa03b0bc518288#47f096b1551ccd4a21adf51084fa03b0bc518288"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=e6d601cf9fbe61eaf099464353eb6db68f363caf#e6d601cf9fbe61eaf099464353eb6db68f363caf"
 dependencies = [
  "arrow",
  "arrow-json 53.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "90
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "47f096b1551ccd4a21adf51084fa03b0bc518288" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "e6d601cf9fbe61eaf099464353eb6db68f363caf" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae" }
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates `datafusion-table-providers` with a fix which makes `LargeUtf8` and `Utf8` equivalent for Postgres connections, because Postgres cannot store strings larger than 1Gb.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #4642 
