### PR TITLE
Support 'from: databricks:model_name'

### DIFF
--- a/crates/llms/src/chat/mod.rs
+++ b/crates/llms/src/chat/mod.rs
@@ -118,6 +118,11 @@ pub enum Error {
     ModelNotFound { model: String, model_source: String },
 
     #[snafu(display(
+        "A model identifier must be provided for source '{model_source}' via `from: {model_source}:<model_id>`"
+    ))]
+    ModelNotProvided { model_source: String },
+
+    #[snafu(display(
         "Failed to load model tokenizer.\nAn error occurred: {source}\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
     ))]
     FailedToLoadTokenizer {
@@ -135,7 +140,10 @@ pub enum Error {
     UnsupportedTaskForModel { from: String, task: String },
 
     #[snafu(display("Invalid value for parameter {param}. {message}"))]
-    InvalidParamError { param: String, message: String },
+    InvalidParamValueError { param: String, message: String },
+
+    #[snafu(display("Expected `param.{param_key}`, but it was not provided"))]
+    MissingParamError { param_key: &'static str },
 
     #[snafu(display(
         "Failed to find weights for the model.\nExpected tensors with a file extension of: {extensions}.\nVerify the model is correctly configured, and try again."

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -102,6 +102,7 @@ pub fn construct_model(
         ModelSource::Azure => azure(model_id, component.name.as_str(), params),
         ModelSource::Xai => xai(model_id.as_deref(), params),
         ModelSource::OpenAi => openai(model_id, params),
+        ModelSource::Databricks => databricks(model_id, params),
         ModelSource::SpiceAI => Err(LlmError::UnsupportedTaskForModel {
             from: "spiceai".into(),
             task: "llm".into(),
@@ -111,7 +112,7 @@ pub fn construct_model(
     let system_prompt = match component.params.get("system_prompt") {
         Some(Value::String(s)) => Some(s.as_str()),
         Some(v) => {
-            return Err(LlmError::InvalidParamError {
+            return Err(LlmError::InvalidParamValueError {
                 param: "system_prompt".to_string(),
                 message: format!("Expected a string, got: {v:?}"),
             });
@@ -221,6 +222,35 @@ fn huggingface(
     llms::chat::create_hf_model(&id, model_type, gguf_path, hf_token)
 }
 
+fn databricks(
+    model_id: Option<String>,
+    params: &HashMap<String, SecretString>,
+) -> Result<Arc<dyn Chat>, LlmError> {
+    let Some(endpoint) = extract_secret!(params, "databricks_endpoint") else {
+        return Err(LlmError::MissingParamError {
+            param_key: "databricks_endpoint",
+        });
+    };
+    let Some(token) = extract_secret!(params, "databricks_token") else {
+        return Err(LlmError::MissingParamError {
+            param_key: "databricks_token",
+        });
+    };
+    let Some(model_id) = model_id else {
+        return Err(LlmError::ModelNotProvided {
+            model_source: "databricks".to_string(),
+        });
+    };
+
+    Ok(Arc::new(llms::openai::new_openai_client(
+        model_id,
+        Some(format!("https://{endpoint}/serving-endpoints").as_str()),
+        Some(token),
+        None,
+        None,
+    )) as Arc<dyn Chat>)
+}
+
 fn openai(
     model_id: Option<String>,
     params: &HashMap<String, SecretString>,
@@ -234,14 +264,14 @@ fn openai(
         match temperature_str.parse::<f64>() {
             Ok(temperature) => {
                 if temperature < 0.0 {
-                    return Err(LlmError::InvalidParamError {
+                    return Err(LlmError::InvalidParamValueError {
                         param: "openai_temperature".to_string(),
                         message: "Ensure it is a non-negative number.".to_string(),
                     });
                 }
             }
             Err(_) => {
-                return Err(LlmError::InvalidParamError {
+                return Err(LlmError::InvalidParamValueError {
                     param: "openai_temperature".to_string(),
                     message: "Ensure it is a non-negative number.".to_string(),
                 });

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -89,6 +89,7 @@ pub enum ModelSource {
     Perplexity,
     SpiceAI,
     File,
+    Databricks,
 }
 
 // Matches model paths in these formats:
@@ -139,6 +140,8 @@ impl TryFrom<&str> for ModelSource {
             Ok(ModelSource::Xai)
         } else if value.starts_with("spiceai") {
             Ok(ModelSource::SpiceAI)
+        } else if value.starts_with("databricks") {
+            Ok(ModelSource::Databricks)
         } else {
             Err("Unknown prefix")
         }
@@ -157,6 +160,7 @@ impl Display for ModelSource {
             ModelSource::HuggingFace => write!(f, "huggingface"),
             ModelSource::File => write!(f, "file"),
             ModelSource::SpiceAI => write!(f, "spiceai"),
+            ModelSource::Databricks => write!(f, "databricks"),
         }
     }
 }
@@ -341,6 +345,7 @@ impl Model {
                 | ModelSource::OpenAi
                 | ModelSource::Anthropic
                 | ModelSource::Xai
+                | ModelSource::Databricks
         ) {
             return Some(ModelType::Llm);
         }


### PR DESCRIPTION
# 🗣 Description
Support LLMs from [databricks](https://docs.databricks.com/aws/en/large-language-models/).
```yaml
models:
  - from: databricks:jeadie
    name: food
    params:
      databricks_endpoint: dbc-46470731-42e5.cloud.databricks.com
      databricks_token: ${ secrets::SPICE_DATABRICKS_TOKEN }
```

## 🔨 Related Issues
 - #5428 

## 📄 Documentation Updates
- [ ] TODO

## 🤔 Concerns
 - Slow and doesn't even support streaming.