### PR TITLE
Improve trace UX for `ai_completion`, fix infinite tool calls

### DIFF
--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -402,9 +402,15 @@ fn create_new_recursive_req(
 ) -> CreateChatCompletionRequest {
     let mut new_req = req.clone();
     new_req.messages = new_msg;
-    if let Some(ChatCompletionToolChoiceOption::Named(t)) = new_req.tool_choice {
-        tracing::debug!("Not recursively using tool_choice named={t:?} in subsequent calls.");
+
+    // Remove tool_choice if it is named (since it was just used), and set it to `Auto`.
+    // This also includes when a tool_choice is not set. It could be set as a default (in spicepod.yaml via openai_tool_choice), but will appear as None here. We want to set it to Auto here to ensure named tool is used once and does cause infinite tool use.
+    if matches!(
+        new_req.tool_choice,
+        Some(ChatCompletionToolChoiceOption::Named(_)) | None
+    ) {
         // Auto is default when tools exist.
+        tracing::debug!("Not recursively using named tool_choice in subsequent calls.");
         new_req.tool_choice = Some(ChatCompletionToolChoiceOption::Auto);
     }
 

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -404,7 +404,7 @@ fn create_new_recursive_req(
     new_req.messages = new_msg;
 
     // Remove tool_choice if it is named (since it was just used), and set it to `Auto`.
-    // This also includes when a tool_choice is not set. It could be set as a default (in spicepod.yaml via openai_tool_choice), but will appear as None here. We want to set it to Auto here to ensure named tool is used once and does cause infinite tool use.
+    // This also includes when a tool_choice is not set. It could be set as a default (in spicepod.yaml via openai_tool_choice), but will appear as None here. We want to set it to Auto here to ensure named tool is used once and does not cause infinite tool use.
     if matches!(
         new_req.tool_choice,
         Some(ChatCompletionToolChoiceOption::Named(_)) | None


### PR DESCRIPTION
# 🗣 Description
Some improvements we need from dogfooding:
1. If a user specifies a named tool choice override (via `models[*].params.openai_tool_choice`), it currently will pick this tool forever and never return. Fix this by only using default override on first iteration of tool use. This is the current behaviour if a user explicitly sets  `tool_choice` in their request payload.
2. Improve error message if openai override is incorrect format. Previously we were exposing arbitrary serde_json errors. 
3. Log the input payload for `ai_completions` after we have prepared them. This means the default overrides, default system prompt (from spicepod) are included in the tracing (i.e. it will be the actual payload sent to the local/hosted model). 