### PR TITLE
Revert "DuckDB acceleration: Use temp table only for append with conflict resolution"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=39be511f00e5d7f24e30248fcff06885a64b8e44#39be511f00e5d7f24e30248fcff06885a64b8e44"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=465faf02bb6a2e6c11237368efbd9da91348bdd0#465faf02bb6a2e6c11237368efbd9da91348bdd0"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f72
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f724d32c09e30394cedb7799de670e43e1" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "39be511f00e5d7f24e30248fcff06885a64b8e44" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "465faf02bb6a2e6c11237368efbd9da91348bdd0" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a2f4f443601f0fc2a2b1919705a9adf74ec493c2" }
 


### PR DESCRIPTION
Reverts spiceai/spiceai#4874

As pointed in https://github.com/spiceai/spiceai/issues/4875 it seems there is still [Over-Eager Unique Constraint Checking](https://duckdb.org/docs/archive/1.1/sql/indexes.html#over-eager-unique-constraint-checking) problem when using large datasets. Thus reverting this improvement