### PR TITLE
add env variables to tools, usable in MCP stdio

### DIFF
--- a/crates/runtime/src/init/tool.rs
+++ b/crates/runtime/src/init/tool.rs
@@ -77,7 +77,10 @@ impl Runtime {
         let params_with_secrets: HashMap<String, SecretString> =
             get_params_with_secrets(self.secrets(), &tool.params).await;
 
-        match tools::factory::forge(tool, params_with_secrets)
+        let env_with_secrets: HashMap<String, SecretString> =
+            get_params_with_secrets(self.secrets(), &tool.env).await;
+
+        match tools::factory::forge(tool, params_with_secrets, env_with_secrets)
             .await
             .context(UnableToInitializeLlmToolSnafu)
         {

--- a/crates/runtime/src/tools/factory/mod.rs
+++ b/crates/runtime/src/tools/factory/mod.rs
@@ -40,10 +40,11 @@ impl ToolFactory {
         &self,
         component: &Tool,
         params_with_secrets: HashMap<String, SecretString>,
+        env: HashMap<String, SecretString>,
     ) -> Result<Tooling, Box<dyn std::error::Error + Send + Sync>> {
         match self {
             ToolFactory::Catalog(c) => c
-                .construct(component, params_with_secrets)
+                .construct(component, params_with_secrets, env)
                 .await
                 .map(Into::into),
             ToolFactory::Tool(t) => t.construct(component, params_with_secrets).map(Into::into),
@@ -79,6 +80,7 @@ pub trait ToolCatalogFactory: Send + Sync {
         &self,
         component: &Tool,
         params_with_secrets: HashMap<String, SecretString>,
+        env: HashMap<String, SecretString>,
     ) -> Result<Arc<dyn SpiceToolCatalog>, Box<dyn std::error::Error + Send + Sync>>;
 }
 
@@ -121,6 +123,7 @@ pub fn default_available_catalogs() -> Vec<Arc<dyn SpiceToolCatalog>> {
 pub async fn forge(
     component: &Tool,
     secrets: HashMap<String, SecretString>,
+    env: HashMap<String, SecretString>,
 ) -> Result<Tooling, Box<dyn std::error::Error + Send + Sync>> {
     let from_source = component
         .from
@@ -130,7 +133,7 @@ pub async fn forge(
     let registry = TOOL_SHED_FACTORY.lock().await;
 
     match registry.get(from_source) {
-        Some(factory) => factory.construct(component, secrets).await,
+        Some(factory) => factory.construct(component, secrets, env).await,
         None => Err(format!("Tool factory not found for source: {from_source}").into()),
     }
 }

--- a/crates/runtime/src/tools/mcp/catalog.rs
+++ b/crates/runtime/src/tools/mcp/catalog.rs
@@ -123,8 +123,8 @@ impl McpToolCatalog {
         cfg: &MCPConfig,
     ) -> std::result::Result<RwLock<Box<dyn McpClientTrait>>, TransportError> {
         match cfg {
-            MCPConfig::Stdio { command, args } => {
-                Self::stdio_client(command.as_str(), args.clone()).await
+            MCPConfig::Stdio { command, args, env } => {
+                Self::stdio_client(command.as_str(), args, env).await
             }
             MCPConfig::Https { url } => Self::https_client(url.clone()).await,
         }
@@ -132,9 +132,10 @@ impl McpToolCatalog {
 
     async fn stdio_client(
         command: &str,
-        args: Option<Vec<String>>,
+        args: &[String],
+        env: &HashMap<String, String>,
     ) -> std::result::Result<RwLock<Box<dyn McpClientTrait>>, TransportError> {
-        let transport = StdioTransport::new(command, args.unwrap_or_default(), HashMap::new());
+        let transport = StdioTransport::new(command, args.to_vec(), env.clone());
         let transport_handle = transport.start().await?;
         let service = McpService::with_timeout(transport_handle, Duration::from_secs(10));
         Ok(RwLock::new(Box::new(McpClient::new(service))))

--- a/crates/runtime/src/tools/mcp/factory.rs
+++ b/crates/runtime/src/tools/mcp/factory.rs
@@ -33,6 +33,7 @@ impl ToolCatalogFactory for McpCatalogFactory {
         &self,
         component: &Tool,
         params_with_secrets: HashMap<String, SecretString>,
+        env: HashMap<String, SecretString>,
     ) -> Result<Arc<dyn SpiceToolCatalog>, Box<dyn std::error::Error + Send + Sync>> {
         let Some(("mcp", id)) = component.from.split_once(':') else {
             return Err(format!(
@@ -43,7 +44,7 @@ impl ToolCatalogFactory for McpCatalogFactory {
         };
 
         let mcp_type = MCPType::from_str(id)?;
-        let cfg = MCPConfig::from_type(&mcp_type, &params_with_secrets);
+        let cfg = MCPConfig::from_type(&mcp_type, &params_with_secrets, &env);
 
         let ctlg = McpToolCatalog::try_new(cfg, component.name.as_str())
             .await

--- a/crates/runtime/src/tools/mcp/mod.rs
+++ b/crates/runtime/src/tools/mcp/mod.rs
@@ -77,29 +77,37 @@ impl FromStr for MCPType {
 pub(crate) enum MCPConfig {
     Stdio {
         command: String,
-        args: Option<Vec<String>>,
+        args: Vec<String>,
+        env: HashMap<String, String>,
     },
     Https {
         url: url::Url,
     },
 }
 impl MCPConfig {
-    fn from_type(mcp_type: &MCPType, params: &HashMap<String, SecretString>) -> Self {
-        match mcp_type {
-            MCPType::Stdio(command) => match params.get("mcp_args") {
-                Some(args) => {
-                    let args = ExposeSecret::expose_secret(args);
-                    Self::Stdio {
-                        command: command.clone(),
-                        args: Some(args.split_whitespace().map(ToString::to_string).collect()),
-                    }
-                }
-                None => Self::Stdio {
-                    command: command.clone(),
-                    args: None,
-                },
-            },
-            MCPType::Https(url) => Self::Https { url: url.clone() },
+    fn from_type(
+        mcp_type: &MCPType,
+        params: &HashMap<String, SecretString>,
+        env: &HashMap<String, SecretString>,
+    ) -> Self {
+        match mcp_type.clone() {
+            MCPType::Stdio(command) => {
+                let args = params
+                    .get("mcp_args")
+                    .map(ExposeSecret::expose_secret)
+                    .unwrap_or_default()
+                    .split_whitespace()
+                    .map(ToString::to_string)
+                    .collect();
+
+                let env = env
+                    .iter()
+                    .map(|(k, v)| (k.clone(), ExposeSecret::expose_secret(v).to_string()))
+                    .collect();
+
+                Self::Stdio { command, args, env }
+            }
+            MCPType::Https(url) => Self::Https { url },
         }
     }
 }

--- a/crates/spicepod/src/component/tool.rs
+++ b/crates/spicepod/src/component/tool.rs
@@ -32,6 +32,9 @@ pub struct Tool {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub params: HashMap<String, String>,
 
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(rename = "dependsOn", default)]
     pub depends_on: Vec<String>,
@@ -50,6 +53,7 @@ impl WithDependsOn<Tool> for Tool {
             name: self.name.clone(),
             description: self.description.clone(),
             params: self.params.clone(),
+            env: self.env.clone(),
             depends_on: depends_on.to_vec(),
         }
     }


### PR DESCRIPTION
# 🗣 Description
1. Enable users to provide environment variables to stdio MCP processes.
2. Add `tools.env` to spicepod component definition.

These two changes allow us to do the following:
```yaml
tools:
  - name: maps
    from: mcp:npx
    params:
      mcp_args: -y @modelcontextprotocol/server-google-maps
    env:
        GOOGLE_MAPS_API_KEY: ${ secrets:SPICE_GOOGLE_MAPS_API_KEY }
```

## 🔨 Related Issues
- #4015

## 📄 Documentation Updates
 - [x] Add `tools.env` to tool docs
 - [x] Add details of stdio env variable to MCP tools docs.