### PR TITLE
Introduce runtime shutdown state

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -269,7 +269,7 @@ pub async fn run(args: Args) -> Result<()> {
         }),
     };
 
-    rt.close().await;
+    rt.shutdown().await;
 
     result
 }

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -215,6 +215,11 @@ impl Runtime {
             let connector = match self.load_dataset_connector(Arc::clone(&ds)).await {
                 Ok(connector) => connector,
                 Err(err) => {
+                    if self.status.is_shutdown() {
+                        // should not retry or trace error if runtime is shutting down
+                        return Err(RetryError::permanent(err));
+                    }
+
                     let ds_name = &ds.name;
                     self.status
                         .update_dataset(ds_name, status::ComponentStatus::Error);
@@ -228,6 +233,10 @@ impl Runtime {
                 .register_loaded_dataset(Arc::clone(&ds), connector, None)
                 .await
             {
+                if self.status.is_shutdown() {
+                    // should not retry if runtime is shutting down
+                    return Err(RetryError::permanent(err));
+                }
                 return Err(RetryError::transient(err));
             };
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -610,13 +610,15 @@ impl Runtime {
     }
 
     // Closes and deallocates all resources (including the static registries)
-    pub async fn close(self) {
+    pub async fn shutdown(self) {
+        self.status.mark_shutdown();
+        // Clean up DataFusion first as there could be datasets loading and accessing registries below.
+        self.df.shutdown().await;
         dataconnector::unregister_all().await;
         catalogconnector::unregister_all().await;
         dataaccelerator::unregister_all().await;
         tools::factory::unregister_all_factories().await;
         document_parse::unregister_all().await;
-        self.df.shutdown().await;
     }
 }
 

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -17,7 +17,10 @@ limitations under the License.
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
-    sync::{Arc, RwLock},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
 };
 
 use datafusion::sql::TableReference;
@@ -44,6 +47,9 @@ pub enum ComponentStatus {
 
     /// The component is in the process of refreshing its state
     Refreshing,
+
+    /// The component is in the process of shutting down
+    ShuttingDown,
 }
 
 impl Display for ComponentStatus {
@@ -54,6 +60,7 @@ impl Display for ComponentStatus {
             ComponentStatus::Disabled => write!(f, "Disabled"),
             ComponentStatus::Error => write!(f, "Error"),
             ComponentStatus::Refreshing => write!(f, "Refreshing"),
+            ComponentStatus::ShuttingDown => write!(f, "ShuttingDown"),
         }
     }
 }
@@ -64,6 +71,8 @@ pub struct RuntimeStatus {
     statuses: Arc<RwLock<HashMap<String, ComponentStatus>>>,
     /// Tracks components that have been in the Ready state at least once.
     ever_ready_components: Arc<RwLock<HashSet<String>>>,
+    /// Tracks if the runtime is in the process of shutting down.
+    is_shutdown: Arc<AtomicBool>,
 }
 
 impl RuntimeStatus {
@@ -72,7 +81,13 @@ impl RuntimeStatus {
         Arc::new(Self {
             statuses: Arc::new(RwLock::new(HashMap::new())),
             ever_ready_components: Arc::new(RwLock::new(HashSet::new())),
+            is_shutdown: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    #[must_use]
+    pub fn is_shutdown(&self) -> bool {
+        self.is_shutdown.load(Ordering::Relaxed)
     }
 
     /// Updates the status of a component and tracks if it has ever been ready.
@@ -139,7 +154,7 @@ impl RuntimeStatus {
         metrics::views::STATUS.record(status as u64, &[KeyValue::new("view", view_name)]);
     }
 
-    /// Checks if all registered components have been ready at least once.
+    /// Checks if all registered components have been ready at least once and the runtime is not shutting down.
     ///
     /// This function returns `true` if all components that have ever been registered
     /// have reached the `Ready` state at least once.
@@ -153,8 +168,13 @@ impl RuntimeStatus {
     /// Returns `false` if:
     /// - No components have been registered yet.
     /// - There are one or more registered components that have never been in the `Ready` state.
+    /// - The runtime is in the process of shutting down.
     #[must_use]
     pub fn is_ready(&self) -> bool {
+        if self.is_shutdown() {
+            return false;
+        }
+
         let statuses = match self.statuses.read() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -201,5 +221,10 @@ impl RuntimeStatus {
                     .map(|model_name| (model_name.to_string(), *v))
             })
             .collect()
+    }
+
+    /// Sets the runtime to the shutting down state.
+    pub fn mark_shutdown(&self) {
+        self.is_shutdown.store(true, Ordering::Relaxed);
     }
 }


### PR DESCRIPTION
# 🗣 Description

Introduce a runtime shutdown state that can be used to gracefully stop in-progress processes such as dataset loading, etc.

Note: As all servers are stopped before runtime termination, and there is no way to access the runtime state or query the runtime, so I don't update component statuses to termination. Only the overall ready state is changed to "Not Ready."

## 🔨 Related Issues

Implements https://github.com/spiceai/spiceai/issues/4888

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

The approach does not include emitting telemetry for components with the ShuttingDown state. This can be added if needed.
