### PR TITLE
Upgrade `delta_kernel` to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,9 +3766,9 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
 name = "delta_kernel"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154ca5936081ed40d59953741adf70b943ead91594767168157fe43f5dc7c434"
+checksum = "2ddd09540e487f7f44a2afc431fdae09c10fe8f8bf339a42fc916dc4f7a21d98"
 dependencies = [
  "arrow",
  "bytes",
@@ -3799,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "delta_kernel_derive"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4958c19b4fee1ea107033532e6fead7eed78f600222e494afd9bb9f3c43769"
+checksum = "7840eaa6ae4eab46e0fa0a1eac28326af191a0227843f95ab14d26d5122852f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5377,12 +5377,12 @@ dependencies = [
 
 [[package]]
 name = "hdfs-native"
-version = "0.10.4"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e72db0dfc43c1e6b7ef6d34f6d38eff079cbd30dbc18924b27108793e47893c"
+checksum = "fd346b82c2d000ecd8906bbba1168325df4001a19aadabea325279093c214ae3"
 dependencies = [
  "aes",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.8.0",
  "bytes",
  "cbc",
@@ -5402,13 +5402,13 @@ dependencies = [
  "md-5",
  "num-traits",
  "once_cell",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost 0.13.4",
+ "prost-types 0.13.4",
  "rand 0.8.5",
  "regex",
  "roxmltree",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "url",
  "uuid 1.13.1",
@@ -5417,9 +5417,9 @@ dependencies = [
 
 [[package]]
 name = "hdfs-native-object-store"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d441ed4b31eceee8ffc10690ac2cbcab68d64c453238fa21ec4926f0dbb217"
+checksum = "5ae6ee5ef30abf453bf66d8e9eb940d0e43f845adf45fa650ad9407d7815a20c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5427,7 +5427,7 @@ dependencies = [
  "futures",
  "hdfs-native",
  "object_store",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -10527,12 +10527,9 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.18.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
-dependencies = [
- "xmlparser",
-]
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,18 +3766,11 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
 name = "delta_kernel"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac29dfbfdf1d1105af0ed897a9af34f34833550a0ed81b14a2fb669e096dac5"
+checksum = "154ca5936081ed40d59953741adf70b943ead91594767168157fe43f5dc7c434"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-json",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow",
  "bytes",
  "chrono",
  "delta_kernel_derive",
@@ -3806,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "delta_kernel_derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29fe0a0c1bd83cad5c92ab1ffa035ebb1dd341b35d2fde9d4cc9fd222706dd2"
+checksum = "1c4958c19b4fee1ea107033532e6fead7eed78f600222e494afd9bb9f3c43769"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -29,7 +29,7 @@ datafusion-federation = { workspace = true }
 datafusion-federation-sql = { workspace = true }
 datafusion-table-providers = { workspace = true }
 db_connection_pool = { path = "../db_connection_pool" }
-delta_kernel = { version = "0.7", features = [
+delta_kernel = { version = "0.9", features = [
     "default-engine",
     "cloud",
     "arrow_54",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -29,9 +29,10 @@ datafusion-federation = { workspace = true }
 datafusion-federation-sql = { workspace = true }
 datafusion-table-providers = { workspace = true }
 db_connection_pool = { path = "../db_connection_pool" }
-delta_kernel = { version = "0.6.1", features = [
+delta_kernel = { version = "0.7", features = [
     "default-engine",
     "cloud",
+    "arrow_54",
 ], optional = true }
 document_parse = { path = "../document_parse" }
 duckdb = { workspace = true, features = [

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -37,6 +37,7 @@ use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::TableReference;
+use delta_kernel::ExpressionRef;
 use delta_kernel::Table;
 use delta_kernel::engine::default::DefaultEngine;
 use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
@@ -363,10 +364,12 @@ impl TableProvider for DeltaTable {
                     .map_err(map_delta_error_to_datafusion_err)?;
 
                 for scan_result in scan_iter {
-                    let data = scan_result.map_err(map_delta_error_to_datafusion_err)?;
+                    let (data, selection_vector, transforms) =
+                        scan_result.map_err(map_delta_error_to_datafusion_err)?;
                     scan_context = delta_kernel::scan::state::visit_scan_files(
-                        data.0.as_ref(),
-                        data.1.as_ref(),
+                        data.as_ref(),
+                        &selection_vector,
+                        &transforms,
                         scan_context,
                         handle_scan_file,
                     )
@@ -546,6 +549,16 @@ struct PartitionFileContext {
     partitioned_file: PartitionedFile,
     selection_vector: Option<Vec<bool>>,
     partition_values: HashMap<String, String>,
+
+    /// These are transforms that Delta wants to apply to the physical data read from the Parquet files.
+    /// Currently this is only used for adding partition columns and mapping the columns read from the Parquet files
+    /// into the correct place in the output schema.
+    ///
+    /// Both of these functions are already handled for us by the `DataFusion` `ParquetExec`. However, we may need to
+    /// revisit this if more complex transformations are required.
+    ///
+    /// See: <https://github.com/delta-io/delta-kernel-rs/blob/7e62d12def00f248eccef23e7672fd4db553274f/kernel/src/scan/mod.rs#L444>
+    _transform: Option<ExpressionRef>,
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -557,6 +570,7 @@ fn handle_scan_file(
     size: i64,
     _stats: Option<Stats>,
     dv_info: DvInfo,
+    transform: Option<ExpressionRef>,
     partition_values: HashMap<String, String>,
 ) {
     let root_url = match Url::parse(&scan_context.scan_state.table_root) {
@@ -619,6 +633,7 @@ fn handle_scan_file(
         partitioned_file,
         selection_vector,
         partition_values,
+        _transform: transform,
     });
 }
 

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -145,13 +145,13 @@ impl DeltaTable {
             .map_err(handle_delta_error)?;
 
         let arrow_schema = Self::get_schema(&snapshot);
-        let delta_schema = snapshot.schema().clone();
+        let delta_schema = snapshot.schema();
 
         Ok(Self {
             table,
             engine,
             arrow_schema: Arc::new(arrow_schema),
-            delta_schema: Arc::new(delta_schema),
+            delta_schema,
         })
     }
 
@@ -360,20 +360,14 @@ impl TableProvider for DeltaTable {
                 let mut scan_context = ScanContext::new(scan_state, Arc::clone(&engine));
 
                 let scan_iter = scan
-                    .scan_data(engine.as_ref())
+                    .scan_metadata(engine.as_ref())
                     .map_err(map_delta_error_to_datafusion_err)?;
 
                 for scan_result in scan_iter {
-                    let (data, selection_vector, transforms) =
-                        scan_result.map_err(map_delta_error_to_datafusion_err)?;
-                    scan_context = delta_kernel::scan::state::visit_scan_files(
-                        data.as_ref(),
-                        &selection_vector,
-                        &transforms,
-                        scan_context,
-                        handle_scan_file,
-                    )
-                    .map_err(map_delta_error_to_datafusion_err)?;
+                    let scan = scan_result.map_err(map_delta_error_to_datafusion_err)?;
+                    scan_context = scan
+                        .visit_scan_files(scan_context, handle_scan_file)
+                        .map_err(map_delta_error_to_datafusion_err)?;
                 }
 
                 Ok::<_, datafusion::error::DataFusionError>((


### PR DESCRIPTION
# 🗣 Description

Upgrades the `delta_kernel` library to `0.9`.

## 🔨 Related Issues

Closes #5325

## 🤔 Concerns

The update to `0.7` introduced the notion of "transforms" that need to be applied to the physical data read from the Parquet files to make it match the logical schema of the table. Currently the only transforms possible are adding in partition columns and mapping physical column indexes to logical column indexes - both of which are handled by the `ParquetExec` from DataFusion.