### PR TITLE
Make McpProxy trait for MCP passthrough

### DIFF
--- a/crates/runtime/src/tools/mcp/mod.rs
+++ b/crates/runtime/src/tools/mcp/mod.rs
@@ -21,9 +21,12 @@ pub mod tool;
 
 use std::{collections::HashMap, str::FromStr};
 
+use async_trait::async_trait;
 use mcp_client::{transport::Error as TransportError, Error as McpError};
+use mcp_core::protocol::CallToolResult;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use snafu::Snafu;
 
 #[derive(Debug, Snafu)]
@@ -110,4 +113,14 @@ impl MCPConfig {
             MCPType::Https(url) => Self::Https { url },
         }
     }
+}
+
+/// [`McpProxy`] is the minimal interface from [`mcp_client::McpClientTrait`] for tools that are fundamentally proxies around MCP tools.
+///
+/// This trait lets Spice pass through all details from the underlying MCP server in its (i.e. Spiced's) MCP server implementation.
+///
+#[async_trait]
+pub trait McpProxy: Send + Sync {
+    /// Unlike [`mcp_client::McpClientTrait`], the implementation should track the appropriate underlying tool name.
+    async fn call_tool(&self, arguments: Value) -> Result<CallToolResult, mcp_client::Error>;
 }

--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -96,6 +96,17 @@ impl mcp_server::Router for RuntimeServer {
             let Some(tool) = self.get_tool(tool_name.as_str()).await else {
                 return Err(ToolError::NotFound(format!("Tool {tool_name} not found")));
             };
+
+            // If possible, we pass the call through to the MCP server.
+            if let Some(mcp_proxy) = tool.as_mcp_proxy().await {
+                tracing::debug!("{tool_name} uses MCP. Will call directly");
+                return mcp_proxy
+                    .call_tool(arguments)
+                    .await
+                    .map(|r| r.content)
+                    .map_err(|e| ToolError::ExecutionError(e.to_string()));
+            }
+
             let args = serde_json::to_string(&arguments)
                 .map_err(|e| ToolError::InvalidParameters(e.to_string()))?;
 

--- a/crates/runtime/src/tools/mcp/tool.rs
+++ b/crates/runtime/src/tools/mcp/tool.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use async_trait::async_trait;
 use mcp_client::McpClientTrait;
-use mcp_core::Tool as McpTool;
+use mcp_core::{protocol::CallToolResult, Tool as McpTool};
 use serde_json::Value;
 use snafu::ResultExt;
 use std::{borrow::Cow, sync::Arc};
@@ -26,7 +26,7 @@ use tracing_futures::Instrument;
 
 use crate::{tools::SpiceModelTool, Runtime};
 
-use super::Result;
+use super::{McpProxy, Result};
 
 pub struct McpToolWrapper {
     client: Arc<RwLock<Box<dyn McpClientTrait>>>,
@@ -56,6 +56,10 @@ impl SpiceModelTool for McpToolWrapper {
 
     fn parameters(&self) -> Option<Value> {
         Some(self.spec.input_schema.clone())
+    }
+
+    async fn as_mcp_proxy(&self) -> Option<&dyn McpProxy> {
+        Some(self)
     }
 
     async fn call(
@@ -93,5 +97,13 @@ impl SpiceModelTool for McpToolWrapper {
                 Err(e)
             }
         }
+    }
+}
+
+#[async_trait]
+impl McpProxy for McpToolWrapper {
+    async fn call_tool(&self, arguments: Value) -> Result<CallToolResult, mcp_client::Error> {
+        let inner = self.client.read().await;
+        inner.call_tool(self.internal_name(), arguments).await
     }
 }

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use async_trait::async_trait;
 use catalog::SpiceToolCatalog;
+#[cfg(feature = "mcp")]
 use mcp::McpProxy;
 use serde_json::Value;
 use std::{borrow::Cow, sync::Arc};
@@ -87,6 +88,7 @@ pub trait SpiceModelTool: Sync + Send {
     /// If the tool is a proxy around an MCP tool, this method should return the proxy. Otherwise, it should return None.
     ///
     /// This enables direct pass through of MCP tool calls.
+    #[cfg(feature = "mcp")]
     async fn as_mcp_proxy(&self) -> Option<&dyn McpProxy> {
         None
     }

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use async_trait::async_trait;
 use catalog::SpiceToolCatalog;
+use mcp::McpProxy;
 use serde_json::Value;
 use std::{borrow::Cow, sync::Arc};
 
@@ -82,6 +83,13 @@ pub trait SpiceModelTool: Sync + Send {
         arg: &str,
         rt: Arc<Runtime>,
     ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>>;
+
+    /// If the tool is a proxy around an MCP tool, this method should return the proxy. Otherwise, it should return None.
+    ///
+    /// This enables direct pass through of MCP tool calls.
+    async fn as_mcp_proxy(&self) -> Option<&dyn McpProxy> {
+        None
+    }
 }
 
 /// Recreate a tool with a new name.


### PR DESCRIPTION
# 🗣 Description
There is an issue with MCP proxying in Spice because the current implementation uses the internal tool call method for all tools, and spice uses this when acting as an MCP server. 

### Example
Consider a system like this `Spice 1 -> Spice 2 -> MCP server`. 
- When we call `get_readiness` (i.e. from Spice 1), we get happy JSON result. 
  ```json
  [
    {
      "type": "text",
      "text":"{\"tool:document_similarity\":\"Ready\",\"tool:sample_distinct_columns\":\"Ready\",\"tool_catalog:auto\":\"Ready\",\"tool:table_schema\":\"Ready\",\"tool:list_datasets\":\"Ready\",\"tool:get_readiness\":\"Ready\",\"tool:random_sample\":\"Ready\",\"tool:store_memory\":\"Ready\",\"tool:sql\":\"Ready\",\"dataset:runtime.task_history\":\"Ready\",\"tool:fs\":\"Ready\",\"tool:load_memory\":\"Ready\",\"tool_catalog:memory\":\"Ready\",\"tool:top_n_sample\":\"Ready\"}",
    }
  ]
  ```
- When we call `spice_mcp/get_readiness` (i.e. from Spice 2), we get a nested JSON result, with the tool call double serialised
  ```json
  [
    {
      "type": "text",
      "text": "[{\"type\": \"text\", \"text\": \"{\\\"tool:document_similarity\\\":\\\"Ready\\\",\\\"tool:sample_distinct_columns\\\":\\\"Ready\\\",\\\"tool_catalog:auto\\\":\\\"Ready\\\",\\\"tool:table_schema\\\":\\\"Ready\\\",\\\"tool:list_datasets\\\":\\\"Ready\\\",\\\"tool:get_readiness\\\":\\\"Ready\\\",\\\"tool:random_sample\\\":\\\"Ready\\\",\\\"tool:store_memory\\\":\\\"Ready\\\",\\\"tool:sql\\\":\\\"Ready\\\",\\\"dataset:runtime.task_history\\\":\\\"Ready\\\",\\\"tool:fs\\\":\\\"Ready\\\",\\\"tool:load_memory\\\":\\\"Ready\\\",\\\"tool_catalog:memory\\\":\\\"Ready\\\",\\\"tool:top_n_sample\\\":\\\"Ready\\\"}\"}]"
    }
  ]
  ```
- Recursively adding nested for each layer. 

### Cause
When Spice is called via its MCP interface, it uses the equivalent of the `v1/tools` method to get the payload, then returns it in the `.text` field. When the tool is a proxy around an MCP server, this payload we get back is a full MCP payload (i.e. ` [{“type": "text", "text":"content"}]`). 

### Solution
When Spice is called via its MCP interface, for MCP tools, directly call its MCP interface. 