### PR TITLE
Add automatic retry for NSQL queries

### DIFF
--- a/crates/llms/src/chat/nsql/default.rs
+++ b/crates/llms/src/chat/nsql/default.rs
@@ -19,7 +19,7 @@ use async_openai::{
     },
 };
 
-use super::{create_prompt, SqlGeneration};
+use super::{create_prompt, QueryGenerationContext, SqlGeneration};
 
 pub struct DefaultSqlGeneration;
 
@@ -28,8 +28,9 @@ impl SqlGeneration for DefaultSqlGeneration {
         &self,
         model_id: &str,
         query: &str,
+        context: &QueryGenerationContext,
     ) -> Result<CreateChatCompletionRequest, OpenAIError> {
-        let prompt = create_prompt(query);
+        let prompt = create_prompt(query, context);
 
         CreateChatCompletionRequestArgs::default()
             .model(model_id)

--- a/crates/llms/src/chat/nsql/json.rs
+++ b/crates/llms/src/chat/nsql/json.rs
@@ -20,7 +20,7 @@ use async_openai::{
     },
 };
 
-use super::{create_prompt, SqlGeneration};
+use super::{create_prompt, QueryGenerationContext, SqlGeneration};
 
 /// Implementation for [`SqlGeneration`] for [`super::Chat`] models that support [`ResponseFormat::JsonObject`].
 pub struct JsonSchemaSqlGeneration;
@@ -38,8 +38,9 @@ impl SqlGeneration for JsonSchemaSqlGeneration {
         &self,
         model_id: &str,
         query: &str,
+        context: &QueryGenerationContext,
     ) -> Result<CreateChatCompletionRequest, OpenAIError> {
-        let prompt = create_prompt(query);
+        let prompt = create_prompt(query, context);
 
         let messages: Vec<ChatCompletionRequestMessage> = vec![
             ChatCompletionRequestSystemMessageArgs::default()

--- a/crates/llms/src/chat/nsql/mod.rs
+++ b/crates/llms/src/chat/nsql/mod.rs
@@ -20,12 +20,33 @@ pub mod default;
 pub(crate) mod json;
 pub(crate) mod structured_output;
 
+#[derive(Default)]
+pub struct QueryGenerationContext {
+    pub failed_attempts: Vec<FailedAttempt>,
+}
+
+pub struct FailedAttempt {
+    pub attempted_query: String,
+    pub error_message: String,
+}
+
+impl FailedAttempt {
+    #[must_use]
+    pub fn new(attempted_query: String, error_message: String) -> Self {
+        Self {
+            attempted_query,
+            error_message,
+        }
+    }
+}
+
 /// Additional methods (beyond [`super::Chat`]), whereby a model can provide improved results for SQL code generation.
 pub trait SqlGeneration: Sync + Send {
     fn create_request_for_query(
         &self,
         model_id: &str,
         query: &str,
+        context: &QueryGenerationContext,
     ) -> Result<CreateChatCompletionRequest, OpenAIError>;
 
     fn parse_response(
@@ -36,10 +57,28 @@ pub trait SqlGeneration: Sync + Send {
 
 /// Default system prompt for SQL code generation.
 #[must_use]
-pub fn create_prompt(query: &str) -> String {
-    format!(
+pub fn create_prompt(query: &str, ctx: &QueryGenerationContext) -> String {
+    let mut prompt = format!(
         r#"Task: Write a SQL query to answer this question: _\"{query}\"_. Instruction: Return only valid SQL code, nothing additional, don't wrap it in ```. Columns with capitals must be quoted. For tables with schemas and catalogs '"catalog"."schema"."table"' not '"catalog.schema.table"'."#
-    )
+    );
+
+    if !ctx.failed_attempts.is_empty() {
+        let failed_atttempts_str = format!("\nUse incorrectly written SQL queries and associated errors below to ensure that the new query avoids repeating the same mistakes or generating identical queries:\n\n{}", failed_attempts_formatted(&ctx.failed_attempts));
+        prompt.push_str(&failed_atttempts_str);
+    }
+
+    prompt
+}
+
+fn failed_attempts_formatted(attempts: &Vec<FailedAttempt>) -> String {
+    let mut previous_attempts = String::new();
+    for attempt in attempts {
+        previous_attempts.push_str(&format!(
+            "sql: `{}`\nerror: `{}`\n\n",
+            attempt.attempted_query, attempt.error_message
+        ));
+    }
+    previous_attempts
 }
 
 #[cfg(test)]
@@ -53,7 +92,11 @@ mod tests {
     #[test]
     fn test_default_create_request_for_query() {
         let req = DefaultSqlGeneration {}
-            .create_request_for_query(MODEL_ID, "SELECT * FROM table")
+            .create_request_for_query(
+                MODEL_ID,
+                "SELECT * FROM table",
+                &QueryGenerationContext::default(),
+            )
             .expect("failed to create request");
         let req_str = serde_json::to_string_pretty(&req).expect("failed to serialize");
 
@@ -63,7 +106,11 @@ mod tests {
     #[test]
     fn test_json_create_request_for_query() {
         let req = json::JsonSchemaSqlGeneration {}
-            .create_request_for_query(MODEL_ID, "SELECT * FROM table")
+            .create_request_for_query(
+                MODEL_ID,
+                "SELECT * FROM table",
+                &QueryGenerationContext::default(),
+            )
             .expect("failed to create request");
         let req_str = serde_json::to_string_pretty(&req).expect("failed to serialize");
 
@@ -73,10 +120,32 @@ mod tests {
     #[test]
     fn test_structured_output_create_request_for_query() {
         let req = structured_output::StructuredOutputSqlGeneration {}
-            .create_request_for_query(MODEL_ID, "SELECT * FROM table")
+            .create_request_for_query(
+                MODEL_ID,
+                "SELECT * FROM table",
+                &QueryGenerationContext::default(),
+            )
             .expect("failed to create request");
         let req_str = serde_json::to_string_pretty(&req).expect("failed to serialize");
 
         insta::assert_snapshot!("sql_gen_structured", req_str);
+    }
+
+    #[test]
+    fn test_default_create_request_for_query_with_failed() {
+        let mut ctx = QueryGenerationContext::default();
+        ctx.failed_attempts.push(FailedAttempt {
+            attempted_query: r#"SELECT * FROM "spice.public.table" LIMIT 1"#.to_string(),
+            error_message:
+                "Error during planning: table 'spice.public.spice.public.table' not found"
+                    .to_string(),
+        });
+
+        let req = DefaultSqlGeneration {}
+            .create_request_for_query(MODEL_ID, "SELECT * FROM table", &ctx)
+            .expect("failed to create request");
+        let req_str = serde_json::to_string_pretty(&req).expect("failed to serialize");
+
+        insta::assert_snapshot!("sql_gen_default_with_failed_attempt", req_str);
     }
 }

--- a/crates/llms/src/chat/nsql/snapshots/llms__chat__nsql__tests__sql_gen_default_with_failed_attempt.snap
+++ b/crates/llms/src/chat/nsql/snapshots/llms__chat__nsql__tests__sql_gen_default_with_failed_attempt.snap
@@ -1,0 +1,16 @@
+---
+source: crates/llms/src/chat/nsql/mod.rs
+expression: req_str
+---
+{
+  "messages": [
+    {
+      "role": "system",
+      "content": "Task: Write a SQL query to answer this question: _\\\"SELECT * FROM table\\\"_. Instruction: Return only valid SQL code, nothing additional, don't wrap it in ```. Columns with capitals must be quoted. For tables with schemas and catalogs '\"catalog\".\"schema\".\"table\"' not '\"catalog.schema.table\"'.\nUse incorrectly written SQL queries and associated errors below to ensure that the new query avoids repeating the same mistakes or generating identical queries:\n\nsql: `SELECT * FROM \"spice.public.table\" LIMIT 1`\nerror: `Error during planning: table 'spice.public.spice.public.table' not found`\n\n"
+    }
+  ],
+  "model": "model_id",
+  "response_format": {
+    "type": "text"
+  }
+}

--- a/crates/llms/src/chat/nsql/structured_output.rs
+++ b/crates/llms/src/chat/nsql/structured_output.rs
@@ -25,7 +25,7 @@ use serde_json::Value;
 
 use crate::chat::nsql::create_prompt;
 
-use super::SqlGeneration;
+use super::{QueryGenerationContext, SqlGeneration};
 
 /// Implementation for [`SqlGeneration`] for [`super::Chat`] models that support [`ResponseFormat::JsonSchema`].
 pub struct StructuredOutputSqlGeneration;
@@ -36,8 +36,9 @@ impl SqlGeneration for StructuredOutputSqlGeneration {
         &self,
         model_id: &str,
         query: &str,
+        context: &QueryGenerationContext,
     ) -> Result<CreateChatCompletionRequest, OpenAIError> {
-        let prompt = create_prompt(query);
+        let prompt = create_prompt(query, context);
 
         let messages: Vec<ChatCompletionRequestMessage> =
             vec![ChatCompletionRequestSystemMessageArgs::default()

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -140,26 +140,34 @@ fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
 
 // Runs query and converts query results to HTTP response (as JSON).
 pub async fn sql_to_http_response(df: Arc<DataFusion>, sql: &str, format: ArrowFormat) -> Response {
-    let query = QueryBuilder::new(sql, Arc::clone(&df)).build();
-
-    let (data, results_cache_status) = match query.run().await {
-        Ok(query_result) => match query_result.data.try_collect::<Vec<RecordBatch>>().await {
-            Ok(batches) => (batches, query_result.results_cache_status),
-            Err(e) => {
-                tracing::debug!("Error executing query: {e}");
-                return (
-                    StatusCode::BAD_REQUEST,
-                    format!("Error processing batch: {e}"),
-                )
-                    .into_response();
-            }
-        },
+    let (data, results_cache_status) = match run_sql(df, sql).await {
+        Ok((data, results_cache_status)) => (data, results_cache_status),
         Err(e) => {
             tracing::debug!("Error executing query: {e}");
             return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
         }
     };
+    to_http_response(data, results_cache_status, format).await
+}
 
+// Runs query and returns the results as a vector of `RecordBatch`.
+pub async fn run_sql(
+    df: Arc<DataFusion>,
+    sql: &str,
+) -> Result<(Vec<RecordBatch>, QueryResultsCacheStatus), Box<dyn std::error::Error + Send + Sync>> {
+    let query_res = QueryBuilder::new(sql, df).build().run().await?;
+    Ok((
+        query_res.data.try_collect::<Vec<RecordBatch>>().await?,
+        query_res.results_cache_status,
+    ))
+}
+
+// Converts query result to HTTP response (as JSON).
+pub async fn to_http_response(
+    data: Vec<RecordBatch>,
+    cache_status: QueryResultsCacheStatus,
+    format: ArrowFormat,
+) -> Response {
     let res = match format {
         ArrowFormat::Json => arrow_to_json(&data),
         ArrowFormat::Csv => arrow_to_csv(&data),
@@ -175,7 +183,7 @@ pub async fn sql_to_http_response(df: Arc<DataFusion>, sql: &str, format: ArrowF
 
     let mut headers = HeaderMap::new();
 
-    attach_cache_headers(&mut headers, results_cache_status);
+    attach_cache_headers(&mut headers, cache_status);
 
     (StatusCode::OK, headers, body).into_response()
 }

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 use crate::{
     datafusion::DataFusion,
-    http::v1::{sql_to_http_response, ArrowFormat},
+    http::v1::{run_sql, to_http_response, ArrowFormat},
     model::LLMModelStore,
     tools::{
         builtin::{
@@ -40,7 +40,7 @@ use datafusion::sql::TableReference;
 use headers_accept::Accept;
 
 use itertools::Itertools;
-use llms::chat::nsql::default::DefaultSqlGeneration;
+use llms::chat::nsql::{default::DefaultSqlGeneration, FailedAttempt, QueryGenerationContext};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -48,6 +48,9 @@ use tracing::Span;
 use tracing_futures::Instrument;
 
 use super::accept_header_types;
+
+// Default number of retries for NSQL queries if the generated query fails to execute
+const DEFAULT_NSQL_RETRIES: u8 = 3;
 
 fn clean_model_based_sql(input: &str) -> String {
     let no_dashes = match input.strip_prefix("--") {
@@ -190,6 +193,7 @@ LIMIT 5
         )))
     )
 ))]
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn post(
     Extension(df): Extension<Arc<DataFusion>>,
     Extension(rt): Extension<Arc<Runtime>>,
@@ -248,55 +252,82 @@ pub(crate) async fn post(
     };
 
     let sql_gen = nql_model.as_sql().unwrap_or(&DefaultSqlGeneration {});
-    let Ok(mut req) = sql_gen.create_request_for_query(&payload.model, &payload.query) else {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Error preparing data for NQL model".to_string(),
-        )
-            .into_response();
-    };
+    // Tracks previously generated queries and associated errors to enable an efficient retry mechanism
+    let mut sql_gen_ctx = QueryGenerationContext::default();
+    let mut num_retries = 0;
 
-    req.messages.extend(schema_messages);
-    req.messages.extend(sample_data_messages);
-
-    let resp = match nql_model.chat_request(req).instrument(span.clone()).await {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::error!("Error running NQL model: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    };
-
-    // Run the SQL from the NSQL model through datafusion.
-    match sql_gen.parse_response(resp) {
-        Ok(Some(model_sql_query)) => {
-            let cleaned_query = clean_model_based_sql(&model_sql_query);
-
-            if return_sql_only(accept.as_ref()) {
-                tracing::trace!("Not running query, requested SQL only:\n{cleaned_query}");
-                return (StatusCode::OK, cleaned_query).into_response();
-            }
-
-            tracing::trace!("Running query:\n{cleaned_query}");
-            sql_to_http_response(
-                Arc::clone(&df),
-                &cleaned_query,
-                ArrowFormat::from_accept_header(accept.as_ref()),
-            )
-            .instrument(span.clone())
-            .await
-        }
-        Ok(None) => {
-            tracing::trace!("No query produced from NSQL model");
-            (
+    loop {
+        let Ok(mut req) =
+            sql_gen.create_request_for_query(&payload.model, &payload.query, &sql_gen_ctx)
+        else {
+            return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "No query produced from NSQL model".to_string(),
+                "Error preparing data for NQL model".to_string(),
             )
-                .into_response()
-        }
-        Err(e) => {
-            tracing::error!("Error running NSQL model: {e}");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-        }
+                .into_response();
+        };
+
+        req.messages.extend(schema_messages.clone());
+        req.messages.extend(sample_data_messages.clone());
+
+        let resp = match nql_model.chat_request(req).instrument(span.clone()).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("Error running NQL model: {e}");
+                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+            }
+        };
+
+        // Run the SQL from the NSQL model through datafusion.
+        match sql_gen.parse_response(resp) {
+            Ok(Some(model_sql_query)) => {
+                let cleaned_query = clean_model_based_sql(&model_sql_query);
+
+                if return_sql_only(accept.as_ref()) {
+                    tracing::trace!("Not running query, requested SQL only:\n{cleaned_query}");
+                    return (StatusCode::OK, cleaned_query).into_response();
+                }
+
+                tracing::debug!("Running query:\n{cleaned_query}");
+
+                match run_sql(Arc::clone(&df), &cleaned_query)
+                    .instrument(span.clone())
+                    .await
+                {
+                    Ok((data, cache_status)) => {
+                        return to_http_response(data, cache_status, ArrowFormat::Json)
+                            .instrument(span.clone())
+                            .await;
+                    }
+                    Err(e) => {
+                        // If query failed, retry with the updated context
+
+                        if num_retries >= DEFAULT_NSQL_RETRIES {
+                            tracing::error!("Error executing query: {e}");
+                            return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+                        }
+
+                        tracing::debug!("Error executing query: {e}. Retrying...");
+
+                        num_retries += 1;
+                        sql_gen_ctx
+                            .failed_attempts
+                            .push(FailedAttempt::new(cleaned_query.clone(), e.to_string()));
+                    }
+                }
+            }
+            Ok(None) => {
+                tracing::trace!("No query produced from NSQL model");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "No query produced from NSQL model".to_string(),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::error!("Error running NSQL model: {e}");
+                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+            }
+        };
     }
 }


### PR DESCRIPTION
# 🗣 Description

This PR introduces `QueryGenerationContext` which keeps track of previously generated and failed queries and is used to generate prompts for the next NSQL attempt.

If the generated NSQL query fails, the retry mechanism will make another attempt (up to 3 times) to generate and execute the query.


## 🔨 Related Issues

Implements 
- https://github.com/spiceai/spiceai/issues/2871

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

We might want to increase default num of retry attempts (currently 3 only) and make it configurable.
