### PR TITLE
feat: Add an initial testoperator vector search command

### DIFF
--- a/crates/test-framework/src/lib.rs
+++ b/crates/test-framework/src/lib.rs
@@ -47,6 +47,7 @@ pub enum TestType {
     DataConsistency,
     HttpConsistency,
     HttpOverhead,
+    VectorSearch,
 }
 
 impl TestType {
@@ -59,6 +60,7 @@ impl TestType {
             TestType::DataConsistency => "testoperator_run_data_consistency.yml",
             TestType::HttpConsistency => "testoperator_run_http_consistency.yml",
             TestType::HttpOverhead => "testoperator_run_http_overhead.yml",
+            TestType::VectorSearch => "testoperator_run_vector_search.yml",
         }
     }
 }
@@ -72,6 +74,7 @@ impl Display for TestType {
             TestType::DataConsistency => write!(f, "data_consistency"),
             TestType::HttpConsistency => write!(f, "http_consistency"),
             TestType::HttpOverhead => write!(f, "http_overhead"),
+            TestType::VectorSearch => write!(f, "vector_search"),
         }
     }
 }

--- a/crates/test-framework/src/spicetest/mod.rs
+++ b/crates/test-framework/src/spicetest/mod.rs
@@ -23,6 +23,7 @@ use crate::spiced::SpicedInstance;
 pub mod append;
 pub mod datasets;
 pub mod http;
+pub mod vector_search;
 
 pub trait TestState {}
 pub trait TestNotStarted: TestState {}

--- a/crates/test-framework/src/spicetest/vector_search/mod.rs
+++ b/crates/test-framework/src/spicetest/vector_search/mod.rs
@@ -1,0 +1,199 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{collections::BTreeMap, time::SystemTime};
+
+use crate::metrics::{
+    system_time_to_unix_epoch_ms, Builder, BuilderTarget, ExtendedMetrics, MetricCollector,
+    NoExtendedMetrics, QueryMetric, QueryStatus,
+};
+use anyhow::{Context, Result};
+use arrow::{
+    array::Float64Builder,
+    datatypes::{DataType, Field},
+};
+use tokio::task::JoinHandle;
+
+use super::{SpiceTest, TestCompleted, TestNotStarted, TestState};
+
+mod worker;
+pub use worker::{SearchConfig, SearchRequest};
+use worker::{VectorSearchWorker, VectorSearchWorkerResult};
+
+#[derive(Default)]
+pub struct NotStarted {
+    parallel_count: usize,
+    config: SearchConfig,
+}
+
+impl NotStarted {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_parallel_count(mut self, parallel_count: usize) -> Self {
+        self.parallel_count = parallel_count;
+        self
+    }
+
+    #[must_use]
+    pub fn with_config(mut self, config: SearchConfig) -> Self {
+        self.config = config;
+        self
+    }
+}
+
+type VectorSearchWorkers = Vec<JoinHandle<Result<VectorSearchWorkerResult>>>;
+
+pub struct Running {
+    vector_workers: VectorSearchWorkers,
+}
+
+pub struct Completed {
+    end_time: SystemTime,
+    results: Vec<VectorSearchWorkerResult>,
+}
+
+impl TestState for NotStarted {}
+impl TestState for Running {}
+impl TestState for Completed {}
+impl TestNotStarted for NotStarted {}
+impl TestCompleted for Completed {
+    fn end_time(&self) -> SystemTime {
+        self.end_time
+    }
+}
+
+impl SpiceTest<NotStarted> {
+    pub fn start(self) -> Result<SpiceTest<Running>> {
+        let http_client = self
+            .spiced_instance
+            .as_ref()
+            .context("Spiced instance should be present")?
+            .http_client()?;
+
+        let workers = (0..self.state.parallel_count)
+            .map(|_| {
+                VectorSearchWorker::new(http_client.clone(), self.state.config.clone()).start()
+            })
+            .collect();
+
+        Ok(SpiceTest {
+            name: self.name,
+            spiced_instance: self.spiced_instance,
+            start_time: self.start_time,
+            use_progress_bars: self.use_progress_bars,
+            api_key: self.api_key,
+            explain_plan_snapshot: self.explain_plan_snapshot,
+            results_snapshot_predicate: self.results_snapshot_predicate,
+            state: Running {
+                vector_workers: workers,
+            },
+        })
+    }
+}
+
+impl SpiceTest<Running> {
+    pub async fn wait(self) -> Result<SpiceTest<Completed>> {
+        let mut results = vec![];
+        for worker in self.state.vector_workers {
+            // TODO: combine results from multiple workers?
+            results.push(
+                worker
+                    .await
+                    .context("Error waiting for vector search worker")??,
+            );
+        }
+
+        Ok(SpiceTest {
+            name: self.name,
+            spiced_instance: self.spiced_instance,
+            start_time: self.start_time,
+            use_progress_bars: self.use_progress_bars,
+            api_key: self.api_key,
+            explain_plan_snapshot: self.explain_plan_snapshot,
+            results_snapshot_predicate: self.results_snapshot_predicate,
+            state: Completed {
+                end_time: SystemTime::now(),
+                results,
+            },
+        })
+    }
+}
+
+impl MetricCollector<SearchScoreMetric, NoExtendedMetrics> for SpiceTest<Completed> {
+    fn start_time(&self) -> SystemTime {
+        self.start_time
+    }
+
+    fn end_time(&self) -> SystemTime {
+        self.state.end_time
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn metrics(&self) -> Result<Vec<QueryMetric<SearchScoreMetric>>> {
+        self.state
+            .results
+            .first()
+            .context("No results found")?
+            .search_results
+            .iter()
+            .map(|(id, result)| {
+                QueryMetric::new_from_durations(
+                    id,
+                    &vec![result.duration],
+                    QueryStatus::Passed,
+                    system_time_to_unix_epoch_ms(self.start_time)?,
+                    system_time_to_unix_epoch_ms(self.state.end_time)?,
+                )
+                .map(|metric| metric.with_extended_metrics(SearchScoreMetric::new(result.score)))
+            })
+            .collect()
+    }
+}
+
+pub struct SearchScoreMetric {
+    pub score: f64,
+}
+impl ExtendedMetrics for SearchScoreMetric {
+    fn fields() -> Vec<Field> {
+        vec![Field::new("score", DataType::Float64, false)]
+    }
+
+    fn builders() -> BTreeMap<String, Builder> {
+        let mut builders = BTreeMap::new();
+        builders.insert("score".to_string(), Builder::Float64(Float64Builder::new()));
+        builders
+    }
+
+    fn build(&self) -> Result<Vec<BuilderTarget>> {
+        Ok(vec![BuilderTarget::Float64((
+            "score".to_string(),
+            self.score,
+        ))])
+    }
+}
+impl SearchScoreMetric {
+    #[must_use]
+    pub fn new(score: f64) -> Self {
+        Self { score }
+    }
+}

--- a/crates/test-framework/src/spicetest/vector_search/worker.rs
+++ b/crates/test-framework/src/spicetest/vector_search/worker.rs
@@ -1,0 +1,172 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
+
+#[derive(Debug, Default, Serialize, Clone)]
+pub struct SearchRequest {
+    #[serde(skip)]
+    pub id: String,
+
+    pub text: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub datasets: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub where_cond: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub additional_columns: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+}
+
+impl SearchRequest {
+    #[must_use]
+    pub fn new(id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            text: text.into(),
+            datasets: vec![],
+            limit: None,
+            where_cond: None,
+            additional_columns: vec![],
+            keywords: vec![],
+        }
+    }
+
+    #[must_use]
+    pub fn with_datasets(mut self, datasets: Vec<impl Into<String>>) -> Self {
+        self.datasets = datasets.into_iter().map(Into::into).collect();
+        self
+    }
+
+    #[must_use]
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    #[must_use]
+    pub fn with_where_cond(mut self, where_cond: impl Into<String>) -> Self {
+        self.where_cond = Some(where_cond.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_additional_columns(mut self, additional_columns: Vec<impl Into<String>>) -> Self {
+        self.additional_columns = additional_columns.into_iter().map(Into::into).collect();
+        self
+    }
+
+    #[must_use]
+    pub fn with_keywords(mut self, keywords: Vec<impl Into<String>>) -> Self {
+        self.keywords = keywords.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SearchConfig {
+    requests: Vec<SearchRequest>,
+}
+
+impl SearchConfig {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { requests: vec![] }
+    }
+
+    #[must_use]
+    pub fn add_request(mut self, request: SearchRequest) -> Self {
+        self.requests.push(request);
+        self
+    }
+}
+
+pub(crate) struct VectorSearchWorkerResult {
+    pub(crate) search_results: BTreeMap<String, SearchResult>,
+}
+
+pub(crate) struct SearchResult {
+    pub(crate) score: f64,
+    pub(crate) duration: Duration,
+}
+
+pub(crate) struct VectorSearchWorker {
+    http_client: Client,
+    config: SearchConfig,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Match {
+    score: f64,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct SearchResponse {
+    matches: Vec<Match>,
+}
+
+impl VectorSearchWorker {
+    pub fn new(http_client: Client, config: SearchConfig) -> Self {
+        Self {
+            http_client,
+            config,
+        }
+    }
+
+    pub fn start(self) -> JoinHandle<Result<VectorSearchWorkerResult>> {
+        tokio::spawn(async move {
+            let mut results: BTreeMap<String, SearchResult> = BTreeMap::new();
+            for request in self.config.requests {
+                let start = Instant::now();
+                let res = self
+                    .http_client
+                    .post("http://localhost:8090/v1/search")
+                    .json(&request)
+                    .send()
+                    .await?;
+                let res: SearchResponse = res.json().await?;
+                let duration = start.elapsed();
+                results.insert(
+                    request.id,
+                    SearchResult {
+                        score: res
+                            .matches
+                            .iter()
+                            .map(|m| m.score)
+                            .max_by(f64::total_cmp)
+                            .unwrap_or(0.0),
+                        duration,
+                    },
+                );
+            }
+
+            Ok(VectorSearchWorkerResult {
+                search_results: results,
+            })
+        })
+    }
+}

--- a/test/spicepods/vector_search/spicecloud_docs.yaml
+++ b/test/spicepods/vector_search/spicecloud_docs.yaml
@@ -1,0 +1,29 @@
+version: v1
+kind: Spicepod
+name: spicecloud_docs
+datasets:
+  - from: spice.ai/spiceai/docs/datasets/spice.spiceai.cookbook
+    name: cookbook
+    params:
+      spiceai_api_key: ${ secrets:SPICEAI_API_KEY }
+    acceleration:
+      enabled: true
+    columns:
+      - name: content
+        embeddings:
+          - from: xl_embed
+  - from: spice.ai/spiceai/docs/datasets/spice.spiceai.docs
+    name: docs
+    params:
+      spiceai_api_key: ${ secrets:SPICEAI_API_KEY }
+    acceleration:
+      enabled: true
+    columns:
+      - name: content
+        embeddings:
+          - from: xl_embed
+embeddings:
+  - from: openai:text-embedding-3-small
+    name: xl_embed
+    params:
+      openai_api_key: ${ secrets:OPENAI_API_KEY }

--- a/tools/testoperator/src/args/mod.rs
+++ b/tools/testoperator/src/args/mod.rs
@@ -52,6 +52,7 @@ pub enum TestCommands {
     HttpOverhead(HttpOverheadTestArgs),
     Evals(EvalsTestArgs),
     Append(DatasetTestArgs),
+    VectorSearch(CommonArgs),
 }
 
 /// Arguments Common to all [`TestCommands`].

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod http;
 pub(crate) mod load;
 pub(crate) mod throughput;
 mod util;
+pub(crate) mod vector_search;
 pub(crate) type RowCounts = BTreeMap<String, usize>;
 
 const TEST_RESULTS_DATASET: &str = "test_results";

--- a/tools/testoperator/src/commands/vector_search/mod.rs
+++ b/tools/testoperator/src/commands/vector_search/mod.rs
@@ -1,0 +1,108 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use super::get_app_and_start_request;
+use crate::{args::CommonArgs, commands::TEST_RESULTS_API_KEY};
+use std::time::Duration;
+use test_framework::{
+    anyhow,
+    arrow::util::pretty::print_batches,
+    metrics::MetricCollector,
+    spiced::SpicedInstance,
+    spicetest::{
+        vector_search::{NotStarted, SearchConfig, SearchRequest},
+        SpiceTest,
+    },
+    TestType,
+};
+
+pub(crate) async fn run(args: &CommonArgs) -> anyhow::Result<()> {
+    let (app, start_request) = get_app_and_start_request(args)?;
+    let mut spiced_instance = SpicedInstance::start(start_request).await?;
+
+    spiced_instance
+        .wait_for_ready(Duration::from_secs(args.ready_wait))
+        .await?;
+
+    // baseline run
+    println!("Running benchmark test");
+
+    // TODO: build search config for vector search elsewhere
+    let config = SearchConfig::new()
+        .add_request(
+            SearchRequest::new("file_connector_recipe_no_keywords", "file connector recipe")
+                .with_additional_columns(vec!["path"]),
+        )
+        .add_request(
+            SearchRequest::new(
+                "file_connector_recipe_separate_keywords",
+                "file connector recipe",
+            )
+            .with_keywords(vec!["file", "connector"])
+            .with_additional_columns(vec!["path"]),
+        )
+        .add_request(
+            SearchRequest::new(
+                "file_connector_recipe_combined_keyword",
+                "file connector recipe",
+            )
+            .with_keywords(vec!["file connector"])
+            .with_additional_columns(vec!["path"]),
+        )
+        .add_request(
+            SearchRequest::new("file_data_connector_no_keywords", "file data connector")
+                .with_additional_columns(vec!["path"]),
+        )
+        .add_request(
+            SearchRequest::new(
+                "file_data_connector_separate_keywords",
+                "file data connector",
+            )
+            .with_keywords(vec!["file", "connector"])
+            .with_additional_columns(vec!["path"]),
+        )
+        .add_request(
+            SearchRequest::new(
+                "file_data_connector_combined_keyword",
+                "file data connector",
+            )
+            .with_keywords(vec!["file connector"])
+            .with_additional_columns(vec!["path"]),
+        );
+
+    let vector_test = SpiceTest::new(
+        app.name.clone(),
+        NotStarted::new().with_config(config).with_parallel_count(1),
+    )
+    .with_spiced_instance(spiced_instance)
+    .with_api_key(if args.upload_results_dataset.is_some() {
+        Some(TEST_RESULTS_API_KEY.to_string())
+    } else {
+        None
+    })
+    .start()?;
+
+    let test = vector_test.wait().await?;
+    let metrics = test.collect(TestType::VectorSearch)?;
+    let mut spiced_instance = test.end()?;
+
+    let records = metrics.build_records()?;
+    print_batches(&records)?;
+
+    spiced_instance.show_memory_usage()?;
+    spiced_instance.stop()?;
+    Ok(())
+}

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -80,6 +80,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::Export(TestCommands::Append(args)) => {
             commands::env_export(&args.common)?;
         }
+        Commands::Run(TestCommands::VectorSearch(args)) => {
+            commands::vector_search::run(&args).await?;
+        }
+        Commands::Export(TestCommands::VectorSearch(args)) => {
+            commands::env_export(&args)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds an initial example for a `run vector-search` test using the testoperator.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4767 

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->

* This is an early PoC/MvP of what vector searching could look like in the testoperator. This is not a final version, and is simply getting something running that we can build upon for a test to replace the benchmarks search runner.