### PR TITLE
fix `v1/models` payload on CLI side

### DIFF
--- a/bin/spice/pkg/api/model.go
+++ b/bin/spice/pkg/api/model.go
@@ -20,6 +20,7 @@ type Model struct {
 	Id      string `json:"id,omitempty" csv:"id" yaml:"id,omitempty"`
 	Object  string `json:"object,omitempty" csv:"object" yaml:"object,omitempty"`
 	OwnedBy string `json:"owned_by,omitempty" csv:"owned_by" yaml:"owned_by,omitempty"`
+	Dataset string `json:"dataset,omitempty" csv:"dataset" yaml:"dataset,omitempty"`
 	Status  string `json:"status,omitempty" csv:"status,omitempty" yaml:"status,omitempty"`
 }
 


### PR DESCRIPTION
# 🗣 Description
 - Difference in expected payload between spiced and spice CLI for `v1/models`.
 - Causes error in `spice chat` when model is not preselected.
    ```shell
    >>> spice chat
    Spice.ai OSS CLI v1.0.4 (https://spiceai.org/docs/cli)
    2025/03/17 08:26:20 ERROR could not list models error="error decoding response: json: cannot unmarshal object into Go value of type []api.Model"
    ```