### PR TITLE
feat: Search with keyword filtering

### DIFF
--- a/crates/runtime/benches/vector_search.rs
+++ b/crates/runtime/benches/vector_search.rs
@@ -294,6 +294,7 @@ async fn run_search_queries(
                         search_limit,
                         None,
                         vec!["_id".to_string()],
+                        vec![],
                     );
 
                     let start = Instant::now();

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -32,6 +32,7 @@ use datafusion::{common::Constraint, datasource::TableProvider, sql::TableRefere
 use datafusion_federation::FederatedTableProviderAdaptor;
 use futures::TryStreamExt;
 use itertools::Itertools;
+use schemars::schema::{Metadata, SchemaObject};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -125,7 +126,7 @@ static VECTOR_DISTANCE_COLUMN_NAME: &str = "dist";
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "lowercase")]
-pub struct SearchRequestJson {
+pub struct SearchRequestBaseJson {
     /// The text to search documents for similarity
     pub text: String,
 
@@ -146,18 +147,58 @@ pub struct SearchRequestJson {
     pub additional_columns: Vec<String>,
 }
 
-impl TryFrom<SearchRequestJson> for SearchRequest {
+/// HTTP request schema is separate from AI requests, so that keywords can be supplied as an optional field for HTTP calls.
+/// `schemars` doesn't allow setting `#[serde(default)]` as well as `#[schemars(required)]` - the field does not become required.
+/// When the field is not required, the model ignores it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub struct SearchRequestHTTPJson {
+    #[serde(flatten)]
+    pub base: SearchRequestBaseJson,
+
+    /// At least one keyword should be supplied for a vector search. Keywords should be individual words.
+    /// Keywords are used to pre-filter the embedding column, applied as a `WHERE col LIKE '%keyword%'` condition.
+    /// Keywords should not contain column names, special characters, or other operators.
+    #[serde(default)]
+    pub keywords: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct SearchRequestAIJson {
+    #[serde(flatten)]
+    pub base: SearchRequestBaseJson,
+
+    /// At least one keyword should be supplied for a vector search. Keywords should be individual words.
+    /// Keywords are used to pre-filter the embedding column, applied as a `WHERE col LIKE '%keyword%'` condition.
+    /// Keywords should not contain column names, special characters, or other operators.
+    pub keywords: Vec<String>,
+}
+
+impl From<SearchRequestHTTPJson> for SearchRequestAIJson {
+    fn from(req: SearchRequestHTTPJson) -> Self {
+        SearchRequestAIJson {
+            base: req.base,
+            keywords: req.keywords.unwrap_or_default(),
+        }
+    }
+}
+
+impl TryFrom<SearchRequestAIJson> for SearchRequest {
     type Error = String;
 
-    fn try_from(req: SearchRequestJson) -> Result<Self, Self::Error> {
+    fn try_from(req: SearchRequestAIJson) -> Result<Self, Self::Error> {
         Ok(SearchRequest::new(
-            req.text,
-            req.datasets,
-            req.limit.unwrap_or(default_limit()),
-            req.where_cond
+            req.base.text,
+            req.base.datasets,
+            req.base.limit.unwrap_or(default_limit()),
+            req.base
+                .where_cond
                 .map(|r| SearchRequest::parse_where_cond(r).map_err(|e| e.to_string()))
                 .transpose()?,
-            req.additional_columns,
+            req.base.additional_columns,
+            req.keywords,
         ))
     }
 }
@@ -178,6 +219,9 @@ pub struct SearchRequest {
 
     /// Additional columns to return from the dataset.
     pub additional_columns: Vec<String>,
+
+    /// Keywords to perform a lexical search and pre-filter the embedding column.
+    pub keywords: Vec<String>,
 }
 
 #[must_use]
@@ -197,6 +241,7 @@ impl SearchRequest {
         limit: usize,
         where_cond: Option<Expr>,
         additional_columns: Vec<String>,
+        keywords: Vec<String>,
     ) -> Self {
         SearchRequest {
             text,
@@ -204,6 +249,7 @@ impl SearchRequest {
             limit,
             where_cond,
             additional_columns,
+            keywords,
         }
     }
 
@@ -555,6 +601,7 @@ impl VectorSearch {
         is_chunked: bool,
         additional_columns: &[String],
         where_cond: Option<&Expr>,
+        keywords: &[&str],
         n: usize,
     ) -> Result<VectorSearchTableResult> {
         let projection: Vec<String> = primary_keys
@@ -566,7 +613,19 @@ impl VectorSearch {
             .map(|s| quote_identifier(&s).to_string())
             .collect();
 
-        let where_str = where_cond.map_or_else(String::new, |cond| format!("WHERE ({cond})"));
+        let keywords_filter = keywords
+            .iter()
+            .map(|k| format!("LOWER({embedding_column}) LIKE '%{}%'", k.to_lowercase()))
+            .join(" OR ");
+
+        let where_str = match (where_cond, keywords.is_empty()) {
+            (Some(cond), false) => {
+                format!("WHERE ({cond}) AND ({keywords_filter})")
+            }
+            (Some(cond), true) => format!("WHERE ({cond})"),
+            (None, false) => format!("WHERE ({keywords_filter})"),
+            (None, true) => String::new(),
+        };
 
         let query = if is_chunked {
             Self::construct_chunk_query_sql(
@@ -632,6 +691,7 @@ impl VectorSearch {
             limit,
             where_cond,
             additional_columns,
+            keywords,
         } = req;
 
         let tables = match data_source_opt {
@@ -664,6 +724,7 @@ impl VectorSearch {
                 .await?;
 
             let mut response: VectorSearchResult = HashMap::new();
+            let keywords = keywords.iter().map(std::string::String::as_str).collect::<Vec<&str>>();
 
             for (tbl, search_vectors) in per_table_embeddings {
                 tracing::debug!("Running vector search for table {:#?}", tbl);
@@ -709,6 +770,7 @@ impl VectorSearch {
                                 embedding_table.is_chunked(embedding_column),
                                 additional_columns,
                                 where_cond.as_ref(),
+                                &keywords,
                                 *limit,
                             )
                             .await?;
@@ -967,7 +1029,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_search_request_schema() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        serde_json::to_value(schema_for!(SearchRequestJson)).boxed()?;
+        serde_json::to_value(schema_for!(SearchRequestAIJson)).boxed()?;
         Ok(())
     }
 

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -32,7 +32,6 @@ use datafusion::{common::Constraint, datasource::TableProvider, sql::TableRefere
 use datafusion_federation::FederatedTableProviderAdaptor;
 use futures::TryStreamExt;
 use itertools::Itertools;
-use schemars::schema::{Metadata, SchemaObject};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -157,9 +156,6 @@ pub struct SearchRequestHTTPJson {
     #[serde(flatten)]
     pub base: SearchRequestBaseJson,
 
-    /// At least one keyword should be supplied for a vector search. Keywords should be individual words.
-    /// Keywords are used to pre-filter the embedding column, applied as a `WHERE col LIKE '%keyword%'` condition.
-    /// Keywords should not contain column names, special characters, or other operators.
     #[serde(default)]
     pub keywords: Option<Vec<String>>,
 }
@@ -615,7 +611,7 @@ impl VectorSearch {
 
         let keywords_filter = keywords
             .iter()
-            .map(|k| format!("LOWER({embedding_column}) LIKE '%{}%'", k.to_lowercase()))
+            .map(|k| format!("{embedding_column} ILIKE '%{k}%'"))
             .join(" OR ");
 
         let where_str = match (where_cond, keywords.is_empty()) {

--- a/crates/runtime/src/tools/builtin/document_similarity.rs
+++ b/crates/runtime/src/tools/builtin/document_similarity.rs
@@ -73,6 +73,7 @@ impl SpiceModelTool for DocumentSimilarityTool {
 
         let tool_use_result = async {
             let req: SearchRequestAIJson = serde_json::from_str(arg)?;
+            tracing::trace!("document_similarity tool use function call request: {req:?}");
 
             let vs = VectorSearch::new(
                 rt.datafusion(),

--- a/crates/runtime/src/tools/builtin/document_similarity.rs
+++ b/crates/runtime/src/tools/builtin/document_similarity.rs
@@ -22,7 +22,7 @@ use tracing_futures::Instrument;
 
 use crate::{
     embeddings::vector_search::{
-        parse_explicit_primary_keys, SearchRequest, SearchRequestJson, VectorSearch,
+        parse_explicit_primary_keys, SearchRequest, SearchRequestAIJson, VectorSearch,
     },
     tools::{utils::parameters, SpiceModelTool},
     Runtime,
@@ -61,7 +61,7 @@ impl SpiceModelTool for DocumentSimilarityTool {
     }
 
     fn parameters(&self) -> Option<Value> {
-        parameters::<SearchRequestJson>()
+        parameters::<SearchRequestAIJson>()
     }
 
     async fn call(
@@ -72,7 +72,7 @@ impl SpiceModelTool for DocumentSimilarityTool {
         let span = tracing::span!(target: "task_history", tracing::Level::INFO, "tool_use::document_similarity", tool = self.name().to_string(), input = arg);
 
         let tool_use_result = async {
-            let req: SearchRequestJson = serde_json::from_str(arg)?;
+            let req: SearchRequestAIJson = serde_json::from_str(arg)?;
 
             let vs = VectorSearch::new(
                 rt.datafusion(),

--- a/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_1_ai_completion_input.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_1_ai_completion_input.snap
@@ -58,6 +58,13 @@ expression: "serde_json::to_string_pretty(&task_input).expect(\"Failed to serial
                 "null"
               ]
             },
+            "keywords": {
+              "description": "At least one keyword should be supplied for a vector search. Keywords should be individual words. Keywords are used to pre-filter the embedding column, applied as a `WHERE col LIKE '%keyword%'` condition. Keywords should not contain column names, special characters, or other operators.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "limit": {
               "default": null,
               "description": "Number of documents to return for each dataset",
@@ -82,9 +89,10 @@ expression: "serde_json::to_string_pretty(&task_input).expect(\"Failed to serial
             }
           },
           "required": [
+            "keywords",
             "text"
           ],
-          "title": "SearchRequestJson",
+          "title": "SearchRequestAIJson",
           "type": "object"
         }
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_2_document_similarity_tasks.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_2_document_similarity_tasks.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/runtime/tests/models/openai.rs
-expression: "sql_to_display(&rt,\nformat!(r#\"SELECT input\n                FROM runtime.task_history\n                WHERE start_time >= '{}' and task='tool_use::document_similarity';\n            \"#,\nInto::<DateTime<Utc>>::into(task_start_time).to_rfc3339()).as_str()).await.expect(\"Failed to execute HTTP SQL query\")"
+expression: "sql_to_display(&rt,\nformat!(\"SELECT input\n                FROM runtime.task_history\n                WHERE start_time >= '{}' and task='tool_use::document_similarity';\",\nInto::<DateTime<Utc>>::into(task_start_time).to_rfc3339()).as_str()).await.expect(\"Failed to execute HTTP SQL query\")"
 ---
-+------------------------------------------------------------------------+
-| input                                                                  |
-+------------------------------------------------------------------------+
-| {"text": "vehicles", "datasets": ["spice.public.item"], "limit": 5}    |
-| {"text": "journalists", "datasets": ["spice.public.item"], "limit": 5} |
-+------------------------------------------------------------------------+
++-----------------------------------------------------------------------------------------------------+
+| input                                                                                               |
++-----------------------------------------------------------------------------------------------------+
+| {"keywords": ["vehicles"], "text": "vehicles", "datasets": ["spice.public.item"], "limit": 5}       |
+| {"keywords": ["journalists"], "text": "journalists", "datasets": ["spice.public.item"], "limit": 5} |
++-----------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds support for `keywords` in vector searches, to pre-filter results for vector searching.
* Splits structs for HTTP and AI search requests, because keywords are optional for HTTP requests but required for AI invocations (e.g. through `document_similarity`, in tool use).

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #3006 

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->

* The OpenAPI spec might look weird with utopia, if it doesn't support `#[serde(flatten)]`. Will observe with the new OpenAPI spec, and documentation updates.
