### PR TITLE
fix: Testoperator uses an exact API key for benchmark metric submission

### DIFF
--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use std::borrow::Cow;
+use std::fmt::Display;
 use std::sync::Arc;
 use std::task::Poll;
 
@@ -175,11 +176,43 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Clone)]
 pub enum Credentials {
+    // Basic authentication used to exchange for a Bearer token
     UsernamePassword {
         username: Arc<str>,
         password: Arc<SecretString>,
     },
+    // Anonymous access
     Anonymous,
+    // An explicitly exact token
+    Exact {
+        token: Arc<SecretString>,
+        bearer: bool, // whether this token is a Bearer token, or if it is set to the 'authorization' header verbatim
+    },
+}
+
+struct Token {
+    value: Arc<SecretString>,
+    bearer: bool,
+}
+
+impl Display for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.bearer {
+            write!(f, "Bearer {}", self.value.expose_secret())
+        } else {
+            write!(f, "{}", self.value.expose_secret())
+        }
+    }
+}
+
+impl Token {
+    #[must_use]
+    fn new(value: &str, bearer: bool) -> Self {
+        Token {
+            value: Arc::new(SecretString::new(value.into())),
+            bearer,
+        }
+    }
 }
 
 impl Credentials {
@@ -276,9 +309,7 @@ impl FlightClient {
         let mut req = tonic::Request::new(descriptor);
 
         let auth_header_value = match &token {
-            Some(token) => format!("Bearer {token}")
-                .parse()
-                .context(InvalidMetadataSnafu)?,
+            Some(token) => token.to_string().parse().context(InvalidMetadataSnafu)?,
             None => {
                 return UnauthorizedSnafu.fail();
             }
@@ -320,9 +351,7 @@ impl FlightClient {
         let mut req = descriptor.into_request();
 
         let auth_header_value = match &token {
-            Some(token) => format!("Bearer {token}")
-                .parse()
-                .context(InvalidMetadataSnafu)?,
+            Some(token) => token.to_string().parse().context(InvalidMetadataSnafu)?,
             None => {
                 return UnauthorizedSnafu.fail();
             }
@@ -364,9 +393,7 @@ impl FlightClient {
         let mut req = descriptor.into_request();
 
         let auth_header_value = match &token {
-            Some(token) => format!("Bearer {token}")
-                .parse()
-                .context(InvalidMetadataSnafu)?,
+            Some(token) => token.to_string().parse().context(InvalidMetadataSnafu)?,
             None => {
                 return UnauthorizedSnafu.fail();
             }
@@ -393,9 +420,7 @@ impl FlightClient {
         if let Some(ticket) = ep.ticket {
             let mut req = ticket.into_request();
             let auth_header_value = match token {
-                Some(token) => format!("Bearer {token}")
-                    .parse()
-                    .context(InvalidMetadataSnafu)?,
+                Some(token) => token.to_string().parse().context(InvalidMetadataSnafu)?,
                 None => {
                     return UnauthorizedSnafu.fail();
                 }
@@ -445,9 +470,7 @@ impl FlightClient {
 
         let mut req = subscription_request.into_streaming_request();
         let auth_header_value = match token {
-            Some(token) => format!("Bearer {token}")
-                .parse()
-                .context(InvalidMetadataSnafu)?,
+            Some(token) => token.to_string().parse().context(InvalidMetadataSnafu)?,
             None => {
                 return UnauthorizedSnafu.fail();
             }
@@ -506,9 +529,7 @@ impl FlightClient {
 
         let mut publish_request = request_stream.into_streaming_request();
         if let Some(token) = token {
-            let auth_header_value = format!("Bearer {token}")
-                .parse()
-                .context(InvalidMetadataSnafu)?;
+            let auth_header_value = token.to_string().parse().context(InvalidMetadataSnafu)?;
 
             publish_request
                 .metadata_mut()
@@ -531,9 +552,15 @@ impl FlightClient {
         Ok(())
     }
 
-    async fn authenticate_basic_token(&self) -> Result<Option<String>> {
-        let Credentials::UsernamePassword { username, password } = &self.credentials else {
-            return Ok(None);
+    async fn authenticate_basic_token(&self) -> Result<Option<Token>> {
+        let (username, password) = match &self.credentials {
+            Credentials::UsernamePassword { username, password } => {
+                (username.as_ref(), password.expose_secret())
+            }
+            Credentials::Anonymous => return Ok(None),
+            Credentials::Exact { token, bearer } => {
+                return Ok(Some(Token::new(token.expose_secret(), *bearer)));
+            }
         };
 
         let cmd = HandshakeRequest {
@@ -541,10 +568,7 @@ impl FlightClient {
             payload: Bytes::default(),
         };
         let mut req = tonic::Request::new(stream::iter(vec![cmd]));
-        let val = BASE64_STANDARD.encode(format!(
-            "{username}:{password}",
-            password = password.expose_secret()
-        ));
+        let val = BASE64_STANDARD.encode(format!("{username}:{password}",));
 
         let val = format!("Basic {val}")
             .parse()
@@ -557,12 +581,12 @@ impl FlightClient {
             .await
             .map_err(TonicStatusError::from)
             .context(UnableToPerformHandshakeSnafu)?;
-        let mut token: Option<String> = None;
+        let mut token: Option<Token> = None;
         if let Some(auth) = resp.metadata().get("authorization") {
             let auth = auth
                 .to_str()
                 .context(UnableToConvertMetadataToStringSnafu)?;
-            token = Some(auth["Bearer ".len()..].to_string());
+            token = Some(Token::new(&auth["Bearer ".len()..], true));
         }
         Ok(token)
     }

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -183,10 +183,10 @@ pub enum Credentials {
     },
     // Anonymous access
     Anonymous,
-    // An explicitly exact token
-    Exact {
+    // An existing bearer token
+    Bearer {
         token: Arc<SecretString>,
-        bearer: bool, // whether this token is a Bearer token, or if it is set to the 'authorization' header verbatim
+        prefix: bool, // whether this token requires the 'Bearer ' prefix, or if it is set to the 'authorization' header verbatim
     },
 }
 
@@ -558,7 +558,10 @@ impl FlightClient {
                 (username.as_ref(), password.expose_secret())
             }
             Credentials::Anonymous => return Ok(None),
-            Credentials::Exact { token, bearer } => {
+            Credentials::Bearer {
+                token,
+                prefix: bearer,
+            } => {
                 return Ok(Some(Token::new(token.expose_secret(), *bearer)));
             }
         };

--- a/crates/telemetry/src/exporter.rs
+++ b/crates/telemetry/src/exporter.rs
@@ -20,7 +20,6 @@ use arrow::array::RecordBatch;
 use async_trait::async_trait;
 use flight_client::{Credentials, FlightClient};
 use opentelemetry_sdk::metrics::MetricError;
-use secrecy::SecretString;
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
@@ -37,7 +36,7 @@ pub enum Error {
 
 #[derive(Debug, Default)]
 pub struct TelemetryExporterBuilder {
-    api_key: Option<SecretString>,
+    credentials: Option<Credentials>,
     service_name: Option<Arc<str>>,
     endpoint: Option<Arc<str>>,
 }
@@ -49,8 +48,8 @@ impl TelemetryExporterBuilder {
     }
 
     #[must_use]
-    pub fn with_api_key(mut self, api_key: SecretString) -> Self {
-        self.api_key = Some(api_key);
+    pub fn with_credentials(mut self, credentials: Credentials) -> Self {
+        self.credentials = Some(credentials);
         self
     }
 
@@ -72,11 +71,7 @@ impl TelemetryExporterBuilder {
     ///
     /// Returns an error if the endpoint is not set.
     pub async fn build(self) -> Result<TelemetryExporter, Error> {
-        let credentials = if let Some(api_key) = self.api_key {
-            Credentials::new("", api_key)
-        } else {
-            Credentials::anonymous()
-        };
+        let credentials = self.credentials.unwrap_or(Credentials::anonymous());
 
         let endpoint = self.endpoint.ok_or(Error::MissingEndpoint)?;
         let flight_client = match FlightClient::try_new(endpoint, credentials, None).await {

--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -671,12 +671,12 @@ pub trait MetricCollector<T: ExtendedMetrics, R: ExtendedMetrics> {
             started_at: usize::try_from(
                 self.start_time()
                     .duration_since(SystemTime::UNIX_EPOCH)?
-                    .as_secs(),
+                    .as_millis(),
             )?,
             finished_at: usize::try_from(
                 self.end_time()
                     .duration_since(SystemTime::UNIX_EPOCH)?
-                    .as_secs(),
+                    .as_millis(),
             )?,
             metrics: self.metrics()?,
             memory_usage: None,

--- a/crates/test-framework/src/telemetry/mod.rs
+++ b/crates/test-framework/src/telemetry/mod.rs
@@ -86,9 +86,9 @@ impl Telemetry {
             println!("Emitting to exporter at {}", *ENDPOINT);
             let telemetry_exporter = otel_arrow::OtelArrowExporter::new(
                 TelemetryExporterBuilder::new()
-                    .with_credentials(flight_client::Credentials::Exact {
+                    .with_credentials(flight_client::Credentials::Bearer {
                         token: api_key.clone().into(),
-                        bearer: false,
+                        prefix: false,
                     })
                     .with_service_name("benchmarks_telemetry".into())
                     .with_endpoint(Arc::clone(&ENDPOINT))

--- a/crates/test-framework/src/telemetry/mod.rs
+++ b/crates/test-framework/src/telemetry/mod.rs
@@ -32,7 +32,7 @@ use telemetry::exporter::TelemetryExporterBuilder;
 pub use telemetry::meter::{METER_PROVIDER, METER_PROVIDER_ONCE};
 use telemetry::reader::InitialReader;
 
-const ENDPOINT_CONST: &str = "https://dev-telemetry.spiceai.io";
+const ENDPOINT_CONST: &str = "https://telemetry.spiceai.io";
 
 pub static ENDPOINT: LazyLock<Arc<str>> = LazyLock::new(|| {
     std::env::var("SPICEAI_TELEMETRY_ENDPOINT")

--- a/crates/test-framework/src/telemetry/mod.rs
+++ b/crates/test-framework/src/telemetry/mod.rs
@@ -32,7 +32,7 @@ use telemetry::exporter::TelemetryExporterBuilder;
 pub use telemetry::meter::{METER_PROVIDER, METER_PROVIDER_ONCE};
 use telemetry::reader::InitialReader;
 
-const ENDPOINT_CONST: &str = "https://telemetry.spiceai.io";
+const ENDPOINT_CONST: &str = "https://dev-telemetry.spiceai.io";
 
 pub static ENDPOINT: LazyLock<Arc<str>> = LazyLock::new(|| {
     std::env::var("SPICEAI_TELEMETRY_ENDPOINT")
@@ -83,9 +83,13 @@ impl Telemetry {
         }
 
         if let Some(api_key) = &self.api_key {
+            println!("Emitting to exporter at {}", *ENDPOINT);
             let telemetry_exporter = otel_arrow::OtelArrowExporter::new(
                 TelemetryExporterBuilder::new()
-                    .with_api_key(api_key.clone())
+                    .with_credentials(flight_client::Credentials::Exact {
+                        token: api_key.clone().into(),
+                        bearer: false,
+                    })
                     .with_service_name("benchmarks_telemetry".into())
                     .with_endpoint(Arc::clone(&ENDPOINT))
                     .build()

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -85,7 +85,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
         KeyValue::new("benchmark.spiced_commit_sha", commit_sha.clone()),
     ]);
 
-    let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_API_KEY");
+    let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
 
     for query in &metrics.metrics {
         let query_name = query.query_name.clone();

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -113,6 +113,9 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
         crate::metrics::ROW_COUNT.record((*row_count).try_into()?, &attributes);
     }
 
+    crate::metrics::TEST_DURATION
+        .record((metrics.finished_at - metrics.started_at).try_into()?, &[]);
+
     telemetry.emit().await?;
 
     let records = metrics.with_memory_usage(max_memory).build_records()?;

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -90,3 +90,11 @@ pub static P99_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .with_unit("ms")
         .build()
 });
+
+pub static TEST_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    METER
+        .u64_gauge("test_duration")
+        .with_description("The entire duration of the test.")
+        .with_unit("s")
+        .build()
+});

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -45,7 +45,7 @@ pub static ROW_COUNT: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub static MEDIAN_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("median_duration")
+        .u64_gauge("median_duration_ms")
         .with_description("Median duration of the query.")
         .with_unit("ms")
         .build()
@@ -53,7 +53,7 @@ pub static MEDIAN_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub static MIN_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("min_duration")
+        .u64_gauge("min_duration_ms")
         .with_description("Minimum duration of the query.")
         .with_unit("ms")
         .build()
@@ -61,7 +61,7 @@ pub static MIN_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub static MAX_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("max_duration")
+        .u64_gauge("max_duration_ms")
         .with_description("Maximum duration of the query.")
         .with_unit("ms")
         .build()
@@ -69,7 +69,7 @@ pub static MAX_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub static P90_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("p90_duration")
+        .u64_gauge("p90_duration_ms")
         .with_description("90th percentile duration of the query.")
         .with_unit("ms")
         .build()
@@ -77,7 +77,7 @@ pub static P90_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub static P95_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("p95_duration")
+        .u64_gauge("p95_duration_ms")
         .with_description("95th percentile duration of the query.")
         .with_unit("ms")
         .build()
@@ -85,7 +85,7 @@ pub static P95_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub static P99_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("p99_duration")
+        .u64_gauge("p99_duration_ms")
         .with_description("99th percentile duration of the query.")
         .with_unit("ms")
         .build()
@@ -93,8 +93,8 @@ pub static P99_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
 
 pub static TEST_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
-        .u64_gauge("test_duration")
+        .u64_gauge("test_duration_ms")
         .with_description("The entire duration of the test.")
-        .with_unit("s")
+        .with_unit("ms")
         .build()
 });


### PR DESCRIPTION
# 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds credential variant `Exact` for the flight client, allowing exact control over the `authorization` header
* Uses the `Credentials::Exact` variant for submitting benchmark metrics, as it uses a static key
* Creates a new `Token` to wrap a resultant token from a handshake exchange. This also updates the token to be stored as a `SecretString` instead of a `String`, to improve security of the flight client.
* Updates the expected benchmark API key path to `SPICEAI_BENCHMARK_METRICS_KEY`
