### PR TITLE
Expose the `mysql_pool_min` and `mysql_pool_max` connection pool parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=86e4a034a3c8d1091491d458ff26a07456c2ae53#86e4a034a3c8d1091491d458ff26a07456c2ae53"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=7fd0a14d03f707937f5131b897ab19092d32ef3b#7fd0a14d03f707937f5131b897ab19092d32ef3b"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b
 object_store = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b7925192b38cfcaca04e0af42f5aa9a3b5dc9ce0" }
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "8b373f95e3fa0eaa4f13b93435275acc4096bf2f" }
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "86e4a034a3c8d1091491d458ff26a07456c2ae53" }
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "7fd0a14d03f707937f5131b897ab19092d32ef3b" }
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "cc3f3b4e00ab22b3d9b3351d69b22147b482d7d3" }
 

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -29,6 +29,7 @@ use datafusion_table_providers::sql::db_connection_pool::{
 };
 use mysql_async::Metrics;
 use opentelemetry::KeyValue;
+use secrecy::ExposeSecret;
 use snafu::prelude::*;
 use std::any::Any;
 use std::future::Future;
@@ -97,9 +98,55 @@ impl DataConnectorFactory for MySQLFactory {
 
     fn create(
         &self,
-        params: ConnectorParams,
+        mut params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
+            let mut pool_min = params
+                .parameters
+                .get("pool_min")
+                .ok()
+                .and_then(|s| {
+                    let pool_min_str = s.expose_secret();
+                    let parsed_pool_min = pool_min_str.parse::<usize>();
+                    if parsed_pool_min.is_err() {
+                        tracing::warn!(
+                            "Invalid pool_min value: {pool_min_str}, using default of 10"
+                        );
+                    }
+                    parsed_pool_min.ok()
+                })
+                .unwrap_or(10);
+            let mut pool_max = params
+                .parameters
+                .get("pool_max")
+                .ok()
+                .and_then(|s| {
+                    let pool_max_str = s.expose_secret();
+                    let parsed_pool_max = pool_max_str.parse::<usize>();
+                    if parsed_pool_max.is_err() {
+                        tracing::warn!(
+                            "Invalid pool_max value: {pool_max_str}, using default of 100"
+                        );
+                    }
+                    parsed_pool_max.ok()
+                })
+                .unwrap_or(100);
+
+            if pool_min > pool_max {
+                tracing::warn!(
+                    "pool_min value: {pool_min} is greater than pool_max value: {pool_max}, using default values of 10 and 100"
+                );
+                pool_min = 10;
+                pool_max = 100;
+
+                params
+                    .parameters
+                    .insert("pool_min".to_string(), pool_min.to_string().into());
+                params
+                    .parameters
+                    .insert("pool_max".to_string(), pool_max.to_string().into());
+            }
+
             let pool = match MySQLConnectionPool::new(params.parameters.to_secret_map()).await {
                 Ok(pool) => Arc::new(pool),
                 Err(error) => match error {

--- a/crates/runtime/src/dataconnector/mysql.rs
+++ b/crates/runtime/src/dataconnector/mysql.rs
@@ -82,6 +82,12 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("db"),
     ParameterSpec::component("sslmode"),
     ParameterSpec::component("sslrootcert"),
+    ParameterSpec::component("pool_min")
+        .description("The minimum number of connections to keep open in the pool, lazily created when requested.")
+        .default("10"),
+    ParameterSpec::component("pool_max")
+        .description("The maximum number of connections to allow in the pool.")
+        .default("100"),
 ];
 
 impl DataConnectorFactory for MySQLFactory {


### PR DESCRIPTION
# 🗣 Description

Exposes new `mysql_pool_min` and `mysql_pool_max` connection pool parameters.

- **mysql_pool_min**: The minimum number of connections to keep open in the pool, lazily created when requested.
- **mysql_pool_max**: The maximum number of connections to allow in the pool.

## 📄 Documentation Updates

Will require a documentation update for the two new params.
