### PR TITLE
Add github token to macos test release download tasks

### DIFF
--- a/.github/workflows/e2e_test_release_install_ai.yml
+++ b/.github/workflows/e2e_test_release_install_ai.yml
@@ -164,6 +164,8 @@ jobs:
       - name: install AI runtime version
         run: |
           spice install ai
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: check installation
         run: |


### PR DESCRIPTION
# 🗣 Description

Add github token to macos tes release tasks, otherwise it would be rate limited due to the same ip address of macos runners and fail

Successful run: 
https://github.com/spiceai/spiceai/actions/runs/14105321097

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
