### PR TITLE
fix: Throughput metric calculation

### DIFF
--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -288,16 +288,6 @@ impl SpiceTest<Completed> {
         self.state.query_durations.values().flatten().copied().sum()
     }
 
-    pub fn get_average_total_queries_executed(&self) -> Result<u32> {
-        // total query count across all workers
-        let total_query_count = self.state.query_durations.values().flatten().count();
-
-        // average query count per worker
-        Ok(u32::try_from(
-            total_query_count / self.state.parallel_count,
-        )?)
-    }
-
     #[must_use]
     pub fn get_test_duration(&self) -> Duration {
         self.state.test_duration
@@ -311,14 +301,12 @@ impl SpiceTest<Completed> {
         let lhs = f64::from(u32::try_from(lhs)?);
 
         // because we perform query sets one after the other, we're not 100% like the original TPCH QpH metric because it expects to only run once
-        // apply a modifier based on the query set count, making an assumption for query set count for duration based tests
+        // apply a modifier based on the query set count
         // e.g. query set count of 5, means our calculated QpH needs to be times 5 because we ran 5 query sets
         // this adjusts for a longer test duration as a result of running multiple query sets, which would otherwise reduce the QpH
         let end_condition_modifier = match self.state.end_condition {
             EndCondition::Duration(_) => {
-                let query_count = self.get_average_total_queries_executed()?;
-                let query_sets_completed = query_count / u32::try_from(self.state.query_count)?;
-                f64::from(query_sets_completed)
+                return Err(anyhow::anyhow!("Throughput metric calculation for duration-based tests is not supported. Use a QuerySetCompleted test instead."))
             }
             EndCondition::QuerySetCompleted(count) => f64::from(u32::try_from(count)?),
         };

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -311,7 +311,7 @@ impl SpiceTest<Completed> {
             EndCondition::QuerySetCompleted(count) => f64::from(u32::try_from(count)?),
         };
 
-        Ok(lhs / self.state.test_duration.as_secs_f64() * scale * end_condition_modifier)
+        Ok((lhs / self.state.test_duration.as_secs_f64()) * scale * end_condition_modifier)
     }
 
     /// Validates that row counts are consistent across queries

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -96,6 +96,7 @@ pub struct Running {
     progress_bar: Option<MultiProgress>,
     query_count: usize,
     parallel_count: usize,
+    end_condition: EndCondition,
 }
 pub struct Completed {
     query_durations: BTreeMap<String, Vec<Duration>>,
@@ -106,6 +107,7 @@ pub struct Completed {
     end_time: SystemTime,
     query_count: usize,
     parallel_count: usize,
+    end_condition: EndCondition,
 }
 
 impl TestState for NotStarted {}
@@ -187,6 +189,7 @@ impl SpiceTest<NotStarted> {
                 progress_bar: multi,
                 query_count: self.state.query_count,
                 parallel_count: self.state.parallel_count,
+                end_condition: self.state.end_condition,
             },
         })
     }
@@ -260,6 +263,7 @@ impl SpiceTest<Running> {
                 end_time: SystemTime::now(),
                 query_count: self.state.query_count,
                 parallel_count: self.state.parallel_count,
+                end_condition: self.state.end_condition,
             },
         })
     }
@@ -284,6 +288,16 @@ impl SpiceTest<Completed> {
         self.state.query_durations.values().flatten().copied().sum()
     }
 
+    pub fn get_average_total_queries_executed(&self) -> Result<u32> {
+        // total query count across all workers
+        let total_query_count = self.state.query_durations.values().flatten().count();
+
+        // average query count per worker
+        Ok(u32::try_from(
+            total_query_count / self.state.parallel_count,
+        )?)
+    }
+
     #[must_use]
     pub fn get_test_duration(&self) -> Duration {
         self.state.test_duration
@@ -292,9 +306,24 @@ impl SpiceTest<Completed> {
     pub fn get_throughput_metric(&self, scale: f64) -> Result<f64> {
         // metric = (Parallel Query Count * Test Suite Query Count * 3600) / Cs * Scale
         let lhs = self.state.parallel_count * self.state.query_count * 3600;
-        let rhs = self.get_cumulative_query_duration().as_secs_f64() * scale;
+
         // u32 is safe because lhs is unlikely to be greater than u32::MAX unless some extreme parameters are used (more than 1000 parallel and query count)
-        Ok(f64::from(u32::try_from(lhs)?) / rhs)
+        let lhs = f64::from(u32::try_from(lhs)?);
+
+        // because we perform query sets one after the other, we're not 100% like the original TPCH QpH metric because it expects to only run once
+        // apply a modifier based on the query set count, making an assumption for query set count for duration based tests
+        // e.g. query set count of 5, means our calculated QpH needs to be times 5 because we ran 5 query sets
+        // this adjusts for a longer test duration as a result of running multiple query sets, which would otherwise reduce the QpH
+        let end_condition_modifier = match self.state.end_condition {
+            EndCondition::Duration(_) => {
+                let query_count = self.get_average_total_queries_executed()?;
+                let query_sets_completed = u32::try_from(self.state.query_count)? / query_count;
+                f64::from(query_sets_completed)
+            }
+            EndCondition::QuerySetCompleted(count) => f64::from(u32::try_from(count)?),
+        };
+
+        Ok(lhs / self.state.test_duration.as_secs_f64() * scale * end_condition_modifier)
     }
 
     /// Validates that row counts are consistent across queries

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -317,7 +317,7 @@ impl SpiceTest<Completed> {
         let end_condition_modifier = match self.state.end_condition {
             EndCondition::Duration(_) => {
                 let query_count = self.get_average_total_queries_executed()?;
-                let query_sets_completed = u32::try_from(self.state.query_count)? / query_count;
+                let query_sets_completed = query_count / u32::try_from(self.state.query_count)?;
                 f64::from(query_sets_completed)
             }
             EndCondition::QuerySetCompleted(count) => f64::from(u32::try_from(count)?),


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

Fixes some bugs with the throughput metric calculation:

1. Uses the test duration for the time factor in the calculation. The previous method used the sum of query durations, which isn't representative of wall clock time because these queries can run in parallel across the worker threads.
2. Adjusts the QpH based on the number of query sets completed. The original QpH calculation relies on the fact that only one round of queries is completed. As a result, if 2 rounds are completed the time factor increases with no other adjustment - resulting in an incorrect (lower) QpH.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4114 
