### PR TITLE
Add 'accelerated_refresh' to 'spice trace' allowlist

### DIFF
--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -33,7 +33,7 @@ var (
 	trace_id string
 )
 
-var supported_trace_tasks = []string{"ai_chat", "ai_completion", "sql_query", "nsql",
+var supported_trace_tasks = []string{"ai_chat", "accelerated_refresh", "ai_completion", "sql_query", "nsql",
 	"tool_use::document_similarity", "tool_use::list_datasets", "tool_use::sql",
 	"tool_use::table_schema", "tool_use::sample_data", "tool_use::sql_query", "tool_use::memory"}
 


### PR DESCRIPTION
# 🗣 Description
 - `accelerated_refresh` not in `spice trace` allowlist

## 🔨 Related Issues
- https://github.com/spiceai/spiceai/issues/4694

## Documentation
 - https://github.com/spiceai/docs/pull/853 
