### PR TITLE
Fix E2E AI release install test on self-hosted runners (macos)

### DIFF
--- a/.github/workflows/e2e_test_release_install_ai.yml
+++ b/.github/workflows/e2e_test_release_install_ai.yml
@@ -130,6 +130,12 @@ jobs:
           nvidia-smi
           nvidia-smi --query-gpu=compute_cap --format=csv
 
+      # on self-hosted runners, there is a newer dev version installed, so we need to remove it first
+      - name: remove existing release
+        if: matrix.target.runner == 'spiceai-macos'
+        run: |
+          rm -rf ~/.spice/bin/
+
       - name: install Spice (https://install.spiceai.org)
         if: matrix.target.target_os != 'windows'
         env:


### PR DESCRIPTION
# 🗣 Description

Fix E2E AI release install test on self-hosted runners (macos)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
