### PR TITLE
Add GitHub Workflow and PoC Spicepod configuration to run FinanceBench tests

### DIFF
--- a/.github/workflows/financebench.yml
+++ b/.github/workflows/financebench.yml
@@ -1,0 +1,146 @@
+---
+name: financebench
+
+on:
+  workflow_dispatch:
+    inputs:
+        model_option:
+          description: "Which model do you want to test? (Default is ALL)"
+          required: false
+          type: choice
+          options:
+            - "gpt-4o"
+          default: "all"
+
+concurrency:
+  # Allow only one workflow per any non-trunk branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+  cancel-in-progress: true
+
+jobs:
+  build-testoperator:
+    name: Build testoperator
+    runs-on: 'spiceai-macos'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: 'darwin'
+
+      - name: Build the testoperator
+        run: |
+          cargo build -p testoperator --release
+
+      - name: make testoperator executable
+        run: |
+          mv target/release/testoperator testoperator
+          chmod +x testoperator
+          
+      - name: Save spice artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: testoperator
+          path: testoperator
+
+  build-spiced:
+    name: Build spiced
+    runs-on: 'spiceai-macos'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          os: darwin
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build spiced
+        if: matrix.target.target_os != 'darwin'
+        run: |
+          make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="models"
+
+      - name: make spiced executable
+        if: matrix.target.target_os != 'windows'
+        run: |
+          mv target/release/spiced spiced
+          chmod +x spiced
+
+      - name: Save spice artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spiced
+          path: spiced
+
+  setup-matrix:
+    name: Setup matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.result }}
+
+    steps:
+      - name: Set up matrix
+        uses: actions/github-script@v7
+        id: setup-matrix
+        with:
+          script: |
+            const matrix = [
+              {
+                name: "gpt-4o",
+                spicepod: "./test/financebench/spicepod_gpt-4o.yaml"
+              }
+            ];
+
+            const model_option = context.payload.inputs.model_option;
+            let filtered = matrix;
+
+            if (model_option !== 'all') {
+              filtered = filtered.filter(m => m.name === model_option);
+            }
+
+            return filtered;
+
+  run-testoperator:
+    name: financebench benchmark
+    needs:
+      - build-testoperator
+      - build-spiced
+      - setup-matrix
+    runs-on: 'spiceai-macos'
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download testoperator
+        uses: actions/download-artifact@v4
+        with:
+          name: testoperator
+  
+      - name: Download spiced
+        uses: actions/download-artifact@v4
+        with:
+          name: spiced
+
+      - name: Mark binaries executable
+        run: |
+          chmod +x ./testoperator
+          chmod +x ./spiced
+
+      - name: Run FinanceBench evals
+        env:
+          SPICEAI_FINANCEBENCH_API_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_FINANCEBENCH_API_KEY}}
+          OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
+        run: |
+          ./testoperator run evals \
+            -s $GITHUB_WORKSPACE/spiced \
+            -p ${{ matrix.target.spicepod }} \
+            --ready-wait 180
+  

--- a/test/financebench/README.md
+++ b/test/financebench/README.md
@@ -1,0 +1,28 @@
+# FinanceBench
+
+Instructions to run the [FinanceBench](https://github.com/patronus-ai/financebench) tests:
+
+1. Run Spice
+1. Run `financebench` eval
+
+```bash
+curl -XPOST "http://localhost:8090/v1/evals/financebench" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o"
+  }'
+[{"id":"a5a4ee4d40dfcfc81a050bc5e23135c9","created_at":"2025-03-24T22:28:14","completed_at":"2025-03-24T22:29:19","dataset":"financebench.evals","model":"gpt-4o","status":"Completed","scorers":["match"],"metrics":{"match/mean":0.0}}]%  
+```
+
+To review model answers and score details:
+
+```bash
+curl -XPOST http://localhost:8090/v1/sql --data "
+WITH latest_run AS (
+  SELECT id FROM spice.eval.runs ORDER BY created_at DESC LIMIT 1
+)
+SELECT run_id, input, expected, actual, value
+FROM eval.results
+WHERE run_id = (SELECT id FROM latest_run)
+" | jq
+```

--- a/test/financebench/spicepod_gpt-4o.yaml
+++ b/test/financebench/spicepod_gpt-4o.yaml
@@ -1,0 +1,79 @@
+version: v1
+kind: Spicepod
+name: financebench
+
+models:
+  - name: gpt-4o
+    from: openai:gpt-4o-2024-08-06
+    datasets: 
+      - financebench.data
+    params:
+      tools: list_datasets, table_schema, document_similarity
+      openai_api_key: ${ secrets:OPENAI_API_KEY}
+      system_prompt: |
+        # Role and Objective
+        You are a financial expert, tasked to precisely answer the question based on information from `financebench.data`:
+        - Conduct thorough document searches to identify complete and accurate relevant information.
+        - Provide a well-structured, accurate, and concise answer based on retrieved information and the question asked.
+          
+        # Search Guidelines
+        - Always document_similarity tool for searches.
+        - When searching, query both 'content' and 'location' columns.
+        - Limit search to top 3 items.
+        - Don't include keywords
+        - If the first search yields insufficient results to respond, refine the search and perform a second search.
+
+        # Mandatory Guidelines
+        - Do not hallucinate or create theoretical knowledge, the answer must be based on the provided and retrieved data.
+        - Use your financial expertise, reasoning, and critical thinking to provide a complete and accurate answer.
+        - Must include all references ('location' column) to documents used to answer.
+
+        When writing SQL queries, do not put double quotes around schema-qualified table names. For example:
+          Correct: SELECT * FROM schema.table
+          Correct: SELECT * FROM database.schema.table
+          Incorrect: SELECT * FROM "schema.table"
+          Incorrect: SELECT * FROM "database.schema.table"
+
+datasets:
+  - from: spice.ai/spiceai/financebench/datasets/spice.financebench.data
+    name: financebench.data
+    description: Financial information
+    params:
+      spiceai_api_key: ${ secrets:SPICEAI_FINANCEBENCH_API_KEY }
+      spiceai_endpoint: https://flight.spiceai.io
+    acceleration:
+      enabled: true
+      # https://github.com/spiceai/spiceai/issues/5143
+      refresh_sql: |
+        select * from financebench.data limit 50;
+    embeddings:
+      - column: content
+        use: openai_embed
+        column_pk:
+        - location
+  
+  - from: spice.ai/spiceai/financebench/datasets/spice.financebench.tests_oss
+    description: Dataset for evaluating model performance. Must be ignored by the model.
+    name: financebench.tests_oss
+    params:
+      spiceai_api_key: ${ secrets:SPICEAI_FINANCEBENCH_API_KEY }
+      spiceai_endpoint: https://flight.spiceai.io
+    acceleration:
+      enabled: true
+
+views:
+  - name: financebench.evals
+    sql: |
+      SELECT financebench_id, question as input, answer as ideal, company, doc_name, question_type, question_reasoning, justification, evidence from financebench.tests_oss
+
+evals:
+  - name: financebench
+    dataset: financebench.evals
+    scorers:
+      - match
+
+embeddings:
+  - from: openai:text-embedding-3-small
+    name: openai_embed
+    params:
+      openai_api_key: ${secrets:OPENAI_API_KEY}

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -260,7 +260,7 @@ static QUERY_EVAL_BENCHMARK_FAILED_TESTS: &str = "
 WITH latest_run AS (
     SELECT id FROM spice.eval.runs ORDER BY created_at DESC LIMIT 1
 )
-SELECT run_id, input, output, actual as expected, value as score
+SELECT run_id, input, expected, actual, value as score
 FROM eval.results
 WHERE run_id = (SELECT id FROM latest_run) and value < 1;
 ";


### PR DESCRIPTION
# 🗣 Description

Add GitHub Workflow and PoC Spicepod configuration (strict match score. gpt-4o only) to run FinanceBench AI tests.

Test corpus is limited to 50 documents due to
- https://github.com/spiceai/spiceai/issues/5143

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3318
Closes https://github.com/spiceai/spiceai/issues/5144

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
