### PR TITLE
fix: Allow metrics endpoint setting in CLI

### DIFF
--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -72,7 +72,7 @@ spice run
 
 func init() {
 	RootCmd.AddCommand(runCmd)
-	runCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight endpoint. Defaults to http://localhost:50051.")
+	runCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight endpoint. Defaults to http://127.0.0.1:50051")
 	runCmd.Flags().String("http-endpoint", "", "Specifies the runtime HTTP endpoint. Defaults to http://127.0.0.1:8090")
 	runCmd.Flags().String("metrics-endpoint", "", "Specifies the runtime Prometheus metrics endpoint. Defaults to http://127.0.0.1:9090")
 }

--- a/bin/spice/cmd/run.go
+++ b/bin/spice/cmd/run.go
@@ -56,6 +56,12 @@ spice run
 			args = append(args, "--http", http)
 		}
 
+		if metrics, err := cmd.Flags().GetString("metrics-endpoint"); err == nil && metrics != "" {
+			args = append(args, "--metrics", metrics)
+		} else {
+			args = append(args, "--metrics", "127.0.0.1:9090")
+		}
+
 		err = runtime.Run(args)
 		if err != nil {
 			slog.Error("error running Spice.ai", "error", err)
@@ -68,4 +74,5 @@ func init() {
 	RootCmd.AddCommand(runCmd)
 	runCmd.Flags().String("flight-endpoint", "", "Specifies the runtime Flight endpoint. Defaults to http://localhost:50051.")
 	runCmd.Flags().String("http-endpoint", "", "Specifies the runtime HTTP endpoint. Defaults to http://127.0.0.1:8090")
+	runCmd.Flags().String("metrics-endpoint", "", "Specifies the runtime Prometheus metrics endpoint. Defaults to http://127.0.0.1:9090")
 }

--- a/bin/spice/pkg/context/context.go
+++ b/bin/spice/pkg/context/context.go
@@ -298,7 +298,6 @@ func (c *RuntimeContext) GetRunCmd(args []string) (*exec.Cmd, error) {
 	spiceCMD := c.binaryFilePath("spiced")
 
 	spiceArgs := []string{
-		"--metrics", "127.0.0.1:9090",
 		"--pods-watcher-enabled",
 	}
 	args = append(spiceArgs, args...)


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the Spice CLI to allow setting a `--metrics-endpoint` value to override the default Prometheus metrics endpoint.
