### PR TITLE
Improve performance of schema inference for object-store data connectors

### DIFF
--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -235,7 +235,7 @@ pub enum DataConnectorError {
     },
 
     #[snafu(display(
-        "Failed to load the {connector_component} ({dataconnector}).\nFailed to detect a table schema.\nReport a bug on GitHub (https://github.com/spiceai/spiceai/issues) and reference the error: {source}"
+        "Failed to load the {connector_component} ({dataconnector}).\nFailed to infer the table schema.\nReport a bug on GitHub (https://github.com/spiceai/spiceai/issues) and reference the error: {source}"
     ))]
     UnableToGetSchemaInternal {
         dataconnector: String,

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -235,6 +235,15 @@ pub enum DataConnectorError {
     },
 
     #[snafu(display(
+        "Failed to load the {connector_component} ({dataconnector}).\nFailed to detect a table schema.\nReport a bug on GitHub (https://github.com/spiceai/spiceai/issues) and reference the error: {source}"
+    ))]
+    UnableToGetSchemaInternal {
+        dataconnector: String,
+        connector_component: ConnectorComponent,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display(
         "Failed to load the {connector_component} ({dataconnector}).\nUnsupported type action is not enabled for the {dataconnector} Data Connector.\nRemove the parameter from your dataset configuration."
     ))]
     UnsupportedTypeAction {

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -404,6 +404,12 @@ pub trait ListingTableConnector: DataConnector {
         let last_updated_url =
             to_listing_table_url(url, &last_updated.location, dataset, &format!("{self}"))?;
 
+        tracing::debug!(
+            "Dataset '{}' schema will be resolved using the path: {}",
+            dataset.name,
+            last_updated_url
+        );
+
         let mut options = ListingOptions::new(file_format).with_file_extension(extension);
 
         let resolved_schema = options
@@ -497,6 +503,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
                 self.create_text_table(dataset, &url, &extension).await
             }
             Some(file_format) => {
+                // Structured tabular data, use a [`ListingTable`].
                 self.create_listing_table(dataset, &url, &extension, file_format)
                     .await
             }
@@ -546,6 +553,9 @@ fn add_last_modified_metadata_column_if_required(
     options
 }
 
+// 1024³
+const BYTES_PER_GIB: f64 = 1_073_741_824.0;
+
 /// Identifies the last modified object for a provided ListingTableConnector/ObjectStore
 /// Infers if the `file_format` specified is valid, based on the existence of files with the required extension
 ///
@@ -561,6 +571,8 @@ async fn get_last_modified(
     ctx: &SessionContext,
     object_store: &Arc<dyn ObjectStore>,
 ) -> DataConnectorResult<ObjectMeta> {
+    tracing::debug!("Detecting the most recently modified object for the path: {table_path}");
+
     let state = ctx.state();
     let mut file_stream = table_path
         .list_all_files(&state, object_store, "")
@@ -574,6 +586,9 @@ async fn get_last_modified(
     let mut best_match: Option<ObjectMeta> = None;
     let mut found_extensions: std::collections::HashSet<String> = std::collections::HashSet::new();
 
+    let mut file_count = 0;
+    let mut total_size = 0;
+
     while let Some(file) =
         file_stream
             .try_next()
@@ -584,6 +599,18 @@ async fn get_last_modified(
                 source: err.into(),
             })?
     {
+        file_count += 1;
+        total_size += file.size;
+
+        #[allow(clippy::cast_precision_loss)]
+        if file_count % 1_000_000 == 0 {
+            tracing::debug!(
+            "Continuing to process {table_path} metadata... {} objects processed so far, representing a total size of: {:.2} GiB",
+            file_count,
+            total_size as f64 / BYTES_PER_GIB
+            );
+        }
+
         if let Some(ext) = file.location.extension() {
             let file_ext = format!(".{ext}");
             found_extensions.insert(file_ext.clone());

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -47,6 +47,7 @@ use object_store::ObjectMeta;
 use object_store::ObjectStore;
 use snafu::prelude::*;
 use std::any::Any;
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -391,7 +392,7 @@ pub trait ListingTableConnector: DataConnector {
 
         // Get the last modified object for the provided ObjectStore to infer the schema.
         // Report an error if no files matching required extension are found.
-        let last_updated = get_last_modified(
+        let last_modified_or_added = get_last_modified(
             format!("{self}"),
             dataset,
             extension,
@@ -401,19 +402,22 @@ pub trait ListingTableConnector: DataConnector {
         )
         .await?;
 
-        let last_updated_url =
-            to_listing_table_url(url, &last_updated.location, dataset, &format!("{self}"))?;
+        let schema_infer_url = to_listing_table_url(
+            url,
+            &last_modified_or_added.location,
+            dataset,
+            &format!("{self}"),
+        )?;
 
         tracing::debug!(
-            "Dataset '{}' schema will be resolved using the path: {}",
-            dataset.name,
-            last_updated_url
+            "Dataset '{}' schema will be resolved based on {schema_infer_url}",
+            dataset.name
         );
 
         let mut options = ListingOptions::new(file_format).with_file_extension(extension);
 
         let resolved_schema = options
-            .infer_schema(&ctx.state(), &last_updated_url)
+            .infer_schema(&ctx.state(), &schema_infer_url)
             .await
             .map_err(|e| match e {
                 DataFusionError::ObjectStore(object_store_error) => {
@@ -583,8 +587,8 @@ async fn get_last_modified(
             source: err.into(),
         })?;
 
-    let mut best_match: Option<ObjectMeta> = None;
-    let mut found_extensions: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut last_modified_file: Option<ObjectMeta> = None;
+    let mut found_extensions = HashSet::new();
 
     let mut file_count = 0;
     let mut total_size = 0;
@@ -615,12 +619,12 @@ async fn get_last_modified(
             let file_ext = format!(".{ext}");
             found_extensions.insert(file_ext.clone());
             if file_ext == extension {
-                if let Some(ref current) = best_match {
+                if let Some(ref current) = last_modified_file {
                     if current.last_modified < file.last_modified {
-                        best_match = Some(file);
+                        last_modified_file = Some(file);
                     }
                 } else {
-                    best_match = Some(file);
+                    last_modified_file = Some(file);
                 }
             }
         }
@@ -634,7 +638,7 @@ async fn get_last_modified(
             });
     }
 
-    if let Some(best) = best_match {
+    if let Some(best) = last_modified_file {
         Ok(best)
     } else {
         let display_extensions = found_extensions

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -644,7 +644,10 @@ fn to_listing_table_url(
 
 #[cfg(test)]
 mod tests {
+    use chrono::{TimeZone, Utc};
     use datafusion_table_providers::util::secrets::to_secret_map;
+    use futures::stream::{self, BoxStream};
+    use futures::StreamExt;
     use std::collections::HashMap;
     use std::future::Future;
     use std::pin::Pin;
@@ -810,5 +813,159 @@ mod tests {
         } else {
             panic!("Unexpected error");
         }
+    }
+
+    #[derive(Debug)]
+    struct TestObjectStore {
+        meta: Vec<ObjectMeta>,
+    }
+
+    impl TestObjectStore {
+        fn new(meta: Vec<ObjectMeta>) -> Self {
+            Self { meta }
+        }
+    }
+
+    impl std::fmt::Display for TestObjectStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "TestObjectStore")
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for TestObjectStore {
+        fn list(&self, _prefix: Option<&Path>) -> BoxStream<'_, object_store::Result<ObjectMeta>> {
+            stream::iter(self.meta.clone().into_iter().map(Ok)).boxed()
+        }
+
+        async fn put(
+            &self,
+            _location: &Path,
+            _payload: object_store::PutPayload,
+        ) -> object_store::Result<object_store::PutResult> {
+            unimplemented!()
+        }
+        async fn put_opts(
+            &self,
+            _location: &Path,
+            _payload: object_store::PutPayload,
+            _opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            unimplemented!()
+        }
+        async fn put_multipart(
+            &self,
+            _location: &Path,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            unimplemented!()
+        }
+        async fn put_multipart_opts(
+            &self,
+            _location: &Path,
+            _opts: object_store::PutMultipartOpts,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            unimplemented!()
+        }
+        async fn get(&self, _location: &Path) -> object_store::Result<object_store::GetResult> {
+            unimplemented!()
+        }
+        async fn get_opts(
+            &self,
+            _location: &Path,
+            _options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            unimplemented!()
+        }
+        async fn delete(&self, _location: &Path) -> object_store::Result<()> {
+            unimplemented!()
+        }
+        fn delete_stream<'a>(
+            &'a self,
+            _locations: BoxStream<'a, object_store::Result<Path>>,
+        ) -> BoxStream<'a, object_store::Result<Path>> {
+            unimplemented!()
+        }
+        async fn list_with_delimiter(
+            &self,
+            _prefix: Option<&Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            unimplemented!()
+        }
+        async fn copy(&self, _from: &Path, _to: &Path) -> object_store::Result<()> {
+            unimplemented!()
+        }
+        async fn copy_if_not_exists(&self, _from: &Path, _to: &Path) -> object_store::Result<()> {
+            unimplemented!()
+        }
+    }
+
+    fn create_meta(location: &str, last_modified_secs: i64, size: usize) -> ObjectMeta {
+        ObjectMeta {
+            location: Path::from(location),
+            last_modified: Utc
+                .timestamp_opt(last_modified_secs, 0)
+                .single()
+                .expect("valid timestamp"),
+            size,
+            e_tag: None,
+            version: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_last_modified_returns_latest() {
+        let url = Url::parse("s3://bucket/").expect("to parse url");
+        let table_path = ListingTableUrl::parse(url.clone()).expect("to parse url");
+        let ctx = SessionContext::new();
+        let dataset = Dataset::try_new("s3://bucket/".to_string(), "test").expect("valid dataset");
+
+        let meta_files = vec![
+            create_meta("file_old.parquet", 100, 100),
+            create_meta("file_new.parquet", 200, 200),
+            create_meta("file_other.csv", 300, 300),
+            create_meta("file_other.parquet", 150, 200),
+        ];
+
+        let test_store = Arc::new(TestObjectStore::new(meta_files)) as Arc<dyn ObjectStore>;
+
+        let last_modified = get_last_modified(
+            "TestListingConnector".to_string(),
+            &dataset,
+            ".parquet",
+            table_path,
+            &ctx,
+            &test_store,
+        )
+        .await
+        .expect("to get last modified");
+
+        assert_eq!(last_modified.location.as_ref(), "file_new.parquet");
+    }
+
+    #[tokio::test]
+    async fn test_get_last_modified_no_matching_extension() {
+        let url = Url::parse("s3://bucket/").expect("to parse url");
+        let table_path = ListingTableUrl::parse(url.clone()).expect("to parse url");
+        let ctx = SessionContext::new();
+        let dataset = Dataset::try_new("s3://bucket/".to_string(), "test").expect("valid dataset");
+
+        let meta_files = vec![
+            create_meta("file_old.parquet", 100, 100),
+            create_meta("file_new.parquet", 200, 200),
+        ];
+
+        let test_store = Arc::new(TestObjectStore::new(meta_files)) as Arc<dyn ObjectStore>;
+
+        let result = get_last_modified(
+            "TestListingConnector".to_string(),
+            &dataset,
+            ".csv",
+            table_path,
+            &ctx,
+            &test_store,
+        )
+        .await;
+
+        assert!(result.is_err());
     }
 }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -42,10 +42,11 @@ use datafusion::error::DataFusionError;
 use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use futures::TryStreamExt;
+use object_store::path::Path;
+use object_store::ObjectMeta;
 use object_store::ObjectStore;
 use snafu::prelude::*;
 use std::any::Any;
-use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -331,6 +332,139 @@ pub trait ListingTableConnector: DataConnector {
             source: error.into(),
         }
     }
+
+    async fn create_text_table(
+        &self,
+        dataset: &Dataset,
+        url: &Url,
+        extension: &str,
+    ) -> DataConnectorResult<Arc<dyn TableProvider>>
+    where
+        Self: Display,
+    {
+        let content_formatter =
+            document_parse::get_parser_factory(extension)
+                .await
+                .map(|factory| {
+                    // TODO: add opts.
+                    factory.default()
+                });
+
+        Ok(ObjectStoreTextTable::try_new(
+            self.get_object_store(dataset)?,
+            &url.clone(),
+            Some(extension.to_string()),
+            content_formatter,
+        )
+        .context(crate::dataconnector::InvalidConfigurationSnafu {
+            dataconnector: format!("{self}"),
+            connector_component: ConnectorComponent::from(dataset),
+            message: format!(
+                "Invalid file extension ({extension}) for source ({})",
+                dataset.name
+            ),
+        })?)
+    }
+
+    async fn create_listing_table(
+        &self,
+        dataset: &Dataset,
+        url: &Url,
+        extension: &str,
+        file_format: Arc<dyn FileFormat>,
+    ) -> DataConnectorResult<Arc<dyn TableProvider>>
+    where
+        Self: Display,
+    {
+        // This shouldn't error because we've already validated the URL in `get_object_store_url`.
+        let table_path = ListingTableUrl::parse(url.clone()).boxed().context(
+            crate::dataconnector::InternalSnafu {
+                dataconnector: format!("{self}"),
+                connector_component: ConnectorComponent::from(dataset),
+                code: "LTC-RP-LTUP".to_string(), // ListingTableConnector-ReadProvider-ListingTableUrlParse
+            },
+        )?;
+
+        let object_store = self.get_object_store(dataset)?;
+
+        let ctx: SessionContext = Self::get_session_context();
+
+        // Get the last modified object for the provided ObjectStore to infer the schema.
+        // Report an error if no files matching required extension are found.
+        let last_updated = get_last_modified(
+            format!("{self}"),
+            dataset,
+            extension,
+            table_path.clone(),
+            &ctx,
+            &object_store,
+        )
+        .await?;
+
+        let last_updated_url =
+            to_listing_table_url(url, &last_updated.location, dataset, &format!("{self}"))?;
+
+        let mut options = ListingOptions::new(file_format).with_file_extension(extension);
+
+        let resolved_schema = options
+            .infer_schema(&ctx.state(), &last_updated_url)
+            .await
+            .map_err(|e| match e {
+                DataFusionError::ObjectStore(object_store_error) => {
+                    self.handle_object_store_error(dataset, object_store_error)
+                }
+                e => crate::dataconnector::DataConnectorError::UnableToConnectInternal {
+                    dataconnector: format!("{self}"),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: e.into(),
+                },
+            })?;
+
+        let expanded_schema = Arc::new(expand_views_schema(&resolved_schema));
+
+        // Add the `last_modified` metadata column if it is defined as a `time_column` or
+        // `time_partition_column` and it doesn't already exist in the schema.
+        options = add_last_modified_metadata_column_if_required(options, &expanded_schema, dataset);
+
+        // If we should infer partitions and the path is a folder, infer the partitions from the folder structure.
+        if dataset.get_param("hive_partitioning_enabled", false) && table_path.is_collection() {
+            let inferred_partitions =
+                infer_partitions_with_types(&ctx.state(), &table_path, extension).await;
+            match inferred_partitions {
+                Ok(partitions) => {
+                    tracing::debug!(
+                        "Inferred partitions for {:?}: {:?}",
+                        table_path,
+                        partitions
+                            .iter()
+                            .map(|(k, _)| k.as_str())
+                            .collect::<Vec<_>>()
+                    );
+                    options = options.with_table_partition_cols(partitions);
+                }
+                Err(e) => {
+                    // This might not be an error, it could be that the table is not partitioned.
+                    tracing::debug!("Failed to infer partitions for {:?}: {e}", table_path);
+                }
+            }
+        }
+
+        let config = ListingTableConfig::new(table_path)
+            .with_listing_options(options)
+            .with_schema(expanded_schema);
+
+        // This shouldn't error because we're passing the schema and options correctly.
+        let table =
+            ListingTable::try_new(config)
+                .boxed()
+                .context(crate::dataconnector::InternalSnafu {
+                    dataconnector: format!("{self}"),
+                    connector_component: ConnectorComponent::from(dataset),
+                    code: "LTC-RP-LTTN".to_string(), // ListingTableConnector-ReadProvider-ListingTableTryNew
+                })?;
+
+        Ok(Arc::new(table))
+    }
 }
 
 #[async_trait]
@@ -354,121 +488,17 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
         &self,
         dataset: &Dataset,
     ) -> DataConnectorResult<Arc<dyn TableProvider>> {
-        let ctx: SessionContext = Self::get_session_context();
         let url = self.get_object_store_url(dataset)?;
-
-        // This shouldn't error because we've already validated the URL in `get_object_store_url`.
-        let table_path = ListingTableUrl::parse(url.clone()).boxed().context(
-            crate::dataconnector::InternalSnafu {
-                dataconnector: format!("{self}"),
-                connector_component: ConnectorComponent::from(dataset),
-                code: "LTC-RP-LTUP".to_string(), // ListingTableConnector-ReadProvider-ListingTableUrlParse
-            },
-        )?;
 
         let (file_format_opt, extension) = self.get_file_format_and_extension(dataset)?;
         match file_format_opt {
             None => {
                 // Assume its unstructured text data. Use a [`ObjectStoreTextTable`].
-                let content_formatter = document_parse::get_parser_factory(extension.as_str())
-                    .await
-                    .map(|factory| {
-                        // TODO: add opts.
-                        factory.default()
-                    });
-
-                Ok(ObjectStoreTextTable::try_new(
-                    self.get_object_store(dataset)?,
-                    &url.clone(),
-                    Some(extension.clone()),
-                    content_formatter,
-                )
-                .context(crate::dataconnector::InvalidConfigurationSnafu {
-                    dataconnector: format!("{self}"),
-                    connector_component: ConnectorComponent::from(dataset),
-                    message: format!(
-                        "Invalid file extension ({extension}) for source ({})",
-                        dataset.name
-                    ),
-                })?)
+                self.create_text_table(dataset, &url, &extension).await
             }
             Some(file_format) => {
-                let object_store = self.get_object_store(dataset)?;
-                check_for_files_and_extensions(
-                    format!("{self}"),
-                    dataset,
-                    &extension,
-                    table_path.clone(),
-                    &ctx,
-                    &object_store,
-                )
-                .await?;
-
-                let mut options = ListingOptions::new(file_format).with_file_extension(&extension);
-
-                let resolved_schema = options
-                    .infer_schema(&ctx.state(), &table_path)
+                self.create_listing_table(dataset, &url, &extension, file_format)
                     .await
-                    .map_err(|e| match e {
-                        DataFusionError::ObjectStore(object_store_error) => {
-                            self.handle_object_store_error(dataset, object_store_error)
-                        }
-                        e => crate::dataconnector::DataConnectorError::UnableToConnectInternal {
-                            dataconnector: format!("{self}"),
-                            connector_component: ConnectorComponent::from(dataset),
-                            source: e.into(),
-                        },
-                    })?;
-
-                let expanded_schema = Arc::new(expand_views_schema(&resolved_schema));
-
-                // Add the `last_modified` metadata column if it is defined as a `time_column` or
-                // `time_partition_column` and it doesn't already exist in the schema.
-                options = add_last_modified_metadata_column_if_required(
-                    options,
-                    &expanded_schema,
-                    dataset,
-                );
-
-                // If we should infer partitions and the path is a folder, infer the partitions from the folder structure.
-                if dataset.get_param("hive_partitioning_enabled", false)
-                    && table_path.is_collection()
-                {
-                    let inferred_partitions =
-                        infer_partitions_with_types(&ctx.state(), &table_path, &extension).await;
-                    match inferred_partitions {
-                        Ok(partitions) => {
-                            tracing::debug!(
-                                "Inferred partitions for {:?}: {:?}",
-                                table_path,
-                                partitions
-                                    .iter()
-                                    .map(|(k, _)| k.as_str())
-                                    .collect::<Vec<_>>()
-                            );
-                            options = options.with_table_partition_cols(partitions);
-                        }
-                        Err(e) => {
-                            // This might not be an error, it could be that the table is not partitioned.
-                            tracing::debug!("Failed to infer partitions for {:?}: {e}", table_path);
-                        }
-                    }
-                }
-
-                let config = ListingTableConfig::new(table_path)
-                    .with_listing_options(options)
-                    .with_schema(expanded_schema);
-
-                // This shouldn't error because we're passing the schema and options correctly.
-                let table = ListingTable::try_new(config).boxed().context(
-                    crate::dataconnector::InternalSnafu {
-                        dataconnector: format!("{self}"),
-                        connector_component: ConnectorComponent::from(dataset),
-                        code: "LTC-RP-LTTN".to_string(), // ListingTableConnector-ReadProvider-ListingTableTryNew
-                    },
-                )?;
-
-                Ok(Arc::new(table))
             }
         }
     }
@@ -516,30 +546,24 @@ fn add_last_modified_metadata_column_if_required(
     options
 }
 
-/// Lists the available files for a ListingTableConnector/ObjectStore
+/// Identifies the last modified object for a provided ListingTableConnector/ObjectStore
 /// Infers if the `file_format` specified is valid, based on the existence of files with the required extension
 ///
 /// # Errors
 ///
 /// - If no files are found at the specified path
 /// - If no files with the specified extension are found
-async fn check_for_files_and_extensions(
+async fn get_last_modified(
     dataconnector: String,
     dataset: &Dataset,
     extension: &str,
     table_path: ListingTableUrl,
     ctx: &SessionContext,
     object_store: &Arc<dyn ObjectStore>,
-) -> DataConnectorResult<()> {
-    let files: Vec<_> = table_path
-        .list_all_files(&ctx.state(), object_store, "")
-        .await
-        .map_err(|err| DataConnectorError::UnableToConnectInternal {
-            dataconnector: dataconnector.clone(),
-            connector_component: ConnectorComponent::from(dataset),
-            source: err.into(),
-        })?
-        .try_collect()
+) -> DataConnectorResult<ObjectMeta> {
+    let state = ctx.state();
+    let mut file_stream = table_path
+        .list_all_files(&state, object_store, "")
         .await
         .map_err(|err| DataConnectorError::UnableToConnectInternal {
             dataconnector: dataconnector.clone(),
@@ -547,45 +571,75 @@ async fn check_for_files_and_extensions(
             source: err.into(),
         })?;
 
-    if files.is_empty() {
+    let mut best_match: Option<ObjectMeta> = None;
+    let mut found_extensions: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    while let Some(file) =
+        file_stream
+            .try_next()
+            .await
+            .map_err(|err| DataConnectorError::UnableToConnectInternal {
+                dataconnector: dataconnector.clone(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: err.into(),
+            })?
+    {
+        if let Some(ext) = file.location.extension() {
+            let file_ext = format!(".{ext}");
+            found_extensions.insert(file_ext.clone());
+            if file_ext == extension {
+                if let Some(ref current) = best_match {
+                    if current.last_modified < file.last_modified {
+                        best_match = Some(file);
+                    }
+                } else {
+                    best_match = Some(file);
+                }
+            }
+        }
+    }
+
+    if found_extensions.is_empty() {
         return Err(DataConnectorError::InvalidConfigurationNoSource {
             dataconnector: dataconnector.clone(),
             connector_component: ConnectorComponent::from(dataset),
-            message:
-                // Url could contain access keys from e.g. S3, so we don't want to log it.
-                "Failed to find any files at the specified path. Check the path and try again."
-                    .to_string(),
-        });
+            message: format!("Failed to find any files matching the extension '{extension}'.\nSpice could not find any files with extensions at the specified path. Check the path and try again."),
+            });
     }
 
-    let extensions = files
-        .iter()
-        .filter_map(|file| file.location.extension().map(|e| format!(".{e}")))
-        .collect::<HashSet<_>>();
-
-    if !extensions.contains(extension) {
-        if extensions.is_empty() {
-            return Err(DataConnectorError::InvalidConfigurationNoSource {
-                dataconnector: dataconnector.clone(),
-            connector_component: ConnectorComponent::from(dataset),
-                message: format!("Failed to find any files matching the extension '{extension}'.\nSpice could not find any files with extensions at the specified path. Check the path and try again."),
-            });
-        }
-
-        let display_extensions = extensions
+    if let Some(best) = best_match {
+        Ok(best)
+    } else {
+        let display_extensions = found_extensions
             .iter()
             .map(|e| format!("'{e}'"))
             .collect::<Vec<_>>()
             .join(", ");
-
-        return Err(DataConnectorError::InvalidConfigurationNoSource {
+        Err(DataConnectorError::InvalidConfigurationNoSource {
             dataconnector: dataconnector.clone(),
             connector_component: ConnectorComponent::from(dataset),
-            message: format!("Failed to find any files matching the extension '{extension}'.\nIs your `file_format` parameter correct? Spice found the following file extensions: {display_extensions}.\nFor details, visit: https://spiceai.org/docs/components/data-connectors#object-store-file-formats")
-        });
+            message: format!(
+                "Failed to find any files matching the extension '{extension}'.\nIs your `file_format` parameter correct? Spice found the following file extensions: {display_extensions}.\nFor details, visit: https://spiceai.org/docs/components/data-connectors#object-store-file-formats"
+            ),
+        })
     }
+}
 
-    Ok(())
+fn to_listing_table_url(
+    original_url: &Url,
+    path: &Path,
+    dataset: &Dataset,
+    dataconnector: &str,
+) -> DataConnectorResult<ListingTableUrl> {
+    let mut new_url = original_url.clone();
+    new_url.set_path(&format!("/{path}"));
+
+    ListingTableUrl::parse(new_url).boxed().context(
+        crate::dataconnector::UnableToGetSchemaInternalSnafu {
+            dataconnector: dataconnector.to_string(),
+            connector_component: ConnectorComponent::from(dataset),
+        },
+    )
 }
 
 #[cfg(test)]

--- a/crates/runtime/tests/s3/mod.rs
+++ b/crates/runtime/tests/s3/mod.rs
@@ -23,8 +23,8 @@ use spicepod::component::{dataset::Dataset, params::Params};
 
 use crate::{get_test_datafusion, init_tracing, utils::test_request_context};
 
-pub fn get_s3_dataset() -> Dataset {
-    let mut dataset = Dataset::new("s3://spiceai-demo-datasets/taxi_trips/2024/", "taxi_trips");
+pub fn get_s3_dataset(s3_uri: &str, name: &str) -> Dataset {
+    let mut dataset = Dataset::new(s3_uri, name);
     dataset.params = Some(Params::from_string_map(
         vec![
             ("file_format".to_string(), "parquet".to_string()),
@@ -60,7 +60,10 @@ async fn s3_federation() -> Result<(), anyhow::Error> {
     test_request_context()
         .scope(async {
             let app = AppBuilder::new("s3_federation")
-                .with_dataset(get_s3_dataset())
+                .with_dataset(get_s3_dataset(
+                    "s3://spiceai-demo-datasets/taxi_trips/2024/",
+                    "taxi_trips",
+                ))
                 .build();
 
             let status = status::RuntimeStatus::new();
@@ -159,6 +162,110 @@ async fn s3_hive_partitioning() -> Result<(), anyhow::Error> {
             let partition_not_inferred = arrow::util::pretty::pretty_format_batches(&batches)
                 .map_err(|e| anyhow::Error::msg(e.to_string()))?;
             insta::assert_snapshot!(partition_not_inferred);
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn s3_schema_evolution() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("s3_schema")
+                .with_dataset(get_s3_dataset(
+                    "s3://spiceai-public-datasets/test_schema_evolution/",
+                    "lineitem",
+                ))
+                .build();
+
+            let status = status::RuntimeStatus::new();
+            let df = get_test_datafusion(Arc::clone(&status));
+
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_datafusion(df)
+                .build()
+                .await;
+
+            // Set a timeout for the test
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = rt.load_components() => {}
+            }
+
+            let mut query_result = rt
+                .datafusion()
+                .query_builder("describe lineitem;")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let mut batches = vec![];
+            while let Some(batch) = query_result.data.next().await {
+                batches.push(batch?);
+            }
+
+            // Test S3 bucket contains Parquet files with different schema, inferred schema must represent the lineitem table
+            // based on the most recently added file: `/test_schema_evolution/2/data_0_2_11-new.parquet`
+            // other Parquet files represent the customer table schema
+            let schema = arrow::util::pretty::pretty_format_batches(&batches)
+                .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+            insta::assert_snapshot!(schema);
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn s3_bulk_bucket_schema() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("s3_schema")
+                .with_dataset(get_s3_dataset(
+                    "s3://spiceai-public-datasets/tpch_sf1000/lineitem/",
+                    "lineitem",
+                ))
+                .build();
+
+            let status = status::RuntimeStatus::new();
+            let df = get_test_datafusion(Arc::clone(&status));
+
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_datafusion(df)
+                .build()
+                .await;
+
+            // Set a timeout for the test
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = rt.load_components() => {}
+            }
+
+            let mut query_result = rt
+                .datafusion()
+                .query_builder("describe lineitem;")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let mut batches = vec![];
+            while let Some(batch) = query_result.data.next().await {
+                batches.push(batch?);
+            }
+            let schema = arrow::util::pretty::pretty_format_batches(&batches)
+                .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+            insta::assert_snapshot!(schema);
 
             Ok(())
         })

--- a/crates/runtime/tests/s3/mod.rs
+++ b/crates/runtime/tests/s3/mod.rs
@@ -64,6 +64,10 @@ async fn s3_federation() -> Result<(), anyhow::Error> {
                     "s3://spiceai-demo-datasets/taxi_trips/2024/",
                     "taxi_trips",
                 ))
+                .with_dataset(get_s3_dataset(
+                    "s3://spiceai-public-datasets/taxi_small_samples/taxi_sample.parquet",
+                    "taxi_sample",
+                ))
                 .build();
 
             let status = status::RuntimeStatus::new();
@@ -90,6 +94,22 @@ async fn s3_federation() -> Result<(), anyhow::Error> {
                 .run()
                 .await
                 .map_err(|e| anyhow::anyhow!(e))?;
+            let mut batches = vec![];
+            while let Some(batch) = query_result.data.next().await {
+                batches.push(batch?);
+            }
+
+            assert_eq!(batches.len(), 1);
+            assert_eq!(batches[0].num_rows(), 10);
+
+            let mut query_result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM taxi_sample LIMIT 10")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+
             let mut batches = vec![];
             while let Some(batch) = query_result.data.next().await {
                 batches.push(batch?);

--- a/crates/runtime/tests/s3/snapshots/integration__s3__s3_bulk_bucket_schema.snap
+++ b/crates/runtime/tests/s3/snapshots/integration__s3__s3_bulk_bucket_schema.snap
@@ -1,0 +1,24 @@
+---
+source: crates/runtime/tests/s3/mod.rs
+expression: schema
+---
++-----------------+-------------------+-------------+
+| column_name     | data_type         | is_nullable |
++-----------------+-------------------+-------------+
+| L_ORDERKEY      | Decimal128(38, 0) | NO          |
+| L_PARTKEY       | Decimal128(38, 0) | NO          |
+| L_SUPPKEY       | Decimal128(38, 0) | NO          |
+| L_LINENUMBER    | Decimal128(38, 0) | NO          |
+| L_QUANTITY      | Decimal128(12, 2) | NO          |
+| L_EXTENDEDPRICE | Decimal128(12, 2) | NO          |
+| L_DISCOUNT      | Decimal128(12, 2) | NO          |
+| L_TAX           | Decimal128(12, 2) | NO          |
+| L_RETURNFLAG    | LargeUtf8         | NO          |
+| L_LINESTATUS    | LargeUtf8         | NO          |
+| L_SHIPDATE      | Date32            | NO          |
+| L_COMMITDATE    | Date32            | NO          |
+| L_RECEIPTDATE   | Date32            | NO          |
+| L_SHIPINSTRUCT  | LargeUtf8         | NO          |
+| L_SHIPMODE      | LargeUtf8         | NO          |
+| L_COMMENT       | LargeUtf8         | NO          |
++-----------------+-------------------+-------------+

--- a/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_evolution.snap
+++ b/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_evolution.snap
@@ -1,0 +1,24 @@
+---
+source: crates/runtime/tests/s3/mod.rs
+expression: schema
+---
++-----------------+-------------------+-------------+
+| column_name     | data_type         | is_nullable |
++-----------------+-------------------+-------------+
+| L_ORDERKEY      | Decimal128(38, 0) | NO          |
+| L_PARTKEY       | Decimal128(38, 0) | NO          |
+| L_SUPPKEY       | Decimal128(38, 0) | NO          |
+| L_LINENUMBER    | Decimal128(38, 0) | NO          |
+| L_QUANTITY      | Decimal128(12, 2) | NO          |
+| L_EXTENDEDPRICE | Decimal128(12, 2) | NO          |
+| L_DISCOUNT      | Decimal128(12, 2) | NO          |
+| L_TAX           | Decimal128(12, 2) | NO          |
+| L_RETURNFLAG    | LargeUtf8         | NO          |
+| L_LINESTATUS    | LargeUtf8         | NO          |
+| L_SHIPDATE      | Date32            | NO          |
+| L_COMMITDATE    | Date32            | NO          |
+| L_RECEIPTDATE   | Date32            | NO          |
+| L_SHIPINSTRUCT  | LargeUtf8         | NO          |
+| L_SHIPMODE      | LargeUtf8         | NO          |
+| L_COMMENT       | LargeUtf8         | NO          |
++-----------------+-------------------+-------------+


### PR DESCRIPTION
# 🗣 Description

Improve the performance of schema inference by using only the last modified file instead of all files. The last modified file is used (rather than the first) to correctly handle potential schema evolution, as the most recent file is more likely to contain the most up-to-date schema.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
