### PR TITLE
Fix ModelGradedScorer error: The 'metadata' parameter is only allowed when 'store' is enabled.

### DIFF
--- a/crates/runtime/src/model/eval/scorer/modelgraded.rs
+++ b/crates/runtime/src/model/eval/scorer/modelgraded.rs
@@ -58,6 +58,7 @@ impl ModelGradedScorer {
                 .content(String::new())
                 .build()?
                 .into()])
+            .store(true)
             .build()
     }
 


### PR DESCRIPTION
# 🗣 Description

As discussed here
https://community.openai.com/t/metadata-parameter-in-chat-completion-api-reference-documentation-needs-to-be-updated/1119240

>metadata can only be used in conjunction with "store": true. Setting only the metadata parameter results in the following error:
The 'metadata' parameter is only allowed when 'store' is enabled.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

The documentation is telling that the `store` must be true by default but similar to discussion above I required to set it manually so it works
https://platform.openai.com/docs/api-reference/responses/create#responses-create-store

>store
boolean or null
Optional
Defaults to true
Whether to store the generated model response for later retrieval via API.


I also see that in async-openai it is false by default

![image](https://github.com/user-attachments/assets/90a79eca-b721-49c1-a104-66f5ed6afd04)


