### PR TITLE
Add support for Flight and HTTP endpoints configuration to Spice CLI (run and sql)

### DIFF
--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -48,6 +48,14 @@ spice run
 			args = append(args, fmt.Sprintf("-%s", strings.Repeat("v", level)))
 		}
 
+		if flight, err := cmd.Flags().GetString("flight"); err == nil && flight != "" {
+			args = append(args, "--flight", flight)
+		}
+
+		if http, err := cmd.Flags().GetString("http"); err == nil && http != "" {
+			args = append(args, "--http", http)
+		}
+
 		err = runtime.Run(args)
 		if err != nil {
 			slog.Error("error running Spice.ai", "error", err)
@@ -58,4 +66,6 @@ spice run
 
 func init() {
 	RootCmd.AddCommand(runCmd)
+	runCmd.Flags().String("flight", "", "Spice.ai runtime Flight address to use (default: http://127.0.0.1:50051)")
+	runCmd.Flags().String("http", "", "Spice.ai runtime HTTP address to use (default: http://127.0.0.1:8090)")
 }

--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -66,6 +66,6 @@ spice run
 
 func init() {
 	RootCmd.AddCommand(runCmd)
-	runCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight address. Defaults to http://localhost:50051.")
-	runCmd.Flags().String("http-endpoint", "", "Specifies the runtime HTTP address. Defaults to http://127.0.0.1:8090")
+	runCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight endpoint. Defaults to http://localhost:50051.")
+	runCmd.Flags().String("http-endpoint", "", "Specifies the runtime HTTP endpoint. Defaults to http://127.0.0.1:8090")
 }

--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -48,11 +48,11 @@ spice run
 			args = append(args, fmt.Sprintf("-%s", strings.Repeat("v", level)))
 		}
 
-		if flight, err := cmd.Flags().GetString("flight"); err == nil && flight != "" {
+		if flight, err := cmd.Flags().GetString("flight-endpoint"); err == nil && flight != "" {
 			args = append(args, "--flight", flight)
 		}
 
-		if http, err := cmd.Flags().GetString("http"); err == nil && http != "" {
+		if http, err := cmd.Flags().GetString("http-endpoint"); err == nil && http != "" {
 			args = append(args, "--http", http)
 		}
 
@@ -66,6 +66,6 @@ spice run
 
 func init() {
 	RootCmd.AddCommand(runCmd)
-	runCmd.Flags().String("flight", "", "Spice.ai runtime Flight address to use (default: http://127.0.0.1:50051)")
-	runCmd.Flags().String("http", "", "Spice.ai runtime HTTP address to use (default: http://127.0.0.1:8090)")
+	runCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight address. Defaults to http://localhost:50051.")
+	runCmd.Flags().String("http-endpoint", "", "Specifies the runtime HTTP address. Defaults to http://127.0.0.1:8090")
 }

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -104,8 +104,8 @@ func init() {
 	sqlCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	sqlCmd.Flags().String("user-agent", "", "The user agent to use for all requests")
 	sqlCmd.Flags().String("cache-control", "cache", "Control whether the results cache is used for queries. [possible values: cache, no-cache]")
-	sqlCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight address. Defaults to http://localhost:50051")
-	sqlCmd.Flags().String("http-endpoint", "", "Specifies the runtime HTTP address. Defaults to http://localhost:8090")
+	sqlCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight endpoint. Defaults to http://localhost:50051")
+	sqlCmd.Flags().String("http-endpoint", "", "Specifies the runtime HTTP endpoint. Defaults to http://localhost:8090")
 
 	RootCmd.AddCommand(sqlCmd)
 }

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -72,6 +72,14 @@ sql> show tables
 			args = append(args, "--cache-control", cacheControl)
 		}
 
+		if flight, err := cmd.Flags().GetString("flight"); err == nil && flight != "" {
+			args = append(args, "--repl-flight-endpoint", flight)
+		}
+
+		if http, err := cmd.Flags().GetString("http"); err == nil && http != "" {
+			args = append(args, "--http-endpoint", http)
+		}
+
 		args = append(spiceArgs, args...)
 
 		execCmd, err := rtcontext.GetRunCmd(args)
@@ -96,5 +104,8 @@ func init() {
 	sqlCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	sqlCmd.Flags().String("user-agent", "", "The user agent to use for all requests")
 	sqlCmd.Flags().String("cache-control", "cache", "Control whether the results cache is used for queries. [possible values: cache, no-cache]")
+	sqlCmd.Flags().String("flight", "", "Spice.ai runtime Flight address to use (default: http://localhost:50051)")
+	sqlCmd.Flags().String("http", "", "Spice.ai runtime HTTP address to use (default: http://localhost:8090)")
+
 	RootCmd.AddCommand(sqlCmd)
 }

--- a/bin/spice/cmd/sql.go
+++ b/bin/spice/cmd/sql.go
@@ -72,11 +72,11 @@ sql> show tables
 			args = append(args, "--cache-control", cacheControl)
 		}
 
-		if flight, err := cmd.Flags().GetString("flight"); err == nil && flight != "" {
+		if flight, err := cmd.Flags().GetString("flight-endpoint"); err == nil && flight != "" {
 			args = append(args, "--repl-flight-endpoint", flight)
 		}
 
-		if http, err := cmd.Flags().GetString("http"); err == nil && http != "" {
+		if http, err := cmd.Flags().GetString("http-endpoint"); err == nil && http != "" {
 			args = append(args, "--http-endpoint", http)
 		}
 
@@ -104,8 +104,8 @@ func init() {
 	sqlCmd.Flags().String("tls-root-certificate-file", "", "The path to the root certificate file used to verify the Spice.ai runtime server certificate")
 	sqlCmd.Flags().String("user-agent", "", "The user agent to use for all requests")
 	sqlCmd.Flags().String("cache-control", "cache", "Control whether the results cache is used for queries. [possible values: cache, no-cache]")
-	sqlCmd.Flags().String("flight", "", "Spice.ai runtime Flight address to use (default: http://localhost:50051)")
-	sqlCmd.Flags().String("http", "", "Spice.ai runtime HTTP address to use (default: http://localhost:8090)")
+	sqlCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight address. Defaults to http://localhost:50051")
+	sqlCmd.Flags().String("http-endpoint", "", "Specifies the runtime HTTP address. Defaults to http://localhost:8090")
 
 	RootCmd.AddCommand(sqlCmd)
 }


### PR DESCRIPTION
# 🗣 Description

Enabled configuring Flight and HTTP addresses for `spice sql` and `spice run` commands:


```
spice run --flight-endpoint=0.0.0.0:80 --http-endpoint=0.0.0.0:8090

spice sql --flight-endpoint=http://localhost:80 --http-endpoint=http://localhost:8090
```

Previously it was possible as below (required special knowledge on additionally supported params)

```

spice run -- --flight=0.0.0.0:80 --http=0.0.0.0:8090

spice sql -- --repl-flight-endpoint=http://localhost:80 --http-endpoint=http://localhost:8090
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
