### PR TITLE
feat: Implement record batch data validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10060,6 +10060,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "remain"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10383,6 +10389,36 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.98",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -12056,6 +12092,7 @@ dependencies = [
  "app",
  "arrow",
  "async-openai",
+ "chrono",
  "clap",
  "duckdb",
  "flight_client",
@@ -12067,6 +12104,7 @@ dependencies = [
  "rand 0.9.0",
  "regex",
  "reqwest 0.12.12",
+ "rstest",
  "rustls 0.23.22",
  "serde",
  "serde_json",

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.95"
 app = { path = "../app" }
 arrow = { workspace = true, features = ["prettyprint"] }
 async-openai.workspace = true
+chrono.workspace = true
 clap.workspace = true
 duckdb = { optional = true, workspace = true, features = [
     "bundled",
@@ -42,6 +43,9 @@ uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(not(windows))'.dependencies]
 nix = { version = "0.29", features = ["signal"] }
+
+[dev-dependencies]
+rstest = "0.25.0"
 
 [features]
 anonymous_telemetry = []

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -125,14 +125,13 @@ fn datatype_equivalent(expected_type: DataType, actual_type: DataType) -> bool {
         return true;
     }
 
-    // Check for logical equivalence
+    // Check for logical equivalence, with a lenient set of rules
+    // E.g. a number could be returned as a string, number, or float.
     matches!(
         (expected_type, actual_type),
         (DataType::Float32, DataType::Float64)
             | (
-                DataType::Float64 | DataType::Int64, // why do we return ints as a decimal?
-                // TODO: the answer store needs to get updated with a defined schema?
-                // the inferred CSV schema isn't right with the context of the originating query
+                DataType::Float64 | DataType::Int64,
                 DataType::Decimal128(_, _)
             )
             | (DataType::Int32, DataType::Int64)

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -193,7 +193,7 @@ macro_rules! downcast_and_format_ts {
 /// Converts a value from an Arrow `Array` at a specific index into its string representation.
 ///
 /// Designed not to be used for production stringification, but rather for producing consistent values for validation results.
-/// Using input `RecordBatch` values, it removes any system differences from underlying sources (e.g. different trailing zeros, etc).
+/// Using input `RecordBatch` values, it attempts to remove any system differences from underlying sources (e.g. timestamp formats, etc).
 ///
 /// # Parameters:
 /// - `array`: A reference to a dynamically typed Arrow `Array`. This is the array that holds the data.

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -20,23 +20,49 @@ use std::{
     sync::{Arc, LazyLock},
 };
 
-use arrow::{array::RecordBatch, csv::reader::Format};
+use anyhow::{anyhow, Result};
+
+use arrow::{
+    array::{
+        Array, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array, Int32Array,
+        Int64Array, LargeStringArray, RecordBatch, StringArray, TimestampMicrosecondArray,
+        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt16Array,
+        UInt32Array, UInt64Array, UInt8Array,
+    },
+    csv::reader::Format,
+    datatypes::TimeUnit,
+};
 use arrow::{
     csv::ReaderBuilder,
     datatypes::{DataType, SchemaRef},
 };
+use chrono::{DateTime, NaiveDate};
 
 use super::Query;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueryValidationReason {
+    NoExpectedAnswer,
     NoAnswer,
     SchemaMismatch,
-    RowCountMismatch { expected: usize, actual: usize },
-    DataMismatch,
+    RowCountMismatch {
+        expected: usize,
+        actual: usize,
+    },
+    DataMismatch {
+        column: String,
+        row_number: usize,
+        expected: String,
+        actual: String,
+    },
+    ColumnLengthMismatch {
+        column_name: String,
+        left_len: usize,
+        right_len: usize,
+    },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueryValidationResult {
     Pass,
     Fail(QueryValidationReason),
@@ -133,16 +159,291 @@ fn equivalent_schemas(expected_schema: &SchemaRef, actual_schema: &SchemaRef) ->
         })
 }
 
+macro_rules! downcast_and_format {
+    ($array:expr, $index:expr, $t:ty) => {{
+        Ok(Some(
+            $array
+                .as_any()
+                .downcast_ref::<$t>()
+                .ok_or_else(|| anyhow!("Failed to downcast array"))?
+                .value($index)
+                .to_string(),
+        ))
+    }};
+}
+
+macro_rules! downcast_and_format_ts {
+    ($array:expr, $index:expr, $t:ty, $scale:expr, $format:expr) => {{
+        let ts = $array
+            .as_any()
+            .downcast_ref::<$t>()
+            .ok_or_else(|| anyhow!("Failed to downcast timestamp array"))?
+            .value($index);
+        let secs = ts / $scale;
+        let sub = ts.rem_euclid($scale);
+        let sub_u32 = u32::try_from(sub)
+            .map_err(|_| anyhow!("Subsecond value out of range for u32: {}", sub))?;
+        let nanos = sub_u32 * (1_000_000_000u32 / $scale as u32);
+        let dt = DateTime::from_timestamp(secs, nanos)
+            .ok_or_else(|| anyhow!("Invalid timestamp from seconds={} nanos={}", secs, nanos))?;
+        Ok(Some(dt.format($format).to_string()))
+    }};
+}
+
+#[allow(clippy::too_many_lines)]
+/// Converts a value from an Arrow `Array` at a specific index into its string representation.
+///
+/// Designed not to be used for production stringification, but rather for producing consistent values for validation results.
+/// Using input `RecordBatch` values, it removes any system differences from underlying sources (e.g. different trailing zeros, etc).
+///
+/// # Parameters:
+/// - `array`: A reference to a dynamically typed Arrow `Array`. This is the array that holds the data.
+/// - `index`: The index of the value to convert to a string.
+///
+/// # Returns:
+/// - `Ok(Some(String))`: A string representation of the value at the specified index.
+/// - `Ok(None)`: If the value is `null` at the given index, or the type is not implemented for conversion.
+/// - `Err(anyhow::Error)`: If there is an error (e.g., invalid index, failed downcast).
+///
+/// # Example:
+/// ```
+/// let array = Int64Array::from(vec![12345]);
+/// let result = array_value_to_string(&array, 0);
+/// assert_eq!(result.unwrap(), Some("12345".to_string()));
+/// ```
+///
+/// # Error Handling:
+/// - If the `index` is out of bounds, the function returns an error indicating the invalid index.
+/// - If the value at the index is `null`, `None` is returned.
+/// - If the function fails to downcast the array to the expected type (e.g., if the array's type is
+///   mismatched), it will return an error.
+/// - If the array's data type is not supported for conversion, `None` is returned.
+pub fn array_value_to_string(array: &dyn Array, index: usize) -> Result<Option<String>> {
+    if array.len() <= index {
+        return Err(anyhow!("Index out of bounds: {index} >= {}", array.len()));
+    }
+
+    if array.is_null(index) {
+        return Ok(None);
+    }
+
+    match array.data_type() {
+        DataType::Int64 => downcast_and_format!(array, index, Int64Array),
+        DataType::Int32 => downcast_and_format!(array, index, Int32Array),
+        DataType::Int16 => downcast_and_format!(array, index, Int32Array),
+        DataType::Int8 => downcast_and_format!(array, index, Int32Array),
+        DataType::UInt64 => downcast_and_format!(array, index, UInt64Array),
+        DataType::UInt32 => downcast_and_format!(array, index, UInt32Array),
+        DataType::UInt16 => downcast_and_format!(array, index, UInt16Array),
+        DataType::UInt8 => downcast_and_format!(array, index, UInt8Array),
+        DataType::Float32 => downcast_and_format!(array, index, Float32Array),
+        DataType::Float64 => downcast_and_format!(array, index, Float64Array),
+        DataType::Utf8 => downcast_and_format!(array, index, StringArray),
+        DataType::LargeUtf8 => downcast_and_format!(array, index, LargeStringArray),
+        DataType::Boolean => downcast_and_format!(array, index, BooleanArray),
+
+        DataType::Date32 => {
+            let days = array
+                .as_any()
+                .downcast_ref::<Date32Array>()
+                .ok_or_else(|| anyhow!("Failed to downcast Date32 array"))?
+                .value(index);
+            let date = NaiveDate::from_ymd_opt(1970, 1, 1)
+                .ok_or_else(|| anyhow!("Invalid base date"))?
+                .checked_add_signed(chrono::Duration::days(i64::from(days)))
+                .ok_or_else(|| anyhow!("Date out of range"))?;
+            Ok(Some(date.format("%Y-%m-%d").to_string()))
+        }
+
+        DataType::Decimal128(_, scale) => {
+            let val = array
+                .as_any()
+                .downcast_ref::<Decimal128Array>()
+                .ok_or_else(|| anyhow!("Failed to downcast Decimal128 array"))?
+                .value(index);
+
+            let sign = if val < 0 { "-" } else { "" };
+            let abs_val = val.abs();
+            let scale = usize::try_from(*scale)?; // Convert scale to usize
+
+            let str_val = abs_val.to_string(); // Convert the absolute value to a string
+
+            // Split the string into integer and fractional parts
+            let len = str_val.len();
+            let (int_part, frac_part) = if len > scale {
+                let (a, b) = str_val.split_at(len - scale);
+                (a.to_string(), b.to_string())
+            } else {
+                ("0".to_string(), format!("{str_val:0>scale$}"))
+            };
+
+            if frac_part.is_empty() {
+                Ok(Some(format!("{sign}{int_part}")))
+            } else {
+                Ok(Some(format!("{sign}{int_part}.{frac_part}")))
+            }
+        }
+
+        DataType::Timestamp(unit, _) => match unit {
+            TimeUnit::Second => {
+                let ts = array
+                    .as_any()
+                    .downcast_ref::<TimestampSecondArray>()
+                    .ok_or_else(|| anyhow!("Failed to downcast TimestampSecondArray"))?
+                    .value(index);
+                let dt = DateTime::from_timestamp(ts, 0)
+                    .ok_or_else(|| anyhow!("Invalid timestamp for seconds={}", ts))?;
+                Ok(Some(dt.format("%Y-%m-%d %H:%M:%S").to_string()))
+            }
+            TimeUnit::Millisecond => {
+                let ts = array
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .ok_or_else(|| anyhow!("Failed to downcast TimestampMillisecondArray"))?
+                    .value(index);
+                let secs = ts / 1000;
+                let sub_ms = ts.rem_euclid(1000);
+                let sub_u32 = u32::try_from(sub_ms)?;
+                let nanos = sub_u32 * 1_000_000;
+                let dt = DateTime::from_timestamp(secs, nanos)
+                    .ok_or_else(|| anyhow!("Invalid timestamp"))?;
+                Ok(Some(dt.format("%Y-%m-%d %H:%M:%S%.3f").to_string()))
+            }
+            TimeUnit::Microsecond => {
+                downcast_and_format_ts!(
+                    array,
+                    index,
+                    TimestampMicrosecondArray,
+                    1_000_000,
+                    "%Y-%m-%d %H:%M:%S%.6f"
+                )
+            }
+            TimeUnit::Nanosecond => {
+                downcast_and_format_ts!(
+                    array,
+                    index,
+                    TimestampNanosecondArray,
+                    1_000_000_000,
+                    "%Y-%m-%d %H:%M:%S%.9f"
+                )
+            }
+        },
+
+        _ => Ok(None),
+    }
+}
+
+pub fn validate_batches_as_strings(
+    expected: &RecordBatch,
+    actual: &RecordBatch,
+) -> Result<QueryValidationResult> {
+    let schema = expected.schema();
+
+    for (i, field) in schema.fields().iter().enumerate() {
+        let column_name = field.name().clone();
+        let data_type = field.data_type();
+        let expected_array = expected.column(i).as_ref();
+        let actual_array = actual.column(i).as_ref();
+
+        if expected_array.len() != actual_array.len() {
+            return Ok(QueryValidationResult::Fail(
+                QueryValidationReason::ColumnLengthMismatch {
+                    column_name: column_name.clone(),
+                    left_len: expected_array.len(),
+                    right_len: actual_array.len(),
+                },
+            ));
+        }
+
+        for row in 0..expected_array.len() {
+            let expected_val = array_value_to_string(expected_array, row)?;
+            let actual_val = array_value_to_string(actual_array, row)?;
+
+            match (expected_val, actual_val) {
+                (None, None) => {}
+                (Some(val), None) => {
+                    return Ok(QueryValidationResult::Fail(
+                        QueryValidationReason::DataMismatch {
+                            column: column_name.clone(),
+                            row_number: row + 1, // indexes are 0-based, counts are 1-based
+                            expected: format!("{val:?}"),
+                            actual: "None".to_string(),
+                        },
+                    ));
+                }
+                (None, Some(val)) => {
+                    return Ok(QueryValidationResult::Fail(
+                        QueryValidationReason::DataMismatch {
+                            column: column_name.clone(),
+                            row_number: row + 1, // indexes are 0-based, counts are 1-based
+                            expected: "None".to_string(),
+                            actual: format!("{val:?}"),
+                        },
+                    ));
+                }
+                (Some(expected_val), Some(actual_val)) => {
+                    if expected_val != actual_val {
+                        if data_type.is_numeric() {
+                            // check if the left value is a subset of the right value, and if the right value ends in trailing zeros
+                            let trimmed_actual_val = actual_val.replace(".00", "");
+                            let trimmed_actual_val = trimmed_actual_val.trim_end_matches('0');
+                            if expected_val.starts_with(trimmed_actual_val) {
+                                let expected_trailing = if expected_val.contains('.') {
+                                    expected_val.split('.').last().unwrap_or("")
+                                } else {
+                                    ""
+                                };
+                                let actual_trailing = if trimmed_actual_val.contains('.') {
+                                    trimmed_actual_val.split('.').last().unwrap_or("")
+                                } else {
+                                    ""
+                                };
+
+                                // if the scale is too long, we drop it for the purpose of this validation
+                                let expected_trailing =
+                                    expected_trailing.chars().take(8).collect::<String>();
+                                let actual_trailing =
+                                    actual_trailing.chars().take(8).collect::<String>();
+                                if expected_trailing == actual_trailing {
+                                    return Ok(QueryValidationResult::Pass);
+                                }
+                            }
+                        }
+
+                        return Ok(QueryValidationResult::Fail(
+                            QueryValidationReason::DataMismatch {
+                                column: column_name.clone(),
+                                row_number: row + 1, // indexes are 0-based, counts are 1-based
+                                expected: format!("{expected_val:?}"),
+                                actual: format!("{actual_val:?}"),
+                            },
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(QueryValidationResult::Pass)
+}
+
 pub fn validate_tpch_query(
     query: &Query,
     batches: &[RecordBatch],
-) -> anyhow::Result<QueryValidationResult> {
+) -> Result<QueryValidationResult> {
     let Some(expected_batches) = TPCH_ANSWERS.get(&query.name) else {
-        return Ok(QueryValidationResult::Fail(QueryValidationReason::NoAnswer));
+        return Ok(QueryValidationResult::Fail(
+            QueryValidationReason::NoExpectedAnswer,
+        ));
     };
 
     match (expected_batches.is_empty(), batches.is_empty()) {
         (true, true) | (false, false) => {}
+        (true, false) => {
+            return Ok(QueryValidationResult::Fail(
+                QueryValidationReason::NoExpectedAnswer,
+            ));
+        }
         _ => return Ok(QueryValidationResult::Fail(QueryValidationReason::NoAnswer)),
     }
 
@@ -180,27 +481,23 @@ pub fn validate_tpch_query(
     }
 
     // check the actual data batches are equal
-    for (_expected, _actual) in expected_batches
-        .columns()
-        .iter()
-        .zip(actual_batches.columns().iter())
-    {
-        // we cannot perform a direct comparison, because some types may not be equal despite their data being equivalent
-        // TODO: validate the data in the columns match
-        // if expected != actual {
-        //     return Ok(QueryValidationResult::Fail(
-        //         QueryValidationReason::DataMismatch,
-        //     ));
-        // }
-    }
-
-    Ok(QueryValidationResult::Pass)
+    validate_batches_as_strings(&expected_batches, &actual_batches)
 }
 
 #[cfg(test)]
+#[allow(clippy::too_many_lines)]
 mod test {
+    use crate::queries::QuerySet;
+
     use super::*;
-    use arrow::datatypes::{Field, Schema, SchemaRef};
+    use arrow::{
+        array::{
+            Decimal128Builder, Float32Array, Int16Array, Int8Array, UInt16Array, UInt32Array,
+            UInt64Array, UInt8Array,
+        },
+        datatypes::{Field, Schema, SchemaRef},
+    };
+    use rstest::rstest;
     use std::sync::Arc;
 
     #[test]
@@ -283,6 +580,383 @@ mod test {
         assert_eq!(
             result.expect("Should validate"),
             QueryValidationResult::Pass
+        );
+    }
+
+    #[test]
+    fn test_correct_answer_wrong_type() {
+        // Use the correct answer, but a different datatype
+        // Q22 from CSV, cntrycode is Utf8. Query returns it as Int64
+        let query = QuerySet::Tpch
+            .get_queries(None)
+            .get(20)
+            .expect("Should have q22")
+            .clone();
+        assert_eq!(query.name, "tpch_q22".into());
+        let schema = Schema::new(vec![
+            Field::new("cntrycode", arrow::datatypes::DataType::Int64, false),
+            Field::new("numcust", arrow::datatypes::DataType::Int64, false),
+            Field::new("totacctbal", arrow::datatypes::DataType::Float64, false),
+        ]);
+
+        let schema_ref: SchemaRef = Arc::new(schema);
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema_ref),
+            vec![
+                Arc::new(arrow::array::Int64Array::from(vec![
+                    13, 17, 18, 23, 29, 30, 31,
+                ])),
+                Arc::new(arrow::array::Int64Array::from(vec![
+                    888, 861, 964, 892, 948, 909, 922,
+                ])),
+                Arc::new(arrow::array::Float64Array::from(vec![
+                    6_737_713.99,
+                    6_460_573.72,
+                    7_236_687.40,
+                    6_701_457.95,
+                    7_158_866.63,
+                    6_808_436.13,
+                    6_806_670.18,
+                ])),
+            ],
+        )
+        .expect("Should create batch");
+
+        let batches = vec![batch];
+        let result = validate_tpch_query(&query, &batches);
+        assert!(result.is_ok());
+        assert_eq!(
+            result.expect("Should validate"),
+            QueryValidationResult::Pass
+        );
+
+        let schema = Schema::new(vec![
+            Field::new("cntrycode", arrow::datatypes::DataType::Utf8, false),
+            Field::new("numcust", arrow::datatypes::DataType::Int64, false),
+            Field::new("totacctbal", arrow::datatypes::DataType::Float64, false),
+        ]);
+
+        let schema_ref: SchemaRef = Arc::new(schema);
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema_ref),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "13", "17", "18", "23", "29", "30", "31",
+                ])),
+                Arc::new(arrow::array::Int64Array::from(vec![
+                    888, 861, 964, 892, 948, 909, 922,
+                ])),
+                Arc::new(arrow::array::Float64Array::from(vec![
+                    6_737_713.99,
+                    6_460_573.72,
+                    7_236_687.40,
+                    6_701_457.95,
+                    7_158_866.63,
+                    6_808_436.13,
+                    6_806_670.18,
+                ])),
+            ],
+        )
+        .expect("Should create batch");
+
+        let batches = vec![batch];
+        let result = validate_tpch_query(&query, &batches);
+        assert!(result.is_ok());
+        assert_eq!(
+            result.expect("Should validate"),
+            QueryValidationResult::Pass
+        );
+    }
+
+    #[test]
+    fn test_wrong_answers() {
+        // Use the correct answer, but a different datatype
+        // Q22 from CSV, cntrycode is Utf8. Query returns it as Int64
+        let query = QuerySet::Tpch
+            .get_queries(None)
+            .get(20)
+            .expect("Should have q22")
+            .clone();
+        assert_eq!(query.name, "tpch_q22".into());
+        let schema = Schema::new(vec![
+            Field::new("cntrycode", arrow::datatypes::DataType::Int64, false),
+            Field::new("numcust", arrow::datatypes::DataType::Int64, false),
+            Field::new("totacctbal", arrow::datatypes::DataType::Float64, false),
+        ]);
+
+        let schema_ref: SchemaRef = Arc::new(schema);
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema_ref),
+            vec![
+                Arc::new(arrow::array::Int64Array::from(vec![
+                    13, 17, 18, 23, 29, 30, 39,
+                ])),
+                Arc::new(arrow::array::Int64Array::from(vec![
+                    888, 861, 964, 892, 948, 909, 922,
+                ])),
+                Arc::new(arrow::array::Float64Array::from(vec![
+                    6_737_713.99,
+                    6_460_573.72,
+                    7_236_687.40,
+                    6_701_457.95,
+                    7_158_866.63,
+                    6_808_436.13,
+                    6_806_670.18,
+                ])),
+            ],
+        )
+        .expect("Should create batch");
+
+        let batches = vec![batch];
+        let result = validate_tpch_query(&query, &batches);
+        assert!(result.is_ok());
+        assert_eq!(
+            result.expect("Should validate"),
+            QueryValidationResult::Fail(QueryValidationReason::DataMismatch {
+                column: "cntrycode".to_string(),
+                row_number: 7,
+                expected: format!("{:?}", Some("31")),
+                actual: format!("{:?}", Some("39")),
+            })
+        );
+
+        let schema = Schema::new(vec![
+            Field::new("cntrycode", arrow::datatypes::DataType::Utf8, false),
+            Field::new("numcust", arrow::datatypes::DataType::Int64, false),
+            Field::new("totacctbal", arrow::datatypes::DataType::Float64, false),
+        ]);
+
+        let schema_ref: SchemaRef = Arc::new(schema);
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema_ref),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "13", "17", "18", "23", "29", "14", "31",
+                ])),
+                Arc::new(arrow::array::Int64Array::from(vec![
+                    888, 861, 964, 892, 948, 909, 922,
+                ])),
+                Arc::new(arrow::array::Float64Array::from(vec![
+                    6_737_713.99,
+                    6_460_573.72,
+                    7_236_687.40,
+                    6_701_457.95,
+                    7_158_866.63,
+                    6_808_436.13,
+                    6_806_670.18,
+                ])),
+            ],
+        )
+        .expect("Should create batch");
+
+        let batches = vec![batch];
+        let result = validate_tpch_query(&query, &batches);
+        assert!(result.is_ok());
+        assert_eq!(
+            result.expect("Should validate"),
+            QueryValidationResult::Fail(QueryValidationReason::DataMismatch {
+                column: "cntrycode".to_string(),
+                row_number: 6,
+                expected: format!("{:?}", Some("30")),
+                actual: format!("{:?}", Some("14")),
+            })
+        );
+    }
+
+    #[rstest]
+    #[case(2, 1_234_567_890_123_456_789_i128, "12345678901234567.89")]
+    #[case(3, 1_234_567_890_123_456_789_i128, "1234567890123456.789")]
+    #[case(10, 1_234_567_890_123_456_789_i128, "123456789.0123456789")]
+    #[case(0, 1_234_567_890_123_456_789_i128, "1234567890123456789")]
+    #[case(2, -1_234_567_890_123_456_789_i128, "-12345678901234567.89")]
+    #[case(3, -1_234_567_890_123_456_789_i128, "-1234567890123456.789")]
+    #[case(10, -1_234_567_890_123_456_789_i128, "-123456789.0123456789")]
+    #[case(0, -1_234_567_890_123_456_789_i128, "-1234567890123456789")]
+    fn test_decimal_values(#[case] scale: i8, #[case] value: i128, #[case] expected: &str) {
+        // Test a positive value with scale = 2
+        let mut builder = Decimal128Builder::new()
+            .with_precision_and_scale(38, scale)
+            .expect("Should create builder");
+        builder.append_value(value);
+        let array = builder.finish();
+
+        let result = array_value_to_string(&array, 0).expect("Should convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+    }
+
+    #[rstest]
+    #[case(123_456_789_i64, "123456789")]
+    #[case(987_654_321_i64, "987654321")]
+    #[case(-123_456_789_i64, "-123456789")]
+    #[case(-987_654_321_i64, "-987654321")]
+    fn test_int64(#[case] value: i64, #[case] expected: &str) {
+        // Test an Int64 array
+        let int_values = vec![value];
+        let array = Int64Array::from(int_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+    }
+
+    #[rstest]
+    #[case(123_456_789_i32, "123456789")]
+    #[case(987_654_321_i32, "987654321")]
+    #[case(-123_456_789_i32, "-123456789")]
+    #[case(-987_654_321_i32, "-987654321")]
+    fn test_int32_64(#[case] value: i32, #[case] expected: &str) {
+        // Test an Int32 array
+        let int_values = vec![value];
+        let array = Int32Array::from(int_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+
+        // Test an Int64 array
+        let int_values = vec![i64::from(value)];
+        let array = Int64Array::from(int_values);
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+    }
+
+    #[rstest]
+    #[case(2_i8, "2")]
+    #[case(3_i8, "3")]
+    #[case(-2_i8, "-2")]
+    #[case(-3_i8, "-3")]
+    fn test_int8_16(#[case] value: i8, #[case] expected: &str) {
+        // Test an Int8 array
+        let int_values = vec![value];
+        let array = Int8Array::from(int_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+
+        // Test an Int16 array
+        let int_values = vec![i16::from(value)];
+        let array = Int16Array::from(int_values);
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+    }
+
+    #[rstest]
+    #[case(123_456_789_u32, "123456789")]
+    #[case(987_654_321_u32, "987654321")]
+    fn test_uint32_64(#[case] value: u32, #[case] expected: &str) {
+        // Test an Int32 array
+        let int_values = vec![value];
+        let array = UInt32Array::from(int_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+
+        // Test an Int64 array
+        let int_values = vec![u64::from(value)];
+        let array = UInt64Array::from(int_values);
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+    }
+
+    #[rstest]
+    #[case(2_u8, "2")]
+    #[case(3_u8, "3")]
+    fn test_uint8_16(#[case] value: u8, #[case] expected: &str) {
+        // Test an Int8 array
+        let int_values = vec![value];
+        let array = UInt8Array::from(int_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+
+        // Test an Int16 array
+        let int_values = vec![u16::from(value)];
+        let array = UInt16Array::from(int_values);
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+    }
+
+    #[rstest]
+    #[case(123_456_789_f64, "123456789")]
+    #[case(987_654_321_f64, "987654321")]
+    #[case(-123_456_789_f64, "-123456789")]
+    #[case(-987_654_321_f64, "-987654321")]
+    #[case(123_456_789.123_456_79_f64, "123456789.12345679")]
+    #[case(987_654_321.987_654_3_f64, "987654321.9876543")]
+    #[case(-123_456_789.123_456_79_f64, "-123456789.12345679")]
+    #[case(-987_654_321.987_654_3_f64, "-987654321.9876543")]
+    fn test_float64(#[case] value: f64, #[case] expected: &str) {
+        // Test a Float64 array
+        let float_values = vec![value];
+        let array = Float64Array::from(float_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+    }
+
+    #[rstest]
+    #[case(123_456_f32, "123456")]
+    #[case(987_654_f32, "987654")]
+    #[case(-123_456_f32, "-123456")]
+    #[case(-987_654_f32, "-987654")]
+    #[case(123_456.12_f32, "123456.12")]
+    #[case(-123_456.12_f32, "-123456.12")]
+    fn test_float32(#[case] value: f32, #[case] expected: &str) {
+        // Test a Float32 array
+        let float_values = vec![value];
+        let array = Float32Array::from(float_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some(expected.to_string()));
+    }
+
+    #[test]
+    fn test_dates_and_timestamps() {
+        // Test a Date32 array
+        let date_values = vec![14_600_i32];
+        let array = Date32Array::from(date_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some("2009-12-22".to_string()));
+
+        // Test a TimestampSecond array
+        let timestamp_values = vec![123_456_789_i64];
+        let array = TimestampSecondArray::from(timestamp_values);
+
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+        assert_eq!(result, Some("1973-11-29 21:33:09".to_string()));
+
+        // Test a TimestampMillisecond array
+        let timestamp_values = vec![123_456_789_123_i64];
+        let array = TimestampMillisecondArray::from(timestamp_values);
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+
+        assert_eq!(result, Some("1973-11-29 21:33:09.123".to_string()));
+
+        // Test a TimestampMicrosecond array
+        let timestamp_values = vec![123_456_789_123_456_i64];
+        let array = TimestampMicrosecondArray::from(timestamp_values);
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+
+        assert_eq!(result, Some("1973-11-29 21:33:09.123456".to_string()));
+
+        // Test a TimestampNanosecond array
+        let timestamp_values = vec![123_456_789_123_456_789_i64];
+        let array = TimestampNanosecondArray::from(timestamp_values);
+        let result = array_value_to_string(&array, 0).expect("Failed to convert value to string");
+
+        assert_eq!(result, Some("1973-11-29 21:33:09.123456789".to_string()));
+    }
+
+    #[test]
+    fn test_invalid_index() {
+        // Test index out of bounds
+        let decimal_values = vec![1_234_567_890_123_456_789_i128];
+        let array = Decimal128Array::from(decimal_values);
+
+        // Index 1 doesn't exist in a 1-element array
+        let result = array_value_to_string(&array, 1);
+        assert_eq!(
+            result.expect_err("Should return an error").to_string(),
+            "Index out of bounds: 1 >= 1"
         );
     }
 }

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -24,10 +24,10 @@ use anyhow::{anyhow, Result};
 
 use arrow::{
     array::{
-        Array, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array, Int32Array,
-        Int64Array, LargeStringArray, RecordBatch, StringArray, TimestampMicrosecondArray,
-        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt16Array,
-        UInt32Array, UInt64Array, UInt8Array,
+        Array, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array, Int16Array,
+        Int32Array, Int64Array, Int8Array, LargeStringArray, RecordBatch, StringArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
     },
     csv::reader::Format,
     datatypes::TimeUnit,
@@ -41,7 +41,7 @@ use chrono::{DateTime, NaiveDate};
 use super::Query;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum QueryValidationReason {
+pub enum QueryValidationFailReason {
     NoExpectedAnswer,
     NoAnswer,
     SchemaMismatch,
@@ -65,7 +65,7 @@ pub enum QueryValidationReason {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueryValidationResult {
     Pass,
-    Fail(QueryValidationReason),
+    Fail(QueryValidationFailReason),
 }
 
 macro_rules! generate_tpch_answers {
@@ -158,7 +158,7 @@ fn equivalent_schemas(expected_schema: &SchemaRef, actual_schema: &SchemaRef) ->
         })
 }
 
-macro_rules! downcast_and_format {
+macro_rules! downcast_and_stringify {
     ($array:expr, $index:expr, $t:ty) => {{
         Ok(Some(
             $array
@@ -171,7 +171,7 @@ macro_rules! downcast_and_format {
     }};
 }
 
-macro_rules! downcast_and_format_ts {
+macro_rules! downcast_and_stringify_ts {
     ($array:expr, $index:expr, $t:ty, $scale:expr, $format:expr) => {{
         let ts = $array
             .as_any()
@@ -227,19 +227,19 @@ pub fn array_value_to_string(array: &dyn Array, index: usize) -> Result<Option<S
     }
 
     match array.data_type() {
-        DataType::Int64 => downcast_and_format!(array, index, Int64Array),
-        DataType::Int32 => downcast_and_format!(array, index, Int32Array),
-        DataType::Int16 => downcast_and_format!(array, index, Int16Array),
-        DataType::Int8 => downcast_and_format!(array, index, Int8Array),
-        DataType::UInt64 => downcast_and_format!(array, index, UInt64Array),
-        DataType::UInt32 => downcast_and_format!(array, index, UInt32Array),
-        DataType::UInt16 => downcast_and_format!(array, index, UInt16Array),
-        DataType::UInt8 => downcast_and_format!(array, index, UInt8Array),
-        DataType::Float32 => downcast_and_format!(array, index, Float32Array),
-        DataType::Float64 => downcast_and_format!(array, index, Float64Array),
-        DataType::Utf8 => downcast_and_format!(array, index, StringArray),
-        DataType::LargeUtf8 => downcast_and_format!(array, index, LargeStringArray),
-        DataType::Boolean => downcast_and_format!(array, index, BooleanArray),
+        DataType::Int64 => downcast_and_stringify!(array, index, Int64Array),
+        DataType::Int32 => downcast_and_stringify!(array, index, Int32Array),
+        DataType::Int16 => downcast_and_stringify!(array, index, Int16Array),
+        DataType::Int8 => downcast_and_stringify!(array, index, Int8Array),
+        DataType::UInt64 => downcast_and_stringify!(array, index, UInt64Array),
+        DataType::UInt32 => downcast_and_stringify!(array, index, UInt32Array),
+        DataType::UInt16 => downcast_and_stringify!(array, index, UInt16Array),
+        DataType::UInt8 => downcast_and_stringify!(array, index, UInt8Array),
+        DataType::Float32 => downcast_and_stringify!(array, index, Float32Array),
+        DataType::Float64 => downcast_and_stringify!(array, index, Float64Array),
+        DataType::Utf8 => downcast_and_stringify!(array, index, StringArray),
+        DataType::LargeUtf8 => downcast_and_stringify!(array, index, LargeStringArray),
+        DataType::Boolean => downcast_and_stringify!(array, index, BooleanArray),
 
         DataType::Date32 => {
             let days = array
@@ -309,7 +309,7 @@ pub fn array_value_to_string(array: &dyn Array, index: usize) -> Result<Option<S
                 Ok(Some(dt.format("%Y-%m-%d %H:%M:%S%.3f").to_string()))
             }
             TimeUnit::Microsecond => {
-                downcast_and_format_ts!(
+                downcast_and_stringify_ts!(
                     array,
                     index,
                     TimestampMicrosecondArray,
@@ -318,7 +318,7 @@ pub fn array_value_to_string(array: &dyn Array, index: usize) -> Result<Option<S
                 )
             }
             TimeUnit::Nanosecond => {
-                downcast_and_format_ts!(
+                downcast_and_stringify_ts!(
                     array,
                     index,
                     TimestampNanosecondArray,
@@ -328,7 +328,9 @@ pub fn array_value_to_string(array: &dyn Array, index: usize) -> Result<Option<S
             }
         },
 
-        _ => Ok(None),
+        dt => Err(anyhow::anyhow!(
+            "Unsupported data type for validation: {dt:?}",
+        )),
     }
 }
 
@@ -346,7 +348,7 @@ pub fn validate_batches_as_strings(
 
         if expected_array.len() != actual_array.len() {
             return Ok(QueryValidationResult::Fail(
-                QueryValidationReason::ColumnLengthMismatch {
+                QueryValidationFailReason::ColumnLengthMismatch {
                     column_name: column_name.clone(),
                     left_len: expected_array.len(),
                     right_len: actual_array.len(),
@@ -362,7 +364,7 @@ pub fn validate_batches_as_strings(
                 (None, None) => {}
                 (Some(val), None) => {
                     return Ok(QueryValidationResult::Fail(
-                        QueryValidationReason::DataMismatch {
+                        QueryValidationFailReason::DataMismatch {
                             column: column_name.clone(),
                             row_number: row + 1, // indexes are 0-based, counts are 1-based
                             expected: format!("{val:?}"),
@@ -372,7 +374,7 @@ pub fn validate_batches_as_strings(
                 }
                 (None, Some(val)) => {
                     return Ok(QueryValidationResult::Fail(
-                        QueryValidationReason::DataMismatch {
+                        QueryValidationFailReason::DataMismatch {
                             column: column_name.clone(),
                             row_number: row + 1, // indexes are 0-based, counts are 1-based
                             expected: "None".to_string(),
@@ -410,7 +412,7 @@ pub fn validate_batches_as_strings(
                         }
 
                         return Ok(QueryValidationResult::Fail(
-                            QueryValidationReason::DataMismatch {
+                            QueryValidationFailReason::DataMismatch {
                                 column: column_name.clone(),
                                 row_number: row + 1, // indexes are 0-based, counts are 1-based
                                 expected: format!("{expected_val:?}"),
@@ -432,7 +434,7 @@ pub fn validate_tpch_query(
 ) -> Result<QueryValidationResult> {
     let Some(expected_batches) = TPCH_ANSWERS.get(&query.name) else {
         return Ok(QueryValidationResult::Fail(
-            QueryValidationReason::NoExpectedAnswer,
+            QueryValidationFailReason::NoExpectedAnswer,
         ));
     };
 
@@ -440,20 +442,28 @@ pub fn validate_tpch_query(
         (true, true) | (false, false) => {}
         (true, false) => {
             return Ok(QueryValidationResult::Fail(
-                QueryValidationReason::NoExpectedAnswer,
+                QueryValidationFailReason::NoExpectedAnswer,
             ));
         }
-        _ => return Ok(QueryValidationResult::Fail(QueryValidationReason::NoAnswer)),
+        _ => {
+            return Ok(QueryValidationResult::Fail(
+                QueryValidationFailReason::NoAnswer,
+            ))
+        }
     }
 
     let Some(expected_schema) = expected_batches
         .first()
         .map(arrow::array::RecordBatch::schema)
     else {
-        return Ok(QueryValidationResult::Fail(QueryValidationReason::NoAnswer));
+        return Ok(QueryValidationResult::Fail(
+            QueryValidationFailReason::NoAnswer,
+        ));
     };
     let Some(actual_schema) = batches.first().map(arrow::array::RecordBatch::schema) else {
-        return Ok(QueryValidationResult::Fail(QueryValidationReason::NoAnswer));
+        return Ok(QueryValidationResult::Fail(
+            QueryValidationFailReason::NoAnswer,
+        ));
     };
 
     if !equivalent_schemas(&expected_schema, &actual_schema) {
@@ -461,7 +471,7 @@ pub fn validate_tpch_query(
         println!("actual_schema: {actual_schema:?}");
 
         return Ok(QueryValidationResult::Fail(
-            QueryValidationReason::SchemaMismatch,
+            QueryValidationFailReason::SchemaMismatch,
         ));
     }
 
@@ -472,7 +482,7 @@ pub fn validate_tpch_query(
     // check the row counts are equal
     if expected_batches.num_rows() != actual_batches.num_rows() {
         return Ok(QueryValidationResult::Fail(
-            QueryValidationReason::RowCountMismatch {
+            QueryValidationFailReason::RowCountMismatch {
                 expected: expected_batches.num_rows(),
                 actual: actual_batches.num_rows(),
             },
@@ -563,7 +573,7 @@ mod test {
         assert!(result.is_ok());
         assert_eq!(
             result.expect("Should validate"),
-            QueryValidationResult::Fail(QueryValidationReason::RowCountMismatch {
+            QueryValidationResult::Fail(QueryValidationFailReason::RowCountMismatch {
                 expected: 4,
                 actual: 2
             })
@@ -710,7 +720,7 @@ mod test {
         assert!(result.is_ok());
         assert_eq!(
             result.expect("Should validate"),
-            QueryValidationResult::Fail(QueryValidationReason::DataMismatch {
+            QueryValidationResult::Fail(QueryValidationFailReason::DataMismatch {
                 column: "cntrycode".to_string(),
                 row_number: 7,
                 expected: format!("{:?}", "31"),
@@ -752,7 +762,7 @@ mod test {
         assert!(result.is_ok());
         assert_eq!(
             result.expect("Should validate"),
-            QueryValidationResult::Fail(QueryValidationReason::DataMismatch {
+            QueryValidationResult::Fail(QueryValidationFailReason::DataMismatch {
                 column: "cntrycode".to_string(),
                 row_number: 6,
                 expected: format!("{:?}", "30"),

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -229,8 +229,8 @@ pub fn array_value_to_string(array: &dyn Array, index: usize) -> Result<Option<S
     match array.data_type() {
         DataType::Int64 => downcast_and_format!(array, index, Int64Array),
         DataType::Int32 => downcast_and_format!(array, index, Int32Array),
-        DataType::Int16 => downcast_and_format!(array, index, Int32Array),
-        DataType::Int8 => downcast_and_format!(array, index, Int32Array),
+        DataType::Int16 => downcast_and_format!(array, index, Int16Array),
+        DataType::Int8 => downcast_and_format!(array, index, Int8Array),
         DataType::UInt64 => downcast_and_format!(array, index, UInt64Array),
         DataType::UInt32 => downcast_and_format!(array, index, UInt32Array),
         DataType::UInt16 => downcast_and_format!(array, index, UInt16Array),
@@ -713,8 +713,8 @@ mod test {
             QueryValidationResult::Fail(QueryValidationReason::DataMismatch {
                 column: "cntrycode".to_string(),
                 row_number: 7,
-                expected: format!("{:?}", Some("31")),
-                actual: format!("{:?}", Some("39")),
+                expected: format!("{:?}", "31"),
+                actual: format!("{:?}", "39"),
             })
         );
 
@@ -755,8 +755,8 @@ mod test {
             QueryValidationResult::Fail(QueryValidationReason::DataMismatch {
                 column: "cntrycode".to_string(),
                 row_number: 6,
-                expected: format!("{:?}", Some("30")),
-                actual: format!("{:?}", Some("14")),
+                expected: format!("{:?}", "30"),
+                actual: format!("{:?}", "14"),
             })
         );
     }

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -669,8 +669,7 @@ mod test {
 
     #[test]
     fn test_wrong_answers() {
-        // Use the correct answer, but a different datatype
-        // Q22 from CSV, cntrycode is Utf8. Query returns it as Int64
+        // Use the wrong answer and validate it fails
         let query = QuerySet::Tpch
             .get_queries(None)
             .get(20)

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -190,7 +190,6 @@ macro_rules! downcast_and_format_ts {
     }};
 }
 
-#[allow(clippy::too_many_lines)]
 /// Converts a value from an Arrow `Array` at a specific index into its string representation.
 ///
 /// Designed not to be used for production stringification, but rather for producing consistent values for validation results.
@@ -218,6 +217,7 @@ macro_rules! downcast_and_format_ts {
 /// - If the function fails to downcast the array to the expected type (e.g., if the array's type is
 ///   mismatched), it will return an error.
 /// - If the array's data type is not supported for conversion, `None` is returned.
+#[allow(clippy::too_many_lines)]
 pub fn array_value_to_string(array: &dyn Array, index: usize) -> Result<Option<String>> {
     if array.len() <= index {
         return Err(anyhow!("Index out of bounds: {index} >= {}", array.len()));

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -431,7 +431,6 @@ impl SpiceTestQueryWorker {
         }
 
         if results_snapshot {
-            println!("snapshotting results");
             let query_name = Arc::clone(&query.name);
             let name = self.name.clone();
 


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Implements data validation for the testoperator, by converting `&dyn Array` columns into their string representations, and comparing these string representations.
  * This works around the issues of differing schema types where underlying results are the same, because we cannot use the builtin `Eq` method of `Array` - when types are different, they are classified as inequal.

Tested on the DuckDB connector as an initial connector, which passed validation successfully! 🎉 

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4932