### PR TITLE
DuckDB acceleration: Use temp table only for append with conflict resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=465faf02bb6a2e6c11237368efbd9da91348bdd0#465faf02bb6a2e6c11237368efbd9da91348bdd0"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=39be511f00e5d7f24e30248fcff06885a64b8e44#39be511f00e5d7f24e30248fcff06885a64b8e44"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f72
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f724d32c09e30394cedb7799de670e43e1" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "465faf02bb6a2e6c11237368efbd9da91348bdd0" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "39be511f00e5d7f24e30248fcff06885a64b8e44" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a2f4f443601f0fc2a2b1919705a9adf74ec493c2" }
 


### PR DESCRIPTION
# 🗣 Description

PR includes the following `datafusion-table-providers` change to simplify DuckDB acceleration to write directly to target table even if table contains constraints. This is now possible after upgrading to DuckDB 1.2.0 that fixes the following limitation
 - https://github.com/datafusion-contrib/datafusion-table-providers/pull/242

https://duckdb.org/2025/02/05/announcing-duckdb-120.html

>[Over-eager constraint checking addressed.](https://github.com/duckdb/duckdb/pull/15092) We also resolved a long-standing issue with [over-eager unique constraint checking](https://duckdb.org/docs/archive/1.1/sql/indexes.html#over-eager-unique-constraint-checking). For example, the following sequence of commands used to throw an error but now works:
CREATE TABLE students (id INTEGER PRIMARY KEY, name VARCHAR);
INSERT INTO students VALUES (1, 'John Doe');
BEGIN; -- start transaction
DELETE FROM students WHERE id = 1;
INSERT INTO students VALUES (1, 'Jane Doe');


## 🔨 Related Issues

Fixes https://github.com/spiceai/spiceai/issues/4814

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
