### PR TITLE
Main performance metrics calculation for Text to SQL Benchmark

### DIFF
--- a/test/nsql_bench/spicepod.yaml
+++ b/test/nsql_bench/spicepod.yaml
@@ -19,6 +19,19 @@ models:
           2. The user asks for specific counts, sums, averages, or other calculations
           3. The query requires joining or comparing data from multiple related tables
 
+        
+        When writing SQL queries, do not put double quotes around schema-qualified table names. For example:
+          Correct: SELECT * FROM schema.table
+          Correct: SELECT * FROM database.schema.table
+          Incorrect: SELECT * FROM "schema.table"
+          Incorrect: SELECT * FROM "database.schema.table"
+
+          Only use double quotes when you need to preserve case sensitivity or when identifiers contain special characters.
+
+          Prefer quoting column names. For example:
+          Correct: `SELECT COUNT(*) AS "total_records" FROM "spice"."public"."taxi_trips"`
+          Incorrect: `SELECT COUNT(*) AS total_records FROM "spice"."public"."taxi_trips"`
+
         Instructions for Responses:
           1. When the answer is known, return information as plain json without additional formatting, example: { "column_name": 42 }
           2. For JSON output use fields defined in question as 'Fields:'


### PR DESCRIPTION
# 🗣 Description

PR adds `completed_at` eval run time column to the `spice.eval.runs` table and queries for main performance metrics calculation (see `README.md`). Next step is to automate benchmark run as test operator.
 - `task_calls` - total number of internal task calls (mostly tools calls)
 - `mean_task_calls` - average number of task calls per test
 - `task_errors` - total number of failed task calls (failed tools)

Main Metrics

```shell
+----------------------------------+-------------+-----------+-------+------------------+--------+------------+-----------------+-------------+
| run_id                           | model       | status    | tests | duration_seconds | score  | task_calls | mean_task_calls | task_errors |
+----------------------------------+-------------+-----------+-------+------------------+--------+------------+-----------------+-------------+
| 58f992e2bdd50794b32c2e2f873ae622 | gpt-4o-mini | Completed | 11    | 111.0            | 0.8182 | 184        | 16.727272       | 66          |
+----------------------------------+-------------+-----------+-------+------------------+--------+------------+-----------------+-------------+
```

Tools Call Summary

```shell
+-------------------------+----------------+------------+---------------------+
| task                    | num_task_calls | num_errors | duration_ms         |
+-------------------------+----------------+------------+---------------------+
| eval_run                | 1              | 0          | 110973.34375        |
| ai_completion           | 56             | 0          | 110828.81155395508  |
| sql_query               | 53             | 33         | 164.28599988669157  |
| tool_use::sql           | 45             | 33         | 115.96799861639738  |
| tool_use::list_datasets | 11             | 0          | 0.9360000062733889  |
| tool_use::table_schema  | 1              | 0          | 0.27900001406669617 |
+-------------------------+----------------+------------+---------------------+
```

Aggregated Errors Information

```shell
+---------------+---------------+---------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| task          | failure_count | error_message                                                                         | input                                                                                                                                                                                                                                                                                       |
+---------------+---------------+---------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| sql_query     | 6             | Failed to execute query: SQL error: ParserError("Expected: an expression:, found: `") | SELECT `c`.`c_name` AS "customer_name", SUM(`o`.`o_totalprice`) AS "total_price"                                                                                                                                                                                                            |
|               |               |                                                                                       | FROM `spice`.`public`.`customer` AS `c`                                                                                                                                                                                                                                                     |
|               |               |                                                                                       | JOIN `spice`.`public`.`orders` AS `o` ON `c`.`c_custkey` = `o`.`o_custkey`                                                                                                                                                                                                                  |
|               |               |                                                                                       | WHERE `c`.`c_name` = 'Customer#000000005'                                                                                                                                                                                                                                                   |
|               |               |                                                                                       | GROUP BY `c`.`c_name`                                                                                                                                                                                                                                                                       |
| tool_use::sql | 5             | Failed to execute query: SQL error: ParserError("Expected: an expression:, found: `") | {"query":"SELECT `c`.`c_name` AS \"customer_name\", SUM(`o`.`o_totalprice`) AS \"total_price\" \nFROM `spice`.`public`.`customer` AS `c` \nJOIN `spice`.`public`.`orders` AS `o` ON `c`.`c_custkey` = `o`.`o_custkey` \nWHERE `c`.`c_name` = 'Customer#000000005' \nGROUP BY `c`.`c_name`"} |
| tool_use::sql | 3             | Failed to execute query: SQL error: ParserError("Expected: an expression:, found: `") | {"query":"SELECT `nation` FROM `spice`.`public`.`customer` WHERE `customer_id` = 'Customer#000000001'"}                                                                                                                                                                                     |
| sql_query     | 3             | Failed to execute query: SQL error: ParserError("Expected: an expression:, found: `") | SELECT `nation` FROM `spice`.`public`.`customer` WHERE `customer_id` = 'Customer#000000001'                                                                                                                                                                                                 |
| sql_query     | 2             | Failed to execute query: SQL error: ParserError("Expected: an expression:, found: `") | SELECT `c`.`name` AS "customer_name", SUM(`o`.`total_price`) AS "total_price"                                                                                                                                                                                                               |
|               |               |                                                                                       | FROM `spice`.`public`.`customer` AS `c`                                                                                                                                                                                                                                                     |
|               |               |                                                                                       | JOIN `spice`.`public`.`orders` AS `o` ON `c`.`id` = `o`.`customer_id`                                                                                                                                                                                                                       |
|               |               |                                                                                       | WHERE `c`.`name` = 'Customer#000000005'                                                                                                                                                                                                                                                     |
|               |               |                                                                                       | GROUP BY `c`.`name`                                                                                                                                                                                                                                                                         |
+---------------+---------------+---------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/4635

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

 1. `sql_query ` and `tool_use::sql` tasks  stat seem to duplicate each other, will be investigated and improved next
 2. For some reason I don't see `tool_use::sample_data` - to be investigated
