### PR TITLE
Don't trace canceled dataset refresh during runtime termination

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -151,15 +151,19 @@ impl RefreshTask {
         .instrument(span.clone())
         .await
         .inspect_err(|e| {
-            tracing::error!(
-                "Failed to refresh dataset {}: {e}",
-                include_source_to_dataset_name(
-                    &self.dataset_name,
-                    self.federated_source.as_deref()
-                )
-            );
-            for span in &spans {
-                tracing::error!(target: "task_history", parent: span, "{e}");
+            // During runtime shutdown, refresh tasks are canceled resulting in acceleration error.
+            // This is expected and should not be logged as an error.
+            if !self.runtime_status.is_shutdown() {
+                tracing::error!(
+                    "Failed to refresh dataset {}: {e}",
+                    include_source_to_dataset_name(
+                        &self.dataset_name,
+                        self.federated_source.as_deref()
+                    )
+                );
+                for span in &spans {
+                    tracing::error!(target: "task_history", parent: span, "{e}");
+                }
             }
         })
     }
@@ -209,14 +213,18 @@ impl RefreshTask {
         )
         .await
         .inspect_err(|e| {
-            tracing::warn!(
-                "Failed to load data for dataset {}: {}",
-                include_source_to_dataset_name(
-                    &self.dataset_name,
-                    self.federated_source.as_deref()
-                ),
-                inner_err_from_retry_ref(e)
-            );
+            // During runtime shutdown, refresh tasks are canceled resulting in acceleration error.
+            // This is expected and should not be logged as an error.
+            if !self.runtime_status.is_shutdown() {
+                tracing::warn!(
+                    "Failed to load data for dataset {}: {}",
+                    include_source_to_dataset_name(
+                        &self.dataset_name,
+                        self.federated_source.as_deref()
+                    ),
+                    inner_err_from_retry_ref(e)
+                );
+            }
         })
     }
 


### PR DESCRIPTION
# 🗣 Description

During runtime shutdown, in-progress refresh tasks are canceled, resulting in an acceleration error. This is expected and should not be logged as an error.

Note: ideally we should verify that task corresponds to cancelled task, but it will require more time/effort to implement,  created addition work item to make this more robust: 
 - https://github.com/spiceai/spiceai/issues/4959

## 🔨 Related Issues

Fixes https://github.com/spiceai/spiceai/issues/4954

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
