### PR TITLE
Fix schema inference for Snowflake tables with large number of columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11625,7 +11625,7 @@ dependencies = [
 [[package]]
 name = "snowflake-api"
 version = "0.9.0"
-source = "git+https://github.com/spiceai/snowflake-rs.git?rev=e7237c22ebb7a94e11de7d77b3225247d24b3581#e7237c22ebb7a94e11de7d77b3225247d24b3581"
+source = "git+https://github.com/spiceai/snowflake-rs.git?rev=0cd20ce6ebc72bec9f9c98ddb7d242bf48d6b8d3#0cd20ce6ebc72bec9f9c98ddb7d242bf48d6b8d3"
 dependencies = [
  "arrow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.30"
 snafu = "0.8.5"
-snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", rev = "e7237c22ebb7a94e11de7d77b3225247d24b3581" } # spiceai
+snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", rev = "0cd20ce6ebc72bec9f9c98ddb7d242bf48d6b8d3" } # spiceai
 ssh2 = { version = "0.9.5" }
 suppaftp = { version = "5.3.1", features = ["async"] }
 tempfile = "3"


### PR DESCRIPTION
# 🗣 Description

- https://github.com/spiceai/snowflake-rs/pull/2

The schema for Snowflake tables with a large number of columns was not being correctly inferred. If a table has more than approximately 600 columns, `SHOW COLUMNS IN {table}` will return chunked json response, which `snowflake-rs` didn't fully support before the fix.

![CleanShot 2025-04-11 at 15 56 45@2x](https://github.com/user-attachments/assets/527df133-85e1-4cc8-aee3-c13173552a33)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
