### PR TITLE
Fix spice chat error handling

### DIFF
--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -131,30 +131,40 @@ spice chat --model <model> --cloud
 			rtcontext.RequireModelsFlavor(cmd)
 		}
 
+		httpEndpoint, err := cmd.Flags().GetString("http-endpoint")
+		if err != nil {
+			slog.Error("could not get http-endpoint flag", "error", err)
+			os.Exit(1)
+		}
+		if httpEndpoint != "" {
+			rtcontext.SetHttpEndpoint(httpEndpoint)
+		}
+
 		model, err := cmd.Flags().GetString(modelKeyFlag)
 		if err != nil {
 			slog.Error("could not get model flag", "error", err)
 			os.Exit(1)
 		}
+
+		models, err := api.GetDataSingle[api.ModelResponse](rtcontext, "/v1/models?status=true")
+		if err != nil {
+			slog.Error("could not list models", "error", err)
+			os.Exit(1)
+		}
+
+		if len(models.Data) == 0 {
+			slog.Error("No models found")
+			os.Exit(1)
+		}
+
+		availableModels := []string{}
+		for _, model := range models.Data {
+			if model.Status == "Ready" {
+				availableModels = append(availableModels, model.Id)
+			}
+		}
+
 		if model == "" {
-			models, err := api.GetDataSingle[api.ModelResponse](rtcontext, "/v1/models?status=true")
-			if err != nil {
-				slog.Error("could not list models", "error", err)
-				os.Exit(1)
-			}
-
-			if len(models.Data) == 0 {
-				slog.Error("No models found")
-				os.Exit(1)
-			}
-
-			availableModels := []string{}
-			for _, model := range models.Data {
-				if model.Status == "Ready" {
-					availableModels = append(availableModels, model.Id)
-				}
-			}
-
 			if len(availableModels) == 0 {
 				slog.Error("No models are ready")
 				os.Exit(1)
@@ -178,15 +188,20 @@ spice chat --model <model> --cloud
 
 			cmd.Printf("Using model: %s\n", selectedModel)
 			model = selectedModel
-		}
+		} else {
+			modelIsAvailable := false
+			for _, availableModel := range availableModels {
+				if availableModel == model {
+					modelIsAvailable = true
+					break
+				}
+			}
 
-		httpEndpoint, err := cmd.Flags().GetString("http-endpoint")
-		if err != nil {
-			slog.Error("could not get http-endpoint flag", "error", err)
-			os.Exit(1)
-		}
-		if httpEndpoint != "" {
-			rtcontext.SetHttpEndpoint(httpEndpoint)
+			if !modelIsAvailable {
+				slog.Error("Requested model is not available", "model", model)
+				slog.Info("Available models", "models", strings.Join(availableModels, ", "))
+				os.Exit(1)
+			}
 		}
 
 		var messages = []Message{}

--- a/bin/spice/pkg/api/util.go
+++ b/bin/spice/pkg/api/util.go
@@ -84,7 +84,7 @@ func doRuntimeApiRequest[T interface{}](rtcontext *context.RuntimeContext, metho
 	}()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return *new(T), fmt.Errorf("Unauthorized: Invalid or missing Spice API key.")
+		return *new(T), fmt.Errorf("unauthorized: invalid or missing Spice API key")
 	}
 
 	if resp.StatusCode == http.StatusNotFound {

--- a/bin/spice/pkg/api/util.go
+++ b/bin/spice/pkg/api/util.go
@@ -84,7 +84,7 @@ func doRuntimeApiRequest[T interface{}](rtcontext *context.RuntimeContext, metho
 	}()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return *new(T), fmt.Errorf("Unauthorized")
+		return *new(T), fmt.Errorf("Unauthorized: Invalid or missing Spice API key.")
 	}
 
 	if resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
# 🗣 Description

Fix the error handling for `spice chat` command, including:

- Verify whether the model passed in with `--model` flag exist:
```
spice chat --model do_not_exist
Spice.ai OSS CLI v1.2.0-unstable-build.ee84b6385-dev
2025/04/18 14:11:38 ERROR Requested model is not available model=do_not_exist
2025/04/18 14:11:38 INFO Available models models="foo, bar"
```
- More informative error on wrong api key
```
spice chat --cloud --model timmy --api-key <invalid-api-key>
Spice.ai OSS CLI v1.2.0-unstable-build.ee84b6385-dev
2025/04/18 14:26:42 ERROR could not list models error="Unauthorized: Invalid or missing Spice API key."
```
- Set the api key in rtcontext before 1st request is made for early detection and propagation of invalid endpoint error.
```
spice chat --http-endpoint  https://data.spicea
Spice.ai OSS CLI v1.2.0-unstable-build.ee84b6385-dev
2025/04/18 14:13:24 ERROR could not list models error="error performing request to https://data.spicea/v1/models?status=true: Get \"https://data.spicea/v1/models?status=true\": dial tcp: lookup data.spicea: no such host"
```

## 🔨 Related Issues

- Close: https://github.com/spiceai/spiceai/issues/5425

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
