### PR TITLE
Upgrade to DuckDB v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,8 +3917,8 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "duckdb"
-version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae#c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae"
+version = "1.2.0"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a2f4f443601f0fc2a2b1919705a9adf74ec493c2#a2f4f443601f0fc2a2b1919705a9adf74ec493c2"
 dependencies = [
  "arrow",
  "cast",
@@ -6503,8 +6503,8 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae#c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae"
+version = "1.2.0"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a2f4f443601f0fc2a2b1919705a9adf74ec493c2#a2f4f443601f0fc2a2b1919705a9adf74ec493c2"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-feder
 datafusion-functions-json = "0.43"
 datafusion-table-providers = "0.1"
 dotenvy = "0.15"
-duckdb = "1.1.3"
+duckdb = "1.2.0"
 fundu = "2.0.1"
 futures = "0.3.30"
 globset = "0.4.15"
@@ -169,7 +169,7 @@ object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "465faf02bb6a2e6c11237368efbd9da91348bdd0" }
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "c7421f30d8ff2d39ed6df01a9ec51bc8781cfaae" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a2f4f443601f0fc2a2b1919705a9adf74ec493c2" }
 
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "dfb1e03a5f0702c1a318db5abf40e762d6b2bcc2" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }


### PR DESCRIPTION
# 🗣 Description

Upgrade to `duckdb` 1.2.0:
 - https://duckdb.org/2025/02/05/announcing-duckdb-120.html
 - https://github.com/duckdb/duckdb-rs/releases/tag/1.2.0

Additional changes inclduded:
 - Arrow version was downgraded from 54 to 53 to match currently used Arrow version by datafusion and other crates, until they are updated to use Arrow 54
 - [Linux build fix](https://github.com/duckdb/duckdb/commit/e8889b7a0e7fb9bf08d312e0397271b0c09b5876):  see discussion  https://github.com/duckdb/duckdb-rs/issues/436#issuecomment-2660973455
 - https://github.com/duckdb/duckdb-rs/pull/437

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
