### PR TITLE
fix: Disable benchmarks schedule, enable testoperator schedule

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,8 +2,8 @@
 name: benchmark tests
 
 on:
-  schedule:
-    - cron: '0 10 * * 0,3,5,6' # Runs at 10 AM UTC (2AM PT) on Wednesday, Friday, Saturday, and Sunday.
+  # schedule:
+  #   - cron: '0 10 * * 0,3,5,6' # Runs at 10 AM UTC (2AM PT) on Wednesday, Friday, Saturday, and Sunday.
   workflow_dispatch:
     inputs:
       run_all:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,8 +2,6 @@
 name: benchmark tests
 
 on:
-  # schedule:
-  #   - cron: '0 10 * * 0,3,5,6' # Runs at 10 AM UTC (2AM PT) on Wednesday, Friday, Saturday, and Sunday.
   workflow_dispatch:
     inputs:
       run_all:

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -85,11 +85,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-      
-      # - name: Dispatch Testoperator - Scheduled Throughput
-      #   if: ${{ github.event_name == 'schedule' && github.event.schedule == '10 22 */3 * *' }}
-      #   run: |
-      #     testoperator dispatch ./tools/testoperator/dispatch --workflow throughput
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -1,6 +1,9 @@
 name: testoperator dispatch
 
 on:
+  schedule:
+    # Every 2nd day, at 9:00 AM UTC
+    - cron: '0 9 */2 * *'
   workflow_dispatch:
     inputs:
       test_files_path:
@@ -59,18 +62,34 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ github.ref }}
 
-      - name: Dispatch Testoperator - Scheduled Bench
+      - name: Dispatch Testoperator - Scheduled Bench - TPCH
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          testoperator dispatch ./tools/testoperator/dispatch --workflow bench
+          testoperator dispatch ./tools/testoperator/dispatch/tpch --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - TPCDS
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpcds --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - ClickBench
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/clickbench --workflow bench
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
       
-      - name: Dispatch Testoperator - Scheduled Throughput
-        if: ${{ github.event_name == 'schedule' && github.event.schedule == '10 22 */3 * *' }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch --workflow throughput
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+      # - name: Dispatch Testoperator - Scheduled Throughput
+      #   if: ${{ github.event_name == 'schedule' && github.event.schedule == '10 22 */3 * *' }}
+      #   run: |
+      #     testoperator dispatch ./tools/testoperator/dispatch --workflow throughput
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -1,4 +1,4 @@
-name: benchmark e2e tests
+name: benchmark e2e tests - ${{ github.event.inputs.spicepod_path | split("/") | last | split(".")[0] }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   run-bench:
-    name: Run benchmark e2e tests - ${{ github.event.inputs.spicepod_path | split("/") | last | split(".")[0] }}
+    name: Run benchmark e2e tests
     runs-on: ${{ github.event.inputs.runner_type }}
     timeout-minutes: 600
     steps:
@@ -95,7 +95,15 @@ jobs:
             echo "MYSQL_DB=tpch_sf1" >> $GITHUB_ENV
           fi
 
-      - name: Run the benchmark test
+      - name: Extract spicepod filename path
+        id: extract_spicepod_filename
+        run: |
+          SPICEPOD_PATH="${{ github.event.inputs.spicepod_path }}"
+          SPICEPOD_FILENAME=$(basename $SPICEPOD_PATH)
+          echo "SPICEPOD_FILENAME=${SPICEPOD_FILENAME}" >> $GITHUB_OUTPUT
+
+
+      - name: Run the benchmark test - ${{ steps.extract_spicepod_filename.outputs.SPICEPOD_FILENAME }}
         if: ${{ github.event.inputs.query_overrides == '' }}
         run: |
           rm -rf .spice/data
@@ -133,7 +141,7 @@ jobs:
           DREMIO_PASSWORD: ${{ secrets.SPICE_DREMIO_PASSWORD}}
           INSTA_UPDATE: ${{ github.event.inputs.update_snapshots}}
 
-      - name: Run the benchmark test (with overrides)
+      - name: Run the benchmark test (with overrides) - ${{ steps.extract_spicepod_filename.outputs.SPICEPOD_FILENAME }}
         if: ${{ github.event.inputs.query_overrides != '' }}
         run: |
           rm -rf .spice/data

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -1,4 +1,4 @@
-name: benchmark e2e tests - ${{ github.event.inputs.spicepod_path | split("/") | last | split(".")[0] }}
+name: benchmark e2e tests
 
 on:
   workflow_dispatch:
@@ -61,7 +61,7 @@ on:
 
 jobs:
   run-bench:
-    name: Run benchmark e2e tests
+    name: Run benchmark e2e tests - ${{ github.event.inputs.spicepod_path | split("/") | last | split(".")[0] }}
     runs-on: ${{ github.event.inputs.runner_type }}
     timeout-minutes: 600
     steps:

--- a/tools/testoperator/dispatch/clickbench/accelerated/on_zero_results/file_duckdb_file.yaml
+++ b/tools/testoperator/dispatch/clickbench/accelerated/on_zero_results/file_duckdb_file.yaml
@@ -3,3 +3,4 @@ tests:
     spicepod_path: ./test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_file.yaml
     query_set: clickbench
     runner_type: spiceai-large-runners
+    ready_wait: 1800

--- a/tools/testoperator/dispatch/clickbench/accelerated/on_zero_results/file_duckdb_memory.yaml
+++ b/tools/testoperator/dispatch/clickbench/accelerated/on_zero_results/file_duckdb_memory.yaml
@@ -3,3 +3,4 @@ tests:
     spicepod_path: ./test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_memory.yaml
     query_set: clickbench
     runner_type: spiceai-large-runners
+    ready_wait: 1800

--- a/tools/testoperator/dispatch/clickbench/accelerated/s3_arrow.yaml
+++ b/tools/testoperator/dispatch/clickbench/accelerated/s3_arrow.yaml
@@ -3,3 +3,4 @@ tests:
     spicepod_path: ./test/spicepods/clickbench/accelerated/s3_arrow.yaml
     query_set: clickbench
     runner_type: spiceai-large-runners
+    ready_wait: 1800

--- a/tools/testoperator/dispatch/clickbench/accelerated/s3_duckdb_file.yaml
+++ b/tools/testoperator/dispatch/clickbench/accelerated/s3_duckdb_file.yaml
@@ -3,3 +3,4 @@ tests:
     spicepod_path: ./test/spicepods/clickbench/accelerated/s3_duckdb_file.yaml
     query_set: clickbench
     runner_type: spiceai-large-runners
+    ready_wait: 1800

--- a/tools/testoperator/dispatch/clickbench/accelerated/s3_duckdb_memory.yaml
+++ b/tools/testoperator/dispatch/clickbench/accelerated/s3_duckdb_memory.yaml
@@ -3,3 +3,4 @@ tests:
     spicepod_path: ./test/spicepods/clickbench/accelerated/s3_duckdb_memory.yaml
     query_set: clickbench
     runner_type: spiceai-large-runners
+    ready_wait: 1800

--- a/tools/testoperator/dispatch/clickbench/accelerated/s3_sqlite_file.yaml
+++ b/tools/testoperator/dispatch/clickbench/accelerated/s3_sqlite_file.yaml
@@ -3,3 +3,4 @@ tests:
     spicepod_path: ./test/spicepods/clickbench/accelerated/s3_sqlite_file.yaml
     query_set: clickbench
     runner_type: spiceai-large-runners
+    ready_wait: 1800

--- a/tools/testoperator/dispatch/clickbench/accelerated/s3_sqlite_memory.yaml
+++ b/tools/testoperator/dispatch/clickbench/accelerated/s3_sqlite_memory.yaml
@@ -3,3 +3,4 @@ tests:
     spicepod_path: ./test/spicepods/clickbench/accelerated/s3_sqlite_memory.yaml
     query_set: clickbench
     runner_type: spiceai-large-runners
+    ready_wait: 1800


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Disables the benchmarks runner schedule
* Enables a schedule for the testoperator to run benchmarks
* Some misc fixes for ClickBench testoperator `ready_wait` parameters
* a QoL fix for the testoperator bench workflow to include the relative spicepod filename in the step name

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4114 
