### PR TITLE
fix: Return BAD_REQUEST when not embeddings are configured

### DIFF
--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -833,7 +833,6 @@ impl VectorSearch {
         })
     }
 
-    #[allow(clippy::too_many_lines)]
     pub async fn search(&self, req: &SearchRequest) -> Result<VectorSearchResult> {
         let SearchRequest {
             text: query,

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -61,6 +61,9 @@ pub enum Error {
     #[snafu(display("Vector search cannot be run on {}.", data_source.to_quoted_string()))]
     CannotVectorSearchDataset { data_source: TableReference },
 
+    #[snafu(display("Vector search cannot be run.\nEmbeddings are not configured for the following datasets: [{}].", data_source.iter().map(TableReference::to_quoted_string).join(", ")))]
+    CannotVectorSearchDatasets { data_source: Vec<TableReference> },
+
     #[snafu(display("Error occurred interacting with datafusion: {source}"))]
     DataFusionError {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -833,6 +836,7 @@ impl VectorSearch {
         })
     }
 
+    #[allow(clippy::too_many_lines)]
     pub async fn search(&self, req: &SearchRequest) -> Result<VectorSearchResult> {
         let SearchRequest {
             text: query,
@@ -843,13 +847,25 @@ impl VectorSearch {
             keywords,
         } = req;
 
+        let tables_with_embeddings = self.user_tables_with_embeddings().await?;
         let tables = match data_source_opt {
             Some(ts) => ts.iter().map(TableReference::from).collect(),
-            None => self.user_tables_with_embeddings().await?,
+            None => tables_with_embeddings.clone(),
         };
 
         if tables.is_empty() {
             return Err(Error::NoTablesWithEmbeddingsFound {});
+        }
+
+        // reference the tables to the tables with embeddings
+        if tables.iter().any(|t| !tables_with_embeddings.contains(t)) {
+            return Err(Error::CannotVectorSearchDatasets {
+                data_source: tables
+                    .iter()
+                    .filter(|t| !tables_with_embeddings.contains(t))
+                    .cloned()
+                    .collect(),
+            });
         }
 
         let span = match Span::current() {

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -61,9 +61,6 @@ pub enum Error {
     #[snafu(display("Vector search cannot be run on {}.", data_source.to_quoted_string()))]
     CannotVectorSearchDataset { data_source: TableReference },
 
-    #[snafu(display("Vector search cannot be run.\nEmbeddings are not configured for the following datasets: [{}].", data_source.iter().map(TableReference::to_quoted_string).join(", ")))]
-    CannotVectorSearchDatasets { data_source: Vec<TableReference> },
-
     #[snafu(display("Error occurred interacting with datafusion: {source}"))]
     DataFusionError {
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -847,25 +844,13 @@ impl VectorSearch {
             keywords,
         } = req;
 
-        let tables_with_embeddings = self.user_tables_with_embeddings().await?;
         let tables = match data_source_opt {
             Some(ts) => ts.iter().map(TableReference::from).collect(),
-            None => tables_with_embeddings.clone(),
+            None => self.user_tables_with_embeddings().await?,
         };
 
         if tables.is_empty() {
             return Err(Error::NoTablesWithEmbeddingsFound {});
-        }
-
-        // reference the tables to the tables with embeddings
-        if tables.iter().any(|t| !tables_with_embeddings.contains(t)) {
-            return Err(Error::CannotVectorSearchDatasets {
-                data_source: tables
-                    .iter()
-                    .filter(|t| !tables_with_embeddings.contains(t))
-                    .cloned()
-                    .collect(),
-            });
         }
 
         let span = match Span::current() {

--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -146,17 +146,14 @@ pub(crate) async fn post(
             Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
         },
         Err(e) => {
-            match e {
+            let error_type = match e {
                 vector_search::Error::NoTablesWithEmbeddingsFound {}
-                | vector_search::Error::CannotVectorSearchDataset { .. }
-                | vector_search::Error::CannotVectorSearchDatasets { .. } => {
-                    return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
-                }
-                _ => {}
+                | vector_search::Error::CannotVectorSearchDataset { .. } => StatusCode::BAD_REQUEST,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
             };
 
             tracing::error!(target: "task_history", parent: &span, "{e}");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+            (error_type, e.to_string()).into_response()
         }
     }
 }

--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use crate::embeddings::vector_search::{
-    to_matches_sorted, Match, SearchRequest, SearchRequestAIJson, SearchRequestHTTPJson,
+    self, to_matches_sorted, Match, SearchRequest, SearchRequestAIJson, SearchRequestHTTPJson,
     VectorSearch,
 };
 use axum::{
@@ -146,6 +146,15 @@ pub(crate) async fn post(
             Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
         },
         Err(e) => {
+            match e {
+                vector_search::Error::NoTablesWithEmbeddingsFound {}
+                | vector_search::Error::CannotVectorSearchDataset { .. }
+                | vector_search::Error::CannotVectorSearchDatasets { .. } => {
+                    return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+                }
+                _ => {}
+            };
+
             tracing::error!(target: "task_history", parent: &span, "{e}");
             (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
         }


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Makes vector search endpoint return a `BAD_REQUEST` instead of an `INTERNAL_SERVER_ERROR` when a search is requested with no datasets with embeddings available.