### PR TITLE
Allow `flightsql` and `spiceai` connectors to override flight max message size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11731,6 +11731,7 @@ dependencies = [
 name = "spicepod"
 version = "1.2.0-unstable"
 dependencies = [
+ "byte-unit",
  "fundu",
  "regex",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ base64 = "0.22.1"
 bb8 = "0.8"
 bb8-postgres = "0.8"
 bytes = "1.10.0"
+byte-unit = "5.1.4"
 charset = "0.1.5"
 chrono = "0.4.38"
 clap = { version = "4.5.36", features = ["derive", "env"] }

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -12,7 +12,7 @@ version.workspace = true
 arrow.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-byte-unit = "5.1.4"
+byte-unit.workspace = true
 datafusion.workspace = true
 fundu = { workspace = true }
 futures.workspace = true

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -244,6 +244,20 @@ impl FlightClient {
         self
     }
 
+    /// Overrides default maximum message size for encoding and decoding.
+    #[must_use]
+    pub fn with_max_message_size(
+        mut self,
+        max_encoding_message_size: usize,
+        max_decoding_message_size: usize,
+    ) -> Self {
+        self.flight_client = self
+            .flight_client
+            .max_encoding_message_size(max_encoding_message_size)
+            .max_decoding_message_size(max_decoding_message_size);
+        self
+    }
+
     /// Queries the flight service for the schema of the path.
     ///
     /// # Arguments

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -586,7 +586,6 @@ pub struct ConnectorParams {
 pub struct ConnectorParamsBuilder {
     connector: Arc<str>,
     component: ConnectorComponent,
-    app: Option<Arc<App>>,
 }
 
 impl ConnectorParamsBuilder {
@@ -595,14 +594,7 @@ impl ConnectorParamsBuilder {
         Self {
             connector,
             component,
-            app: None,
         }
-    }
-
-    #[must_use]
-    pub fn with_app(mut self, app: Arc<App>) -> Self {
-        self.app = Some(app);
-        self
     }
 
     pub async fn build(
@@ -611,7 +603,7 @@ impl ConnectorParamsBuilder {
     ) -> Result<ConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
         let name = self.connector.to_string();
         let mut unsupported_type_action = None;
-        let (params, prefix, parameters) = match &self.component {
+        let (params, prefix, parameters, app) = match &self.component {
             ConnectorComponent::Catalog(catalog) => {
                 let guard = CATALOG_CONNECTOR_FACTORY_REGISTRY.lock().await;
                 let connector_factory = guard.get(&name);
@@ -626,6 +618,7 @@ impl ConnectorParamsBuilder {
                     get_params_with_secrets(Arc::clone(&secrets), &catalog.params).await,
                     factory.prefix(),
                     factory.parameters(),
+                    None,
                 )
             }
             ConnectorComponent::Dataset(dataset) => {
@@ -649,7 +642,12 @@ impl ConnectorParamsBuilder {
 
                 let params = get_params_with_secrets(Arc::clone(&secrets), &dataset.params).await;
 
-                (params, factory.prefix(), factory.parameters())
+                (
+                    params,
+                    factory.prefix(),
+                    factory.parameters(),
+                    Some(Arc::clone(&dataset.app)),
+                )
             }
         };
 
@@ -666,7 +664,7 @@ impl ConnectorParamsBuilder {
             parameters,
             unsupported_type_action: unsupported_type_action.map(UnsupportedTypeAction::from),
             component: self.component,
-            app: self.app,
+            app,
         })
     }
 }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -27,6 +27,7 @@ use crate::get_params_with_secrets;
 use crate::parameters::ParameterSpec;
 use crate::parameters::Parameters;
 use crate::secrets::Secrets;
+use app::App;
 use arrow_schema::SchemaRef;
 use arrow_tools::schema::schema_meta_get_computed_columns;
 use async_trait::async_trait;
@@ -579,11 +580,13 @@ pub struct ConnectorParams {
     pub(crate) parameters: Parameters,
     pub(crate) unsupported_type_action: Option<UnsupportedTypeAction>,
     pub(crate) component: ConnectorComponent,
+    pub(crate) app: Option<Arc<App>>,
 }
 
 pub struct ConnectorParamsBuilder {
     connector: Arc<str>,
     component: ConnectorComponent,
+    app: Option<Arc<App>>,
 }
 
 impl ConnectorParamsBuilder {
@@ -592,7 +595,14 @@ impl ConnectorParamsBuilder {
         Self {
             connector,
             component,
+            app: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_app(mut self, app: Arc<App>) -> Self {
+        self.app = Some(app);
+        self
     }
 
     pub async fn build(
@@ -656,6 +666,7 @@ impl ConnectorParamsBuilder {
             parameters,
             unsupported_type_action: unsupported_type_action.map(UnsupportedTypeAction::from),
             component: self.component,
+            app: self.app,
         })
     }
 }

--- a/crates/runtime/src/dataconnector/flightsql.rs
+++ b/crates/runtime/src/dataconnector/flightsql.rs
@@ -43,6 +43,14 @@ pub enum Error {
 
     #[snafu(display("Failed to connect to the Flight server.\n{source}"))]
     UnableToPerformHandshake { source: arrow::error::ArrowError },
+
+    #[snafu(display(
+        "Failed to apply parameter '{parameter}': {source}. Ensure the value is valid and retry.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/flightsql#params"
+    ))]
+    InvalidParameterValue {
+        parameter: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -95,9 +103,24 @@ impl DataConnectorFactory for FlightSQLFactory {
                 .await
                 .context(UnableToConstructTlsChannelSnafu)?;
 
+            let max_message_size =
+                match params
+                    .app
+                    .as_ref()
+                    .and_then(|app| app.runtime.flight.as_ref())
+                {
+                    Some(flight) => flight.max_message_size_bytes().map_err(|err| {
+                        Error::InvalidParameterValue {
+                            parameter: "max_message_size".to_string(),
+                            source: err,
+                        }
+                    })?,
+                    None => None,
+                };
+
             let flight_client = FlightServiceClient::new(flight_channel)
-                .max_encoding_message_size(MAX_ENCODING_MESSAGE_SIZE)
-                .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
+                .max_encoding_message_size(max_message_size.unwrap_or(MAX_ENCODING_MESSAGE_SIZE))
+                .max_decoding_message_size(max_message_size.unwrap_or(MAX_DECODING_MESSAGE_SIZE));
 
             let mut client = FlightSqlServiceClient::new_from_inner(flight_client);
             let username = params.parameters.get("username").expose().ok();

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -72,6 +72,14 @@ pub enum Error {
         value: Arc<str>,
         source: InvalidMetadataValue,
     },
+
+    #[snafu(display(
+        "Failed to apply parameter '{parameter}': {source}. Ensure the value is valid and retry.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/spiceai#parameters"
+    ))]
+    InvalidParameterValue {
+        parameter: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -189,9 +197,12 @@ impl DataConnectorFactory for SpiceAIFactory {
                 .ok_or_else(|p| MissingRequiredParameterSnafu { parameter: p.0 }.build())?;
             let credentials = Credentials::new("", api_key);
 
-            let flight_client = FlightClient::try_new(url, credentials, None)
+            let mut flight_client = FlightClient::try_new(url, credentials, None)
                 .await
                 .context(UnableToCreateFlightClientSnafu)?;
+
+            flight_client = configure_max_message_size(flight_client, &params)?;
+
             let flight_factory = FlightFactory::new(
                 "spice.ai",
                 flight_client,
@@ -210,6 +221,29 @@ impl DataConnectorFactory for SpiceAIFactory {
     fn parameters(&self) -> &'static [ParameterSpec] {
         PARAMETERS
     }
+}
+
+/// Configures flight client's message size based on app parameters
+fn configure_max_message_size(
+    mut flight_client: FlightClient,
+    params: &ConnectorParams,
+) -> Result<FlightClient> {
+    if let Some(app) = params.app.as_ref() {
+        if let Some(flight) = app.runtime.flight.as_ref() {
+            if let Some(max_message_size) =
+                flight
+                    .max_message_size_bytes()
+                    .map_err(|err| Error::InvalidParameterValue {
+                        parameter: "max_message_size".to_string(),
+                        source: err,
+                    })?
+            {
+                flight_client =
+                    flight_client.with_max_message_size(max_message_size, max_message_size);
+            }
+        }
+    }
+    Ok(flight_client)
 }
 
 #[async_trait]

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -197,6 +197,7 @@ impl Runtime {
 
         let source = ds.source();
         let params = ConnectorParamsBuilder::new(source.into(), (&ds).into())
+            .with_app(Arc::clone(&ds.app))
             .build(self.secrets())
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -197,7 +197,6 @@ impl Runtime {
 
         let source = ds.source();
         let params = ConnectorParamsBuilder::new(source.into(), (&ds).into())
-            .with_app(Arc::clone(&ds.app))
             .build(self.secrets())
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+byte-unit.workspace = true
 fundu.workspace = true
 regex.workspace = true
 schemars = { version = "0.8.22", optional = true }

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -56,6 +56,9 @@ pub struct Runtime {
     #[serde(default, skip_serializing_if = "is_default")]
     pub cors: CorsConfig,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flight: Option<Flight>,
+
     /// Configures where the runtime will store temporary files needed for operations like
     /// spilling to disk for queries & accelerations that are larger than memory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -155,6 +158,30 @@ impl Default for TelemetryConfig {
             enabled: true,
             user_agent_collection: UserAgentCollection::default(),
             properties: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct Flight {
+    pub max_message_size: Option<String>,
+}
+
+impl Flight {
+    pub fn max_message_size_bytes(&self) -> Result<Option<usize>, Box<dyn Error + Send + Sync>> {
+        if let Some(size_str) = &self.max_message_size {
+            let size_in_bytes = usize::try_from(
+                byte_unit::Byte::parse_str(size_str, true)
+                    .map_err(|e| {
+                        format!("Failed to parse 'max_message_size' value '{size_str}': {e}")
+                    })?
+                    .as_u64(),
+            )
+            .unwrap_or_default();
+            Ok(Some(size_in_bytes))
+        } else {
+            Ok(None)
         }
     }
 }


### PR DESCRIPTION
# 🗣 Description

This PR introduces a new `runtime.flight.max_message_size` parameter that allows `flightsql` and `spiceai` connectors to override the default values (100 MB) for Flight's `max_encoding_message_size` and `max_decoding_message_size`, enabling support for receiving larger Flight messages.

```yaml
runtime:
  flight:
    max_message_size: 512MiB 
``` 

Notes: 
 1. support for Dremio connector is not included in this PR, can be added the same way as support for `spiceai`.
 2. Parameter is not currently applied to Flight Server configuration

## 🔨 Related Issues

Fixes 
- https://github.com/spiceai/spiceai/issues/5143

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

Support for new parameter must be documented

## 🤔 Concerns

1. Passing additional reference to the app configuration extends scope of `ConnectorParams`, but I was unable to come up with alternative good approach to propagate runtime configuration to connectors.
2. `max_message_size` is runtime / not dataset-level configuration - this is due to plans to reflect this setting to Flight Server as well so there is single configuration.
