### PR TITLE
Improve servers shutdown sequence during runtime termination

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -123,7 +123,7 @@ tokio.workspace = true
 tokio-rusqlite = { workspace = true, optional = true }
 tokio-rustls = "0.26.0"
 tokio-stream.workspace = true
-tokio-util = { workspace = true, optional = true }
+tokio-util.workspace = true
 tonic.workspace = true
 tonic-health.workspace = true
 tower.workspace = true
@@ -190,7 +190,7 @@ keyring-secret-store = ["dep:keyring"]
 mcp = ["dep:mcp-client", "dep:mcp-core"]
 metal = ["llms/metal"]
 models = ["model_components/full"]
-mssql = ["dep:tiberius", "dep:tokio-util", "data_components/mssql"]
+mssql = ["dep:tiberius", "data_components/mssql"]
 mysql = ["dep:mysql_async", "db_connection_pool/mysql", "data_components/mysql"]
 odbc = ["db_connection_pool/odbc", "data_components/odbc"]
 openapi = ["dep:utoipa-swagger-ui", "dep:utoipa"]

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -187,7 +187,7 @@ impl RuntimeBuilder {
             prometheus_registry: self.prometheus_registry,
             rate_limits: self.rate_limits.unwrap_or_default(),
             status,
-            running_components: Arc::new(RwLock::new(HashMap::new())),
+            server_components: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let mut extensions: HashMap<String, Arc<dyn Extension>> = HashMap::new();

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -187,6 +187,7 @@ impl RuntimeBuilder {
             prometheus_registry: self.prometheus_registry,
             rate_limits: self.rate_limits.unwrap_or_default(),
             status,
+            running_components: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let mut extensions: HashMap<String, Arc<dyn Extension>> = HashMap::new();

--- a/crates/runtime/src/cancellable_task.rs
+++ b/crates/runtime/src/cancellable_task.rs
@@ -25,7 +25,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{Error, FailedToExecuteTaskSnafu};
 
 /// A handle for a spawned task that allows external cancellation.
-/// 
+///
 /// This handle supports both graceful cancellation and forced termination:
 /// - If a [`CancellationToken`] is provided, it enables graceful shutdown.
 /// - If the task does not exit within the specified timeout after a termination request, it is forcibly aborted.
@@ -65,7 +65,10 @@ impl CancellableTaskHandle {
 pub(crate) fn spawn_cancellable_task<F>(
     task_fn: F,
     task_cancellation: Option<CancellationToken>,
-) -> (impl Future<Output = Result<(), Error>>, CancellableTaskHandle)
+) -> (
+    impl Future<Output = Result<(), Error>>,
+    CancellableTaskHandle,
+)
 where
     F: Future<Output = Result<(), Error>> + Send + 'static,
 {

--- a/crates/runtime/src/cancellable_task.rs
+++ b/crates/runtime/src/cancellable_task.rs
@@ -24,21 +24,19 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{Error, FailedToExecuteTaskSnafu};
 
-/// A handle for managing the lifecycle of a spawned task.
-///
-/// Allows external control over a task's execution, supporting
-/// both graceful cancellation via provided [`CancellationToken`] and forced termination.
-///
+/// A handle for a spawned task that allows external cancellation.
+/// 
+/// This handle supports both graceful cancellation and forced termination:
 /// - If a [`CancellationToken`] is provided, it enables graceful shutdown.
-/// - If the task does not exit within the allowed time after termination request, it is forcefully aborted.
-pub(crate) struct ManagedTaskHandle {
+/// - If the task does not exit within the specified timeout after a termination request, it is forcibly aborted.
+pub(crate) struct CancellableTaskHandle {
     notify_abort_task: oneshot::Sender<()>,
     cancellation_token: Option<CancellationToken>,
     on_task_completed: oneshot::Receiver<()>,
 }
 
-impl ManagedTaskHandle {
-    pub async fn shutdown(mut self, timeout: Duration) {
+impl CancellableTaskHandle {
+    pub async fn cancel(mut self, timeout: Duration) {
         let Some(token) = self.cancellation_token.take() else {
             // The task does not support graceful cancellation, so we abort it.
             // The error is expected if the receiver has already been deallocated, indicating the task has completed or aborted.
@@ -60,21 +58,21 @@ impl ManagedTaskHandle {
     }
 }
 
-/// Spawns a managed task with termination support.
+/// Spawns a task that allows external cancellation.
 ///
 /// Returns a future that resolves when the task completes or is canceled,
-/// along with a [`ManagedTaskHandle`] for external task control.
-pub(crate) fn spawn_managed_task<F>(
+/// along with a [`CancellableTaskHandle`] for external task control.
+pub(crate) fn spawn_cancellable_task<F>(
     task_fn: F,
     task_cancellation: Option<CancellationToken>,
-) -> (impl Future<Output = Result<(), Error>>, ManagedTaskHandle)
+) -> (impl Future<Output = Result<(), Error>>, CancellableTaskHandle)
 where
     F: Future<Output = Result<(), Error>> + Send + 'static,
 {
     let (notify_abort_task, on_abort_task) = oneshot::channel();
     let (notify_task_completed, on_task_completed) = oneshot::channel();
 
-    let task_handle = ManagedTaskHandle {
+    let task_handle = CancellableTaskHandle {
         notify_abort_task,
         cancellation_token: task_cancellation,
         on_task_completed,

--- a/crates/runtime/src/cancellable_task.rs
+++ b/crates/runtime/src/cancellable_task.rs
@@ -63,8 +63,8 @@ impl CancellableTaskHandle {
 /// Returns a future that resolves when the task completes or is canceled,
 /// along with a [`CancellableTaskHandle`] for external task control.
 pub(crate) fn spawn_cancellable_task<F>(
-    task_fn: F,
     task_cancellation: Option<CancellationToken>,
+    task_fn: F,
 ) -> (
     impl Future<Output = Result<(), Error>>,
     CancellableTaskHandle,
@@ -106,4 +106,135 @@ where
     };
 
     (task_future, task_handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_task_completes_successfully() {
+        let task_fn = async { Ok::<(), Error>(()) };
+        let (task_future, _handle) = spawn_cancellable_task(None, task_fn);
+        let result = task_future.await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_task_fails() {
+        // test that correct error is returned
+        let task_fn =
+            async { Err::<(), Error>(Error::AcceleratedReadWriteTableWithoutReplication {}) };
+        let (task_future, _handle) = spawn_cancellable_task(None, task_fn);
+        let result = task_future.await;
+        assert!(matches!(
+            result,
+            Err(Error::AcceleratedReadWriteTableWithoutReplication { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_task_is_cancelled_gracefully() {
+        let cancellation_token = CancellationToken::new();
+        let (task_future, handle) =
+            spawn_cancellable_task(Some(cancellation_token.clone()), async move {
+                // Simulate some work
+                cancellation_token.cancelled().await;
+                Ok::<(), Error>(())
+            });
+
+        // cancel the task async after 100 ms
+        let cancel_future = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::select! {
+                // We expect the task to be cancelled immediately (before timeout)
+                () = handle.cancel(Duration::from_secs(5)) => {}
+                () = tokio::time::sleep(Duration::from_secs(1)) => {
+                    panic!("Timed out waiting for task to complete");
+                }
+            }
+        });
+
+        let (task_result, cancel_result) = tokio::join!(task_future, cancel_future);
+        assert!(task_result.is_ok());
+        assert!(cancel_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_task_is_aborted() {
+        let (task_future, handle) = spawn_cancellable_task(None, async move {
+            // Simulate some work
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            Ok::<(), Error>(())
+        });
+
+        // cancel the task async after 100 ms
+        let cancel_future = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::select! {
+                // We expect the task to be cancelled immediately (before timeout)
+                () = handle.cancel(Duration::from_secs(5)) => {}
+                () = tokio::time::sleep(Duration::from_secs(1)) => {
+                    panic!("Timed out waiting for task to complete");
+                }
+            }
+        });
+
+        let (task_result, cancel_result) = tokio::join!(task_future, cancel_future);
+        assert!(task_result.is_ok());
+        assert!(cancel_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_task_can_be_force_aborted() {
+        // test that the task can be aborted after timeout when cancellation token is provided
+        let (task_future, handle) =
+            spawn_cancellable_task(Some(CancellationToken::new()), async move {
+                // Simulate some work
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                Ok::<(), Error>(())
+            });
+
+        // cancel the task async after 100 ms
+        let cancel_future = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::select! {
+                // the task must be force aborted after timeout
+                () = handle.cancel(Duration::from_millis(200)) => {}
+                () = tokio::time::sleep(Duration::from_secs(1)) => {
+                    panic!("Timed out waiting for task to complete");
+                }
+            }
+        });
+
+        let (task_result, cancel_result) = tokio::join!(task_future, cancel_future);
+        assert!(task_result.is_ok());
+        assert!(cancel_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_already_completed_task() {
+        let cancellation_token = CancellationToken::new();
+        let (task_future, handle) = spawn_cancellable_task(Some(cancellation_token), async move {
+            // complete the task immediatly
+            Ok::<(), Error>(())
+        });
+
+        assert!(task_future.await.is_ok());
+
+        // attempt to cancel already completed task after 100 ms
+        let cancel_result = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::select! {
+                // We expect the task to be cancelled immediately (before timeout)
+                () = handle.cancel(Duration::from_secs(5)) => {}
+                () = tokio::time::sleep(Duration::from_secs(1)) => {
+                    panic!("Timed out waiting for task to complete");
+                }
+            }
+        })
+        .await;
+
+        assert!(cancel_result.is_ok());
+    }
 }

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -1286,6 +1286,7 @@ impl DataFusion {
     pub async fn shutdown(&self) {
         // Don't block self.accelerated_tables as it needs to be modified during table removal
         // and will be cleaned up authomatically by removing accelerated tables.
+        tracing::debug!("Datafusion shutdown started");
 
         let accelerated_tables = self.accelerated_tables.read().await.clone();
 
@@ -1312,4 +1313,10 @@ pub fn is_spice_internal_schema(catalog: &str, schema: &str) -> bool {
         && (schema == SPICE_RUNTIME_SCHEMA
             || schema == SPICE_METADATA_SCHEMA
             || schema == SPICE_EVAL_SCHEMA)
+}
+
+impl Drop for DataFusion {
+    fn drop(&mut self) {
+        tracing::debug!("DataFusion resources cleanup");
+    }
 }

--- a/crates/runtime/src/flight.rs
+++ b/crates/runtime/src/flight.rs
@@ -46,6 +46,7 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use tokio::sync::broadcast::Sender;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tonic::{Request, Response, Status, Streaming};
 
@@ -321,6 +322,7 @@ pub async fn start(
     tls_config: Option<Arc<TlsConfig>>,
     endpoint_auth: EndpointAuth,
     rate_limits: Arc<RateLimits>,
+    shutdown_signal: Option<CancellationToken>,
 ) -> Result<()> {
     let service = Service {
         datafusion: Arc::clone(&df),
@@ -348,16 +350,24 @@ pub async fn start(
         .layer(BasicAuthLayer::new(endpoint_auth.flight_basic_auth))
         .into_inner();
 
-    server
+    let server = server
         .layer(RequestContextLayer::new(app))
         .layer(WriteRateLimitLayer::new(RateLimiter::direct(
             rate_limits.flight_write_limit,
         )))
         .layer(auth_layer)
-        .add_service(svc)
-        .serve(bind_address)
-        .await
-        .context(UnableToStartFlightServerSnafu)?;
+        .add_service(svc);
+
+    if let Some(token) = shutdown_signal {
+        server
+            .serve_with_shutdown(bind_address, token.cancelled())
+            .await
+    } else {
+        server.serve(bind_address).await
+    }
+    .context(UnableToStartFlightServerSnafu)?;
+
+    tracing::debug!("Spice Runtime Flight stopped");
 
     Ok(())
 }

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::embeddings::vector_search;
+use crate::{embeddings::vector_search, status::RuntimeStatus};
 
 #[cfg(feature = "openapi")]
 use crate::http::v1::{
@@ -26,7 +26,7 @@ use crate::Runtime;
 use crate::{config, request::RequestContext};
 
 use app::App;
-use axum::routing::patch;
+use axum::{extract::State, routing::patch};
 use opentelemetry::KeyValue;
 use spicepod::component::runtime::CorsConfig;
 use std::sync::Arc;
@@ -181,6 +181,7 @@ pub(crate) fn routes(
 
     unauthenticated_router
         .merge(authenticated_router)
+        .route_layer(middleware::from_fn_with_state(rt.status(), check_shutdown))
         .route_layer(middleware::from_fn(track_metrics))
         .layer(Extension(Arc::clone(&rt.app)))
         .layer(cors_layer(cors_config))
@@ -259,4 +260,25 @@ fn cors_layer(cors_config: &CorsConfig) -> CorsLayer {
 
     cors.allow_methods([Method::GET, Method::POST, Method::PATCH])
         .allow_origin(allowed_origins)
+}
+
+async fn check_shutdown(
+    State(status): State<Arc<RuntimeStatus>>,
+    req: axum::http::Request<Body>,
+    next: Next,
+) -> impl IntoResponse {
+    // Allow /health to bypass shutdown check
+    if req.uri().path() == "/health" {
+        return next.run(req).await;
+    }
+
+    if status.is_shutdown() {
+        return (
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "Runtime is shutting down",
+        )
+            .into_response();
+    }
+
+    next.run(req).await
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 
+use std::future::Future;
 use std::net::SocketAddr;
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
@@ -278,6 +279,12 @@ pub enum Error {
     ComponentError { source: component::Error },
 }
 
+const HTTP_SERVER: &str = "http_server";
+const METRICS_SERVER: &str = "metrics_server";
+const FLIGHT_SERVER: &str = "flight_server";
+const OPENTELEMETRY_SERVER: &str = "opentelemetry_server";
+const PODS_WATCHER: &str = "pods_watcher";
+
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Clone, Copy)]
@@ -306,7 +313,7 @@ pub struct Runtime {
 
     status: Arc<status::RuntimeStatus>,
 
-    running_components: Arc<RwLock<HashMap<String, ManagedTaskHandle>>>,
+    server_components: Arc<RwLock<HashMap<String, ManagedTaskHandle>>>,
 }
 
 impl Runtime {
@@ -385,106 +392,84 @@ impl Runtime {
         self.register_metrics_table(self.prometheus_registry.is_some())
             .await?;
 
-        let cloned_self = Arc::clone(&self);
-        let cloned_config = config.clone();
+        // Start Http server
         let cloned_tls_config = tls_config.clone();
-
-        // Start HTTP server
+        let cloned_config = config.clone();
         let http_auth = endpoint_auth.http_auth.clone();
-        let (http_future, http_handle) = spawn_managed_task(
-            async move {
+        let self_ref = Arc::clone(&self);
+
+        let http_future = self
+            .start_server_component(HTTP_SERVER, None, async move {
                 http::start(
                     cloned_config.http_bind_address,
-                    cloned_self,
+                    self_ref,
                     cloned_config.into(),
                     cloned_tls_config,
                     http_auth,
                 )
                 .await
                 .context(UnableToStartHttpServerSnafu)
-            },
-            None,
-        );
-
-        self.running_components
-            .write()
-            .await
-            .insert("http_server".to_string(), http_handle);
+            })
+            .await;
 
         // Start Metrics server
         let metrics_endpoint = self.metrics_endpoint;
         let prometheus_registry = self.prometheus_registry.clone();
         let cloned_tls_config = tls_config.clone();
 
-        let (metrics_future, metrics_handle) = spawn_managed_task(
-            async move {
+        let metrics_future = self
+            .start_server_component(METRICS_SERVER, None, async move {
                 metrics_server::start(metrics_endpoint, prometheus_registry, cloned_tls_config)
                     .await
                     .context(UnableToStartMetricsServerSnafu)
-            },
-            None,
-        );
+            })
+            .await;
 
-        self.running_components
-            .write()
-            .await
-            .insert("metrics_server".to_string(), metrics_handle);
-
-        let flight_graceful_shutdown = CancellationToken::new();
-        let flight_graceful_shutdown_clone = flight_graceful_shutdown.clone();
-
-        let cloned_self = Arc::clone(&self);
+        // Start Flight server
+        let flight_shutdown = CancellationToken::new();
+        let self_ref = Arc::clone(&self);
         let cloned_tls_config = tls_config.clone();
         let cloned_endpoint_auth = endpoint_auth.clone();
 
-        // Start Flight server
-        let (flight_future, flight_handle) = spawn_managed_task(
-            async move {
+        let flight_future = self
+            .start_server_component(FLIGHT_SERVER, Some(flight_shutdown.clone()), async move {
                 flight::start(
                     config.flight_bind_address,
-                    cloned_self.app.read().await.as_ref().map(Arc::clone),
-                    Arc::clone(&cloned_self.df),
+                    self_ref.app.read().await.as_ref().map(Arc::clone),
+                    Arc::clone(&self_ref.df),
                     cloned_tls_config,
                     cloned_endpoint_auth,
-                    Arc::clone(&cloned_self.rate_limits),
-                    Some(flight_graceful_shutdown_clone),
+                    Arc::clone(&self_ref.rate_limits),
+                    Some(flight_shutdown),
                 )
                 .await
                 .context(UnableToStartFlightServerSnafu)
-            },
-            Some(flight_graceful_shutdown),
-        );
-
-        self.running_components
-            .write()
-            .await
-            .insert("flight_server".to_string(), flight_handle);
+            })
+            .await;
 
         // Start OpenTelemetry server
         let opentelemetry_graceful_shutdown = CancellationToken::new();
-        let opentelemetry_graceful_shutdown_clone = opentelemetry_graceful_shutdown.clone();
-        let cloned_self = Arc::clone(&self);
+        let df_ref = Arc::clone(&self.df);
         let cloned_tls_config = tls_config.clone();
         let grpc_auth = endpoint_auth.grpc_auth.clone();
 
-        let (opentelemetry_future, opentelemetry_handle) = spawn_managed_task(
-            async move {
-                opentelemetry::start(
-                    config.open_telemetry_bind_address,
-                    Arc::clone(&cloned_self.df),
-                    cloned_tls_config,
-                    grpc_auth,
-                    Some(opentelemetry_graceful_shutdown_clone),
-                )
-                .await
-                .context(UnableToStartOpenTelemetryServerSnafu)
-            },
-            Some(opentelemetry_graceful_shutdown),
-        );
-        self.running_components
-            .write()
-            .await
-            .insert("opentelemetry_server".to_string(), opentelemetry_handle);
+        let opentelemetry_future = self
+            .start_server_component(
+                OPENTELEMETRY_SERVER,
+                Some(opentelemetry_graceful_shutdown.clone()),
+                async move {
+                    opentelemetry::start(
+                        config.open_telemetry_bind_address,
+                        df_ref,
+                        cloned_tls_config,
+                        grpc_auth,
+                        Some(opentelemetry_graceful_shutdown),
+                    )
+                    .await
+                    .context(UnableToStartOpenTelemetryServerSnafu)
+                },
+            )
+            .await;
 
         if let Some(tls_config) = tls_config {
             match tls_config.subject_name() {
@@ -497,26 +482,19 @@ impl Runtime {
             }
         }
 
-        // Pods watcher
-        let cloned_self = Arc::clone(&self);
-        let (pods_watcher_future, posd_watcher_handle) = spawn_managed_task(
-            async move {
-                cloned_self
+        // Start Spicepod watcher
+        let self_ref = Arc::clone(&self);
+        let pods_watcher_future = self
+            .start_server_component(PODS_WATCHER, None, async move {
+                self_ref
                     .start_pods_watcher()
                     .await
                     .context(UnableToInitializePodsWatcherSnafu)
-            },
-            None,
-        );
+            })
+            .await;
 
-        self.running_components
-            .write()
-            .await
-            .insert("pods_watcher".to_string(), posd_watcher_handle);
-
-        // Start Spicepod watcher
-
-        let shutdown_signnal_future = async {
+        // Shutdown signal
+        let shutdown_signal_future = async {
             shutdown_signal().await;
             tracing::debug!("Shutdown signal received.");
             self.shutdown().await;
@@ -530,7 +508,7 @@ impl Runtime {
             metrics_future,
             opentelemetry_future,
             pods_watcher_future,
-            shutdown_signnal_future
+            shutdown_signal_future
         ) {
             Err(err) => Err(err),
             _ => Ok(()),
@@ -684,7 +662,7 @@ impl Runtime {
         self.status.mark_shutdown();
 
         // shutdown all running components except the HTTP and Metrics servers
-        let mut running_components = self.running_components.write().await;
+        let mut running_components = self.server_components.write().await;
         for (name, handle) in running_components.drain() {
             // if name == "http_server" || name == "metrics_server" {
             //     continue;
@@ -700,6 +678,26 @@ impl Runtime {
         dataaccelerator::unregister_all().await;
         tools::factory::unregister_all_factories().await;
         document_parse::unregister_all().await;
+    }
+
+    /// Spawns and registers a server component with optional cancellation support.
+    async fn start_server_component<F>(
+        self: &Arc<Self>,
+        component_name: &str,
+        cancellation_token: Option<CancellationToken>,
+        task_fn: F,
+    ) -> impl Future<Output = Result<(), Error>>
+    where
+        F: Future<Output = Result<(), Error>> + Send + 'static,
+    {
+        let (future, handle) = spawn_managed_task(task_fn, cancellation_token);
+
+        self.server_components
+            .write()
+            .await
+            .insert(component_name.to_string(), handle);
+
+        future
     }
 }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -29,6 +29,7 @@ use ::datafusion::error::DataFusionError;
 use ::datafusion::sql::{sqlparser, TableReference};
 use app::App;
 use builder::RuntimeBuilder;
+use cancellable_task::{spawn_cancellable_task, CancellableTaskHandle};
 use config::Config;
 use dataconnector::ConnectorComponent;
 use datasets_health_monitor::DatasetsHealthMonitor;
@@ -37,7 +38,6 @@ use flight::RateLimits;
 use futures::future::join_all;
 #[cfg(feature = "openapi")]
 pub use http::ApiDoc;
-use cancellable_task::{spawn_cancellable_task, CancellableTaskHandle};
 use model::{EmbeddingModelStore, EvalScorerRegistry, LLMModelStore};
 
 use model_components::model::Model;
@@ -58,6 +58,7 @@ use crate::extension::Extension;
 pub mod accelerated_table;
 pub mod auth;
 mod builder;
+mod cancellable_task;
 pub mod catalogconnector;
 pub mod component;
 pub mod config;
@@ -74,7 +75,6 @@ pub mod flight;
 mod http;
 mod init;
 pub mod internal_table;
-mod cancellable_task;
 mod metrics;
 mod metrics_server;
 pub mod model;
@@ -670,11 +670,17 @@ impl Runtime {
         let mut running_components = self.server_components.write().await;
 
         // HTTP and METRICS servers must be shutdown last
-        let (to_shutdown, to_shutdown_last) = running_components
-            .drain()
-            .partition::<Vec<_>, _>(|(name, _)| *name != HTTP_SERVER && *name != METRICS_SERVER);
+        let mut first_shutdown_group = Vec::new();
+        let mut last_shutdown_group = Vec::new();
 
-        let shutdown_futures: Vec<_> = to_shutdown
+        for (name, handle) in running_components.drain() {
+            match name.as_str() {
+                HTTP_SERVER | METRICS_SERVER => last_shutdown_group.push((name, handle)),
+                _ => first_shutdown_group.push((name, handle)),
+            }
+        }
+
+        let shutdown_futures: Vec<_> = first_shutdown_group
             .into_iter()
             .map(|(name, handle)| {
                 tracing::debug!("Shutting down {name}");
@@ -693,7 +699,7 @@ impl Runtime {
         document_parse::unregister_all().await;
 
         // Shutdown HTTP & Metrics servers last
-        let shutdown_futures: Vec<_> = to_shutdown_last
+        let shutdown_futures: Vec<_> = last_shutdown_group
             .into_iter()
             .map(|(name, handle)| {
                 tracing::debug!("Shutting down {name}");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -34,6 +34,7 @@ use dataconnector::ConnectorComponent;
 use datasets_health_monitor::DatasetsHealthMonitor;
 use extension::ExtensionFactory;
 use flight::RateLimits;
+use futures::future::join_all;
 #[cfg(feature = "openapi")]
 pub use http::ApiDoc;
 use managed_task::{spawn_managed_task, ManagedTaskHandle};
@@ -285,6 +286,9 @@ const FLIGHT_SERVER: &str = "flight_server";
 const OPENTELEMETRY_SERVER: &str = "opentelemetry_server";
 const PODS_WATCHER: &str = "pods_watcher";
 
+// Allow 30 seconds for server components to shutdown
+const SERVER_COMPONENT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Clone, Copy)]
@@ -502,6 +506,7 @@ impl Runtime {
             Ok(())
         };
 
+        // wait for all servers to shut down or if any of the servers fail to start
         match tokio::try_join!(
             http_future,
             flight_future,
@@ -658,18 +663,26 @@ impl Runtime {
             return;
         }
 
-        tracing::info!("Shutting down...");
+        tracing::info!("Shutting down runtime...");
         self.status.mark_shutdown();
 
         // shutdown all running components except the HTTP and Metrics servers
         let mut running_components = self.server_components.write().await;
-        for (name, handle) in running_components.drain() {
-            // if name == "http_server" || name == "metrics_server" {
-            //     continue;
-            // }
-            handle.shutdown(Duration::from_secs(10)).await;
-            tracing::debug!("Shutdown component: {name}");
-        }
+
+        // HTTP and METRICS servers must be shutdown last
+        let (to_shutdown, to_shutdown_last) = running_components
+            .drain()
+            .partition::<Vec<_>, _>(|(name, _)| *name != HTTP_SERVER && *name != METRICS_SERVER);
+
+        let shutdown_futures: Vec<_> = to_shutdown
+            .into_iter()
+            .map(|(name, handle)| {
+                tracing::debug!("Shutting down {name}");
+                handle.shutdown(SERVER_COMPONENT_SHUTDOWN_TIMEOUT)
+            })
+            .collect();
+
+        join_all(shutdown_futures).await;
 
         // Clean up DataFusion first as there could be datasets loading and accessing registries below.
         self.df.shutdown().await;
@@ -678,6 +691,19 @@ impl Runtime {
         dataaccelerator::unregister_all().await;
         tools::factory::unregister_all_factories().await;
         document_parse::unregister_all().await;
+
+        // Shutdown HTTP & Metrics servers last
+        let shutdown_futures: Vec<_> = to_shutdown_last
+            .into_iter()
+            .map(|(name, handle)| {
+                tracing::debug!("Shutting down {name}");
+                handle.shutdown(SERVER_COMPONENT_SHUTDOWN_TIMEOUT)
+            })
+            .collect();
+
+        join_all(shutdown_futures).await;
+
+        tracing::debug!("Shutdown complete.");
     }
 
     /// Spawns and registers a server component with optional cancellation support.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -37,7 +37,7 @@ use flight::RateLimits;
 use futures::future::join_all;
 #[cfg(feature = "openapi")]
 pub use http::ApiDoc;
-use managed_task::{spawn_managed_task, ManagedTaskHandle};
+use cancellable_task::{spawn_cancellable_task, CancellableTaskHandle};
 use model::{EmbeddingModelStore, EvalScorerRegistry, LLMModelStore};
 
 use model_components::model::Model;
@@ -74,7 +74,7 @@ pub mod flight;
 mod http;
 mod init;
 pub mod internal_table;
-mod managed_task;
+mod cancellable_task;
 mod metrics;
 mod metrics_server;
 pub mod model;
@@ -317,7 +317,7 @@ pub struct Runtime {
 
     status: Arc<status::RuntimeStatus>,
 
-    server_components: Arc<RwLock<HashMap<String, ManagedTaskHandle>>>,
+    server_components: Arc<RwLock<HashMap<String, CancellableTaskHandle>>>,
 }
 
 impl Runtime {
@@ -678,7 +678,7 @@ impl Runtime {
             .into_iter()
             .map(|(name, handle)| {
                 tracing::debug!("Shutting down {name}");
-                handle.shutdown(SERVER_COMPONENT_SHUTDOWN_TIMEOUT)
+                handle.cancel(SERVER_COMPONENT_SHUTDOWN_TIMEOUT)
             })
             .collect();
 
@@ -697,7 +697,7 @@ impl Runtime {
             .into_iter()
             .map(|(name, handle)| {
                 tracing::debug!("Shutting down {name}");
-                handle.shutdown(SERVER_COMPONENT_SHUTDOWN_TIMEOUT)
+                handle.cancel(SERVER_COMPONENT_SHUTDOWN_TIMEOUT)
             })
             .collect();
 
@@ -716,7 +716,7 @@ impl Runtime {
     where
         F: Future<Output = Result<(), Error>> + Send + 'static,
     {
-        let (future, handle) = spawn_managed_task(task_fn, cancellation_token);
+        let (future, handle) = spawn_cancellable_task(task_fn, cancellation_token);
 
         self.server_components
             .write()

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -16,12 +16,14 @@ limitations under the License.
 #![allow(clippy::missing_errors_doc)]
 
 use std::net::SocketAddr;
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     auth::EndpointAuth, dataconnector::DataConnector, datafusion::DataFusion,
     internal_table::Error as InternalTableError, model::ENABLE_MODEL_SUPPORT_MESSAGE,
 };
+
 use ::datafusion::error::DataFusionError;
 use ::datafusion::sql::{sqlparser, TableReference};
 use app::App;
@@ -33,6 +35,7 @@ use extension::ExtensionFactory;
 use flight::RateLimits;
 #[cfg(feature = "openapi")]
 pub use http::ApiDoc;
+use managed_task::{spawn_managed_task, ManagedTaskHandle};
 use model::{EmbeddingModelStore, EvalScorerRegistry, LLMModelStore};
 
 use model_components::model::Model;
@@ -44,6 +47,7 @@ use spicepod::component::eval::Eval;
 use status::ComponentStatus;
 use tls::TlsConfig;
 use tokio::sync::{oneshot::error::RecvError, RwLock};
+use tokio_util::sync::CancellationToken;
 use tools::factory::default_available_catalogs;
 use tools::{catalog::SpiceToolCatalog, Tooling};
 pub use util::shutdown_signal;
@@ -68,6 +72,7 @@ pub mod flight;
 mod http;
 mod init;
 pub mod internal_table;
+mod managed_task;
 mod metrics;
 mod metrics_server;
 pub mod model;
@@ -94,8 +99,8 @@ pub enum Error {
     #[snafu(display("Unable to start HTTP server: {source}"))]
     UnableToStartHttpServer { source: http::Error },
 
-    #[snafu(display("{source}"))]
-    UnableToJoinTask { source: tokio::task::JoinError },
+    #[snafu(display("Task execution failed: {source}\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"))]
+    FailedToExecuteTask { source: tokio::task::JoinError },
 
     #[snafu(display("Unable to start Prometheus metrics server: {source}"))]
     UnableToStartMetricsServer { source: metrics_server::Error },
@@ -300,6 +305,8 @@ pub struct Runtime {
     spaced_tracer: Arc<tracers::SpacedTracer>,
 
     status: Arc<status::RuntimeStatus>,
+
+    running_components: Arc<RwLock<HashMap<String, ManagedTaskHandle>>>,
 }
 
 impl Runtime {
@@ -368,6 +375,7 @@ impl Runtime {
     /// The future returned by this function drives the individual server futures and will only return once the servers are shutdown.
     ///
     /// It is recommended to start the servers in parallel to loading the Runtime components to speed up startup.
+    #[allow(clippy::too_many_lines)]
     pub async fn start_servers(
         self: Arc<Self>,
         config: Config,
@@ -377,48 +385,106 @@ impl Runtime {
         self.register_metrics_table(self.prometheus_registry.is_some())
             .await?;
 
-        let http_auth = endpoint_auth.http_auth.clone();
-        let http_server_future = tokio::spawn(http::start(
-            config.http_bind_address,
-            Arc::clone(&self),
-            config.clone().into(),
-            tls_config.clone(),
-            http_auth,
-        ));
+        let cloned_self = Arc::clone(&self);
+        let cloned_config = config.clone();
+        let cloned_tls_config = tls_config.clone();
 
-        // Spawn the metrics server in the background
+        // Start HTTP server
+        let http_auth = endpoint_auth.http_auth.clone();
+        let (http_future, http_handle) = spawn_managed_task(
+            async move {
+                http::start(
+                    cloned_config.http_bind_address,
+                    cloned_self,
+                    cloned_config.into(),
+                    cloned_tls_config,
+                    http_auth,
+                )
+                .await
+                .context(UnableToStartHttpServerSnafu)
+            },
+            None,
+        );
+
+        self.running_components
+            .write()
+            .await
+            .insert("http_server".to_string(), http_handle);
+
+        // Start Metrics server
         let metrics_endpoint = self.metrics_endpoint;
         let prometheus_registry = self.prometheus_registry.clone();
         let cloned_tls_config = tls_config.clone();
-        tokio::spawn(async move {
-            if let Err(e) =
+
+        let (metrics_future, metrics_handle) = spawn_managed_task(
+            async move {
                 metrics_server::start(metrics_endpoint, prometheus_registry, cloned_tls_config)
                     .await
-            {
-                tracing::error!("Prometheus metrics server error: {e}");
-            }
-        });
+                    .context(UnableToStartMetricsServerSnafu)
+            },
+            None,
+        );
 
-        let flight_server_future = tokio::spawn(flight::start(
-            config.flight_bind_address,
-            self.app.read().await.as_ref().map(Arc::clone),
-            Arc::clone(&self.df),
-            tls_config.clone(),
-            endpoint_auth.clone(),
-            Arc::clone(&self.rate_limits),
-        ));
-        let open_telemetry_server_future = tokio::spawn(opentelemetry::start(
-            config.open_telemetry_bind_address,
-            Arc::clone(&self.df),
-            tls_config.clone(),
-            endpoint_auth.grpc_auth.clone(),
-        ));
+        self.running_components
+            .write()
+            .await
+            .insert("metrics_server".to_string(), metrics_handle);
 
-        let pods_watcher_future = if self.pods_watcher.read().await.is_some() {
-            Some(self.start_pods_watcher())
-        } else {
-            None
-        };
+        let flight_graceful_shutdown = CancellationToken::new();
+        let flight_graceful_shutdown_clone = flight_graceful_shutdown.clone();
+
+        let cloned_self = Arc::clone(&self);
+        let cloned_tls_config = tls_config.clone();
+        let cloned_endpoint_auth = endpoint_auth.clone();
+
+        // Start Flight server
+        let (flight_future, flight_handle) = spawn_managed_task(
+            async move {
+                flight::start(
+                    config.flight_bind_address,
+                    cloned_self.app.read().await.as_ref().map(Arc::clone),
+                    Arc::clone(&cloned_self.df),
+                    cloned_tls_config,
+                    cloned_endpoint_auth,
+                    Arc::clone(&cloned_self.rate_limits),
+                    Some(flight_graceful_shutdown_clone),
+                )
+                .await
+                .context(UnableToStartFlightServerSnafu)
+            },
+            Some(flight_graceful_shutdown),
+        );
+
+        self.running_components
+            .write()
+            .await
+            .insert("flight_server".to_string(), flight_handle);
+
+        // Start OpenTelemetry server
+        let opentelemetry_graceful_shutdown = CancellationToken::new();
+        let opentelemetry_graceful_shutdown_clone = opentelemetry_graceful_shutdown.clone();
+        let cloned_self = Arc::clone(&self);
+        let cloned_tls_config = tls_config.clone();
+        let grpc_auth = endpoint_auth.grpc_auth.clone();
+
+        let (opentelemetry_future, opentelemetry_handle) = spawn_managed_task(
+            async move {
+                opentelemetry::start(
+                    config.open_telemetry_bind_address,
+                    Arc::clone(&cloned_self.df),
+                    cloned_tls_config,
+                    grpc_auth,
+                    Some(opentelemetry_graceful_shutdown_clone),
+                )
+                .await
+                .context(UnableToStartOpenTelemetryServerSnafu)
+            },
+            Some(opentelemetry_graceful_shutdown),
+        );
+        self.running_components
+            .write()
+            .await
+            .insert("opentelemetry_server".to_string(), opentelemetry_handle);
 
         if let Some(tls_config) = tls_config {
             match tls_config.subject_name() {
@@ -431,44 +497,43 @@ impl Runtime {
             }
         }
 
-        tokio::select! {
-            http_res = http_server_future => {
-                match http_res {
-                    Ok(http_res) => http_res.context(UnableToStartHttpServerSnafu),
-                    Err(source) => {
-                        Err(Error::UnableToJoinTask { source })
-                    }
-                }
-             },
-            flight_res = flight_server_future => {
-                match flight_res {
-                    Ok(flight_res) => flight_res.context(UnableToStartFlightServerSnafu),
-                    Err(source) => {
-                        Err(Error::UnableToJoinTask { source })
-                    }
-                }
+        // Pods watcher
+        let cloned_self = Arc::clone(&self);
+        let (pods_watcher_future, posd_watcher_handle) = spawn_managed_task(
+            async move {
+                cloned_self
+                    .start_pods_watcher()
+                    .await
+                    .context(UnableToInitializePodsWatcherSnafu)
             },
-            open_telemetry_res = open_telemetry_server_future => {
-                match open_telemetry_res {
-                    Ok(open_telemetry_res) => open_telemetry_res.context(UnableToStartOpenTelemetryServerSnafu),
-                    Err(source) => {
-                        Err(Error::UnableToJoinTask { source })
-                    }
-                }
-            },
-            pods_watcher_res = async {
-                if let Some(fut) = pods_watcher_future {
-                    fut.await
-                } else {
-                    futures::future::pending().await
-                }
-            } => {
-                pods_watcher_res.context(UnableToInitializePodsWatcherSnafu)
-            },
-            () = shutdown_signal() => {
-                tracing::info!("Goodbye!");
-                Ok(())
-            },
+            None,
+        );
+
+        self.running_components
+            .write()
+            .await
+            .insert("pods_watcher".to_string(), posd_watcher_handle);
+
+        // Start Spicepod watcher
+
+        let shutdown_signnal_future = async {
+            shutdown_signal().await;
+            tracing::debug!("Shutdown signal received.");
+            self.shutdown().await;
+            tracing::info!("Goodbye!");
+            Ok(())
+        };
+
+        match tokio::try_join!(
+            http_future,
+            flight_future,
+            metrics_future,
+            opentelemetry_future,
+            pods_watcher_future,
+            shutdown_signnal_future
+        ) {
+            Err(err) => Err(err),
+            _ => Ok(()),
         }
     }
 
@@ -610,8 +675,24 @@ impl Runtime {
     }
 
     // Closes and deallocates all resources (including the static registries)
-    pub async fn shutdown(self) {
+    pub async fn shutdown(&self) {
+        if self.status.is_shutdown() {
+            return;
+        }
+
+        tracing::info!("Shutting down...");
         self.status.mark_shutdown();
+
+        // shutdown all running components except the HTTP and Metrics servers
+        let mut running_components = self.running_components.write().await;
+        for (name, handle) in running_components.drain() {
+            // if name == "http_server" || name == "metrics_server" {
+            //     continue;
+            // }
+            handle.shutdown(Duration::from_secs(10)).await;
+            tracing::debug!("Shutdown component: {name}");
+        }
+
         // Clean up DataFusion first as there could be datasets loading and accessing registries below.
         self.df.shutdown().await;
         dataconnector::unregister_all().await;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -722,7 +722,7 @@ impl Runtime {
     where
         F: Future<Output = Result<(), Error>> + Send + 'static,
     {
-        let (future, handle) = spawn_cancellable_task(task_fn, cancellation_token);
+        let (future, handle) = spawn_cancellable_task(cancellation_token, task_fn);
 
         self.server_components
             .write()

--- a/crates/runtime/src/managed_task.rs
+++ b/crates/runtime/src/managed_task.rs
@@ -24,6 +24,13 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{Error, FailedToExecuteTaskSnafu};
 
+/// A handle for managing the lifecycle of a spawned task.
+///
+/// Allows external control over a task's execution, supporting
+/// both graceful cancellation via provided [`CancellationToken`] and forced termination.
+///
+/// - If a [`CancellationToken`] is provided, it enables graceful shutdown.
+/// - If the task does not exit within the allowed time after termination request, it is forcefully aborted.
 pub(crate) struct ManagedTaskHandle {
     notify_abort_task: oneshot::Sender<()>,
     cancellation_token: Option<CancellationToken>,
@@ -53,7 +60,10 @@ impl ManagedTaskHandle {
     }
 }
 
-/// Spawns a task with optional external `CancellationToken`.
+/// Spawns a managed task with termination support.
+///
+/// Returns a future that resolves when the task completes or is canceled,
+/// along with a [`ManagedTaskHandle`] for external task control.
 pub(crate) fn spawn_managed_task<F>(
     task_fn: F,
     task_cancellation: Option<CancellationToken>,

--- a/crates/runtime/src/managed_task.rs
+++ b/crates/runtime/src/managed_task.rs
@@ -98,7 +98,7 @@ where
     let task_future = async move {
         match handle.await {
             Ok(result) => result,
-            // If the task was canceled (for example during termination), we return Ok(()) so that other tasks can continue.
+            // If task was cancelled (for example during runtime termination), we return Ok (expected behavior).
             Err(err) if err.is_cancelled() => Ok(()),
             Err(err) => Err(err).context(FailedToExecuteTaskSnafu),
         }

--- a/crates/runtime/src/managed_task.rs
+++ b/crates/runtime/src/managed_task.rs
@@ -1,0 +1,98 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::future::Future;
+use std::time::Duration;
+
+use snafu::ResultExt;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::{Error, FailedToExecuteTaskSnafu};
+
+pub(crate) struct ManagedTaskHandle {
+    notify_abort_task: oneshot::Sender<()>,
+    cancellation_token: Option<CancellationToken>,
+    on_task_completed: oneshot::Receiver<()>,
+}
+
+impl ManagedTaskHandle {
+    pub async fn shutdown(mut self, timeout: Duration) {
+        let Some(token) = self.cancellation_token.take() else {
+            // The task does not support graceful cancellation, so we abort it.
+            // The error is expected if the receiver has already been deallocated, indicating the task has completed or aborted.
+            self.notify_abort_task.send(()).ok();
+            return;
+        };
+
+        // Attempt to gracefully cancel the task and wait for its completion.
+        token.cancel();
+
+        tokio::select! {
+            () = tokio::time::sleep(timeout) => {
+                // If the task hasn't completed within the timeout, we forcefully abort it.
+                self.notify_abort_task.send(()).ok();
+            }
+            // Wait for task completion.
+            _ = self.on_task_completed => {}
+        };
+    }
+}
+
+/// Spawns a task with optional external `CancellationToken`.
+pub(crate) fn spawn_managed_task<F>(
+    task_fn: F,
+    task_cancellation: Option<CancellationToken>,
+) -> (impl Future<Output = Result<(), Error>>, ManagedTaskHandle)
+where
+    F: Future<Output = Result<(), Error>> + Send + 'static,
+{
+    let (notify_abort_task, on_abort_task) = oneshot::channel();
+    let (notify_task_completed, on_task_completed) = oneshot::channel();
+
+    let task_handle = ManagedTaskHandle {
+        notify_abort_task,
+        cancellation_token: task_cancellation,
+        on_task_completed,
+    };
+
+    let handle: JoinHandle<Result<(), Error>> = tokio::task::spawn(async move {
+        let result = tokio::select! {
+            res = task_fn => {
+                res
+            }
+            _ = on_abort_task => {
+                Ok(())
+            }
+        };
+
+        notify_task_completed.send(()).ok();
+
+        result
+    });
+
+    let task_future = async move {
+        match handle.await {
+            Ok(result) => result,
+            // If the task was canceled (for example during termination), we return Ok(()) so that other tasks can continue.
+            Err(err) if err.is_cancelled() => Ok(()),
+            Err(err) => Err(err).context(FailedToExecuteTaskSnafu),
+        }
+    };
+
+    (task_future, task_handle)
+}

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -46,6 +46,7 @@ use runtime_auth::layer::grpc::make_interceptor;
 use runtime_auth::GrpcAuth;
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
+use tokio_util::sync::CancellationToken;
 use tonic::async_trait;
 use tonic::codec::CompressionEncoding;
 use tonic::service::interceptor;
@@ -589,6 +590,7 @@ pub async fn start(
     datafusion: Arc<DataFusion>,
     tls_config: Option<Arc<TlsConfig>>,
     grpc_auth: Option<Arc<dyn GrpcAuth + Send + Sync>>,
+    shutdown_signal: Option<CancellationToken>,
 ) -> Result<()> {
     let service = Service {
         datafusion,
@@ -610,13 +612,21 @@ pub async fn start(
             .context(UnableToConfigureTlsSnafu)?;
     }
 
-    server
+    let server = server
         .layer(interceptor(make_interceptor(grpc_auth)))
         .add_service(create_health_service().await)
-        .add_service(svc)
-        .serve(bind_address)
-        .await
-        .context(UnableToServeSnafu)?;
+        .add_service(svc);
+
+    if let Some(token) = shutdown_signal {
+        server
+            .serve_with_shutdown(bind_address, token.cancelled())
+            .await
+    } else {
+        server.serve(bind_address).await
+    }
+    .context(UnableToServeSnafu)?;
+
+    tracing::debug!("Spice Runtime OpenTelemetry stopped");
 
     Ok(())
 }


### PR DESCRIPTION
# 🗣 Description

PR implements `spawn_cancellable_task` functionality to spawn a Tokio task and return `CancellableTaskHandle` that allows external control over a task's execution, supporting both graceful cancellation via the provided [`CancellationToken`] and forced termination. 

Runtime server initialization has been updated to create and register each background task using `CancellableTaskHandle`, with `Runtime.shutdown` performing shutdown in the following order:

```
1. Shutdown initiated (Ctrl-C)
2. HTTP API including /ready, /status, /sql turns 503 except /health which continue 200
3. Components shutdown
   - Step1: Flight, OpenTelemetry (metrics ingestion) servers graceful shutdown: wait until in-progress requests are completed, stop serving new requests
   - Step2: Datasets, Models, etc shutdown (currently Runtime.shutdown / Datafusion.shutdown)
5. HTTP API complete shutdown
6. Metrics (9090) endpoint shutdown
7. All resources clean up (termination)
```

Also, Tonic based API (Flight, OpenTelemetry) has been updated with support of `CancellationToken` for more graceful shutdown.

## 🔨 Related Issues

Implements https://github.com/spiceai/spiceai/issues/4888

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
