### PR TITLE
Enable task name override for non-static span names; add dynamic MCP tool task names

### DIFF
--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -83,7 +83,7 @@ impl TaskHistoryExporter {
         } else {
             Some(span.parent_span_id.to_string().into())
         };
-        let task: Arc<str> = span.name.into();
+        let task: Arc<str> = extract_attr!(span, "task_override").unwrap_or(span.name.into());
         let input: Arc<str> = span
             .attributes
             .iter()

--- a/crates/runtime/src/tools/mcp/catalog.rs
+++ b/crates/runtime/src/tools/mcp/catalog.rs
@@ -39,7 +39,7 @@ const HEARTBEAT_INTERVAL_SECONDS: u64 = 30; // 30 seconds
 pub(crate) struct McpToolCatalog {
     client: Arc<RwLock<Box<dyn McpClientTrait>>>,
 
-    /// User defined name & description, not from underlying MCP.
+    /// Spicepod defined name & description, not from underlying MCP.
     name: String,
     heartbeat_task: tokio::task::JoinHandle<()>,
 }
@@ -190,8 +190,11 @@ impl SpiceToolCatalog for McpToolCatalog {
         tools
             .into_iter()
             .map(|t| {
-                Arc::new(McpToolWrapper::new(Arc::clone(&self.client), t))
-                    as Arc<dyn SpiceModelTool>
+                Arc::new(McpToolWrapper::new(
+                    Arc::clone(&self.client),
+                    t,
+                    self.name.clone(),
+                )) as Arc<dyn SpiceModelTool>
             })
             .collect()
     }
@@ -221,6 +224,7 @@ impl SpiceToolCatalog for McpToolCatalog {
         Some(Arc::new(McpToolWrapper::new(
             Arc::clone(&self.client),
             tool,
+            self.name.clone(),
         )))
     }
 }

--- a/crates/runtime/src/tools/mcp/tool.rs
+++ b/crates/runtime/src/tools/mcp/tool.rs
@@ -31,11 +31,22 @@ use super::{McpProxy, Result};
 pub struct McpToolWrapper {
     client: Arc<RwLock<Box<dyn McpClientTrait>>>,
     spec: McpTool,
+
+    /// Spicepod defined name, not from underlying MCP.
+    server_name: String,
 }
 
 impl McpToolWrapper {
-    pub fn new(client: Arc<RwLock<Box<dyn McpClientTrait>>>, spec: McpTool) -> Self {
-        Self { client, spec }
+    pub fn new(
+        client: Arc<RwLock<Box<dyn McpClientTrait>>>,
+        spec: McpTool,
+        server_name: String,
+    ) -> Self {
+        Self {
+            client,
+            spec,
+            server_name,
+        }
     }
 
     #[must_use]
@@ -68,6 +79,10 @@ impl SpiceModelTool for McpToolWrapper {
         _rt: Arc<Runtime>,
     ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
         let span: Span = tracing::span!(target: "task_history", tracing::Level::INFO, "tool_use::mcp", tool = self.name().to_string(), input = arg);
+        span.in_scope(
+            || tracing::info!(target: "task_history", task_override = %format!("tool_use::{}/{}", self.server_name, self.spec.name), "labels"),
+        );
+
         let tool_use_result: Result<Value, Box<dyn std::error::Error + Send + Sync>> = async {
             let client = self.client.read().await;
 


### PR DESCRIPTION
# 🗣 Description
 - `tracing::Span` require `&'static str` for the span name. For task history, the span name is used as the task name. 
 - This PR enables span attributes, specifically `task_override` to be used as the task name if it is present.
 - This is useful for MCP tools where we don't know the task name at compile time. This PR also updates `tool_use::mcp` to `tool_use::{mcp server spicepod name}/{mcp tool name}` (e.g. `tool_use::fs/list_directories`). 
 
 ### Example
 ```
>>> spice trace ai_chat
TREE                   STATUS DURATION   TASK
f068afe967857377       ✅     11899.12ms ai_chat
  ├── 6e362bd54c5af12e ✅     11896.64ms ai_completion
  ├── aa233ab5ad58ceb0 ✅         6.54ms tool_use::fs/list_directory
  └── 63d7d7b3b14ef970 ✅     10304.54ms ai_completion
```

## 📄 Documentation Updates
 - [ ] Update docs for the presence of `tool_use::*` task names (from MCP tools)