### PR TITLE
Verify the checkpoints existence before shutting down runtime in integration tests directly querying checkpoint

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,10 +35,10 @@ on:
         required: false
         default: false
 
-concurrency:
-  # Allow only one workflow per any non-trunk branch.
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
-  cancel-in-progress: true
+# concurrency:
+#   # Allow only one workflow per any non-trunk branch.
+#   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+#   cancel-in-progress: true
 
 env:
   CONTAINER_REGISTRY: spiceaitestimages.azurecr.io/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,10 +35,10 @@ on:
         required: false
         default: false
 
-# concurrency:
-#   # Allow only one workflow per any non-trunk branch.
-#   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
-#   cancel-in-progress: true
+concurrency:
+  # Allow only one workflow per any non-trunk branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'trunk' && github.sha || 'any-sha' }}
+  cancel-in-progress: true
 
 env:
   CONTAINER_REGISTRY: spiceaitestimages.azurecr.io/

--- a/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
@@ -88,7 +88,7 @@ async fn test_acceleration_duckdb_checkpoint() -> Result<(), anyhow::Error> {
 
             runtime_ready_check(&rt).await;
 
-            // Verify if checkpoints are created before shutting down runtime
+            // Verify checkpoints are created before shutting down runtime
             wait_for_checkpoints(&runtime_datasets, 120).await?;
 
             // Wait for the checkpoint to be created

--- a/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
@@ -91,8 +91,6 @@ async fn test_acceleration_duckdb_checkpoint() -> Result<(), anyhow::Error> {
             // Verify checkpoints are created before shutting down runtime
             wait_for_checkpoints(&runtime_datasets, 120).await?;
 
-            // Wait for the checkpoint to be created
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             drop(rt);
             runtime::dataaccelerator::unregister_all().await;
             runtime::dataaccelerator::register_all().await;

--- a/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_duckdb.rs
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::acceleration::wait_for_checkpoints;
 use app::AppBuilder;
 use arrow::array::RecordBatch;
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::DbConnectionPool;
 use duckdb::AccessMode;
 use futures::TryStreamExt;
-use runtime::{status, Runtime};
+use runtime::{component::dataset::Dataset as RuntimeDataset, status, Runtime};
 use spicepod::component::dataset::{
     acceleration::{Acceleration, Mode, RefreshMode},
     Dataset,
@@ -62,6 +63,13 @@ async fn test_acceleration_duckdb_checkpoint() -> Result<(), anyhow::Error> {
                 .with_dataset(dataset)
                 .build();
 
+            let runtime_datasets = app
+                .datasets
+                .clone()
+                .into_iter()
+                .map(RuntimeDataset::try_from)
+                .collect::<Result<Vec<_>, _>>()?;
+
             let rt = Arc::new(
                 Runtime::builder()
                     .with_app(app)
@@ -79,6 +87,9 @@ async fn test_acceleration_duckdb_checkpoint() -> Result<(), anyhow::Error> {
             }
 
             runtime_ready_check(&rt).await;
+
+            // Verify if checkpoints are created before shutting down runtime
+            wait_for_checkpoints(&runtime_datasets, 120).await?;
 
             // Wait for the checkpoint to be created
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/crates/runtime/tests/acceleration/checkpoint_postgres.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_postgres.rs
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::acceleration::wait_for_checkpoints;
 use app::AppBuilder;
 use arrow::array::RecordBatch;
 use datafusion_table_providers::sql::db_connection_pool::DbConnectionPool;
 use futures::TryStreamExt;
-use runtime::{status, Runtime};
+use runtime::{component::dataset::Dataset as RuntimeDataset, status, Runtime};
 use secrecy::ExposeSecret;
 use spicepod::component::dataset::acceleration::{Acceleration, RefreshMode};
 use spicepod::component::dataset::Dataset;
@@ -67,6 +68,13 @@ async fn test_acceleration_postgres_checkpoint() -> Result<(), anyhow::Error> {
                 .with_dataset(dataset)
                 .build();
 
+            let runtime_datasets = app
+                .datasets
+                .clone()
+                .into_iter()
+                .map(RuntimeDataset::try_from)
+                .collect::<Result<Vec<_>, _>>()?;
+
             let rt = Arc::new(
                 Runtime::builder()
                     .with_app(app)
@@ -85,6 +93,9 @@ async fn test_acceleration_postgres_checkpoint() -> Result<(), anyhow::Error> {
             }
 
             runtime_ready_check(&rt).await;
+
+            // Verify if checkpoints are created before shutting down runtime
+            wait_for_checkpoints(&runtime_datasets, 120).await?;
 
             // Wait for the checkpoint to be created
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/crates/runtime/tests/acceleration/checkpoint_postgres.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_postgres.rs
@@ -94,7 +94,7 @@ async fn test_acceleration_postgres_checkpoint() -> Result<(), anyhow::Error> {
 
             runtime_ready_check(&rt).await;
 
-            // Verify if checkpoints are created before shutting down runtime
+            // Verify checkpoints are created before shutting down runtime
             wait_for_checkpoints(&runtime_datasets, 120).await?;
 
             // Wait for the checkpoint to be created

--- a/crates/runtime/tests/acceleration/checkpoint_postgres.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_postgres.rs
@@ -97,8 +97,6 @@ async fn test_acceleration_postgres_checkpoint() -> Result<(), anyhow::Error> {
             // Verify checkpoints are created before shutting down runtime
             wait_for_checkpoints(&runtime_datasets, 120).await?;
 
-            // Wait for the checkpoint to be created
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             drop(rt);
             runtime::dataaccelerator::unregister_all().await;
             runtime::dataaccelerator::register_all().await;

--- a/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
@@ -86,7 +86,7 @@ async fn test_acceleration_sqlite_checkpoint() -> Result<(), anyhow::Error> {
 
             runtime_ready_check(&rt).await;
 
-            // Verify if checkpoints are created before shutting down runtime
+            // Verify checkpoints are created before shutting down runtime
             wait_for_checkpoints(&runtime_datasets, 120).await?;
 
             // Wait for the checkpoint to be created

--- a/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::acceleration::wait_for_checkpoints;
 use app::AppBuilder;
 use arrow::array::RecordBatch;
 use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::DbConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::JoinPushDown;
 use futures::TryStreamExt;
-use runtime::{status, Runtime};
+use runtime::{component::dataset::Dataset as RuntimeDataset, status, Runtime};
 use spicepod::component::dataset::acceleration::Mode;
 use spicepod::component::dataset::acceleration::{Acceleration, RefreshMode};
 use spicepod::component::dataset::Dataset;
@@ -60,6 +61,13 @@ async fn test_acceleration_sqlite_checkpoint() -> Result<(), anyhow::Error> {
                 .with_dataset(dataset)
                 .build();
 
+            let runtime_datasets = app
+                .datasets
+                .clone()
+                .into_iter()
+                .map(RuntimeDataset::try_from)
+                .collect::<Result<Vec<_>, _>>()?;
+
             let rt = Arc::new(
                 Runtime::builder()
                     .with_app(app)
@@ -77,6 +85,9 @@ async fn test_acceleration_sqlite_checkpoint() -> Result<(), anyhow::Error> {
             }
 
             runtime_ready_check(&rt).await;
+
+            // Verify if checkpoints are created before shutting down runtime
+            wait_for_checkpoints(&runtime_datasets, 120).await?;
 
             // Wait for the checkpoint to be created
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
+++ b/crates/runtime/tests/acceleration/checkpoint_sqlite.rs
@@ -89,8 +89,6 @@ async fn test_acceleration_sqlite_checkpoint() -> Result<(), anyhow::Error> {
             // Verify checkpoints are created before shutting down runtime
             wait_for_checkpoints(&runtime_datasets, 120).await?;
 
-            // Wait for the checkpoint to be created
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             drop(rt);
             runtime::dataaccelerator::unregister_all().await;
             runtime::dataaccelerator::register_all().await;

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -16,6 +16,9 @@ limitations under the License.
 
 use std::sync::LazyLock;
 
+use runtime::{
+    component::dataset::Dataset, dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint,
+};
 use spicepod::component::{dataset::acceleration::Mode, params::Params};
 use tokio::sync::Mutex;
 
@@ -47,4 +50,35 @@ fn get_params(mode: &Mode, file: Option<String>, engine: &str) -> Option<Params>
         ));
     }
     None
+}
+
+async fn wait_for_checkpoints(
+    datasets: &Vec<Dataset>,
+    timeout_secs: u64,
+) -> Result<(), anyhow::Error> {
+    let mut checkpoint_futures = Vec::new();
+
+    for dataset in datasets {
+        let check_future = async move {
+            match DatasetCheckpoint::try_new(dataset).await {
+                Ok(checkpoint) => {
+                    while !checkpoint.exists().await {
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(anyhow::anyhow!("Failed to create checkpoint: {}", e)),
+            }
+        };
+        checkpoint_futures.push(check_future);
+    }
+
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)) => {
+            Err(anyhow::anyhow!("Timed out waiting for dataset checkpoints"))
+        },
+        result = futures::future::try_join_all(checkpoint_futures) => {
+            result.map(|_| ())
+        }
+    }
 }

--- a/crates/runtime/tests/acceleration/mod.rs
+++ b/crates/runtime/tests/acceleration/mod.rs
@@ -67,7 +67,7 @@ async fn wait_for_checkpoints(
                     }
                     Ok(())
                 }
-                Err(e) => Err(anyhow::anyhow!("Failed to create checkpoint: {}", e)),
+                Err(e) => Err(anyhow::anyhow!("Failed to verify checkpoint: {e}")),
             }
         };
         checkpoint_futures.push(check_future);

--- a/crates/runtime/tests/acceleration/single_instance_duckdb.rs
+++ b/crates/runtime/tests/acceleration/single_instance_duckdb.rs
@@ -98,7 +98,7 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
 
             runtime_ready_check(&rt).await;
 
-            // Verify if checkpoints are created before shutting down runtime
+            // Verify checkpoints are created before shutting down runtime
             wait_for_checkpoints(&runtime_datasets, 120).await?;
 
             rt.shutdown().await;

--- a/crates/runtime/tests/acceleration/single_instance_duckdb.rs
+++ b/crates/runtime/tests/acceleration/single_instance_duckdb.rs
@@ -96,6 +96,8 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
                 () = rt.load_components() => {}
             }
 
+            runtime_ready_check(&rt).await;
+
             // Verify if checkpoints are created before shutting down runtime
             wait_for_checkpoints(&runtime_datasets, 120).await?;
 
@@ -181,7 +183,7 @@ async fn wait_for_checkpoints(
     }
 
     tokio::select! {
-        _ = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)) => {
+        () = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)) => {
             Err(anyhow::anyhow!("Timed out waiting for dataset checkpoints"))
         },
         result = futures::future::try_join_all(checkpoint_futures) => {

--- a/crates/runtime/tests/acceleration/single_instance_duckdb.rs
+++ b/crates/runtime/tests/acceleration/single_instance_duckdb.rs
@@ -20,7 +20,8 @@ use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConne
 use datafusion_table_providers::sql::db_connection_pool::DbConnectionPool;
 use duckdb::AccessMode;
 use futures::TryStreamExt;
-use runtime::{status, Runtime};
+use runtime::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
+use runtime::{component::dataset::Dataset as RuntimeDataset, status, Runtime};
 use spicepod::component::dataset::{
     acceleration::{Acceleration, Mode, RefreshMode},
     Dataset,
@@ -72,6 +73,13 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
                 ))
                 .build();
 
+            let runtime_datasets = app
+                .datasets
+                .clone()
+                .into_iter()
+                .map(RuntimeDataset::try_from)
+                .collect::<Result<Vec<_>, _>>()?;
+
             let rt = Arc::new(
                 Runtime::builder()
                     .with_app(app)
@@ -88,9 +96,9 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
                 () = rt.load_components() => {}
             }
 
-            runtime_ready_check(&rt).await;
+            // Verify if checkpoints are created before shutting down runtime
+            wait_for_checkpoints(&runtime_datasets, 120).await?;
 
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             rt.shutdown().await;
             runtime::dataaccelerator::unregister_all().await;
             runtime::dataaccelerator::register_all().await;
@@ -149,4 +157,35 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
             Ok(())
         })
         .await
+}
+
+async fn wait_for_checkpoints(
+    datasets: &Vec<RuntimeDataset>,
+    timeout_secs: u64,
+) -> Result<(), anyhow::Error> {
+    let mut checkpoint_futures = Vec::new();
+
+    for dataset in datasets {
+        let check_future = async move {
+            match DatasetCheckpoint::try_new(dataset).await {
+                Ok(checkpoint) => {
+                    while !checkpoint.exists().await {
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(anyhow::anyhow!("Failed to create checkpoint: {}", e)),
+            }
+        };
+        checkpoint_futures.push(check_future);
+    }
+
+    tokio::select! {
+        _ = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)) => {
+            Err(anyhow::anyhow!("Timed out waiting for dataset checkpoints"))
+        },
+        result = futures::future::try_join_all(checkpoint_futures) => {
+            result.map(|_| ())
+        }
+    }
 }

--- a/crates/runtime/tests/acceleration/single_instance_duckdb.rs
+++ b/crates/runtime/tests/acceleration/single_instance_duckdb.rs
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::acceleration::wait_for_checkpoints;
 use app::AppBuilder;
 use arrow::array::RecordBatch;
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::DbConnectionPool;
 use duckdb::AccessMode;
 use futures::TryStreamExt;
-use runtime::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
 use runtime::{component::dataset::Dataset as RuntimeDataset, status, Runtime};
 use spicepod::component::dataset::{
     acceleration::{Acceleration, Mode, RefreshMode},
@@ -159,35 +159,4 @@ async fn test_acceleration_duckdb_single_instance() -> Result<(), anyhow::Error>
             Ok(())
         })
         .await
-}
-
-async fn wait_for_checkpoints(
-    datasets: &Vec<RuntimeDataset>,
-    timeout_secs: u64,
-) -> Result<(), anyhow::Error> {
-    let mut checkpoint_futures = Vec::new();
-
-    for dataset in datasets {
-        let check_future = async move {
-            match DatasetCheckpoint::try_new(dataset).await {
-                Ok(checkpoint) => {
-                    while !checkpoint.exists().await {
-                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                    }
-                    Ok(())
-                }
-                Err(e) => Err(anyhow::anyhow!("Failed to create checkpoint: {}", e)),
-            }
-        };
-        checkpoint_futures.push(check_future);
-    }
-
-    tokio::select! {
-        () = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)) => {
-            Err(anyhow::anyhow!("Timed out waiting for dataset checkpoints"))
-        },
-        result = futures::future::try_join_all(checkpoint_futures) => {
-            result.map(|_| ())
-        }
-    }
 }


### PR DESCRIPTION
# 🗣 Description

In all integration tests which involve a direct connection to database for querying the checkpoint table, wait until spice runtime confirmed checkpoints are created beforehand

Test is verified with CI runs from `test #1` [e3744b5](https://github.com/spiceai/spiceai/pull/5232/commits/e3744b5ab856967007138ae8030107c73eafbb42) to `test #15` https://github.com/spiceai/spiceai/pull/5232/commits/cf8cf4c4416c50cc058fe4c0da101d88b02bcca6. The tests fixed in this PR passed 15/15.

## 🔨 Related Issues

- Close: https://github.com/spiceai/spiceai/issues/5218
- Close: https://github.com/spiceai/spiceai/issues/5233

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
