### PR TITLE
Return non-existing model for v1/chat endpoint

### DIFF
--- a/crates/runtime/src/http/v1/chat.rs
+++ b/crates/runtime/src/http/v1/chat.rs
@@ -157,7 +157,7 @@ pub(crate) async fn post(
                     }
                 }
             }
-            None => StatusCode::NOT_FOUND.into_response(),
+            None => (StatusCode::NOT_FOUND, format!("model '{model_id}' not found")).into_response(),
         }
     }
     .instrument(span)


### PR DESCRIPTION
# 🗣 Description

Minor UX improvement for v1/chat endpoint. I found that the chat endpoint returns empty responses when the model is not found, without any concrete information in response it's hard to know the chat request is actually failing. Therefore add the information in the response to make it clear that the model is not found.

Before:
![image](https://github.com/user-attachments/assets/d4f48521-8e1e-4e27-a850-77381f345271)
After:
![image](https://github.com/user-attachments/assets/5011e166-c008-4637-88ef-1e7ae44c8b98)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
