### PR TITLE
Include newly detected view as changed view

### DIFF
--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -121,11 +121,15 @@ impl Runtime {
         let views_that_changed = valid_views
             .iter()
             .filter_map(|v| {
-                let old_v = existing_views.iter().find(|vv| v.name == vv.name)?;
-                if old_v == v {
-                    None
-                } else {
-                    Some(v.name.clone())
+                match existing_views.iter().find(|vv| v.name == vv.name) {
+                    Some(old_v) => {
+                        if old_v == v {
+                            None // No change, don't include
+                        } else {
+                            Some(v.name.clone()) // Changed, include the name
+                        }
+                    }
+                    None => Some(v.name.clone()), // New view, include the name
                 }
             })
             .collect_vec();


### PR DESCRIPTION
# 🗣 Description

When dynamically include new view in spicepod, the new view should also be detected as `views_that_changed` in `apply_view_diff`, so that it will correctly be detected as affected view to be updated / load in `construct_effected_in_topological_order` function

## 🔨 Related Issues

- Close: https://github.com/spiceai/spiceai/issues/4880

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
