### PR TITLE
Fix Datafusion resources deallocation during shutdown

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -236,7 +236,7 @@ pub async fn run(args: Args) -> Result<()> {
     .context(UnableToInitializeTracingSnafu)?;
 
     if let Some(metrics_registry) = prometheus_registry {
-        init_metrics(rt.datafusion(), metrics_registry).context(UnableToInitializeMetricsSnafu)?;
+        init_metrics(&rt.datafusion(), metrics_registry).context(UnableToInitializeMetricsSnafu)?;
     }
 
     let tls_config = tls::load_tls_config(&args, spicepod_tls_config.as_ref(), rt.secrets())
@@ -275,7 +275,7 @@ pub async fn run(args: Args) -> Result<()> {
 }
 
 fn init_metrics(
-    df: Arc<DataFusion>,
+    df: &Arc<DataFusion>,
     registry: prometheus::Registry,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let resource = Resource::default();

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use clap::Parser;
 use opentelemetry::global;
 use rustls::crypto::{self, CryptoProvider};
+use telemetry::noop::NoopMeterProvider;
 use tokio::runtime::Runtime;
 
 #[global_allocator]
@@ -55,6 +56,8 @@ fn main() {
     }
 
     global::shutdown_tracer_provider();
+    // There is no global::shutdown_meter_provider, so we replace currently used meter provider with a noop one to clean up resources
+    global::set_meter_provider(NoopMeterProvider::new());
 }
 
 async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use arrow::array::RecordBatch;
@@ -44,12 +44,14 @@ pub enum Error {
 }
 
 pub struct SpiceMetricsExporter {
-    datafusion: Arc<DataFusion>,
+    datafusion: Weak<DataFusion>,
 }
 
 impl SpiceMetricsExporter {
-    pub fn new(datafusion: Arc<DataFusion>) -> Self {
-        SpiceMetricsExporter { datafusion }
+    pub fn new(datafusion: &Arc<DataFusion>) -> Self {
+        SpiceMetricsExporter {
+            datafusion: Arc::downgrade(datafusion),
+        }
     }
 }
 
@@ -62,8 +64,13 @@ impl otel_arrow::ArrowExporter for SpiceMetricsExporter {
             update_type: UpdateType::Append,
         };
 
-        self.datafusion
-            .write_data(&get_metrics_table_reference(), data_update)
+        let Some(df) = self.datafusion.upgrade() else {
+            return Err(MetricError::Other(
+                "DataFusion is not available".to_string(),
+            ));
+        };
+
+        df.write_data(&get_metrics_table_reference(), data_update)
             .await
             .map_err(|e| MetricError::Other(e.to_string()))
     }

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -43,6 +43,8 @@ pub enum Error {
     UnableToRegisterToMetricsTable { source: DataFusionError },
 }
 
+/// Uses a `Weak` reference to `DataFusion` to prevent blocking its cleanup after runtime termination.
+/// This ensures `DataFusion` can gracefully shut down, even when metrics persist.
 pub struct SpiceMetricsExporter {
     datafusion: Weak<DataFusion>,
 }
@@ -65,8 +67,9 @@ impl otel_arrow::ArrowExporter for SpiceMetricsExporter {
         };
 
         let Some(df) = self.datafusion.upgrade() else {
+            // this should never happen as the exporter must be shutdown before the DataFusion instance is dropped
             return Err(MetricError::Other(
-                "DataFusion is not available".to_string(),
+                "Failed to export metrics as the DataFusion instance has already been dropped.\nReport an issue on GitHub: https://github.com/spiceai/spiceai/issues".to_string(),
             ));
         };
 

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -25,7 +25,7 @@ use std::{sync::LazyLock, time::Duration};
 pub mod anonymous;
 mod exporter;
 mod meter;
-mod noop;
+pub mod noop;
 
 static QUERY_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER

--- a/crates/telemetry/src/noop.rs
+++ b/crates/telemetry/src/noop.rs
@@ -11,13 +11,14 @@ use std::sync::Arc;
 
 /// A no-op instance of a `MetricProvider`
 #[derive(Debug, Default)]
-pub(crate) struct NoopMeterProvider {
+pub struct NoopMeterProvider {
     _private: (),
 }
 
 impl NoopMeterProvider {
     /// Create a new no-op meter provider.
-    pub(crate) fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         NoopMeterProvider { _private: () }
     }
 }


### PR DESCRIPTION
# 🗣 Description

`SpiceMetricsExporter` has reference to Datafusion and is used by global `SdkMeterProvider` when metrics are enabled. Even if we add clean up logic for global meter at the end, and the  `SdkMeterProvider` and all it is internal structures are dropped, already created metrics which are static in our case will still have references to `OtelArrowExporter`/`Datafusion` preventing  Datafusion to gracefully shutdown and clean up resources including closing open connections.

PR updates `SpiceMetricsExporter` to use Weak reference to Datafusion so it can be dropped, when export is performed the SpiceMetricsExporter checks that Datafusion is still available by creating temporary strong reference using `upgrade`.

PR also resets global meter provider at the end of runtime termination to clean up SdkMeterProvider instance as global meter use static field to keep reference to meter provider which is not dropped during termination.

## 🔨 Related Issues

Fixes
 - https://github.com/spiceai/spiceai/issues/4814

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns
1. Will add more debug tracing (when Datafusion is dropping, etc as part of next step: https://github.com/spiceai/spiceai/issues/4888 )
1. Alternative approach considered was implementing static metrics clean up during termination (or special utility/abstraction around metrics), this approach does not seem very robust as requires tracking all metrics and ensure all new metrics are manually cleaned up during termination. Note: we might combine both.


Example metric

```
 pub(crate) static TOOLS_METER: LazyLock<Meter> = LazyLock::new(|| global::meter("tool"));

    pub(crate) static COUNT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
        TOOLS_METER
            .i64_up_down_counter("tool_active_count")
            .with_description("Number of currently loaded LLM tools.")
            .build()
    });
```
