### PR TITLE
Provide link to supported OS list when user platform is not supported

### DIFF
--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -50,7 +50,7 @@ verifySupported() {
         fi
     done
 
-    echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
+    echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/reference/system_requirements#operating-systems-and-architectures"
     exit 1
 }
 

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -50,7 +50,7 @@ verifySupported() {
         fi
     done
 
-    echo "Unfortunately, ${current_osarch} is not supported. If you want to check the supported OS architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
+    echo "Unfortunately, ${current_osarch} is not supported. For supported architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
     exit 1
 }
 

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -50,7 +50,7 @@ verifySupported() {
         fi
     done
 
-    echo "No prebuilt binary for ${current_osarch}"
+    echo "Unfortunately, ${current_osarch} is not supported. If you want to check the supported OS architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
     exit 1
 }
 

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -50,7 +50,7 @@ verifySupported() {
         fi
     done
 
-    echo echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
+    echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
     exit 1
 }
 

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -50,7 +50,7 @@ verifySupported() {
         fi
     done
 
-    echo "Unfortunately, ${current_osarch} is not supported. For supported architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
+    echo echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
     exit 1
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -52,7 +52,7 @@ verifySupported() {
         fi
     done
 
-    echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
+    echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/reference/system_requirements#operating-systems-and-architectures"
     exit 1
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -52,7 +52,7 @@ verifySupported() {
         fi
     done
 
-    echo "Unfortunately, ${current_osarch} is not supported. For supported architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
+    echo echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
     exit 1
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -52,7 +52,7 @@ verifySupported() {
         fi
     done
 
-    echo echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
+    echo "${current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
     exit 1
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -52,7 +52,7 @@ verifySupported() {
         fi
     done
 
-    echo "Unfortunately, ${current_osarch} is not supported. If you want to check the supported OS architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
+    echo "Unfortunately, ${current_osarch} is not supported. For supported architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
     exit 1
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -52,7 +52,7 @@ verifySupported() {
         fi
     done
 
-    echo "No prebuilt binary for ${current_osarch}"
+    echo "Unfortunately, ${current_osarch} is not supported. If you want to check the supported OS architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
     exit 1
 }
 


### PR DESCRIPTION
# 🗣 Description

Provide link to supported OS list in error msg if user OS platform is not supported

## 🔨 Related Issues

[#4780](https://github.com/spiceai/spiceai/issues/4780)

## 📄 Documentation Updates

Same as above.

## 🤔 Concerns

1. This PR should be applied after the website is deployed (https://github.com/spiceai/docs/pull/878), to make the url (in error msg) valid.
(cf. even if the website is not updated, the url itself makes user land to spiceai.org/docs/installation anyway)

2. If you want to change the error message, please feel free to modify it.
