### PR TITLE
Improve Vector Search performance for large content w/o primary key defined

### DIFF
--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -127,8 +127,11 @@ impl Display for RetrievalLimit {
     }
 }
 
+// Distance column name for the vector search query.
 static VECTOR_DISTANCE_COLUMN_NAME: &str = "dist";
+// Surrogate unique identifier name to use when no primary keys are provided.
 static VSS_TEMP_GEN_ID_COLUMN: &str = "vss_temp_gen_id";
+// Temporary table name to provide surrogate unique id for vector search query when no primary keys are provided.
 static VSS_TEMP_TABLE_NAME: &str = "vss_temp_table";
 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]

--- a/crates/runtime/src/embeddings/vector_search.rs
+++ b/crates/runtime/src/embeddings/vector_search.rs
@@ -128,6 +128,8 @@ impl Display for RetrievalLimit {
 }
 
 static VECTOR_DISTANCE_COLUMN_NAME: &str = "dist";
+static VSS_TEMP_GEN_ID_COLUMN: &str = "vss_temp_gen_id";
+static VSS_TEMP_TABLE_NAME: &str = "vss_temp_table";
 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -685,14 +687,63 @@ impl VectorSearch {
         where_cond: &str,
         n: usize,
     ) -> String {
-        let pks = if primary_keys.is_empty() {
-            // If the dataset has no true primary keys, the only known unique key is the embedding column.
-            vec![quote_identifier(embedding_column).to_string()]
+        let (pks, distances_cte, proj_table) = if primary_keys.is_empty() {
+            // If the dataset has no primary keys, we use an additional surrogate temp table and a generated primary key.
+            // An alternative approach is using the full content as the primary key, but it is less efficient as primary keys
+            // are duplicated along with unnest, resulting in large memory allocation and inefficient final selection (join condition).
+            let distances_table =  format!(
+                    "WITH {VSS_TEMP_TABLE_NAME} AS (
+                        SELECT 
+                            ROW_NUMBER() OVER () AS {VSS_TEMP_GEN_ID_COLUMN},
+                            {additional_columns}     
+                            {embedding_column},
+                            {embed_col_offset},
+                            {embed_col_embedding}
+                        FROM {table_name}
+                        {where_cond}
+                    ), 
+                    distances as (
+                        SELECT
+                            {VSS_TEMP_GEN_ID_COLUMN},
+                            unnest({embed_col_offset}) AS offset,
+                            cosine_distance(unnest({embed_col_embedding}), {embedding:?}) AS {VECTOR_DISTANCE_COLUMN_NAME}
+                        FROM {VSS_TEMP_TABLE_NAME}
+                    )",
+                    embed_col_offset=offset_col!(quote_identifier(embedding_column).to_string()),
+                    embed_col_embedding=embedding_col!(quote_identifier(embedding_column).to_string()),
+                    additional_columns = if projection.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{},", projection.iter().join(", "))
+                    },
+                );
+
+            (
+                vec![VSS_TEMP_GEN_ID_COLUMN.to_string()],
+                distances_table,
+                VSS_TEMP_TABLE_NAME.to_string(),
+            )
         } else {
-            primary_keys
+            let pks = primary_keys
                 .iter()
                 .map(|s| quote_identifier(s).to_string())
-                .collect_vec()
+                .collect_vec();
+
+            let distances_table =  format!(
+                    "WITH distances as (
+                        SELECT
+                            {pks},
+                            unnest({embed_col_offset}) AS offset,
+                            cosine_distance(unnest({embed_col_embedding}), {embedding:?}) AS {VECTOR_DISTANCE_COLUMN_NAME}
+                        FROM {table_name}
+                        {where_cond}
+                    )",
+                    pks = pks.iter().join(", "),
+                    embed_col_offset=offset_col!(quote_identifier(embedding_column).to_string()),
+                    embed_col_embedding=embedding_col!(quote_identifier(embedding_column).to_string())
+                );
+
+            (pks, distances_table, table_name.to_string())
         };
 
         let final_projection_str = if projection.is_empty() {
@@ -706,14 +757,7 @@ impl VectorSearch {
         };
 
         format!(
-            "WITH distances as (
-                SELECT
-                    {pks},
-                    unnest({embed_col_offset}) AS offset,
-                    cosine_distance(unnest({embed_col_embedding}), {embedding:?}) AS {VECTOR_DISTANCE_COLUMN_NAME}
-                FROM {table_name}
-                {where_cond}
-            ),
+            "{distances_cte},
             ranks as (
                 SELECT
                     {pks},
@@ -734,10 +778,8 @@ impl VectorSearch {
                 {projection_str}
                 rd.{VECTOR_DISTANCE_COLUMN_NAME}
             FROM ranked_docs rd
-            JOIN {table_name} t ON {join_on_conditions}",
+            JOIN {proj_table} t ON {join_on_conditions}",
                 embed_col=quote_identifier(embedding_column).to_string(),
-                embed_col_offset=offset_col!(quote_identifier(embedding_column).to_string()),
-                embed_col_embedding=embedding_col!(quote_identifier(embedding_column).to_string()),
                 pks = pks.iter().join(", "),
                 projection_str = final_projection_str,
                 join_on_conditions = pks

--- a/crates/runtime/tests/models/hf.rs
+++ b/crates/runtime/tests/models/hf.rs
@@ -186,6 +186,7 @@ mod search {
     use super::*;
 
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn huggingface_test_search() -> Result<(), anyhow::Error> {
         let _tracing = init_tracing(None);
 
@@ -200,7 +201,7 @@ mod search {
                 }];
 
                 let mut ds_tpcds_cp_with_chunking =
-                    get_tpcds_dataset("catalog_page", Some("catalog_page_with_chunking"), Some("select cp_description, cp_catalog_page_sk from catalog_page_with_chunking limit 20"));
+                    get_tpcds_dataset("catalog_page", Some("catalog_page_with_chunking"), Some("select cp_description, cp_catalog_page_sk, cp_department, cp_catalog_number from catalog_page_with_chunking limit 20"));
                 ds_tpcds_cp_with_chunking.embeddings = vec![ColumnEmbeddingConfig {
                     column: "cp_description".to_string(),
                     model: "hf_minilm".to_string(),
@@ -213,9 +214,24 @@ mod search {
                     }),
                 }];
 
+                let mut ds_tpcds_cp_with_chunking_no_pk =
+                    get_tpcds_dataset("catalog_page", Some("catalog_page_with_chunking_no_pk"), Some("select cp_description, cp_catalog_page_sk, cp_department, cp_catalog_number from catalog_page_with_chunking_no_pk limit 20"));
+                ds_tpcds_cp_with_chunking_no_pk.embeddings = vec![ColumnEmbeddingConfig {
+                    column: "cp_description".to_string(),
+                    model: "hf_minilm".to_string(),
+                    primary_keys: None,
+                    chunking: Some(EmbeddingChunkConfig {
+                        enabled: true,
+                        target_chunk_size: 512,
+                        overlap_size: 128,
+                        trim_whitespace: false,
+                    }),
+                }];
+
                 let app = AppBuilder::new("text-to-sql")
                     .with_dataset(ds_tpcds_item)
                     .with_dataset(ds_tpcds_cp_with_chunking)
+                    .with_dataset(ds_tpcds_cp_with_chunking_no_pk)
                     .with_embedding(get_huggingface_embeddings(
                         "sentence-transformers/all-MiniLM-L6-v2",
                         "hf_minilm",
@@ -264,6 +280,52 @@ mod search {
                         body: json!({
                             "text": "friends",
                             "datasets": ["catalog_page_with_chunking"],
+                            "limit": 1,
+                        }),
+                    },
+                    TestCase {
+                        name: "hf_chunking_with_extra_columns",
+                        body: json!({
+                            "text": "friends",
+                            "datasets": ["catalog_page_with_chunking"],
+                            "additional_columns": ["cp_department"],
+                            "limit": 1,
+                        }),
+                    },
+                    TestCase {
+                        name: "hf_chunking_with_extra_columns_and_where",
+                        body: json!({
+                            "text": "friends",
+                            "datasets": ["catalog_page_with_chunking"],
+                            "additional_columns": ["cp_department"],
+                            "where": "cp_catalog_number>0",
+                            "limit": 1,
+                        }),
+                    },
+                    TestCase {
+                        name: "hf_chunking_no_pk",
+                        body: json!({
+                            "text": "friends",
+                            "datasets": ["catalog_page_with_chunking_no_pk"],
+                            "limit": 1,
+                        }),
+                    },
+                    TestCase {
+                        name: "hf_chunking_with_extra_column_no_pk",
+                        body: json!({
+                            "text": "friends",
+                            "datasets": ["catalog_page_with_chunking_no_pk"],
+                            "additional_columns": ["cp_department"],
+                            "limit": 1,
+                        }),
+                    },
+                    TestCase {
+                        name: "hf_chunking_with_extra_columns_and_where_no_pk",
+                        body: json!({
+                            "text": "friends",
+                            "datasets": ["catalog_page_with_chunking_no_pk"],
+                            "additional_columns": ["cp_department"],
+                            "where": "cp_catalog_number>0",
                             "limit": 1,
                         }),
                     },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_no_pk_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_no_pk_response.snap
@@ -1,0 +1,13 @@
+---
+source: crates/runtime/tests/models/mod.rs
+expression: normalize_search_response(response)
+---
+{
+  "duration_ms": "duration_ms_val",
+  "matches": [
+    {
+      "dataset": "catalog_page_with_chunking_no_pk",
+      "value": "In general basic characters welcome. Clearly lively friends con"
+    }
+  ]
+}

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_column_no_pk_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_column_no_pk_response.snap
@@ -1,0 +1,16 @@
+---
+source: crates/runtime/tests/models/mod.rs
+expression: normalize_search_response(response)
+---
+{
+  "duration_ms": "duration_ms_val",
+  "matches": [
+    {
+      "dataset": "catalog_page_with_chunking_no_pk",
+      "metadata": {
+        "cp_department": "DEPARTMENT"
+      },
+      "value": "In general basic characters welcome. Clearly lively friends con"
+    }
+  ]
+}

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_and_where_no_pk_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_and_where_no_pk_response.snap
@@ -1,0 +1,16 @@
+---
+source: crates/runtime/tests/models/mod.rs
+expression: normalize_search_response(response)
+---
+{
+  "duration_ms": "duration_ms_val",
+  "matches": [
+    {
+      "dataset": "catalog_page_with_chunking_no_pk",
+      "metadata": {
+        "cp_department": "DEPARTMENT"
+      },
+      "value": "In general basic characters welcome. Clearly lively friends con"
+    }
+  ]
+}

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_and_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_and_where_response.snap
@@ -1,0 +1,19 @@
+---
+source: crates/runtime/tests/models/mod.rs
+expression: normalize_search_response(response)
+---
+{
+  "duration_ms": "duration_ms_val",
+  "matches": [
+    {
+      "dataset": "catalog_page_with_chunking",
+      "metadata": {
+        "cp_department": "DEPARTMENT"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
+      },
+      "value": "In general basic characters welcome. Clearly lively friends con"
+    }
+  ]
+}

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hf_chunking_with_extra_columns_response.snap
@@ -1,0 +1,19 @@
+---
+source: crates/runtime/tests/models/mod.rs
+expression: normalize_search_response(response)
+---
+{
+  "duration_ms": "duration_ms_val",
+  "matches": [
+    {
+      "dataset": "catalog_page_with_chunking",
+      "metadata": {
+        "cp_department": "DEPARTMENT"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
+      },
+      "value": "In general basic characters welcome. Clearly lively friends con"
+    }
+  ]
+}


### PR DESCRIPTION
# 🗣 Description

Existing search logic unnests search content based on the number of chunks corresponding to each record if there is no primary key specified as part of embedding definition. As a result, each document appears in search results 100–200 times (num chunks per document), leading to significantly increased resource allocation. Content column is also used to match search results (`FROM ranked_docs rd JOIN my_data t ON rd.content = t.content`) with the final record which is not very efficient as content could be large.

```sql
WITH distances as (
    SELECT
        content, <-- Content is duplicated for each offset due to unnest
        unnest(content_offset) AS offset,
        array_cosine_distance(unnest(content_embedding), [-0.009877119, .. -0.019920357]::FLOAT[1536]) AS dist
    FROM my_data    
),
ranks as (
    SELECT
        content,
        distances.offset,
        distances.dist,
        ROW_NUMBER() OVER (PARTITION BY (content) ORDER BY distances.dist ASC) AS chunk_rank
    FROM distances
),
ranked_docs as (
    select content, ranks.dist, ranks.offset
    from ranks
    WHERE chunk_rank = 1
    ORDER by dist ASC
    LIMIT 10
)
SELECT
    substring(t.content, rd.offset[1], rd.offset[2] - rd.offset[1]) AS content_chunk,
    rd.dist
FROM ranked_docs rd
JOIN my_data t ON rd.content = t.content <-- This is slow
```

This PR proposes using an additional temporary CTE with a surrogate ID based on the row number that can be used as a unique identifier to avoid content duplication and content based matching.

With this change, a search that previously crashed after approximately 30 seconds now executes in 200ms.
- Fixes https://github.com/spiceai/spiceai/issues/5000

## 🔨 Related Issues

Fixes https://github.com/spiceai/spiceai/issues/5000

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

1. Vector search logic becomes more complex and not very easy to read, we might think how to refactor / improve this.
2. If there are additional columns defined we must include them into temporary CTE scan now, previously additional columns were fetched based on final join with original row (we can't match original row anymore as we operate using new ID (or we need to fallback to original content matching or embeddings matching) - I was thinking if we can use the same generated ID for final matching so we don't need to fetch content initially and also include extra columns but I don't think this will be robust, at least for Arrow optimizations / partitioning and parallel execution)
