### PR TITLE
fix: Fail testoperator on failed queries

### DIFF
--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -335,6 +335,15 @@ impl SpiceTest<Completed> {
 
         Ok(returned_row_counts)
     }
+
+    /// Returns true if every query status is passed. Returns false if any query status is failed.
+    #[must_use]
+    pub fn succeeded(&self) -> bool {
+        self.state
+            .query_statuses
+            .values()
+            .all(|status| status == &QueryStatus::Passed)
+    }
 }
 
 impl std::fmt::Display for SpiceTest<Completed> {

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -77,6 +77,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     let row_counts = test.validate_returned_row_counts()?;
     let metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Benchmark)?;
+    let test_succeeded = test.succeeded();
     let mut spiced_instance = test.end()?;
     let (max_memory, _) = observe_memory(memory_token, memory_readings).await?;
 
@@ -92,6 +93,13 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     }
 
     spiced_instance.stop()?;
+
+    if !test_succeeded {
+        return Err(anyhow::anyhow!(
+            "Benchmark test failed due to failed queries"
+        ));
+    }
+
     Ok(row_counts)
 }
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* When any query fails in a benchmark, return an error to get a failed action. Notably, return the error **after** uploading any metrics - so that we still get metrics for failures.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4114
