### PR TITLE
Add basic support for `application/vnd.spiceai.sql.v1+json` format

### DIFF
--- a/crates/runtime/src/http/v1/eval.rs
+++ b/crates/runtime/src/http/v1/eval.rs
@@ -36,7 +36,7 @@ use crate::{
 #[cfg(feature = "openapi")]
 use crate::model::EvalRunResponse;
 
-use super::{sql_to_http_response, ArrowFormat};
+use super::{sql_to_http_response, DataFormat};
 
 /// Input parameters to start an evaluation run for a given model.
 #[derive(Debug, Serialize, Deserialize)]
@@ -138,7 +138,7 @@ pub(crate) async fn post(
             sql_to_http_response(
                 Arc::clone(&df),
                 sql_query_for(&id).as_str(),
-                ArrowFormat::from_accept_header(accept.as_ref()),
+                DataFormat::from_accept_header(accept.as_ref()),
             )
             .await
         }

--- a/crates/runtime/src/http/v1/eval.rs
+++ b/crates/runtime/src/http/v1/eval.rs
@@ -36,7 +36,7 @@ use crate::{
 #[cfg(feature = "openapi")]
 use crate::model::EvalRunResponse;
 
-use super::{sql_to_http_response, DataFormat};
+use super::{sql_to_http_response, ResponseMimeType};
 
 /// Input parameters to start an evaluation run for a given model.
 #[derive(Debug, Serialize, Deserialize)]
@@ -138,7 +138,7 @@ pub(crate) async fn post(
             sql_to_http_response(
                 Arc::clone(&df),
                 sql_query_for(&id).as_str(),
-                DataFormat::from_accept_header(accept.as_ref()),
+                ResponseMimeType::from_accept_header(accept.as_ref()),
             )
             .await
         }

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -94,7 +94,7 @@ impl utoipa::IntoParams for Format {
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// The various formats that the Arrow data can be converted and returned from HTTP requests.
-pub enum DataFormat {
+pub enum ResponseMimeType {
     #[default]
     Json,
     Csv,
@@ -125,19 +125,19 @@ pub(crate) fn accept_header_types(accept: &TypedHeader<Accept>) -> Vec<String> {
     accept.0.media_types().map(ToString::to_string).collect()
 }
 
-impl DataFormat {
-    pub fn from_accept_header(accept: Option<&TypedHeader<Accept>>) -> DataFormat {
-        accept.map_or(DataFormat::default(), |header| {
+impl ResponseMimeType {
+    pub fn from_accept_header(accept: Option<&TypedHeader<Accept>>) -> ResponseMimeType {
+        accept.map_or(ResponseMimeType::default(), |header| {
             accept_header_types(header)
                 .iter()
                 .find_map(|h| match h.as_str() {
-                    "application/json" => Some(DataFormat::Json),
-                    "application/vnd.spiceai.v1+json" => Some(DataFormat::VndJsonV1),
-                    "text/csv" => Some(DataFormat::Csv),
-                    "text/plain" => Some(DataFormat::Plain),
+                    "application/json" => Some(ResponseMimeType::Json),
+                    "application/vnd.spiceai.sql.v1+json" => Some(ResponseMimeType::VndJsonV1),
+                    "text/csv" => Some(ResponseMimeType::Csv),
+                    "text/plain" => Some(ResponseMimeType::Plain),
                     _ => None,
                 })
-                .unwrap_or(DataFormat::default())
+                .unwrap_or(ResponseMimeType::default())
         })
     }
 }
@@ -160,7 +160,11 @@ fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
 }
 
 // Runs query and converts query results to HTTP response (as JSON).
-pub async fn sql_to_http_response(df: Arc<DataFusion>, sql: &str, format: DataFormat) -> Response {
+pub async fn sql_to_http_response(
+    df: Arc<DataFusion>,
+    sql: &str,
+    format: ResponseMimeType,
+) -> Response {
     let (data, results_cache_status) = match run_sql(df, sql).await {
         Ok((data, results_cache_status)) => (data, results_cache_status),
         Err(e) => {
@@ -194,14 +198,14 @@ pub async fn run_sql(
 pub async fn to_http_response(
     data: Vec<RecordBatch>,
     cache_status: QueryResultsCacheStatus,
-    format: DataFormat,
+    format: ResponseMimeType,
     meta: ResponseMetadata,
 ) -> Response {
     let res = match format {
-        DataFormat::Json => arrow_to_json(&data),
-        DataFormat::Csv => arrow_to_csv(&data),
-        DataFormat::Plain => arrow_to_plain(&data),
-        DataFormat::VndJsonV1 => arrow_to_vnd_json_v1(&data, meta),
+        ResponseMimeType::Json => arrow_to_json(&data),
+        ResponseMimeType::Csv => arrow_to_csv(&data),
+        ResponseMimeType::Plain => arrow_to_plain(&data),
+        ResponseMimeType::VndJsonV1 => arrow_to_vnd_json_v1(&data, meta),
     };
 
     let body = match res {

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -52,6 +52,7 @@ use csv::Writer;
 use headers_accept::Accept;
 use http::HeaderValue;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use snafu::ResultExt;
 
 use futures::TryStreamExt;
@@ -93,11 +94,30 @@ impl utoipa::IntoParams for Format {
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// The various formats that the Arrow data can be converted and returned from HTTP requests.
-pub enum ArrowFormat {
+pub enum DataFormat {
     #[default]
     Json,
     Csv,
     Plain,
+    VndJsonV1,
+}
+
+/// Represents additional metadata to produce a response, such as the SQL query used, etc.
+#[derive(Debug)]
+pub struct ResponseMetadata {
+    pub sql: Option<String>,
+}
+
+impl ResponseMetadata {
+    /// Creates an empty `ResponseMetadata`
+    pub fn empty() -> Self {
+        Self { sql: None }
+    }
+
+    pub fn with_sql(mut self, sql: impl Into<String>) -> Self {
+        self.sql = Some(sql.into());
+        self
+    }
 }
 
 /// Gets all possible media types from a `Accept` header.
@@ -105,18 +125,19 @@ pub(crate) fn accept_header_types(accept: &TypedHeader<Accept>) -> Vec<String> {
     accept.0.media_types().map(ToString::to_string).collect()
 }
 
-impl ArrowFormat {
-    pub fn from_accept_header(accept: Option<&TypedHeader<Accept>>) -> ArrowFormat {
-        accept.map_or(ArrowFormat::default(), |header| {
+impl DataFormat {
+    pub fn from_accept_header(accept: Option<&TypedHeader<Accept>>) -> DataFormat {
+        accept.map_or(DataFormat::default(), |header| {
             accept_header_types(header)
                 .iter()
                 .find_map(|h| match h.as_str() {
-                    "application/json" => Some(ArrowFormat::Json),
-                    "text/csv" => Some(ArrowFormat::Csv),
-                    "text/plain" => Some(ArrowFormat::Plain),
+                    "application/json" => Some(DataFormat::Json),
+                    "application/vnd.spiceai.v1+json" => Some(DataFormat::VndJsonV1),
+                    "text/csv" => Some(DataFormat::Csv),
+                    "text/plain" => Some(DataFormat::Plain),
                     _ => None,
                 })
-                .unwrap_or(ArrowFormat::default())
+                .unwrap_or(DataFormat::default())
         })
     }
 }
@@ -139,7 +160,7 @@ fn dataset_status(df: &DataFusion, ds: &Dataset) -> ComponentStatus {
 }
 
 // Runs query and converts query results to HTTP response (as JSON).
-pub async fn sql_to_http_response(df: Arc<DataFusion>, sql: &str, format: ArrowFormat) -> Response {
+pub async fn sql_to_http_response(df: Arc<DataFusion>, sql: &str, format: DataFormat) -> Response {
     let (data, results_cache_status) = match run_sql(df, sql).await {
         Ok((data, results_cache_status)) => (data, results_cache_status),
         Err(e) => {
@@ -147,7 +168,14 @@ pub async fn sql_to_http_response(df: Arc<DataFusion>, sql: &str, format: ArrowF
             return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
         }
     };
-    to_http_response(data, results_cache_status, format).await
+
+    to_http_response(
+        data,
+        results_cache_status,
+        format,
+        ResponseMetadata::empty(),
+    )
+    .await
 }
 
 // Runs query and returns the results as a vector of `RecordBatch`.
@@ -166,12 +194,14 @@ pub async fn run_sql(
 pub async fn to_http_response(
     data: Vec<RecordBatch>,
     cache_status: QueryResultsCacheStatus,
-    format: ArrowFormat,
+    format: DataFormat,
+    meta: ResponseMetadata,
 ) -> Response {
     let res = match format {
-        ArrowFormat::Json => arrow_to_json(&data),
-        ArrowFormat::Csv => arrow_to_csv(&data),
-        ArrowFormat::Plain => arrow_to_plain(&data),
+        DataFormat::Json => arrow_to_json(&data),
+        DataFormat::Csv => arrow_to_csv(&data),
+        DataFormat::Plain => arrow_to_plain(&data),
+        DataFormat::VndJsonV1 => arrow_to_vnd_json_v1(&data, meta),
     };
 
     let body = match res {
@@ -249,4 +279,70 @@ fn arrow_to_plain(
     data: &[RecordBatch],
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     pretty_format_batches(data).map(|d| format!("{d}")).boxed()
+}
+
+/// Converts a vector of `RecordBatch` to a application/vnd.spiceai.v1+json format
+fn arrow_to_vnd_json_v1(
+    data: &[RecordBatch],
+    meta: ResponseMetadata,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let buf = Vec::new();
+    let mut writer = arrow_json::ArrayWriter::new(buf);
+
+    // Convert manually instead of reusing arrow_to_json
+    // to avoid an extra serialization-deserialization cycle
+    writer
+        .write_batches(data.iter().collect::<Vec<&RecordBatch>>().as_slice())
+        .boxed()?;
+    writer.finish().boxed()?;
+
+    let mut result = json!({
+        "data": serde_json::from_slice::<serde_json::Value>(&writer.into_inner()).boxed()?,
+    });
+
+    if let Some(sql) = meta.sql {
+        result["sql"] = serde_json::Value::String(sql);
+    }
+
+    serde_json::to_string(&result).boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_arrow_to_vnd_json_v1() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("customer_id", DataType::Utf8, false),
+            Field::new("total_sales", DataType::Int64, false),
+        ]));
+
+        let customer_ids = StringArray::from(vec!["12345", "67890"]);
+        let total_sales = Int64Array::from(vec![150_000, 125_000]);
+
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(customer_ids), Arc::new(total_sales)])
+                .expect("to create batch");
+
+        // Test conversion without SQL
+        let result_without_sql =
+            arrow_to_vnd_json_v1(&[batch.clone()], ResponseMetadata::empty()).expect("to convert");
+        insta::assert_json_snapshot!(
+            "vnd_json_v1_without_sql",
+            serde_json::from_str::<serde_json::Value>(&result_without_sql).expect("to parse")
+        );
+
+        // Test conversion with SQL
+        let metadata = ResponseMetadata::empty()
+            .with_sql("SELECT customer_id, total_sales FROM sales_summary LIMIT 2;");
+        let result_with_sql = arrow_to_vnd_json_v1(&[batch], metadata).expect("to convert");
+        insta::assert_json_snapshot!(
+            "vnd_json_v1_with_sql",
+            serde_json::from_str::<serde_json::Value>(&result_with_sql).expect("to parse")
+        );
+    }
 }

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 use crate::{
     datafusion::DataFusion,
-    http::v1::{run_sql, to_http_response, DataFormat, ResponseMetadata},
+    http::v1::{run_sql, to_http_response, ResponseMetadata, ResponseMimeType},
     model::LLMModelStore,
     tools::{
         builtin::{
@@ -298,7 +298,7 @@ pub(crate) async fn post(
                         return to_http_response(
                             data,
                             cache_status,
-                            DataFormat::from_accept_header(accept.as_ref()),
+                            ResponseMimeType::from_accept_header(accept.as_ref()),
                             ResponseMetadata::empty().with_sql(&cleaned_query),
                         )
                         .instrument(span.clone())

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 use crate::{
     datafusion::DataFusion,
-    http::v1::{run_sql, to_http_response, ArrowFormat},
+    http::v1::{run_sql, to_http_response, DataFormat, ResponseMetadata},
     model::LLMModelStore,
     tools::{
         builtin::{
@@ -295,9 +295,14 @@ pub(crate) async fn post(
                     .await
                 {
                     Ok((data, cache_status)) => {
-                        return to_http_response(data, cache_status, ArrowFormat::Json)
-                            .instrument(span.clone())
-                            .await;
+                        return to_http_response(
+                            data,
+                            cache_status,
+                            DataFormat::from_accept_header(accept.as_ref()),
+                            ResponseMetadata::empty().with_sql(&cleaned_query),
+                        )
+                        .instrument(span.clone())
+                        .await;
                     }
                     Err(e) => {
                         // If query failed, retry with the updated context

--- a/crates/runtime/src/http/v1/query.rs
+++ b/crates/runtime/src/http/v1/query.rs
@@ -26,7 +26,7 @@ use headers_accept::Accept;
 
 use crate::datafusion::DataFusion;
 
-use super::{sql_to_http_response, DataFormat};
+use super::{sql_to_http_response, ResponseMimeType};
 
 /// SQL Query
 ///
@@ -115,5 +115,10 @@ pub(crate) async fn post(
         }
     };
 
-    sql_to_http_response(df, &query, DataFormat::from_accept_header(accept.as_ref())).await
+    sql_to_http_response(
+        df,
+        &query,
+        ResponseMimeType::from_accept_header(accept.as_ref()),
+    )
+    .await
 }

--- a/crates/runtime/src/http/v1/query.rs
+++ b/crates/runtime/src/http/v1/query.rs
@@ -26,7 +26,7 @@ use headers_accept::Accept;
 
 use crate::datafusion::DataFusion;
 
-use super::{sql_to_http_response, ArrowFormat};
+use super::{sql_to_http_response, DataFormat};
 
 /// SQL Query
 ///
@@ -115,5 +115,5 @@ pub(crate) async fn post(
         }
     };
 
-    sql_to_http_response(df, &query, ArrowFormat::from_accept_header(accept.as_ref())).await
+    sql_to_http_response(df, &query, DataFormat::from_accept_header(accept.as_ref())).await
 }

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__tests__vnd_json_v1_with_sql.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__tests__vnd_json_v1_with_sql.snap
@@ -1,0 +1,17 @@
+---
+source: crates/runtime/src/http/v1/mod.rs
+expression: "serde_json::from_str::<serde_json::Value>(&result_with_sql).unwrap()"
+---
+{
+  "data": [
+    {
+      "customer_id": "12345",
+      "total_sales": 150000
+    },
+    {
+      "customer_id": "67890",
+      "total_sales": 125000
+    }
+  ],
+  "sql": "SELECT customer_id, total_sales FROM sales_summary LIMIT 2;"
+}

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__tests__vnd_json_v1_without_sql.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__tests__vnd_json_v1_without_sql.snap
@@ -1,0 +1,16 @@
+---
+source: crates/runtime/src/http/v1/mod.rs
+expression: "serde_json::from_str::<serde_json::Value>(&result_without_sql).unwrap()"
+---
+{
+  "data": [
+    {
+      "customer_id": "12345",
+      "total_sales": 150000
+    },
+    {
+      "customer_id": "67890",
+      "total_sales": 125000
+    }
+  ]
+}


### PR DESCRIPTION
# 🗣 Description

PR introduces new response format for `v1/nsql` and `v1/sql` HTTP API: `application/vnd.spiceai.sql.v1+json`. When format is specified via `Accept` header the returned JSON contains data and additional metadata, such as `sql` query used to get the data. 

Note: PR includes only initial `application/vnd.spiceai.sql.v1+json` support, `schema` and `row_count` will be added via separate PR.

```bash
curl -XPOST "http://localhost:8090/v1/nsql" \
  -H "Content-Type: application/json" \
  -H "Accept: application/vnd.spiceai.sql.v1+json" \
  -d '{
    "query": "Which vendors have made the most trips in 2024?"
  }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   390  100   322  100    68     86     18  0:00:03  0:00:03 --:--:--   105
{
  "data": [
    {
      "VendorID": 2,
      "trip_count": 2234617
    },
    {
      "VendorID": 1,
      "trip_count": 729732
    },
    {
      "VendorID": 6,
      "trip_count": 260
    }
  ],
  "sql": "SELECT \"VendorID\", COUNT(*) AS \"trip_count\"\nFROM \"spice\".\"public\".\"taxi_trips\"\nWHERE EXTRACT(YEAR FROM \"tpep_pickup_datetime\") = 2024\nGROUP BY \"VendorID\"\nORDER BY \"trip_count\" DESC"
}
```


## 🔨 Related Issues

Part of 
- https://github.com/spiceai/spiceai/issues/5329


## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
