### PR TITLE
fix: models runtime not required for cloud chat

### DIFF
--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -127,7 +127,9 @@ spice chat --model <model> --cloud
 			rtcontext.SetUserAgentClient("chat")
 		}
 
-		rtcontext.RequireModelsFlavor(cmd)
+		if !cloud {
+			rtcontext.RequireModelsFlavor(cmd)
+		}
 
 		model, err := cmd.Flags().GetString(modelKeyFlag)
 		if err != nil {

--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -73,7 +73,9 @@ spice search --cloud
 		cloud, _ := cmd.Flags().GetBool(cloudKeyFlag)
 		rtcontext := context.NewContext().WithCloud(cloud)
 
-		rtcontext.RequireModelsFlavor(cmd)
+		if !cloud {
+			rtcontext.RequireModelsFlavor(cmd)
+		}
 
 		datasets, err := api.GetDatasetsWithStatus(rtcontext)
 		if err != nil {


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* When `--cloud` is used with `spice chat` or `spice search`, the requirement that a models Runtime flavor be installed is skipped.

This allows the use of `spice chat --cloud` without any Runtime installed, or without a models flavor Runtime installed.