### PR TITLE
Allow homebrew spice cli to upgrade the runtime

### DIFF
--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -207,7 +207,6 @@ jobs:
               Select-Object FullName, Length, LastWriteTime | 
               Format-Table -AutoSize
 
-
   test_spice_upgrade_without_runtime:
     name: 'Test spice upgrade without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
     continue-on-error: true
@@ -288,3 +287,51 @@ jobs:
               Where-Object { $_.Name -like "spice*" } | 
               Select-Object FullName, Length, LastWriteTime | 
               Format-Table -AutoSize
+
+  test_spice_upgrade_from_brew:
+    name: 'Test spice upgrade from a homebrew spice cli'
+    continue-on-error: true
+    runs-on: ${{ matrix.target.runner }}
+    env:
+      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs:
+      - build
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        target: 
+          - name: "macOS aarch64 (Apple Silicon)"
+          - runner: "macos-14"
+          - target_os: "darwin"
+          - target_arch: "aarch64"
+          - target_arch_go: "arm64"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+        if: github.event.inputs.build_cli != 'false'
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: ./build
+
+      - name: download spice cli from homebrew
+        run: |
+          brew install spiceai/spiceai/spice
+          spice version
+          which spice
+
+      - name: download spice cli from homebrew
+        run: |
+          brewSpicePath=$(which spice)
+          brewSpiceDir=$(dirname "$spicePath")
+          sudo mv ./build/spice "$spiceDir/spice"
+          chmod +x "$brewSpicePath"
+          spice version
+
+      - name: Mimic the homebrew spice upgrade
+        run: |
+          spice upgrade

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -290,6 +290,7 @@ jobs:
 
   test_spice_upgrade_from_brew:
     name: 'Test spice upgrade from a homebrew spice cli'
+    if: github.event.inputs.build_cli == 'true'
     continue-on-error: true
     runs-on: ${{ matrix.target.runner }}
     env:
@@ -324,7 +325,7 @@ jobs:
           spice version
           which spice
 
-      - name: download spice cli from homebrew
+      - name: move the built spice cli to brew directory
         run: |
           sudo mv ./build/spice /opt/homebrew/bin
           sudo chmod +x /opt/homebrew/bin/spice

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -326,10 +326,9 @@ jobs:
 
       - name: download spice cli from homebrew
         run: |
-          brewSpicePath=$(which spice)
-          brewSpiceDir=$(dirname "$spicePath")
-          sudo mv ./build/spice "$spiceDir/spice"
-          chmod +x "$brewSpicePath"
+          sudo mv ./build/spice /opt/homebrew/bin
+          sudo chmod +x /opt/homebrew/bin/spice
+          which spice
           spice version
 
       - name: Mimic the homebrew spice upgrade

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -332,6 +332,6 @@ jobs:
           which spice
           spice version
 
-      - name: Mimic the homebrew spice upgrade
+      - name: run spice upgrade
         run: |
           spice upgrade

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -301,13 +301,13 @@ jobs:
 
     strategy:
       matrix:
-        target: 
+        target:
           - name: "macOS aarch64 (Apple Silicon)"
-          - runner: "macos-14"
-          - target_os: "darwin"
-          - target_arch: "aarch64"
-          - target_arch_go: "arm64"
-
+            runner: "macos-14"
+            target_os: "darwin"
+            target_arch: "aarch64"
+            target_arch_go: "arm64"
+            
     steps:
       - uses: actions/checkout@v4
 

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -162,7 +162,7 @@ func upgradeCli(force bool, rtcontext *context.RuntimeContext) bool {
 
 	cliVersion := version.Version()
 	if cliVersion == release.TagName && !force {
-		slog.Info(fmt.Sprintf("Using the latest version %s. No CLI upgrade required.", release.TagName))
+		slog.Info(fmt.Sprintf("Using the latest version %s. CLI upgrade not required.", release.TagName))
 		return true
 	}
 

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -174,7 +174,7 @@ func upgradeCli(force bool, rtcontext *context.RuntimeContext) bool {
 
 	switch spicePathVar {
 	case constants.BrewInstall:
-		slog.Info("Spice is downloaded from Homebrew. Run `brew upgrade spiceai/spiceai/spice` to upgrade the CLI and Runtime.")
+		slog.Info("Spice is installed via Homebrew. To upgrade the CLI and Runtime, run: `brew upgrade spiceai/spiceai/spice`.")
 		return false
 	case constants.OtherInstall:
 		msg := fmt.Sprintf("Spice upgrade failed: Spice CLI found at non-standard location '%s'. To upgrade:\n"+

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -177,10 +177,10 @@ func upgradeCli(force bool, rtcontext *context.RuntimeContext) bool {
 		slog.Info("Spice is installed via Homebrew. To upgrade the CLI and Runtime, run: `brew upgrade spiceai/spiceai/spice`.")
 		return false
 	case constants.OtherInstall:
-		msg := fmt.Sprintf("Spice upgrade failed: Spice CLI found at non-standard location '%s'. To upgrade:\n"+
-			"1. Remove current installation\n"+
-			"2. Refer to https://spiceai.org/docs/installation to reinstall spice\n"+
-			"3. Try upgrade again", spicePath)
+		msg := fmt.Sprintf("Spice upgrade failed: Spice CLI installed in non-standard location '%s'\n"+
+			"To upgrade:\n"+
+			"1. Remove existing installation\n"+
+			"2. Follow https://spiceai.org/docs/installation to reinstall spice", spicePath)
 		slog.Info(msg)
 		return false
 	}

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -174,13 +174,15 @@ func upgradeCli(force bool, rtcontext *context.RuntimeContext) bool {
 
 	switch spicePathVar {
 	case constants.BrewInstall:
-		slog.Info("Spice is installed via Homebrew. To upgrade the CLI and Runtime, run: `brew upgrade spiceai/spiceai/spice`.")
+		slog.Info("Spice is installed via Homebrew. Upgrade the CLI and Runtime by running:\n\n  brew upgrade spiceai/spiceai/spice\n")
 		return false
 	case constants.OtherInstall:
-		msg := fmt.Sprintf("Spice upgrade failed: Spice CLI installed in non-standard location '%s'\n"+
+		msg := fmt.Sprintf("Spice upgrade failed: The Spice CLI is installed in a non-standard location: '%s'.\n\n"+
 			"To upgrade:\n"+
-			"1. Remove existing installation\n"+
-			"2. Follow https://spiceai.org/docs/installation to reinstall spice", spicePath)
+			"1. Remove the existing installation. Example:\n"+
+			"   rm -rf %s\n\n"+
+			"2. Reinstall Spice by following the instructions at:\n"+
+			"   https://spiceai.org/docs/installation", spicePath, spicePath)
 		slog.Info(msg)
 		return false
 	}

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -82,7 +82,7 @@ spice upgrade
 		}
 
 		if runtimeUpgradeRequired == "" {
-			slog.Info(fmt.Sprintf("Using version %s. No runtime upgrade required.", currentVersion))
+			slog.Info(fmt.Sprintf("Using version %s. Runtime upgrade not required.", currentVersion))
 			return
 		}
 

--- a/bin/spice/cmd/upgrade.go
+++ b/bin/spice/cmd/upgrade.go
@@ -55,25 +55,6 @@ spice upgrade
 			os.Exit(1)
 		}
 
-		spicePathVar, spicePath, err := rtcontext.SpicePath()
-		if err != nil {
-			slog.Error("finding spice binary location", "error", err)
-			os.Exit(1)
-		}
-
-		switch spicePathVar {
-		case constants.BrewInstall:
-			slog.Info("Spice is downloaded from Homebrew. Run `brew upgrade spiceai/spiceai/spice` to upgrade the CLI.")
-			return
-		case constants.OtherInstall:
-			msg := fmt.Sprintf("Spice upgrade failed: Spice CLI found at non-standard location '%s'. To upgrade:\n"+
-				"1. Remove current installation\n"+
-				"2. Refer to https://spiceai.org/docs/installation to reinstall spice\n"+
-				"3. Try upgrade again", spicePath)
-			slog.Info(msg)
-			return
-		}
-
 		if os.Getenv(constants.SpiceUpgradeReloadEnv) != "true" {
 			// Run CLI upgrade
 			if !upgradeCli(force, rtcontext) {
@@ -101,7 +82,7 @@ spice upgrade
 		}
 
 		if runtimeUpgradeRequired == "" {
-			slog.Info(fmt.Sprintf("Using version %s. No upgrade required.", currentVersion))
+			slog.Info(fmt.Sprintf("Using version %s. No runtime upgrade required.", currentVersion))
 			return
 		}
 
@@ -181,8 +162,27 @@ func upgradeCli(force bool, rtcontext *context.RuntimeContext) bool {
 
 	cliVersion := version.Version()
 	if cliVersion == release.TagName && !force {
-		slog.Info(fmt.Sprintf("Using the latest version %s. No upgrade required.", release.TagName))
+		slog.Info(fmt.Sprintf("Using the latest version %s. No CLI upgrade required.", release.TagName))
 		return true
+	}
+
+	spicePathVar, spicePath, err := rtcontext.SpicePath()
+	if err != nil {
+		slog.Error("finding spice binary location", "error", err)
+		os.Exit(1)
+	}
+
+	switch spicePathVar {
+	case constants.BrewInstall:
+		slog.Info("Spice is downloaded from Homebrew. Run `brew upgrade spiceai/spiceai/spice` to upgrade the CLI and Runtime.")
+		return false
+	case constants.OtherInstall:
+		msg := fmt.Sprintf("Spice upgrade failed: Spice CLI found at non-standard location '%s'. To upgrade:\n"+
+			"1. Remove current installation\n"+
+			"2. Refer to https://spiceai.org/docs/installation to reinstall spice\n"+
+			"3. Try upgrade again", spicePath)
+		slog.Info(msg)
+		return false
 	}
 
 	assetName := github.GetAssetName(constants.SpiceCliFilename)


### PR DESCRIPTION
# 🗣 Description

Allow the homebrew spice cli to upgrade the runtime, and block the homebrew spice cli from upgrading the cli.

Together with the homebrew formula update to run `spice upgrade` after `brew upgrade spiceai/spiceai/spice` https://github.com/spiceai/homebrew-spiceai/pull/54, this allows the runtime to be correctly upgraded for homebrew Spice CLI.

Block the homebrew spice cli to upgrade cli:
![image](https://github.com/user-attachments/assets/fd3a2713-7970-4091-b142-4c2d85329850)

When homebrew cli is upgraded to latest, allow it to run `spice upgrade` to upgrade runtime:
- Runtime Installed
![image](https://github.com/user-attachments/assets/b2bb3422-d31c-4809-98a8-e2fcd1583dd3)
- Runtime not installed
![image](https://github.com/user-attachments/assets/c1b1cda7-a92e-46b1-b40e-0f0771391880)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
