### PR TITLE
fix: Use PostgreSQL interval style for Spice.ai

### DIFF
--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -123,7 +123,7 @@ impl Dialect for SpiceCloudPlatformDialect {
     }
 
     fn interval_style(&self) -> IntervalStyle {
-        IntervalStyle::SQLStandard
+        IntervalStyle::PostgresVerbose
     }
 
     fn identifier_quote_style(&self, identifier: &str) -> Option<char> {


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Uses the `PostgresVerbose` interval expression style for the Spice.ai data connector, because queries run against a `spiced` instance which uses a PostgreSQL-style SQL

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #4666
