### PR TITLE
feat: Release Spice.ai RC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,7 +5696,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a80b3807a5082662fa608d85dedb1a5341ae395c#a80b3807a5082662fa608d85dedb1a5341ae395c"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -5745,7 +5745,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a80b3807a5082662fa608d85dedb1a5341ae395c#a80b3807a5082662fa608d85dedb1a5341ae395c"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5770,7 +5770,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a80b3807a5082662fa608d85dedb1a5341ae395c#a80b3807a5082662fa608d85dedb1a5341ae395c"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,7 +5696,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=3597335f0238cc9bb8fbf5a5287a080020549f48#3597335f0238cc9bb8fbf5a5287a080020549f48"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -5745,7 +5745,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=3597335f0238cc9bb8fbf5a5287a080020549f48#3597335f0238cc9bb8fbf5a5287a080020549f48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5770,7 +5770,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2#07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=3597335f0238cc9bb8fbf5a5287a080020549f48#3597335f0238cc9bb8fbf5a5287a080020549f48"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,8 +179,8 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "3597335f0238cc9bb8fbf5a5287a080020549f48" }
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "3597335f0238cc9bb8fbf5a5287a080020549f48" }
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "3597335f0238cc9bb8fbf5a5287a080020549f48" }
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,8 +179,8 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a80b3807a5082662fa608d85dedb1a5341ae395c" }
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a80b3807a5082662fa608d85dedb1a5341ae395c" }
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a80b3807a5082662fa608d85dedb1a5341ae395c" }
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "07940c3fdaef24a5a4ddaf58f5c495d2fc4ce7d2" }
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ See more demos on [YouTube](https://www.youtube.com/playlist?list=PLesJrUXEx3U9a
 | `s3`                               | [S3][s3]                              | Stable            | Parquet, CSV                 |
 | `mysql`                            | MySQL                                 | Stable            |                              |
 | `graphql`                          | GraphQL                               | Release Candidate | JSON                         |
+| `spice.ai`                         | [Spice.ai][spiceai]                   | Release Candidate | Arrow Flight                 |
 | `databricks (mode: spark_connect)` | [Databricks][databricks]              | Beta              | [Spark Connect][spark]       |
 | `flightsql`                        | FlightSQL                             | Beta              | Arrow Flight SQL             |
 | `iceberg`                          | [Apache Iceberg][iceberg]             | Beta              | Parquet                      |
@@ -167,7 +168,6 @@ See more demos on [YouTube](https://www.youtube.com/playlist?list=PLesJrUXEx3U9a
 | `odbc`                             | ODBC                                  | Beta              | ODBC                         |
 | `snowflake`                        | Snowflake                             | Beta              | Arrow                        |
 | `spark`                            | Spark                                 | Beta              | [Spark Connect][spark]       |
-| `spice.ai`                         | [Spice.ai][spiceai]                   | Beta              | Arrow Flight                 |
 | `abfs`                             | Azure BlobFS                          | Alpha             | Parquet, CSV                 |
 | `clickhouse`                       | Clickhouse                            | Alpha             |                              |
 | `debezium`                         | Debezium CDC                          | Alpha             | Kafka + JSON                 |

--- a/crates/data_components/src/iceberg/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog.rs
@@ -23,12 +23,11 @@ use iceberg::{
     table::Table, Catalog, Error as IcebergError, ErrorKind, Namespace, NamespaceIdent,
     Result as IcebergResult, TableCommit, TableCreation, TableIdent,
 };
-use iceberg_catalog_rest::{HttpClient, RestCatalog as IcebergRestCatalog, RestCatalogConfig};
+use iceberg_catalog_rest::{RestCatalog as IcebergRestCatalog, RestCatalogConfig};
 
 #[derive(Debug)]
 pub struct RestCatalog {
     inner: IcebergRestCatalog,
-    pub(crate) catalog_config: RestCatalogConfig,
 }
 
 impl RestCatalog {
@@ -36,13 +35,8 @@ impl RestCatalog {
     #[allow(clippy::missing_panics_doc)]
     pub fn new(catalog_config: RestCatalogConfig) -> Self {
         Self {
-            inner: IcebergRestCatalog::new(catalog_config.clone()),
-            catalog_config,
+            inner: IcebergRestCatalog::new(catalog_config),
         }
-    }
-
-    pub fn http_client(&self) -> IcebergResult<HttpClient> {
-        HttpClient::new(&self.catalog_config)
     }
 }
 

--- a/docs/criteria/connectors/rc.md
+++ b/docs/criteria/connectors/rc.md
@@ -27,7 +27,7 @@ All criteria must be met for the connector to be considered [RC](../definitions.
 | PostgreSQL                       | ✅         | @Sevenannn   |
 | Sharepoint                       | ➖         |              |
 | Snowflake                        | ➖         |              |
-| Spice.ai Cloud Platform          | ➖         |              |
+| Spice.ai Cloud Platform          | ✅         | @peasee      |
 | S3                               | ✅         | @Sevenannn   |
 | Azure BlobFS                     | ➖         |              |
 | Spark                            | ➖         |              |


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Rolls back the Iceberg version to remove the pub methods that are no longer needed. Needs to be updated again once https://github.com/spiceai/iceberg-rust/pull/3 merges.
* Releases Spice.ai Data Connector as RC.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4035

* Docs release: https://github.com/spiceai/docs/pull/864