### PR TITLE
fix: validate_results not validate

### DIFF
--- a/tools/testoperator/dispatch/tpch/accelerated/file_arrow.yaml
+++ b/tools/testoperator/dispatch/tpch/accelerated/file_arrow.yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: ./test/spicepods/tpch/accelerated/file_arrow.yaml
     query_set: tpch
     runner_type: spiceai-runners
-    validate: true
+    validate_results: true
   throughput:
     spicepod_path: ./test/spicepods/tpch/accelerated/file_arrow.yaml
     query_set: tpch

--- a/tools/testoperator/dispatch/tpch/accelerated/file_duckdb_file.yaml
+++ b/tools/testoperator/dispatch/tpch/accelerated/file_duckdb_file.yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: ./test/spicepods/tpch/accelerated/file_duckdb_file.yaml
     query_set: tpch
     runner_type: spiceai-runners
-    validate: true
+    validate_results: true
   throughput:
     spicepod_path: ./test/spicepods/tpch/accelerated/file_duckdb_file.yaml
     query_set: tpch

--- a/tools/testoperator/dispatch/tpch/accelerated/file_duckdb_memory.yaml
+++ b/tools/testoperator/dispatch/tpch/accelerated/file_duckdb_memory.yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: ./test/spicepods/tpch/accelerated/file_duckdb_memory.yaml
     query_set: tpch
     runner_type: spiceai-runners
-    validate: true
+    validate_results: true
   throughput:
     spicepod_path: ./test/spicepods/tpch/accelerated/file_duckdb_memory.yaml
     query_set: tpch

--- a/tools/testoperator/dispatch/tpch/duckdb.yaml
+++ b/tools/testoperator/dispatch/tpch/duckdb.yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: ./test/spicepods/tpch/duckdb.yaml
     query_set: tpch
     runner_type: spiceai-runners
-    validate: true
+    validate_results: true
   throughput:
     spicepod_path: ./test/spicepods/tpch/duckdb.yaml
     query_set: tpch

--- a/tools/testoperator/dispatch/tpch/file.yaml
+++ b/tools/testoperator/dispatch/tpch/file.yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: ./test/spicepods/tpch/file.yaml
     query_set: tpch
     runner_type: spiceai-runners
-    validate: true
+    validate_results: true
   throughput:
     spicepod_path: ./test/spicepods/tpch/file.yaml
     query_set: tpch

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -101,7 +101,7 @@ pub struct BenchArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update_snapshots: Option<UpdateSnapshots>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub validate: Option<bool>,
+    pub validate_results: Option<bool>,
 }
 
 impl BenchArgs {
@@ -113,7 +113,7 @@ impl BenchArgs {
 
     #[must_use]
     pub fn with_validate(mut self, validate: bool) -> Self {
-        self.validate = Some(validate);
+        self.validate_results = Some(validate);
         self
     }
 }


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* The workflow parameter is `validate_results`, not `validate`

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of #4932
