### PR TITLE
Prompt user to download runtime when running spice sql

### DIFF
--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -50,7 +50,7 @@ sql> show tables
 
 		_, err := rtcontext.Version()
 		if err != nil {
-			slog.Error("Failed to run `spice sql`: Spice runtime is not installed. Run `spice install` to install the runtime.")
+			slog.Error("Failed to run `spice sql`: The Spice runtime is not installed. Run `spice install` and retry.")
 			return
 		}
 

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -48,6 +48,12 @@ sql> show tables
 	Run: func(cmd *cobra.Command, args []string) {
 		rtcontext := context.NewContext()
 
+		_, err := rtcontext.Version()
+		if err != nil {
+			slog.Error("Failed to run `spice sql`: Spice runtime is not installed. Run `spice install` to install the runtime.")
+			return
+		}
+
 		spiceArgs := []string{"--repl"}
 
 		if rootCertPath, err := cmd.Flags().GetString("tls-root-certificate-file"); err == nil && rootCertPath != "" {


### PR DESCRIPTION
# 🗣 Description

Instruct user to download runtime if user try to run `spice sql` without a runtime installed.

![image](https://github.com/user-attachments/assets/1ce4f56e-26ae-470f-89db-15d5901f40da)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
