### PR TITLE
Implement proper `ready_state: on_registration` for federation enabled accelerators

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
       "program": "${workspaceFolder}/target/debug/spiced",
       "args": [],
       "cwd": "${workspaceFolder}",
-      "preLaunchTask": "rust: cargo build"
+      "preLaunchTask": "rust: cargo build",
+      "sourceLanguages": ["rust"]
     },
     {
       "type": "lldb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=a889f4bd47cba6b96d24a63a03891c64dadb6e15#a889f4bd47cba6b96d24a63a03891c64dadb6e15"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=8b373f95e3fa0eaa4f13b93435275acc4096bf2f#8b373f95e3fa0eaa4f13b93435275acc4096bf2f"
 dependencies = [
  "arrow-json",
  "async-stream",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation-sql"
 version = "0.1.6"
-source = "git+https://github.com/spiceai/datafusion-federation.git?rev=a889f4bd47cba6b96d24a63a03891c64dadb6e15#a889f4bd47cba6b96d24a63a03891c64dadb6e15"
+source = "git+https://github.com/spiceai/datafusion-federation.git?rev=8b373f95e3fa0eaa4f13b93435275acc4096bf2f#8b373f95e3fa0eaa4f13b93435275acc4096bf2f"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=da158b131df59d7948bac3e57726030a255198d5#da158b131df59d7948bac3e57726030a255198d5"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=47b06460a6f743cf1bdf489767c4f33c4c1068d9#47b06460a6f743cf1bdf489767c4f33c4c1068d9"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ datafusion-common = "43"
 datafusion-execution = "43"
 datafusion-expr = "43"
 datafusion-federation = "0.1"
-datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
+datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
 datafusion-functions-json = "0.43"
 datafusion-table-providers = "0.1"
 dotenvy = "0.15"
@@ -168,8 +168,8 @@ arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b
 arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 
-datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "da158b131df59d7948bac3e57726030a255198d5" }
+datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "47b06460a6f743cf1bdf489767c4f33c4c1068d9" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "13907e028f45ec987092c7efb1140c03be79a462" }
 

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -39,24 +39,12 @@ impl AcceleratedTable {
         Some(Arc::new(poly.clone()))
     }
 
-    fn get_federation_provider_for_federated_table(&self) -> Option<Arc<dyn FederationProvider>> {
-        let federated_table = self.federated.table_provider_immediate()?;
-
-        let adaptor = federated_table
-            .as_any()
-            .downcast_ref::<FederatedTableProviderAdaptor>()?;
-
-        Some(adaptor.source.federation_provider())
-    }
-
     #[must_use]
     fn create_federated_table_source(&self) -> Arc<dyn FederatedTableSource> {
         let schema = Arc::clone(&self.schema());
         let accelerated_table_federation_provider = self
             .get_federation_provider_for_accelerator()
             .map(|x| x as Arc<dyn FederationProvider>);
-        let federated_table_federation_provider =
-            self.get_federation_provider_for_federated_table();
 
         let enabled = self.zero_results_action != ZeroResultsAction::UseSource
             && !self.disable_query_push_down;
@@ -64,8 +52,6 @@ impl AcceleratedTable {
         let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
             enabled,
             accelerated_table_federation_provider,
-            federated_table_federation_provider,
-            self.ready_state,
             self.refresher(),
         ));
 

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -42,22 +42,26 @@ impl AcceleratedTable {
     #[must_use]
     fn create_federated_table_source(&self) -> Arc<dyn FederatedTableSource> {
         let schema = Arc::clone(&self.schema());
-        let accelerated_table_federation_provider = self
-            .get_federation_provider_for_accelerator()
-            .map(|x| x as Arc<dyn FederationProvider>);
+        let accelerated_table_federation_provider = self.get_federation_provider_for_accelerator();
 
         let enabled = self.zero_results_action != ZeroResultsAction::UseSource
             && !self.disable_query_push_down;
 
+        let remote_table_name = accelerated_table_federation_provider
+            .as_ref()
+            .and_then(|provider| provider.get_table_source())
+            .and_then(|source| source.remote_table_name());
+
         let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
             enabled,
-            accelerated_table_federation_provider,
+            accelerated_table_federation_provider.map(|x| x as Arc<dyn FederationProvider>),
             self.refresher(),
         ));
 
         Arc::new(AcceleratedTableFederatedTableSource::new_with_schema(
             fed_provider,
             schema,
+            remote_table_name,
         ))
     }
 

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -14,18 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{any::Any, sync::Arc};
+use std::sync::Arc;
 
 use super::AcceleratedTable;
 use crate::component::dataset::acceleration::ZeroResultsAction;
-use arrow::datatypes::SchemaRef;
 use data_components::poly::PolyTableProvider;
-use datafusion::datasource::TableType;
-use datafusion::error::Result as DataFusionResult;
-use datafusion::{datasource::TableProvider, logical_expr::TableSource};
+use datafusion::datasource::TableProvider;
 use datafusion_federation::{
     FederatedTableProviderAdaptor, FederatedTableSource, FederationProvider,
 };
+use provider::AcceleratedTableFederationProvider;
+use source::AcceleratedTableFederatedTableSource;
+
+mod provider;
+mod source;
 
 impl AcceleratedTable {
     fn get_federation_provider_for_accelerator(&self) -> Option<Arc<PolyTableProvider>> {
@@ -37,102 +39,45 @@ impl AcceleratedTable {
         Some(Arc::new(poly.clone()))
     }
 
-    fn create_federated_table_source(&self) -> DataFusionResult<Arc<dyn FederatedTableSource>> {
+    fn get_federation_provider_for_federated_table(&self) -> Option<Arc<dyn FederationProvider>> {
+        let federated_table = self.federated.table_provider_immediate()?;
+
+        let adaptor = federated_table
+            .as_any()
+            .downcast_ref::<FederatedTableProviderAdaptor>()?;
+
+        Some(adaptor.source.federation_provider())
+    }
+
+    #[must_use]
+    fn create_federated_table_source(&self) -> Arc<dyn FederatedTableSource> {
         let schema = Arc::clone(&self.schema());
-        let inner = self.get_federation_provider_for_accelerator();
+        let accelerated_table_federation_provider = self
+            .get_federation_provider_for_accelerator()
+            .map(|x| x as Arc<dyn FederationProvider>);
+        let federated_table_federation_provider =
+            self.get_federation_provider_for_federated_table();
 
         let enabled = self.zero_results_action != ZeroResultsAction::UseSource
             && !self.disable_query_push_down;
 
-        let fed_provider = Arc::new(FederationAdaptor::new(
-            inner.clone().map(|x| x as Arc<dyn FederationProvider>),
+        let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
             enabled,
+            accelerated_table_federation_provider,
+            federated_table_federation_provider,
+            self.ready_state,
+            self.refresher(),
         ));
 
-        if enabled {
-            if let Some(inner) = inner {
-                if let Some(table_source) = inner.get_table_source() {
-                    return Ok(table_source);
-                }
-            }
-        }
-
-        // For other queries to continue running without enabling federation
-        Ok(Arc::new(
-            AcceleratedTableFederatedTableSource::new_with_schema(fed_provider, schema)?,
+        Arc::new(AcceleratedTableFederatedTableSource::new_with_schema(
+            fed_provider,
+            schema,
         ))
     }
 
-    pub fn create_federated_table_provider(
-        self: Arc<Self>,
-    ) -> DataFusionResult<FederatedTableProviderAdaptor> {
-        let table_source = self.create_federated_table_source()?;
-        Ok(FederatedTableProviderAdaptor::new_with_provider(
-            table_source,
-            self,
-        ))
-    }
-}
-
-pub struct FederationAdaptor {
-    pub inner: Option<Arc<dyn FederationProvider>>,
-    pub enabled: bool,
-}
-
-impl FederationAdaptor {
-    fn new(inner: Option<Arc<dyn FederationProvider>>, enabled: bool) -> Self {
-        Self { inner, enabled }
-    }
-}
-
-impl FederationProvider for FederationAdaptor {
-    fn name(&self) -> &'static str {
-        "FederationProviderForAcceleratedDataset"
-    }
-
-    fn compute_context(&self) -> Option<String> {
-        if !self.enabled {
-            return None;
-        }
-        self.inner.clone().and_then(|x| x.compute_context())
-    }
-
-    fn analyzer(&self) -> Option<Arc<datafusion::optimizer::Analyzer>> {
-        if !self.enabled {
-            return None;
-        }
-        self.inner.clone().and_then(|x| x.analyzer())
-    }
-}
-
-pub struct AcceleratedTableFederatedTableSource {
-    provider: Arc<FederationAdaptor>,
-    schema: SchemaRef,
-}
-
-impl AcceleratedTableFederatedTableSource {
-    pub fn new_with_schema(
-        provider: Arc<FederationAdaptor>,
-        schema: SchemaRef,
-    ) -> DataFusionResult<Self> {
-        Ok(Self { provider, schema })
-    }
-}
-
-impl FederatedTableSource for AcceleratedTableFederatedTableSource {
-    fn federation_provider(&self) -> Arc<dyn FederationProvider> {
-        Arc::clone(&self.provider) as Arc<dyn FederationProvider>
-    }
-}
-
-impl TableSource for AcceleratedTableFederatedTableSource {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn schema(&self) -> SchemaRef {
-        Arc::clone(&self.schema)
-    }
-    fn table_type(&self) -> TableType {
-        TableType::Temporary
+    #[must_use]
+    pub fn create_federated_table_provider(self: Arc<Self>) -> FederatedTableProviderAdaptor {
+        let table_source = self.create_federated_table_source();
+        FederatedTableProviderAdaptor::new_with_provider(table_source, self)
     }
 }

--- a/crates/runtime/src/accelerated_table/federation/provider.rs
+++ b/crates/runtime/src/accelerated_table/federation/provider.rs
@@ -1,0 +1,91 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use datafusion_federation::FederationProvider;
+
+use crate::component::dataset::ReadyState;
+
+#[allow(clippy::struct_field_names)]
+pub struct AcceleratedTableFederationProvider {
+    enabled: bool,
+    accelerated_table_federation_provider: Option<Arc<dyn FederationProvider>>,
+    federated_table_federation_provider: Option<Arc<dyn FederationProvider>>,
+    ready_state: ReadyState,
+    refresher: Arc<crate::accelerated_table::refresh::Refresher>,
+}
+
+impl AcceleratedTableFederationProvider {
+    pub fn new(
+        enabled: bool,
+        accelerated_table_federation_provider: Option<Arc<dyn FederationProvider>>,
+        federated_table_federation_provider: Option<Arc<dyn FederationProvider>>,
+        ready_state: ReadyState,
+        refresher: Arc<crate::accelerated_table::refresh::Refresher>,
+    ) -> Self {
+        Self {
+            enabled,
+            accelerated_table_federation_provider,
+            federated_table_federation_provider,
+            ready_state,
+            refresher,
+        }
+    }
+
+    fn federation_provider(&self) -> Option<Arc<dyn FederationProvider>> {
+        if !self.enabled {
+            return None;
+        }
+
+        // If the initial load has completed, we can use the accelerated table federation provider.
+        if self.refresher.initial_load_completed() {
+            return self.accelerated_table_federation_provider.clone();
+        }
+
+        // Otherwise, we need to use the federated table federation provider if the ready state is OnRegistration.
+        if self.ready_state == ReadyState::OnRegistration {
+            return self.federated_table_federation_provider.clone();
+        }
+
+        // If we get here then we need to wait for the initial load to complete.
+        None
+    }
+}
+
+impl FederationProvider for AcceleratedTableFederationProvider {
+    fn name(&self) -> &'static str {
+        "FederationProviderForAcceleratedDataset"
+    }
+
+    fn compute_context(&self) -> Option<String> {
+        if !self.enabled {
+            return None;
+        }
+        self.federation_provider()
+            .clone()
+            .and_then(|x| x.compute_context())
+    }
+
+    fn analyzer(&self) -> Option<Arc<datafusion::optimizer::Analyzer>> {
+        if !self.enabled {
+            return None;
+        }
+        self.federation_provider()
+            .clone()
+            .and_then(|x| x.analyzer())
+    }
+}

--- a/crates/runtime/src/accelerated_table/federation/provider.rs
+++ b/crates/runtime/src/accelerated_table/federation/provider.rs
@@ -18,51 +18,32 @@ use std::sync::Arc;
 
 use datafusion_federation::FederationProvider;
 
-use crate::component::dataset::ReadyState;
-
 #[allow(clippy::struct_field_names)]
 pub struct AcceleratedTableFederationProvider {
     enabled: bool,
-    accelerated_table_federation_provider: Option<Arc<dyn FederationProvider>>,
-    federated_table_federation_provider: Option<Arc<dyn FederationProvider>>,
-    ready_state: ReadyState,
+    provider: Option<Arc<dyn FederationProvider>>,
     refresher: Arc<crate::accelerated_table::refresh::Refresher>,
 }
 
 impl AcceleratedTableFederationProvider {
     pub fn new(
         enabled: bool,
-        accelerated_table_federation_provider: Option<Arc<dyn FederationProvider>>,
-        federated_table_federation_provider: Option<Arc<dyn FederationProvider>>,
-        ready_state: ReadyState,
+        provider: Option<Arc<dyn FederationProvider>>,
         refresher: Arc<crate::accelerated_table::refresh::Refresher>,
     ) -> Self {
         Self {
             enabled,
-            accelerated_table_federation_provider,
-            federated_table_federation_provider,
-            ready_state,
+            provider,
             refresher,
         }
     }
 
     fn federation_provider(&self) -> Option<Arc<dyn FederationProvider>> {
-        if !self.enabled {
-            return None;
+        // If the initial load has completed and this provider is enabled, we can use the accelerated table federation provider.
+        match (self.enabled, self.refresher.initial_load_completed()) {
+            (true, true) => self.provider.clone(),
+            _ => None,
         }
-
-        // If the initial load has completed, we can use the accelerated table federation provider.
-        if self.refresher.initial_load_completed() {
-            return self.accelerated_table_federation_provider.clone();
-        }
-
-        // Otherwise, we need to use the federated table federation provider if the ready state is OnRegistration.
-        if self.ready_state == ReadyState::OnRegistration {
-            return self.federated_table_federation_provider.clone();
-        }
-
-        // If we get here then we need to wait for the initial load to complete.
-        None
     }
 }
 
@@ -75,17 +56,13 @@ impl FederationProvider for AcceleratedTableFederationProvider {
         if !self.enabled {
             return None;
         }
-        self.federation_provider()
-            .clone()
-            .and_then(|x| x.compute_context())
+        self.federation_provider().and_then(|x| x.compute_context())
     }
 
     fn analyzer(&self) -> Option<Arc<datafusion::optimizer::Analyzer>> {
         if !self.enabled {
             return None;
         }
-        self.federation_provider()
-            .clone()
-            .and_then(|x| x.analyzer())
+        self.federation_provider().and_then(|x| x.analyzer())
     }
 }

--- a/crates/runtime/src/accelerated_table/federation/source.rs
+++ b/crates/runtime/src/accelerated_table/federation/source.rs
@@ -1,0 +1,55 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{any::Any, sync::Arc};
+
+use arrow_schema::SchemaRef;
+use datafusion::{datasource::TableType, logical_expr::TableSource};
+use datafusion_federation::{FederatedTableSource, FederationProvider};
+
+use super::AcceleratedTableFederationProvider;
+
+pub struct AcceleratedTableFederatedTableSource {
+    provider: Arc<AcceleratedTableFederationProvider>,
+    schema: SchemaRef,
+}
+
+impl AcceleratedTableFederatedTableSource {
+    pub fn new_with_schema(
+        provider: Arc<AcceleratedTableFederationProvider>,
+        schema: SchemaRef,
+    ) -> Self {
+        Self { provider, schema }
+    }
+}
+
+impl FederatedTableSource for AcceleratedTableFederatedTableSource {
+    fn federation_provider(&self) -> Arc<dyn FederationProvider> {
+        Arc::clone(&self.provider) as Arc<dyn FederationProvider>
+    }
+}
+
+impl TableSource for AcceleratedTableFederatedTableSource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+}

--- a/crates/runtime/src/accelerated_table/federation/source.rs
+++ b/crates/runtime/src/accelerated_table/federation/source.rs
@@ -18,25 +18,37 @@ use std::{any::Any, sync::Arc};
 
 use arrow_schema::SchemaRef;
 use datafusion::{datasource::TableType, logical_expr::TableSource};
-use datafusion_federation::{FederatedTableSource, FederationProvider};
+use datafusion_federation::{
+    table_reference::MultiPartTableReference, FederatedTableSource, FederationProvider,
+};
 
 use super::AcceleratedTableFederationProvider;
 
 pub struct AcceleratedTableFederatedTableSource {
     provider: Arc<AcceleratedTableFederationProvider>,
     schema: SchemaRef,
+    remote_table_name: Option<MultiPartTableReference>,
 }
 
 impl AcceleratedTableFederatedTableSource {
     pub fn new_with_schema(
         provider: Arc<AcceleratedTableFederationProvider>,
         schema: SchemaRef,
+        remote_table_name: Option<MultiPartTableReference>,
     ) -> Self {
-        Self { provider, schema }
+        Self {
+            provider,
+            schema,
+            remote_table_name,
+        }
     }
 }
 
 impl FederatedTableSource for AcceleratedTableFederatedTableSource {
+    fn remote_table_name(&self) -> Option<MultiPartTableReference> {
+        self.remote_table_name.clone()
+    }
+
     fn federation_provider(&self) -> Arc<dyn FederationProvider> {
         Arc::clone(&self.provider) as Arc<dyn FederationProvider>
     }

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -375,12 +375,7 @@ impl DataFusion {
                     self.ctx
                         .register_table(
                             dataset_table_ref.clone(),
-                            Arc::new(
-                                Arc::new(accelerated_table)
-                                    .create_federated_table_provider()
-                                    .map_err(find_datafusion_root)
-                                    .context(UnableToRegisterTableToDataFusionSnafu)?,
-                            ),
+                            Arc::new(Arc::new(accelerated_table).create_federated_table_provider()),
                         )
                         .map_err(find_datafusion_root)
                         .context(UnableToRegisterTableToDataFusionSnafu)?;
@@ -954,12 +949,7 @@ impl DataFusion {
         self.ctx
             .register_table(
                 dataset.name.clone(),
-                Arc::new(
-                    Arc::new(accelerated_table)
-                        .create_federated_table_provider()
-                        .map_err(find_datafusion_root)
-                        .context(UnableToRegisterTableToDataFusionSnafu)?,
-                ),
+                Arc::new(Arc::new(accelerated_table).create_federated_table_provider()),
             )
             .map_err(find_datafusion_root)
             .context(UnableToRegisterTableToDataFusionSnafu)?;

--- a/crates/runtime/src/federated_table/mod.rs
+++ b/crates/runtime/src/federated_table/mod.rs
@@ -126,13 +126,6 @@ impl FederatedTable {
         }))
     }
 
-    pub fn table_provider_immediate(&self) -> Option<Arc<dyn TableProvider>> {
-        match self {
-            Self::Immediate(table_provider) => Some(Arc::clone(table_provider)),
-            Self::Deferred(_) => None,
-        }
-    }
-
     pub async fn table_provider(&self) -> Arc<dyn TableProvider> {
         let deferred_table_provider = match self {
             Self::Immediate(table_provider) => return Arc::clone(table_provider),

--- a/crates/runtime/src/federated_table/mod.rs
+++ b/crates/runtime/src/federated_table/mod.rs
@@ -126,6 +126,13 @@ impl FederatedTable {
         }))
     }
 
+    pub fn table_provider_immediate(&self) -> Option<Arc<dyn TableProvider>> {
+        match self {
+            Self::Immediate(table_provider) => Some(Arc::clone(table_provider)),
+            Self::Deferred(_) => None,
+        }
+    }
+
     pub async fn table_provider(&self) -> Arc<dyn TableProvider> {
         let deferred_table_provider = match self {
             Self::Immediate(table_provider) => return Arc::clone(table_provider),


### PR DESCRIPTION
# 🗣 Description

Fixes an issue that prevents the `ready_state: on_registration` setting from working correctly when datasets are accelerated using an engine that itself supports federation, i.e. DuckDB.

## 🔨 Related Issues

Fixes #5016

