### PR TITLE
Handle delta tables partitioned by a date column with large date values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,8 +326,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "53.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf3437355979f1e93ba84ba108c38be5767713051f3c8ffbf07c094e2e61f9f"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=5feaa5f724d32c09e30394cedb7799de670e43e1#5feaa5f724d32c09e30394cedb7799de670e43e1"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -336,7 +335,7 @@ dependencies = [
  "arrow-csv",
  "arrow-data",
  "arrow-ipc",
- "arrow-json 53.4.0",
+ "arrow-json",
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
@@ -390,8 +389,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "53.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=5feaa5f724d32c09e30394cedb7799de670e43e1#5feaa5f724d32c09e30394cedb7799de670e43e1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -484,28 +482,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "53.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=63d05723107d6dc5f08acc5461417ee42937adcc#63d05723107d6dc5f08acc5461417ee42937adcc"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "indexmap 2.7.1",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "arrow-json"
 version = "53.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eff38eeb8a971ad3a4caf62c5d57f0cff8a48b64a55e3207c4fd696a9234aad"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=5feaa5f724d32c09e30394cedb7799de670e43e1#5feaa5f724d32c09e30394cedb7799de670e43e1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -622,6 +600,7 @@ name = "arrow_tools"
 version = "1.1.0"
 dependencies = [
  "arrow",
+ "arrow-cast",
  "arrow-schema",
  "datafusion",
  "snafu",
@@ -3275,7 +3254,7 @@ name = "datafusion-federation"
 version = "0.1.6"
 source = "git+https://github.com/spiceai/datafusion-federation.git?rev=a889f4bd47cba6b96d24a63a03891c64dadb6e15#a889f4bd47cba6b96d24a63a03891c64dadb6e15"
 dependencies = [
- "arrow-json 53.4.0",
+ "arrow-json",
  "async-stream",
  "async-trait",
  "datafusion",
@@ -3542,7 +3521,7 @@ version = "0.1.0"
 source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=e6d601cf9fbe61eaf099464353eb6db68f363caf#e6d601cf9fbe61eaf099464353eb6db68f363caf"
 dependencies = [
  "arrow",
- "arrow-json 53.4.0",
+ "arrow-json",
  "arrow-schema",
  "async-stream",
  "async-trait",
@@ -3633,7 +3612,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-json 53.4.0",
+ "arrow-json",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
@@ -4343,7 +4322,7 @@ version = "1.1.0"
 dependencies = [
  "ansi_term",
  "arrow-flight",
- "arrow-json 53.1.0",
+ "arrow-json",
  "clap",
  "datafusion",
  "flight_client",
@@ -8046,7 +8025,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4#cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=5feaa5f724d32c09e30394cedb7799de670e43e1#5feaa5f724d32c09e30394cedb7799de670e43e1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10020,7 +9999,7 @@ dependencies = [
  "arrow-csv",
  "arrow-flight",
  "arrow-ipc",
- "arrow-json 53.1.0",
+ "arrow-json",
  "arrow-schema",
  "arrow_sql_gen",
  "arrow_tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,13 @@ rust-version = "1.84"
 version = "1.1.0"
 
 [workspace.dependencies]
-arrow = "53"
+arrow = { version = "53", features = ["prettyprint"] }
 arrow-buffer = "53"
 arrow-flight = "53"
 # Use published version once https://github.com/apache/arrow-rs/pull/6606 is released
 arrow-ipc = "53"
-arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "63d05723107d6dc5f08acc5461417ee42937adcc" }
+arrow-json = "53"
+arrow-cast = "53"
 arrow-odbc = "11.2.0"
 arrow-schema = "53"
 async-openai = { git = "https://github.com/spiceai/async-openai", rev = "75e6bf715760f63f3dd3e7a43222ec1e6fb9707f" }
@@ -160,7 +161,10 @@ datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "
 datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "90409dee317a2accd63f9649807e52d51aa74097" }
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "90409dee317a2accd63f9649807e52d51aa74097" }
 
-object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "cee50b7d2ccf749eac89d0fe26fbd8a06c0bb3c4" }
+arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f724d32c09e30394cedb7799de670e43e1" }
+arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f724d32c09e30394cedb7799de670e43e1" }
+arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f724d32c09e30394cedb7799de670e43e1" }
+object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f724d32c09e30394cedb7799de670e43e1" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "e6d601cf9fbe61eaf099464353eb6db68f363caf" }

--- a/crates/arrow_tools/Cargo.toml
+++ b/crates/arrow_tools/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 
 [dependencies]
 arrow.workspace = true
+arrow-cast.workspace = true
 arrow-schema.workspace = true
 snafu.workspace = true
 datafusion.workspace = true

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -17,10 +17,10 @@ limitations under the License.
 use arrow::{
     array::{new_null_array, Array, ArrayRef, ListArray, RecordBatch, StructArray},
     buffer::{Buffer, OffsetBuffer},
-    compute::cast,
     datatypes::{DataType, Field, SchemaRef},
     error::ArrowError,
 };
+use arrow_cast::cast;
 use snafu::prelude::*;
 use std::sync::Arc;
 


### PR DESCRIPTION
# 🗣 Description

Supports reading from delta tables that are partitioned by date columns that contain large values.

This required two separate fixes:

1) An upstream fix in `arrow-rs` to handle casting from strings with large dates to Date32: https://github.com/apache/arrow-rs/pull/7074. Until this fix is upstreamed, I brought it into our `arrow-rs` fork.
2) Fix in the `delta_lake` data component to handle URL encoded paths properly.

## 🔨 Related Issues

Closes #4645

## 🤔 Concerns

I'm not sure if it is intentional that the `delta_kernel` crate returns URL encoded paths. The integration test I added should ensure that if this behavior ever changes, we will catch it.
