### PR TITLE
Include all FinanceBench documents in benchmark tests

### DIFF
--- a/test/financebench/spicepod_gpt-4o.yaml
+++ b/test/financebench/spicepod_gpt-4o.yaml
@@ -2,6 +2,10 @@ version: v1
 kind: Spicepod
 name: financebench
 
+runtime:
+  flight:
+    max_message_size: 1G
+
 models:
   - name: gpt-4o
     from: openai:gpt-4o-2024-08-06
@@ -114,9 +118,8 @@ datasets:
       spiceai_endpoint: https://flight.spiceai.io
     acceleration:
       enabled: true
-      # https://github.com/spiceai/spiceai/issues/5143
-      refresh_sql: |
-        select * from financebench.data limit 50;
+      engine: duckdb
+      mode: file
     embeddings:
       - column: content
         use: openai_embed


### PR DESCRIPTION
# 🗣 Description

After the following restriction is resolved we can now include all documents when running FinanceBench tests
 - https://github.com/spiceai/spiceai/issues/5143


Example run: https://github.com/spiceai/spiceai/actions/runs/14522444747/job/40746939699

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3318

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
