### PR TITLE
Don't refresh more often than `refresh_check_interval` across restarts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10496,6 +10496,7 @@ version = "0.31.0"
 source = "git+https://github.com/spiceai/rusqlite.git?rev=97054b6af725caf5d3e952e349746706e00d0ea5#97054b6af725caf5d3e952e349746706e00d0ea5"
 dependencies = [
  "bitflags 2.8.0",
+ "chrono",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ prometheus = "0.13"
 r2d2 = "0.8.10"
 regex = "1.10.3"
 reqwest = { version = "0.12.5", features = ["json", "rustls-tls"] }
-rusqlite = { version = "0.31.0", features = ["bundled-decimal"] }
+rusqlite = { version = "0.31.0", features = ["bundled-decimal", "chrono"] }
 rustls = "0.23"
 rustls-pemfile = "2.1.3"
 secrecy = "0.10.3"

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -1751,6 +1751,11 @@ mod tests {
                 // Not needed for this test
                 Ok(None)
             }
+
+            async fn last_checkpoint_time(&self) -> Result<Option<SystemTime>> {
+                // Not needed for this test
+                Ok(None)
+            }
         }
 
         // Test case 1: No checkpoint, should refresh regardless of mode

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -113,6 +113,11 @@ where
     }
 }
 
+pub(crate) enum NextRefresh {
+    WaitFor(Duration),
+    Disabled,
+}
+
 impl Refresh {
     #[allow(clippy::needless_pass_by_value)]
     #[must_use]
@@ -240,31 +245,59 @@ impl Refresh {
         Ok(())
     }
 
-    pub(crate) async fn should_refresh(
+    /// Determine the next refresh when Spice starts based on the refresh mode and the last checkpoint.
+    pub(crate) async fn startup_next_refresh(
         &self,
+        refresh_on_startup: RefreshOnStartup,
         last_checkpoint: Option<Arc<dyn DatasetCheckpointer>>,
-    ) -> bool {
-        // If there is no checkpoint, we need to start a refresh.
-        let Some(last_checkpoint) = last_checkpoint else {
-            return true;
-        };
-
-        let has_previous_checkpoint = match self.mode {
-            RefreshMode::Full => last_checkpoint.exists().await,
+    ) -> NextRefresh {
+        let previous_checkpoint = match self.mode {
+            RefreshMode::Full => {
+                // If there is no checkpoint, we need to start a refresh.
+                let Some(last_checkpoint) = last_checkpoint else {
+                    return NextRefresh::WaitFor(Duration::ZERO);
+                };
+                last_checkpoint.last_checkpoint_time().await.ok().flatten()
+            }
             // Append and Changes modes are always refreshed since they stream changes from the source table.
-            RefreshMode::Append | RefreshMode::Changes => return true,
-            RefreshMode::Disabled => return false,
+            RefreshMode::Append | RefreshMode::Changes => {
+                return NextRefresh::WaitFor(Duration::ZERO)
+            }
+            RefreshMode::Disabled => return NextRefresh::Disabled,
         };
 
         // If there is no previous checkpoint, we need to start a refresh.
-        if !has_previous_checkpoint {
-            return true;
-        }
+        let Some(prev_checkpoint_time) = previous_checkpoint else {
+            return NextRefresh::WaitFor(Duration::ZERO);
+        };
 
-        // Current behavior is temporary - we simply refresh if an interval is set.
-        // Future implementation should compare the elapsed time since last checkpoint against the refresh interval
-        // to determine if a refresh is needed.
-        self.check_interval.is_some()
+        // If the refresh interval is set, we need to start a refresh if the elapsed time since the last checkpoint is greater than the refresh interval.
+        // Otherwise, we don't need to start a refresh.
+        if let Some(check_interval) = self.check_interval {
+            let elapsed_time_since_checkpoint = SystemTime::now()
+                .duration_since(prev_checkpoint_time)
+                .unwrap_or(Duration::ZERO);
+            if elapsed_time_since_checkpoint > check_interval {
+                // The elapsed time since the last checkpoint is greater than the refresh interval, so we need to refresh now.
+                NextRefresh::WaitFor(Duration::ZERO)
+            } else {
+                match refresh_on_startup {
+                    // The elapsed time since the last checkpoint is less than the refresh interval, so we need to wait for the refresh interval to pass.
+                    RefreshOnStartup::Auto => {
+                        NextRefresh::WaitFor(check_interval - elapsed_time_since_checkpoint)
+                    }
+                    // The refresh mode is `Always`, so we need to refresh now.
+                    RefreshOnStartup::Always => NextRefresh::WaitFor(Duration::ZERO),
+                }
+            }
+        } else {
+            match refresh_on_startup {
+                // We have a previous checkpoint, but no refresh interval, so we don't need to refresh.
+                RefreshOnStartup::Auto => NextRefresh::Disabled,
+                // We have a previous checkpoint, but the refresh mode is `Always`, so we need to refresh now.
+                RefreshOnStartup::Always => NextRefresh::WaitFor(Duration::ZERO),
+            }
+        }
     }
 }
 
@@ -476,22 +509,35 @@ impl Refresher {
         acceleration_refresh_mode: AccelerationRefreshMode,
         ready_sender: oneshot::Sender<()>,
     ) -> Option<tokio::task::JoinHandle<()>> {
+        let dataset_name = self.dataset_name.clone();
         let time_column = self.refresh.read().await.time_column.clone();
-        {
+        let initial_refresh_delay = {
             let refresh = self.refresh.read().await;
 
             // If the table already has an existing acceleration and the refresh options wouldn't start a new refresh,
             // we can exit early.
-            if self.refresh_on_startup == RefreshOnStartup::Auto
-                && !refresh.should_refresh(self.checkpointer.clone()).await
+            match refresh
+                .startup_next_refresh(self.refresh_on_startup, self.checkpointer.clone())
+                .await
             {
-                tracing::debug!(
-                    "Skipped refresh for {}: existing acceleration is available",
-                    self.dataset_name
-                );
-                return None;
+                NextRefresh::Disabled => {
+                    tracing::debug!(
+                        "Skipped refresh for {}: existing acceleration is available",
+                        self.dataset_name
+                    );
+                    return None;
+                }
+                NextRefresh::WaitFor(duration) => {
+                    if !duration.is_zero() {
+                        tracing::info!(
+                            "{dataset_name}: Waiting {} seconds before first refresh",
+                            duration.as_secs()
+                        );
+                    }
+                    duration
+                }
             }
-        }
+        };
 
         let mut on_start_refresh_external = match (acceleration_refresh_mode, time_column) {
             (AccelerationRefreshMode::Disabled, _) => return None,
@@ -518,7 +564,6 @@ impl Refresher {
         self.refresh_task_runner = Some(refresh_task_runner);
 
         let mut ready_sender = Some(ready_sender);
-        let dataset_name = self.dataset_name.clone();
         let refresh = Arc::clone(&self.refresh);
 
         let cache_provider = self.cache_provider.clone();
@@ -542,9 +587,8 @@ impl Refresher {
         //   2. The periodic refresh happening less than `refresh_check_interval` after a manual
         //        refresh (the sleep future is reset when a manual refresh completes).
         Some(tokio::spawn(async move {
-            // first refresh is on start, thus duration is 0
             let mut next_scheduled_refresh_timer = Some(sleep(Self::compute_delay(
-                Duration::from_secs(0),
+                initial_refresh_delay,
                 max_jitter,
             )));
 
@@ -757,9 +801,51 @@ mod tests {
     use prometheus::proto::MetricType;
     use tokio::{sync::mpsc, time::timeout};
 
+    use crate::dataaccelerator::spice_sys::{dataset_checkpoint::DatasetCheckpointer, Result};
     use crate::status;
+    use arrow::datatypes::SchemaRef;
+    use async_trait::async_trait;
 
     use super::*;
+
+    // Mock implementation of DatasetCheckpointer trait
+    struct MockCheckpointer {
+        exists_value: bool,
+        last_checkpoint_time: Option<SystemTime>,
+    }
+
+    impl MockCheckpointer {
+        fn new_arc(
+            exists_value: bool,
+            last_checkpoint_time: Option<SystemTime>,
+        ) -> Arc<dyn DatasetCheckpointer> {
+            Arc::new(Self {
+                exists_value,
+                last_checkpoint_time,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl DatasetCheckpointer for MockCheckpointer {
+        async fn exists(&self) -> bool {
+            self.exists_value
+        }
+
+        async fn checkpoint(&self, _schema: &SchemaRef) -> Result<()> {
+            // Not needed for this test
+            Ok(())
+        }
+
+        async fn get_schema(&self) -> Result<Option<SchemaRef>> {
+            // Not needed for this test
+            Ok(None)
+        }
+
+        async fn last_checkpoint_time(&self) -> Result<Option<SystemTime>> {
+            Ok(self.last_checkpoint_time)
+        }
+    }
 
     async fn setup_and_test(
         status: Arc<status::RuntimeStatus>,
@@ -1720,81 +1806,247 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_should_refresh() {
-        use crate::dataaccelerator::spice_sys::{dataset_checkpoint::DatasetCheckpointer, Result};
-        use arrow::datatypes::SchemaRef;
-        use async_trait::async_trait;
-
-        // Mock implementation of DatasetCheckpointer trait
-        struct MockCheckpointer {
-            exists_value: bool,
+    #[allow(clippy::too_many_lines)]
+    async fn test_startup_next_refresh() {
+        struct TestCase {
+            description: &'static str,
+            refresh_mode: RefreshMode,
+            refresh_on_startup: RefreshOnStartup,
+            checkpoint: Option<Arc<dyn DatasetCheckpointer>>,
+            check_interval: Option<Duration>,
+            assert_fn: Box<dyn Fn(NextRefresh) -> bool>,
         }
 
-        impl MockCheckpointer {
-            fn new_arc(exists_value: bool) -> Arc<dyn DatasetCheckpointer> {
-                Arc::new(Self { exists_value })
+        let now = SystemTime::now();
+        let checkpoint = MockCheckpointer::new_arc(true, Some(now));
+        let non_existing_checkpoint = MockCheckpointer::new_arc(false, None);
+
+        let test_cases = vec![
+            TestCase {
+                description: "No checkpoint, Full mode should refresh immediately",
+                refresh_mode: RefreshMode::Full,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: None,
+                check_interval: None,
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+            TestCase {
+                description: "No checkpoint, Append mode should refresh immediately",
+                refresh_mode: RefreshMode::Append,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: None,
+                check_interval: None,
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+            TestCase {
+                description: "No checkpoint, Changes mode should refresh immediately",
+                refresh_mode: RefreshMode::Changes,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: None,
+                check_interval: None,
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+            TestCase {
+                description: "No checkpoint, Disabled mode should be disabled",
+                refresh_mode: RefreshMode::Disabled,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: None,
+                check_interval: None,
+                assert_fn: Box::new(|result| matches!(result, NextRefresh::Disabled)),
+            },
+            TestCase {
+                description: "Checkpoint exists, Append mode should refresh immediately",
+                refresh_mode: RefreshMode::Append,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: Some(Arc::clone(&checkpoint)),
+                check_interval: None,
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+            TestCase {
+                description: "Checkpoint exists, Changes mode should refresh immediately",
+                refresh_mode: RefreshMode::Changes,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: Some(Arc::clone(&checkpoint)),
+                check_interval: None,
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+            TestCase {
+                description: "Checkpoint exists, Disabled mode should be disabled",
+                refresh_mode: RefreshMode::Disabled,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: Some(Arc::clone(&checkpoint)),
+                check_interval: None,
+                assert_fn: Box::new(|result| matches!(result, NextRefresh::Disabled)),
+            },
+            TestCase {
+                description: "Checkpoint exists, Full mode with no check interval should be disabled",
+                refresh_mode: RefreshMode::Full,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: Some(Arc::clone(&checkpoint)),
+                check_interval: None,
+                assert_fn: Box::new(|result| matches!(result, NextRefresh::Disabled)),
+            },
+            TestCase {
+                description: "Checkpoint exists, Full mode with check interval should wait appropriate time",
+                refresh_mode: RefreshMode::Full,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: Some(Arc::clone(&checkpoint)),
+                check_interval: Some(Duration::from_secs(60)),
+                assert_fn: Box::new(|result| {
+                    if let NextRefresh::WaitFor(duration) = result {
+                        duration <= Duration::from_secs(60) && duration > Duration::ZERO
+                    } else {
+                        false
+                    }
+                }),
+            },
+            TestCase {
+                description: "Non-existent checkpoint, Full mode should refresh immediately",
+                refresh_mode: RefreshMode::Full,
+                refresh_on_startup: RefreshOnStartup::Auto,
+                checkpoint: Some(non_existing_checkpoint),
+                check_interval: None,
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+            TestCase {
+                description: "Checkpoint exists, Full mode with RefreshOnStartup::Always should refresh immediately",
+                refresh_mode: RefreshMode::Full,
+                refresh_on_startup: RefreshOnStartup::Always,
+                checkpoint: Some(Arc::clone(&checkpoint)),
+                check_interval: None,
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+            TestCase {
+                description: "No checkpoint, Full mode with RefreshOnStartup::Always should refresh immediately",
+                refresh_mode: RefreshMode::Full,
+                refresh_on_startup: RefreshOnStartup::Always,
+                checkpoint: None,
+                check_interval: None,
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+            TestCase {
+                description: "Checkpoint exists, Full mode with check interval and RefreshOnStartup::Always should refresh immediately",
+                refresh_mode: RefreshMode::Full,
+                refresh_on_startup: RefreshOnStartup::Always,
+                checkpoint: Some(checkpoint),
+                check_interval: Some(Duration::from_secs(60)),
+                assert_fn: Box::new(|result| {
+                    matches!(result, NextRefresh::WaitFor(duration) if duration.is_zero())
+                }),
+            },
+        ];
+
+        for case in test_cases {
+            let mut refresh = Refresh::new(case.refresh_mode);
+            if let Some(check_interval) = case.check_interval {
+                refresh = refresh.check_interval(check_interval);
             }
+
+            let result = refresh
+                .startup_next_refresh(case.refresh_on_startup, case.checkpoint)
+                .await;
+
+            assert!(
+                (case.assert_fn)(result),
+                "Test case failed: {}",
+                case.description
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn test_startup_next_refresh_wait_time() {
+        struct TestCase {
+            description: &'static str,
+            last_checkpoint_time: SystemTime,
+            check_interval: Duration,
+            expected_wait_time: Duration,
         }
 
-        #[async_trait]
-        impl DatasetCheckpointer for MockCheckpointer {
-            async fn exists(&self) -> bool {
-                self.exists_value
-            }
+        let now = SystemTime::now();
+        let test_cases = vec![
+            TestCase {
+                description: "Checkpoint just happened, should wait full interval",
+                last_checkpoint_time: now,
+                check_interval: Duration::from_secs(60),
+                expected_wait_time: Duration::from_secs(60),
+            },
+            TestCase {
+                description: "Checkpoint happened 30 seconds ago, should wait 30 seconds",
+                last_checkpoint_time: now - Duration::from_secs(30),
+                check_interval: Duration::from_secs(60),
+                expected_wait_time: Duration::from_secs(30),
+            },
+            TestCase {
+                description: "Checkpoint happened 45 seconds ago, should wait 15 seconds",
+                last_checkpoint_time: now - Duration::from_secs(45),
+                check_interval: Duration::from_secs(60),
+                expected_wait_time: Duration::from_secs(15),
+            },
+            TestCase {
+                description: "Checkpoint happened 59 seconds ago, should wait 1 second",
+                last_checkpoint_time: now - Duration::from_secs(59),
+                check_interval: Duration::from_secs(60),
+                expected_wait_time: Duration::from_secs(1),
+            },
+            TestCase {
+                description:
+                    "Checkpoint happened more than interval ago, should refresh immediately",
+                last_checkpoint_time: now - Duration::from_secs(61),
+                check_interval: Duration::from_secs(60),
+                expected_wait_time: Duration::ZERO,
+            },
+        ];
 
-            async fn checkpoint(&self, _schema: &SchemaRef) -> Result<()> {
-                // Not needed for this test
-                Ok(())
-            }
+        for case in test_cases {
+            let checkpoint = MockCheckpointer::new_arc(true, Some(case.last_checkpoint_time));
+            let refresh = Refresh::new(RefreshMode::Full).check_interval(case.check_interval);
 
-            async fn get_schema(&self) -> Result<Option<SchemaRef>> {
-                // Not needed for this test
-                Ok(None)
-            }
+            let result = refresh
+                .startup_next_refresh(RefreshOnStartup::Auto, Some(Arc::clone(&checkpoint)))
+                .await;
 
-            async fn last_checkpoint_time(&self) -> Result<Option<SystemTime>> {
-                // Not needed for this test
-                Ok(None)
+            match result {
+                NextRefresh::WaitFor(duration) => {
+                    // Allow for a small margin of error due to test execution time
+                    let margin = Duration::from_millis(100);
+                    let min_expected = case.expected_wait_time.saturating_sub(margin);
+                    let max_expected = case.expected_wait_time + margin;
+                    assert!(
+                        duration >= min_expected && duration <= max_expected,
+                        "Test case failed: {}. Expected wait time between {:?} and {:?}, got {:?}",
+                        case.description,
+                        min_expected,
+                        max_expected,
+                        duration
+                    );
+                }
+                NextRefresh::Disabled => {
+                    assert!(
+                        case.expected_wait_time.is_zero(),
+                        "Test case failed: {}. Expected wait time of {:?}, got Disabled",
+                        case.description,
+                        case.expected_wait_time
+                    );
+                }
             }
         }
-
-        // Test case 1: No checkpoint, should refresh regardless of mode
-        let refresh = Refresh::new(RefreshMode::Full);
-        assert!(refresh.should_refresh(None).await);
-
-        let refresh = Refresh::new(RefreshMode::Append);
-        assert!(refresh.should_refresh(None).await);
-
-        let refresh = Refresh::new(RefreshMode::Changes);
-        assert!(refresh.should_refresh(None).await);
-
-        let refresh = Refresh::new(RefreshMode::Disabled);
-        assert!(refresh.should_refresh(None).await);
-
-        // Test case 2: Checkpoint exists, but mode is Append or Changes - should always refresh
-        let checkpoint = MockCheckpointer::new_arc(true);
-
-        let refresh = Refresh::new(RefreshMode::Append);
-        assert!(refresh.should_refresh(Some(Arc::clone(&checkpoint))).await);
-
-        let refresh = Refresh::new(RefreshMode::Changes);
-        assert!(refresh.should_refresh(Some(Arc::clone(&checkpoint))).await);
-
-        // Test case 3: Checkpoint exists, mode is Disabled - should never refresh
-        let refresh = Refresh::new(RefreshMode::Disabled);
-        assert!(!refresh.should_refresh(Some(Arc::clone(&checkpoint))).await);
-
-        // Test case 4: Checkpoint exists, mode is Full, previous checkpoint exists
-        let refresh = Refresh::new(RefreshMode::Full);
-        assert!(!refresh.should_refresh(Some(Arc::clone(&checkpoint))).await);
-
-        // Test case 5: Checkpoint exists, mode is Full, previous checkpoint exists, check_interval is set
-        let refresh = Refresh::new(RefreshMode::Full).check_interval(Duration::from_secs(60));
-        assert!(refresh.should_refresh(Some(checkpoint)).await);
-
-        // Test case 6: Checkpoint exists, mode is Full, previous checkpoint doesn't exist
-        let non_existing_checkpoint = MockCheckpointer::new_arc(false);
-        let refresh = Refresh::new(RefreshMode::Full);
-        assert!(refresh.should_refresh(Some(non_existing_checkpoint)).await);
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -530,7 +530,7 @@ impl Refresher {
                 NextRefresh::WaitFor(duration) => {
                     if !duration.is_zero() {
                         tracing::info!(
-                            "{dataset_name}: Waiting {} seconds before first refresh",
+                            "{dataset_name}: Waiting {}s until next refresh",
                             duration.as_secs()
                         );
                     }

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/duckdb.rs
@@ -15,7 +15,10 @@ limitations under the License.
 */
 
 use datafusion::arrow::datatypes::SchemaRef;
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME, SCHEMA_MIGRATION_01_STMT};
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
@@ -54,6 +57,38 @@ impl DatasetCheckpoint {
             .map_err(|e| e.to_string())?;
 
         Ok(rows.next().map_err(|e| e.to_string())?.is_some())
+    }
+
+    pub(super) fn last_checkpoint_time_duckdb(
+        &self,
+        pool: &Arc<DuckDbConnectionPool>,
+    ) -> Result<Option<SystemTime>> {
+        let mut db_conn = Arc::clone(pool).connect_sync().map_err(|e| e.to_string())?;
+        let duckdb_conn = datafusion_table_providers::duckdb::DuckDB::duckdb_conn(&mut db_conn)
+            .map_err(|e| e.to_string())?
+            .get_underlying_conn_mut();
+
+        let query = format!(
+            "SELECT updated_at FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ? LIMIT 1"
+        );
+        let mut stmt = duckdb_conn.prepare(&query).map_err(|e| e.to_string())?;
+        let mut rows = stmt
+            .query([&self.dataset_name])
+            .map_err(|e| e.to_string())?;
+
+        let checkpoint_time_micros: Option<u64> = rows
+            .next()
+            .map_err(|e| e.to_string())?
+            .map(|row| row.get(0))
+            .transpose()
+            .map_err(|e| e.to_string())?;
+
+        if let Some(checkpoint_time_micros) = checkpoint_time_micros {
+            let duration = Duration::from_micros(checkpoint_time_micros);
+            Ok(Some(UNIX_EPOCH + duration))
+        } else {
+            Ok(None)
+        }
     }
 
     pub(super) fn checkpoint_duckdb(
@@ -353,5 +388,66 @@ mod tests {
         } else {
             panic!("Unexpected acceleration connection type");
         }
+    }
+
+    #[tokio::test]
+    async fn test_duckdb_last_checkpoint_time() {
+        let (checkpoint, _) = create_in_memory_duckdb_checkpoint();
+
+        // Initially, there should be no checkpoint time
+        assert!(checkpoint
+            .last_checkpoint_time()
+            .await
+            .expect("Unexpected checkpoint failure")
+            .is_none());
+
+        // Create a test schema
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let schema_ref = std::sync::Arc::new(schema);
+
+        // Create the checkpoint
+        checkpoint
+            .checkpoint(&schema_ref)
+            .await
+            .expect("Failed to create checkpoint");
+
+        // Now there should be a checkpoint time
+        let checkpoint_time = checkpoint
+            .last_checkpoint_time()
+            .await
+            .expect("Failed to get checkpoint time")
+            .expect("Checkpoint time should exist");
+
+        // Verify the checkpoint time is recent
+        let now = SystemTime::now();
+        let time_diff = now
+            .duration_since(checkpoint_time)
+            .expect("Time difference should be positive");
+        assert!(time_diff.as_secs() < 5, "Checkpoint time should be recent");
+
+        // Sleep for a short time to ensure the timestamp changes
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        // Update the checkpoint
+        checkpoint
+            .checkpoint(&schema_ref)
+            .await
+            .expect("Failed to update checkpoint");
+
+        // Get the new checkpoint time
+        let new_checkpoint_time = checkpoint
+            .last_checkpoint_time()
+            .await
+            .expect("Failed to get new checkpoint time")
+            .expect("New checkpoint time should exist");
+
+        // Verify the new checkpoint time is more recent than the old one
+        assert!(
+            new_checkpoint_time > checkpoint_time,
+            "New checkpoint time should be more recent"
+        );
     }
 }

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
@@ -21,7 +21,7 @@ limitations under the License.
 //!     `updated_at` TIMESTAMP DEFAULT `CURRENT_TIMESTAMP` ON UPDATE `CURRENT_TIMESTAMP`,
 //! );
 
-use std::sync::Arc;
+use std::{sync::Arc, time::SystemTime};
 
 use super::{acceleration_connection, AccelerationConnection, Result};
 use crate::component::dataset::Dataset;
@@ -45,6 +45,7 @@ pub trait DatasetCheckpointer: Send + Sync {
     async fn exists(&self) -> bool;
     async fn checkpoint(&self, schema: &SchemaRef) -> Result<()>;
     async fn get_schema(&self) -> Result<Option<SchemaRef>>;
+    async fn last_checkpoint_time(&self) -> Result<Option<SystemTime>>;
 }
 
 #[async_trait]
@@ -59,6 +60,10 @@ impl DatasetCheckpointer for DatasetCheckpoint {
 
     async fn get_schema(&self) -> Result<Option<SchemaRef>> {
         self.get_schema().await
+    }
+
+    async fn last_checkpoint_time(&self) -> Result<Option<SystemTime>> {
+        self.last_checkpoint_time().await
     }
 }
 
@@ -128,6 +133,21 @@ impl DatasetCheckpoint {
             }
             #[cfg(not(any(feature = "sqlite", feature = "duckdb", feature = "postgres")))]
             _ => false,
+        }
+    }
+
+    pub async fn last_checkpoint_time(&self) -> Result<Option<SystemTime>> {
+        match &self.acceleration_connection {
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::DuckDB(pool) => self.last_checkpoint_time_duckdb(pool),
+            #[cfg(feature = "postgres")]
+            AccelerationConnection::Postgres(pool) => {
+                self.last_checkpoint_time_postgres(pool).await
+            }
+            #[cfg(feature = "sqlite")]
+            AccelerationConnection::SQLite(conn) => self.last_checkpoint_time_sqlite(conn).await,
+            #[cfg(not(any(feature = "sqlite", feature = "duckdb", feature = "postgres")))]
+            _ => Err("No acceleration connection available".into()),
         }
     }
 

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/postgres.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::time::SystemTime;
+
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 
@@ -49,6 +51,29 @@ impl DatasetCheckpoint {
             .await
             .map_err(|e| e.to_string())?;
         Ok(row.is_some())
+    }
+
+    pub(super) async fn last_checkpoint_time_postgres(
+        &self,
+        pool: &PostgresConnectionPool,
+    ) -> Result<Option<SystemTime>> {
+        let conn = pool.connect_direct().await.map_err(|e| e.to_string())?;
+
+        let query = format!(
+            "SELECT updated_at FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ? LIMIT 1"
+        );
+        let stmt = conn.conn.prepare(&query).await.map_err(|e| e.to_string())?;
+        let rows = conn
+            .conn
+            .query(&stmt, &[&self.dataset_name])
+            .await
+            .map_err(|e| e.to_string())?;
+        let Some(row) = rows.first() else {
+            return Ok(None);
+        };
+
+        let checkpoint_time: Option<SystemTime> = row.get(0);
+        Ok(checkpoint_time)
     }
 
     pub(super) async fn checkpoint_postgres(

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/sqlite.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::time::SystemTime;
+
 use super::{DatasetCheckpoint, Result, CHECKPOINT_TABLE_NAME};
+use chrono::{DateTime, Utc};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion_table_providers::sql::db_connection_pool::{
     dbconnection::sqliteconn::SqliteConnection, sqlitepool::SqliteConnectionPool,
@@ -87,6 +90,35 @@ impl DatasetCheckpoint {
             })
             .await
             .map_err(|e| e.to_string().into())
+    }
+
+    pub(super) async fn last_checkpoint_time_sqlite(
+        &self,
+        pool: &SqliteConnectionPool,
+    ) -> Result<Option<SystemTime>> {
+        let conn_sync = pool.connect_sync();
+        let Some(conn) = conn_sync.as_any().downcast_ref::<SqliteConnection>() else {
+            return Err("Failed to downcast to SqliteConnection".into());
+        };
+        let dataset_name = self.dataset_name.clone();
+
+        let query = format!(
+            "SELECT updated_at FROM {CHECKPOINT_TABLE_NAME} WHERE dataset_name = ? LIMIT 1"
+        );
+        let checkpoint_time: Option<DateTime<Utc>> = conn
+            .conn
+            .call(move |conn| {
+                let mut stmt = conn.prepare(&query)?;
+                let mut rows = stmt.query([&dataset_name])?;
+                Ok(rows.next()?.map(|row| row.get(0)))
+            })
+            .await
+            .map_err(|e| e.to_string())?
+            .transpose()
+            .map_err(|e| e.to_string())?;
+
+        let checkpoint_time = checkpoint_time.map(Into::into);
+        Ok(checkpoint_time)
     }
 
     pub(super) async fn checkpoint_sqlite(
@@ -395,6 +427,67 @@ mod tests {
         assert_ne!(
             created_at, updated_at,
             "created_at and updated_at should be different"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_last_checkpoint_time() {
+        let checkpoint = create_in_memory_sqlite_checkpoint().await;
+
+        // Initially, there should be no checkpoint time
+        assert!(checkpoint
+            .last_checkpoint_time()
+            .await
+            .expect("Unexpected checkpoint failure")
+            .is_none());
+
+        // Create a test schema
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let schema_ref = std::sync::Arc::new(schema);
+
+        // Create the checkpoint
+        checkpoint
+            .checkpoint(&schema_ref)
+            .await
+            .expect("Failed to create checkpoint");
+
+        // Now there should be a checkpoint time
+        let checkpoint_time = checkpoint
+            .last_checkpoint_time()
+            .await
+            .expect("Failed to get checkpoint time")
+            .expect("Checkpoint time should exist");
+
+        // Verify the checkpoint time is recent
+        let now = SystemTime::now();
+        let time_diff = now
+            .duration_since(checkpoint_time)
+            .expect("Time difference should be positive");
+        assert!(time_diff.as_secs() < 5, "Checkpoint time should be recent");
+
+        // Sleep for a short time to ensure the timestamp changes
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+        // Update the checkpoint
+        checkpoint
+            .checkpoint(&schema_ref)
+            .await
+            .expect("Failed to update checkpoint");
+
+        // Get the new checkpoint time
+        let new_checkpoint_time = checkpoint
+            .last_checkpoint_time()
+            .await
+            .expect("Failed to get new checkpoint time")
+            .expect("New checkpoint time should exist");
+
+        // Verify the new checkpoint time is more recent than the old one
+        assert!(
+            new_checkpoint_time > checkpoint_time,
+            "New checkpoint time should be more recent"
         );
     }
 }


### PR DESCRIPTION
# 🗣 Description

Improves the `refresh_on_startup: auto` functionality introduced in #5086 to respect the `refresh_check_interval` across restarts, so that refreshes that are scheduled to happen every hour will not trigger a refresh on startup if the last refresh completed within the past hour.

This was implemented by exposing a new function on the `DatasetCheckpointer` that returns the last checkpoint time, if any. The `exists()` method is still present because it is slightly more efficient for just checking if there was a checkpoint, rather than when it happened. The new `last_checkpoint_time` will return the `SystemTime` representing when the last checkpoint completed - utilizing the `updated_at` column that already exists in the checkpoint system table.

The refresh method was reworked from a `should_refresh` that returns a `bool` to `startup_next_refresh` that returns an enum `NextRefresh` with the following options:

```rust
pub(crate) enum NextRefresh {
    WaitFor(Duration),
    Disabled,
}
```

The `startup_next_refresh` method also accepts the `RefreshOnStartup` enum to internalize the complicated logic of figuring out when we should refresh (if at all). Comprehensive unit tests were added to ensure all cases were covered.

## 🔨 Related Issues

Closes #5084

## 📄 Documentation Updates

https://github.com/spiceai/docs/pull/918
