### PR TITLE
Implement `Cache-Control: no-cache` to bypass results cache.

### DIFF
--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -68,6 +68,10 @@ sql> show tables
 			args = append(args, "--user-agent", userAgent)
 		}
 
+		if cacheControl, err := cmd.Flags().GetString("cache-control"); err == nil && cacheControl != "" {
+			args = append(args, "--cache-control", cacheControl)
+		}
+
 		args = append(spiceArgs, args...)
 
 		execCmd, err := rtcontext.GetRunCmd(args)
@@ -91,5 +95,6 @@ sql> show tables
 func init() {
 	sqlCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	sqlCmd.Flags().String("user-agent", "", "The user agent to use for all requests")
+	sqlCmd.Flags().String("cache-control", "cache", "Control whether the results cache is used for queries. [possible values: cache, no-cache]")
 	RootCmd.AddCommand(sqlCmd)
 }

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -63,13 +63,20 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct QueryResult {
     pub data: SendableRecordBatchStream,
-    pub from_cache: Option<bool>,
+    pub cache_status: QueryCacheStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryCacheStatus {
+    CacheNotChecked,
+    CacheHit,
+    CacheMiss,
 }
 
 impl QueryResult {
     #[must_use]
-    pub fn new(data: SendableRecordBatchStream, from_cache: Option<bool>) -> Self {
-        QueryResult { data, from_cache }
+    pub fn new(data: SendableRecordBatchStream, cache_status: QueryCacheStatus) -> Self {
+        QueryResult { data, cache_status }
     }
 }
 

--- a/crates/flightrepl/src/cache_control.rs
+++ b/crates/flightrepl/src/cache_control.rs
@@ -1,0 +1,24 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use clap::ValueEnum;
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum CacheControl {
+    #[default]
+    Cache,
+    NoCache,
+}

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -87,7 +87,7 @@ pub struct ReplConfig {
     #[arg(long, value_name = "USER_AGENT", help_heading = "SQL REPL")]
     pub user_agent: Option<String>,
 
-    /// Control whether the cache is used for queries.
+    /// Control whether the results cache is used for queries.
     #[arg(
         long,
         value_enum,

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -50,6 +50,7 @@ use tonic::metadata::{Ascii, AsciiMetadataKey, MetadataValue};
 use tonic::transport::{Channel, ClientTlsConfig};
 use tonic::{Code, IntoRequest, Status};
 
+mod cache_control;
 mod config;
 
 #[derive(Parser, Debug)]
@@ -85,6 +86,16 @@ pub struct ReplConfig {
 
     #[arg(long, value_name = "USER_AGENT", help_heading = "SQL REPL")]
     pub user_agent: Option<String>,
+
+    /// Control whether the cache is used for queries.
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = cache_control::CacheControl::Cache,
+        value_name = "CACHE_CONTROL",
+        help_heading = "SQL REPL"
+    )]
+    pub cache_control: cache_control::CacheControl,
 }
 
 const NQL_LINE_PREFIX: &str = "nql ";
@@ -312,6 +323,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
             line,
             repl_config.api_key.as_ref(),
             &user_agent,
+            repl_config.cache_control,
         )
         .await
         {
@@ -348,6 +360,7 @@ pub async fn get_records(
     line: &str,
     api_key: Option<&String>,
     user_agent: &str,
+    cache_control: cache_control::CacheControl,
 ) -> Result<(Vec<RecordBatch>, usize, bool), FlightError> {
     let sql_command = CommandStatementQuery {
         query: line.to_string(),
@@ -368,6 +381,13 @@ pub async fn get_records(
         return Err(FlightError::Tonic(Status::internal("No ticket")));
     };
     let mut request = add_api_key(ticket.into_request(), api_key);
+
+    if cache_control == cache_control::CacheControl::NoCache {
+        request
+            .metadata_mut()
+            .insert("cache-control", MetadataValue::from_static("no-cache"));
+    }
+
     let user_agent_key = AsciiMetadataKey::from_str("User-Agent")
         .map_err(|e| FlightError::ExternalError(e.into()))?;
     let user_agent_value = user_agent

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -50,7 +50,7 @@ use tonic::metadata::{Ascii, AsciiMetadataKey, MetadataValue};
 use tonic::transport::{Channel, ClientTlsConfig};
 use tonic::{Code, IntoRequest, Status};
 
-mod cache_control;
+pub mod cache_control;
 mod config;
 
 #[derive(Parser, Debug)]

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -148,9 +148,15 @@ impl Query {
         ))
     }
 
-    fn should_cache_results(df: &DataFusion, plan: &LogicalPlan) -> bool {
-        df.cache_provider()
-            .is_some_and(|provider| provider.cache_is_enabled_for_plan(plan))
+    fn should_cache_results(
+        df: &DataFusion,
+        plan: &LogicalPlan,
+        cache_status: QueryCacheStatus,
+    ) -> (bool, QueryCacheStatus) {
+        match df.cache_provider() {
+            Some(provider) if provider.cache_is_enabled_for_plan(plan) => (true, cache_status),
+            _ => (false, QueryCacheStatus::CacheNotChecked),
+        }
     }
 
     fn wrap_stream_with_cache(
@@ -214,7 +220,8 @@ impl Query {
                 CacheResult::Error(e) => return Err(e),
             };
 
-            let plan_is_cache_enabled = Self::should_cache_results(&ctx.df, &plan);
+            let (plan_is_cache_enabled, cache_status) =
+                Self::should_cache_results(&ctx.df, &plan, cache_status);
             let plan_cache_key = cache::key_for_logical_plan(&plan);
             tracker = tracker.results_cache_hit(false);
 

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -14,19 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{cell::LazyCell, sync::Arc};
+use std::{cell::LazyCell, collections::HashSet, sync::Arc};
 
 use arrow::{
     array::RecordBatch,
     datatypes::{Schema, SchemaRef},
 };
 use arrow_tools::schema::verify_schema;
-use cache::{get_logical_plan_input_tables, to_cached_record_batch_stream, QueryResult};
+use cache::{
+    get_logical_plan_input_tables, to_cached_record_batch_stream, QueryCacheStatus, QueryResult,
+};
 use datafusion::{
     error::DataFusionError,
     execution::{context::SQLOptions, SendableRecordBatchStream},
+    logical_expr::LogicalPlan,
     physical_plan::{memory::MemoryStream, stream::RecordBatchStreamAdapter},
     prelude::DataFrame,
+    sql::TableReference,
 };
 use error_code::ErrorCode;
 use snafu::{ResultExt, Snafu};
@@ -44,9 +48,9 @@ mod tracker;
 use async_stream::stream;
 use futures::StreamExt;
 
-use crate::request::{AsyncMarker, RequestContext};
+use crate::request::{AsyncMarker, CacheControl, RequestContext};
 
-use super::{error::find_datafusion_root, SPICE_RUNTIME_SCHEMA};
+use super::{error::find_datafusion_root, DataFusion, SPICE_RUNTIME_SCHEMA};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -92,7 +96,76 @@ macro_rules! handle_error {
     }};
 }
 
+enum CacheResult {
+    Hit(QueryResult),
+    MissOrSkipped(QueryTracker, QueryCacheStatus),
+    Error(Error),
+}
+
 impl Query {
+    async fn try_get_cached_result(
+        df: &DataFusion,
+        ctx: Arc<RequestContext>,
+        mut tracker: QueryTracker,
+        plan: &LogicalPlan,
+    ) -> CacheResult {
+        let Some(cache_provider) = df.cache_provider() else {
+            return CacheResult::MissOrSkipped(tracker, QueryCacheStatus::CacheNotChecked);
+        };
+
+        // If the user requested no caching, skip the cache lookup
+        if matches!(ctx.cache_control(), CacheControl::NoCache) {
+            return CacheResult::MissOrSkipped(tracker, QueryCacheStatus::CacheNotChecked);
+        }
+
+        let cached_result = match cache_provider.get(plan).await {
+            Ok(Some(result)) => result,
+            Ok(None) => return CacheResult::MissOrSkipped(tracker, QueryCacheStatus::CacheMiss),
+            Err(e) => return CacheResult::Error(Error::FailedToAccessCache { source: e }),
+        };
+
+        tracker = tracker
+            .datasets(cached_result.input_tables)
+            .results_cache_hit(true);
+
+        let record_batch_stream =
+            match MemoryStream::try_new(cached_result.records.to_vec(), cached_result.schema, None)
+            {
+                Ok(stream) => stream,
+                Err(e) => {
+                    return CacheResult::Error(Error::UnableToCreateMemoryStream { source: e })
+                }
+            };
+
+        CacheResult::Hit(QueryResult::new(
+            attach_query_tracker_to_stream(
+                Span::current(),
+                ctx,
+                tracker,
+                Box::pin(record_batch_stream),
+            ),
+            QueryCacheStatus::CacheHit,
+        ))
+    }
+
+    fn should_cache_results(df: &DataFusion, plan: &LogicalPlan) -> bool {
+        df.cache_provider()
+            .is_some_and(|provider| provider.cache_is_enabled_for_plan(plan))
+    }
+
+    fn wrap_stream_with_cache(
+        df: &DataFusion,
+        stream: SendableRecordBatchStream,
+        plan_cache_key: u64,
+        datasets: Arc<HashSet<TableReference>>,
+    ) -> SendableRecordBatchStream {
+        if let Some(cache_provider) = df.cache_provider() {
+            to_cached_record_batch_stream(cache_provider, stream, plan_cache_key, datasets)
+        } else {
+            stream
+        }
+    }
+
     #[allow(clippy::too_many_lines)]
     pub async fn run(self) -> Result<QueryResult> {
         let request_context = RequestContext::current(AsyncMarker::new().await);
@@ -105,7 +178,7 @@ impl Query {
             let mut session = self.df.ctx.state();
 
             let ctx = self;
-            let mut tracker = ctx.tracker;
+            let tracker = ctx.tracker;
 
             // Sets the request context as an extension on DataFusion, to allow recovering it to track telemetry
             session
@@ -127,59 +200,23 @@ impl Query {
                 }
             };
 
-            let mut plan_is_cache_enabled = false;
+            // Try to get cached results first
+            let (mut tracker, cache_status) = match Self::try_get_cached_result(
+                &ctx.df,
+                Arc::clone(&request_context),
+                tracker,
+                &plan,
+            )
+            .await
+            {
+                CacheResult::Hit(result) => return Ok(result),
+                CacheResult::MissOrSkipped(tracker, status) => (tracker, status),
+                CacheResult::Error(e) => return Err(e),
+            };
+
+            let plan_is_cache_enabled = Self::should_cache_results(&ctx.df, &plan);
             let plan_cache_key = cache::key_for_logical_plan(&plan);
-
-            if let Some(cache_provider) = &ctx.df.cache_provider() {
-                if let Some(cached_result) = match cache_provider.get(&plan).await {
-                    Ok(Some(v)) => Some(v),
-                    Ok(None) => None,
-                    Err(e) => {
-                        handle_error!(
-                            tracker,
-                            &request_context,
-                            ErrorCode::InternalError,
-                            e,
-                            FailedToAccessCache
-                        )
-                    }
-                } {
-                    tracker = tracker
-                        .datasets(cached_result.input_tables)
-                        .results_cache_hit(true);
-
-                    let record_batch_stream = match MemoryStream::try_new(
-                        cached_result.records.to_vec(),
-                        cached_result.schema,
-                        None,
-                    ) {
-                        Ok(stream) => stream,
-                        Err(e) => {
-                            let e = find_datafusion_root(e);
-                            handle_error!(
-                                tracker,
-                                &request_context,
-                                ErrorCode::InternalError,
-                                e,
-                                UnableToCreateMemoryStream
-                            )
-                        }
-                    };
-
-                    return Ok(QueryResult::new(
-                        attach_query_tracker_to_stream(
-                            inner_span,
-                            Arc::clone(&request_context),
-                            tracker,
-                            Box::pin(record_batch_stream),
-                        ),
-                        Some(true),
-                    ));
-                }
-
-                plan_is_cache_enabled = cache_provider.cache_is_enabled_for_plan(&plan);
-                tracker = tracker.results_cache_hit(false);
-            }
+            tracker = tracker.results_cache_hit(false);
 
             if let Err(e) =
                 RESTRICTED_SQL_OPTIONS.with(|sql_options| sql_options.verify_plan(&plan))
@@ -250,35 +287,25 @@ impl Query {
                 )
             };
 
-            if plan_is_cache_enabled {
-                if let Some(cache_provider) = &ctx.df.cache_provider() {
-                    let record_batch_stream = to_cached_record_batch_stream(
-                        Arc::clone(cache_provider),
-                        res_stream,
-                        plan_cache_key,
-                        Arc::clone(&tracker.datasets),
-                    );
-
-                    return Ok(QueryResult::new(
-                        attach_query_tracker_to_stream(
-                            inner_span,
-                            Arc::clone(&request_context),
-                            tracker,
-                            record_batch_stream,
-                        ),
-                        Some(false),
-                    ));
-                }
-            }
+            let final_stream = if plan_is_cache_enabled {
+                Self::wrap_stream_with_cache(
+                    &ctx.df,
+                    res_stream,
+                    plan_cache_key,
+                    Arc::clone(&tracker.datasets),
+                )
+            } else {
+                res_stream
+            };
 
             Ok(QueryResult::new(
                 attach_query_tracker_to_stream(
                     inner_span,
                     Arc::clone(&request_context),
                     tracker,
-                    res_stream,
+                    final_stream,
                 ),
-                None,
+                cache_status,
             ))
         }
         .instrument(span.clone())

--- a/crates/runtime/src/flight/do_get.rs
+++ b/crates/runtime/src/flight/do_get.rs
@@ -81,7 +81,7 @@ async fn do_get_simple(
     tracing::trace!("do_get_simple: {ticket:?}");
     match std::str::from_utf8(&ticket.ticket) {
         Ok(sql) => {
-            let (output, from_cache) =
+            let (output, cache_status) =
                 Box::pin(Service::sql_to_flight_stream(datafusion, sql)).await?;
 
             let timed_output = TimedStream::new(output, move || start);
@@ -89,7 +89,7 @@ async fn do_get_simple(
             let mut response =
                 Response::new(Box::pin(timed_output) as <Service as FlightService>::DoGetStream);
 
-            attach_cache_metadata(&mut response, from_cache);
+            attach_cache_metadata(&mut response, cache_status);
 
             Ok(response)
         }

--- a/crates/runtime/src/request/cache_control.rs
+++ b/crates/runtime/src/request/cache_control.rs
@@ -1,0 +1,41 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use http::{header::CACHE_CONTROL, HeaderMap};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum CacheControl {
+    #[default]
+    Cache,
+    NoCache,
+}
+
+impl CacheControl {
+    #[must_use]
+    pub fn from_headers(headers: &HeaderMap) -> Self {
+        let Some(cache_control) = headers.get(CACHE_CONTROL) else {
+            return Self::Cache;
+        };
+        let Ok(cache_control_str) = cache_control.to_str() else {
+            return Self::Cache;
+        };
+
+        match cache_control_str {
+            "no-cache" => Self::NoCache,
+            _ => Self::Cache,
+        }
+    }
+}

--- a/crates/runtime/src/request/mod.rs
+++ b/crates/runtime/src/request/mod.rs
@@ -15,68 +15,12 @@ limitations under the License.
 */
 
 mod baggage;
+mod cache_control;
 mod context;
+mod protocol;
 mod user_agent;
 
-use std::sync::atomic::AtomicU8;
-
+pub use cache_control::*;
 pub use context::*;
+pub use protocol::*;
 pub use user_agent::*;
-
-#[derive(Debug, Copy, Clone)]
-#[repr(u8)]
-pub enum Protocol {
-    Invalid = 0,
-    Http = 1,
-    Flight = 2,
-    FlightSQL = 3,
-    Internal = 4,
-}
-
-static HTTP: &str = "http";
-static FLIGHT: &str = "flight";
-static FLIGHTSQL: &str = "flightsql";
-static INTERNAL: &str = "internal";
-
-impl Protocol {
-    #[must_use]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Protocol::Http => HTTP,
-            Protocol::Flight => FLIGHT,
-            Protocol::FlightSQL => FLIGHTSQL,
-            Protocol::Internal => INTERNAL,
-            Protocol::Invalid => unreachable!(),
-        }
-    }
-}
-
-impl From<AtomicU8> for Protocol {
-    fn from(value: AtomicU8) -> Self {
-        Protocol::from(value.load(std::sync::atomic::Ordering::Relaxed))
-    }
-}
-
-impl From<u8> for Protocol {
-    fn from(value: u8) -> Self {
-        match value {
-            1 => Protocol::Http,
-            2 => Protocol::Flight,
-            3 => Protocol::FlightSQL,
-            4 => Protocol::Internal,
-            _ => Protocol::Invalid,
-        }
-    }
-}
-
-impl std::fmt::Display for Protocol {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Protocol::Http => write!(f, "{HTTP}"),
-            Protocol::Flight => write!(f, "{FLIGHT}"),
-            Protocol::FlightSQL => write!(f, "{FLIGHTSQL}"),
-            Protocol::Internal => write!(f, "{INTERNAL}"),
-            Protocol::Invalid => unreachable!(),
-        }
-    }
-}

--- a/crates/runtime/src/request/protocol.rs
+++ b/crates/runtime/src/request/protocol.rs
@@ -1,0 +1,75 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::atomic::AtomicU8;
+
+#[derive(Debug, Copy, Clone)]
+#[repr(u8)]
+pub enum Protocol {
+    Invalid = 0,
+    Http = 1,
+    Flight = 2,
+    FlightSQL = 3,
+    Internal = 4,
+}
+
+static HTTP: &str = "http";
+static FLIGHT: &str = "flight";
+static FLIGHTSQL: &str = "flightsql";
+static INTERNAL: &str = "internal";
+
+impl Protocol {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Protocol::Http => HTTP,
+            Protocol::Flight => FLIGHT,
+            Protocol::FlightSQL => FLIGHTSQL,
+            Protocol::Internal => INTERNAL,
+            Protocol::Invalid => unreachable!(),
+        }
+    }
+}
+
+impl From<AtomicU8> for Protocol {
+    fn from(value: AtomicU8) -> Self {
+        Protocol::from(value.load(std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
+impl From<u8> for Protocol {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => Protocol::Http,
+            2 => Protocol::Flight,
+            3 => Protocol::FlightSQL,
+            4 => Protocol::Internal,
+            _ => Protocol::Invalid,
+        }
+    }
+}
+
+impl std::fmt::Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Protocol::Http => write!(f, "{HTTP}"),
+            Protocol::Flight => write!(f, "{FLIGHT}"),
+            Protocol::FlightSQL => write!(f, "{FLIGHTSQL}"),
+            Protocol::Internal => write!(f, "{INTERNAL}"),
+            Protocol::Invalid => unreachable!(),
+        }
+    }
+}

--- a/crates/runtime/tests/endpoint_auth/flight.rs
+++ b/crates/runtime/tests/endpoint_auth/flight.rs
@@ -25,6 +25,7 @@ use crate::{
     utils::{test_request_context, wait_until_true},
 };
 use arrow_flight::{error::FlightError, flight_service_client::FlightServiceClient};
+use flightrepl::cache_control;
 use rand::Rng;
 use runtime::{auth::EndpointAuth, config::Config, Runtime};
 use runtime_auth::{api_key::ApiKeyAuth, FlightBasicAuth};
@@ -96,6 +97,7 @@ async fn test_flight_auth() -> Result<(), anyhow::Error> {
             "SELECT 1",
             Some(&"valid".to_string()),
             &format!("spiceci/{}", env!("CARGO_PKG_VERSION")),
+            cache_control::CacheControl::Cache,
         )
         .await;
         assert!(result.is_ok());
@@ -105,6 +107,7 @@ async fn test_flight_auth() -> Result<(), anyhow::Error> {
             "SELECT 1",
             None,
             &format!("spiceci/{}", env!("CARGO_PKG_VERSION")),
+            cache_control::CacheControl::Cache,
         )
         .await
         else {

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -99,7 +99,7 @@ async fn execute_query_and_check_cache_status(
         .await
         .map_err(|e| format!("Failed to collect query results: {e}"))?;
 
-    assert_eq!(query_result.from_cache, expected_cache_status);
+    assert_eq!(query_result.cache_status, expected_cache_status);
 
     Ok(records)
 }

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use app::AppBuilder;
 use arrow::array::RecordBatch;
+use cache::QueryCacheStatus;
 use futures::TryStreamExt;
 use runtime::{datafusion::query::QueryBuilder, status, Runtime};
 use spicepod::component::{dataset::Dataset, params::Params, runtime::ResultsCache};

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -65,16 +65,20 @@ async fn results_cache_system_queries() -> Result<(), String> {
 
             rt.load_components().await;
 
-            assert!(
-                execute_query_and_check_cache_status(&rt, "show tables", None)
-                    .await
-                    .is_ok()
-            );
-            assert!(
-                execute_query_and_check_cache_status(&rt, "describe customer", None)
-                    .await
-                    .is_ok()
-            );
+            assert!(execute_query_and_check_cache_status(
+                &rt,
+                "show tables",
+                QueryCacheStatus::CacheNotChecked
+            )
+            .await
+            .is_ok());
+            assert!(execute_query_and_check_cache_status(
+                &rt,
+                "describe customer",
+                QueryCacheStatus::CacheNotChecked
+            )
+            .await
+            .is_ok());
 
             Ok(())
         })
@@ -84,7 +88,7 @@ async fn results_cache_system_queries() -> Result<(), String> {
 async fn execute_query_and_check_cache_status(
     rt: &Runtime,
     query: &str,
-    expected_cache_status: Option<bool>,
+    expected_cache_status: QueryCacheStatus,
 ) -> Result<Vec<RecordBatch>, String> {
     let query = QueryBuilder::new(query, rt.datafusion()).build();
 


### PR DESCRIPTION
# 🗣 Description

Implements a new feature that supports reading `Cache-Control: no-cache` headers on the SQL query APIs to control whether the results cache is considered for the execution of a given query.

I've also added a `--cache-control` CLI argument to `spice sql` that allows specifying this behavior via CLI as well.

`spice sql --cache-control cache` (Default)
`spice sql --cache-control no-cache`

Via HTTP Endpoint:

```bash
curl -H "cache-control: no-cache" -XPOST -i http://localhost:8090/v1/sql -d 'SELECT 1'
```

## Refactoring

I've taken the liberty of refactoring the cache logic in the main query path to make it easier to understand.

Also instead of storing the cache status as an `Option<bool>`, I've refactored it to use an explicit enum with the states we expect:

```rust
pub enum QueryCacheStatus {
    CacheNotChecked,
    CacheHit,
    CacheMiss,
}
```

## 🔨 Related Issues

Part of #4758 

## 📄 Documentation Updates

Needs a docs update for explaining how to use this new feature.

## 🤔 Concerns

N/A
