### PR TITLE
Update helm chart to v1.0.5

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: spiceai
 description: Spice.ai OSS
-version: 1.0.4
+version: 1.0.5

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,6 +1,10 @@
 ---
 apiVersion: apps/v1
+{{- if .Values.persistence.enabled }}
 kind: StatefulSet
+{{- else }}
+kind: Deployment
+{{- end }}
 metadata:
   labels:
     {{- include "spiceai.labels" . | indent 4 }}
@@ -11,7 +15,9 @@ spec:
   {{- if .Values.replicaCount }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if .Values.persistence.enabled }}
   serviceName: {{ template "spiceai.fullname" .  }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "spiceai.selectorLabels" . | indent 6 }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
     {{- include "spiceai.labels" . | indent 4 }}
@@ -11,6 +11,7 @@ spec:
   {{- if .Values.replicaCount }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  serviceName: {{ template "spiceai.fullname" .  }}
   selector:
     matchLabels:
       {{- include "spiceai.selectorLabels" . | indent 6 }}
@@ -89,6 +90,10 @@ spec:
             - name: spiceai-config-volume
               mountPath: /app/spicepod.yaml
               subPath: spicepod.yaml
+            {{- if .Values.persistence.enabled }}
+            - name: {{ .Release.Name }}-data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
           {{- if .Values.resources }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           {{- end }}
@@ -99,3 +104,16 @@ spec:
         - name: spiceai-config-volume
           configMap:
             name: {{ template "spiceai.fullname" .  }}-spicepod
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ .Release.Name }}-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: apps/v1
-{{- if .Values.persistence.enabled }}
+{{- if .Values.stateful.enabled }}
 kind: StatefulSet
 {{- else }}
 kind: Deployment
@@ -15,7 +15,7 @@ spec:
   {{- if .Values.replicaCount }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- if .Values.persistence.enabled }}
+  {{- if .Values.stateful.enabled }}
   serviceName: {{ template "spiceai.fullname" .  }}
   {{- end }}
   selector:
@@ -96,9 +96,9 @@ spec:
             - name: spiceai-config-volume
               mountPath: /app/spicepod.yaml
               subPath: spicepod.yaml
-            {{- if .Values.persistence.enabled }}
+            {{- if .Values.stateful.enabled }}
             - name: {{ .Release.Name }}-data
-              mountPath: {{ .Values.persistence.mountPath }}
+              mountPath: {{ .Values.stateful.mountPath }}
             {{- end }}
           {{- if .Values.resources }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
@@ -110,16 +110,16 @@ spec:
         - name: spiceai-config-volume
           configMap:
             name: {{ template "spiceai.fullname" .  }}-spicepod
-  {{- if .Values.persistence.enabled }}
+  {{- if .Values.stateful.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: {{ .Release.Name }}-data
       spec:
         accessModes: ["ReadWriteOnce"]
-        {{- if .Values.persistence.storageClass }}
-        storageClassName: {{ .Values.persistence.storageClass }}
+        {{- if .Values.stateful.storageClass }}
+        storageClassName: {{ .Values.stateful.storageClass }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistence.size }}
+            storage: {{ .Values.stateful.size }}
   {{- end }}

--- a/deploy/chart/templates/service.yaml
+++ b/deploy/chart/templates/service.yaml
@@ -15,6 +15,9 @@ spec:
   {{- if .Values.service.type }}
   type: {{ .Values.service.type }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     - port: 8090
       name: http
@@ -25,5 +28,9 @@ spec:
     - port: 50052
       name: otel
   selector:
+    {{- if .Values.service.selector }}
+    {{- toYaml .Values.service.selector | nindent 4 }}
+    {{- else }}
     {{- include "spiceai.labels" . | indent 4 }}
     app: {{ .Release.Name }}
+    {{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -62,7 +62,7 @@ serviceAccount:
 
 # Persistent volume for the StatefulSet
 stateful:
-  enabled: true
+  enabled: false
   # Storage class for the volume claim template
   storageClass: "standard"
   # Size of each PV in the StatefulSet
@@ -81,19 +81,19 @@ spicepod:
   version: v1
   kind: Spicepod
 
-  datasets:
+  datasets: []
   # Example:
-  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
-    name: taxi_trips
-    description: Demo taxi trips in s3
-    params:
-      file_format: parquet
-    acceleration:
-      enabled: true
-      engine: duckdb
-      mode: file
-      params:
-        duckdb_file: /data/taxi_trips.db
-      # Uncomment to refresh the acceleration on a schedule
-      # refresh_check_interval: 1h
-      # refresh_mode: full
+  # - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+  #   name: taxi_trips
+  #   description: Demo taxi trips in s3
+  #   params:
+  #     file_format: parquet
+  #   acceleration:
+  #     enabled: true
+  #     engine: duckdb
+  #     mode: file
+  #     params:
+  #       duckdb_file: /data/taxi_trips.db
+  #     # Uncomment to refresh the acceleration on a schedule
+  #     # refresh_check_interval: 1h
+  #     # refresh_mode: full

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -7,8 +7,16 @@ image:
 replicaCount: 1
 
 service:
+  # type can be null, ClusterIP, NodePort, or LoadBalancer
   type: null
   additionalAnnotations: {}
+  # If service type is LoadBalancer, specify the source IP ranges to whitelist
+  # loadBalancerSourceRanges:
+  #   - 10.0.0.0/8
+  #   - 172.16.0.0/12
+  # The selector to use for the service
+  # selector:
+  #   custom-selector: value
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
@@ -16,6 +24,51 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# Resource requests and limits
+# resources:
+#   limits:
+#     cpu: 1000m
+#     memory: 2Gi
+#   requests:
+#     cpu: 500m
+#     memory: 1Gi
+
+# Additional environment variables
+# additionalEnv:
+#   - name: ENV_VAR_NAME
+#     value: "value"
+#   - name: SECRET_ENV_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key
+
+# Define volumes to be mounted to the container
+# volumes:
+#   - name: custom-data
+#     persistentVolumeClaim:
+#       claimName: my-custom-pvc
+#   - name: config-volume
+#     configMap:
+#       name: custom-config
+
+# Define volume mounts for the container
+# volumeMounts:
+#   - name: custom-data
+#     mountPath: /data
+#   - name: config-volume
+#     mountPath: /config
+
+# Persistent volume for the StatefulSet
+persistence:
+  enabled: false
+  # Storage class for the volume claim template
+  # storageClass: "standard"
+  # Size of each PV in the StatefulSet
+  size: 10Gi
+  # Mount path in container
+  mountPath: /data
 
 monitoring:
   podMonitor:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -3,7 +3,7 @@ additionalLabels: {}
 
 image:
   repository: spiceai/spiceai
-  tag: 1.0.4
+  tag: 1.0.5
 replicaCount: 1
 
 service:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -61,12 +61,12 @@ serviceAccount:
 #     mountPath: /config
 
 # Persistent volume for the StatefulSet
-persistence:
-  enabled: false
+stateful:
+  enabled: true
   # Storage class for the volume claim template
-  # storageClass: "standard"
+  storageClass: "standard"
   # Size of each PV in the StatefulSet
-  size: 10Gi
+  size: 1Gi
   # Mount path in container
   mountPath: /data
 
@@ -81,15 +81,19 @@ spicepod:
   version: v1
   kind: Spicepod
 
-  datasets: []
+  datasets:
   # Example:
-  # - from: s3://spiceai-demo-datasets/taxi_trips/2024/
-  #   name: taxi_trips
-  #   description: Demo taxi trips in s3
-  #   params:
-  #     file_format: parquet
-  #   acceleration:
-  #     enabled: true
-  #     # Uncomment to refresh the acceleration on a schedule
-  #     # refresh_check_interval: 1h
-  #     # refresh_mode: full
+  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+    name: taxi_trips
+    description: Demo taxi trips in s3
+    params:
+      file_format: parquet
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      params:
+        duckdb_file: /data/taxi_trips.db
+      # Uncomment to refresh the acceleration on a schedule
+      # refresh_check_interval: 1h
+      # refresh_mode: full

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -60,7 +60,7 @@ serviceAccount:
 #   - name: config-volume
 #     mountPath: /config
 
-# Persistent volume for the StatefulSet
+# Use a StatefulSet with a PVC for the data volume
 stateful:
   enabled: false
   # Storage class for the volume claim template


### PR DESCRIPTION
# 🗣 Description

This pull request updates the helm chart to version v1.0.5 while introducing optional persistence support via StatefulSet, and adds enhancements to the service configuration. Key changes include:

Conditional rendering of StatefulSet vs Deployment based on the stateful.enabled flag.
Addition of loadBalancerSourceRanges and an optional service selector in the service template.
Version updates in both the image tag (values.yaml) and chart (Chart.yaml).
