### PR TITLE
Add test Spicepod for DuckDB full acceleration with constraints

### DIFF
--- a/test/spicepods/tpch/accelerated/constraints/duckdb_full_with_pk_and_indexes.yaml
+++ b/test/spicepods/tpch/accelerated/constraints/duckdb_full_with_pk_and_indexes.yaml
@@ -1,0 +1,106 @@
+version: v1
+kind: Spicepod
+name: tpch-indexes
+
+extensions:
+  tpc:
+    enabled: true
+    params:
+      benchmark: tpch
+      scale_factor: "1"
+      path: .spice/tpch.db
+
+runtime:
+  task_history:
+    enabled: true
+    captured_output: truncated
+  results_cache:
+    enabled: false
+
+defaults: &default_params
+  duckdb_open: .spice/tpch.db
+
+datasets:
+  - from: duckdb:customer
+    name: customer
+    params: *default_params
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: &default_refresh_check_interval 10s
+      primary_key: c_custkey
+      indexes:
+        c_mktsegment: enabled
+
+  - from: duckdb:lineitem
+    name: lineitem
+    params: *default_params
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: *default_refresh_check_interval
+      primary_key: '(l_orderkey, l_linenumber)'
+      indexes:
+        l_orderkey: enabled
+        l_shipdate: enabled
+
+  - from: duckdb:nation
+    params: *default_params
+    name: nation
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: *default_refresh_check_interval
+      primary_key: n_nationkey
+    
+  - from: duckdb:orders
+    name: orders
+    params: *default_params
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: *default_refresh_check_interval
+      primary_key: o_orderkey
+
+  - from: duckdb:part
+    name: part
+    params: *default_params
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: *default_refresh_check_interval
+      primary_key: p_partkey
+
+  - from: duckdb:partsupp
+    name: partsupp
+    params: *default_params
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: *default_refresh_check_interval
+      primary_key: '(ps_partkey, ps_suppkey)'
+
+  - from: duckdb:region
+    name: region
+    params: *default_params
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: *default_refresh_check_interval
+  
+  - from: duckdb:supplier
+    name: supplier
+    params: *default_params
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: *default_refresh_check_interval
+      primary_key: s_suppkey

--- a/test/spicepods/tpch/accelerated/constraints/oha_test.sh
+++ b/test/spicepods/tpch/accelerated/constraints/oha_test.sh
@@ -1,0 +1,1 @@
+oha --method POST "http://127.0.0.1:8090/v1/sql" -D tpch_query.sql -z 10s -c 10

--- a/test/spicepods/tpch/accelerated/constraints/tpch_query.sql
+++ b/test/spicepods/tpch/accelerated/constraints/tpch_query.sql
@@ -1,0 +1,23 @@
+-- TPC-H Query 3
+select
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    o_orderdate,
+    o_shippriority
+from
+    customer,
+    orders,
+    lineitem
+where
+      c_mktsegment = 'BUILDING'
+  and c_custkey = o_custkey
+  and l_orderkey = o_orderkey
+  and o_orderdate < date '1995-03-15'
+  and l_shipdate > date '1995-03-15'
+group by
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+order by
+    revenue desc,
+    o_orderdate;


### PR DESCRIPTION
# 🗣 Description

Add a test Spicepod to test DuckDB acceleration for a dataset with primary keys and indexes.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

To run with testoperator the Spicepod requires `tpc-extension` feature to be enabled, I'll review separately how to improve this.
