### PR TITLE
feat: Add vector search tracing

### DIFF
--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -40,9 +40,12 @@ var (
 	include_output bool
 )
 
-var supported_trace_tasks = []string{"ai_chat", "accelerated_refresh", "ai_completion", "sql_query", "nsql",
+var supported_trace_tasks = []string{
+	"ai_chat", "accelerated_refresh", "ai_completion", "sql_query", "nsql",
 	"tool_use::document_similarity", "tool_use::list_datasets", "tool_use::sql",
-	"tool_use::table_schema", "tool_use::sample_data", "tool_use::sql_query", "tool_use::memory"}
+	"tool_use::table_schema", "tool_use::sample_data", "tool_use::sql_query", "tool_use::memory",
+	"vector_search",
+}
 
 func isValidTraceTask(task string) bool {
 	for _, supported_task := range supported_trace_tasks {


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds `vector_search` to the allowed trace types, supporting tracing for both AI-initiated vector searches and HTTP-initiated.

Example trace from an AI search:

```console
TREE                       STATUS DURATION   TASK                          
cd2bde5ccb41ceae           ✅      8543.26ms ai_chat                       
  ├── 3384358288584855     ✅         0.33ms tool_use::list_datasets       
  ├── 27c9cf2a5d86ed00     ✅      8539.95ms ai_completion                 
  ├── e2cdf0ede292e71a     🚫       706.39ms tool_use::document_similarity 
  │ └── 1e90640f1a03cd76   🚫       705.82ms vector_search                 
  │   ├── ea33e1fe4ba02230 ✅       670.80ms text_embed                    
  │   └── bbf8ffa129baeac4 🚫        32.57ms sql_query                     
  ├── b47a51e2727384ad     ✅      6049.74ms ai_completion                 
  ├── fd684d597907335a     ✅         0.94ms tool_use::table_schema        
  ├── b574d7a8f1bfe2d6     ✅      4752.08ms ai_completion                 
  ├── ac855628205d7747     ✅       928.76ms tool_use::document_similarity 
  │ └── 69f7c683799fcb60   ✅       928.10ms vector_search                 
  │   ├── b44fd9453290f984 ✅       832.36ms text_embed                    
  │   └── 22007a126a481403 ✅        93.70ms sql_query                     
  └── 68c586165e469cf2     ✅      2019.04ms ai_completion
```

Example trace from a HTTP call:

```console
TREE                   STATUS DURATION   TASK          
a3558af79de2915f       ✅       898.73ms vector_search 
  ├── 8e10187994b57e37 ✅       803.36ms text_embed    
  └── 17a1c34df86bb387 ✅        93.22ms sql_query
```