### PR TITLE
Extend `application/vnd.spiceai.sql.v1+json` with `schema` and `row_count` fields

### DIFF
--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -287,7 +287,7 @@ fn arrow_to_plain(
     pretty_format_batches(data).map(|d| format!("{d}")).boxed()
 }
 
-/// Converts a vector of `RecordBatch` to a application/vnd.spiceai.v1+json format
+/// Converts a vector of `RecordBatch` to an application/vnd.spiceai.sql.v1+json format
 fn arrow_to_vnd_sql_json_v1(
     data: &[RecordBatch],
     meta: ResponseMetadata,

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -101,7 +101,7 @@ pub enum ResponseMimeType {
     Json,
     Csv,
     Plain,
-    VndJsonV1,
+    VndSqlJsonV1,
 }
 
 /// Represents additional metadata to produce a response, such as the SQL query used, etc.
@@ -134,7 +134,7 @@ impl ResponseMimeType {
                 .iter()
                 .find_map(|h| match h.as_str() {
                     "application/json" => Some(ResponseMimeType::Json),
-                    "application/vnd.spiceai.sql.v1+json" => Some(ResponseMimeType::VndJsonV1),
+                    "application/vnd.spiceai.sql.v1+json" => Some(ResponseMimeType::VndSqlJsonV1),
                     "text/csv" => Some(ResponseMimeType::Csv),
                     "text/plain" => Some(ResponseMimeType::Plain),
                     _ => None,
@@ -207,7 +207,7 @@ pub async fn to_http_response(
         ResponseMimeType::Json => arrow_to_json(&data),
         ResponseMimeType::Csv => arrow_to_csv(&data),
         ResponseMimeType::Plain => arrow_to_plain(&data),
-        ResponseMimeType::VndJsonV1 => arrow_to_vnd_json_v1(&data, meta),
+        ResponseMimeType::VndSqlJsonV1 => arrow_to_vnd_sql_json_v1(&data, meta),
     };
 
     let body = match res {
@@ -288,7 +288,7 @@ fn arrow_to_plain(
 }
 
 /// Converts a vector of `RecordBatch` to a application/vnd.spiceai.v1+json format
-fn arrow_to_vnd_json_v1(
+fn arrow_to_vnd_sql_json_v1(
     data: &[RecordBatch],
     meta: ResponseMetadata,
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
@@ -302,7 +302,19 @@ fn arrow_to_vnd_json_v1(
         .boxed()?;
     writer.finish().boxed()?;
 
+    // Calculate total row count across all batches
+    let row_count = data.iter().map(RecordBatch::num_rows).sum::<usize>();
+
+    let schema_json = if let Some(batch) = data.first() {
+        // Use built-in Arrow JSON schema representation: https://github.com/apache/arrow/blob/main/docs/source/format/Integration.rst#json-test-data-format
+        serde_json::to_value(batch.schema())?
+    } else {
+        serde_json::json!({})
+    };
+
     let mut result = json!({
+        "row_count": row_count,
+        "schema": schema_json,
         "data": serde_json::from_slice::<serde_json::Value>(&writer.into_inner()).boxed()?,
     });
 
@@ -336,7 +348,8 @@ mod tests {
 
         // Test conversion without SQL
         let result_without_sql =
-            arrow_to_vnd_json_v1(&[batch.clone()], ResponseMetadata::empty()).expect("to convert");
+            arrow_to_vnd_sql_json_v1(&[batch.clone()], ResponseMetadata::empty())
+                .expect("to convert");
         insta::assert_json_snapshot!(
             "vnd_json_v1_without_sql",
             serde_json::from_str::<serde_json::Value>(&result_without_sql).expect("to parse")
@@ -345,7 +358,7 @@ mod tests {
         // Test conversion with SQL
         let metadata = ResponseMetadata::empty()
             .with_sql("SELECT customer_id, total_sales FROM sales_summary LIMIT 2;");
-        let result_with_sql = arrow_to_vnd_json_v1(&[batch], metadata).expect("to convert");
+        let result_with_sql = arrow_to_vnd_sql_json_v1(&[batch], metadata).expect("to convert");
         insta::assert_json_snapshot!(
             "vnd_json_v1_with_sql",
             serde_json::from_str::<serde_json::Value>(&result_with_sql).expect("to parse")

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__tests__vnd_json_v1_with_sql.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__tests__vnd_json_v1_with_sql.snap
@@ -1,8 +1,30 @@
 ---
 source: crates/runtime/src/http/v1/mod.rs
-expression: "serde_json::from_str::<serde_json::Value>(&result_with_sql).unwrap()"
+expression: "serde_json::from_str::<serde_json::Value>(&result_with_sql).expect(\"to parse\")"
 ---
 {
+  "row_count": 2,
+  "schema": {
+    "fields": [
+      {
+        "name": "customer_id",
+        "data_type": "Utf8",
+        "nullable": false,
+        "dict_id": 0,
+        "dict_is_ordered": false,
+        "metadata": {}
+      },
+      {
+        "name": "total_sales",
+        "data_type": "Int64",
+        "nullable": false,
+        "dict_id": 0,
+        "dict_is_ordered": false,
+        "metadata": {}
+      }
+    ],
+    "metadata": {}
+  },
   "data": [
     {
       "customer_id": "12345",

--- a/crates/runtime/src/http/v1/snapshots/runtime__http__v1__tests__vnd_json_v1_without_sql.snap
+++ b/crates/runtime/src/http/v1/snapshots/runtime__http__v1__tests__vnd_json_v1_without_sql.snap
@@ -1,8 +1,30 @@
 ---
 source: crates/runtime/src/http/v1/mod.rs
-expression: "serde_json::from_str::<serde_json::Value>(&result_without_sql).unwrap()"
+expression: "serde_json::from_str::<serde_json::Value>(&result_without_sql).expect(\"to parse\")"
 ---
 {
+  "row_count": 2,
+  "schema": {
+    "fields": [
+      {
+        "name": "customer_id",
+        "data_type": "Utf8",
+        "nullable": false,
+        "dict_id": 0,
+        "dict_is_ordered": false,
+        "metadata": {}
+      },
+      {
+        "name": "total_sales",
+        "data_type": "Int64",
+        "nullable": false,
+        "dict_id": 0,
+        "dict_is_ordered": false,
+        "metadata": {}
+      }
+    ],
+    "metadata": {}
+  },
   "data": [
     {
       "customer_id": "12345",


### PR DESCRIPTION
# 🗣 Description

Add `schema` and `row_count` fields when using `application/vnd.spiceai.sql.v1+json` format.

```json
{
  "row_count": 2,
  "schema": {
    "fields": [
      {
        "name": "customer_id",
        "data_type": "Utf8",
        "nullable": false,
        "dict_id": 0,
        "dict_is_ordered": false,
        "metadata": {}
      },
      {
        "name": "total_sales",
        "data_type": "Int64",
        "nullable": false,
        "dict_id": 0,
        "dict_is_ordered": false,
        "metadata": {}
      }
    ],
    "metadata": {}
  },
  "data": [
...
```


## 🔨 Related Issues

Closes 
- https://github.com/spiceai/spiceai/issues/5329

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

1. The built-in Arrow JSON format for schema representation can be more complex to use compared to [JSON Schema](https://json-schema.org/understanding-json-schema/reference/type#footnotes), which supports only a limited set of types. In contrast, the Arrow schema format provides more detailed and granular type definitions, making it more closely aligned with Arrow's internal type system. For example, JSON Schema does not distinguish between integers and floating-point numbers—they are both represented as the `number` type:

> [JSON Schema](https://json-schema.org/understanding-json-schema/reference/type#footnotes):  
> JSON does not have separate types for integer and floating-point.

1.  `metadata` part `schema` does not seems to be very valuable, keeping it for consistency with Arrow Schema JSON format, we might want to remove metadata and flatten fielads so it is 
```json

{
  "row_count": 2,
  "schema": [
      {
        "name": "customer_id",
        "data_type": "Utf8",
        "nullable": false,
        "dict_id": 0,
        "dict_is_ordered": false,
        "metadata": {}
      },
      {
        "name": "total_sales",
        "data_type": "Int64",
        "nullable": false,
        "dict_id": 0,
        "dict_is_ordered": false,
        "metadata": {}
      }
    ],
...
```
