### PR TITLE
Fix CORS support for json content-type api

### DIFF
--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -27,6 +27,7 @@ use crate::{config, request::RequestContext};
 
 use app::App;
 use axum::{extract::State, routing::patch};
+use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use opentelemetry::KeyValue;
 use spicepod::component::runtime::CorsConfig;
 use std::sync::Arc;
@@ -301,7 +302,8 @@ fn cors_layer(cors_config: &CorsConfig) -> CorsLayer {
         cors_config.allowed_origins
     );
 
-    cors.allow_methods([Method::GET, Method::POST, Method::PATCH])
+    cors.allow_methods([Method::GET, Method::POST, Method::PATCH, Method::OPTIONS])
+        .allow_headers([ACCEPT, CONTENT_TYPE, AUTHORIZATION])
         .allow_origin(allowed_origins)
 }
 

--- a/crates/runtime/tests/cors/mod.rs
+++ b/crates/runtime/tests/cors/mod.rs
@@ -102,7 +102,7 @@ async fn test_enabled_cors_endpoints() -> Result<(), anyhow::Error> {
                 .headers()
                 .get("access-control-allow-methods")
                 .expect("cors header is present");
-            assert_eq!(cors_allow_methods_header, "GET,POST,PATCH");
+            assert_eq!(cors_allow_methods_header, "GET,POST,PATCH,OPTIONS");
 
             Ok(())
         }).await


### PR DESCRIPTION
# 🗣 Description

This is required for Vector Search, Chat Completion and other json based API to work.

 - OPTIONS must be allowed for the browser to make preflight requests (when requests includes Accept: application/json, it considered as a non-simple request, which triggers a preflight OPTIONS request and also requires allow_header to work)
 - CONTENT_TYPE must be explicitly allowed if using application/json.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

Must add integration or E2E tests for CORS (or cookbook recipe) - to be added separately.
