### PR TITLE
feat: Add truncate command for spice trace

### DIFF
--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -155,7 +155,8 @@ func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput 
 		if len(t.Input) == 0 {
 			t.Input = "<empty>"
 		} else if truncateLength > 0 && len(t.Input) > truncateLength {
-			t.Input = t.Input[:truncateLength] + "..."
+			originalLength := len(t.Input)
+			t.Input = t.Input[:truncateLength] + "... " + fmt.Sprintf("(%d characters omitted)", originalLength-truncateLength)
 		}
 	}
 
@@ -164,7 +165,8 @@ func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput 
 		if len(*t.CapturedOutput) == 0 {
 			output = "<empty>"
 		} else if truncateLength > 0 && len(*t.CapturedOutput) > truncateLength {
-			output = (*t.CapturedOutput)[:truncateLength] + "..."
+			originalLength := len(*t.CapturedOutput)
+			output = (*t.CapturedOutput)[:truncateLength] + "... " + fmt.Sprintf("(%d characters omitted)", originalLength-truncateLength)
 		} else {
 			output = *t.CapturedOutput
 		}

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -151,8 +151,12 @@ func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput 
 		base.Status = "🚫"
 	}
 
-	if truncateLength > 0 && includeInput && len(t.Input) > truncateLength {
-		t.Input = t.Input[:truncateLength] + "..."
+	if includeInput {
+		if len(t.Input) == 0 {
+			t.Input = "<empty>"
+		} else if truncateLength > 0 && len(t.Input) > truncateLength {
+			t.Input = t.Input[:truncateLength] + "..."
+		}
 	}
 
 	var output string

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -38,6 +38,9 @@ var (
 
 	// The include output flag
 	include_output bool
+
+	// The truncation length
+	truncateLength int
 )
 
 var supported_trace_tasks = []string{
@@ -102,7 +105,7 @@ $ spice trace ai_chat --id chatcmpl-At6ZmDE8iAYRPeuQLA0FLlWxGKNnM
 
 		table := make([]interface{}, len(rows))
 		for i, dataset := range rows {
-			table[i] = ToRowInterface(dataset.Tree, &dataset.Task, include_input, include_output)
+			table[i] = ToRowInterface(dataset.Tree, &dataset.Task, include_input, include_output, truncateLength)
 		}
 
 		util.WriteTable(table)
@@ -115,7 +118,7 @@ $ spice trace ai_chat --id chatcmpl-At6ZmDE8iAYRPeuQLA0FLlWxGKNnM
 // Must use a struct because `util.WriteTable` uses `reflect` functions that require a struct.
 // Must use separate structs for each combination of input/output. Otherwise table will have columns with all `nil`s. A
 // `json:"fieldName,omitempty"` tag does not work.
-func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput bool, includeOutput bool) interface{} {
+func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput bool, includeOutput bool, truncateLength int) interface{} {
 	type TaskRowBase struct {
 		Tree     string `json:"tree"`
 		Status   string `json:"status"`
@@ -148,17 +151,28 @@ func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput 
 		base.Status = "🚫"
 	}
 
+	if truncateLength > 0 && includeInput && len(t.Input) > truncateLength {
+		t.Input = t.Input[:truncateLength] + "..."
+	}
+
+	var output string
+	if t.CapturedOutput != nil {
+		if len(*t.CapturedOutput) == 0 {
+			output = "<empty>"
+		} else if truncateLength > 0 && len(*t.CapturedOutput) > truncateLength {
+			output = (*t.CapturedOutput)[:truncateLength] + "..."
+		} else {
+			output = *t.CapturedOutput
+		}
+	} else {
+		output = "<empty>"
+	}
+
 	if includeInput && includeOutput {
-		return TaskRowFull{TaskRowBase: base, Input: t.Input, Output: t.CapturedOutput}
+		return TaskRowFull{TaskRowBase: base, Input: t.Input, Output: output}
 	} else if includeInput {
 		return TaskRowWithInput{TaskRowBase: base, Input: t.Input}
 	} else if includeOutput {
-		var output string
-		if t.CapturedOutput != nil {
-			output = *t.CapturedOutput
-		} else {
-			output = ""
-		}
 		return TaskRowWithOutput{TaskRowBase: base, Output: output}
 	}
 	return base
@@ -170,6 +184,8 @@ func init() {
 	traceCmd.Flags().StringVar(&trace_id, "trace-id", "", "Return the trace with the given trace id")
 	traceCmd.Flags().BoolVar(&include_input, "include-input", false, "Include input data in the trace")
 	traceCmd.Flags().BoolVar(&include_output, "include-output", false, "Include output data in the trace")
+	traceCmd.Flags().IntVar(&truncateLength, "truncate", 0, "Truncate output to 80 characters if no value is specified")
+	traceCmd.Flags().Lookup("truncate").NoOptDefVal = "80"
 }
 
 func getTraceFilter(task string, id string, trace_id string) (string, error) {

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -184,7 +184,7 @@ func init() {
 	traceCmd.Flags().StringVar(&trace_id, "trace-id", "", "Return the trace with the given trace id")
 	traceCmd.Flags().BoolVar(&include_input, "include-input", false, "Include input data in the trace")
 	traceCmd.Flags().BoolVar(&include_output, "include-output", false, "Include output data in the trace")
-	traceCmd.Flags().IntVar(&truncateLength, "truncate", 0, "Truncate output to 80 characters if no value is specified")
+	traceCmd.Flags().IntVar(&truncateLength, "truncate", 0, "Truncates the input/output data to 80 when set, or to the given length")
 	traceCmd.Flags().Lookup("truncate").NoOptDefVal = "80"
 }
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Fixes a bug for displaying output when both `--include-input` and `--include-output` were supplied, where the output wasn't being de-referenced and was displaying a pointer address.
* Updated the input/output when value is empty to display `<empty>` on the line, instead of nothing (empty string)
* Added `--truncate`, defaulted to 80 length. Can be used as `--truncate` or `--truncate={length}` for an arbitrary truncation length.

Example output:

```console
TREE                   STATUS DURATION   TASK                    INPUT                                                                                                         OUTPUT  
5122013bb0035d84       ✅       908.08ms ai_chat                 {"messages":[{"role":"user","content":"Hello, how are you?"}],"model":"openai","... (53 characters omitted)   <empty> 
  ├── 7374cf7f07b37915 ✅         0.33ms tool_use::list_datasets <empty>                                                                                                       <empty> 
  └── a8a33044a9081926 ✅       905.79ms ai_completion           {"messages":[{"role":"assistant","tool_calls":[{"id":"initial_list_datasets","ty... (4223 characters omitted) <empty>
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4710 