### PR TITLE
fix: Increase tries for refresh_status_change_to_ready test

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -933,7 +933,7 @@ mod tests {
             wait_until_ready_status(
                 &registry,
                 status::ComponentStatus::Ready,
-                30,
+                60,
                 Duration::from_millis(50)
             )
             .await,
@@ -951,7 +951,7 @@ mod tests {
             wait_until_ready_status(
                 &registry,
                 status::ComponentStatus::Ready,
-                20,
+                60,
                 Duration::from_millis(50)
             )
             .await,


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Increases the number of retries for the `test_refresh_status_change_to_ready` test, effectively increasing the wait from 1.5s to 3s.
