### PR TITLE
Use model that supports tools in hf_test

### DIFF
--- a/test/models/spicepod_hf.yml
+++ b/test/models/spicepod_hf.yml
@@ -17,7 +17,7 @@ datasets:
       reference_url_template: https://github.com/spiceai/spiceai/issues/<issue_id>
     params:
       github_token: ${secrets:GITHUB_TOKEN}
-      github_query_mode: 'search'
+      github_query_mode: "search"
     acceleration:
       enabled: true
       refresh_retry_max_attempts: 3
@@ -54,11 +54,11 @@ datasets:
 
 models:
   - name: hf_local_model
-    from: huggingface:huggingface.co/microsoft/Phi-3-mini-4k-instruct
+    from: huggingface:huggingface.co/Qwen/Qwen2.5-3B-Instruct
     params:
       model_type: phi3
       system_prompt: |
-        Instructions for Responses: 
+        Instructions for Responses:
           - Do not include any private metadata provided to the model as context such as \"reference_url_template\" or \"instructions\" in your responses.
 
 embeddings:

--- a/test/models/spicepod_hf.yml
+++ b/test/models/spicepod_hf.yml
@@ -17,7 +17,7 @@ datasets:
       reference_url_template: https://github.com/spiceai/spiceai/issues/<issue_id>
     params:
       github_token: ${secrets:GITHUB_TOKEN}
-      github_query_mode: "search"
+      github_query_mode: 'search'
     acceleration:
       enabled: true
       refresh_retry_max_attempts: 3

--- a/test/models/spicepod_hf.yml
+++ b/test/models/spicepod_hf.yml
@@ -56,7 +56,6 @@ models:
   - name: hf_local_model
     from: huggingface:huggingface.co/Qwen/Qwen2.5-3B-Instruct
     params:
-      model_type: phi3
       system_prompt: |
         Instructions for Responses:
           - Do not include any private metadata provided to the model as context such as \"reference_url_template\" or \"instructions\" in your responses.


### PR DESCRIPTION
# 🗣 Description
 - Use model that properly handles tools within their chat template. 
     - `huggingface:huggingface.co/microsoft/Phi-3-mini-4k-instruct` does not.
     - Use `Qwen/Qwen2.5-3B-Instruct`.
 - Model quality/performance is not required in these tests (`.github/workflows/e2e_test_ci_models.yml` and `.github/workflows/e2e_test_release_install_ai.yml`). Therefore no need to validate quality in responses is maintained. 

## 🔨 Related Issues
 - Issue found and resolved in #3936 . This PR updates tests to not use incompatible models. 

## CI
 - Successful CI run: https://github.com/spiceai/spiceai/actions/runs/13231562446/job/36929728313 
