### PR TITLE
Update 'spice trace' output format

### DIFF
--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -106,15 +106,19 @@ $ spice trace ai_chat --id chatcmpl-At6ZmDE8iAYRPeuQLA0FLlWxGKNnM
 	},
 }
 
+// Reduce the `taskhistory.TaskHistory` to only the columns that are needed for the table. This includes the
+// `treePrefix` as the first column.
+//
+// Must use a struct because `util.WriteTable` uses `reflect` functions that require a struct.
+// Must use separate structs for each combination of input/output. Otherwise table will have columns with all `nil`s. A
+// `json:"fieldName,omitempty"` tag does not work.
 func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput bool, includeOutput bool) interface{} {
-
 	type TaskRowBase struct {
 		Tree     string `json:"tree"`
 		Status   string `json:"status"`
 		Duration string `json:"duration"`
 		Task     string `json:"task"`
 	}
-	// Need additional struct for each combination of input/output. Otherwise table will have empty columns.
 	type TaskRowFull struct {
 		TaskRowBase
 		Input  interface{} `json:"input"`
@@ -138,7 +142,7 @@ func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput 
 	if t.ErrorMessage == nil || *t.ErrorMessage == "" {
 		base.Status = "✅"
 	} else {
-		base.Status = "❌"
+		base.Status = "🚫"
 	}
 
 	if includeInput && includeOutput {

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
 	"github.com/spiceai/spiceai/bin/spice/pkg/taskhistory"
+	"github.com/spiceai/spiceai/bin/spice/pkg/util"
 )
 
 var (
@@ -31,6 +32,12 @@ var (
 
 	// The trace_id of the trace to provide
 	trace_id string
+
+	// The include input flag
+	include_input bool
+
+	// The include output flag
+	include_output bool
 )
 
 var supported_trace_tasks = []string{"ai_chat", "accelerated_refresh", "ai_completion", "sql_query", "nsql",
@@ -87,18 +94,75 @@ $ spice trace ai_chat --id chatcmpl-At6ZmDE8iAYRPeuQLA0FLlWxGKNnM
 			cmd.PrintErrln("Error: No events found")
 			return
 		}
-		taskhistory.PrintTreeFromTraces(cmd.OutOrStdout(), traces, Display)
+
+		rows := taskhistory.TreeRowsFromTraces(traces)
+
+		table := make([]interface{}, len(rows))
+		for i, dataset := range rows {
+			table[i] = ToRowInterface(dataset.Tree, &dataset.Task, include_input, include_output)
+		}
+
+		util.WriteTable(table)
 	},
 }
 
-func Display(t *taskhistory.TaskHistory) string {
-	return fmt.Sprintf("(%8.2fms) %s ", t.ExecutionDurationMs, t.Task)
+func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput bool, includeOutput bool) interface{} {
+
+	type TaskRowBase struct {
+		Tree     string `json:"tree"`
+		Status   string `json:"status"`
+		Duration string `json:"duration"`
+		Task     string `json:"task"`
+	}
+	// Need additional struct for each combination of input/output. Otherwise table will have empty columns.
+	type TaskRowFull struct {
+		TaskRowBase
+		Input  interface{} `json:"input"`
+		Output interface{} `json:"output"`
+	}
+	type TaskRowWithInput struct {
+		TaskRowBase
+		Input interface{} `json:"input"`
+	}
+	type TaskRowWithOutput struct {
+		TaskRowBase
+		Output interface{} `json:"output"`
+	}
+
+	base := TaskRowBase{
+		Tree:     treePrefix,
+		Duration: fmt.Sprintf("%8.2fms", t.ExecutionDurationMs),
+		Task:     t.Task,
+	}
+
+	if t.ErrorMessage == nil || *t.ErrorMessage == "" {
+		base.Status = "✅"
+	} else {
+		base.Status = "❌"
+	}
+
+	if includeInput && includeOutput {
+		return TaskRowFull{TaskRowBase: base, Input: t.Input, Output: t.CapturedOutput}
+	} else if includeInput {
+		return TaskRowWithInput{TaskRowBase: base, Input: t.Input}
+	} else if includeOutput {
+		var output string
+		if t.CapturedOutput != nil {
+			output = *t.CapturedOutput
+		} else {
+			output = ""
+		}
+		return TaskRowWithOutput{TaskRowBase: base, Output: output}
+	}
+	return base
 }
 
 func init() {
 	RootCmd.AddCommand(traceCmd)
 	traceCmd.Flags().StringVar(&id, "id", "", "Return the trace with the given id")
 	traceCmd.Flags().StringVar(&trace_id, "trace-id", "", "Return the trace with the given trace id")
+	traceCmd.Flags().BoolVar(&include_input, "include-input", false, "Include input data in the trace")
+	traceCmd.Flags().BoolVar(&include_output, "include-output", false, "Include output data in the trace")
 }
 
 func getTraceFilter(task string, id string, trace_id string) (string, error) {

--- a/bin/spice/pkg/taskhistory/format.go
+++ b/bin/spice/pkg/taskhistory/format.go
@@ -18,16 +18,31 @@ package taskhistory
 
 import (
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 )
 
-// PrintTreeFromTraces prints a hierarchical tree of TaskHistory entries to the provided writer.
+type TaskHistoryRow struct {
+	/// The tree structure (i.e. with indentations, etc) for the `TaskHistory` row.
+	Tree string
+	Task TaskHistory
+}
+
 // Expects all `traces` to be from the same trace (i.e. same `TraceId`).
-// The `fn` function is used to format details to display on each task history line.
-func PrintTreeFromTraces(w io.Writer, traces []TaskHistory, fn func(t *TaskHistory) string) {
-	printTree(w, buildTraceTree(traces), "", true, fn)
+func TreeRowsFromTraces(traces []TaskHistory) []TaskHistoryRow {
+	tree := buildTraceTree(traces)
+	c := make(chan TaskHistoryRow)
+	go func() {
+		defer close(c)
+		printTree(c, tree, "", true)
+	}()
+
+	rows := make([]TaskHistoryRow, 0)
+	for cc := range c {
+		rows = append(rows, cc)
+	}
+
+	return rows
 }
 
 func ConvertLabelsToString(labels map[string]string) string {
@@ -56,7 +71,7 @@ func ConvertLabelsToString(labels map[string]string) string {
 }
 
 // printTree prints the tree in ASCII format.
-func printTree(w io.Writer, node *TreeNode, indent string, isLast bool, fn func(t *TaskHistory) string) {
+func printTree(c chan TaskHistoryRow, node *TreeNode, indent string, isLast bool) {
 	if node == nil {
 		return
 	}
@@ -68,8 +83,7 @@ func printTree(w io.Writer, node *TreeNode, indent string, isLast bool, fn func(
 	if indent == "" {
 		connector = ""
 	}
-
-	fmt.Fprintf(w, "%s%s[%s] %s\n", indent, connector, node.TaskHistory.SpanID, fn(&node.TaskHistory))
+	c <- TaskHistoryRow{fmt.Sprintf("%s%s%s", indent, connector, node.TaskHistory.SpanID), node.TaskHistory}
 
 	// Recurse for children
 	newIndent := indent + "│ "
@@ -78,7 +92,7 @@ func printTree(w io.Writer, node *TreeNode, indent string, isLast bool, fn func(
 	}
 
 	for i, child := range node.Children {
-		printTree(w, child, newIndent, i == len(node.Children)-1, fn)
+		printTree(c, child, newIndent, i == len(node.Children)-1)
 	}
 }
 

--- a/bin/spice/pkg/taskhistory/format.go
+++ b/bin/spice/pkg/taskhistory/format.go
@@ -18,23 +18,24 @@ package taskhistory
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 )
 
+// Represents a table row to display a `TaskHistory` with an additional column to display the
+// tree structure of the trace.
 type TaskHistoryRow struct {
-	/// The tree structure (i.e. with indentations, etc) for the `TaskHistory` row.
+	// The tree structure (i.e. with indentations, etc) for the `TaskHistory` row.
 	Tree string
 	Task TaskHistory
 }
 
+// Constructs an ordered list of `TaskHistoryRow` from a trace of `TaskHistory`s.
 // Expects all `traces` to be from the same trace (i.e. same `TraceId`).
 func TreeRowsFromTraces(traces []TaskHistory) []TaskHistoryRow {
 	tree := buildTraceTree(traces)
 	c := make(chan TaskHistoryRow)
 	go func() {
 		defer close(c)
-		printTree(c, tree, "", true)
+		recurseThroughTree(c, tree, "", true)
 	}()
 
 	rows := make([]TaskHistoryRow, 0)
@@ -45,33 +46,8 @@ func TreeRowsFromTraces(traces []TaskHistory) []TaskHistoryRow {
 	return rows
 }
 
-func ConvertLabelsToString(labels map[string]string) string {
-	var sb strings.Builder
-	sb.WriteString("{")
-
-	i := 0
-	for key, value := range labels {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-
-		switch {
-		case isBool(value):
-			sb.WriteString(fmt.Sprintf("%s: %t", key, mustParseBool(value)))
-		case isInt(value):
-			sb.WriteString(fmt.Sprintf("%s: %d", key, mustParseInt(value)))
-		default:
-			sb.WriteString(fmt.Sprintf("%s: %s", key, value))
-		}
-		i++
-	}
-
-	sb.WriteString("}")
-	return sb.String()
-}
-
-// printTree prints the tree in ASCII format.
-func printTree(c chan TaskHistoryRow, node *TreeNode, indent string, isLast bool) {
+// Recurse through the tree and construct the formatted tree column. Push each row to the channel.
+func recurseThroughTree(c chan TaskHistoryRow, node *TreeNode, indent string, isLast bool) {
 	if node == nil {
 		return
 	}
@@ -92,26 +68,6 @@ func printTree(c chan TaskHistoryRow, node *TreeNode, indent string, isLast bool
 	}
 
 	for i, child := range node.Children {
-		printTree(c, child, newIndent, i == len(node.Children)-1)
+		recurseThroughTree(c, child, newIndent, i == len(node.Children)-1)
 	}
-}
-
-func isBool(s string) bool {
-	_, err := strconv.ParseBool(s)
-	return err == nil
-}
-
-func mustParseBool(s string) bool {
-	b, _ := strconv.ParseBool(s)
-	return b
-}
-
-func isInt(s string) bool {
-	_, err := strconv.Atoi(s)
-	return err == nil
-}
-
-func mustParseInt(s string) int {
-	n, _ := strconv.Atoi(s)
-	return n
 }

--- a/bin/spice/pkg/taskhistory/taskhistory.go
+++ b/bin/spice/pkg/taskhistory/taskhistory.go
@@ -76,6 +76,7 @@ type TaskHistory struct {
 	Labels              map[string]string    `json:"labels"`
 }
 
+// TimeWithMilliSeconds is a custom time type that can be unmarshalled from a JSON string with millisecond precision.
 type TimeWithMilliSeconds time.Time
 
 func (tMs *TimeWithMilliSeconds) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
# 🗣 Description
- Update output format of `spice trace ...`
    ```
    TREE                   STATUS DURATION   TASK
    a97f52ccd7687e64       ✅       673.14ms ai_chat
      ├── 4eebde7b04321803 ✅         0.04ms tool_use::list_datasets
      └── 4c9049e1bf1c3500 ✅       671.91ms ai_completion
    ```
 - New flags `--include-output`, `--include-input` alters the additional columns returned.
    ```
    spice trace ai_chat --include-output
    
    TREE                   STATUS DURATION   TASK                    OUTPUT
    a97f52ccd7687e64       ✅       673.14ms ai_chat                 The capital of New York is Albany.
      ├── 4eebde7b04321803 ✅         0.04ms tool_use::list_datasets []
      └── 4c9049e1bf1c3500 ✅       671.91ms ai_completion           [{"content":"The capital of New York is Albany.","refusal":null,"tool_calls":null,"role":"assistant","function_call":null,"audio":null}] 
    ```

## 🔨 Related Issues
 - #4710 

## 📄 Documentation Updates
- https://github.com/spiceai/docs/pull/863
