### PR TITLE
Use span task name in 'spice trace' tree, not span_id

### DIFF
--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -131,7 +131,7 @@ func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput 
 		Tree     string `json:"tree"`
 		Status   string `json:"status"`
 		Duration string `json:"duration"`
-		Task     string `json:"task"`
+		SpanID   string `json:"span_id"`
 	}
 	type TaskRowFull struct {
 		TaskRowBase
@@ -150,7 +150,7 @@ func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput 
 	base := TaskRowBase{
 		Tree:     treePrefix,
 		Duration: fmt.Sprintf("%8.2fms", t.ExecutionDurationMs),
-		Task:     t.Task,
+		SpanID:   t.SpanID,
 	}
 
 	if t.ErrorMessage == nil || *t.ErrorMessage == "" {

--- a/bin/spice/pkg/taskhistory/format.go
+++ b/bin/spice/pkg/taskhistory/format.go
@@ -59,7 +59,7 @@ func recurseThroughTree(c chan TaskHistoryRow, node *TreeNode, indent string, is
 	if indent == "" {
 		connector = ""
 	}
-	c <- TaskHistoryRow{fmt.Sprintf("%s%s%s", indent, connector, node.TaskHistory.SpanID), node.TaskHistory}
+	c <- TaskHistoryRow{fmt.Sprintf("%s%s%s", indent, connector, node.TaskHistory.Task), node.TaskHistory}
 
 	// Recurse for children
 	newIndent := indent + "│ "


### PR DESCRIPTION
# 🗣 Description
- Use task name in 'spice trace' tree, not span_id. Still provide SpanID.
- This is very useful in long traces
```bash
>> spice trace eval_run
TREE                  STATUS DURATION   SPANID
eval_run              ✅     12513.97ms d4168a0d569bcbb5
  ├── sql_query       ✅       239.19ms b07145511049e772
  ├── eval_step       ✅       445.04ms 409a8a195178f873
  │ └── ai_completion ✅       443.92ms 86c8860d9acee914
  ├── eval_step       ✅       476.40ms b44705353ec158c6
  │ └── ai_completion ✅       475.74ms 31dbb669f39ef87e
  ├── eval_scoring    ✅      7835.18ms a327e62d6266b5a4
  │ ├── ai_completion ✅       838.40ms db823d60466e6050
  │ ├── ai_completion ✅       692.83ms c371edce94b7106f
  └── sql_query       ✅        13.61ms ceae5c9100dd9c48
  ```

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->
