### PR TITLE
Add `duckdb_memory_limit` param support for DuckDB acceleration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a1f7173691675238607867e6ae5c6a881700de5b#a1f7173691675238607867e6ae5c6a881700de5b"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=da158b131df59d7948bac3e57726030a255198d5#da158b131df59d7948bac3e57726030a255198d5"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -3577,6 +3577,7 @@ dependencies = [
  "bb8",
  "bb8-postgres",
  "bigdecimal",
+ "byte-unit",
  "byteorder",
  "chrono",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a1f7173691675238607867e6ae5c6a881700de5b" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "da158b131df59d7948bac3e57726030a255198d5" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "13907e028f45ec987092c7efb1140c03be79a462" }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -158,6 +158,7 @@ impl Default for DuckDBAccelerator {
 const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("file"),
     ParameterSpec::runtime("file_watcher"),
+    ParameterSpec::component("memory_limit"),
 ];
 
 #[async_trait]


### PR DESCRIPTION
# 🗣 Description

Adds `duckdb_memory_limit` param support for DuckDB acceleration
 - https://github.com/datafusion-contrib/datafusion-table-providers/pull/251

```yaml
- from: file:sample_data.parquet
  name: test
  acceleration:
    params: 
      duckdb_memory_limit: '2GB'
    enabled: true
    engine: duckdb
    mode: file
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
