### PR TITLE
Log CLI and Runtime Versions on startup

### DIFF
--- a/bin/spice/cmd/spice.go
+++ b/bin/spice/cmd/spice.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/spiceai/spiceai/bin/spice/pkg/util"
+	"github.com/spiceai/spiceai/bin/spice/pkg/version"
 )
 
 var verbosity = util.NewVerbosity()
@@ -31,6 +32,15 @@ var verbosity = util.NewVerbosity()
 var RootCmd = &cobra.Command{
 	Use:   "spice",
 	Short: "Spice.ai CLI",
+
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+
+		if cmd.Name() == "version" {
+			// don't duplicate version information in version command
+			return
+		}
+		cmd.Printf("Spice.ai OSS CLI %s (https://spiceai.org/docs/cli)\n", version.Version())
+	},
 }
 
 // Execute adds all child commands to the root command.

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -69,7 +69,11 @@ fn get_version_string() -> String {
     if cfg!(feature = "release") {
         format!("v{}{}", env!("CARGO_PKG_VERSION"), build_metadata())
     } else {
-        let mut version = format!("v{}-build.{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT_HASH"));
+        let mut version = format!(
+            "v{}-build.{}",
+            env!("CARGO_PKG_VERSION"),
+            env!("GIT_COMMIT_HASH")
+        );
         if cfg!(feature = "dev") {
             version.push_str("-dev");
         }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -26,24 +26,7 @@ fn main() {
     let args = spiced::Args::parse();
 
     if args.version {
-        if cfg!(feature = "release") {
-            println!("v{}{}", env!("CARGO_PKG_VERSION"), build_metadata());
-        } else {
-            print!(
-                "v{}-build.{}",
-                env!("CARGO_PKG_VERSION"),
-                env!("GIT_COMMIT_HASH")
-            );
-
-            if cfg!(feature = "dev") {
-                print!("-dev");
-            }
-
-            print!("{}", build_metadata());
-
-            println!();
-        };
-
+        println!("{}", get_version_string());
         return;
     }
 
@@ -75,8 +58,24 @@ fn main() {
 }
 
 async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Error>> {
+    spiced::in_tracing_context(|| {
+        tracing::info!("Starting Spice Runtime {version}", version = get_version_string());
+    });
     spiced::run(args).await?;
     Ok(())
+}
+
+fn get_version_string() -> String {
+    if cfg!(feature = "release") {
+        format!("v{}{}", env!("CARGO_PKG_VERSION"), build_metadata())
+    } else {
+        let mut version = format!("v{}-build.{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT_HASH"));
+        if cfg!(feature = "dev") {
+            version.push_str("-dev");
+        }
+        version.push_str(&build_metadata());
+        version
+    }
 }
 
 /// Build metadata conforming to <https://semver.org/#spec-item-10>

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -77,7 +77,7 @@ fn get_version_string() -> String {
         if cfg!(feature = "dev") {
             version.push_str("-dev");
         }
-        version.push_str(&build_metadata());
+        version.push_str(build_metadata());
         version
     }
 }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
 
 async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Error>> {
     spiced::in_tracing_context(|| {
-        tracing::info!("Starting Spice Runtime {version}", version = get_version_string());
+        tracing::info!("Starting runtime {version}", version = get_version_string());
     });
     spiced::run(args).await?;
     Ok(())


### PR DESCRIPTION
# 🗣 Description

Add version information to runtime and CLI when started

```
spice run
Spice.ai OSS CLI v1.1.0-unstable-build.3ea213f7 (https://spiceai.org/docs/cli)
2025/02/16 01:42:14 INFO Checking for latest Spice runtime release...
2025/02/16 01:42:15 INFO Spice.ai runtime starting...
2025-02-16T09:42:15.985352Z  INFO spiced: Starting Spice Runtime v1.1.0-unstable-build.3ea213f7+models.metal
2025-02-16T09:42:15.989786Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
..
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
