### PR TITLE
Add ENVs to MCP tools, and support nested secrets for tool params

### DIFF
--- a/crates/runtime/src/init/tool.rs
+++ b/crates/runtime/src/init/tool.rs
@@ -14,15 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
-    get_params_with_secrets, metrics, status,
+    metrics, status,
     tools::{self, factory::default_available_catalogs, Tooling},
     Runtime, SpiceToolCatalog, UnableToInitializeLlmToolSnafu,
 };
 use opentelemetry::KeyValue;
-use secrecy::SecretString;
 use snafu::ResultExt;
 use spicepod::component::tool::Tool;
 
@@ -74,10 +73,8 @@ impl Runtime {
     async fn load_tool(&self, tool: &Tool) {
         self.status
             .update_tool(&tool.name, status::ComponentStatus::Initializing);
-        let params_with_secrets: HashMap<String, SecretString> =
-            get_params_with_secrets(self.secrets(), &tool.params).await;
 
-        match tools::factory::forge(tool, params_with_secrets)
+        match tools::factory::forge(tool, self.secrets())
             .await
             .context(UnableToInitializeLlmToolSnafu)
         {

--- a/crates/runtime/src/tools/builtin/catalog.rs
+++ b/crates/runtime/src/tools/builtin/catalog.rs
@@ -19,9 +19,14 @@ use secrecy::{ExposeSecret, SecretString};
 use snafu::{ResultExt, Snafu};
 use spicepod::component::tool::Tool;
 use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
 
-use crate::tools::{
-    catalog::SpiceToolCatalog, factory::IndividualToolFactory, options::SpiceToolsOptions,
+use crate::{
+    get_params_with_secrets, secrets,
+    tools::{
+        catalog::SpiceToolCatalog, factory::IndividualToolFactory, options::SpiceToolsOptions,
+        utils::downgrade_values_to_strings,
+    },
 };
 
 use super::{
@@ -94,16 +99,20 @@ impl BuiltinToolCatalog {
     }
 }
 
+#[async_trait]
 impl IndividualToolFactory for BuiltinToolCatalog {
-    fn construct(
+    async fn construct(
         &self,
         component: &Tool,
-        params_with_secrets: HashMap<String, SecretString>,
+        secrets: Arc<RwLock<secrets::Secrets>>,
     ) -> Result<Arc<dyn SpiceModelTool>, Box<dyn std::error::Error + Send + Sync>> {
         let id = component
             .from
             .split_once(':')
             .map_or(component.from.as_str(), |(_, id)| id);
+
+        let params = downgrade_values_to_strings(&component.params);
+        let params_with_secrets = get_params_with_secrets(secrets, &params).await;
 
         Self::construct_builtin(
             id,

--- a/crates/runtime/src/tools/factory/mod.rs
+++ b/crates/runtime/src/tools/factory/mod.rs
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use async_trait::async_trait;
-use secrecy::SecretString;
 use spicepod::component::tool::Tool;
 use std::{
     collections::HashMap,
     sync::{Arc, LazyLock},
 };
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
+
+use crate::secrets;
 
 #[cfg(feature = "mcp")]
 use super::mcp::factory::McpCatalogFactory;
@@ -39,14 +40,11 @@ impl ToolFactory {
     async fn construct(
         &self,
         component: &Tool,
-        params_with_secrets: HashMap<String, SecretString>,
+        secrets: Arc<RwLock<secrets::Secrets>>,
     ) -> Result<Tooling, Box<dyn std::error::Error + Send + Sync>> {
         match self {
-            ToolFactory::Catalog(c) => c
-                .construct(component, params_with_secrets)
-                .await
-                .map(Into::into),
-            ToolFactory::Tool(t) => t.construct(component, params_with_secrets).map(Into::into),
+            ToolFactory::Catalog(c) => c.construct(component, secrets).await.map(Into::into),
+            ToolFactory::Tool(t) => t.construct(component, secrets).await.map(Into::into),
         }
     }
 }
@@ -64,11 +62,12 @@ impl From<Arc<dyn IndividualToolFactory>> for ToolFactory {
 }
 
 /// A factory that can create individual [`SpiceModelTool`]s from a spicepod [`Tool`] component.
+#[async_trait]
 pub trait IndividualToolFactory: Send + Sync {
-    fn construct(
+    async fn construct(
         &self,
         component: &Tool,
-        params_with_secrets: HashMap<String, SecretString>,
+        secrets: Arc<RwLock<secrets::Secrets>>,
     ) -> Result<Arc<dyn SpiceModelTool>, Box<dyn std::error::Error + Send + Sync>>;
 }
 
@@ -78,7 +77,7 @@ pub trait ToolCatalogFactory: Send + Sync {
     async fn construct(
         &self,
         component: &Tool,
-        params_with_secrets: HashMap<String, SecretString>,
+        secrets: Arc<RwLock<secrets::Secrets>>,
     ) -> Result<Arc<dyn SpiceToolCatalog>, Box<dyn std::error::Error + Send + Sync>>;
 }
 
@@ -120,7 +119,7 @@ pub fn default_available_catalogs() -> Vec<Arc<dyn SpiceToolCatalog>> {
 #[allow(clippy::implicit_hasher)]
 pub async fn forge(
     component: &Tool,
-    secrets: HashMap<String, SecretString>,
+    secrets: Arc<RwLock<secrets::Secrets>>,
 ) -> Result<Tooling, Box<dyn std::error::Error + Send + Sync>> {
     let from_source = component
         .from

--- a/crates/runtime/src/tools/mcp/catalog.rs
+++ b/crates/runtime/src/tools/mcp/catalog.rs
@@ -123,8 +123,8 @@ impl McpToolCatalog {
         cfg: &MCPConfig,
     ) -> std::result::Result<RwLock<Box<dyn McpClientTrait>>, TransportError> {
         match cfg {
-            MCPConfig::Stdio { command, args } => {
-                Self::stdio_client(command.as_str(), args.clone()).await
+            MCPConfig::Stdio { command, args, env } => {
+                Self::stdio_client(command.as_str(), args, env).await
             }
             MCPConfig::Https { url } => Self::https_client(url.clone()).await,
         }
@@ -132,9 +132,10 @@ impl McpToolCatalog {
 
     async fn stdio_client(
         command: &str,
-        args: Option<Vec<String>>,
+        args: &[String],
+        env: &HashMap<String, String>,
     ) -> std::result::Result<RwLock<Box<dyn McpClientTrait>>, TransportError> {
-        let transport = StdioTransport::new(command, args.unwrap_or_default(), HashMap::new());
+        let transport = StdioTransport::new(command, args.to_vec(), env.clone());
         let transport_handle = transport.start().await?;
         let service = McpService::with_timeout(transport_handle, Duration::from_secs(10));
         Ok(RwLock::new(Box::new(McpClient::new(service))))

--- a/crates/runtime/src/tools/mcp/factory.rs
+++ b/crates/runtime/src/tools/mcp/factory.rs
@@ -15,13 +15,16 @@ limitations under the License.
 */
 
 use async_trait::async_trait;
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
+use tokio::sync::RwLock;
 
-use secrecy::SecretString;
 use snafu::ResultExt;
 use spicepod::component::tool::Tool;
 
-use crate::tools::{catalog::SpiceToolCatalog, factory::ToolCatalogFactory};
+use crate::{
+    secrets,
+    tools::{catalog::SpiceToolCatalog, factory::ToolCatalogFactory},
+};
 
 use super::{catalog::McpToolCatalog, MCPConfig, MCPType};
 
@@ -32,7 +35,7 @@ impl ToolCatalogFactory for McpCatalogFactory {
     async fn construct(
         &self,
         component: &Tool,
-        params_with_secrets: HashMap<String, SecretString>,
+        secrets: Arc<RwLock<secrets::Secrets>>,
     ) -> Result<Arc<dyn SpiceToolCatalog>, Box<dyn std::error::Error + Send + Sync>> {
         let Some(("mcp", id)) = component.from.split_once(':') else {
             return Err(format!(
@@ -43,7 +46,7 @@ impl ToolCatalogFactory for McpCatalogFactory {
         };
 
         let mcp_type = MCPType::from_str(id)?;
-        let cfg = MCPConfig::from_type(&mcp_type, &params_with_secrets);
+        let cfg = MCPConfig::from_type(&mcp_type, &component.params, &secrets).await;
 
         let ctlg = McpToolCatalog::try_new(cfg, component.name.as_str())
             .await

--- a/crates/runtime/src/tools/mcp/mod.rs
+++ b/crates/runtime/src/tools/mcp/mod.rs
@@ -19,12 +19,18 @@ pub mod factory;
 pub mod server;
 pub mod tool;
 
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use mcp_client::{transport::Error as TransportError, Error as McpError};
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use snafu::Snafu;
+use tokio::sync::RwLock;
+
+use crate::secrets;
+
+use super::utils::{get_secret_map, get_secret_string};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -77,28 +83,43 @@ impl FromStr for MCPType {
 pub(crate) enum MCPConfig {
     Stdio {
         command: String,
-        args: Option<Vec<String>>,
+        args: Vec<String>,
+        env: HashMap<String, String>,
     },
     Https {
         url: url::Url,
     },
 }
 impl MCPConfig {
-    fn from_type(mcp_type: &MCPType, params: &HashMap<String, SecretString>) -> Self {
+    async fn from_type(
+        mcp_type: &MCPType,
+        params: &HashMap<String, Value>,
+        secrets: &Arc<RwLock<secrets::Secrets>>,
+    ) -> Self {
         match mcp_type {
-            MCPType::Stdio(command) => match params.get("mcp_args") {
-                Some(args) => {
-                    let args = ExposeSecret::expose_secret(args);
-                    Self::Stdio {
-                        command: command.clone(),
-                        args: Some(args.split_whitespace().map(ToString::to_string).collect()),
-                    }
-                }
-                None => Self::Stdio {
+            MCPType::Stdio(command) => {
+                let args: Vec<String> = get_secret_string("mcp_args", params, secrets)
+                    .await
+                    .map(|s| s.expose_secret().to_string())
+                    .unwrap_or_default()
+                    .split_whitespace()
+                    .map(ToString::to_string)
+                    .collect();
+
+                let env = match get_secret_map("mcp_env", params, secrets).await {
+                    Some(envs) => envs
+                        .iter()
+                        .map(|(k, v)| (k.clone(), ExposeSecret::expose_secret(v).to_string()))
+                        .collect(),
+                    None => HashMap::new(),
+                };
+
+                Self::Stdio {
                     command: command.clone(),
-                    args: None,
-                },
-            },
+                    args,
+                    env,
+                }
+            }
             MCPType::Https(url) => Self::Https { url: url.clone() },
         }
     }

--- a/crates/runtime/src/tools/memory/catalog.rs
+++ b/crates/runtime/src/tools/memory/catalog.rs
@@ -15,13 +15,16 @@ limitations under the License.
 */
 
 use async_trait::async_trait;
-use secrecy::SecretString;
 use spicepod::component::tool::Tool;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
-use crate::tools::{
-    catalog::SpiceToolCatalog, factory::IndividualToolFactory, memory::store::StoreMemoryTool,
-    SpiceModelTool,
+use crate::{
+    secrets,
+    tools::{
+        catalog::SpiceToolCatalog, factory::IndividualToolFactory, memory::store::StoreMemoryTool,
+        SpiceModelTool,
+    },
 };
 
 use super::load::LoadMemoryTool;
@@ -43,11 +46,12 @@ impl MemoryToolCatalog {
     }
 }
 
+#[async_trait]
 impl IndividualToolFactory for MemoryToolCatalog {
-    fn construct(
+    async fn construct(
         &self,
         component: &Tool,
-        _params_with_secrets: HashMap<String, SecretString>,
+        _secrets: Arc<RwLock<secrets::Secrets>>,
     ) -> Result<Arc<dyn SpiceModelTool>, Box<dyn std::error::Error + Send + Sync>> {
         let Some(("memory", id)) = component.from.split_once(':') else {
             return Err(format!(
@@ -56,7 +60,6 @@ impl IndividualToolFactory for MemoryToolCatalog {
             )
             .into());
         };
-
         Self::get_tool(
             id,
             Some(component.name.as_str()),

--- a/crates/runtime/src/tools/utils.rs
+++ b/crates/runtime/src/tools/utils.rs
@@ -22,11 +22,16 @@ use async_openai::{
     },
 };
 use schemars::{schema_for, JsonSchema};
+use secrecy::SecretString;
 use serde::Serialize;
 use serde_json::Value;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
 
-use crate::Runtime;
+use crate::{
+    secrets::{self, ParamStr},
+    Runtime,
+};
 
 use super::{options::SpiceToolsOptions, SpiceModelTool, Tooling};
 
@@ -118,4 +123,54 @@ pub async fn get_tools(rt: Arc<Runtime>, opts: &SpiceToolsOptions) -> Vec<Arc<dy
     }
 
     tools
+}
+
+pub(crate) fn downgrade_values_to_strings(
+    params: &HashMap<String, serde_json::Value>,
+) -> HashMap<String, String> {
+    params
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.clone(),
+                match v {
+                    serde_json::Value::String(s) => s.to_string(),
+                    _ => v.to_string(),
+                },
+            )
+        })
+        .collect()
+}
+
+pub(crate) async fn get_secret_string(
+    key: &str,
+    params: &HashMap<String, Value>,
+    secrets: &Arc<RwLock<secrets::Secrets>>,
+) -> Option<SecretString> {
+    if let Some(Value::String(value)) = params.get(key) {
+        let secret_lock = secrets.read().await;
+        let s = secret_lock.inject_secrets(key, ParamStr(value)).await;
+        Some(s)
+    } else {
+        None
+    }
+}
+
+pub(crate) async fn get_secret_map(
+    key: &str,
+    params: &HashMap<String, Value>,
+    secrets: &Arc<RwLock<secrets::Secrets>>,
+) -> Option<HashMap<String, SecretString>> {
+    let Some(Value::Object(value)) = params.get(key) else {
+        return None;
+    };
+    let mut result = HashMap::new();
+    let secret_lock = secrets.read().await;
+    for (k, v) in value {
+        if let Value::String(v) = v {
+            let s = secret_lock.inject_secrets(k, ParamStr(v)).await;
+            result.insert(k.clone(), s);
+        }
+    }
+    Some(result)
 }

--- a/crates/spicepod/src/component/tool.rs
+++ b/crates/spicepod/src/component/tool.rs
@@ -20,6 +20,7 @@ use super::{Nameable, WithDependsOn};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
@@ -30,7 +31,7 @@ pub struct Tool {
     pub description: Option<String>,
 
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub params: HashMap<String, String>,
+    pub params: HashMap<String, Value>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "dependsOn", default)]


### PR DESCRIPTION
# 🗣 Description
Two significant changes to improve MCP:
1. Enable users to provide environment variables to stdio MCP processes (via `params.mcp_env`).
2. Enable nested values, and resolving of secrets, in tool params. 

These two changes allow us to do the following:
```yaml
tools:
  - name: maps
    from: mcp:npx
    params:
      mcp_args: -y @modelcontextprotocol/server-google-maps
      mcp_env:
        GOOGLE_MAPS_API_KEY: ${ secrets:SPICE_GOOGLE_MAPS_API_KEY }
```

## 🔨 Related Issues
- #4015

## 📄 Documentation Updates
 - [ ] Add `mcp_env` to MCP tool docs
