### PR TITLE
upgrade mistral.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,17 +2171,17 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/candle.git?rev=296f14fefc8166574d3270c524494c49d8f2c893#296f14fefc8166574d3270c524494c49d8f2c893"
+source = "git+https://github.com/spiceai/candle.git?rev=708efab695fd7b4aa138ff3f4c631e489e0e6865#708efab695fd7b4aa138ff3f4c631e489e0e6865"
 dependencies = [
  "byteorder",
  "candle-kernels 0.8.0",
  "candle-metal-kernels 0.8.0",
+ "cudarc 0.13.9",
  "float8",
  "gemm",
  "half",
  "memmap2",
  "metal 0.27.0",
- "mistralrs_cudarc_fork",
  "num-traits",
  "num_cpus",
  "rand 0.8.5",
@@ -2202,7 +2202,7 @@ dependencies = [
  "byteorder",
  "candle-kernels 0.8.2",
  "candle-metal-kernels 0.8.2",
- "cudarc",
+ "cudarc 0.12.2",
  "gemm",
  "half",
  "memmap2",
@@ -2227,14 +2227,14 @@ version = "0.2.2"
 source = "git+https://github.com/spiceai/candle-cublaslt?rev=147f4424b0567131c41cf1ee667645120682170b#147f4424b0567131c41cf1ee667645120682170b"
 dependencies = [
  "candle-core 0.8.2",
- "cudarc",
+ "cudarc 0.12.2",
  "half",
 ]
 
 [[package]]
 name = "candle-flash-attn"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/candle.git?rev=296f14fefc8166574d3270c524494c49d8f2c893#296f14fefc8166574d3270c524494c49d8f2c893"
+source = "git+https://github.com/spiceai/candle.git?rev=708efab695fd7b4aa138ff3f4c631e489e0e6865#708efab695fd7b4aa138ff3f4c631e489e0e6865"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.5",
@@ -2266,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/candle.git?rev=296f14fefc8166574d3270c524494c49d8f2c893#296f14fefc8166574d3270c524494c49d8f2c893"
+source = "git+https://github.com/spiceai/candle.git?rev=708efab695fd7b4aa138ff3f4c631e489e0e6865#708efab695fd7b4aa138ff3f4c631e489e0e6865"
 dependencies = [
  "bindgen_cuda 0.1.5",
 ]
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/candle.git?rev=296f14fefc8166574d3270c524494c49d8f2c893#296f14fefc8166574d3270c524494c49d8f2c893"
+source = "git+https://github.com/spiceai/candle.git?rev=708efab695fd7b4aa138ff3f4c631e489e0e6865#708efab695fd7b4aa138ff3f4c631e489e0e6865"
 dependencies = [
  "metal 0.27.0",
  "once_cell",
@@ -2318,7 +2318,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.8.0"
-source = "git+https://github.com/spiceai/candle.git?rev=296f14fefc8166574d3270c524494c49d8f2c893#296f14fefc8166574d3270c524494c49d8f2c893"
+source = "git+https://github.com/spiceai/candle.git?rev=708efab695fd7b4aa138ff3f4c631e489e0e6865#708efab695fd7b4aa138ff3f4c631e489e0e6865"
 dependencies = [
  "candle-core 0.8.0",
  "candle-metal-kernels 0.8.0",
@@ -2974,6 +2974,16 @@ dependencies = [
 name = "cudarc"
 version = "0.12.2"
 source = "git+https://github.com/EricLBuehler/cudarc?rev=f6e5bf51153d40e34eb1262b98895ac1235b6422#f6e5bf51153d40e34eb1262b98895ac1235b6422"
+dependencies = [
+ "half",
+ "libloading",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.13.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
 dependencies = [
  "half",
  "libloading",
@@ -3930,6 +3940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "doctest-file"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+
+[[package]]
 name = "document_parse"
 version = "1.1.0-unstable"
 dependencies = [
@@ -4427,6 +4443,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a14d1c3d88fdab81b5886c34b2a424b3fba5123564ea415ff98b160cf44c432f"
 dependencies = [
+ "cudarc 0.13.9",
  "half",
  "mistralrs_cudarc_fork",
  "num-traits",
@@ -6210,6 +6227,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "interprocess"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6810,7 +6840,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
- "cudarc",
+ "cudarc 0.12.2",
  "dotenvy",
  "either",
  "futures",
@@ -7280,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "mistralrs"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
+source = "git+https://github.com/spiceai/mistral.rs?rev=0e025c11deb7bbbbcb73371b06180d655470d033#0e025c11deb7bbbbcb73371b06180d655470d033"
 dependencies = [
  "anyhow",
  "candle-core 0.8.0",
@@ -7301,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-core"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
+source = "git+https://github.com/spiceai/mistral.rs?rev=0e025c11deb7bbbbcb73371b06180d655470d033#0e025c11deb7bbbbcb73371b06180d655470d033"
 dependencies = [
  "akin",
  "anyhow",
@@ -7330,10 +7360,10 @@ dependencies = [
  "image 0.25.5",
  "indexmap 2.7.1",
  "indicatif",
+ "interprocess",
  "itertools 0.13.0",
  "llguidance",
  "lrtable",
- "memmap2",
  "metal 0.27.0",
  "minijinja",
  "minijinja-contrib",
@@ -7353,6 +7383,7 @@ dependencies = [
  "safetensors",
  "schemars",
  "serde",
+ "serde-big-array",
  "serde_json",
  "serde_plain",
  "serde_yaml",
@@ -7371,13 +7402,12 @@ dependencies = [
  "uuid 1.15.1",
  "variantly",
  "vob",
- "yoke",
 ]
 
 [[package]]
 name = "mistralrs-paged-attn"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
+source = "git+https://github.com/spiceai/mistral.rs?rev=0e025c11deb7bbbbcb73371b06180d655470d033#0e025c11deb7bbbbcb73371b06180d655470d033"
 dependencies = [
  "anyhow",
  "bindgen_cuda 0.1.6",
@@ -7392,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "mistralrs-quant"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
+source = "git+https://github.com/spiceai/mistral.rs?rev=0e025c11deb7bbbbcb73371b06180d655470d033#0e025c11deb7bbbbcb73371b06180d655470d033"
 dependencies = [
  "bindgen_cuda 0.1.5",
  "byteorder",
@@ -7401,20 +7431,24 @@ dependencies = [
  "float8",
  "half",
  "lazy_static",
+ "memmap2",
  "metal 0.27.0",
  "once_cell",
  "paste",
  "rayon",
+ "regex",
+ "safetensors",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tracing",
+ "yoke",
 ]
 
 [[package]]
 name = "mistralrs-vision"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/mistral.rs?rev=b8f7eab30b7ef54ec30d24b8de14b1583a277039#b8f7eab30b7ef54ec30d24b8de14b1583a277039"
+source = "git+https://github.com/spiceai/mistral.rs?rev=0e025c11deb7bbbbcb73371b06180d655470d033#0e025c11deb7bbbbcb73371b06180d655470d033"
 dependencies = [
  "candle-core 0.8.0",
  "image 0.25.5",
@@ -9755,6 +9789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10882,6 +10922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11901,7 +11950,7 @@ dependencies = [
  "candle-nn 0.8.2",
  "candle-rotary",
  "candle-transformers",
- "cudarc",
+ "cudarc 0.12.2",
  "memmap2",
  "nohash-hasher",
  "safetensors",
@@ -13006,7 +13055,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4dcab280ad0ef3957e153a82dcad608c954d02cf253b695322f502d1f8902e"
 dependencies = [
- "cudarc",
+ "cudarc 0.12.2",
  "half",
  "serde",
  "serde_json",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,8 +41,8 @@ text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "5
 pulldown-cmark = "0.12.1"
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "b8f7eab30b7ef54ec30d24b8de14b1583a277039" }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "b8f7eab30b7ef54ec30d24b8de14b1583a277039", package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "0e025c11deb7bbbbcb73371b06180d655470d033" }
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "0e025c11deb7bbbbcb73371b06180d655470d033", package = "mistralrs-core" }
 rand = "0.9.0"
 tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
     "candle",


### PR DESCRIPTION
# 🗣 Description
Before working on long term solution to #4634  (move mistral.rs to use async HF library), updating mistral.rs and dependencies to avoid future conflicts.

## 🔨 Related Issues/PRs
 - https://github.com/spiceai/candle/pull/5
 - https://github.com/spiceai/mistral.rs/pull/25

