### PR TITLE
Fix test operator snapshot update

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -188,7 +188,7 @@ jobs:
         if: github.event.inputs.update_snapshots == 'always'
         run: |
           # if the spiced commit is set, use that as the branch ID
-          if [[ ${{ github.event.inputs.spiced_commit }} ]]; then
+          if [ -n "${{ github.event.inputs.spiced_commit || '' }}" ]; then
             BRANCH_ID=${{ github.event.inputs.spiced_commit }}
           else
             BRANCH_ID=${{ github.run_id }}


### PR DESCRIPTION
# 🗣 Description

The current script causes syntax error when `github.event.inputs.spiced_commit` is not presented. Fix it so that snapshots can be generated.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
