### PR TITLE
fix: Use RefreshOverrides for the refresh API definition

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -96,7 +96,7 @@ pub struct RefreshOverrides {
         rename = "refresh_jitter_max",
         deserialize_with = "parse_max_jitter"
     )]
-    #[schema(value_type = Option<String>, example = "10s")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = "10s"))]
     pub max_jitter: Option<Duration>,
 }
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -80,18 +80,23 @@ pub struct Refresh {
 
 /// [`RefreshOverrides`] specifies the configurable options for a individual run of a refresh task.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RefreshOverrides {
+    /// The SQL statement used for this refresh. Defaults to the `refresh_sql` specified in the spicepod, if any.
     #[serde(default, rename = "refresh_sql")]
     pub sql: Option<String>,
 
+    /// The refresh mode to use for this refresh. Defaults to the `refresh_mode` specified in the spicepod, or `full`.
     #[serde(default, rename = "refresh_mode")]
     pub mode: Option<RefreshMode>,
 
+    /// The maximum amount of jitter to add to the refresh. Defaults to the `refresh_jitter_max` specified in the spicepod, or 10% of the `refresh_check_interval`.
     #[serde(
         default,
         rename = "refresh_jitter_max",
         deserialize_with = "parse_max_jitter"
     )]
+    #[schema(value_type = Option<String>, example = "10s")]
     pub max_jitter: Option<Duration>,
 }
 

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -24,6 +24,7 @@ pub mod on_conflict;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum RefreshMode {
     Disabled,
     Full,

--- a/crates/runtime/src/http/v1/datasets.rs
+++ b/crates/runtime/src/http/v1/datasets.rs
@@ -225,9 +225,11 @@ pub struct AccelerationRequest {
     request_body(
         description = "On-demand refresh request for a specific dataset.",
         content((
-            AccelerationRequest = "application/json",
+            RefreshOverrides = "application/json",
             example = json!({
-                "refresh_sql": "SELECT * FROM taxi_trips WHERE tip_amount > 10.0"
+                "refresh_sql": "SELECT * FROM taxi_trips WHERE tip_amount > 10.0",
+                "refresh_mode": "full",
+                "refresh_jitter_max": "10s"
             })
         ))
     ),


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* [`crates/runtime/src/accelerated_table/refresh.rs`](diffhunk://#diff-fc6c4697d8c3043b806c6861fb6e426c7c4cd15208f51c115e41b956065f563dR83-R99): Added `utoipa::ToSchema` derivation to the `RefreshOverrides` struct and included detailed documentation for the request fields `refresh_sql`, `refresh_mode`, and `refresh_jitter_max`.
* [`crates/runtime/src/component/dataset/acceleration.rs`](diffhunk://#diff-06a609276374dc5843d7d4aabfe2103557bfdbaae8789fe2708d3b4b397e7433R27): Added `utoipa::ToSchema` derivation to the `RefreshMode` enum.

Updates to example requests:

* [`crates/runtime/src/http/v1/datasets.rs`](diffhunk://#diff-f9566632e29ee7f608e91f1265776f1692986c0bddf7f5f1f2998e1a17965e4fL228-R232): Updated the OpenAPI route body type for refreshes to `RefreshOverrides` - instead of the invalid `AccelerationRequest`, which is not used in this route.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of https://github.com/spiceai/docs/issues/817
