### PR TITLE
Set default tool recursion limit to 10 to prevent infinite loops

### DIFF
--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -50,7 +50,7 @@ use tracing_futures::Instrument;
 use super::accept_header_types;
 
 // Default number of retries for NSQL queries if the generated query fails to execute
-const DEFAULT_NSQL_RETRIES: u8 = 3;
+const DEFAULT_NSQL_RETRIES: u8 = 10;
 
 fn clean_model_based_sql(input: &str) -> String {
     let no_dashes = match input.strip_prefix("--") {

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -34,6 +34,10 @@ use crate::{
 
 pub type LLMModelStore = HashMap<String, Box<dyn Chat>>;
 
+// Default recursion limit for tool usage to prevent infinite loops.
+// This limit can be adjusted using the `tool_recursion_limit` model parameter.
+const DEFAULT_SPICE_TOOL_RECURSION_LIMIT: usize = 10;
+
 /// Extract a secret from a hashmap of secrets, if it exists.
 macro_rules! extract_secret {
     ($params:expr, $key:expr) => {
@@ -65,7 +69,9 @@ pub async fn try_to_chat_model(
                 .into(),
             })
         })
-        .transpose()?;
+        .transpose()?
+        // Prevent infinite recursion in case of circular tool calls.
+        .or(Some(DEFAULT_SPICE_TOOL_RECURSION_LIMIT));
 
     let tool_model = match spice_tool_opt {
         Some(opts) if opts.can_use_tools() => Box::new(ToolUsingChat::new(


### PR DESCRIPTION
# 🗣 Description

Default `tool_recursion_limit` to 10 to prevent infinite loops.

Also updates nsql retries from 3 to 10

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

 - https://github.com/spiceai/docs/pull/915

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
