### PR TITLE
Use fixed data directory for test operator

### DIFF
--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -38,17 +38,15 @@ pub async fn record_explain_plan(
     let mut assertion_err: Option<String> = None;
 
     let temp_dir = std::env::temp_dir();
-
-    println!("Temp dir: {:?}", temp_dir);
     let temp_dir_str = temp_dir.to_str().unwrap_or_default();
-    let temp_dir_clean = temp_dir_str.trim_end_matches('/');
+    let temp_dir_clean = temp_dir_str.trim_end_matches('/').trim_start_matches('/');
     let temp_dir_pattern = regex::escape(temp_dir_clean);
 
-    // Match two patterns:
-    // 1. Exact match starting with the temp_dir: {temp_dir}/dir1/data
-    // 2. (macos) Match with "private" prefix: private{temp_dir}/dir1/data
+    // Create two patterns:
+    // 1. Exact match starting with the temp_dir: {temp_dir}/some_dir/data
+    // 2. Match with "private" prefix: private{temp_dir}/some_dir/data
     let path_filter_pattern =
-        format!(r"(?:{temp_dir_pattern}|private{temp_dir_pattern})/[^/]*/data",);
+        format!(r"(?:{temp_dir_pattern}|private/{temp_dir_pattern})/[^/]*/data",);
 
     insta::with_settings!({
         description => format!("Query: {query_name}"),

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -38,6 +38,8 @@ pub async fn record_explain_plan(
     let mut assertion_err: Option<String> = None;
 
     let temp_dir = std::env::temp_dir();
+
+    println!("Temp dir: {:?}", temp_dir);
     let temp_dir_str = temp_dir.to_str().unwrap_or_default();
     let temp_dir_clean = temp_dir_str.trim_end_matches('/');
     let temp_dir_pattern = regex::escape(temp_dir_clean);

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -71,3 +71,43 @@ pub async fn record_explain_plan(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_temp_dir_regex_pattern() -> Result<(), String> {
+        let test_cases = [
+            // Test case 1: Mac temp dir path without leading path
+            (
+                "/var/folders/hs/xq6mn_y9293d05rw5bvhfm_c0000gn/T/",
+                "var/folders/hs/xq6mn_y9293d05rw5bvhfm_c0000gn/T/.tmpGbYR27/data/partsupp.parquet:3474778..5212167",
+                "/data/partsupp.parquet:3474778..5212167",
+            ),
+            // Test case 2: Mac temp dir path with leading path
+            (
+                "/var/folders/hs/xq6mn_y9293d05rw5bvhfm_c0000gn/T/",
+                "private/var/folders/hs/xq6mn_y9293d05rw5bvhfm_c0000gn/T/.tmpGbYR27/data/partsupp.parquet:3474778..5212167",
+                "/data/partsupp.parquet:3474778..5212167",
+            ),
+            // Test case 3: Linux temp dir path
+            (
+                "/tmp",
+                "tmp/.tmpJ1DebA/data/orders.parquet:0..2311466",
+                "/data/orders.parquet:0..2311466",
+            ),
+        ];
+
+        for (tmp_dir, input, expected) in test_cases {
+            let temp_dir_clean = tmp_dir.trim_end_matches('/').trim_start_matches('/');
+            let temp_dir_pattern = regex::escape(temp_dir_clean);
+            let path_filter_pattern =
+                format!(r"(?:{temp_dir_pattern}|private/{temp_dir_pattern})/[^/]*/data",);
+
+            let regex = regex::Regex::new(&path_filter_pattern).map_err(|e| format!("{e}"))?;
+            let result = regex.replace(input, "/data");
+            assert_eq!(result, expected, "Failed for input: {input}");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -37,11 +37,23 @@ pub async fn record_explain_plan(
 
     let mut assertion_err: Option<String> = None;
 
+    let temp_dir = std::env::temp_dir();
+    let temp_dir_str = temp_dir.to_str().unwrap_or_default();
+    let temp_dir_clean = temp_dir_str.trim_end_matches('/');
+    let temp_dir_pattern = regex::escape(temp_dir_clean);
+
+    // Match two patterns:
+    // 1. Exact match starting with the temp_dir: {temp_dir}/dir1/data
+    // 2. (macos) Match with "private" prefix: private{temp_dir}/dir1/data
+    let path_filter_pattern =
+        format!(r"(?:{temp_dir_pattern}|private{temp_dir_pattern})/[^/]*/data",);
+
     insta::with_settings!({
         description => format!("Query: {query_name}"),
         omit_expression => true,
         snapshot_path => "snapshots/explain",
         filters => vec![
+            (path_filter_pattern.as_str(), "/data"),
             (r"required_guarantees=\[[^\]]*\]", "required_guarantees=[N]"),
         ],
     }, {

--- a/crates/test-framework/src/spiced/mod.rs
+++ b/crates/test-framework/src/spiced/mod.rs
@@ -24,29 +24,43 @@ use anyhow::Result;
 use flight_client::{Credentials, FlightClient};
 use spicepod::spec::SpicepodDefinition;
 use sysinfo::{Pid, ProcessesToUpdate, System};
-use tempfile::TempDir;
 
 use crate::utils::wait_until_true;
 
 pub struct SpicedInstance {
     child: Child,
-    tempdir: TempDir,
+    tempdir: PathBuf,
 }
 
 pub struct StartRequest {
     spiced_path: PathBuf,
     spicepod: SpicepodDefinition,
-    tempdir: TempDir,
+    tempdir: PathBuf,
     data_dir: Option<PathBuf>,
     prepared: bool,
 }
 
 impl StartRequest {
     pub fn new(spiced_path: PathBuf, spicepod: SpicepodDefinition) -> Result<Self> {
+        let tempdir = {
+            #[cfg(not(target_os = "windows"))]
+            {
+                let path = PathBuf::from("/tmp/spice_test_operator");
+                std::fs::create_dir_all(&path)?;
+                path
+            }
+            #[cfg(target_os = "windows")]
+            {
+                // For Windows, use the default temp directory
+                let path = TempDir::new()?;
+                path.path().to_path_buf()
+            }
+        };
+
         Ok(Self {
             spiced_path,
             spicepod,
-            tempdir: TempDir::new()?,
+            tempdir,
             prepared: false,
             data_dir: None,
         })
@@ -60,13 +74,13 @@ impl StartRequest {
 
     #[must_use]
     pub fn get_tempdir_path(&self) -> PathBuf {
-        self.tempdir.path().to_path_buf()
+        self.tempdir.clone()
     }
 
     pub fn prepare(&mut self) -> Result<()> {
         // Serialize spicepod to `spicepod.yaml` in the tempdir
         let spicepod_yaml = serde_yaml::to_string(&self.spicepod)?;
-        let spicepod_yaml_path = self.tempdir.path().join("spicepod.yaml");
+        let spicepod_yaml_path = self.tempdir.join("spicepod.yaml");
         std::fs::write(spicepod_yaml_path.clone(), spicepod_yaml)?;
 
         // Create a symlink to the data directory if one is set
@@ -74,7 +88,7 @@ impl StartRequest {
             // resolve the data directory path to an absolute path
             let data_dir = data_dir.canonicalize()?;
 
-            let data_dir_symlink = self.tempdir.path().join("data");
+            let data_dir_symlink = self.tempdir.join("data");
             #[cfg(not(target_os = "windows"))]
             {
                 std::os::unix::fs::symlink(data_dir, data_dir_symlink)?;
@@ -115,7 +129,7 @@ impl SpicedInstance {
 
         // Start the spiced instance
         let mut cmd = Command::new(start_request.spiced_path);
-        cmd.current_dir(tempdir.path());
+        cmd.current_dir(tempdir.clone());
         cmd.arg("--telemetry-enabled=false");
         let child = cmd.spawn()?;
 
@@ -124,7 +138,7 @@ impl SpicedInstance {
 
     #[must_use]
     pub fn get_tempdir_path(&self) -> PathBuf {
-        self.tempdir.path().to_path_buf()
+        self.tempdir.clone()
     }
 
     /// Get a flight client for the spiced instance

--- a/crates/test-framework/src/spiced/mod.rs
+++ b/crates/test-framework/src/spiced/mod.rs
@@ -24,43 +24,29 @@ use anyhow::Result;
 use flight_client::{Credentials, FlightClient};
 use spicepod::spec::SpicepodDefinition;
 use sysinfo::{Pid, ProcessesToUpdate, System};
+use tempfile::TempDir;
 
 use crate::utils::wait_until_true;
 
 pub struct SpicedInstance {
     child: Child,
-    tempdir: PathBuf,
+    tempdir: TempDir,
 }
 
 pub struct StartRequest {
     spiced_path: PathBuf,
     spicepod: SpicepodDefinition,
-    tempdir: PathBuf,
+    tempdir: TempDir,
     data_dir: Option<PathBuf>,
     prepared: bool,
 }
 
 impl StartRequest {
     pub fn new(spiced_path: PathBuf, spicepod: SpicepodDefinition) -> Result<Self> {
-        let tempdir = {
-            #[cfg(not(target_os = "windows"))]
-            {
-                let path = PathBuf::from("/tmp/spice_test_operator");
-                std::fs::create_dir_all(&path)?;
-                path
-            }
-            #[cfg(target_os = "windows")]
-            {
-                // For Windows, use the default temp directory
-                let path = TempDir::new()?;
-                path.path().to_path_buf()
-            }
-        };
-
         Ok(Self {
             spiced_path,
             spicepod,
-            tempdir,
+            tempdir: TempDir::new()?,
             prepared: false,
             data_dir: None,
         })
@@ -74,13 +60,13 @@ impl StartRequest {
 
     #[must_use]
     pub fn get_tempdir_path(&self) -> PathBuf {
-        self.tempdir.clone()
+        self.tempdir.path().to_path_buf()
     }
 
     pub fn prepare(&mut self) -> Result<()> {
         // Serialize spicepod to `spicepod.yaml` in the tempdir
         let spicepod_yaml = serde_yaml::to_string(&self.spicepod)?;
-        let spicepod_yaml_path = self.tempdir.join("spicepod.yaml");
+        let spicepod_yaml_path = self.tempdir.path().join("spicepod.yaml");
         std::fs::write(spicepod_yaml_path.clone(), spicepod_yaml)?;
 
         // Create a symlink to the data directory if one is set
@@ -88,7 +74,7 @@ impl StartRequest {
             // resolve the data directory path to an absolute path
             let data_dir = data_dir.canonicalize()?;
 
-            let data_dir_symlink = self.tempdir.join("data");
+            let data_dir_symlink = self.tempdir.path().join("data");
             #[cfg(not(target_os = "windows"))]
             {
                 std::os::unix::fs::symlink(data_dir, data_dir_symlink)?;
@@ -129,7 +115,7 @@ impl SpicedInstance {
 
         // Start the spiced instance
         let mut cmd = Command::new(start_request.spiced_path);
-        cmd.current_dir(tempdir.clone());
+        cmd.current_dir(tempdir.path());
         cmd.arg("--telemetry-enabled=false");
         let child = cmd.spawn()?;
 
@@ -138,7 +124,7 @@ impl SpicedInstance {
 
     #[must_use]
     pub fn get_tempdir_path(&self) -> PathBuf {
-        self.tempdir.clone()
+        self.tempdir.path().to_path_buf()
     }
 
     /// Get a flight client for the spiced instance


### PR DESCRIPTION
# 🗣 Description

Utilize the insta filter to get reliable snapshots for file data connectors, the temporary file paths will be converted to a consistent /data/some_file.parquet

file path is persistent after this change: https://github.com/spiceai/spiceai/actions/runs/13921456269/job/38955484474

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/5059

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns