### PR TITLE
Add Support for AWS Session Token in S3 Data Connector

### DIFF
--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -23,7 +23,6 @@ use super::{
 use crate::parameters::ParamLookup;
 use crate::{component::dataset::Dataset, dataconnector::listing::LISTING_TABLE_PARAMETERS};
 
-use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::any::Any;
 use std::clone::Clone;
@@ -136,7 +135,7 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
             ParameterSpec::component("endpoint").secret(),
             ParameterSpec::component("key").secret(),
             ParameterSpec::component("secret").secret(),
-            ParameterSpec::component("session_token").secret(),
+            ParameterSpec::component("session_token").secret().disable_auto_load(),
             ParameterSpec::component("auth")
                 .description("Configures the authentication method for S3. Supported methods are: public (i.e. no auth), iam_role, key.")
                 .secret(),
@@ -232,16 +231,6 @@ impl DataConnectorFactory for S3Factory {
                             return Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>);
                         }
                     }
-
-                    // Session token is optional; log if present
-                    if let ParamLookup::Present(secret) = params.parameters.get("session_token") {
-                        tracing::info!(
-                            "Using temporary credentials with session token for S3 auth."
-                        );
-
-                        // Set environment variable because session token cannot be used in URL fragment
-                        std::env::set_var("AWS_SESSION_TOKEN", secret.expose_secret());
-                    }
                 }
                 Some(auth) => {
                     return Err(Box::new(Error::UnsupportedAuthenticationMethod {
@@ -307,7 +296,7 @@ impl ListingTableConnector for S3 {
                 "client_timeout",
                 "allow_http",
                 "auth",
-                // "session_token" cannot be sent via URL fragments
+                "session_token",
             ],
         )));
 

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -238,6 +238,8 @@ impl DataConnectorFactory for S3Factory {
                         tracing::info!(
                             "Using temporary credentials with session token for S3 auth."
                         );
+
+                        // Set environment variable because session token cannot be used in URL fragment
                         std::env::set_var("AWS_SESSION_TOKEN", secret.expose_secret());
                     }
                 }
@@ -305,6 +307,7 @@ impl ListingTableConnector for S3 {
                 "client_timeout",
                 "allow_http",
                 "auth",
+                // "session_token" cannot be sent via URL fragments
             ],
         )));
 

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -23,6 +23,7 @@ use super::{
 use crate::parameters::ParamLookup;
 use crate::{component::dataset::Dataset, dataconnector::listing::LISTING_TABLE_PARAMETERS};
 
+use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::any::Any;
 use std::clone::Clone;
@@ -245,6 +246,11 @@ impl DataConnectorFactory for S3Factory {
                 }
             };
 
+            if let ParamLookup::Present(secret) = params.parameters.get("session_token") {
+                tracing::debug!("Setting AWS_SESSION_TOKEN env variable");
+                std::env::set_var("AWS_SESSION_TOKEN", secret.expose_secret());
+            }
+
             let s3 = S3 {
                 params: params.parameters,
             };
@@ -298,7 +304,6 @@ impl ListingTableConnector for S3 {
                 "endpoint",
                 "key",
                 "secret",
-                "session_token",
                 "client_timeout",
                 "allow_http",
                 "auth",

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -234,13 +234,11 @@ impl DataConnectorFactory for S3Factory {
                     }
 
                     // Session token is optional; log if present
-                    if matches!(
-                        params.parameters.get("session_token"),
-                        ParamLookup::Present(_)
-                    ) {
+                    if let ParamLookup::Present(secret) = params.parameters.get("session_token") {
                         tracing::info!(
                             "Using temporary credentials with session token for S3 auth."
                         );
+                        std::env::set_var("AWS_SESSION_TOKEN", secret.expose_secret());
                     }
                 }
                 Some(auth) => {
@@ -250,11 +248,6 @@ impl DataConnectorFactory for S3Factory {
                         as Box<dyn std::error::Error + Send + Sync>);
                 }
             };
-
-            if let ParamLookup::Present(secret) = params.parameters.get("session_token") {
-                tracing::debug!("Setting AWS_SESSION_TOKEN env variable");
-                std::env::set_var("AWS_SESSION_TOKEN", secret.expose_secret());
-            }
 
             let s3 = S3 {
                 params: params.parameters,

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -76,6 +76,9 @@ pub enum Error {
     #[snafu(display("S3 auth method 'key' requires an AWS access key.\nSpecify an access key with the `s3_key` parameter.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#auth"))]
     NoAccessKey,
 
+    #[snafu(display("S3 auth method 'key' requires an AWS session token.\nSpecify a session token with the `s3_key` parameter.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#auth"))]
+    NoAccessSessionToken,
+
     #[snafu(display("Unsupported S3 auth method '{method}'.\nUse 'public', 'iam_role', or 'key' for `s3_auth` parameter.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#auth"))]
     UnsupportedAuthenticationMethod { method: String },
 
@@ -133,6 +136,7 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
             ParameterSpec::component("endpoint").secret(),
             ParameterSpec::component("key").secret(),
             ParameterSpec::component("secret").secret(),
+            ParameterSpec::component("session_token").secret(),
             ParameterSpec::component("auth")
                 .description("Configures the authentication method for S3. Supported methods are: public (i.e. no auth), iam_role, key.")
                 .secret(),
@@ -206,33 +210,29 @@ impl DataConnectorFactory for S3Factory {
                 }
             }
 
+            let key_params = ["key", "secret", "session_token"];
             match params.parameters.get("auth").expose().ok() {
                 None | Some("public" | "iam_role") => {
-                    if matches!(params.parameters.get("key"), ParamLookup::Present(_)) {
-                        // The 's3_key' parameter cannot be set unless the `s3_auth` parameter is set to 'key'.
-                        return Err(Box::new(Error::InvalidAuthParameterCombination {
-                            parameter: "s3_key".to_string(),
-                            auth: "key".to_string(),
-                        })
-                            as Box<dyn std::error::Error + Send + Sync>);
-                    }
-                    if matches!(params.parameters.get("secret"), ParamLookup::Present(_)) {
-                        // The 's3_secret' parameter cannot be set unless the `s3_auth` parameter is set to 'key'.
-                        return Err(Box::new(Error::InvalidAuthParameterCombination {
-                            parameter: "s3_secret".to_string(),
-                            auth: "key".to_string(),
-                        })
-                            as Box<dyn std::error::Error + Send + Sync>);
+                    // These parameters cannot be set unless the `s3_auth` parameter is set to 'key'.
+                    for param in key_params {
+                        if matches!(params.parameters.get(param), ParamLookup::Present(_)) {
+                            return Err(Box::new(Error::InvalidAuthParameterCombination {
+                                parameter: format!("s3_{param}"),
+                                auth: "key".to_string(),
+                            })
+                                as Box<dyn std::error::Error + Send + Sync>);
+                        }
                     }
                 }
                 Some("key") => {
-                    if matches!(params.parameters.get("key"), ParamLookup::Absent(_)) {
-                        return Err(Box::new(Error::NoAccessKey)
-                            as Box<dyn std::error::Error + Send + Sync>);
-                    }
-                    if matches!(params.parameters.get("secret"), ParamLookup::Absent(_)) {
-                        return Err(Box::new(Error::NoAccessSecret)
-                            as Box<dyn std::error::Error + Send + Sync>);
+                    for (param, e) in key_params.iter().zip([
+                        Error::NoAccessKey,
+                        Error::NoAccessSecret,
+                        Error::NoAccessSessionToken,
+                    ]) {
+                        if matches!(params.parameters.get(param), ParamLookup::Absent(_)) {
+                            return Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>);
+                        }
                     }
                 }
                 Some(auth) => {
@@ -296,6 +296,7 @@ impl ListingTableConnector for S3 {
                 "endpoint",
                 "key",
                 "secret",
+                "session_token",
                 "client_timeout",
                 "allow_http",
                 "auth",

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -79,9 +79,6 @@ pub enum Error {
     #[snafu(display("S3 auth method 'key' requires an AWS access key.\nSpecify an access key with the `s3_key` parameter.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#auth"))]
     NoAccessKey,
 
-    #[snafu(display("S3 auth method 'key' requires an AWS session token.\nSpecify a session token with the `s3_key` parameter.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#auth"))]
-    NoAccessSessionToken,
-
     #[snafu(display("Unsupported S3 auth method '{method}'.\nUse 'public', 'iam_role', or 'key' for `s3_auth` parameter.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#auth"))]
     UnsupportedAuthenticationMethod { method: String },
 
@@ -213,11 +210,10 @@ impl DataConnectorFactory for S3Factory {
                 }
             }
 
-            let key_params = ["key", "secret", "session_token"];
             match params.parameters.get("auth").expose().ok() {
                 None | Some("public" | "iam_role") => {
                     // These parameters cannot be set unless the `s3_auth` parameter is set to 'key'.
-                    for param in key_params {
+                    for param in ["key", "secret", "session_token"] {
                         if matches!(params.parameters.get(param), ParamLookup::Present(_)) {
                             return Err(Box::new(Error::InvalidAuthParameterCombination {
                                 parameter: format!("{PREFIX}_{param}"),
@@ -228,14 +224,23 @@ impl DataConnectorFactory for S3Factory {
                     }
                 }
                 Some("key") => {
-                    for (param, e) in key_params.iter().zip([
-                        Error::NoAccessKey,
-                        Error::NoAccessSecret,
-                        Error::NoAccessSessionToken,
-                    ]) {
+                    for (param, e) in [
+                        ("key", Error::NoAccessKey),
+                        ("secret", Error::NoAccessSecret),
+                    ] {
                         if matches!(params.parameters.get(param), ParamLookup::Absent(_)) {
                             return Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>);
                         }
+                    }
+
+                    // Session token is optional; log if present
+                    if matches!(
+                        params.parameters.get("session_token"),
+                        ParamLookup::Present(_)
+                    ) {
+                        tracing::info!(
+                            "Using temporary credentials with session token for S3 auth."
+                        );
                     }
                 }
                 Some(auth) => {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -32,6 +32,8 @@ use std::string::String;
 use std::sync::{Arc, LazyLock};
 use url::Url;
 
+static PREFIX: &str = "s3";
+
 // https://docs.aws.amazon.com/general/latest/gr/rande.html
 pub const AWS_REGIONS: [&str; 32] = [
     "us-east-1",
@@ -217,7 +219,7 @@ impl DataConnectorFactory for S3Factory {
                     for param in key_params {
                         if matches!(params.parameters.get(param), ParamLookup::Present(_)) {
                             return Err(Box::new(Error::InvalidAuthParameterCombination {
-                                parameter: format!("s3_{param}"),
+                                parameter: format!("{PREFIX}_{param}"),
                                 auth: "key".to_string(),
                             })
                                 as Box<dyn std::error::Error + Send + Sync>);
@@ -251,7 +253,7 @@ impl DataConnectorFactory for S3Factory {
     }
 
     fn prefix(&self) -> &'static str {
-        "s3"
+        PREFIX
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
@@ -261,7 +263,7 @@ impl DataConnectorFactory for S3Factory {
 
 impl std::fmt::Display for S3 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "s3")
+        write!(f, "{PREFIX}")
     }
 }
 
@@ -285,7 +287,7 @@ impl ListingTableConnector for S3 {
                 .boxed()
                 .context(super::InvalidConfigurationSnafu {
                     dataconnector: format!("{self}"),
-                    message: format!("The specified URL is not valid: {url}.\nEnsure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/s3#from"),
+                    message: format!("The specified URL is not valid: {url}.\nEnsure the URL is valid and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/{PREFIX}#from"),
                     connector_component: ConnectorComponent::from(dataset)
                 })?;
 

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -135,7 +135,7 @@ static PARAMETERS: LazyLock<Vec<ParameterSpec>> = LazyLock::new(|| {
             ParameterSpec::component("endpoint").secret(),
             ParameterSpec::component("key").secret(),
             ParameterSpec::component("secret").secret(),
-            ParameterSpec::component("session_token").secret().disable_auto_load(),
+            ParameterSpec::component("session_token").secret(),
             ParameterSpec::component("auth")
                 .description("Configures the authentication method for S3. Supported methods are: public (i.e. no auth), iam_role, key.")
                 .secret(),

--- a/crates/runtime/src/object_store_registry.rs
+++ b/crates/runtime/src/object_store_registry.rs
@@ -84,6 +84,9 @@ impl SpiceObjectStoreRegistry {
         if let (Some(key), Some(secret)) = (params.get("key"), params.get("secret")) {
             s3_builder = s3_builder.with_access_key_id(key);
             s3_builder = s3_builder.with_secret_access_key(secret);
+            if let Some(token) = params.get("session_token") {
+                s3_builder = s3_builder.with_token(token);
+            }
         } else {
             match params.get("auth") {
                 Some(auth) if auth == "iam_role" => {

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -92,7 +92,7 @@ impl Parameters {
         let secret_guard = secrets.read().await;
 
         // Try to autoload secrets that might be missing from params.
-        for secret_key in all_params.iter().filter(|p| p.secret && p.auto_load) {
+        for secret_key in all_params.iter().filter(|p| p.secret) {
             let secret_key_with_prefix = if secret_key.name.starts_with(prefix) {
                 secret_key.name.to_string()
             } else {
@@ -312,7 +312,6 @@ impl<'a> ExposedParamLookup<'a> {
 pub struct ParameterSpec {
     pub name: &'static str,
     pub required: bool,
-    pub auto_load: bool,
     pub default: Option<&'static str>,
     pub secret: bool,
     pub description: &'static str,
@@ -328,7 +327,6 @@ impl ParameterSpec {
         Self {
             name,
             required: false,
-            auto_load: true,
             default: None,
             secret: false,
             description: "",
@@ -344,7 +342,6 @@ impl ParameterSpec {
         Self {
             name,
             required: false,
-            auto_load: true,
             default: None,
             secret: false,
             description: "",
@@ -358,12 +355,6 @@ impl ParameterSpec {
     #[must_use]
     pub const fn required(mut self) -> Self {
         self.required = true;
-        self
-    }
-
-    #[must_use]
-    pub const fn disable_auto_load(mut self) -> Self {
-        self.auto_load = false;
         self
     }
 

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -92,7 +92,7 @@ impl Parameters {
         let secret_guard = secrets.read().await;
 
         // Try to autoload secrets that might be missing from params.
-        for secret_key in all_params.iter().filter(|p| p.secret) {
+        for secret_key in all_params.iter().filter(|p| p.secret && p.auto_load) {
             let secret_key_with_prefix = if secret_key.name.starts_with(prefix) {
                 secret_key.name.to_string()
             } else {
@@ -312,6 +312,7 @@ impl<'a> ExposedParamLookup<'a> {
 pub struct ParameterSpec {
     pub name: &'static str,
     pub required: bool,
+    pub auto_load: bool,
     pub default: Option<&'static str>,
     pub secret: bool,
     pub description: &'static str,
@@ -327,6 +328,7 @@ impl ParameterSpec {
         Self {
             name,
             required: false,
+            auto_load: true,
             default: None,
             secret: false,
             description: "",
@@ -342,6 +344,7 @@ impl ParameterSpec {
         Self {
             name,
             required: false,
+            auto_load: true,
             default: None,
             secret: false,
             description: "",
@@ -355,6 +358,12 @@ impl ParameterSpec {
     #[must_use]
     pub const fn required(mut self) -> Self {
         self.required = true;
+        self
+    }
+
+    #[must_use]
+    pub const fn disable_auto_load(mut self) -> Self {
+        self.auto_load = false;
         self
     }
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->
This PR enhances the S3 data connector in Spice AI to support temporary AWS credentials enabling compatibility with AWS SSO and STS-based authentication. Key changes include:

**Added session_token Parameter:** Introduced `s3_session_token` as an optional parameter for the s3_auth=key method, allowing users to provide a session token alongside `s3_key` and `s3_secret` for temporary credentials.

**Flexible Validation:** Updated the key auth method to require only `s3_key` and `s3_secret`, with `s3_session_token` being optional. This preserves compatibility with static IAM credentials while adding support for temporary credentials.

**Improved Parameter Handling:** Refactored auth validation to use a loop for `key`, `secret`, and `session_token`, ensuring consistent error messages and reducing code duplication.

**Code Consistency:** Moved the "s3" string to a static `PREFIX` constant and updated references for better maintainability.

**Opt-out of Parameter Auto Loading:** Disabled auto-loading for the `s3_session_token` parameter to prevent implicity use when multiple S3 datasets are used.


## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->
Addresses #5226 

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->
* [ ] needs to be documented in the S3 data connector param list.

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
