### PR TITLE
Fix string escaping of system prompt

### DIFF
--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -22,6 +22,7 @@ use llms::{
 };
 use llms::{config::GenericAuthMechanism, openai::DEFAULT_LLM_MODEL};
 use secrecy::{ExposeSecret, SecretString};
+use serde_json::Value;
 use spicepod::component::model::{Model, ModelFileType, ModelSource};
 use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
 
@@ -102,11 +103,11 @@ pub fn construct_model(
     }?;
 
     // Handle runtime wrapping
-    let system_prompt = component
-        .params
-        .get("system_prompt")
-        .cloned()
-        .map(|s| s.to_string());
+    let system_prompt = if let Some(Value::String(s)) = component.params.get("system_prompt") {
+        Some(s.as_str())
+    } else {
+        None
+    };
     let wrapper = ChatWrapper::new(
         model,
         component.name.as_str(),

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -107,7 +107,7 @@ pub fn construct_model(
         Some(v) => {
             return Err(LlmError::InvalidParamError {
                 param: "system_prompt".to_string(),
-                message: format!("Expected a string, got: {:?}", v),
+                message: format!("Expected a string, got: {v:?}"),
             });
         }
         None => None,

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::implicit_hasher)]
+use async_graphql::OutputType;
 use llms::{
     anthropic::Anthropic,
     chat::{Chat, Error as LlmError},
@@ -102,11 +103,15 @@ pub fn construct_model(
         }),
     }?;
 
-    // Handle runtime wrapping
-    let system_prompt = if let Some(Value::String(s)) = component.params.get("system_prompt") {
-        Some(s.as_str())
-    } else {
-        None
+    let system_prompt = match component.params.get("system_prompt") {
+        Some(Value::String(s)) => Some(s.as_str()),
+        Some(v) => {
+            return Err(LlmError::InvalidParamError {
+                param: "system_prompt".to_string(),
+                message: format!("Expected a string, got: {:?}", v),
+            });
+        }
+        None => None,
     };
     let wrapper = ChatWrapper::new(
         model,

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::implicit_hasher)]
-use async_graphql::OutputType;
 use llms::{
     anthropic::Anthropic,
     chat::{Chat, Error as LlmError},

--- a/crates/runtime/src/model/wrapper.rs
+++ b/crates/runtime/src/model/wrapper.rs
@@ -68,13 +68,13 @@ impl ChatWrapper {
     pub fn new(
         chat: Box<dyn Chat>,
         public_name: &str,
-        system_prompt: Option<String>,
+        system_prompt: Option<&str>,
         defaults: Vec<(String, serde_json::Value)>,
     ) -> Self {
         let s = Self {
             public_name: public_name.to_string(),
             chat,
-            system_prompt,
+            system_prompt: system_prompt.map(ToString::to_string),
             defaults,
         };
 


### PR DESCRIPTION
# 🗣 Description
The system prompt from `models[*].params.system_prompt`, would be incorrectly string escaped. 
```diff
- "\"You are comparing a submitted answer to an expert answer on a given SQL coding question. Here is the data:\\n\""
+ "You are comparing a submitted answer to an expert answer on a given SQL coding question. Here is the data:\n"
```
