### PR TITLE
Add support for `schema_source_path` param for object-store data connectors

### DIFF
--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -243,13 +243,19 @@ impl ListingTableConnector for AzureBlobFS {
         &self.params
     }
 
-    fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
+    fn get_object_store_url(
+        &self,
+        dataset: &Dataset,
+        url: Option<&str>,
+    ) -> DataConnectorResult<Url> {
+        let url = url.unwrap_or(dataset.from.as_str());
+
         let mut azure_url =
-            Url::parse(&dataset.from)
+            Url::parse(url)
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("{} is not a valid URL. Ensure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/abfs#from", &dataset.from),
+                    message: format!("{url} is not a valid URL. Ensure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/abfs#from"),
                     connector_component: ConnectorComponent::from(dataset)
                 })?;
 

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -102,9 +102,17 @@ impl ListingTableConnector for File {
     /// Creates a valid file [`url::Url`], from the dataset, supporting both
     ///   1. Relative paths
     ///   2. Datasets prefixed with `file://` (not just `file:/`). This is to mirror the UX of [`Url::parse`].
-    fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
-        let path = get_path(dataset).to_string_lossy().into_owned();
-
+    fn get_object_store_url(
+        &self,
+        dataset: &Dataset,
+        path: Option<&str>,
+    ) -> DataConnectorResult<Url> {
+        let path = match path {
+            Some(p) => PathBuf::from(p.trim_start_matches("file:"))
+                .to_string_lossy()
+                .into_owned(),
+            None => get_path(dataset).to_string_lossy().into_owned(),
+        };
         // Convert relative path to absolute path
         let url_str = if path.starts_with('/') {
             format!("file:{path}")
@@ -116,7 +124,7 @@ impl ListingTableConnector for File {
                     message: "Could not identify current directory for a relative file path. Does the running user have the right filesystem permissions?".to_string(),
                     connector_component: ConnectorComponent::from(dataset),
                 })?
-                .join(path)
+                .join(&path)
                 .to_string_lossy()
                 .to_string();
 
@@ -127,7 +135,7 @@ impl ListingTableConnector for File {
             .boxed()
             .context(InvalidConfigurationSnafu {
                 dataconnector: "file".to_string(),
-                message: "The specified file path created an invalid URL. Check your file path and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/file".to_string(),
+                message: format!("The specified file path {path} created an invalid URL. Check your file path and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/file"),
                 connector_component: ConnectorComponent::from(dataset),
             })
     }
@@ -249,5 +257,30 @@ mod tests {
             let result = get_path(&dataset);
             assert_eq!(result, expected, "Failed for input: {input}");
         }
+    }
+
+    #[test]
+    fn test_get_object_store_url() {
+        let dataset = Dataset::try_new("file:/tmp/".into(), "test").expect("to create dataset");
+        let connector = File {
+            params: Parameters::new(([]).to_vec(), "test", &[]),
+        };
+
+        let url = connector
+            .get_object_store_url(&dataset, None)
+            .expect("should get a valid URL");
+        assert_eq!(url.as_str(), "file:///tmp/");
+
+        // object store override path with `file:` prefix
+        let url = connector
+            .get_object_store_url(&dataset, Some("file:/tmp/1/"))
+            .expect("should get a valid URL");
+        assert_eq!(url.as_str(), "file:///tmp/1/");
+
+        // object store override without `file:` prefix
+        let url = connector
+            .get_object_store_url(&dataset, Some("/tmp/2/"))
+            .expect("should get a valid URL");
+        assert_eq!(url.as_str(), "file:///tmp/2/");
     }
 }

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -101,13 +101,18 @@ impl ListingTableConnector for FTP {
         &self.params
     }
 
-    fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
+    fn get_object_store_url(
+        &self,
+        dataset: &Dataset,
+        url: Option<&str>,
+    ) -> DataConnectorResult<Url> {
+        let url = url.unwrap_or(dataset.from.as_str());
         let mut ftp_url =
-            Url::parse(&dataset.from)
+            Url::parse(url)
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("{} is not a valid URL. Ensure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/ftp", dataset.from),
+                    message: format!("{url} is not a valid URL. Ensure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/ftp"),
                     connector_component: ConnectorComponent::from(dataset),
                 })?;
 

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -103,11 +103,16 @@ impl ListingTableConnector for Https {
         &self.params
     }
 
-    fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
-        let mut u = Url::parse(&dataset.from).boxed().map_err(|e| {
+    fn get_object_store_url(
+        &self,
+        dataset: &Dataset,
+        url: Option<&str>,
+    ) -> DataConnectorResult<Url> {
+        let url = url.unwrap_or(dataset.from.as_str());
+        let mut u = Url::parse(url).boxed().map_err(|e| {
             DataConnectorError::InvalidConfiguration {
                 dataconnector: "https".to_string(),
-                message: "The specified URL in the dataset 'from' is not valid. Ensure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/https".to_string(),
+                message: format!("{url} is not a valid URL. Ensure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/https"),
                 connector_component: ConnectorComponent::from(dataset),
                 source: e,
             }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -62,7 +62,25 @@ use super::DelimitedFormat;
 pub trait ListingTableConnector: DataConnector {
     fn as_any(&self) -> &dyn Any;
 
-    fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url>;
+    /// Retrieves the object store URL for a given dataset.
+    ///
+    /// Determines the URL of the object store associated with the dataset.
+    /// If a specific URL is provided as an argument, it uses that; otherwise, it derives
+    /// the URL based on the dataset's configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `dataset` - A reference to the [`Dataset`] for which the object store URL is being retrieved.
+    /// * `url` - An optional reference to a string representing a specific Path or URL to use.
+    ///
+    /// # Returns
+    ///
+    /// A [`DataConnectorResult`] containing the resolved [`Url`] of the object store.
+    fn get_object_store_url(
+        &self,
+        dataset: &Dataset,
+        url: Option<&str>,
+    ) -> DataConnectorResult<Url>;
 
     fn get_params(&self) -> &Parameters;
 
@@ -81,7 +99,7 @@ pub trait ListingTableConnector: DataConnector {
     where
         Self: Display,
     {
-        let store_url = self.get_object_store_url(dataset)?;
+        let store_url = self.get_object_store_url(dataset, None)?;
         let listing_store_url = ListingTableUrl::parse(store_url.clone()).boxed().context(
             crate::dataconnector::UnableToConnectInternalSnafu {
                 dataconnector: format!("{self}"),
@@ -105,7 +123,7 @@ pub trait ListingTableConnector: DataConnector {
     where
         Self: Display,
     {
-        let store_url: Url = self.get_object_store_url(dataset)?;
+        let store_url: Url = self.get_object_store_url(dataset, None)?;
         let store = self.get_object_store(dataset)?;
         let (_, extension) = self.get_file_format_and_extension(dataset)?;
 
@@ -390,24 +408,34 @@ pub trait ListingTableConnector: DataConnector {
 
         let ctx: SessionContext = Self::get_session_context();
 
-        // Get the last modified object for the provided ObjectStore to infer the schema.
-        // Report an error if no files matching required extension are found.
-        let last_modified_or_added = get_last_modified(
-            format!("{self}"),
-            dataset,
-            extension,
-            table_path.clone(),
-            &ctx,
-            &object_store,
-        )
-        .await?;
+        let schema_infer_url = if let Some(url) = dataset.params.get("schema_source_path") {
+            let url = self.get_object_store_url(dataset, Some(url))?;
+            ListingTableUrl::parse(url).boxed().context(
+                crate::dataconnector::UnableToGetSchemaInternalSnafu {
+                    dataconnector: format!("{self}"),
+                    connector_component: ConnectorComponent::from(dataset),
+                },
+            )?
+        } else {
+            // Get the last modified object for the provided ObjectStore to infer the schema.
+            // Report an error if no files matching required extension are found.
+            let last_modified_or_added = get_last_modified(
+                format!("{self}"),
+                dataset,
+                extension,
+                table_path.clone(),
+                &ctx,
+                &object_store,
+            )
+            .await?;
 
-        let schema_infer_url = to_listing_table_url(
-            url,
-            &last_modified_or_added.location,
-            dataset,
-            &format!("{self}"),
-        )?;
+            to_listing_table_url(
+                url,
+                &last_modified_or_added.location,
+                dataset,
+                &format!("{self}"),
+            )?
+        };
 
         tracing::debug!(
             "Dataset '{}' schema will be resolved based on {schema_infer_url}",
@@ -498,7 +526,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
         &self,
         dataset: &Dataset,
     ) -> DataConnectorResult<Arc<dyn TableProvider>> {
-        let url = self.get_object_store_url(dataset)?;
+        let url = self.get_object_store_url(dataset, None)?;
 
         let (file_format_opt, extension) = self.get_file_format_and_extension(dataset)?;
         match file_format_opt {
@@ -736,7 +764,11 @@ mod tests {
             &self.params
         }
 
-        fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
+        fn get_object_store_url(
+            &self,
+            dataset: &Dataset,
+            _url: Option<&str>,
+        ) -> DataConnectorResult<Url> {
             Url::parse("test")
                 .boxed()
                 .context(crate::dataconnector::InvalidConfigurationSnafu {

--- a/crates/runtime/src/dataconnector/listing/mod.rs
+++ b/crates/runtime/src/dataconnector/listing/mod.rs
@@ -47,7 +47,9 @@ pub const LISTING_TABLE_PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("file_compression_type")
         .description("The type of compression used on the file. Supported types are: GZIP, BZIP2, XZ, ZSTD, UNCOMPRESSED"),
     ParameterSpec::runtime("hive_partitioning_enabled")
-        .description("Enable partitioning using hive-style partitioning from the folder structure. Defaults to false.")
+        .description("Enable partitioning using hive-style partitioning from the folder structure. Defaults to false."),
+    ParameterSpec::runtime("schema_source_path")
+        .description("Specify a path to use for schema inference.")
 ];
 
 pub enum DelimitedFormat {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -274,13 +274,18 @@ impl ListingTableConnector for S3 {
         &self.params
     }
 
-    fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
+    fn get_object_store_url(
+        &self,
+        dataset: &Dataset,
+        url: Option<&str>,
+    ) -> DataConnectorResult<Url> {
+        let url = url.unwrap_or(dataset.from.as_str());
         let mut s3_url =
-            Url::parse(&dataset.from)
+            Url::parse(url)
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("The specified URL is not valid: {}.\nEnsure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#from", dataset.from),
+                    message: format!("The specified URL is not valid: {url}.\nEnsure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#from"),
                     connector_component: ConnectorComponent::from(dataset)
                 })?;
 

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -112,13 +112,18 @@ impl ListingTableConnector for SFTP {
         &self.params
     }
 
-    fn get_object_store_url(&self, dataset: &Dataset) -> DataConnectorResult<Url> {
+    fn get_object_store_url(
+        &self,
+        dataset: &Dataset,
+        url: Option<&str>,
+    ) -> DataConnectorResult<Url> {
+        let url = url.unwrap_or(dataset.from.as_str());
         let mut ftp_url =
-            Url::parse(&dataset.from)
+            Url::parse(url)
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("The specified URL is not valid: {}.\nEnsure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/ftp", dataset.from),
+                    message: format!("The specified URL is not valid: {url}.\nEnsure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/ftp"),
                     connector_component: ConnectorComponent::from(dataset)
                 })?;
 

--- a/crates/runtime/tests/s3/mod.rs
+++ b/crates/runtime/tests/s3/mod.rs
@@ -19,7 +19,10 @@ use std::sync::Arc;
 use app::AppBuilder;
 use futures::StreamExt;
 use runtime::{status, Runtime};
-use spicepod::component::{dataset::Dataset, params::Params};
+use spicepod::component::{
+    dataset::Dataset,
+    params::{ParamValue, Params},
+};
 
 use crate::{get_test_datafusion, init_tracing, utils::test_request_context};
 
@@ -286,6 +289,107 @@ async fn s3_bulk_bucket_schema() -> Result<(), anyhow::Error> {
             let schema = arrow::util::pretty::pretty_format_batches(&batches)
                 .map_err(|e| anyhow::Error::msg(e.to_string()))?;
             insta::assert_snapshot!(schema);
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn s3_schema_source_path() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let mut ds1 = get_s3_dataset(
+                "s3://spiceai-public-datasets/test_schema_evolution/",
+                "ds1_customer",
+            );
+
+            // refer to s3 bucket containing `customer` schema objects to infer schema
+            if let Some(params) = ds1.params.as_mut() {
+                params.data.insert(
+                    "schema_source_path".to_string(),
+                    ParamValue::String(
+                        "s3://spiceai-public-datasets/test_schema_evolution/1/"
+                            .to_string(),
+                    ),
+                );
+            }
+
+            let mut ds2 = get_s3_dataset(
+                "s3://spiceai-public-datasets/test_schema_evolution/",
+                "ds2_customer",
+            );
+
+            // refer to s3 object containing `customer` schema to infer schema
+            if let Some(params) = ds2.params.as_mut() {
+                params.data.insert(
+                    "schema_source_path".to_string(),
+                    ParamValue::String(
+                        "s3://spiceai-public-datasets/test_schema_evolution/1/data_0_0_10.parquet"
+                            .to_string(),
+                    ),
+                );
+            }
+
+            let mut ds3 = get_s3_dataset(
+                "s3://spiceai-public-datasets/test_schema_evolution/",
+                "ds3_lineitem",
+            );
+
+            // refer to s3 object containing `lineitem` schema to infer schema
+            if let Some(params) = ds3.params.as_mut() {
+                params.data.insert(
+                    "schema_source_path".to_string(),
+                    ParamValue::String(
+                        "s3://spiceai-public-datasets/test_schema_evolution/2/data_0_2_11-new.parquet"
+                            .to_string(),
+                    ),
+                );
+            }
+
+            let app = AppBuilder::new("s3_schema_source_path")
+                .with_dataset(ds1)
+                .with_dataset(ds2)
+                .with_dataset(ds3)
+                .build();
+
+            let status = status::RuntimeStatus::new();
+            let df = get_test_datafusion(Arc::clone(&status));
+
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_datafusion(df)
+                .build()
+                .await;
+
+            // Set a timeout for the test
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = rt.load_components() => {}
+            }
+
+            for dataset_name in &["ds1_customer", "ds2_customer", "ds3_lineitem"] {
+                let query = format!("describe {dataset_name};");
+                let mut query_result = rt
+                    .datafusion()
+                    .query_builder(&query)
+                    .build()
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                let mut batches = vec![];
+                while let Some(batch) = query_result.data.next().await {
+                    batches.push(batch?);
+                }
+
+                let schema = arrow::util::pretty::pretty_format_batches(&batches)
+                .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+                insta::assert_snapshot!(format!("s3_schema_source_path_{dataset_name}"), schema);
+            }
 
             Ok(())
         })

--- a/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_source_path_ds1_customer.snap
+++ b/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_source_path_ds1_customer.snap
@@ -1,0 +1,16 @@
+---
+source: crates/runtime/tests/s3/mod.rs
+expression: schema
+---
++--------------+-------------------+-------------+
+| column_name  | data_type         | is_nullable |
++--------------+-------------------+-------------+
+| C_CUSTKEY    | Decimal128(38, 0) | NO          |
+| C_NAME       | LargeUtf8         | NO          |
+| C_ADDRESS    | LargeUtf8         | NO          |
+| C_NATIONKEY  | Decimal128(38, 0) | NO          |
+| C_PHONE      | LargeUtf8         | NO          |
+| C_ACCTBAL    | Decimal128(12, 2) | NO          |
+| C_MKTSEGMENT | LargeUtf8         | YES         |
+| C_COMMENT    | LargeUtf8         | YES         |
++--------------+-------------------+-------------+

--- a/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_source_path_ds2_customer.snap
+++ b/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_source_path_ds2_customer.snap
@@ -1,0 +1,16 @@
+---
+source: crates/runtime/tests/s3/mod.rs
+expression: schema
+---
++--------------+-------------------+-------------+
+| column_name  | data_type         | is_nullable |
++--------------+-------------------+-------------+
+| C_CUSTKEY    | Decimal128(38, 0) | NO          |
+| C_NAME       | LargeUtf8         | NO          |
+| C_ADDRESS    | LargeUtf8         | NO          |
+| C_NATIONKEY  | Decimal128(38, 0) | NO          |
+| C_PHONE      | LargeUtf8         | NO          |
+| C_ACCTBAL    | Decimal128(12, 2) | NO          |
+| C_MKTSEGMENT | LargeUtf8         | YES         |
+| C_COMMENT    | LargeUtf8         | YES         |
++--------------+-------------------+-------------+

--- a/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_source_path_ds3_lineitem.snap
+++ b/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_source_path_ds3_lineitem.snap
@@ -1,0 +1,24 @@
+---
+source: crates/runtime/tests/s3/mod.rs
+expression: schema
+---
++-----------------+-------------------+-------------+
+| column_name     | data_type         | is_nullable |
++-----------------+-------------------+-------------+
+| L_ORDERKEY      | Decimal128(38, 0) | NO          |
+| L_PARTKEY       | Decimal128(38, 0) | NO          |
+| L_SUPPKEY       | Decimal128(38, 0) | NO          |
+| L_LINENUMBER    | Decimal128(38, 0) | NO          |
+| L_QUANTITY      | Decimal128(12, 2) | NO          |
+| L_EXTENDEDPRICE | Decimal128(12, 2) | NO          |
+| L_DISCOUNT      | Decimal128(12, 2) | NO          |
+| L_TAX           | Decimal128(12, 2) | NO          |
+| L_RETURNFLAG    | LargeUtf8         | NO          |
+| L_LINESTATUS    | LargeUtf8         | NO          |
+| L_SHIPDATE      | Date32            | NO          |
+| L_COMMITDATE    | Date32            | NO          |
+| L_RECEIPTDATE   | Date32            | NO          |
+| L_SHIPINSTRUCT  | LargeUtf8         | NO          |
+| L_SHIPMODE      | LargeUtf8         | NO          |
+| L_COMMENT       | LargeUtf8         | NO          |
++-----------------+-------------------+-------------+


### PR DESCRIPTION
# 🗣 Description

Add support for `schema_source_path` param that could be used to specify exact URL to infer dataset schema:
1. Faster dataset registration for large datasets  
1. Support scenarios when the last modified file (default schema inference approach) does not fully represent the target schema

Notes:  
 - When the schema infer parameter is specified, verification of the dataset location containing the provided file format via listing all objects is skipped. This is to support scenario 1 (avoid listing all objects).  
 - When the schema infer parameter is specified, all matched objects are used for schema inference, not only the last modified one from the path provided. This is to support scenario 2 above

Example Spicepod.yml configuration:


```yaml
- from: s3://spiceai-public-datasets/bucket/
  name: ds1
  params:
    file_format: parquet
    schema_source_path: s3://spiceai-public-datasets/bucket/day=2024-01-10/ #or s3://spiceai-public-datasets/bucket/day=2024-01-10/data.parquet

- from: file:my_local_dataset/
  name: ds2
  params:
    file_format: parquet
    schema_source_path: my_local_dataset/path/ # or my_local_dataset/path/data.parquet
```

## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/5172

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

Param must be documented in docs (to be done via separate PR)

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
