### PR TITLE
List available operations in 'spice trace <operation>'

### DIFF
--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -45,10 +45,10 @@ var (
 )
 
 var supported_trace_tasks = []string{
-	"ai_chat", "accelerated_refresh", "ai_completion", "sql_query", "nsql",
-	"tool_use::document_similarity", "tool_use::list_datasets", "tool_use::sql",
-	"tool_use::table_schema", "tool_use::sample_data", "tool_use::sql_query", "tool_use::memory", "eval_run",
-	"vector_search",
+	"ai_chat", "accelerated_refresh", "ai_completion", "eval_run", "nsql", "sql_query",
+	"tool_use::document_similarity", "tool_use::list_datasets", "tool_use::load_memory",
+	"tool_use::sample_data", "tool_use::sql", "tool_use::store_memory",
+	"tool_use::table_schema", "vector_search",
 }
 
 func isValidTraceTask(task string) bool {

--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spiceai/spiceai/bin/spice/pkg/context"
@@ -62,6 +63,10 @@ func isValidTraceTask(task string) bool {
 var traceCmd = &cobra.Command{
 	Use:   "trace",
 	Short: "Return a user friendly trace into an operation that occurred in Spice",
+	Long: fmt.Sprintf(`
+	Available operations:
+	  %s
+	`, strings.Join(supported_trace_tasks, ", ")),
 	Example: `
 # returns the last trace
 $ spice trace ai_chat


### PR DESCRIPTION
# 🗣 Description
- Useful for new users who discover the tool via CLI.
```bash
spice trace --help

        Available operations:
          ai_chat, accelerated_refresh, ai_completion, sql_query, nsql, tool_use::document_similarity, tool_use::list_datasets, tool_use::sql, tool_use::table_schema, tool_use::sample_data, tool_use::sql_query, tool_use::memory, eval_run, vector_search

Usage:
  spice trace [flags]

Examples:

# returns the last trace
$ spice trace ai_chat

# returns the trace for the given id
$ spice trace ai_chat --id chatcmpl-At6ZmDE8iAYRPeuQLA0FLlWxGKNnM

Include the input and truncate to 120 characters (default is 80).
$ spice trace ai_chat --include-input --truncate=120


Flags:
      --id string           Return the trace with the given id
      --include-input       Include input data in the trace
      --include-output      Include output data in the trace
      --trace-id string     Return the trace with the given trace id
      --truncate int[=80]   Truncates the input/output data to 80 when set, or to the given length

Global Flags:
      --api-key string   The API key to use for authentication
  -h, --help             Print this help message
  -v, --verbose count    Verbose logging
      --very-verbose     Very verbose logging
      ```