### PR TITLE
Fix bug: Ensure refresh only retrieves data within the retention period

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -799,7 +799,7 @@ impl DataFusion {
             refresh = refresh.append_overlap(append_overlap);
         }
 
-        // we must not fetch data longer than explicitly set refresh data window or retention period
+        // we must not fetch data older than the explicitly set refresh data window or retention period
         let refresh_data_window = dataset.refresh_data_window().or(dataset.retention_period());
 
         if let Some(refresh_data_window) = refresh_data_window {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -802,8 +802,8 @@ impl DataFusion {
         // we must not fetch data longer than explicitly set refresh data window or retention period
         let refresh_data_window = dataset.refresh_data_window().or(dataset.retention_period());
 
-        if let Some(refresh_data_windows) = refresh_data_window {
-            refresh = refresh.period(refresh_data_windows);
+        if let Some(refresh_data_window) = refresh_data_window {
+            refresh = refresh.period(refresh_data_window);
         }
         refresh
             .validate_time_format(dataset.name.to_string(), &refresh_schema)

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -798,8 +798,12 @@ impl DataFusion {
         if let Some(append_overlap) = acceleration_settings.refresh_append_overlap {
             refresh = refresh.append_overlap(append_overlap);
         }
-        if let Some(refresh_data_window) = dataset.refresh_data_window() {
-            refresh = refresh.period(refresh_data_window);
+
+        // we must not fetch data longer than explicitly set refresh data window or retention period
+        let refresh_data_window = dataset.refresh_data_window().or(dataset.retention_period());
+
+        if let Some(refresh_data_windows) = refresh_data_window {
+            refresh = refresh.period(refresh_data_windows);
         }
         refresh
             .validate_time_format(dataset.name.to_string(), &refresh_schema)


### PR DESCRIPTION
# 🗣 Description

Currently, initial refresh fetches all data even if retention period is defined. This PR fixes the bug by ensuring that the refresh only retrieves data within the retention period

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

If both `refresh_data_window` and `retention_period` are defined, we technically need only data within min of the two. Current implementation always use `refresh_data_window` if defined as it is explicit configuration for refresh defined by user.
