### PR TITLE
Fix Snowflake Case-Sensitive Identifiers support

### DIFF
--- a/crates/data_components/src/snowflake.rs
+++ b/crates/data_components/src/snowflake.rs
@@ -16,7 +16,10 @@ limitations under the License.
 
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use datafusion::{datasource::TableProvider, sql::TableReference};
+use datafusion::{
+    datasource::TableProvider,
+    sql::{unparser::dialect, TableReference},
+};
 use datafusion_table_providers::sql::{
     db_connection_pool::DbConnectionPool,
     sql_provider_datafusion::{self, SqlTable},
@@ -51,6 +54,12 @@ impl SnowflakeTableFactory {
     }
 }
 
+fn snowflake_dialect() -> dialect::CustomDialect {
+    dialect::CustomDialectBuilder::new()
+        .with_identifier_quote_style('"')
+        .build()
+}
+
 #[async_trait]
 impl Read for SnowflakeTableFactory {
     async fn table_provider(
@@ -58,19 +67,19 @@ impl Read for SnowflakeTableFactory {
         table_reference: TableReference,
         schema: Option<SchemaRef>,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
+        let dialect = Arc::new(snowflake_dialect());
+
         let pool = Arc::clone(&self.pool);
         let table_provider = match schema {
-            Some(schema) => Arc::new(SqlTable::new_with_schema(
-                "snowflake",
-                &pool,
-                schema,
-                table_reference,
-                None,
-            )),
+            Some(schema) => Arc::new(
+                SqlTable::new_with_schema("snowflake", &pool, schema, table_reference, None)
+                    .with_dialect(dialect),
+            ),
             None => Arc::new(
                 SqlTable::new("snowflake", &pool, table_reference, None)
                     .await
-                    .context(UnableToConstructSQLTableSnafu)?,
+                    .context(UnableToConstructSQLTableSnafu)?
+                    .with_dialect(dialect),
             ),
         };
 


### PR DESCRIPTION
# 🗣 Description

By default Snowflake converts non-quoted columns and tables to uppercase. PR adds Snowflake dialect to quote identifiers (column names and table reference).


Before

```shell
rewritten_sql=SELECT DEMO.Test.TestTable.FirstName, DEMO.Test.TestTable.LastName, DEMO.Test.TestTable.Age FROM DEMO.Test.TestTable 

Query Error: Failed to execute query.
Error executing query: Snowflake API error. Code: `002003`. Message: `SQL compilation error:
Schema 'DEMO.TEST' does not exist or not authorized.
``` 

After 


```
rewritten_sql=SELECT "DEMO"."Test"."TestTable"."FirstName", "DEMO"."Test"."TestTable"."LastName", "DEMO"."Test"."TestTable"."Age" FROM "DEMO"."Test"."TestTable"

sql> select * from test_table;
+-----------+----------+-----+
| FirstName | LastName | Age |
+-----------+----------+-----+
| John      | Smith    | 30  |
|           |          |     |
+-----------+----------+-----+
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
