### PR TITLE
Run benchmark tests w/o uploading test results (pending improvements)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -409,7 +409,7 @@ jobs:
         run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" INSTA_UPDATE=${{ github.event.inputs.update_snapshots}} ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:
-          UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
+          # UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
           PG_BENCHMARK_PG_HOST: localhost
           PG_BENCHMARK_PG_USER: postgres
           PG_BENCHMARK_PG_PASS: postgres
@@ -575,7 +575,7 @@ jobs:
         run: INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./spice_bench --bench ${{ matrix.cmd }}
         continue-on-error: true
         env:
-          UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
+          # UPLOAD_RESULTS_DATASET: 'spiceai.tests.oss_benchmarks'
           S3_ENDPOINT: ${{ secrets.CLICKBENCH_S3_ENDPOINT}}
           S3_KEY: ${{ secrets.CLICKBENCH_S3_KEY}}
           S3_SECRET: ${{ secrets.CLICKBENCH_S3_SECRET}}


### PR DESCRIPTION
# 🗣 Description

'oss_benchmarks' table is not currently available and requires improvements to work, temporary disable it to allow benchmark tests to run

>2025-02-23T10:34:05.640859Z  WARN runtime::init::dataset: Failed to load the dataset oss_benchmarks (spice.ai).
Failed to detect a table schema. Ensure the table, '"spiceai"."tests"."oss_benchmarks"', exists in the data source.
thread 'main' panicked at crates/runtime/benches/setup/mod.rs:81:13:
Timed out waiting for datasets to load in setup_benchmark()

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
