### PR TITLE
Setup `tpc-extension`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11149,6 +11149,7 @@ dependencies = [
  "spice-cloud",
  "telemetry",
  "tokio",
+ "tpc-extension",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -12286,6 +12287,18 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tpc-extension"
+version = "1.1.0"
+dependencies = [
+ "async-trait",
+ "datafusion",
+ "duckdb",
+ "runtime",
+ "snafu",
+ "tracing",
+]
 
 [[package]]
 name = "tqdm"

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -30,6 +30,7 @@ serde_yaml.workspace = true
 snafu.workspace = true
 snmalloc-rs = "0.3.6"
 spice-cloud = { path = "../../crates/spice_cloud" }
+tpc-extension = { path = "../../crates/tpc_extension", optional = true }
 tokio.workspace = true
 telemetry = { path = "../../crates/telemetry" }
 tracing.workspace = true
@@ -84,3 +85,4 @@ spark = ["runtime/spark"]
 sqlite = ["runtime/sqlite"]
 sharepoint = ["runtime/sharepoint"]
 postgres-write = ["runtime/postgres-write"]
+tpc-extension = ["dep:tpc-extension"]

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -41,6 +41,8 @@ use serde_yaml::Value;
 use snafu::prelude::*;
 use spice_cloud::SpiceExtensionFactory;
 use spiced_tracing::LogVerbosity;
+#[cfg(feature = "tpc-extension")]
+use tpc_extension::TpcExtensionFactory;
 use tracing::subscriber;
 
 #[path = "tracing.rs"]
@@ -187,6 +189,11 @@ pub async fn run(args: Args) -> Result<()> {
         if let Some(manifest) = app.extensions.get("spice_cloud") {
             let spice_extension_factory = SpiceExtensionFactory::new(manifest.clone());
             extension_factories.push(Box::new(spice_extension_factory));
+        }
+        #[cfg(feature = "tpc-extension")]
+        if let Some(manifest) = app.extensions.get("tpc") {
+            let tpc_extension_factory = TpcExtensionFactory::new(manifest.clone());
+            extension_factories.push(Box::new(tpc_extension_factory));
         }
     }
 

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -57,9 +57,9 @@ impl LogVerbosity {
 impl From<LogVerbosity> for EnvFilter {
     fn from(v: LogVerbosity) -> Self {
         match v {
-            LogVerbosity::Default => EnvFilter::new("task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO,llms=INFO,reqwest_retry::middleware=off,opentelemetry_sdk=off,WARN"),
-            LogVerbosity::Verbose => EnvFilter::new("task_history=DEBUG,spiced=DEBUG,runtime=DEBUG,secrets=DEBUG,data_components=DEBUG,cache=DEBUG,extensions=DEBUG,spice_cloud=DEBUG,llms=DEBUG,INFO"),
-            LogVerbosity::VeryVerbose => EnvFilter::new("task_history=TRACE,spiced=TRACE,runtime=TRACE,secrets=TRACE,data_components=TRACE,cache=TRACE,extensions=TRACE,spice_cloud=TRACE,llms=TRACE,DEBUG"),
+            LogVerbosity::Default => EnvFilter::new("task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO,llms=INFO,tpc_extension=INFO,reqwest_retry::middleware=off,opentelemetry_sdk=off,WARN"),
+            LogVerbosity::Verbose => EnvFilter::new("task_history=DEBUG,spiced=DEBUG,runtime=DEBUG,secrets=DEBUG,data_components=DEBUG,cache=DEBUG,extensions=DEBUG,spice_cloud=DEBUG,llms=DEBUG,tpc_extension=DEBUG,INFO"),
+            LogVerbosity::VeryVerbose => EnvFilter::new("task_history=TRACE,spiced=TRACE,runtime=TRACE,secrets=TRACE,data_components=TRACE,cache=TRACE,extensions=TRACE,spice_cloud=TRACE,llms=TRACE,tpc_extension=TRACE,DEBUG"),
             LogVerbosity::Specific(filter) => EnvFilter::new(filter),
         }
     }

--- a/crates/tpc_extension/Cargo.toml
+++ b/crates/tpc_extension/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "tpc-extension"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+datafusion.workspace = true
+runtime = { path = "../runtime" }
+snafu.workspace = true
+tracing.workspace = true
+duckdb.workspace = true

--- a/crates/tpc_extension/src/lib.rs
+++ b/crates/tpc_extension/src/lib.rs
@@ -1,0 +1,174 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// use std::{collections::HashMap, sync::Arc};
+
+use std::{fs, path::PathBuf};
+
+// use datafusion::catalog::TableProvider;
+use duckdb::Connection;
+use snafu::prelude::*;
+
+use async_trait::async_trait;
+use runtime::{
+    extension::{Error as ExtensionError, Extension, ExtensionFactory, ExtensionManifest, Result},
+    Runtime,
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unable to setup DuckDB connection: {}", source))]
+    UnableToSetupDuckDBConnection { source: duckdb::Error },
+
+    #[snafu(display(
+        "Invalid benchmark type. Must be either 'tpch' or 'tpcds', got: {}",
+        benchmark
+    ))]
+    InvalidBenchmark { benchmark: String },
+}
+
+pub struct TpcExtension {
+    manifest: ExtensionManifest,
+}
+
+impl TpcExtension {
+    #[must_use]
+    pub fn new(manifest: ExtensionManifest) -> Self {
+        TpcExtension { manifest }
+    }
+}
+
+impl Default for TpcExtension {
+    fn default() -> Self {
+        TpcExtension::new(ExtensionManifest::default())
+    }
+}
+
+#[async_trait]
+impl Extension for TpcExtension {
+    fn name(&self) -> &'static str {
+        "tpc"
+    }
+
+    async fn initialize(&mut self, _runtime: &Runtime) -> Result<()> {
+        if !self.manifest.enabled {
+            return Ok(());
+        }
+
+        let benchmark = self
+            .manifest
+            .params
+            .get("benchmark")
+            .map_or(String::from("tpch"), |v| v.to_string());
+
+        if benchmark != "tpch" && benchmark != "tpcds" {
+            return Err(ExtensionError::UnableToInitializeExtension {
+                source: Box::new(Error::InvalidBenchmark {
+                    benchmark: benchmark.clone(),
+                }),
+            });
+        }
+
+        let path = self
+            .manifest
+            .params
+            .get("path")
+            .map_or(String::from(format!(".spice/data/{benchmark}.db")), |v| {
+                v.to_string()
+            });
+
+        if let Some(parent) = PathBuf::from(&path).parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                ExtensionError::UnableToInitializeExtension {
+                    source: Box::new(e),
+                }
+            })?;
+        }
+
+        let scale_factor = self
+            .manifest
+            .params
+            .get("scale_factor")
+            .and_then(|v| v.parse::<i32>().ok())
+            .unwrap_or(1);
+
+        tracing::info!("TPC extension is loading");
+
+        let connection = Connection::open(path.clone())
+            .boxed()
+            .map_err(|source| ExtensionError::UnableToInitializeExtension { source })?;
+
+        tracing::info!("Setting up {benchmark} benchamrk datasets.");
+
+        let gen_func = match benchmark.as_str() {
+            "tpch" => String::from("dbgen"),
+            "tpcds" => String::from("dsdgen"),
+            _ => {
+                return Err(ExtensionError::UnableToInitializeExtension {
+                    source: Box::new(Error::InvalidBenchmark {
+                        benchmark: benchmark.clone(),
+                    }),
+                })
+            }
+        };
+
+        let query = format!(
+            r"
+            INSTALL {benchmark};
+            LOAD {benchmark};
+            CALL {gen_func}(sf = {scale_factor});"
+        );
+
+        connection
+            .execute_batch(&query.as_str())
+            .boxed()
+            .map_err(|source| ExtensionError::UnableToInitializeExtension { source })?;
+
+        connection
+            .close()
+            .map_err(|(_, err)| ExtensionError::UnableToInitializeExtension {
+                source: Box::new(err),
+            })?;
+
+        tracing::info!("{benchmark} data loaded");
+
+        Ok(())
+    }
+
+    async fn on_start(&self, _runtime: &Runtime) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct TpcExtensionFactory {
+    manifest: ExtensionManifest,
+}
+
+impl TpcExtensionFactory {
+    #[must_use]
+    pub fn new(manifest: ExtensionManifest) -> Self {
+        TpcExtensionFactory { manifest }
+    }
+}
+
+impl ExtensionFactory for TpcExtensionFactory {
+    fn create(&self) -> Box<dyn Extension> {
+        Box::new(TpcExtension {
+            manifest: self.manifest.clone(),
+        })
+    }
+}

--- a/crates/tpc_extension/src/lib.rs
+++ b/crates/tpc_extension/src/lib.rs
@@ -72,7 +72,7 @@ impl Extension for TpcExtension {
             .manifest
             .params
             .get("benchmark")
-            .map_or(String::from("tpch"), |v| v.to_string());
+            .map_or(String::from("tpch"), std::string::ToString::to_string);
 
         if benchmark != "tpch" && benchmark != "tpcds" {
             return Err(ExtensionError::UnableToInitializeExtension {
@@ -82,13 +82,10 @@ impl Extension for TpcExtension {
             });
         }
 
-        let path = self
-            .manifest
-            .params
-            .get("path")
-            .map_or(String::from(format!(".spice/data/{benchmark}.db")), |v| {
-                v.to_string()
-            });
+        let path = self.manifest.params.get("path").map_or(
+            format!(".spice/data/{benchmark}.db"),
+            std::string::ToString::to_string,
+        );
 
         if let Some(parent) = PathBuf::from(&path).parent() {
             fs::create_dir_all(parent).map_err(|e| {
@@ -133,7 +130,7 @@ impl Extension for TpcExtension {
         );
 
         connection
-            .execute_batch(&query.as_str())
+            .execute_batch(query.as_str())
             .boxed()
             .map_err(|source| ExtensionError::UnableToInitializeExtension { source })?;
 

--- a/crates/tpc_extension/src/lib.rs
+++ b/crates/tpc_extension/src/lib.rs
@@ -68,6 +68,14 @@ impl Extension for TpcExtension {
             return Ok(());
         }
 
+        Ok(())
+    }
+
+    async fn on_start(&self, _runtime: &Runtime) -> Result<()> {
+        if !self.manifest.enabled {
+            return Ok(());
+        }
+
         let benchmark = self
             .manifest
             .params
@@ -75,7 +83,7 @@ impl Extension for TpcExtension {
             .map_or(String::from("tpch"), std::string::ToString::to_string);
 
         if benchmark != "tpch" && benchmark != "tpcds" {
-            return Err(ExtensionError::UnableToInitializeExtension {
+            return Err(ExtensionError::UnableToStartExtension {
                 source: Box::new(Error::InvalidBenchmark {
                     benchmark: benchmark.clone(),
                 }),
@@ -88,10 +96,8 @@ impl Extension for TpcExtension {
         );
 
         if let Some(parent) = PathBuf::from(&path).parent() {
-            fs::create_dir_all(parent).map_err(|e| {
-                ExtensionError::UnableToInitializeExtension {
-                    source: Box::new(e),
-                }
+            fs::create_dir_all(parent).map_err(|e| ExtensionError::UnableToStartExtension {
+                source: Box::new(e),
             })?;
         }
 
@@ -106,15 +112,15 @@ impl Extension for TpcExtension {
 
         let connection = Connection::open(path.clone())
             .boxed()
-            .map_err(|source| ExtensionError::UnableToInitializeExtension { source })?;
+            .map_err(|source| ExtensionError::UnableToStartExtension { source })?;
 
-        tracing::info!("Setting up {benchmark} benchamrk datasets.");
+        tracing::info!("Setting up {benchmark} benchamrk datasets with scale factor {scale_factor}, using file {path}");
 
         let gen_func = match benchmark.as_str() {
             "tpch" => String::from("dbgen"),
             "tpcds" => String::from("dsdgen"),
             _ => {
-                return Err(ExtensionError::UnableToInitializeExtension {
+                return Err(ExtensionError::UnableToStartExtension {
                     source: Box::new(Error::InvalidBenchmark {
                         benchmark: benchmark.clone(),
                     }),
@@ -132,20 +138,16 @@ impl Extension for TpcExtension {
         connection
             .execute_batch(query.as_str())
             .boxed()
-            .map_err(|source| ExtensionError::UnableToInitializeExtension { source })?;
+            .map_err(|source| ExtensionError::UnableToStartExtension { source })?;
 
         connection
             .close()
-            .map_err(|(_, err)| ExtensionError::UnableToInitializeExtension {
+            .map_err(|(_, err)| ExtensionError::UnableToStartExtension {
                 source: Box::new(err),
             })?;
 
         tracing::info!("{benchmark} data loaded");
 
-        Ok(())
-    }
-
-    async fn on_start(&self, _runtime: &Runtime) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
# 🗣 Description

Added a TPC runtime extension that enables the setup and preloading of TPC-H or TPC-DS datasets into duckdb file with a specified scale factor on runtime start. Datasets must be configured manually in Spicepod to load from the generated DuckDB file.

Extension is disabled by default and can be enabled by building the runtime with the feature flag `tpc-extension`:
`make install SPICED_NON_DEFAULT_FEATURES="models,tpc-extension"`

Extension params:
- `benchmark`: `tpch` (default) or `tpcds`, optional
- `scale_factor`: optional, default 1
- `path`: optional, default `.spice/data/<benchmark>.db`

Examples:

```yaml
version: v1
kind: Spicepod
name: spiceai

extensions:
  tpc:
    enabled: true
    params:
      benchmark: tpch # `tpch` ot `tpcds`
      scale_factor: "1" # optional, 1 by default
      path: .spice/data/tpch.db # optional, .spice/data/<benchmark>.db by default

datasets:
  - from: duckdb:customer
    name: customer
    params:
      duckdb_open: .spice/data/tpch.db
...
```
---

<details><summary>full tpch spicepod</summary>

```yaml
version: v1
kind: Spicepod
name: spiceai

extensions:
  tpc:
    enabled: true
    params:
      benchmark: tpch
      scale_factor: "1"
      path: ./.spice/data/tpch.db

datasets:
  - from: duckdb:customer
    name: customer
    params:
      duckdb_open: ./.spice/data/tpch.db

  - from: duckdb:lineitem
    name: lineitem
    params:
      duckdb_open: .spice/data/tpch.db

  - from: duckdb:nation
    name: nation
    params:
      duckdb_open: .spice/data/tpch.db

  - from: duckdb:orders
    name: orders
    params:
      duckdb_open: .spice/data/tpch.db

  - from: duckdb:part
    name: part
    params:
      duckdb_open: .spice/data/tpch.db

  - from: duckdb:partsupp
    name: partsupp
    params:
      duckdb_open: .spice/data/tpch.db

  - from: duckdb:region
    name: region
    params:
      duckdb_open: .spice/data/tpch.db

  - from: duckdb:supplier
    name: supplier
    params:
      duckdb_open: .spice/data/tpch.db
```

</details> 

<details><summary>full tpcds spicepod</summary>

```yaml
version: v1
kind: Spicepod
name: spiceai

extensions:
  tpc:
    enabled: true
    params:
      benchmark: tpcds
      scale_factor: "1"
      path: ./.spice/data/tpcds.db

datasets:
- from: duckdb:call_center
  name: call_center
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:catalog_page
  name: catalog_page
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:catalog_returns
  name: catalog_returns
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:catalog_sales
  name: catalog_sales
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:customer_address
  name: customer_address
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:customer_demographics
  name: customer_demographics
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:customer
  name: customer
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:date_dim
  name: date_dim
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:household_demographics
  name: household_demographics
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:income_band
  name: income_band
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:inventory
  name: inventory
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:promotion
  name: promotion
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:reason
  name: reason
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:ship_mode
  name: ship_mode
  params:
    duckdb_open: ./.spice/data/tpcds.db
  
- from: duckdb:store_returns
  name: store_returns
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:store_sales
  name: store_sales
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:store
  name: store
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:time_dim
  name: time_dim
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:warehouse
  name: warehouse
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:web_page
  name: web_page
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:web_returns
  name: web_returns
  params:
    duckdb_open: ./.spice/data/tpcds.db

- from: duckdb:web_sales
  name: web_sales
  params:
    duckdb_open: ./.spice/data/tpcds.db
```

</details> 


