### PR TITLE
Update to latest async-openai fork. Update secrecy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,15 +699,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-convert"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
-dependencies = [
- "async-trait",
-]
-
-[[package]]
 name = "async-executor"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,10 +850,10 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.26.0"
-source = "git+https://github.com/spiceai/async-openai?rev=9debf2001eaf8f1b6407fdf4b8cf9aa28fb3465e#9debf2001eaf8f1b6407fdf4b8cf9aa28fb3465e"
+version = "0.28.0"
+source = "git+https://github.com/spiceai/async-openai?rev=506340b655b017e7235743e7d7bcc037b381ff43#506340b655b017e7235743e7d7bcc037b381ff43"
 dependencies = [
- "async-convert",
+ "async-openai-macros",
  "backoff",
  "base64 0.22.1",
  "bytes",
@@ -872,15 +863,25 @@ dependencies = [
  "rand 0.8.5",
  "reqwest 0.12.12",
  "reqwest-eventsource",
- "secrecy 0.8.0",
+ "secrecy",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
  "utoipa",
+]
+
+[[package]]
+name = "async-openai-macros"
+version = "0.1.0"
+source = "git+https://github.com/spiceai/async-openai?rev=506340b655b017e7235743e7d7bcc037b381ff43#506340b655b017e7235743e7d7bcc037b381ff43"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3074,7 +3075,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.12",
  "rusqlite",
- "secrecy 0.8.0",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu",
@@ -3517,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=5efd341539735a2f8fa89e1be4948f2e288852af#5efd341539735a2f8fa89e1be4948f2e288852af"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=44d4b86adb615b0b5f87ba9a5b437b3307e6fa46#44d4b86adb615b0b5f87ba9a5b437b3307e6fa46"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -3548,7 +3549,7 @@ dependencies = [
  "rand 0.8.5",
  "rusqlite",
  "sea-query",
- "secrecy 0.8.0",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu",
@@ -3578,7 +3579,7 @@ dependencies = [
  "futures",
  "odbc-api",
  "pkcs8",
- "secrecy 0.8.0",
+ "secrecy",
  "serde_json",
  "sha2",
  "snafu",
@@ -6758,7 +6759,7 @@ dependencies = [
  "reqwest 0.12.12",
  "reqwest-eventsource",
  "schemars",
- "secrecy 0.8.0",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu",
@@ -7372,7 +7373,7 @@ dependencies = [
  "ndarray 0.15.6",
  "regex",
  "reqwest 0.12.12",
- "secrecy 0.8.0",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu",
@@ -8156,7 +8157,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project",
- "secrecy 0.10.3",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -10206,7 +10207,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "schemars",
  "scopeguard",
- "secrecy 0.8.0",
+ "secrecy",
  "serde",
  "serde_json",
  "snafu",
@@ -10692,20 +10693,11 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
+ "serde",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "async-openai"
 version = "0.28.0"
-source = "git+https://github.com/spiceai/async-openai?rev=506340b655b017e7235743e7d7bcc037b381ff43#506340b655b017e7235743e7d7bcc037b381ff43"
+source = "git+https://github.com/spiceai/async-openai?rev=08f8c9df21275f0b59a99233994eac62153afb94#08f8c9df21275f0b59a99233994eac62153afb94"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "async-openai-macros"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/async-openai?rev=506340b655b017e7235743e7d7bcc037b381ff43#506340b655b017e7235743e7d7bcc037b381ff43"
+source = "git+https://github.com/spiceai/async-openai?rev=08f8c9df21275f0b59a99233994eac62153afb94#08f8c9df21275f0b59a99233994eac62153afb94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=44d4b86adb615b0b5f87ba9a5b437b3307e6fa46#44d4b86adb615b0b5f87ba9a5b437b3307e6fa46"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a1f7173691675238607867e6ae5c6a881700de5b#a1f7173691675238607867e6ae5c6a881700de5b"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ arrow-json = "53"
 arrow-cast = "53"
 arrow-odbc = "11.2.0"
 arrow-schema = "53"
-async-openai = { git = "https://github.com/spiceai/async-openai", rev = "506340b655b017e7235743e7d7bcc037b381ff43", features = ["byot"] }
+async-openai = { git = "https://github.com/spiceai/async-openai", rev = "08f8c9df21275f0b59a99233994eac62153afb94", features = ["byot"] }
 async-stream = "0.3.5"
 async-trait = "0.1.86"
 axum = { version = "0.7", features = ["macros"] }
@@ -167,7 +167,7 @@ arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f72
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f724d32c09e30394cedb7799de670e43e1" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "44d4b86adb615b0b5f87ba9a5b437b3307e6fa46" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a1f7173691675238607867e6ae5c6a881700de5b" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "1d184df043060a9425afa415eec5f39f0c3e17fe" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ arrow-json = "53"
 arrow-cast = "53"
 arrow-odbc = "11.2.0"
 arrow-schema = "53"
-async-openai = { git = "https://github.com/spiceai/async-openai", rev = "9debf2001eaf8f1b6407fdf4b8cf9aa28fb3465e" }
+async-openai = { git = "https://github.com/spiceai/async-openai", rev = "506340b655b017e7235743e7d7bcc037b381ff43" }
 async-stream = "0.3.5"
 async-trait = "0.1.86"
 axum = { version = "0.7", features = ["macros"] }
@@ -122,7 +122,7 @@ reqwest = { version = "0.12.5", features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.31.0", features = ["bundled-decimal"] }
 rustls = "0.23"
 rustls-pemfile = "2.1.3"
-secrecy = "0.8"
+secrecy = "0.10.3"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.30"
@@ -167,7 +167,7 @@ arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f72
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "5feaa5f724d32c09e30394cedb7799de670e43e1" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "5efd341539735a2f8fa89e1be4948f2e288852af" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "44d4b86adb615b0b5f87ba9a5b437b3307e6fa46" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "1d184df043060a9425afa415eec5f39f0c3e17fe" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ arrow-json = "53"
 arrow-cast = "53"
 arrow-odbc = "11.2.0"
 arrow-schema = "53"
-async-openai = { git = "https://github.com/spiceai/async-openai", rev = "506340b655b017e7235743e7d7bcc037b381ff43" }
+async-openai = { git = "https://github.com/spiceai/async-openai", rev = "506340b655b017e7235743e7d7bcc037b381ff43", features = ["byot"] }
 async-stream = "0.3.5"
 async-trait = "0.1.86"
 axum = { version = "0.7", features = ["macros"] }

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -110,10 +110,10 @@ impl DeltaTable {
                     continue;
                 }
                 "client_timeout" => {
-                    storage_options.insert("timeout".into(), value.expose_secret().clone());
+                    storage_options.insert("timeout".into(), value.expose_secret().to_string());
                 }
                 _ => {
-                    storage_options.insert(key.to_string(), value.expose_secret().clone());
+                    storage_options.insert(key.to_string(), value.expose_secret().to_string());
                 }
             }
         }

--- a/crates/db_connection_pool/src/dbconnection/odbcconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/odbcconn.rs
@@ -42,7 +42,7 @@ use odbc_api::handles::StatementImpl;
 use odbc_api::parameter::InputParameter;
 use odbc_api::Cursor;
 use odbc_api::CursorImpl;
-use secrecy::{ExposeSecret, Secret, SecretString};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
 use snafu::prelude::*;
 use snafu::Snafu;
 use tokio::runtime::Handle;
@@ -291,8 +291,8 @@ fn build_odbc_reader<C: Cursor>(
     let bind_as_usize = |k: &str, default: Option<usize>, f: &mut dyn FnMut(usize)| {
         params
             .get(k)
-            .map(Secret::expose_secret)
-            .cloned()
+            .map(SecretBox::expose_secret)
+            .map(String::from)
             .and_then(|s| s.parse::<usize>().ok())
             .or(default)
             .into_iter()

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -436,7 +436,7 @@ fn parse_schema_from_json(resp: &serde_json::Value) -> Result<SchemaRef, Error> 
 
         let is_nullable = column[4]
             .as_str()
-            .map_or(true, |s| s.to_uppercase() == "TRUE");
+            .is_none_or(|s| s.to_uppercase() == "TRUE");
 
         fields.push(Field::new(column_name, data_type, is_nullable));
     }

--- a/crates/db_connection_pool/src/odbcpool.rs
+++ b/crates/db_connection_pool/src/odbcpool.rs
@@ -19,7 +19,7 @@ use crate::dbconnection::odbcconn::{ODBCDbConnection, ODBCParameter};
 use async_trait::async_trait;
 use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, JoinPushDown};
 use odbc_api::{sys::AttrConnectionPooling, Connection, ConnectionOptions, Environment};
-use secrecy::{ExposeSecret, Secret, SecretString};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
 use sha2::{Digest, Sha256};
 use snafu::prelude::*;
 use std::{
@@ -77,7 +77,7 @@ impl ODBCPool {
     pub fn new(params: HashMap<String, SecretString>) -> Result<Self, Error> {
         let connection_string = params
             .get("connection_string")
-            .map(Secret::expose_secret)
+            .map(SecretBox::expose_secret)
             .map(ToString::to_string)
             .context(MissingConnectionStringSnafu)?;
 

--- a/crates/llms/src/chat/mistral.rs
+++ b/crates/llms/src/chat/mistral.rs
@@ -40,7 +40,7 @@ use mistralrs::{
     TokenSource, Tool, ToolCallResponse, ToolChoice, ToolType,
 };
 
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 use snafu::ResultExt;
 use std::{
     collections::HashMap,
@@ -299,7 +299,7 @@ impl MistralLlama {
     pub fn from_hf(
         model_id: &str,
         arch: Option<&str>,
-        hf_token_literal: Option<&Secret<String>>,
+        hf_token_literal: Option<&SecretString>,
         gguf_filename: Option<PathBuf>,
     ) -> Result<Self> {
         let model_parts: Vec<&str> = model_id.split(':').collect();
@@ -339,7 +339,7 @@ impl MistralLlama {
         let device = Self::get_device();
         let token_source = hf_token_literal.map_or(TokenSource::CacheToken, |secret| {
             tracing::debug!("A HuggingFace token was specified in parameters. The specified token will be used instead of any system/environment defaults.");
-            TokenSource::Literal(secret.expose_secret().clone())
+            TokenSource::Literal(secret.expose_secret().to_string())
         });
 
         let pipeline = loader?

--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -21,7 +21,7 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use nsql::SqlGeneration;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-use secrecy::Secret;
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::path::PathBuf;
@@ -681,7 +681,7 @@ pub fn create_hf_model(
     model_id: &str,
     model_type: Option<&str>,
     from_gguf: Option<PathBuf>,
-    hf_token_literal: Option<&Secret<String>>,
+    hf_token_literal: Option<&SecretString>,
 ) -> Result<Box<dyn Chat>> {
     mistral::MistralLlama::from_hf(model_id, model_type, hf_token_literal, from_gguf)
         .map(|x| Box::new(x) as Box<dyn Chat>)

--- a/crates/llms/src/perplexity/mod.rs
+++ b/crates/llms/src/perplexity/mod.rs
@@ -56,7 +56,7 @@ impl PerplexitySonar {
             .filter_map(|(k, v)| {
                 if k != "perplexity_auth_token" {
                     if let Some(p) = k.strip_prefix("perplexity_") {
-                        return Some((p.to_string(), v.expose_secret().clone()));
+                        return Some((p.to_string(), v.expose_secret().to_string()));
                     }
                 };
                 None

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -26,7 +26,7 @@ use llms::{
     perplexity::PerplexitySonar,
     xai::Xai,
 };
-use secrecy::{Secret, SecretString};
+use secrecy::SecretString;
 use std::{
     collections::HashMap,
     fs,
@@ -76,7 +76,10 @@ pub(crate) fn create_hf(model_id: &str) -> Result<Arc<Box<dyn Chat>>, ChatError>
         model_id,
         None,
         None,
-        std::env::var("HF_TOKEN").ok().map(Secret::new).as_ref(),
+        std::env::var("HF_TOKEN")
+            .ok()
+            .map(SecretString::from)
+            .as_ref(),
     )?))
 }
 
@@ -85,7 +88,7 @@ pub(crate) fn create_perplexity() -> Result<Arc<Box<dyn Chat>>, ChatError> {
     if let Ok(api_key) = std::env::var("SPICE_PERPLEXITY_AUTH_TOKEN") {
         params.insert(
             "perplexity_auth_token".to_string(),
-            SecretString::new(api_key),
+            SecretString::from(api_key),
         );
     }
     let sonar = PerplexitySonar::from_params(None, &params)

--- a/crates/model_components/src/modelsource/huggingface.rs
+++ b/crates/model_components/src/modelsource/huggingface.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::Error;
 use super::ModelSource;
 use async_trait::async_trait;
-use secrecy::{ExposeSecret, Secret, SecretString};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
 use snafu::prelude::*;
 use spicepod::component::model::HUGGINGFACE_PATH_REGEX;
 use std::collections::HashMap;
@@ -31,7 +31,7 @@ impl ModelSource for Huggingface {
     async fn pull(&self, params: Arc<HashMap<String, SecretString>>) -> super::Result<String> {
         let name = params
             .get("name")
-            .map(Secret::expose_secret)
+            .map(SecretBox::expose_secret)
             .map(ToString::to_string);
 
         let Some(name) = name else {
@@ -43,7 +43,7 @@ impl ModelSource for Huggingface {
 
         let files_param = params
             .get("files")
-            .map(Secret::expose_secret)
+            .map(SecretBox::expose_secret)
             .map(ToString::to_string);
 
         let files = match files_param {
@@ -56,7 +56,7 @@ impl ModelSource for Huggingface {
 
         let remote_path = params
             .get("path")
-            .map(Secret::expose_secret)
+            .map(SecretBox::expose_secret)
             .map(ToString::to_string);
 
         let Some(remote_path) = remote_path else {
@@ -119,7 +119,7 @@ impl ModelSource for Huggingface {
                 .bearer_auth(
                     params
                         .get("token")
-                        .map(Secret::expose_secret)
+                        .map(SecretBox::expose_secret)
                         .map(ToString::to_string)
                         .unwrap_or_default(),
                 )

--- a/crates/model_components/src/modelsource/local.rs
+++ b/crates/model_components/src/modelsource/local.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use async_trait::async_trait;
 
 use super::ModelSource;
-use secrecy::{ExposeSecret, Secret, SecretString};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
 use std::collections::HashMap;
 use std::string::ToString;
 use std::sync::Arc;
@@ -28,7 +28,7 @@ impl ModelSource for Local {
     async fn pull(&self, params: Arc<HashMap<String, SecretString>>) -> super::Result<String> {
         let name = params
             .get("name")
-            .map(Secret::expose_secret)
+            .map(SecretBox::expose_secret)
             .map(ToString::to_string);
 
         let Some(name) = name else {
@@ -43,7 +43,7 @@ impl ModelSource for Local {
 
         let path = params
             .get("from")
-            .map(Secret::expose_secret)
+            .map(SecretBox::expose_secret)
             .map(ToString::to_string);
 
         let Some(path) = path else {

--- a/crates/model_components/src/modelsource/spiceai.rs
+++ b/crates/model_components/src/modelsource/spiceai.rs
@@ -18,7 +18,7 @@ pub struct SpiceAI {}
 
 use super::ModelSource;
 use async_trait::async_trait;
-use secrecy::{ExposeSecret, Secret, SecretString};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::prelude::*;
@@ -34,7 +34,7 @@ impl ModelSource for SpiceAI {
     async fn pull(&self, params: Arc<HashMap<String, SecretString>>) -> super::Result<String> {
         let name = params
             .get("name")
-            .map(Secret::expose_secret)
+            .map(SecretBox::expose_secret)
             .map(ToString::to_string);
 
         let Some(name) = name else {
@@ -49,7 +49,7 @@ impl ModelSource for SpiceAI {
 
         let remote_path = params
             .get("path")
-            .map(Secret::expose_secret)
+            .map(SecretBox::expose_secret)
             .map(ToString::to_string);
 
         let Some(remote_path) = remote_path else {
@@ -106,7 +106,7 @@ impl ModelSource for SpiceAI {
             .bearer_auth(
                 params
                     .get("token")
-                    .map(Secret::expose_secret)
+                    .map(SecretBox::expose_secret)
                     .map(ToString::to_string)
                     .unwrap_or_default(),
             )

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -235,7 +235,7 @@ pub trait ListingTableConnector: DataConnector {
             .get(&format!("{delimiter}_has_header"))
             .expose()
             .ok()
-            .map_or(true, |f| f.eq_ignore_ascii_case("true"));
+            .is_none_or(|f| f.eq_ignore_ascii_case("true"));
         let quote = params
             .get(&format!("{delimiter}_quote"))
             .expose()
@@ -346,10 +346,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
             return None;
         }
 
-        Some(
-            self.construct_metadata_provider(dataset)
-                .map_err(Into::into),
-        )
+        Some(self.construct_metadata_provider(dataset))
     }
 
     async fn read_provider(

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -21,7 +21,7 @@ use llms::{
     xai::Xai,
 };
 use llms::{config::GenericAuthMechanism, openai::DEFAULT_LLM_MODEL};
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::SecretString;
 use serde_json::Value;
 use spicepod::component::model::{Model, ModelFileType, ModelSource};
 use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
@@ -37,7 +37,7 @@ pub type LLMModelStore = HashMap<String, Box<dyn Chat>>;
 /// Extract a secret from a hashmap of secrets, if it exists.
 macro_rules! extract_secret {
     ($params:expr, $key:expr) => {
-        $params.get($key).map(|s| s.expose_secret())
+        $params.get($key).map(secrecy::ExposeSecret::expose_secret)
     };
 }
 
@@ -315,7 +315,9 @@ fn file(
     let config_path = component.find_any_file_path(ModelFileType::Config);
     let generation_config = component.find_any_file_path(ModelFileType::GenerationConfig);
 
-    let chat_template_literal = params.get("chat_template").map(|s| s.expose_secret());
+    let chat_template_literal = params
+        .get("chat_template")
+        .map(secrecy::ExposeSecret::expose_secret);
 
     llms::chat::create_local_model(
         model_weights.as_slice(),

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -37,7 +37,7 @@ pub type LLMModelStore = HashMap<String, Box<dyn Chat>>;
 /// Extract a secret from a hashmap of secrets, if it exists.
 macro_rules! extract_secret {
     ($params:expr, $key:expr) => {
-        $params.get($key).map(|s| s.expose_secret().as_str())
+        $params.get($key).map(|s| s.expose_secret())
     };
 }
 
@@ -317,7 +317,7 @@ fn file(
 
     let chat_template_literal = params
         .get("chat_template")
-        .map(|s| s.expose_secret().as_str());
+        .map(|s| s.expose_secret());
 
     llms::chat::create_local_model(
         model_weights.as_slice(),

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -315,9 +315,7 @@ fn file(
     let config_path = component.find_any_file_path(ModelFileType::Config);
     let generation_config = component.find_any_file_path(ModelFileType::GenerationConfig);
 
-    let chat_template_literal = params
-        .get("chat_template")
-        .map(|s| s.expose_secret());
+    let chat_template_literal = params.get("chat_template").map(|s| s.expose_secret());
 
     llms::chat::create_local_model(
         model_weights.as_slice(),

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -41,7 +41,7 @@ pub type EmbeddingModelStore = HashMap<String, Box<dyn Embed>>;
 /// Extract a secret from a hashmap of secrets, if it exists.
 macro_rules! extract_secret {
     ($params:expr, $key:expr) => {
-        $params.get($key).map(|s| s.expose_secret())
+        $params.get($key).map(secrecy::ExposeSecret::expose_secret)
     };
 }
 
@@ -178,15 +178,15 @@ async fn openai(
         params
             .get("api_key")
             .or(params.get("openai_api_key"))
-            .map(|s| s.expose_secret()),
+            .map(secrecy::ExposeSecret::expose_secret),
         params
             .get("org_id")
             .or(params.get("openai_org_id"))
-            .map(|s| s.expose_secret()),
+            .map(secrecy::ExposeSecret::expose_secret),
         params
             .get("project_id")
             .or(params.get("openai_project_id"))
-            .map(|s| s.expose_secret()),
+            .map(secrecy::ExposeSecret::expose_secret),
     ));
 
     // For OpenAI compatible embedding models, we allow users to
@@ -230,7 +230,9 @@ async fn get_bytes_for_file(
                 model_id,
                 Some(branch),
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret()),
+                params
+                    .get("hf_token")
+                    .map(secrecy::ExposeSecret::expose_secret),
             )
             .await
         }
@@ -243,7 +245,9 @@ async fn get_bytes_for_file(
                 model_id,
                 branch,
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret()),
+                params
+                    .get("hf_token")
+                    .map(secrecy::ExposeSecret::expose_secret),
             )
             .await
         }
@@ -255,11 +259,14 @@ async fn get_bytes_for_file(
                 model_id,
                 branch,
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret()),
+                params
+                    .get("hf_token")
+                    .map(secrecy::ExposeSecret::expose_secret),
             )
             .await
         }
-        ["hf:", "", "models", org_id, model_id_revision, file @ ..] => {
+        ["hf:", "", "models", org_id, model_id_revision, file @ ..]
+        | ["hf:", "", org_id, model_id_revision, file @ ..] => {
             let (model_id, branch) = parse_model_id_w_revision(model_id_revision);
             get_file_from_hf(
                 Some("models"),
@@ -267,19 +274,9 @@ async fn get_bytes_for_file(
                 model_id,
                 branch,
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret()),
-            )
-            .await
-        }
-        ["hf:", "", org_id, model_id_revision, file @ ..] => {
-            let (model_id, branch) = parse_model_id_w_revision(model_id_revision);
-            get_file_from_hf(
-                Some("models"),
-                org_id,
-                model_id,
-                branch,
-                file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret()),
+                params
+                    .get("hf_token")
+                    .map(secrecy::ExposeSecret::expose_secret),
             )
             .await
         }
@@ -342,11 +339,12 @@ fn max_seq_length_from_params(
     params
         .get("max_seq_length")
         .map(|s| {
-            s.expose_secret().parse().boxed().map_err(|e| {
-                EmbedError::FailedToInstantiateEmbeddingModel {
+            secrecy::ExposeSecret::expose_secret(s)
+                .parse()
+                .boxed()
+                .map_err(|e| EmbedError::FailedToInstantiateEmbeddingModel {
                     source: format!("Failed to parse 'max_seq_length' parameter: {e}").into(),
-                }
-            })
+                })
         })
         .transpose()
 }

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -23,7 +23,7 @@ use llms::embeddings::{
 };
 use llms::openai::embed::OpenaiEmbed;
 use llms::openai::DEFAULT_EMBEDDING_MODEL;
-use secrecy::{ExposeSecret, Secret, SecretString};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
 use snafu::ResultExt;
 use spicepod::component::{embeddings::EmbeddingPrefix, model::ModelFileType};
 use std::path::{Path, PathBuf};
@@ -41,7 +41,7 @@ pub type EmbeddingModelStore = HashMap<String, Box<dyn Embed>>;
 /// Extract a secret from a hashmap of secrets, if it exists.
 macro_rules! extract_secret {
     ($params:expr, $key:expr) => {
-        $params.get($key).map(|s| s.expose_secret().as_str())
+        $params.get($key).map(|s| s.expose_secret())
     };
 }
 
@@ -108,7 +108,10 @@ fn file(
             source: "No 'tokenizer_path' parameter provided".into(),
         })?
         .clone();
-    let pooling = params.get("pooling").map(Secret::expose_secret).cloned();
+    let pooling = params
+        .get("pooling")
+        .map(SecretBox::expose_secret)
+        .map(String::from);
     let max_seq_len = max_seq_length_from_params(params)?;
     Ok(Box::new(TeiEmbed::from_local(
         Path::new(&weights_path),
@@ -175,15 +178,15 @@ async fn openai(
         params
             .get("api_key")
             .or(params.get("openai_api_key"))
-            .map(|s| s.expose_secret().as_str()),
+            .map(|s| s.expose_secret()),
         params
             .get("org_id")
             .or(params.get("openai_org_id"))
-            .map(|s| s.expose_secret().as_str()),
+            .map(|s| s.expose_secret()),
         params
             .get("project_id")
             .or(params.get("openai_project_id"))
-            .map(|s| s.expose_secret().as_str()),
+            .map(|s| s.expose_secret()),
     ));
 
     // For OpenAI compatible embedding models, we allow users to
@@ -217,7 +220,7 @@ async fn openai(
 ///   - Huggingface `FssSpec`: `hf://[<repo_type_prefix>]<repo_id>[@<revision>]/<path/in/repo>`.
 async fn get_bytes_for_file(
     url: &str,
-    params: &HashMap<String, Secret<String>>,
+    params: &HashMap<String, SecretString>,
 ) -> Result<Bytes, Box<dyn std::error::Error + Send + Sync>> {
     match url.split('/').collect_vec().as_slice() {
         ["https:", "", "huggingface.co", org_id, model_id, "blob", branch, file @ ..] => {
@@ -227,7 +230,7 @@ async fn get_bytes_for_file(
                 model_id,
                 Some(branch),
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret().as_str()),
+                params.get("hf_token").map(|s| s.expose_secret()),
             )
             .await
         }
@@ -240,7 +243,7 @@ async fn get_bytes_for_file(
                 model_id,
                 branch,
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret().as_str()),
+                params.get("hf_token").map(|s| s.expose_secret()),
             )
             .await
         }
@@ -252,7 +255,7 @@ async fn get_bytes_for_file(
                 model_id,
                 branch,
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret().as_str()),
+                params.get("hf_token").map(|s| s.expose_secret()),
             )
             .await
         }
@@ -264,7 +267,7 @@ async fn get_bytes_for_file(
                 model_id,
                 branch,
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret().as_str()),
+                params.get("hf_token").map(|s| s.expose_secret()),
             )
             .await
         }
@@ -276,7 +279,7 @@ async fn get_bytes_for_file(
                 model_id,
                 branch,
                 file.join("/").as_str(),
-                params.get("hf_token").map(|s| s.expose_secret().as_str()),
+                params.get("hf_token").map(|s| s.expose_secret()),
             )
             .await
         }

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::SecretString;
 use snafu::prelude::*;
 use tokio::sync::RwLock;
 
@@ -264,7 +264,9 @@ impl<'a> ParamLookup<'a> {
     #[must_use]
     pub fn expose(self) -> ExposedParamLookup<'a> {
         match self {
-            ParamLookup::Present(s) => ExposedParamLookup::Present(s.expose_secret()),
+            ParamLookup::Present(s) => {
+                ExposedParamLookup::Present(secrecy::ExposeSecret::expose_secret(s))
+            }
             ParamLookup::Absent(s) => ExposedParamLookup::Absent(s),
         }
     }

--- a/crates/runtime/src/secrets.rs
+++ b/crates/runtime/src/secrets.rs
@@ -148,7 +148,7 @@ impl Secrets {
         // Append the remaining text after the last match
         result.push_str(&param_str.0[last_end..]);
 
-        SecretString::new(result)
+        SecretString::from(result)
     }
 
     /// Gets a secret key from the connected secret stores in precedence order.
@@ -376,10 +376,7 @@ mod tests {
                 super::ParamStr(&format!("This is a secret: ${{ env:{key} }}! 🫡")),
             )
             .await;
-        assert_eq!(
-            "This is a secret: super_secret! 🫡",
-            result.expose_secret().as_str()
-        );
+        assert_eq!("This is a secret: super_secret! 🫡", result.expose_secret());
     }
 
     #[tokio::test]
@@ -398,6 +395,6 @@ mod tests {
                 super::ParamStr(&format!("This is a secret: ${{ env:{key} }}! 🫡")),
             )
             .await;
-        assert_eq!("This is a secret: ! 🫡", result.expose_secret().as_str());
+        assert_eq!("This is a secret: ! 🫡", result.expose_secret());
     }
 }

--- a/crates/runtime/src/secrets/stores/aws_secrets_manager.rs
+++ b/crates/runtime/src/secrets/stores/aws_secrets_manager.rs
@@ -128,9 +128,9 @@ impl SecretStore for AwsSecretsManager {
         if let Some(secret_str) = secret_value.secret_string() {
             let data = parse_json_to_hashmap(secret_str)?;
             if let Some(value) = data.get(&prefixed_key) {
-                return Ok(Some(SecretString::new(value.clone())));
+                return Ok(Some(SecretString::from(value.clone())));
             }
-            return Ok(data.get(key).cloned().map(SecretString::new));
+            return Ok(data.get(key).cloned().map(SecretString::from));
         }
 
         Ok(None)

--- a/crates/runtime/src/secrets/stores/env.rs
+++ b/crates/runtime/src/secrets/stores/env.rs
@@ -98,10 +98,10 @@ impl SecretStore for EnvSecretStore {
         // First try looking for `SPICE_MY_KEY` and then `MY_KEY`
         let prefixed_key = format!("{ENV_SECRET_PREFIX}{upper_key}");
         match std::env::var(prefixed_key) {
-            Ok(value) => Ok(Some(SecretString::new(value))),
+            Ok(value) => Ok(Some(SecretString::from(value))),
             // If the prefixed key is not found, try the original key
             Err(std::env::VarError::NotPresent) => match std::env::var(upper_key) {
-                Ok(value) => Ok(Some(SecretString::new(value))),
+                Ok(value) => Ok(Some(SecretString::from(value))),
                 Err(std::env::VarError::NotPresent) => Ok(None),
                 Err(err) => Err(Box::new(err)),
             },

--- a/crates/runtime/src/secrets/stores/keyring.rs
+++ b/crates/runtime/src/secrets/stores/keyring.rs
@@ -62,11 +62,11 @@ impl SecretStore for KeyringSecretStore {
             (Ok(prefixed_entry), Ok(fallback_entry)) => {
                 // Try getting password with prefixed key first
                 match prefixed_entry.get_password() {
-                    Ok(secret) => return Ok(Some(SecretString::new(secret))),
+                    Ok(secret) => return Ok(Some(SecretString::from(secret))),
                     Err(keyring::Error::NoEntry) => {
                         // Prefixed key failed, try fallback
                         match fallback_entry.get_password() {
-                            Ok(secret) => Ok(Some(SecretString::new(secret))),
+                            Ok(secret) => Ok(Some(SecretString::from(secret))),
                             Err(keyring::Error::NoEntry) => Ok(None),
                             Err(err) => {
                                 Err(Box::new(Error::UnableToGetSecretValue { source: err }))
@@ -79,7 +79,7 @@ impl SecretStore for KeyringSecretStore {
             (Err(keyring::Error::NoEntry), Ok(fallback_entry)) => {
                 // Prefixed entry creation failed, try fallback
                 match fallback_entry.get_password() {
-                    Ok(secret) => Ok(Some(SecretString::new(secret))),
+                    Ok(secret) => Ok(Some(SecretString::from(secret))),
                     Err(keyring::Error::NoEntry) => Ok(None),
                     Err(err) => Err(Box::new(Error::UnableToGetSecretValue { source: err })),
                 }

--- a/crates/runtime/src/secrets/stores/kubernetes.rs
+++ b/crates/runtime/src/secrets/stores/kubernetes.rs
@@ -199,9 +199,9 @@ impl SecretStore for KubernetesSecretStore {
         match self.kubernetes_client.get_secret(&self.secret_name).await {
             Ok(secret) => {
                 if let Some(value) = secret.get(&prefixed_key) {
-                    return Ok(Some(SecretString::new(value.clone())));
+                    return Ok(Some(SecretString::from(value.clone())));
                 }
-                Ok(secret.get(key).cloned().map(SecretString::new))
+                Ok(secret.get(key).cloned().map(SecretString::from))
             }
             Err(err) => Err(Box::new(StoreError::UnableToGetSecret { source: err })),
         }

--- a/crates/runtime/src/tls.rs
+++ b/crates/runtime/src/tls.rs
@@ -19,7 +19,7 @@ use rustls::{
     ServerConfig,
 };
 use rustls_pemfile::{certs, private_key};
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretBox};
 use std::{
     io::{self, Cursor},
     sync::Arc,
@@ -27,8 +27,8 @@ use std::{
 use x509_certificate::X509Certificate;
 
 pub struct TlsConfig {
-    pub cert: Secret<Vec<u8>>,
-    pub key: Secret<Vec<u8>>,
+    pub cert: SecretBox<Vec<u8>>,
+    pub key: SecretBox<Vec<u8>>,
     pub server_config: Arc<ServerConfig>,
 }
 
@@ -45,8 +45,8 @@ impl TlsConfig {
             .with_single_cert(certs, key)?;
 
         Ok(Self {
-            cert: Secret::new(cert_bytes),
-            key: Secret::new(key_bytes),
+            cert: SecretBox::new(Box::new(cert_bytes)),
+            key: SecretBox::new(Box::new(key_bytes)),
             server_config: Arc::new(config),
         })
     }

--- a/crates/runtime/src/tools/builtin/web_search/mod.rs
+++ b/crates/runtime/src/tools/builtin/web_search/mod.rs
@@ -65,11 +65,9 @@ impl TryFrom<&HashMap<String, SecretString>> for SearchEngine {
             return Err("Missing 'engine' parameter".into());
         };
 
-        match engine.as_str() {
+        match engine {
             "perplexity" => {
-                let model_id = params
-                    .get("perplexity_model")
-                    .map(|s| s.expose_secret().as_str());
+                let model_id = params.get("perplexity_model").map(|s| s.expose_secret());
                 let sonar = PerplexitySonar::from_params(model_id, params)?;
                 Ok(SearchEngine::Perplexity(sonar))
             }

--- a/crates/runtime/src/tools/builtin/web_search/mod.rs
+++ b/crates/runtime/src/tools/builtin/web_search/mod.rs
@@ -67,7 +67,9 @@ impl TryFrom<&HashMap<String, SecretString>> for SearchEngine {
 
         match engine {
             "perplexity" => {
-                let model_id = params.get("perplexity_model").map(|s| s.expose_secret());
+                let model_id = params
+                    .get("perplexity_model")
+                    .map(secrecy::ExposeSecret::expose_secret);
                 let sonar = PerplexitySonar::from_params(model_id, params)?;
                 Ok(SearchEngine::Perplexity(sonar))
             }

--- a/crates/runtime/src/tools/mcp/mod.rs
+++ b/crates/runtime/src/tools/mcp/mod.rs
@@ -87,7 +87,7 @@ impl MCPConfig {
         match mcp_type {
             MCPType::Stdio(command) => match params.get("mcp_args") {
                 Some(args) => {
-                    let args = args.expose_secret();
+                    let args = argsecrecy::ExposeSecret::expose_secret(s);
                     Self::Stdio {
                         command: command.clone(),
                         args: Some(args.split_whitespace().map(|s| s.to_string()).collect()),


### PR DESCRIPTION
# 🗣 Description

This PR can only be merged after the follwoing 2 PRs are merged and dependency is updated in Cargo.toml.
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/248
- https://github.com/spiceai/async-openai/pull/10

Update to the async-openai fork that incorporates latest changes upstream. Update secrecy to accomodate updates in async openai crate.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
