### PR TITLE
fix: Redundant results snapshotting

### DIFF
--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -160,7 +160,8 @@ impl SpiceTestQueryWorker {
 
                         let snapshot_results = self
                             .results_snapshot_predicate
-                            .is_some_and(|predicate| predicate(query.0));
+                            .is_some_and(|predicate| predicate(query.0))
+                            && self.id == 0; // only one worker should snapshot results
 
                         // Additional round of query run before recording results.
                         // To discard the abnormal results caused by: establishing initial connection / spark cluster startup time
@@ -183,7 +184,7 @@ impl SpiceTestQueryWorker {
                             ));
                         }
 
-                        if self.explain_plan_snapshot {
+                        if self.explain_plan_snapshot && self.id == 0 {
                             if let Err(e) = record_explain_plan(
                                 &self.flight_client,
                                 self.name.as_str(),

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -218,7 +218,7 @@ impl SpiceTestQueryWorker {
                                     query,
                                     &mut query_durations,
                                     &mut row_counts,
-                                    true,
+                                    false, // don't attempt to snapshot results more than once
                                 )
                                 .await?;
 
@@ -370,6 +370,7 @@ impl SpiceTestQueryWorker {
         }
 
         if results_snapshot {
+            println!("snapshotting results");
             let query_name = query.0;
             let name = self.name.clone();
 

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -153,7 +153,6 @@ impl SpiceTestQueryWorker {
                 }
                 EndCondition::QuerySetCompleted(target_count) => {
                     // For QuerySetCompleted, run each query target_count times before moving to next
-                    // let start = SystemTime::now();
                     let start = SystemTime::now();
                     for query in &self.query_set {
                         let mut current_query_count = 0;

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -153,9 +153,11 @@ impl SpiceTestQueryWorker {
                 }
                 EndCondition::QuerySetCompleted(target_count) => {
                     // For QuerySetCompleted, run each query target_count times before moving to next
+                    // let start = SystemTime::now();
+                    let start = SystemTime::now();
                     for query in &self.query_set {
                         let mut current_query_count = 0;
-                        let start = SystemTime::now();
+                        let query_start = SystemTime::now();
                         let mut query_status = QueryStatus::Passed;
 
                         let snapshot_results = self
@@ -203,9 +205,12 @@ impl SpiceTestQueryWorker {
                         }
 
                         while current_query_count < target_count {
-                            if self.progress_bar.is_none() && self.id == 0 {
+                            if self.progress_bar.is_none()
+                                && self.id == 0
+                                && current_query_count % 10 == 0
+                            {
                                 println!(
-                                    "Worker {} - Query '{}' count: {}/{} - Elapsed time: {:?}",
+                                    "Worker {} - Query '{}' - {}/{} - Elapsed time: {:?}",
                                     self.id,
                                     query.0,
                                     current_query_count + 1,
@@ -240,7 +245,7 @@ impl SpiceTestQueryWorker {
                             current_query_count += 1;
                         }
                         let end = SystemTime::now();
-                        query_iteration_durations.insert(query.0.to_string(), (start, end));
+                        query_iteration_durations.insert(query.0.to_string(), (query_start, end));
                         query_statuses.insert(query.0.to_string(), query_status);
                     }
                 }

--- a/test/spicepods/tpch/accelerated/s3_sf5_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sf5_arrow.yaml
@@ -1,0 +1,45 @@
+version: v1
+kind: Spicepod
+name: s3_sf5_duckdb_file
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/accelerated/s3_sf5_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sf5_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_file
+name: s3_sf5_arrow
 datasets:
   - from: s3://benchmarks/tpch_sf5/customer/
     name: customer
@@ -13,8 +13,7 @@ datasets:
       s3_secret: ${secrets:S3_SECRET}
     acceleration: &acceleration
       enabled: true
-      engine: duckdb
-      mode: file
+      engine: arrow
   - from: s3://benchmarks/tpch_sf5/lineitem/
     name: lineitem
     params: *s3_params

--- a/test/spicepods/tpch/accelerated/s3_sf5_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sf5_duckdb_file.yaml
@@ -1,0 +1,45 @@
+version: v1
+kind: Spicepod
+name: s3_sf5_duckdb_file
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/accelerated/s3_sf5_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sf5_duckdb_memory.yaml
@@ -1,0 +1,45 @@
+version: v1
+kind: Spicepod
+name: s3_sf5_duckdb_memory
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: memory
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/mysql_1gb.yaml
+++ b/test/spicepods/tpch/cache/mysql_1gb.yaml
@@ -1,0 +1,54 @@
+version: v1
+kind: Spicepod
+name: mysql_tpch
+
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 1Gib
+    item_ttl: 60s
+
+# Define common anchors
+definitions:
+  
+  # Common mysql parameters
+  - &mysql_params
+    mysql_host: ${env:MYSQL_HOST}
+    mysql_tcp_port: ${env:MYSQL_TCP_PORT}
+    mysql_db: ${env:MYSQL_DB}
+    mysql_user: ${env:MYSQL_USER}
+    mysql_pass: ${env:MYSQL_PASSWORD}
+    mysql_sslmode: disabled
+
+datasets:
+  - from: mysql:customer
+    name: customer
+    params: *mysql_params
+
+  - from: mysql:lineitem
+    name: lineitem
+    params: *mysql_params
+
+  - from: mysql:nation
+    name: nation
+    params: *mysql_params
+
+  - from: mysql:orders
+    name: orders
+    params: *mysql_params
+
+  - from: mysql:part
+    name: part
+    params: *mysql_params
+
+  - from: mysql:partsupp
+    name: partsupp
+    params: *mysql_params
+
+  - from: mysql:region
+    name: region
+    params: *mysql_params
+  
+  - from: mysql:supplier
+    name: supplier
+    params: *mysql_params

--- a/test/spicepods/tpch/cache/mysql_1gb.yaml
+++ b/test/spicepods/tpch/cache/mysql_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql_tpch
+name: mysql_cache_1gb
 
 runtime:
   results_cache:

--- a/test/spicepods/tpch/cache/mysql_4gb.yaml
+++ b/test/spicepods/tpch/cache/mysql_4gb.yaml
@@ -1,0 +1,54 @@
+version: v1
+kind: Spicepod
+name: mysql_tpch
+
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 4Gib
+    item_ttl: 300s
+
+# Define common anchors
+definitions:
+  
+  # Common mysql parameters
+  - &mysql_params
+    mysql_host: ${env:MYSQL_HOST}
+    mysql_tcp_port: ${env:MYSQL_TCP_PORT}
+    mysql_db: ${env:MYSQL_DB}
+    mysql_user: ${env:MYSQL_USER}
+    mysql_pass: ${env:MYSQL_PASSWORD}
+    mysql_sslmode: disabled
+
+datasets:
+  - from: mysql:customer
+    name: customer
+    params: *mysql_params
+
+  - from: mysql:lineitem
+    name: lineitem
+    params: *mysql_params
+
+  - from: mysql:nation
+    name: nation
+    params: *mysql_params
+
+  - from: mysql:orders
+    name: orders
+    params: *mysql_params
+
+  - from: mysql:part
+    name: part
+    params: *mysql_params
+
+  - from: mysql:partsupp
+    name: partsupp
+    params: *mysql_params
+
+  - from: mysql:region
+    name: region
+    params: *mysql_params
+  
+  - from: mysql:supplier
+    name: supplier
+    params: *mysql_params

--- a/test/spicepods/tpch/cache/mysql_4gb.yaml
+++ b/test/spicepods/tpch/cache/mysql_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql_tpch
+name: mysql_cache_4gb
 
 runtime:
   results_cache:

--- a/test/spicepods/tpch/cache/mysql_ttl.yaml
+++ b/test/spicepods/tpch/cache/mysql_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql_tpch
+name: mysql_cache_ttl
 
 runtime:
   results_cache:

--- a/test/spicepods/tpch/cache/mysql_ttl.yaml
+++ b/test/spicepods/tpch/cache/mysql_ttl.yaml
@@ -1,0 +1,53 @@
+version: v1
+kind: Spicepod
+name: mysql_tpch
+
+runtime:
+  results_cache:
+    enabled: true
+    item_ttl: 120s
+
+# Define common anchors
+definitions:
+  
+  # Common mysql parameters
+  - &mysql_params
+    mysql_host: ${env:MYSQL_HOST}
+    mysql_tcp_port: ${env:MYSQL_TCP_PORT}
+    mysql_db: ${env:MYSQL_DB}
+    mysql_user: ${env:MYSQL_USER}
+    mysql_pass: ${env:MYSQL_PASSWORD}
+    mysql_sslmode: disabled
+
+datasets:
+  - from: mysql:customer
+    name: customer
+    params: *mysql_params
+
+  - from: mysql:lineitem
+    name: lineitem
+    params: *mysql_params
+
+  - from: mysql:nation
+    name: nation
+    params: *mysql_params
+
+  - from: mysql:orders
+    name: orders
+    params: *mysql_params
+
+  - from: mysql:part
+    name: part
+    params: *mysql_params
+
+  - from: mysql:partsupp
+    name: partsupp
+    params: *mysql_params
+
+  - from: mysql:region
+    name: region
+    params: *mysql_params
+  
+  - from: mysql:supplier
+    name: supplier
+    params: *mysql_params

--- a/test/spicepods/tpch/cache/s3_arrow_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_arrow_cache_1gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_arrow_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_1gb.yaml
@@ -1,0 +1,49 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 1Gib
+    item_ttl: 60s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: arrow
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_arrow_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_4gb.yaml
@@ -1,0 +1,49 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 4Gib
+    item_ttl: 300s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: arrow
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_arrow_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_arrow_cache_4gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_arrow_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_arrow_cache_ttl
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_arrow_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_ttl.yaml
@@ -1,0 +1,48 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    item_ttl: 30s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: arrow
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_cache_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch
+name: s3_sf5_cache_1gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_cache_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_1gb.yaml
@@ -1,0 +1,39 @@
+version: v1
+kind: Spicepod
+name: s3_tpch
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 1Gib
+    item_ttl: 60s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params

--- a/test/spicepods/tpch/cache/s3_cache_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_4gb.yaml
@@ -1,0 +1,39 @@
+version: v1
+kind: Spicepod
+name: s3_tpch
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 4Gib
+    item_ttl: 300s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params

--- a/test/spicepods/tpch/cache/s3_cache_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch
+name: s3_sf5_cache_4gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_cache_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch
+name: s3_sf5_cache_ttl
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_cache_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_ttl.yaml
@@ -1,0 +1,38 @@
+version: v1
+kind: Spicepod
+name: s3_tpch
+runtime:
+  results_cache:
+    enabled: true
+    item_ttl: 120s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params

--- a/test/spicepods/tpch/cache/s3_duckdb_file_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_duckdb_file_cache_1gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_file_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_1gb.yaml
@@ -1,0 +1,50 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 1Gib
+    item_ttl: 60s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_duckdb_file_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_duckdb_file_cache_4gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_file_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_4gb.yaml
@@ -1,0 +1,50 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 4Gib
+    item_ttl: 300s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_duckdb_file_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_duckdb_file_cache_ttl
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_file_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_ttl.yaml
@@ -1,0 +1,49 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    item_ttl: 30s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_1gb.yaml
@@ -1,0 +1,50 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 1Gib
+    item_ttl: 60s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: memory
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_duckdb_memory_cache_1gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_duckdb_memory_cache_4gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_4gb.yaml
@@ -1,0 +1,50 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 4Gib
+    item_ttl: 300s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: memory
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_ttl.yaml
@@ -1,0 +1,49 @@
+version: v1
+kind: Spicepod
+name: s3_tpch_arrow
+runtime:
+  results_cache:
+    enabled: true
+    item_ttl: 30s
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: memory
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch_arrow
+name: s3_sf5_duckdb_memory_cache_ttl
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/s3_sf5.yaml
+++ b/test/spicepods/tpch/s3_sf5.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_tpch
+name: s3_sf5
 datasets:
   - from: s3://benchmarks/tpch_sf5/customer/
     name: customer

--- a/test/spicepods/tpch/s3_sf5.yaml
+++ b/test/spicepods/tpch/s3_sf5.yaml
@@ -1,0 +1,34 @@
+version: v1
+kind: Spicepod
+name: s3_tpch
+datasets:
+  - from: s3://benchmarks/tpch_sf5/customer/
+    name: customer
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+  - from: s3://benchmarks/tpch_sf5/lineitem/
+    name: lineitem
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/nation/
+    name: nation
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/orders/
+    name: orders
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/part/
+    name: part
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/partsupp/
+    name: partsupp
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/region/
+    name: region
+    params: *s3_params
+  - from: s3://benchmarks/tpch_sf5/supplier/
+    name: supplier
+    params: *s3_params


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Fixes redundant results snapshotting, which runs on every query iteration on every query worker.
* Makes snapshotting only occur from the first worker, to reduce lock poisons.
* Adds spicepods for cache scenarios

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4114