### PR TITLE
Upgrade to DuckDB 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3975,8 +3975,8 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "duckdb"
-version = "1.2.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=13907e028f45ec987092c7efb1140c03be79a462#13907e028f45ec987092c7efb1140c03be79a462"
+version = "1.2.1"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=77df1e2513afdd6e3b5a543e51f38fc9eac224c0#77df1e2513afdd6e3b5a543e51f38fc9eac224c0"
 dependencies = [
  "arrow",
  "cast",
@@ -6589,8 +6589,8 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.2.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=13907e028f45ec987092c7efb1140c03be79a462#13907e028f45ec987092c7efb1140c03be79a462"
+version = "1.2.1"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=77df1e2513afdd6e3b5a543e51f38fc9eac224c0#77df1e2513afdd6e3b5a543e51f38fc9eac224c0"
 dependencies = [
  "autocfg",
  "cc",
@@ -6633,7 +6633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12846,7 +12846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-feder
 datafusion-functions-json = "0.43"
 datafusion-table-providers = "0.1"
 dotenvy = "0.15"
-duckdb = "1.2.0"
+duckdb = "1.2.1"
 fundu = "2.0.1"
 futures = "0.3.30"
 globset = "0.4.16"
@@ -171,7 +171,7 @@ object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b792519
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a889f4bd47cba6b96d24a63a03891c64dadb6e15" }
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "da158b131df59d7948bac3e57726030a255198d5" }
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "13907e028f45ec987092c7efb1140c03be79a462" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "77df1e2513afdd6e3b5a543e51f38fc9eac224c0" }
 
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "dfb1e03a5f0702c1a318db5abf40e762d6b2bcc2" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }


### PR DESCRIPTION
# 🗣 Description

Official duckdb-rs v1.2.1 with Arrow version downgraded to 53:
 - https://github.com/spiceai/duckdb-rs/commit/77df1e2513afdd6e3b5a543e51f38fc9eac224c0

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
