### PR TITLE
Fix Postgres JSON type and add Dictionary type support for DuckDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3652,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=f60653b6ff9a0f26e5b44a1d43d947fdf1fd8853#f60653b6ff9a0f26e5b44a1d43d947fdf1fd8853"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=1713e9af2729f686aac46aef63e8c84545083e29#1713e9af2729f686aac46aef63e8c84545083e29"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,8 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "e0e423e9e29a711d076892865d51747b06429d1b" } # spiceai-45
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "1c814422cfbdeb7f7bd2399e3369656710413aa8" } # spiceai-45
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "f60653b6ff9a0f26e5b44a1d43d947fdf1fd8853" } # spiceai
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "1713e9af2729f686aac46aef63e8c84545083e29" } # spiceai
+
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b850ae60dbe67209320c86daeadf47b51f937660" } # spiceai-1.2.2
 


### PR DESCRIPTION
# 🗣 Description

Upgrade `datafusion-table-providers` crate to add the following improvements:
 - https://github.com/datafusion-contrib/datafusion-table-providers/pull/319
 - https://github.com/datafusion-contrib/datafusion-table-providers/pull/317

## 🔨 Related Issues

Fixes [Bug: DuckDB acceleration data_type Dictionary(Int8, Utf8) is not supported yet error](https://github.com/spiceai/spiceai/issues/5438)
Fixes [Bug: DuckDB acceleration Spice.ai error="os: process already finished" on jsonb type](https://github.com/spiceai/spiceai/issues/5439)

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
