### PR TITLE
spice init: Fixes windows bug where full path is used for spicepod name

### DIFF
--- a/bin/spice/cmd/init.go
+++ b/bin/spice/cmd/init.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/logrusorgru/aurora"
@@ -46,7 +47,7 @@ spice init my_app
 				slog.Error("getting current working directory", "error", err)
 				return
 			}
-			dirName := path.Base(wd)
+			dirName := filepath.Base(wd)
 
 			cmd.Printf("name: (%s)? ", dirName)
 			_, _ = fmt.Scanf("%s", &spicepodName)


### PR DESCRIPTION
# 🗣 Description

spice init: Fixes windows bug where full path is used for spicepod name


## 🔨 Related Issues

#4445


## 📄 Documentation Updates

Corrects `spice init` functionality to match docs.

