### PR TITLE
Fix 'actual" and "output" columns in `eval.results`. 

### DIFF
--- a/crates/runtime/src/model/eval/mod.rs
+++ b/crates/runtime/src/model/eval/mod.rs
@@ -269,21 +269,21 @@ async fn write_results(
     run_id: &EvalRunId,
     df: Arc<DataFusion>,
     input: &[DatasetInput],
-    output: &[DatasetOutput],
+    actual: &[DatasetOutput],
     expected: &[DatasetOutput],
     scores: &HashMap<String, Vec<f32>>,
 ) -> Result<()> {
     let mut bldr = ResultBuilder::new();
     for i in 0..input.len() {
         let input = &input[i];
-        let output = &output[i];
+        let actual = &actual[i];
         let expected = &expected[i];
         for (name, score) in scores {
             bldr.append(
                 run_id,
                 chrono::Utc::now(),
                 input,
-                output,
+                actual,
                 expected,
                 name,
                 score[i],

--- a/crates/runtime/src/model/eval/mod.rs
+++ b/crates/runtime/src/model/eval/mod.rs
@@ -283,8 +283,8 @@ async fn write_results(
                 run_id,
                 chrono::Utc::now(),
                 input,
-                expected,
                 actual,
+                expected,
                 name,
                 score[i],
             )?;

--- a/crates/runtime/src/model/eval/mod.rs
+++ b/crates/runtime/src/model/eval/mod.rs
@@ -283,8 +283,8 @@ async fn write_results(
                 run_id,
                 chrono::Utc::now(),
                 input,
-                actual,
                 expected,
+                actual,
                 name,
                 score[i],
             )?;

--- a/crates/runtime/src/model/eval/result.rs
+++ b/crates/runtime/src/model/eval/result.rs
@@ -48,7 +48,7 @@ pub static EVAL_RESULTS_TABLE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
             false,
         ),
         Field::new("input", DataType::Utf8, false),
-        Field::new("output", DataType::Utf8, false),
+        Field::new("expected", DataType::Utf8, false),
         Field::new("actual", DataType::Utf8, false),
         Field::new("scorer", DataType::Utf8, false),
         Field::new("value", DataType::Float32, false),
@@ -87,7 +87,7 @@ pub(super) struct ResultBuilder {
     run_id: StringBuilder,
     created_at: TimestampSecondBuilder,
     input: StringBuilder,
-    output: StringBuilder, // expected output given the `input`.
+    expected: StringBuilder,
     actual: StringBuilder,
     scorer: StringBuilder,
     value: Float32Builder,
@@ -99,7 +99,7 @@ impl ResultBuilder {
             run_id: StringBuilder::new(),
             created_at: TimestampSecondBuilder::new(),
             input: StringBuilder::new(),
-            output: StringBuilder::new(),
+            expected: StringBuilder::new(),
             actual: StringBuilder::new(),
             scorer: StringBuilder::new(),
             value: Float32Builder::new(),
@@ -120,7 +120,7 @@ impl ResultBuilder {
         self.run_id.append_value(id);
         self.created_at.append_value(created_at.timestamp());
         self.input.append_value(input.try_serialize()?);
-        self.output.append_value(expected.try_serialize()?);
+        self.expected.append_value(expected.try_serialize()?);
         self.actual.append_value(actual.try_serialize()?);
         self.scorer.append_value(scorer);
         self.value.append_value(value);
@@ -134,7 +134,7 @@ impl ResultBuilder {
                 Arc::new(self.run_id.finish()),
                 Arc::new(self.created_at.finish()),
                 Arc::new(self.input.finish()),
-                Arc::new(self.output.finish()),
+                Arc::new(self.expected.finish()),
                 Arc::new(self.actual.finish()),
                 Arc::new(self.scorer.finish()),
                 Arc::new(self.value.finish()),

--- a/crates/runtime/src/model/eval/result.rs
+++ b/crates/runtime/src/model/eval/result.rs
@@ -48,8 +48,8 @@ pub static EVAL_RESULTS_TABLE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
             false,
         ),
         Field::new("input", DataType::Utf8, false),
-        Field::new("expected", DataType::Utf8, false),
         Field::new("actual", DataType::Utf8, false),
+        Field::new("expected", DataType::Utf8, false),
         Field::new("scorer", DataType::Utf8, false),
         Field::new("value", DataType::Float32, false),
     ]))
@@ -87,8 +87,8 @@ pub(super) struct ResultBuilder {
     run_id: StringBuilder,
     created_at: TimestampSecondBuilder,
     input: StringBuilder,
-    expected: StringBuilder,
     actual: StringBuilder,
+    expected: StringBuilder,
     scorer: StringBuilder,
     value: Float32Builder,
 }
@@ -99,8 +99,8 @@ impl ResultBuilder {
             run_id: StringBuilder::new(),
             created_at: TimestampSecondBuilder::new(),
             input: StringBuilder::new(),
-            expected: StringBuilder::new(),
             actual: StringBuilder::new(),
+            expected: StringBuilder::new(),
             scorer: StringBuilder::new(),
             value: Float32Builder::new(),
         }
@@ -120,8 +120,8 @@ impl ResultBuilder {
         self.run_id.append_value(id);
         self.created_at.append_value(created_at.timestamp());
         self.input.append_value(input.try_serialize()?);
-        self.expected.append_value(expected.try_serialize()?);
         self.actual.append_value(actual.try_serialize()?);
+        self.expected.append_value(expected.try_serialize()?);
         self.scorer.append_value(scorer);
         self.value.append_value(value);
         Ok(())
@@ -134,11 +134,74 @@ impl ResultBuilder {
                 Arc::new(self.run_id.finish()),
                 Arc::new(self.created_at.finish()),
                 Arc::new(self.input.finish()),
-                Arc::new(self.expected.finish()),
                 Arc::new(self.actual.finish()),
+                Arc::new(self.expected.finish()),
                 Arc::new(self.scorer.finish()),
                 Arc::new(self.value.finish()),
             ],
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::StringArray;
+    use chrono::Utc;
+
+    #[test]
+    fn test_builder_column_order() {
+        let mut builder = ResultBuilder::new();
+
+        let test_run_id: EvalRunId = "run_123".into();
+        let test_created_at = Utc::now();
+        let test_input = DatasetInput::from_raw("input_test");
+        let test_actual = DatasetOutput::from_raw("actual_test");
+        let test_expected = DatasetOutput::from_raw("expected_test");
+        let test_scorer = "scorer_test";
+        let test_value = 42.0_f32;
+
+        builder
+            .append(
+                &test_run_id,
+                test_created_at,
+                &test_input,
+                &test_actual,
+                &test_expected,
+                test_scorer,
+                test_value,
+            )
+            .expect("append should succeed");
+
+        let record_batch = builder.finish().expect("finish should succeed");
+
+        // Verify the schema order.
+        let schema = record_batch.schema();
+        let fields = schema.fields();
+
+        // Expected order (by index):
+        assert_eq!(fields[2].name(), "input");
+        assert_eq!(fields[3].name(), "actual");
+        assert_eq!(fields[4].name(), "expected");
+
+        let input_array = record_batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Column input should be a StringArray");
+        let actual_array = record_batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Column expected should be a StringArray");
+        let expected_array = record_batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Column actual should be a StringArray");
+
+        assert_eq!(input_array.value(0), "input_test");
+        assert_eq!(actual_array.value(0), "actual_test");
+        assert_eq!(expected_array.value(0), "expected_test");
     }
 }

--- a/crates/runtime/src/model/eval/result.rs
+++ b/crates/runtime/src/model/eval/result.rs
@@ -87,7 +87,7 @@ pub(super) struct ResultBuilder {
     run_id: StringBuilder,
     created_at: TimestampSecondBuilder,
     input: StringBuilder,
-    output: StringBuilder,
+    output: StringBuilder, // expected output given the `input`.
     actual: StringBuilder,
     scorer: StringBuilder,
     value: Float32Builder,
@@ -112,15 +112,15 @@ impl ResultBuilder {
         id: &EvalRunId,
         created_at: DateTime<Utc>,
         input: &DatasetInput,
-        output: &DatasetOutput,
         actual: &DatasetOutput,
+        expected: &DatasetOutput,
         scorer: &str,
         value: f32,
     ) -> Result<()> {
         self.run_id.append_value(id);
         self.created_at.append_value(created_at.timestamp());
         self.input.append_value(input.try_serialize()?);
-        self.output.append_value(output.try_serialize()?);
+        self.output.append_value(expected.try_serialize()?);
         self.actual.append_value(actual.try_serialize()?);
         self.scorer.append_value(scorer);
         self.value.append_value(value);

--- a/crates/runtime/src/model/eval/scorer/mod.rs
+++ b/crates/runtime/src/model/eval/scorer/mod.rs
@@ -45,14 +45,14 @@ pub type EvalScorerRegistry = Arc<RwLock<HashMap<String, Arc<dyn Scorer>>>>;
 /// Compute the scores for each [`Scorer`] selected given the results of running a model.
 pub(crate) async fn score_results(
     input: &[DatasetInput],
-    output: &[DatasetOutput],
+    actual: &[DatasetOutput],
     expected: &[DatasetOutput],
     scorers: &HashMap<String, Arc<dyn Scorer>>,
 ) -> HashMap<String, Vec<f32>> {
-    let mut aggregate: HashMap<String, Vec<f32>> = HashMap::with_capacity(output.len());
-    for ((input, output), expected) in input.iter().zip(output.iter()).zip(expected.iter()) {
+    let mut aggregate: HashMap<String, Vec<f32>> = HashMap::with_capacity(actual.len());
+    for ((input, actual), expected) in input.iter().zip(actual.iter()).zip(expected.iter()) {
         for (name, scorer) in scorers {
-            let s = scorer.score(input, output, expected).await;
+            let s = scorer.score(input, actual, expected).await;
             if let Some(scorer_results) = aggregate.get_mut(name) {
                 scorer_results.push(s);
             } else {

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -256,16 +256,6 @@ impl ToolUsingChat {
             let inner_req = self.add_runtime_tools(&req);
 
             let resp = self.inner_chat.chat_request(inner_req.clone()).await?;
-            let proceed_with_tools = resp.choices.first().is_some_and(|c| {
-                c.finish_reason
-                    .is_some_and(|f| matches!(f, FinishReason::ToolCalls))
-            });
-
-            // Return reason was not to call tools, so return early.
-            if !proceed_with_tools {
-                return Ok(resp);
-            }
-
             let usage = resp.usage.clone();
 
             let tools_used = resp

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -256,6 +256,16 @@ impl ToolUsingChat {
             let inner_req = self.add_runtime_tools(&req);
 
             let resp = self.inner_chat.chat_request(inner_req.clone()).await?;
+            let proceed_with_tools = resp.choices.first().is_some_and(|c| {
+                c.finish_reason
+                    .is_some_and(|f| matches!(f, FinishReason::ToolCalls))
+            });
+
+            // Return reason was not to call tools, so return early.
+            if !proceed_with_tools {
+                return Ok(resp);
+            }
+
             let usage = resp.usage.clone();
 
             let tools_used = resp


### PR DESCRIPTION
# 🗣 Description
 - Previously we were writing the expect and actual model responses in the opposite columns in the `eval.results` table.
 - Change naming to be clear which is from model, vs from eval dataset.
 
 ## Breaking Change
```diff
sql> describe eval.results;
  +-------------+-------------------------+-------------+
  | column_name | data_type               | is_nullable |
  +-------------+-------------------------+-------------+
  | run_id      | Utf8                    | NO          |
  | created_at  | Timestamp(Second, None) | NO          |
  | input       | Utf8                    | NO          |
- | output      | Utf8                    | NO          |
+ | expected    | Utf8                    | NO          |
  | actual      | Utf8                    | NO          |
  | scorer      | Utf8                    | NO          |
  | value       | Float32                 | NO          | 
  +-------------+-------------------------+-------------+
```

Docs:
- https://github.com/spiceai/cookbook/pull/92 