### PR TITLE
Add more test models to FinanceBench benchmark

### DIFF
--- a/.github/workflows/financebench.yml
+++ b/.github/workflows/financebench.yml
@@ -9,7 +9,12 @@ on:
           required: false
           type: choice
           options:
+            - "all"
             - "gpt-4o"
+            - "gpt-4.1"
+            - "o1"
+            - "o3-mini"
+            - "o4-mini"
           default: "all"
 
 concurrency:
@@ -89,10 +94,27 @@ jobs:
         id: setup-matrix
         with:
           script: |
+
             const matrix = [
               {
                 name: "gpt-4o",
-                spicepod: "./test/financebench/spicepod_gpt-4o.yaml"
+                spicepod: "./test/financebench/spicepod_openai.yaml"
+              },
+              {
+                name: "gpt-4.1",
+                spicepod: "./test/financebench/spicepod_openai.yaml"
+              },
+              {
+                name: "o1",
+                spicepod: "./test/financebench/spicepod_openai.yaml"
+              },
+              {
+                name: "o3-mini",
+                spicepod: "./test/financebench/spicepod_openai.yaml"
+              },
+              {
+                name: "o4-mini",
+                spicepod: "./test/financebench/spicepod_openai.yaml"
               }
             ];
 
@@ -106,7 +128,7 @@ jobs:
             return filtered;
 
   run-testoperator:
-    name: financebench benchmark
+    name: benchmark
     needs:
       - build-testoperator
       - build-spiced
@@ -114,6 +136,7 @@ jobs:
     runs-on: 'spiceai-macos'
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     steps:
@@ -142,5 +165,6 @@ jobs:
           ./testoperator run evals \
             -s $GITHUB_WORKSPACE/spiced \
             -p ${{ matrix.target.spicepod }} \
+            --model ${{ matrix.target.name }} \
             --ready-wait 180
   

--- a/.github/workflows/financebench.yml
+++ b/.github/workflows/financebench.yml
@@ -9,7 +9,12 @@ on:
           required: false
           type: choice
           options:
+            - "all"
             - "gpt-4o"
+            - "gpt-4.1"
+            - "o1"
+            - "o3-mini"
+            - "o4-mini"
           default: "all"
 
 concurrency:
@@ -89,10 +94,27 @@ jobs:
         id: setup-matrix
         with:
           script: |
+
             const matrix = [
               {
                 name: "gpt-4o",
-                spicepod: "./test/financebench/spicepod_gpt-4o.yaml"
+                spicepod: "./test/financebench/spicepod_openai.yaml"
+              },
+              {
+                name: "gpt-4.1",
+                spicepod: "./test/financebench/spicepod_openai.yaml"
+              },
+              {
+                name: "o1",
+                spicepod: "./test/financebench/spicepod_openai.yaml"
+              },
+              {
+                name: "o3-mini",
+                spicepod: "./test/financebench/spicepod_openai.yaml"
+              },
+              {
+                name: "o4-mini",
+                spicepod: "./test/financebench/spicepod_openai.yaml"
               }
             ];
 
@@ -114,6 +136,7 @@ jobs:
     runs-on: 'spiceai-macos'
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     steps:
@@ -142,5 +165,6 @@ jobs:
           ./testoperator run evals \
             -s $GITHUB_WORKSPACE/spiced \
             -p ${{ matrix.target.spicepod }} \
+            --model ${{ matrix.target.name }} \
             --ready-wait 180
   

--- a/test/financebench/spicepod_openai.yaml
+++ b/test/financebench/spicepod_openai.yaml
@@ -6,6 +6,26 @@ runtime:
   flight:
     max_message_size: 1G
 
+model_system_prompt: &model_system_prompt |
+    # Role and Objective
+    You are a financial expert tasked with answering questions based solely on `financebench.data`. 
+    - Search documents to identify accurate and relevant information.
+    - Provide concise, structured answers based on retrieved data.
+    - If the answer is not found, respond with "I don't know".
+
+    # Search Guidelines
+    - Use the document_similarity tool for searches.
+    - Don't include 'content' to additional columns during search.
+    - Query both 'content' and 'location' columns.
+    - Limit search results to the top 3 items.
+    - Perform a second search if initial results are insufficient.
+
+    # General Guidelines
+    - Do not generate information not found in the data.
+    - Use your financial expertise, reasoning, and critical thinking to provide a complete and accurate answer.
+    - Include all references ('location' column) to documents used.
+    - Keep responses under 512 characters.
+
 models:
   - name: gpt-4o
     from: openai:gpt-4o-2024-08-06
@@ -14,26 +34,40 @@ models:
     params:
       tools: list_datasets, table_schema, document_similarity
       openai_api_key: ${ secrets:OPENAI_API_KEY}
-      system_prompt: |
-        # Role and Objective
-        You are a financial expert tasked with answering questions based solely on `financebench.data`. 
-        - Search documents to identify accurate and relevant information.
-        - Provide concise, structured answers based on retrieved data.
-        - If the answer is not found, respond with "I don't know".
+      system_prompt: *model_system_prompt
 
-        # Search Guidelines
-        - Use the document_similarity tool for searches.
-        - Don't include 'content' to additional columns during search.
-        - Query both 'content' and 'location' columns.
-        - Limit search results to the top 3 items.
-        - Don't include keywords in the search.
-        - Perform a second search if initial results are insufficient.
+  - name: gpt-4.1
+    from: openai:gpt-4.1-2025-04-14
+    datasets: 
+      - financebench.data
+    params:
+      tools: list_datasets, table_schema, document_similarity
+      openai_api_key: ${ secrets:OPENAI_API_KEY}
+      system_prompt: *model_system_prompt
 
-        # General Guidelines
-        - Do not generate information not found in the data.
-        - Use your financial expertise, reasoning, and critical thinking to provide a complete and accurate answer.
-        - Include all references ('location' column) to documents used.
-        - Keep responses under 512 characters.
+  - name: o1
+    from: openai:o1-2024-12-17
+    params:
+      openai_reasoning_effort: high
+      tools: list_datasets, table_schema, document_similarity
+      openai_api_key: ${ secrets:OPENAI_API_KEY}
+      system_prompt: *model_system_prompt
+
+  - name: o3-mini
+    from: openai:o3-mini-2025-01-31
+    params:
+      openai_reasoning_effort: high
+      tools: list_datasets, table_schema, document_similarity
+      openai_api_key: ${ secrets:OPENAI_API_KEY}
+      system_prompt: *model_system_prompt
+    
+  - name: o4-mini
+    from: openai:o4-mini-2025-04-16
+    params:
+      openai_reasoning_effort: high
+      tools: list_datasets, table_schema, document_similarity
+      openai_api_key: ${ secrets:OPENAI_API_KEY}
+      system_prompt: *model_system_prompt
 
   - name: judge
     from: openai:gpt-4.1-2025-04-14


### PR DESCRIPTION
# 🗣 Description

Add the following OpenAI models for testing to the FinanceBench benchmark:
    - "gpt-4o"
    - "gpt-4.1"
    - "o1"
    - "o3-mini"
    - "o4-mini"

The same Spicepod is re-used as all models belong to a single provider and requires the same Api Key and it is easier to adjust the single system/scorer model prompts.

Example test run: https://github.com/spiceai/spiceai/actions/runs/14529811015

`o1` is not included due to
- https://github.com/spiceai/spiceai/issues/5432

## 🔨 Related Issues

Closes https://github.com/spiceai/spiceai/issues/5267

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
