### PR TITLE
Enable Spice to load larger than memory datasets into DuckDB accelerations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b959ba80b0ed2b5d2374b85f337d95b6634e83cd#b959ba80b0ed2b5d2374b85f337d95b6634e83cd"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a6cf76d88271aeb53dd6acc79dd5530e2f3502ad#a6cf76d88271aeb53dd6acc79dd5530e2f3502ad"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4047,7 +4047,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "duckdb"
 version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=ffb4e4d5b73db64178a641e7c6980f4bfe5eef18#ffb4e4d5b73db64178a641e7c6980f4bfe5eef18"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3#cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3"
 dependencies = [
  "arrow",
  "cast",
@@ -6677,7 +6677,7 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 [[package]]
 name = "libduckdb-sys"
 version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=ffb4e4d5b73db64178a641e7c6980f4bfe5eef18#ffb4e4d5b73db64178a641e7c6980f4bfe5eef18"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3#cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=584408f375fea318f22eb2dcef48956c57610b95#584408f375fea318f22eb2dcef48956c57610b95"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a53e0ee19a50deb6cf3c14ad1d3c750bd86cc635#a53e0ee19a50deb6cf3c14ad1d3c750bd86cc635"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a53e0ee19a50deb6cf3c14ad1d3c750bd86cc635#a53e0ee19a50deb6cf3c14ad1d3c750bd86cc635"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=b959ba80b0ed2b5d2374b85f337d95b6634e83cd#b959ba80b0ed2b5d2374b85f337d95b6634e83cd"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -13715,7 +13715,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a6cf76d88271aeb53dd6acc79dd5530e2f3502ad#a6cf76d88271aeb53dd6acc79dd5530e2f3502ad"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=58257d9652e1cc7e9ae096d12ecfabc3fd8158d0#58257d9652e1cc7e9ae096d12ecfabc3fd8158d0"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=58257d9652e1cc7e9ae096d12ecfabc3fd8158d0#58257d9652e1cc7e9ae096d12ecfabc3fd8158d0"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=760ece6ac52b7d180d697f347642af403c2e711c#760ece6ac52b7d180d697f347642af403c2e711c"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,9 +169,9 @@ arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "584408f375fea318f22eb2dcef48956c57610b95" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a53e0ee19a50deb6cf3c14ad1d3c750bd86cc635" }
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "ffb4e4d5b73db64178a641e7c6980f4bfe5eef18" }
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3" }
 
 arrow-odbc = { git = "https://github.com/spiceai/arrow-odbc.git", rev = "dfb1e03a5f0702c1a318db5abf40e762d6b2bcc2" }
 odbc-api = { git = "https://github.com/spiceai/odbc-api.git", rev = "9807702dafdd8679d6bcecb0730b17e55c13e2e1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "58257d9652e1cc7e9ae096d12ecfabc3fd8158d0" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "760ece6ac52b7d180d697f347642af403c2e711c" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a6cf76d88271aeb53dd6acc79dd5530e2f3502ad" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "58257d9652e1cc7e9ae096d12ecfabc3fd8158d0" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b959ba80b0ed2b5d2374b85f337d95b6634e83cd" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a6cf76d88271aeb53dd6acc79dd5530e2f3502ad" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a53e0ee19a50deb6cf3c14ad1d3c750bd86cc635" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "b959ba80b0ed2b5d2374b85f337d95b6634e83cd" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3" }
 

--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -25,13 +25,16 @@ use datafusion::{
     sql::TableReference,
 };
 use datafusion_table_providers::{
-    duckdb::{write::DuckDBTableWriter, DuckDB, DuckDBTableFactory},
+    duckdb::{write::DuckDBTableWriter, DuckDB, DuckDBTableFactory, TableDefinition},
     sql::{
-        db_connection_pool::dbconnection::duckdbconn::DuckDbConnection,
+        db_connection_pool::{
+            dbconnection::duckdbconn::DuckDbConnection, duckdbpool::DuckDbConnectionPool,
+        },
         sql_provider_datafusion::expr::Engine,
     },
     util,
 };
+use duckdb::Transaction;
 use snafu::prelude::*;
 use std::sync::Arc;
 
@@ -60,21 +63,31 @@ impl DeletionTableProvider for DuckDBTableWriter {
         filters: &[Expr],
     ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(DeletionExec::new(
-            Arc::new(DuckDBDeletionSink::new(self.duckdb(), filters)),
+            Arc::new(DuckDBDeletionSink::new(
+                self.pool(),
+                self.table_definition(),
+                filters,
+            )),
             &self.schema(),
         )))
     }
 }
 
 struct DuckDBDeletionSink {
-    duckdb: Arc<DuckDB>,
+    pool: Arc<DuckDbConnectionPool>,
+    table_definition: Arc<TableDefinition>,
     filters: Vec<Expr>,
 }
 
 impl DuckDBDeletionSink {
-    fn new(duckdb: Arc<DuckDB>, filters: &[Expr]) -> Self {
+    fn new(
+        pool: Arc<DuckDbConnectionPool>,
+        table_definition: Arc<TableDefinition>,
+        filters: &[Expr],
+    ) -> Self {
         Self {
-            duckdb,
+            pool,
+            table_definition,
             filters: filters.to_vec(),
         }
     }
@@ -83,10 +96,20 @@ impl DuckDBDeletionSink {
 #[async_trait]
 impl DeletionSink for DuckDBDeletionSink {
     async fn delete_from(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
-        let mut db_conn = self.duckdb.connect_sync()?;
+        let pool = Arc::clone(&self.pool);
+        let mut db_conn = pool.connect_sync()?;
         let duckdb_conn = DuckDB::duckdb_conn(&mut db_conn)?;
+        let tx = duckdb_conn
+            .conn
+            .transaction()
+            .context(UnableToBeginTransactionSnafu)?;
+        let mut internal_tables = self.table_definition.list_internal_tables(&tx)?;
+        let Some((table_name, _)) = internal_tables.pop() else {
+            return Ok(0);
+        };
+
         let sql = util::filters_to_sql(&self.filters, Some(Engine::DuckDB))?;
-        let count = delete_from(self.duckdb.table_name(), duckdb_conn, &sql)?;
+        let count = delete_from(&table_name.to_string(), tx, &sql)?;
 
         Ok(count)
     }
@@ -114,16 +137,7 @@ impl ReadWrite for DuckDBTableFactory {
     }
 }
 
-fn delete_from(
-    table_name: &str,
-    duckdb_conn: &mut DuckDbConnection,
-    where_clause: &str,
-) -> Result<u64> {
-    let tx = duckdb_conn
-        .conn
-        .transaction()
-        .context(UnableToBeginTransactionSnafu)?;
-
+fn delete_from(table_name: &str, tx: Transaction<'_>, where_clause: &str) -> Result<u64> {
     let count_sql = format!(r#"SELECT COUNT(*) FROM "{table_name}" WHERE {where_clause}"#);
 
     let mut count: u64 = tx

--- a/crates/data_components/src/duckdb.rs
+++ b/crates/data_components/src/duckdb.rs
@@ -27,10 +27,7 @@ use datafusion::{
 use datafusion_table_providers::{
     duckdb::{write::DuckDBTableWriter, DuckDB, DuckDBTableFactory, TableDefinition},
     sql::{
-        db_connection_pool::{
-            dbconnection::duckdbconn::DuckDbConnection, duckdbpool::DuckDbConnectionPool,
-        },
-        sql_provider_datafusion::expr::Engine,
+        db_connection_pool::duckdbpool::DuckDbConnectionPool, sql_provider_datafusion::expr::Engine,
     },
     util,
 };
@@ -51,6 +48,12 @@ pub enum Error {
 
     #[snafu(display("Unable to begin duckdb transaction: {source}"))]
     UnableToBeginTransaction { source: duckdb::Error },
+
+    #[snafu(display("Unable to delete data from the duckdb table.\nAn internal table and base table exist for the same table.\nManually migrate the table by deleting '{internal_table}' or {table_name}', and try again."))]
+    UnableToDeleteDataInternalTable {
+        internal_table: String,
+        table_name: String,
+    },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -103,9 +106,20 @@ impl DeletionSink for DuckDBDeletionSink {
             .conn
             .transaction()
             .context(UnableToBeginTransactionSnafu)?;
+        let has_table = self.table_definition.has_table(&tx)?;
         let mut internal_tables = self.table_definition.list_internal_tables(&tx)?;
-        let Some((table_name, _)) = internal_tables.pop() else {
-            return Ok(0);
+        let table_name = match (internal_tables.pop(), has_table) {
+            (Some((table_name, _)), true) => {
+                return Err(Box::new(Error::UnableToDeleteDataInternalTable {
+                    internal_table: table_name.to_string(),
+                    table_name: self.table_definition.name().to_string(),
+                }));
+            }
+            (Some((table_name, _)), false) => table_name,
+            (None, true) => self.table_definition.name().clone(),
+            (None, false) => {
+                return Ok(0);
+            }
         };
 
         let sql = util::filters_to_sql(&self.filters, Some(Engine::DuckDB))?;


### PR DESCRIPTION
# 🗣 Description

Brings in the following PRs from datafusion-table-providers:
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/280
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/287
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/288
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/289
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/290

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
