### PR TITLE
Handle second Ctrl-C to force runtime termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,6 +3025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cudarc"
 version = "0.12.2"
 source = "git+https://github.com/EricLBuehler/cudarc?rev=f6e5bf51153d40e34eb1262b98895ac1235b6422#f6e5bf51153d40e34eb1262b98895ac1235b6422"
@@ -13672,6 +13682,7 @@ name = "util"
 version = "1.2.0-unstable"
 dependencies = [
  "backoff",
+ "ctrlc",
  "humantime",
  "rand 0.9.0",
  "tokio",

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -266,7 +266,7 @@ pub async fn run(args: Args) -> Result<()> {
 
     let result = match server_thread.await {
         // Don't treat force terminated as an error
-        Ok(Err(err)) if matches!(err, runtime::Error::ForceTerminated { .. }) => Ok(()),
+        Ok(Err(runtime::Error::ForceTerminated { .. })) => Ok(()),
         Ok(ok) => ok.context(UnableToStartServersSnafu),
         Err(_) => Err(Error::GenericError {
             reason: "Unable to start spiced".into(),

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -265,6 +265,8 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     let result = match server_thread.await {
+        // Don't treat force terminated as an error
+        Ok(Err(err)) if matches!(err, runtime::Error::ForceTerminated { .. }) => Ok(()),
         Ok(ok) => ok.context(UnableToStartServersSnafu),
         Err(_) => Err(Error::GenericError {
             reason: "Unable to start spiced".into(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
+use util::force_shutdown_signal;
 
 use crate::dataaccelerator::AcceleratorEngineRegistry;
 use crate::{
@@ -314,6 +315,9 @@ pub enum Error {
 
     #[snafu(display("Initialization has been cancelled"))]
     ComponentsInitializationCancelled,
+
+    #[snafu(display("Force shutdown requested"))]
+    ForceTerminated,
 }
 
 const HTTP_SERVER: &str = "http_server";
@@ -546,10 +550,20 @@ impl Runtime {
 
         // Shutdown signal
         let shutdown_signal_future = async {
-            shutdown_signal().await;
-            tracing::debug!("Shutdown signal received.");
-            self.shutdown().await;
-            Ok(())
+            let graceful_shutdown = async {
+                shutdown_signal().await;
+                tracing::debug!("Shutdown signal received.");
+                self.shutdown().await;
+                Ok(())
+            };
+            tokio::select! {
+                result = graceful_shutdown => result,
+                _ = force_shutdown_signal() => {
+                    tracing::warn!("Force shutdown signal received. Terminating immediately.");
+                    // return error to force stop waiting for other tasks and terminate immediately
+                    Err(Error::ForceTerminated)
+                }
+            }
         };
 
         // wait for all servers to shut down or if any of the servers fail to start

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -558,8 +558,8 @@ impl Runtime {
             };
             tokio::select! {
                 result = graceful_shutdown => result,
-                _ = force_shutdown_signal() => {
-                    tracing::warn!("Force shutdown signal received. Terminating immediately.");
+                () = force_shutdown_signal() => {
+                    tracing::info!("Force shutdown signal received. Terminating immediately.");
                     // return error to force stop waiting for other tasks and terminate immediately
                     Err(Error::ForceTerminated)
                 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -552,7 +552,7 @@ impl Runtime {
         let shutdown_signal_future = async {
             let graceful_shutdown = async {
                 shutdown_signal().await;
-                tracing::debug!("Shutdown signal received.");
+                tracing::debug!("Shutdown signal received. Press Ctrl-C again to force exit.");
                 self.shutdown().await;
                 Ok(())
             };

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -14,3 +14,4 @@ humantime = "2.1.0"
 rand = "0.9.0"
 tokio = { workspace = true }
 tracing = { workspace = true }
+ctrlc = "3.4"

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -16,12 +16,14 @@ limitations under the License.
 
 use std::{
     cmp,
+    sync::Arc,
     time::{Duration, SystemTime, SystemTimeError},
 };
 
 pub mod fibonacci_backoff;
 pub use backoff::Error as RetryError;
 pub use backoff::future::retry;
+use tokio::{sync::oneshot, time::Instant};
 
 #[allow(clippy::cast_precision_loss)]
 #[allow(clippy::cast_sign_loss)]
@@ -57,6 +59,36 @@ pub fn pretty_print_number(num: usize) -> String {
 
 pub async fn shutdown_signal() {
     shutdown_signal_impl().await;
+}
+
+pub async fn force_shutdown_signal() {
+    shutdown_signal_impl().await;
+
+    // use 500ms as a debounce window to prevent the same Ctrl-C signal from being handled multiple times
+    let last_signal_time = Instant::now();
+
+    let (notify_ctrl_c, on_second_ctrl_c) = oneshot::channel::<()>();
+    let notify_ctrl_c = Arc::new(std::sync::Mutex::new(Some(notify_ctrl_c)));
+
+    if let Err(err) = ctrlc::set_handler({
+        move || {
+            if Instant::now().duration_since(last_signal_time) < Duration::from_millis(500) {
+                return;
+            }
+            if let Some(tx) = notify_ctrl_c
+                .lock()
+                .ok()
+                .and_then(|mut tx_opt| tx_opt.take())
+            {
+                tracing::debug!("Received Ctrl-C again, shutting down immediately.");
+                tx.send(()).ok();
+            }
+        }
+    }) {
+        tracing::error!("Failed to set listener for Ctrl-C: {err}");
+        // do not exit; otherwise, it will be interpreted as a force shutdown signal
+    };
+    on_second_ctrl_c.await.ok();
 }
 
 #[cfg(unix)]

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -61,6 +61,7 @@ pub async fn shutdown_signal() {
     shutdown_signal_impl().await;
 }
 
+/// Waits for an additional Ctrl-C after the initial shutdown signal to trigger a forced shutdown.
 pub async fn force_shutdown_signal() {
     shutdown_signal().await;
 
@@ -80,7 +81,7 @@ pub async fn force_shutdown_signal() {
                 .ok()
                 .and_then(|mut tx_opt| tx_opt.take())
             {
-                tracing::debug!("Received Ctrl-C again, shutting down immediately.");
+                tracing::debug!("Received Ctrl-C after the initial shutdown signal");
                 tx.send(()).ok();
             }
         }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -62,7 +62,7 @@ pub async fn shutdown_signal() {
 }
 
 pub async fn force_shutdown_signal() {
-    shutdown_signal_impl().await;
+    shutdown_signal().await;
 
     // use 500ms as a debounce window to prevent the same Ctrl-C signal from being handled multiple times
     let last_signal_time = Instant::now();


### PR DESCRIPTION
# 🗣 Description

Implements logic to cancel runtime grace termination in case of user pressed Ctrl-C to force terminate the runtime.

Note: force termination is considered dev mode currently and triggered by Ctrl-C only.

## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/5396

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

Current implementation only cancel runtime grace termination and does not guarantee immediate termination. Alternative approach could be moving handler to spiced and terminate the process.
