### PR TITLE
Exclude slow tests from regular pr runs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build integration test binary
         run: |
           FEATURES="postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,spark"
-          if [[ "${{ github.event.inputs.run_slow_tests }}" == "true" ]] || [[ "${{ github.ref }}" == "refs/heads/release-"* ]]; then
+          if [[ "${{ github.event.inputs.run_slow_tests }}" == "true" ]] || [[ "${{ github.ref }}" == "refs/heads/release"* ]]; then
             FEATURES="${FEATURES},slow_tests"
             echo "Including slow tests"
           else

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,11 +65,11 @@ jobs:
       - name: Build integration test binary
         run: |
           FEATURES="postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,spark"
-          if [[ "${{ github.event.inputs.run_slow_tests }}" == "true" ]] || [[ "${{ github.ref }}" == "refs/heads/release"* ]]; then
-            FEATURES="${FEATURES},slow_tests"
-            echo "Including slow tests"
+          if [[ "${{ github.event.inputs.run_all_tests }}" == "true" ]] || [[ "${{ github.ref }}" == "refs/heads/release"* ]]; then
+            FEATURES="${FEATURES},extended_tests"
+            echo "Including extended_tests"
           else
-            echo "Excluding slow tests"
+            echo "Excluding extended_tests"
           fi
           
           TEST_BINARY_PATH=$(cargo test -p runtime --test integration --features ${FEATURES} --no-run --message-format=json | jq -r 'select(.reason == "compiler-artifact" and (.target.kind | contains(["test"])) and .executable != null) | .executable')

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ on:
 
   workflow_dispatch:
     inputs:
-      run_slow_tests:
+      run_all_tests:
         description: 'Run all tests'
         type: boolean
         required: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,6 +28,12 @@ on:
       - 'bin/spice/**'
 
   workflow_dispatch:
+    inputs:
+      run_slow_tests:
+        description: 'Run all tests'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   # Allow only one workflow per any non-trunk branch.
@@ -58,7 +64,15 @@ jobs:
       # Build the test binary without running tests
       - name: Build integration test binary
         run: |
-          TEST_BINARY_PATH=$(cargo test -p runtime --test integration --features postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,spark --no-run --message-format=json | jq -r 'select(.reason == "compiler-artifact" and (.target.kind | contains(["test"])) and .executable != null) | .executable')
+          FEATURES="postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,spark"
+          if [[ "${{ github.event.inputs.run_slow_tests }}" == "true" ]] || [[ "${{ github.ref }}" == "refs/heads/release-"* ]]; then
+            FEATURES="${FEATURES},slow_tests"
+            echo "Including slow tests"
+          else
+            echo "Excluding slow tests"
+          fi
+          
+          TEST_BINARY_PATH=$(cargo test -p runtime --test integration --features ${FEATURES} --no-run --message-format=json | jq -r 'select(.reason == "compiler-artifact" and (.target.kind | contains(["test"])) and .executable != null) | .executable')
           cp $TEST_BINARY_PATH ./integration_test
 
       # Upload the test binary as an artifact

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -215,7 +215,7 @@ sqlite = [
     "data_components/sqlite",
     "dep:rusqlite",
 ]
-slow_tests = []
+extended_tests = []
 
 [[bench]]
 harness = false

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -215,6 +215,7 @@ sqlite = [
     "data_components/sqlite",
     "dep:rusqlite",
 ]
+slow_tests = []
 
 [[bench]]
 harness = false

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -18,11 +18,7 @@ use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use crate::{
     accelerated_table::AcceleratedTable,
-    component::dataset::{
-        self,
-        acceleration::{Engine, RefreshMode},
-        Dataset,
-    },
+    component::dataset::{self, acceleration::RefreshMode, Dataset},
     dataaccelerator,
     dataconnector::{
         self,

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -641,15 +641,6 @@ impl Runtime {
     async fn initialize_accelerators(&self, datasets: &[Arc<Dataset>]) -> Vec<Arc<Dataset>> {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
 
-        let mut duckdb_dataset_cnt = 0;
-        for ds in datasets {
-            if let Some(acc) = &ds.acceleration {
-                if acc.engine == Engine::DuckDB {
-                    duckdb_dataset_cnt += 1;
-                }
-            }
-        }
-
         let mut initialized_datasets = vec![];
         for ds in datasets {
             if let Some(acceleration) = &ds.acceleration {

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -18,7 +18,11 @@ use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use crate::{
     accelerated_table::AcceleratedTable,
-    component::dataset::{self, acceleration::RefreshMode, Dataset},
+    component::dataset::{
+        self,
+        acceleration::{Engine, RefreshMode},
+        Dataset,
+    },
     dataaccelerator,
     dataconnector::{
         self,
@@ -636,6 +640,15 @@ impl Runtime {
     /// which is important for acceleration federation for some acceleration engines (e.g. `SQLite`).
     async fn initialize_accelerators(&self, datasets: &[Arc<Dataset>]) -> Vec<Arc<Dataset>> {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
+
+        let mut duckdb_dataset_cnt = 0;
+        for ds in datasets {
+            if let Some(acc) = &ds.acceleration {
+                if acc.engine == Engine::DuckDB {
+                    duckdb_dataset_cnt += 1;
+                }
+            }
+        }
 
         let mut initialized_datasets = vec![];
         for ds in datasets {

--- a/crates/runtime/tests/iceberg/catalog/mod.rs
+++ b/crates/runtime/tests/iceberg/catalog/mod.rs
@@ -27,6 +27,10 @@ use spicepod::component::{catalog::Catalog, params::Params};
 use std::sync::Arc;
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "slow_tests"),
+    ignore = "Slow test - run with --features slow_tests"
+)]
 async fn glue_iceberg_integration_test_catalog() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(None);
     let _ = rustls::crypto::CryptoProvider::install_default(

--- a/crates/runtime/tests/iceberg/catalog/mod.rs
+++ b/crates/runtime/tests/iceberg/catalog/mod.rs
@@ -28,8 +28,8 @@ use std::sync::Arc;
 
 #[tokio::test]
 #[cfg_attr(
-    not(feature = "slow_tests"),
-    ignore = "Slow test - run with --features slow_tests"
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
 )]
 async fn glue_iceberg_integration_test_catalog() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(None);


### PR DESCRIPTION
# 🗣 Description

Add a feature flag `extended_tests ` in runtime integration test to separate the long-running tests from the fast ones. The long running test won't be running on the pr / trunk check, it only runs on release branch and when the workflow dispatch chooses to enable slow tests.

slow test is excluded in the pr run (see from the integration test time ~5 min)

Enable slow test in workflow dispatch: https://github.com/spiceai/spiceai/actions/runs/13948807200 (~11 min)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
