### PR TITLE
Fix Postgres and MySQL installation on macos14-runner (E2E CI)

### DIFF
--- a/.github/actions/install-postgres/action.yml
+++ b/.github/actions/install-postgres/action.yml
@@ -27,6 +27,8 @@ runs:
       if: inputs.os == 'darwin'
       shell: bash
       run: |
+        # macos-14 runner bug requires 'brew update': https://github.com/actions/runner-images/issues/11855#issuecomment-2754201066
+        brew update
         brew install postgresql
         brew services start postgresql
         sleep 5

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -652,6 +652,8 @@ jobs:
       - name: Install MySQL (MacOS)
         if: matrix.target.target_os == 'darwin'
         run: |
+          # macos-14 runner bug requires 'brew update': https://github.com/actions/runner-images/issues/11855#issuecomment-2754201066
+          brew update
           brew install mysql@8.4
           brew link mysql@8.4 --force --overwrite
           brew services start mysql@8.4


### PR DESCRIPTION
# 🗣 Description

macos-14 runner bug requires `brew update` before `brew services`: https://github.com/actions/runner-images/issues/11855#issuecomment-2754201066

Example test run with the fix: https://github.com/spiceai/spiceai/actions/runs/14092290110

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
