### PR TITLE
docs: Update endgame template with SpiceQA, update qa analytics

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -203,6 +203,9 @@ assignees: ''
 - [ ] Update [brew taps](https://github.com/spiceai/homebrew-spiceai) after the final build completes.
 - [ ] Remove or mark the released version in the [ROADMAP](https://github.com/spiceai/spiceai/blob/trunk/docs/ROADMAP.md).
 - [ ] Update the supported version in `SECURITY.md` if necessary.
+- [ ] QA DRI: Run SpiceQA via SCP over the following recipes using the template prompt from the [SpiceQA workflow](https://github.com/spiceai/cookbook/blob/trunk/.github/workflows/spice-qa.yml#L45):
+  - [ ] File Data Connector
+  - [ ] Dremio Data Connector
 - [ ] QA DRI: Add metrics to [QA analytics](https://github.com/spiceai/spiceai/blob/trunk/docs/release_notes/qa_analytics.csv).
   - Use number of recipes total from [spiceai.org/docs/cookbook](https://spiceai.org/docs/cookbook).
 

--- a/.github/workflows/e2e_test_release_install_ai.yml
+++ b/.github/workflows/e2e_test_release_install_ai.yml
@@ -8,9 +8,7 @@ on:
           type: choice
           options:
             - "all"
-            - "Linux x64 (GPU T4)"
             - "macOS aarch64 (GPU M4)"
-            - "Windows x64 (GPU T4)"
             - "Linux aarch64"
             - "macOS aarch64"
             - "Windows x64"
@@ -31,25 +29,11 @@ jobs:
           script: |
             const matrix = [
               {
-                name: "Linux x64 (GPU T4)",
-                runner: "ubuntu-gpu-t4-4-core",
-                target_os: "linux",
-                target_arch: "x86_64",
-                tags: ["cuda"]
-              },
-              {
                 name: "macOS aarch64 (GPU M4)",
                 runner: "spiceai-macos",
                 target_os: "darwin",
                 target_arch: "aarch64",
                 tags: ["metal"]
-              },
-              {
-                name: "Windows x64 (GPU T4)",
-                runner: "windows-gpu-t4-4-core",
-                target_os: "windows",
-                target_arch: "x86_64",
-                tags: ["cuda"]
               },
               {
                 name: "Linux aarch64",

--- a/docs/release_notes/qa_analytics.csv
+++ b/docs/release_notes/qa_analytics.csv
@@ -5,4 +5,5 @@ version,qa_start_time,qa_end_time,human_count,human_hours,recipes_total,recipes_
 1.0.6,2025-03-18T22:00:00Z,2025-03-19T07:00:00Z,4,12,63,8,1,AI QA engineer runs recipes post-release.
 1.0.7,2025-03-26T14:00:00Z,2025-03-27T03:00:00Z,3,13,63,63,1,AI QA engineer runs recipes post-release.
 1.1.0,2025-03-31T07:11:00Z,2025-03-31T12:00:00Z,4,5,65,65,1,AI QA engineer runs recipes post-release.
-1.1.1,2025-04-07T11:00:00Z,2025-04-08T00:00:00Z,4,6,65,65,2,AI QA engineer runs recipes post-release; new recipe tested by AI QA: Dremio data connector
+1.1.1,2025-04-07T11:00:00Z,2025-04-08T00:00:00Z,4,6,65,65,2,AI QA engineer runs recipes post-release; new recipe tested by AI QA: Dremio data connector
+1.1.2,2025-04-14T08:00:00Z,2025,04-15T06:00:00Z,8,12,65,65,1,AI QA engineer runs recipes post-release. Dremio data connector recipe failed.


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the endgame template to include steps for running SpiceQA
* Updates the QA analytics file
* Removes the T4 GPU E2E release installation targets, as they are compute cap 7.5 which we do not ship GPU binaries for
