### PR TITLE
Fix test-operator benchmark metrics collection

### DIFF
--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -166,11 +166,14 @@ impl StatisticsCollector<Duration, Vec<Duration>> for Vec<Duration> {
     }
 
     fn median(&self) -> Result<Duration> {
-        let half = self.len() / 2;
-        if self.len() % 2 == 0 {
-            Ok((self[half - 1] + self[half]) / 2)
+        let mut sorted_durations = self.clone();
+        sorted_durations.sort();
+
+        let half = sorted_durations.len() / 2;
+        if sorted_durations.len() % 2 == 0 {
+            Ok((sorted_durations[half - 1] + sorted_durations[half]) / 2)
         } else {
-            Ok(self[half])
+            Ok(sorted_durations[half])
         }
     }
 

--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -81,6 +81,7 @@ impl<T: ExtendedMetrics> QueryMetric<T> {
     pub fn new_from_durations(
         name: &str,
         durations: &Vec<Duration>,
+        query_status: QueryStatus,
         started_at: usize,
         finished_at: usize,
     ) -> Result<Self> {
@@ -92,7 +93,7 @@ impl<T: ExtendedMetrics> QueryMetric<T> {
         let durations = durations.statistical_set()?;
         Ok(Self {
             query_name: name.to_string(),
-            query_status: QueryStatus::Passed,
+            query_status,
             started_at,
             finished_at,
             min_duration_ms: durations.min_duration()?.as_millis() as i64,

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -53,5 +53,9 @@ pub async fn record_explain_plan(
         }
     });
 
+    if let Some(assertion_err) = assertion_err {
+        return Err(assertion_err);
+    }
+
     Ok(())
 }

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -21,7 +21,7 @@ use std::{
 
 use crate::metrics::{
     system_time_to_unix_epoch_ms, DatasetMetrics, MetricCollector, NoExtendedMetrics, QueryMetric,
-    ThroughputMetrics,
+    QueryStatus, ThroughputMetrics,
 };
 use anyhow::Result;
 use futures::future::join_all;
@@ -101,6 +101,7 @@ pub struct Completed {
     query_durations: BTreeMap<String, Vec<Duration>>,
     query_iteration_durations: BTreeMap<String, (SystemTime, SystemTime)>,
     row_counts: BTreeMap<String, Vec<usize>>,
+    query_statuses: BTreeMap<String, QueryStatus>,
     test_duration: Duration,
     end_time: SystemTime,
     query_count: usize,
@@ -196,6 +197,7 @@ impl SpiceTest<Running> {
         let mut query_durations = BTreeMap::new();
         let mut query_iteration_durations = BTreeMap::new();
         let mut row_counts = BTreeMap::new();
+        let mut query_statuses = BTreeMap::new();
         for worker_result in join_all(self.state.query_workers).await {
             let worker_result = worker_result??;
             if worker_result.connection_failed {
@@ -223,6 +225,18 @@ impl SpiceTest<Running> {
                     .or_insert_with(Vec::new)
                     .extend(query_row_counts);
             }
+
+            for (query, worker_status) in worker_result.query_statuses {
+                query_statuses
+                    .entry(query)
+                    .and_modify(|existing_status| {
+                        // If the worker reports failure, update the status to Failed
+                        if worker_status == QueryStatus::Failed {
+                            *existing_status = QueryStatus::Failed;
+                        }
+                    })
+                    .or_insert(worker_status);
+            }
         }
 
         if let Some(multi) = self.state.progress_bar {
@@ -241,6 +255,7 @@ impl SpiceTest<Running> {
                 query_durations,
                 query_iteration_durations,
                 row_counts,
+                query_statuses,
                 test_duration: self.state.start_time.elapsed(),
                 end_time: SystemTime::now(),
                 query_count: self.state.query_count,
@@ -339,10 +354,17 @@ impl MetricCollector<DatasetMetrics, NoExtendedMetrics> for SpiceTest<Completed>
                     query_iteration_durations.map_or(self.start_time, |(start, _)| *start);
                 let query_end_time =
                     query_iteration_durations.map_or(self.state.end_time, |(_, end)| *end);
+                let query_status = self
+                    .state
+                    .query_statuses
+                    .get(query)
+                    .unwrap_or(&QueryStatus::Failed)
+                    .to_owned();
 
                 let metric = QueryMetric::new_from_durations(
                     query,
                     durations,
+                    query_status,
                     system_time_to_unix_epoch_ms(query_start_time)?,
                     system_time_to_unix_epoch_ms(query_end_time)?,
                 );
@@ -377,10 +399,17 @@ impl MetricCollector<NoExtendedMetrics, ThroughputMetrics> for SpiceTest<Complet
                     query_iteration_durations.map_or(self.start_time, |(start, _)| *start);
                 let query_end_time =
                     query_iteration_durations.map_or(self.state.end_time, |(_, end)| *end);
+                let query_status = self
+                    .state
+                    .query_statuses
+                    .get(query)
+                    .unwrap_or(&QueryStatus::Failed)
+                    .to_owned();
 
                 QueryMetric::new_from_durations(
                     query,
                     durations,
+                    query_status,
                     system_time_to_unix_epoch_ms(query_start_time)?,
                     system_time_to_unix_epoch_ms(query_end_time)?,
                 )

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -26,7 +26,7 @@ use futures::TryStreamExt;
 use indicatif::ProgressBar;
 use tokio::task::JoinHandle;
 
-use crate::snapshot::record_explain_plan;
+use crate::{metrics::QueryStatus, snapshot::record_explain_plan};
 
 use super::EndCondition;
 
@@ -44,6 +44,7 @@ pub(crate) struct SpiceTestQueryWorker {
 pub struct SpiceTestQueryWorkerResult {
     pub query_durations: BTreeMap<String, Vec<Duration>>,
     pub query_iteration_durations: BTreeMap<String, (SystemTime, SystemTime)>,
+    pub query_statuses: BTreeMap<String, QueryStatus>,
     pub connection_failed: bool,
     pub row_counts: BTreeMap<String, Vec<usize>>,
 }
@@ -52,12 +53,14 @@ impl SpiceTestQueryWorkerResult {
     pub fn new(
         query_durations: BTreeMap<String, Vec<Duration>>,
         query_iteration_durations: BTreeMap<String, (SystemTime, SystemTime)>,
+        query_statuses: BTreeMap<String, QueryStatus>,
         connection_failed: bool,
         row_counts: BTreeMap<String, Vec<usize>>,
     ) -> Self {
         Self {
             query_durations,
             query_iteration_durations,
+            query_statuses,
             connection_failed,
             row_counts,
         }
@@ -110,6 +113,8 @@ impl SpiceTestQueryWorker {
             // Keeps track of the start and end time of each query iteration
             let mut query_iteration_durations: BTreeMap<String, (SystemTime, SystemTime)> =
                 BTreeMap::new();
+
+            let mut query_statuses: BTreeMap<String, QueryStatus> = BTreeMap::new();
             let mut row_counts: BTreeMap<String, Vec<usize>> = BTreeMap::new();
             let mut query_set_count = 0;
             let start = Instant::now();
@@ -134,6 +139,7 @@ impl SpiceTestQueryWorker {
                             return Ok(SpiceTestQueryWorkerResult::new(
                                 query_durations,
                                 query_iteration_durations,
+                                query_statuses,
                                 true,
                                 row_counts,
                             ));
@@ -146,6 +152,7 @@ impl SpiceTestQueryWorker {
                     for query in &self.query_set {
                         let mut current_query_count = 0;
                         let start = SystemTime::now();
+                        let mut query_status = QueryStatus::Passed;
 
                         let snapshot_results = self
                             .results_snapshot_predicate
@@ -153,32 +160,36 @@ impl SpiceTestQueryWorker {
 
                         // Additional round of query run before recording results.
                         // To discard the abnormal results caused by: establishing initial connection / spark cluster startup time
-                        if !self
+
+                        let (connection_succeed, _) = self
                             .run_single_query(
                                 query,
                                 &mut BTreeMap::new(),
                                 &mut BTreeMap::new(),
                                 snapshot_results,
                             )
-                            .await?
-                        {
+                            .await?;
+                        if !connection_succeed {
                             return Ok(SpiceTestQueryWorkerResult::new(
                                 query_durations,
                                 query_iteration_durations,
+                                query_statuses,
                                 true,
                                 row_counts,
                             ));
                         }
 
-                        if self.explain_plan_snapshot {
-                            record_explain_plan(
+                        if self.explain_plan_snapshot
+                            && record_explain_plan(
                                 &self.flight_client,
                                 self.name.as_str(),
                                 query.0,
                                 query.1,
                             )
                             .await
-                            .map_err(|e| anyhow::anyhow!("Failed to record explain plan: {}", e))?;
+                            .is_err()
+                        {
+                            query_status = QueryStatus::Failed;
                         }
 
                         while current_query_count < target_count {
@@ -193,26 +204,34 @@ impl SpiceTestQueryWorker {
                                 );
                             }
 
-                            if !self
+                            let (connection_succeed, query_succeed) = self
                                 .run_single_query(
                                     query,
                                     &mut query_durations,
                                     &mut row_counts,
                                     false,
                                 )
-                                .await?
-                            {
+                                .await?;
+
+                            if !connection_succeed {
                                 return Ok(SpiceTestQueryWorkerResult::new(
                                     query_durations,
                                     query_iteration_durations,
+                                    query_statuses,
                                     true,
                                     row_counts,
                                 ));
                             }
+
+                            if !query_succeed {
+                                query_status = QueryStatus::Failed;
+                            }
+
                             current_query_count += 1;
                         }
                         let end = SystemTime::now();
                         query_iteration_durations.insert(query.0.to_string(), (start, end));
+                        query_statuses.insert(query.0.to_string(), query_status);
                     }
                 }
             }
@@ -220,6 +239,7 @@ impl SpiceTestQueryWorker {
             Ok(SpiceTestQueryWorkerResult::new(
                 query_durations,
                 query_iteration_durations,
+                query_statuses,
                 false,
                 row_counts,
             ))
@@ -232,10 +252,10 @@ impl SpiceTestQueryWorker {
         row_counts: &mut BTreeMap<String, Vec<usize>>,
     ) -> Result<bool> {
         for query in &self.query_set {
-            if !self
+            let (connection_succeed, _) = self
                 .run_single_query(query, query_durations, row_counts, false)
-                .await?
-            {
+                .await?;
+            if !connection_succeed {
                 return Ok(false);
             }
         }
@@ -248,12 +268,12 @@ impl SpiceTestQueryWorker {
         query_durations: &mut BTreeMap<String, Vec<Duration>>,
         row_counts: &mut BTreeMap<String, Vec<usize>>,
         results_snapshot: bool,
-    ) -> Result<bool> {
+    ) -> Result<(bool, bool)> {
         match self
             .execute_query(query, query_durations, row_counts, results_snapshot)
             .await
         {
-            Ok(()) => Ok(true),
+            Ok(()) => Ok((true, true)),
             Err(e) => {
                 let flight_error = e.downcast_ref::<flight_client::Error>();
 
@@ -266,14 +286,14 @@ impl SpiceTestQueryWorker {
                         "FAIL - EARLY EXIT - Worker {} - Query '{}' failed: {}",
                         self.id, query.0, e
                     );
-                    Ok(false)
+                    Ok((false, false))
                 } else {
                     eprintln!(
                         "FAIL - Worker {} - Query '{}' failed: {}",
                         self.id, query.0, e
                     );
                     query_durations.entry(query.0.to_string()).or_default();
-                    Ok(true)
+                    Ok((true, false))
                 }
             }
         }

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -213,7 +213,7 @@ impl SpiceTestQueryWorker {
                                     query,
                                     &mut query_durations,
                                     &mut row_counts,
-                                    false,
+                                    true,
                                 )
                                 .await?;
 

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -183,17 +183,22 @@ impl SpiceTestQueryWorker {
                             ));
                         }
 
-                        if self.explain_plan_snapshot
-                            && record_explain_plan(
+                        if self.explain_plan_snapshot {
+                            if let Err(e) = record_explain_plan(
                                 &self.flight_client,
                                 self.name.as_str(),
                                 query.0,
                                 query.1,
                             )
                             .await
-                            .is_err()
-                        {
-                            query_status = QueryStatus::Failed;
+                            {
+                                println!(
+                                    "Worker {} - Query '{}' explain plan failed: {}",
+                                    self.id, query.0, e
+                                );
+
+                                query_status = QueryStatus::Failed;
+                            }
                         }
 
                         while current_query_count < target_count {
@@ -250,6 +255,7 @@ impl SpiceTestQueryWorker {
         })
     }
 
+    // run queries as a duration-based test
     async fn run_query_set(
         &self,
         query_durations: &mut BTreeMap<String, Vec<Duration>>,
@@ -283,6 +289,7 @@ impl SpiceTestQueryWorker {
         Ok(true)
     }
 
+    // run queries as a set-completion based test
     async fn run_single_query(
         &self,
         query: &(&'static str, &'static str),

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -133,7 +133,11 @@ impl SpiceTestQueryWorker {
                         }
 
                         if !self
-                            .run_query_set(&mut query_durations, &mut row_counts)
+                            .run_query_set(
+                                &mut query_durations,
+                                &mut query_statuses,
+                                &mut row_counts,
+                            )
                             .await?
                         {
                             return Ok(SpiceTestQueryWorkerResult::new(
@@ -249,15 +253,32 @@ impl SpiceTestQueryWorker {
     async fn run_query_set(
         &self,
         query_durations: &mut BTreeMap<String, Vec<Duration>>,
+        query_statuses: &mut BTreeMap<String, QueryStatus>,
         row_counts: &mut BTreeMap<String, Vec<usize>>,
     ) -> Result<bool> {
         for query in &self.query_set {
-            let (connection_succeed, _) = self
+            let (connection_succeed, query_succeed) = self
                 .run_single_query(query, query_durations, row_counts, false)
                 .await?;
             if !connection_succeed {
                 return Ok(false);
             }
+
+            let worker_status = if query_succeed {
+                QueryStatus::Passed
+            } else {
+                QueryStatus::Failed
+            };
+
+            query_statuses
+                .entry(query.0.to_string())
+                .and_modify(|existing_status| {
+                    // If the worker reports failure, update the status to Failed
+                    if worker_status == QueryStatus::Failed {
+                        *existing_status = QueryStatus::Failed;
+                    }
+                })
+                .or_insert(worker_status);
         }
         Ok(true)
     }
@@ -276,7 +297,6 @@ impl SpiceTestQueryWorker {
             Ok(()) => Ok((true, true)),
             Err(e) => {
                 let flight_error = e.downcast_ref::<flight_client::Error>();
-
                 if let Some(
                     flight_client::Error::UnableToConnectToServer { .. }
                     | flight_client::Error::UnableToPerformHandshake { .. },

--- a/crates/test-framework/src/spicetest/http/consistency.rs
+++ b/crates/test-framework/src/spicetest/http/consistency.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use super::HttpConfig;
 use crate::metrics::{
-    system_time_to_unix_epoch_ms, MetricCollector, NoExtendedMetrics, QueryMetric,
+    system_time_to_unix_epoch_ms, MetricCollector, NoExtendedMetrics, QueryMetric, QueryStatus,
 };
 use crate::spicetest::{SpiceTest, TestCompleted, TestNotStarted, TestState};
 use crate::utils::get_random_element;
@@ -222,6 +222,7 @@ impl MetricCollector<NoExtendedMetrics, NoExtendedMetrics> for SpiceTest<Complet
                 QueryMetric::new_from_durations(
                     format!("{i}").as_str(),
                     durations,
+                    QueryStatus::Passed,
                     system_time_to_unix_epoch_ms(self.start_time)?,
                     system_time_to_unix_epoch_ms(self.state.end_time)?,
                 )

--- a/crates/test-framework/src/spicetest/http/overhead.rs
+++ b/crates/test-framework/src/spicetest/http/overhead.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::component::HttpComponent;
 use super::HttpConfig;
 use crate::metrics::{
-    system_time_to_unix_epoch_ms, MetricCollector, NoExtendedMetrics, QueryMetric,
+    system_time_to_unix_epoch_ms, MetricCollector, NoExtendedMetrics, QueryMetric, QueryStatus,
 };
 use crate::spicetest::{SpiceTest, TestCompleted, TestNotStarted, TestState};
 use crate::utils::get_random_element;
@@ -197,12 +197,14 @@ impl MetricCollector<NoExtendedMetrics, NoExtendedMetrics> for SpiceTest<Complet
         let baseline = QueryMetric::new_from_durations(
             "baseline",
             &self.state.baseline_results.durations,
+            QueryStatus::Passed,
             system_time_to_unix_epoch_ms(self.start_time)?,
             system_time_to_unix_epoch_ms(self.state.end_time)?,
         )?;
         let spice = QueryMetric::new_from_durations(
             "spice",
             &self.state.spice_results.durations,
+            QueryStatus::Passed,
             system_time_to_unix_epoch_ms(self.start_time)?,
             system_time_to_unix_epoch_ms(self.state.end_time)?,
         )?;


### PR DESCRIPTION
# 🗣 Description

Fixes for test-operator benchmark metrics collection.

- Properly propagte the query result & explain snapshot assertion failure to query results.
- Use the correctly ordered durations to compute the median statistics

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
