### PR TITLE
Add `temp_directory` runtime parameter and insert it for DuckDB accelerations

### DIFF
--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -240,6 +240,15 @@ impl DataAccelerator for DuckDBAccelerator {
         }
 
         if let Some(this_dataset) = dataset {
+            if let Some(temp_directory) = &this_dataset
+                .app
+                .as_ref()
+                .and_then(|app| app.runtime.temp_directory.clone())
+            {
+                cmd.options
+                    .insert("temp_directory".to_string(), temp_directory.to_string());
+            }
+
             if this_dataset.is_file_accelerated() {
                 // If the user didn't specify a DuckDB file and this is a file-mode DuckDB,
                 // then use the shared DuckDB file `accelerated_duckdb.db`

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -55,6 +55,11 @@ pub struct Runtime {
 
     #[serde(default, skip_serializing_if = "is_default")]
     pub cors: CorsConfig,
+
+    /// Configures where the runtime will store temporary files needed for operations like
+    /// spilling to disk for queries & accelerations that are larger than memory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temp_directory: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
# 🗣 Description

Adds a new runtime parameter:

```yaml
runtime:
  temp_directory: /my_super_fast_disk
```

This controls where Spice will create temporary files that are needed for operations like spilling to disk for queries and accelerations that are larger than memory.

Currently this only is passed to the DuckDB acceleration to control where DuckDB creates its temporary files.

## 📄 Documentation Updates

Yes, this new parameter will need to be documented.

