### PR TITLE
Allow overriding spicerack base url in the CLI

### DIFF
--- a/bin/spice/pkg/registry/spicerack.go
+++ b/bin/spice/pkg/registry/spicerack.go
@@ -36,6 +36,11 @@ import (
 type SpiceRackRegistry struct{}
 
 func getSpiceRackBaseUrl() string {
+	spiceRackBaseUrl := os.Getenv("SPICERACK_BASE_URL")
+	if spiceRackBaseUrl != "" {
+		return spiceRackBaseUrl
+	}
+
 	if strings.HasSuffix(version.Version(), "-dev") {
 		return "https://dev-data.spiceai.io/v1"
 	} else {


### PR DESCRIPTION
# 🗣 Description

Allows overriding the Spicerack base URL in the CLI.