### PR TITLE
Disable label check for a draft pr

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -9,8 +9,16 @@ jobs:
   enforce-label:
     runs-on: spiceai-runners
     steps:
+      - name: Check if PR is a draft
+        id: check-draft
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const isDraft = context.payload.pull_request && context.payload.pull_request.draft === true;
+            core.setOutput('is_draft', isDraft.toString());
+
       - uses: yogevbd/enforce-label-action@2.2.2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.check-draft.outputs.is_draft != 'true'
         with:
           REQUIRED_LABELS_ANY: 'kind/refactor,kind/bug,kind/enhancement,kind/documentation,kind/optimization,kind/dependencies'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['kind/refactor','kind/bug','kind/enhancement','kind/documentation', 'kind/optimization', 'kind/dependencies']"

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -6,8 +6,10 @@ on:
   merge_group:
     types: [checks_requested]
 jobs:
-  enforce-label:
-    runs-on: spiceai-runners
+  check-draft-status:
+    runs-on: ubuntu-latest  # Use a lightweight runner for this check
+    outputs:
+      is_draft: ${{ steps.check-draft.outputs.is_draft }}
     steps:
       - name: Check if PR is a draft
         id: check-draft
@@ -17,8 +19,13 @@ jobs:
             const isDraft = context.payload.pull_request && context.payload.pull_request.draft === true;
             core.setOutput('is_draft', isDraft.toString());
 
+  enforce-label:
+    needs: check-draft-status
+    runs-on: spiceai-runners
+    if: needs.check-draft-status.outputs.is_draft != 'true'
+    steps:
       - uses: yogevbd/enforce-label-action@2.2.2
-        if: github.event_name == 'pull_request' && steps.check-draft.outputs.is_draft != 'true'
+        if: github.event_name == 'pull_request'
         with:
           REQUIRED_LABELS_ANY: 'kind/refactor,kind/bug,kind/enhancement,kind/documentation,kind/optimization,kind/dependencies'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['kind/refactor','kind/bug','kind/enhancement','kind/documentation', 'kind/optimization', 'kind/dependencies']"


### PR DESCRIPTION
# 🗣 Description

Disable PR label check for PR that's still draft. This will save some docker image pull limit since the check pr action require pull from docker hub.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
