### PR TITLE
Track `ai_inferences_count` with used tools flag. Extensible runtime request context. 

### DIFF
--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -181,7 +181,7 @@ pub(crate) fn routes(
             .route("/v1/models", get(v1::models::get))
             .route("/v1/models/:name/predict", get(v1::inference::get))
             .route("/v1/predict", post(v1::inference::post))
-            .route("/v1/nsql", post(v1::nsql::post))
+            .route("/v1/nsql", post(v1::nsql::post).layer(ModelContextLayer))
             .route(
                 "/v1/chat/completions",
                 post(v1::chat::post).layer(ModelContextLayer),

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::model::ModelContextLayer;
 use crate::{embeddings::vector_search, status::RuntimeStatus};
 
 use crate::Runtime;
@@ -181,7 +182,10 @@ pub(crate) fn routes(
             .route("/v1/models/:name/predict", get(v1::inference::get))
             .route("/v1/predict", post(v1::inference::post))
             .route("/v1/nsql", post(v1::nsql::post))
-            .route("/v1/chat/completions", post(v1::chat::post))
+            .route(
+                "/v1/chat/completions",
+                post(v1::chat::post).layer(ModelContextLayer),
+            )
             .route("/v1/embeddings", post(v1::embeddings::post))
             .route("/v1/search", post(v1::search::post))
             .route("/v1/tools", get(v1::tools::list))

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -17,7 +17,7 @@ use crate::{
     Runtime,
     datafusion::DataFusion,
     http::v1::{ResponseMetadata, ResponseMimeType, run_sql, to_http_response},
-    model::{LLMModelStore, ModelContextExtension},
+    model::LLMModelStore,
     request::{AsyncMarker, RequestContext},
     tools::{
         builtin::{
@@ -239,9 +239,7 @@ pub(crate) async fn post(
 ) -> Response {
     // track ai_inferences_count metric
     let context = RequestContext::current(AsyncMarker::new().await);
-    if let Some(model_context) = context.extension::<ModelContextExtension>().await {
-        model_context.set_tools_used(true);
-    }
+    crate::model::set_tools_used(&context, true);
 
     let span = tracing::span!(target: "task_history", tracing::Level::INFO, "nsql", input = %payload.query, model = %payload.model, "labels");
 

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -17,7 +17,8 @@ use crate::{
     Runtime,
     datafusion::DataFusion,
     http::v1::{ResponseMetadata, ResponseMimeType, run_sql, to_http_response},
-    model::LLMModelStore,
+    model::{LLMModelStore, ModelContextExtension},
+    request::{AsyncMarker, RequestContext},
     tools::{
         builtin::{
             sample::{
@@ -236,6 +237,12 @@ pub(crate) async fn post(
     accept: Option<TypedHeader<Accept>>,
     Json(payload): Json<Request>,
 ) -> Response {
+    // track ai_inferences_count metric
+    let context = RequestContext::current(AsyncMarker::new().await);
+    if let Some(model_context) = context.extension::<ModelContextExtension>().await {
+        model_context.set_tools_used(true);
+    }
+
     let span = tracing::span!(target: "task_history", tracing::Level::INFO, "nsql", input = %payload.query, model = %payload.model, "labels");
 
     // Default to all available tables if specific table(s) are not provided.

--- a/crates/runtime/src/metrics/telemetry/mod.rs
+++ b/crates/runtime/src/metrics/telemetry/mod.rs
@@ -90,3 +90,16 @@ pub fn track_query_execution_duration(duration: Duration, dimensions: &[KeyValue
     telemetry::track_query_execution_duration(duration, dimensions);
     QUERY_EXECUTION_DURATION_MS.record(duration.as_secs_f64() * 1000.0, dimensions);
 }
+
+static AI_INFERENCES_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    TELEMETRY_METER
+        .u64_counter("ai_inferences_count")
+        .with_description("Number of AI Inferences")
+        .with_unit("inferences")
+        .build()
+});
+
+pub fn track_ai_inferences_count(dimensions: &[KeyValue]) {
+    telemetry::track_ai_inferences_count(dimensions);
+    AI_INFERENCES_COUNT.add(1, dimensions);
+}

--- a/crates/runtime/src/metrics/telemetry/mod.rs
+++ b/crates/runtime/src/metrics/telemetry/mod.rs
@@ -99,7 +99,7 @@ static AI_INFERENCES_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .build()
 });
 
-pub fn track_ai_inferences_count(dimensions: &[KeyValue]) {
+pub fn track_ai_inferences_with_spice_count(dimensions: &[KeyValue]) {
     telemetry::track_ai_inferences_count(dimensions);
     AI_INFERENCES_COUNT.add(1, dimensions);
 }

--- a/crates/runtime/src/metrics/telemetry/mod.rs
+++ b/crates/runtime/src/metrics/telemetry/mod.rs
@@ -94,7 +94,7 @@ pub fn track_query_execution_duration(duration: Duration, dimensions: &[KeyValue
 static AI_INFERENCES_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     TELEMETRY_METER
         .u64_counter("ai_inferences_with_spice_count")
-        .with_description("Number of AI Inferences")
+        .with_description("AI Inferences with Spice count")
         .with_unit("inferences")
         .build()
 });

--- a/crates/runtime/src/metrics/telemetry/mod.rs
+++ b/crates/runtime/src/metrics/telemetry/mod.rs
@@ -93,7 +93,7 @@ pub fn track_query_execution_duration(duration: Duration, dimensions: &[KeyValue
 
 static AI_INFERENCES_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     TELEMETRY_METER
-        .u64_counter("ai_inferences_count")
+        .u64_counter("ai_inferences_with_spice_count")
         .with_description("Number of AI Inferences")
         .with_unit("inferences")
         .build()

--- a/crates/runtime/src/metrics/telemetry/mod.rs
+++ b/crates/runtime/src/metrics/telemetry/mod.rs
@@ -91,7 +91,7 @@ pub fn track_query_execution_duration(duration: Duration, dimensions: &[KeyValue
     QUERY_EXECUTION_DURATION_MS.record(duration.as_secs_f64() * 1000.0, dimensions);
 }
 
-static AI_INFERENCES_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+static AI_INFERENCES_WITH_SPICE_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     TELEMETRY_METER
         .u64_counter("ai_inferences_with_spice_count")
         .with_description("AI Inferences with Spice count")
@@ -100,6 +100,6 @@ static AI_INFERENCES_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
 });
 
 pub fn track_ai_inferences_with_spice_count(dimensions: &[KeyValue]) {
-    telemetry::track_ai_inferences_count(dimensions);
-    AI_INFERENCES_COUNT.add(1, dimensions);
+    telemetry::track_ai_inferences_with_spice_count(dimensions);
+    AI_INFERENCES_WITH_SPICE_COUNT.add(1, dimensions);
 }

--- a/crates/runtime/src/model/mod.rs
+++ b/crates/runtime/src/model/mod.rs
@@ -24,6 +24,7 @@ mod chat;
 mod embed;
 pub(crate) mod eval;
 mod metrics;
+mod model_context;
 mod tool_use;
 mod wrapper;
 
@@ -41,6 +42,7 @@ pub use eval::{
     },
     scorer::{EvalScorerRegistry, Scorer, builtin_scorer},
 };
+pub use model_context::ModelContextLayer;
 pub use tool_use::ToolUsingChat;
 
 use crate::DataFusion;

--- a/crates/runtime/src/model/mod.rs
+++ b/crates/runtime/src/model/mod.rs
@@ -42,7 +42,9 @@ pub use eval::{
     },
     scorer::{EvalScorerRegistry, Scorer, builtin_scorer},
 };
-pub use model_context::{ModelContextExtension, ModelContextLayer};
+pub use model_context::{
+    ModelContextExtension, ModelContextLayer, set_tools_used, track_ai_inferences_count,
+};
 pub use tool_use::ToolUsingChat;
 
 use crate::DataFusion;

--- a/crates/runtime/src/model/mod.rs
+++ b/crates/runtime/src/model/mod.rs
@@ -42,7 +42,7 @@ pub use eval::{
     },
     scorer::{EvalScorerRegistry, Scorer, builtin_scorer},
 };
-pub use model_context::ModelContextLayer;
+pub use model_context::{ModelContextExtension, ModelContextLayer};
 pub use tool_use::ToolUsingChat;
 
 use crate::DataFusion;

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -22,6 +22,7 @@ use std::sync::{
 use axum::body::Body;
 use axum::http::Request;
 use futures::future::BoxFuture;
+use opentelemetry::KeyValue;
 use std::task::{Context, Poll};
 use tower::{Layer, Service};
 
@@ -39,11 +40,11 @@ impl ModelContextExtension {
         }
     }
 
-    pub fn used_tools(&self) -> bool {
+    pub fn tools_used(&self) -> bool {
         self.used_tools.load(Ordering::Relaxed)
     }
 
-    pub fn set_used_tools(&self, value: bool) {
+    pub fn set_tools_used(&self, value: bool) {
         self.used_tools.store(value, Ordering::Relaxed);
     }
 }
@@ -92,5 +93,15 @@ impl<S> Layer<S> for ModelContextLayer {
 
     fn layer(&self, service: S) -> Self::Service {
         ModelContextService { inner: service }
+    }
+}
+
+/// Emit the ai_inference_count metric with the tools_used dimension set to true or false.
+/// It requires the model extension to be set for the request context.
+pub async fn track_ai_inferences_count() {
+    let context = RequestContext::current(AsyncMarker::new().await);
+    if let Some(model_context) = context.extension::<ModelContextExtension>().await {
+        let dimensions = vec![KeyValue::new("tools_used", model_context.tools_used())];
+        crate::metrics::telemetry::track_ai_inferences_count(&dimensions);
     }
 }

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -74,12 +74,8 @@ where
             let context = RequestContext::current(AsyncMarker::new().await);
             context.insert_extension(ModelContextExtension::new()).await;
 
-            context
-                .scope(async move {
-                    let mut inner_service = inner;
-                    inner_service.call(req).await
-                })
-                .await
+            let mut inner_service = inner;
+            inner_service.call(req).await
         })
     }
 }

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -94,10 +94,11 @@ impl<S> Layer<S> for ModelContextLayer {
 
 /// Emit the `ai_inference_count` metric with the `tools_used` dimension set to true or false.
 /// It requires the model extension to be set for the request context.
-pub async fn track_ai_inferences_count() {
-    let context = RequestContext::current(AsyncMarker::new().await);
+pub async fn track_ai_inferences_count(context: &Arc<RequestContext>) {
     if let Some(model_context) = context.extension::<ModelContextExtension>().await {
         let dimensions = vec![KeyValue::new("tools_used", model_context.tools_used())];
         crate::metrics::telemetry::track_ai_inferences_count(&dimensions);
+    } else if cfg!(feature = "dev") {
+        panic!("ModelContextExtension not found in request context");
     }
 }

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -109,7 +109,7 @@ impl<S> Layer<S> for ModelContextLayer {
 pub fn track_ai_inferences_count(context: &Arc<RequestContext>) {
     if let Some(model_context) = context.extension::<ModelContextExtension>() {
         let dimensions = vec![KeyValue::new("tools_used", model_context.tools_used())];
-        crate::metrics::telemetry::track_ai_inferences_count(&dimensions);
+        crate::metrics::telemetry::track_ai_inferences_with_spice_count(&dimensions);
     } else if cfg!(feature = "dev") {
         panic!("ModelContextExtension not found in request context");
     }

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -1,0 +1,96 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use axum::body::Body;
+use axum::http::Request;
+use futures::future::BoxFuture;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+use crate::request::{AsyncMarker, RequestContext};
+
+#[derive(Clone)]
+pub struct ModelContextExtension {
+    used_tools: Arc<AtomicBool>,
+}
+
+impl ModelContextExtension {
+    pub fn new() -> Self {
+        Self {
+            used_tools: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn used_tools(&self) -> bool {
+        self.used_tools.load(Ordering::Relaxed)
+    }
+
+    pub fn set_used_tools(&self, value: bool) {
+        self.used_tools.store(value, Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone)]
+pub struct ModelContextService<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for ModelContextService<S>
+where
+    S: Service<Request<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let inner = self.inner.clone();
+
+        Box::pin(async move {
+            let context = RequestContext::current(AsyncMarker::new().await);
+            context.insert_extension(ModelContextExtension::new()).await;
+
+            context
+                .scope(async move {
+                    let mut inner_service = inner;
+                    inner_service.call(req).await
+                })
+                .await
+        })
+    }
+}
+
+// The layer that will apply our service
+#[derive(Clone)]
+pub struct ModelContextLayer;
+
+impl<S> Layer<S> for ModelContextLayer {
+    type Service = ModelContextService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        ModelContextService { inner: service }
+    }
+}

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -108,7 +108,10 @@ impl<S> Layer<S> for ModelContextLayer {
 /// Panics if the model extension is not found in the request context.
 pub fn track_ai_inferences_count(context: &Arc<RequestContext>) {
     if let Some(model_context) = context.extension::<ModelContextExtension>() {
-        let dimensions = vec![KeyValue::new("tools_used", model_context.tools_used())];
+        let dimensions = vec![KeyValue::new(
+            "tools_used",
+            model_context.tools_used().to_string(),
+        )];
         crate::metrics::telemetry::track_ai_inferences_with_spice_count(&dimensions);
     } else if cfg!(feature = "dev") {
         panic!("ModelContextExtension not found in request context");

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -94,6 +94,10 @@ impl<S> Layer<S> for ModelContextLayer {
 
 /// Emit the `ai_inference_count` metric with the `tools_used` dimension set to true or false.
 /// It requires the model extension to be set for the request context.
+///
+/// # Panics
+///
+/// Panics if the model extension is not found in the request context.
 pub fn track_ai_inferences_count(context: &Arc<RequestContext>) {
     if let Some(model_context) = context.extension::<ModelContextExtension>() {
         let dimensions = vec![KeyValue::new("tools_used", model_context.tools_used())];
@@ -103,6 +107,12 @@ pub fn track_ai_inferences_count(context: &Arc<RequestContext>) {
     }
 }
 
+/// Set the `tools_used` flag in the model context extension for further metric tracking.
+/// It requires the model extension to be set for the request context.
+///
+/// # Panics
+///
+/// Panics if the model extension is not found in the request context.
 pub fn set_tools_used(context: &Arc<RequestContext>, value: bool) {
     if let Some(model_context) = context.extension::<ModelContextExtension>() {
         model_context.set_tools_used(value);

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -72,7 +72,7 @@ where
 
         Box::pin(async move {
             let context = RequestContext::current(AsyncMarker::new().await);
-            context.insert_extension(ModelContextExtension::new()).await;
+            context.insert_extension(ModelContextExtension::new());
 
             let mut inner_service = inner;
             inner_service.call(req).await
@@ -94,10 +94,18 @@ impl<S> Layer<S> for ModelContextLayer {
 
 /// Emit the `ai_inference_count` metric with the `tools_used` dimension set to true or false.
 /// It requires the model extension to be set for the request context.
-pub async fn track_ai_inferences_count(context: &Arc<RequestContext>) {
-    if let Some(model_context) = context.extension::<ModelContextExtension>().await {
+pub fn track_ai_inferences_count(context: &Arc<RequestContext>) {
+    if let Some(model_context) = context.extension::<ModelContextExtension>() {
         let dimensions = vec![KeyValue::new("tools_used", model_context.tools_used())];
         crate::metrics::telemetry::track_ai_inferences_count(&dimensions);
+    } else if cfg!(feature = "dev") {
+        panic!("ModelContextExtension not found in request context");
+    }
+}
+
+pub fn set_tools_used(context: &Arc<RequestContext>, value: bool) {
+    if let Some(model_context) = context.extension::<ModelContextExtension>() {
+        model_context.set_tools_used(value);
     } else if cfg!(feature = "dev") {
         panic!("ModelContextExtension not found in request context");
     }

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -34,18 +34,26 @@ pub struct ModelContextExtension {
 }
 
 impl ModelContextExtension {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             used_tools: Arc::new(AtomicBool::new(false)),
         }
     }
 
+    #[must_use]
     pub fn tools_used(&self) -> bool {
         self.used_tools.load(Ordering::Relaxed)
     }
 
     pub fn set_tools_used(&self, value: bool) {
         self.used_tools.store(value, Ordering::Relaxed);
+    }
+}
+
+impl Default for ModelContextExtension {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/runtime/src/model/model_context.rs
+++ b/crates/runtime/src/model/model_context.rs
@@ -96,7 +96,7 @@ impl<S> Layer<S> for ModelContextLayer {
     }
 }
 
-/// Emit the ai_inference_count metric with the tools_used dimension set to true or false.
+/// Emit the `ai_inference_count` metric with the `tools_used` dimension set to true or false.
 /// It requires the model extension to be set for the request context.
 pub async fn track_ai_inferences_count() {
     let context = RequestContext::current(AsyncMarker::new().await);

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -224,7 +224,7 @@ impl ToolUsingChat {
         messages.push(assistant_message);
         messages.extend(tool_messages);
 
-        if messages.len() > 0 {
+        if !messages.is_empty() {
             // exclude "list_datasets" tool from counting, since it is used on every AI inference call
             let used_tools = spiced_tools
                 .iter()
@@ -382,14 +382,14 @@ impl Chat for ToolUsingChat {
         req: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
         let inner_req = self.prepare_req(req).await?;
-        let res = self
+        let response = self
             .chat_request_inner(inner_req, self.recursion_limit)
             .await;
 
         // track ai_inferences_count metric
         track_ai_inferences_count().await;
 
-        res
+        response
     }
 
     fn as_sql(&self) -> Option<&dyn SqlGeneration> {

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -36,12 +36,14 @@ use async_openai::types::{
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
+use opentelemetry::KeyValue;
 use serde_json::Value;
 
 use tokio::sync::mpsc;
 use tracing::{Instrument, Span};
 
 use crate::Runtime;
+use crate::model::model_context::ModelContextExtension;
 use crate::request::{AsyncMarker, RequestContext};
 use crate::tools::SpiceModelTool;
 use crate::tools::builtin::list_datasets::ListDatasetsTool;
@@ -198,7 +200,7 @@ impl ToolUsingChat {
                 .into();
 
         let mut tool_and_response_content = vec![];
-        for t in spiced_tools {
+        for t in spiced_tools.clone() {
             let content = self.call_tool(&t.function).await;
             tool_and_response_content.push((t, content));
         }
@@ -222,6 +224,20 @@ impl ToolUsingChat {
         let mut messages = original_messages.clone();
         messages.push(assistant_message);
         messages.extend(tool_messages);
+
+        if messages.len() > 0 {
+            // exclude "list_datasets" tool from counting, since it is used on every AI inference call
+            let used_tools = spiced_tools
+                .iter()
+                .any(|t| t.function.name != "list_datasets");
+
+            if used_tools {
+                let context = RequestContext::current(AsyncMarker::new().await);
+                if let Some(model_context) = context.extension::<ModelContextExtension>().await {
+                    model_context.set_used_tools(true);
+                }
+            }
+        }
 
         Ok(Some(messages))
     }
@@ -365,8 +381,18 @@ impl Chat for ToolUsingChat {
         req: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
         let inner_req = self.prepare_req(req).await?;
-        self.chat_request_inner(inner_req, self.recursion_limit)
-            .await
+        let res = self
+            .chat_request_inner(inner_req, self.recursion_limit)
+            .await;
+
+        // track ai_inferences_count metric
+        let context = RequestContext::current(AsyncMarker::new().await);
+        if let Some(model_context) = context.extension::<ModelContextExtension>().await {
+            let dimensions = vec![KeyValue::new("tools_used", model_context.used_tools())];
+            crate::metrics::telemetry::track_ai_inferences_count(&dimensions);
+        }
+
+        res
     }
 
     fn as_sql(&self) -> Option<&dyn SqlGeneration> {

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -36,7 +36,6 @@ use async_openai::types::{
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
-use opentelemetry::KeyValue;
 use serde_json::Value;
 
 use tokio::sync::mpsc;

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -36,6 +36,7 @@ use async_openai::types::{
 
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
+use pin_project::pin_project;
 use serde_json::Value;
 
 use tokio::sync::mpsc;
@@ -318,7 +319,6 @@ impl ToolUsingChat {
     async fn chat_stream_inner(
         &self,
         req: CreateChatCompletionRequest,
-        is_root_call: bool,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
         // Don't use spice runtime tools if users has explicitly chosen to not use any tools.
         if req
@@ -351,7 +351,6 @@ impl ToolUsingChat {
             ),
             req,
             s,
-            is_root_call,
         ))
     }
 }
@@ -373,8 +372,12 @@ impl Chat for ToolUsingChat {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
+        let context = RequestContext::current(AsyncMarker::new().await);
         let inner_req = self.prepare_req(req).await?;
-        self.chat_stream_inner(inner_req, true).await
+
+        // wrap the completion stream to track the `ai_inferences_count` when it is ready.
+        let stream = self.chat_stream_inner(inner_req).await?;
+        Ok(Box::pin(InferenceTrackingStream::new(stream, context)))
     }
 
     async fn chat_request(
@@ -387,7 +390,8 @@ impl Chat for ToolUsingChat {
             .await;
 
         // track ai_inferences_count metric
-        track_ai_inferences_count().await;
+        let context = RequestContext::current(AsyncMarker::new().await);
+        track_ai_inferences_count(&context).await;
 
         response
     }
@@ -523,7 +527,6 @@ fn make_a_stream(
     model: ToolUsingChat,
     req: CreateChatCompletionRequest,
     mut s: ChatCompletionResponseStream,
-    is_root_call: bool,
 ) -> ChatCompletionResponseStream {
     let (sender, receiver) = mpsc::channel(100);
     let sender_clone = sender.clone();
@@ -654,7 +657,7 @@ fn make_a_stream(
                                         &req,
                                         new_messages,
                                         response.usage.as_ref(),
-                                    ), false)
+                                    ))
                                     .await
                                 {
                                     Ok(mut s) => {
@@ -710,11 +713,6 @@ fn make_a_stream(
                     }
                 }
 
-                // track ai_inferences_count metric
-                if is_root_call {
-                    track_ai_inferences_count().await;
-                }
-
                 tracing::info!(target: "task_history", captured_output = %chat_output);
             })
             .instrument(span),
@@ -728,5 +726,39 @@ fn encode_tool_name(name: &str) -> String {
         name.replace('_', "__").replace('/', "_")
     } else {
         name.to_string()
+    }
+}
+
+#[pin_project]
+struct InferenceTrackingStream<S> {
+    #[pin]
+    stream: S,
+    context: Arc<RequestContext>,
+}
+
+impl<S: Stream> InferenceTrackingStream<S> {
+    pub fn new(stream: S, context: Arc<RequestContext>) -> Self {
+        InferenceTrackingStream { stream, context }
+    }
+}
+
+impl<S: Stream> Stream for InferenceTrackingStream<S> {
+    type Item = S::Item;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        let stream = &mut this.stream;
+        let context = this.context;
+
+        match stream.as_mut().poll_next(cx) {
+            Poll::Ready(None) => {
+                let context = Arc::clone(context);
+                tokio::task::spawn(async move {
+                    track_ai_inferences_count(&context).await;
+                });
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -43,7 +43,6 @@ use tokio::sync::mpsc;
 use tracing::{Instrument, Span};
 
 use crate::Runtime;
-use crate::model::model_context::{ModelContextExtension, track_ai_inferences_count};
 use crate::request::{AsyncMarker, RequestContext};
 use crate::tools::SpiceModelTool;
 use crate::tools::builtin::list_datasets::ListDatasetsTool;
@@ -233,9 +232,7 @@ impl ToolUsingChat {
 
             if used_tools {
                 let context = RequestContext::current(AsyncMarker::new().await);
-                if let Some(model_context) = context.extension::<ModelContextExtension>().await {
-                    model_context.set_tools_used(true);
-                }
+                crate::model::set_tools_used(&context, true);
             }
         }
 
@@ -391,7 +388,7 @@ impl Chat for ToolUsingChat {
 
         // track ai_inferences_count metric
         let context = RequestContext::current(AsyncMarker::new().await);
-        track_ai_inferences_count(&context).await;
+        crate::model::track_ai_inferences_count(&context);
 
         response
     }
@@ -752,9 +749,7 @@ impl<S: Stream> Stream for InferenceTrackingStream<S> {
         match stream.as_mut().poll_next(cx) {
             Poll::Ready(None) => {
                 let context = Arc::clone(context);
-                tokio::task::spawn(async move {
-                    track_ai_inferences_count(&context).await;
-                });
+                crate::model::track_ai_inferences_count(&context);
                 Poll::Ready(None)
             }
             Poll::Ready(Some(item)) => Poll::Ready(Some(item)),

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -43,7 +43,7 @@ use tokio::sync::mpsc;
 use tracing::{Instrument, Span};
 
 use crate::Runtime;
-use crate::model::model_context::ModelContextExtension;
+use crate::model::model_context::{ModelContextExtension, track_ai_inferences_count};
 use crate::request::{AsyncMarker, RequestContext};
 use crate::tools::SpiceModelTool;
 use crate::tools::builtin::list_datasets::ListDatasetsTool;
@@ -234,7 +234,7 @@ impl ToolUsingChat {
             if used_tools {
                 let context = RequestContext::current(AsyncMarker::new().await);
                 if let Some(model_context) = context.extension::<ModelContextExtension>().await {
-                    model_context.set_used_tools(true);
+                    model_context.set_tools_used(true);
                 }
             }
         }
@@ -319,6 +319,7 @@ impl ToolUsingChat {
     async fn chat_stream_inner(
         &self,
         req: CreateChatCompletionRequest,
+        is_root_call: bool,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
         // Don't use spice runtime tools if users has explicitly chosen to not use any tools.
         if req
@@ -351,6 +352,7 @@ impl ToolUsingChat {
             ),
             req,
             s,
+            is_root_call,
         ))
     }
 }
@@ -373,7 +375,7 @@ impl Chat for ToolUsingChat {
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
         let inner_req = self.prepare_req(req).await?;
-        self.chat_stream_inner(inner_req).await
+        self.chat_stream_inner(inner_req, true).await
     }
 
     async fn chat_request(
@@ -386,11 +388,7 @@ impl Chat for ToolUsingChat {
             .await;
 
         // track ai_inferences_count metric
-        let context = RequestContext::current(AsyncMarker::new().await);
-        if let Some(model_context) = context.extension::<ModelContextExtension>().await {
-            let dimensions = vec![KeyValue::new("tools_used", model_context.used_tools())];
-            crate::metrics::telemetry::track_ai_inferences_count(&dimensions);
-        }
+        track_ai_inferences_count().await;
 
         res
     }
@@ -526,6 +524,7 @@ fn make_a_stream(
     model: ToolUsingChat,
     req: CreateChatCompletionRequest,
     mut s: ChatCompletionResponseStream,
+    is_root_call: bool,
 ) -> ChatCompletionResponseStream {
     let (sender, receiver) = mpsc::channel(100);
     let sender_clone = sender.clone();
@@ -656,7 +655,7 @@ fn make_a_stream(
                                         &req,
                                         new_messages,
                                         response.usage.as_ref(),
-                                    ))
+                                    ), false)
                                     .await
                                 {
                                     Ok(mut s) => {
@@ -710,6 +709,11 @@ fn make_a_stream(
                             }
                         }
                     }
+                }
+
+                // track ai_inferences_count metric
+                if is_root_call {
+                    track_ai_inferences_count().await;
                 }
 
                 tracing::info!(target: "task_history", captured_output = %chat_output);

--- a/crates/runtime/src/request/context.rs
+++ b/crates/runtime/src/request/context.rs
@@ -33,6 +33,7 @@ use super::{CacheControl, CacheKeyType, Protocol, UserAgent, baggage};
 type Extensions = HashMap<TypeId, Arc<dyn Any + Send + Sync>>;
 
 pub struct RequestContext {
+    // Use an AtomicU8 to allow updating the protocol without locking
     protocol: AtomicU8,
     cache_control: CacheControl,
     dimensions: Vec<KeyValue>,

--- a/crates/runtime/src/request/context.rs
+++ b/crates/runtime/src/request/context.rs
@@ -150,16 +150,16 @@ impl RequestContext {
         self.cache_control
     }
 
-    pub async fn extension<T: 'static + Send + Sync>(&self) -> Option<Arc<T>>
+    pub async fn extension<T>(&self) -> Option<Arc<T>>
     where
-        T: Clone,
+        T: 'static + Send + Sync + Clone,
     {
         let extensions = self.extensions.read().await;
         let type_id = TypeId::of::<T>();
 
         extensions
             .get(&type_id)
-            .and_then(|arc_any| arc_any.clone().downcast::<T>().ok())
+            .and_then(|arc_any| Arc::clone(arc_any).downcast::<T>().ok())
     }
 
     pub async fn insert_extension<T: 'static + Send + Sync>(&self, extension: T) {

--- a/crates/runtime/src/request/context.rs
+++ b/crates/runtime/src/request/context.rs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
     future::Future,
     marker::PhantomData,
     sync::{Arc, LazyLock, OnceLock, atomic::AtomicU8},
@@ -25,15 +27,18 @@ use http::HeaderMap;
 use opentelemetry::KeyValue;
 use runtime_auth::{AuthPrincipalRef, AuthRequestContext};
 use spicepod::component::runtime::UserAgentCollection;
+use tokio::sync::RwLock;
 
 use super::{CacheControl, CacheKeyType, Protocol, UserAgent, baggage};
 
+type Extensions = HashMap<TypeId, Arc<dyn Any + Send + Sync>>;
+
 pub struct RequestContext {
-    // Use an AtomicU8 to allow updating the protocol without locking
     protocol: AtomicU8,
     cache_control: CacheControl,
     dimensions: Vec<KeyValue>,
     auth_principal: OnceLock<AuthPrincipalRef>,
+    extensions: RwLock<Extensions>,
 }
 
 tokio::task_local! {
@@ -143,6 +148,23 @@ impl RequestContext {
     #[must_use]
     pub fn cache_control(&self) -> CacheControl {
         self.cache_control
+    }
+
+    pub async fn extension<T: 'static + Send + Sync>(&self) -> Option<Arc<T>>
+    where
+        T: Clone,
+    {
+        let extensions = self.extensions.read().await;
+        let type_id = TypeId::of::<T>();
+
+        extensions
+            .get(&type_id)
+            .and_then(|arc_any| arc_any.clone().downcast::<T>().ok())
+    }
+
+    pub async fn insert_extension<T: 'static + Send + Sync>(&self, extension: T) {
+        let mut extensions = self.extensions.write().await;
+        extensions.insert(TypeId::of::<T>(), Arc::new(extension));
     }
 }
 
@@ -278,6 +300,7 @@ impl RequestContextBuilder {
             cache_control,
             dimensions,
             auth_principal: OnceLock::new(),
+            extensions: RwLock::new(HashMap::new()),
         }
     }
 }

--- a/crates/runtime/src/request/context.rs
+++ b/crates/runtime/src/request/context.rs
@@ -19,7 +19,7 @@ use std::{
     collections::HashMap,
     future::Future,
     marker::PhantomData,
-    sync::{Arc, LazyLock, OnceLock, atomic::AtomicU8},
+    sync::{Arc, LazyLock, OnceLock, RwLock, atomic::AtomicU8},
 };
 
 use app::App;
@@ -27,7 +27,6 @@ use http::HeaderMap;
 use opentelemetry::KeyValue;
 use runtime_auth::{AuthPrincipalRef, AuthRequestContext};
 use spicepod::component::runtime::UserAgentCollection;
-use tokio::sync::RwLock;
 
 use super::{CacheControl, CacheKeyType, Protocol, UserAgent, baggage};
 
@@ -150,21 +149,21 @@ impl RequestContext {
         self.cache_control
     }
 
-    pub async fn extension<T>(&self) -> Option<Arc<T>>
+    pub fn extension<T>(&self) -> Option<Arc<T>>
     where
         T: 'static + Send + Sync + Clone,
     {
-        let extensions = self.extensions.read().await;
+        let extensions = self.extensions.read().ok()?;
         let type_id = TypeId::of::<T>();
-
         extensions
             .get(&type_id)
             .and_then(|arc_any| Arc::clone(arc_any).downcast::<T>().ok())
     }
 
-    pub async fn insert_extension<T: 'static + Send + Sync>(&self, extension: T) {
-        let mut extensions = self.extensions.write().await;
-        extensions.insert(TypeId::of::<T>(), Arc::new(extension));
+    pub fn insert_extension<T: 'static + Send + Sync>(&self, extension: T) {
+        if let Ok(mut extensions) = self.extensions.write() {
+            extensions.insert(TypeId::of::<T>(), Arc::new(extension));
+        }
     }
 }
 

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -91,14 +91,14 @@ pub fn track_query_execution_duration(duration: Duration, dimensions: &[KeyValue
     QUERY_EXECUTION_DURATION_MS.record(duration.as_secs_f64() * 1000.0, dimensions);
 }
 
-static AI_INFERENCES_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+static AI_INFERENCES_WITH_SPICE_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
     METER
-        .u64_counter("ai_inferences_count")
-        .with_description("Number of AI Inferences")
+        .u64_counter("ai_inferences_with_spice_count")
+        .with_description("AI Inferences with Spice count")
         .with_unit("inferences")
         .build()
 });
 
-pub fn track_ai_inferences_count(dimensions: &[KeyValue]) {
-    AI_INFERENCES_COUNT.add(1, dimensions);
+pub fn track_ai_inferences_with_spice_count(dimensions: &[KeyValue]) {
+    AI_INFERENCES_WITH_SPICE_COUNT.add(1, dimensions);
 }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -90,3 +90,15 @@ static QUERY_EXECUTION_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| 
 pub fn track_query_execution_duration(duration: Duration, dimensions: &[KeyValue]) {
     QUERY_EXECUTION_DURATION_MS.record(duration.as_secs_f64() * 1000.0, dimensions);
 }
+
+static AI_INFERENCES_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("ai_inferences_count")
+        .with_description("Number of AI Inferences")
+        .with_unit("inferences")
+        .build()
+});
+
+pub fn track_ai_inferences_count(dimensions: &[KeyValue]) {
+    AI_INFERENCES_COUNT.add(1, dimensions);
+}


### PR DESCRIPTION
# 🗣 Description

Added the `ai_inferences_count` metric, which includes the `tools_used: bool` dimension. This metric tracks the number of AI inferences made by the runtime, with the `tools_used` dimension indicating whether **runtime** tools were utilized (Only built-in and MCP tools counted, client-defined tools are excluded).

If multiple tools are called during a single AI inference call (v1/chat/completions), it is still counted as one ai_inferences_count.

> [!NOTE]  
> `list_datasets` tool excluded from counting to track fair numbers, as it is always called if tools are enabled

Tool use tracking is managed through the request context extension `ModelContextExtension`, which allows to handle recursive chat completion calls and streaming. The model extension is injected only for the `/v1/chat/completions` API handler.

---

Request extensions example:

```rs

// create new extension
#[derive(Clone)]
pub struct MyContextExtension {
    <...>
}

impl MyContextExtension {
    <...>
}

// get current context and insert extension instance
let context = RequestContext::current(AsyncMarker::new().await);
context.insert_extension(MyContextExtension::new()).await;

// override scope with extended context
context
    .scope(async move {
        let mut inner_service = inner;
        inner_service.call(req).await
    })
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
