### PR TITLE
Upgrade to DuckDB 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,8 +4081,8 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "duckdb"
-version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=2e24b958e44ec7419290249e27a15f1a19703fff#2e24b958e44ec7419290249e27a15f1a19703fff"
+version = "1.2.2"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b850ae60dbe67209320c86daeadf47b51f937660#b850ae60dbe67209320c86daeadf47b51f937660"
 dependencies = [
  "arrow",
  "cast",
@@ -6718,8 +6718,8 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=2e24b958e44ec7419290249e27a15f1a19703fff#2e24b958e44ec7419290249e27a15f1a19703fff"
+version = "1.2.2"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b850ae60dbe67209320c86daeadf47b51f937660#b850ae60dbe67209320c86daeadf47b51f937660"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ datafusion-federation-sql = { git = "https://github.com/spiceai/datafusion-feder
 datafusion-functions-json = "0.45"
 datafusion-table-providers = "0.1"
 dotenvy = "0.15"
-duckdb = "1.1.3"
+duckdb = "1.2.2"
 fundu = "2.0.1"
 futures = "0.3.30"
 globset = "0.4.16"
@@ -168,7 +168,7 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "e0
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "1c814422cfbdeb7f7bd2399e3369656710413aa8" } # spiceai-45
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "f60653b6ff9a0f26e5b44a1d43d947fdf1fd8853" } # spiceai
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "2e24b958e44ec7419290249e27a15f1a19703fff" } # spiceai-1.1.3-backported-arrow-54
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b850ae60dbe67209320c86daeadf47b51f937660" } # spiceai-1.2.2
 
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af725caf5d3e952e349746706e00d0ea5" }
 


### PR DESCRIPTION
# 🗣 Description

Upgrades DuckDB to 1.2.2

## 🔨 Related Issues

Closes #5326
Part of #4643
