### PR TITLE
Add Results-Cache-Status to indicate query result came from cache

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -1208,7 +1208,7 @@ jobs:
         run: |
           response=$(curl -i -XPOST "127.0.0.1:8090/v1/sql" --data "SELECT c_name FROM (SELECT * FROM customer)")
           echo "$response"
-          if echo "$response" | grep -q "x-cache: Miss from spiceai"; then
+          if echo "$response" | grep -q "results-cache-status: MISS"; then
             echo "Cache miss detected as expected"
           else
             echo "Cache miss not detected" >&2
@@ -1220,7 +1220,7 @@ jobs:
         run: |
           response=$(curl -i -XPOST "127.0.0.1:8090/v1/sql" --data "select c_name from (select * from customer)")
           echo "$response"
-          if echo "$response" | grep -q "x-cache: Hit from spiceai"; then
+          if echo "$response" | grep -q "results-cache-status: HIT"; then
             echo "Cache hit detected as expected"
           else
             echo "Cache hit not detected" >&2
@@ -1245,7 +1245,7 @@ jobs:
         run: |
           response=$(curl -i -XPOST "127.0.0.1:8090/v1/sql" --data "SELECT c_name FROM (SELECT * FROM customer)")
           echo "$response"
-          if echo "$response" | grep -q "x-cache: Miss from spiceai"; then
+          if echo "$response" | grep -q "results-cache-status: MISS"; then
             echo "Cache miss detected as expected"
           else
             echo "Cache miss not detected" >&2

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -63,20 +63,31 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct QueryResult {
     pub data: SendableRecordBatchStream,
-    pub cache_status: QueryCacheStatus,
+    pub results_cache_status: QueryResultsCacheStatus,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QueryCacheStatus {
-    CacheNotChecked,
+pub enum QueryResultsCacheStatus {
+    // The request was not eligible for caching, and thus the results cache was not checked.
+    CacheDisabled,
+    // The request asked to bypass the cache, i.e. via `Cache-Control: no-cache`.
+    CacheBypass,
+    // The request was a cache hit.
     CacheHit,
+    // The request was a cache miss.
     CacheMiss,
 }
 
 impl QueryResult {
     #[must_use]
-    pub fn new(data: SendableRecordBatchStream, cache_status: QueryCacheStatus) -> Self {
-        QueryResult { data, cache_status }
+    pub fn new(
+        data: SendableRecordBatchStream,
+        results_cache_status: QueryResultsCacheStatus,
+    ) -> Self {
+        QueryResult {
+            data,
+            results_cache_status,
+        }
     }
 }
 

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -401,7 +401,7 @@ pub async fn get_records(
     let response = client.do_get(request).await?;
     let from_cache = response
         .metadata()
-        .get("x-cache")
+        .get("results-cache-status")
         .and_then(|value| value.to_str().ok())
         .is_some_and(|s| s.to_lowercase().starts_with("hit"));
 

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -29,7 +29,7 @@ use arrow_flight::encode::FlightDataEncoderBuilder;
 use arrow_flight::{Action, ActionType, Criteria, IpcMessage, PollInfo, SchemaResult};
 use arrow_ipc::writer::IpcWriteOptions;
 use bytes::Bytes;
-use cache::QueryCacheStatus;
+use cache::QueryResultsCacheStatus;
 use datafusion::error::DataFusionError;
 use datafusion::sql::sqlparser::parser::ParserError;
 use datafusion::sql::TableReference;
@@ -180,7 +180,7 @@ impl Service {
     ) -> Result<
         (
             BoxStream<'static, Result<FlightData, Status>>,
-            QueryCacheStatus,
+            QueryResultsCacheStatus,
         ),
         Status,
     > {
@@ -230,7 +230,7 @@ impl Service {
 
         let flights_stream = stream::once(async { Ok(schema_flight_data) }).chain(batches_stream);
 
-        Ok((flights_stream.boxed(), query_result.cache_status))
+        Ok((flights_stream.boxed(), query_result.results_cache_status))
     }
 }
 

--- a/crates/runtime/tests/results_cache/mod.rs
+++ b/crates/runtime/tests/results_cache/mod.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use app::AppBuilder;
 use arrow::array::RecordBatch;
-use cache::QueryCacheStatus;
+use cache::QueryResultsCacheStatus;
 use futures::TryStreamExt;
 use runtime::{datafusion::query::QueryBuilder, status, Runtime};
 use spicepod::component::{dataset::Dataset, params::Params, runtime::ResultsCache};
@@ -69,14 +69,14 @@ async fn results_cache_system_queries() -> Result<(), String> {
             assert!(execute_query_and_check_cache_status(
                 &rt,
                 "show tables",
-                QueryCacheStatus::CacheNotChecked
+                QueryResultsCacheStatus::CacheDisabled
             )
             .await
             .is_ok());
             assert!(execute_query_and_check_cache_status(
                 &rt,
                 "describe customer",
-                QueryCacheStatus::CacheNotChecked
+                QueryResultsCacheStatus::CacheDisabled
             )
             .await
             .is_ok());
@@ -89,7 +89,7 @@ async fn results_cache_system_queries() -> Result<(), String> {
 async fn execute_query_and_check_cache_status(
     rt: &Runtime,
     query: &str,
-    expected_cache_status: QueryCacheStatus,
+    expected_cache_status: QueryResultsCacheStatus,
 ) -> Result<Vec<RecordBatch>, String> {
     let query = QueryBuilder::new(query, rt.datafusion()).build();
 
@@ -104,7 +104,7 @@ async fn execute_query_and_check_cache_status(
         .await
         .map_err(|e| format!("Failed to collect query results: {e}"))?;
 
-    assert_eq!(query_result.cache_status, expected_cache_status);
+    assert_eq!(query_result.results_cache_status, expected_cache_status);
 
     Ok(records)
 }


### PR DESCRIPTION
# 🗣 Description

Adds a new header `Results-Cache-Status` that can be used to determine if the results from a given query came from the results cache or not.

There are 4 possible states:
1) `Results-Cache-Status: HIT` - the query results were served from the results cache
2) `Results-Cache-Status: MISS` - the query results looked in the cache, couldn't find a matching cached value and performed the query
3) `Results-Cache-Status: BYPASS` - the request had a directive to bypass the cache, i.e. via `Cache-Control: no-cache`
4) header is omitted - the results cache was disabled

The previous `X-Cache` header is kept for backwards compatibility.

Examples:
```bash
# Ask the runtime to bypass the cache
$ curl -H "cache-control: no-cache" -XPOST -i http://localhost:8090/v1/sql -d 'select * from test limit 1;'
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
results-cache-status: BYPASS
vary: origin, access-control-request-method, access-control-request-headers
content-length: 85
date: Fri, 14 Feb 2025 06:21:09 GMT

# Cache miss
$ curl -XPOST -i http://localhost:8090/v1/sql -d 'select * from test limit 1;'
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
x-cache: Miss from spiceai
results-cache-status: MISS
vary: origin, access-control-request-method, access-control-request-headers
content-length: 85
date: Fri, 14 Feb 2025 06:21:03 GMT

# Cache hit
$ curl -XPOST -i http://localhost:8090/v1/sql -d 'select * from test limit 1;'
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
x-cache: Hit from spiceai
results-cache-status: HIT
vary: origin, access-control-request-method, access-control-request-headers
content-length: 85
date: Fri, 14 Feb 2025 06:20:38 GMT

# Results cache disabled (no header)
$ curl -XPOST -i http://localhost:8090/v1/sql -d 'select * from runtime.task_history limit 1;'
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
vary: origin, access-control-request-method, access-control-request-headers
content-length: 305
date: Fri, 14 Feb 2025 06:20:54 GMT
```


## 📄 Documentation Updates

Will require a docs update.

## 🤔 Concerns

N/A
