### PR TITLE
add integration test for reading encrypted PDFs from S3

### DIFF
--- a/crates/runtime/tests/s3/mod.rs
+++ b/crates/runtime/tests/s3/mod.rs
@@ -127,6 +127,60 @@ async fn s3_federation() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
+async fn s3_pdfs() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    let mut dataset = Dataset::new("s3://spiceai-public-datasets/test_pdf_files", "pdfs");
+    dataset.params = Some(Params::from_string_map(
+        vec![
+            ("file_format".to_string(), "pdf".to_string()),
+            ("client_timeout".to_string(), "120s".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    ));
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("s3_pdfs").with_dataset(dataset).build();
+
+            let status = status::RuntimeStatus::new();
+            let df = get_test_datafusion(Arc::clone(&status));
+
+            let rt = Runtime::builder()
+                .with_datafusion(df)
+                .with_app(app)
+                .build()
+                .await;
+
+            // Set a timeout for the test
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = rt.load_components() => {}
+            }
+
+            let mut query_result = rt
+                .datafusion()
+                .query_builder("SELECT * FROM pdfs")
+                .build()
+                .run()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let mut batches = vec![];
+            while let Some(batch) = query_result.data.next().await {
+                batches.push(batch?);
+            }
+
+            assert_eq!(batches.len(), 2);
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
 async fn s3_hive_partitioning() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

An integration test was added that reads PDFs from a public S3 bucket and queries them to test the ability to extract text from unencrypted and encrypted PDFs.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
