### PR TITLE
Remove the filter for the `list_datasets` tool in the AI inferences metric count.

### DIFF
--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -225,12 +225,7 @@ impl ToolUsingChat {
         messages.extend(tool_messages);
 
         if !messages.is_empty() {
-            // exclude "list_datasets" tool from counting, since it is used on every AI inference call
-            let used_tools = spiced_tools
-                .iter()
-                .filter(|t| t.function.name != "list_datasets")
-                .count();
-
+            let used_tools = spiced_tools.len();
             if used_tools > 0 {
                 let context = RequestContext::current(AsyncMarker::new().await);
                 crate::model::add_tools_used(&context, used_tools);


### PR DESCRIPTION
# 🗣 Description

This filter doesn't make sence, since initial list_datasets call handled separately by the runtime, and result just injected into the completions request body.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
