### PR TITLE
Fixing Go installation in the setup script for Linux Arm64

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,6 @@ export PATH="$PATH:$HOME/.spice/bin"
 
 # Initialize and run a test app to ensure everything is working
 cd ../
-mkdir test-app
 spice init test-app
 cd test-app
 spice run
@@ -164,7 +163,6 @@ export PATH="$PATH:$HOME/.spice/bin"
 
 # Initialize and run a test app to ensure everything is working
 cd ../
-mkdir test-app
 spice init test-app
 cd test-app
 spice run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,12 +128,13 @@ sudo apt update
 sudo apt install build-essential curl openssl libssl-dev pkg-config protobuf-compiler cmake
 
 # Install Go
-export GO_VERSION="1.23.4"
+export GO_VERSION="1.24.0"
+export ARCH="arm64" # See https://golang.org/dl/ for available architectures
 rm -rf /tmp/spice
 mkdir -p /tmp/spice
 cd /tmp/spice
-wget https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz
-tar xvfz go$GO_VERSION.linux-amd64.tar.gz
+wget https://go.dev/dl/go$GO_VERSION.linux-$ARCH.tar.gz
+tar xvfz go$GO_VERSION.linux-$ARCH.tar.gz
 sudo mv ./go /usr/local/go
 echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.profile
 source $HOME/.profile
@@ -164,8 +165,8 @@ export PATH="$PATH:$HOME/.spice/bin"
 # Initialize and run a test app to ensure everything is working
 cd ../
 mkdir test-app
-cd test-app
 spice init test-app
+cd test-app
 spice run
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,8 +115,8 @@ export PATH="$PATH:$HOME/.spice/bin"
 # Initialize and run a test app to ensure everything is working
 cd ../
 mkdir test-app
-cd test-app
 spice init test-app
+cd test-app
 spice run
 ```
 
@@ -129,7 +129,7 @@ sudo apt install build-essential curl openssl libssl-dev pkg-config protobuf-com
 
 # Install Go
 export GO_VERSION="1.24.0"
-export ARCH="arm64" # See https://golang.org/dl/ for available architectures
+export ARCH="amd64" # E.g. arm64. See https://golang.org/dl/ for available architectures
 rm -rf /tmp/spice
 mkdir -p /tmp/spice
 cd /tmp/spice

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,11 +126,9 @@ spice run
 sudo apt update
 sudo apt install build-essential curl openssl libssl-dev pkg-config protobuf-compiler cmake
 
-# Detect the machine's architecture
-ARCH=$(uname -m)
-
-# Map uname output to Go's naming convention
-case "$ARCH" in
+# Install Go
+ARCH=$(uname -m) # Detect the machine's architecture
+case "$ARCH" in # Map uname output to Go's naming convention
   x86_64)
     ARCH="amd64"
     ;;
@@ -142,7 +140,7 @@ case "$ARCH" in
     exit 1
     ;;
 esac
-
+export GO_VERSION="1.24.0"
 rm -rf /tmp/spice
 mkdir -p /tmp/spice
 cd /tmp/spice

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,9 +126,23 @@ spice run
 sudo apt update
 sudo apt install build-essential curl openssl libssl-dev pkg-config protobuf-compiler cmake
 
-# Install Go
-export GO_VERSION="1.24.0"
-export ARCH="amd64" # E.g. arm64. See https://golang.org/dl/ for available architectures
+# Detect the machine's architecture
+ARCH=$(uname -m)
+
+# Map uname output to Go's naming convention
+case "$ARCH" in
+  x86_64)
+    ARCH="amd64"
+    ;;
+  aarch64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
 rm -rf /tmp/spice
 mkdir -p /tmp/spice
 cd /tmp/spice


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

Several issues were fixed in CONTRIBUTING.MD:

1. Allow changing the platform (e.g. ARM64) when installing Go.
2. `spiceai init` creates a directory. So the correct sequence should be
   ```sh
   spice init test-app
   cd test-app
   spice run
   ```
3. Update GO_VERSION to 1.24.0.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

Fix for the [./CONTRIBUTING.md](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md).

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->

Perhaps we should use `sudo apt install golang-go` instead? Unless we need a specific version of Go.