### PR TITLE
Include chat completion id to task history

### DIFF
--- a/crates/runtime/src/model/wrapper.rs
+++ b/crates/runtime/src/model/wrapper.rs
@@ -253,7 +253,7 @@ impl Chat for ChatWrapper {
         let result = match self.chat.chat_request(req).instrument(span.clone()).await {
             Ok(mut resp) => {
                 if let Some(usage) = resp.usage.clone() {
-                    tracing::info!(target: "task_history", parent: &span, completion_tokens = %usage.completion_tokens, total_tokens = %usage.total_tokens, prompt_tokens = %usage.prompt_tokens, "labels");
+                    tracing::info!(target: "task_history", parent: &span, completion_tokens = %usage.completion_tokens, total_tokens = %usage.total_tokens, prompt_tokens = %usage.prompt_tokens, id=resp.id, "labels");
                 };
                 let captured_output: Vec<_> = resp.choices.iter().map(|c| &c.message).collect();
                 match serde_json::to_string(&captured_output) {


### PR DESCRIPTION
# 🗣 Description

Include chat completion response id as `id` to task history

Labels example: `id: chatcmpl-BCsqX2ZRRo8BWZAYXNr7o8xh7sRfd`

```console
{stream: false, id: chatcmpl-BCsqX2ZRRo8BWZAYXNr7o8xh7sRfd, completion_tokens: 1055, prompt_tokens: 5822, total_tokens: 6877, model: base-researcher}
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
