### PR TITLE
fix: Skip sccache in PR for external users

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,9 +82,17 @@ jobs:
         if: needs.check_changes.outputs.relevant_changes == 'true'
         with:
           os: 'linux'
+      
+      - name: Check if sccache can be set up
+        run: |
+          if [ -z "${{ secrets.MINIO_ENDPOINT }}" ]; then
+            echo "SCCACHE_SETUP=false" >> $GITHUB_ENV
+          else
+            echo "SCCACHE_SETUP=true" >> $GITHUB_ENV
+          fi
         
       - name: Set up sccache
-        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && secrets.MINIO_ENDPOINT != '' }}
+        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' &&  env.SCCACHE_SETUP == 'true' }}
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}
@@ -105,7 +113,7 @@ jobs:
       - run: make lint && sccache --show-stats
         if: needs.check_changes.outputs.relevant_changes == 'true'
         env:
-          RUSTC_WRAPPER: ${{ secrets.MINIO_ENDPOINT && 'sccache' || '' }}
+          RUSTC_WRAPPER: ${{ env.SCCACHE_SETUP && 'sccache' || '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           CARGO_INCREMENTAL: 0
@@ -140,9 +148,17 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           os: 'linux'
-        
+      
+      - name: Check if sccache can be set up
+        run: |
+          if [ -z "${{ secrets.MINIO_ENDPOINT }}" ]; then
+            echo "SCCACHE_SETUP=false" >> $GITHUB_ENV
+          else
+            echo "SCCACHE_SETUP=true" >> $GITHUB_ENV
+          fi
+      
       - name: Set up sccache
-        if: ${{ secrets.MINIO_ENDPOINT != '' }}
+        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}
@@ -157,7 +173,7 @@ jobs:
       - run: make ci test && sccache --show-stats
         if: needs.check_changes.outputs.relevant_changes == 'true'
         env:
-          RUSTC_WRAPPER: ${{ secrets.MINIO_ENDPOINT && 'sccache' || '' }}
+          RUSTC_WRAPPER: ${{ env.SCCACHE_SETUP && 'sccache' || '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           CARGO_INCREMENTAL: 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,7 +84,7 @@ jobs:
           os: 'linux'
         
       - name: Set up sccache
-        if: needs.check_changes.outputs.relevant_changes == 'true' && secrets.MINIO_ENDPOINT != ''
+        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && secrets.MINIO_ENDPOINT != '' }}
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}
@@ -142,7 +142,7 @@ jobs:
           os: 'linux'
         
       - name: Set up sccache
-        if: secrets.MINIO_ENDPOINT != ''
+        if: ${{ secrets.MINIO_ENDPOINT != '' }}
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,7 +84,7 @@ jobs:
           os: 'linux'
         
       - name: Set up sccache
-        if: needs.check_changes.outputs.relevant_changes == 'true'
+        if: needs.check_changes.outputs.relevant_changes == 'true' && secrets.MINIO_ENDPOINT != ''
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}
@@ -105,7 +105,7 @@ jobs:
       - run: make lint && sccache --show-stats
         if: needs.check_changes.outputs.relevant_changes == 'true'
         env:
-          RUSTC_WRAPPER: sccache
+          RUSTC_WRAPPER: ${{ secrets.MINIO_ENDPOINT && 'sccache' || '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           CARGO_INCREMENTAL: 0
@@ -142,6 +142,7 @@ jobs:
           os: 'linux'
         
       - name: Set up sccache
+        if: secrets.MINIO_ENDPOINT != ''
         uses: ./.github/actions/setup-sccache
         with:
           minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}
@@ -156,7 +157,7 @@ jobs:
       - run: make ci test && sccache --show-stats
         if: needs.check_changes.outputs.relevant_changes == 'true'
         env:
-          RUSTC_WRAPPER: sccache
+          RUSTC_WRAPPER: ${{ secrets.MINIO_ENDPOINT && 'sccache' || '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           CARGO_INCREMENTAL: 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,7 +118,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           CARGO_INCREMENTAL: 0
       
-      - run: Show sccache stats
+      - name: Show sccache stats
         if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
         run: sccache --show-stats
 
@@ -182,7 +182,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           CARGO_INCREMENTAL: 0
       
-      - run: Show sccache stats
+      - name: Show sccache stats
         if: ${{ env.SCCACHE_SETUP == 'true' }}
         run: sccache --show-stats
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,13 +110,17 @@ jobs:
       - name: Set up cc
         uses: ./.github/actions/setup-cc
 
-      - run: make lint && sccache --show-stats
+      - run: make lint
         if: needs.check_changes.outputs.relevant_changes == 'true'
         env:
           RUSTC_WRAPPER: ${{ env.SCCACHE_SETUP && 'sccache' || '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           CARGO_INCREMENTAL: 0
+      
+      - run: Show sccache stats
+        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
+        run: sccache --show-stats
 
       - name: Check if Cargo.lock is updated
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -170,13 +174,17 @@ jobs:
       - name: Set up cc
         uses: ./.github/actions/setup-cc
 
-      - run: make ci test && sccache --show-stats
+      - run: make ci test
         if: needs.check_changes.outputs.relevant_changes == 'true'
         env:
           RUSTC_WRAPPER: ${{ env.SCCACHE_SETUP && 'sccache' || '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
           CARGO_INCREMENTAL: 0
+      
+      - run: Show sccache stats
+        if: ${{ env.SCCACHE_SETUP == 'true' }}
+        run: sccache --show-stats
 
   build-docker:
     name: Build Docker Image


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* When the `MINIO_ENDPOINT` is empty, don't setup sccache. The MinIO endpoint will be empty for actions invocations from PRs from forked/external contributors.
