### PR TITLE
Allow for one-shot chat request using `spice chat <message>`

### DIFF
--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -138,8 +138,19 @@ spice chat --model <model>
 
 # Start a chat session with spiced instance in spice.ai cloud
 spice chat --model <model> --cloud
+
+# Send a single message and exit
+spice chat --model <model> "What is Spice.ai?"
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 1 {
+			slog.Error("too many arguments provided", "expected", "0 or 1", "got", len(args))
+			cmd.Println("Usage: spice chat [message]")
+			cmd.Println("  - With no message: starts an interactive chat")
+			cmd.Println("  - With one message: sends the message and exits")
+			os.Exit(1)
+		}
+
 		cloud, _ := cmd.Flags().GetBool(cloudKeyFlag)
 		rtcontext := context.NewContext().WithCloud(cloud)
 		err := rtcontext.Init()
@@ -247,31 +258,18 @@ spice chat --model <model> --cloud
 			}
 		}
 
-		var messages = []Message{}
+		getChatResponse := func(messages []Message, useSpinner bool) error {
+			// Only create these variables if using spinner
+			var done chan bool
+			var doneLoading bool
 
-		line := liner.NewLiner()
-		line.SetCtrlCAborts(true)
-		defer func() {
-			if err := line.Close(); err != nil {
-				slog.Error("closing line", "error", err)
+			if useSpinner {
+				done = make(chan bool)
+				doneLoading = false
+				go func() {
+					util.ShowSpinner(done)
+				}()
 			}
-		}()
-		for {
-			message, err := line.Prompt("chat> ")
-			if err == liner.ErrPromptAborted {
-				break
-			} else if err != nil {
-				slog.Error("reading input line", "error", err)
-				continue
-			}
-
-			line.AppendHistory(message)
-			messages = append(messages, Message{Role: "user", Content: message})
-
-			done := make(chan bool)
-			go func() {
-				util.ShowSpinner(done)
-			}()
 
 			body := NewChatRequestBody(messages, model, true, &StreamOptions{
 				IncludeUsage: true,
@@ -284,7 +282,7 @@ spice chat --model <model> --cloud
 			response, err := sendChatRequest(rtcontext, body)
 			if err != nil {
 				slog.Error("failed to send chat request to spiced", "error", err)
-				continue
+				return fmt.Errorf("failed to send chat request: %w", err)
 			}
 
 			scanner := bufio.NewScanner(response.Body)
@@ -292,7 +290,10 @@ spice chat --model <model> --cloud
 
 			/// Usage for the entire stream, and related timing.
 			var usage Usage
-			doneLoading := false
+
+			if useSpinner {
+				doneLoading = false
+			}
 
 			for scanner.Scan() {
 				chunk := scanner.Text()
@@ -324,7 +325,7 @@ spice chat --model <model> --cloud
 					continue
 				}
 
-				if !doneLoading {
+				if useSpinner && !doneLoading {
 					done <- true
 					doneLoading = true
 				}
@@ -344,10 +345,10 @@ spice chat --model <model> --cloud
 			}
 
 			if err := scanner.Err(); err != nil {
-				slog.Error("error occurred while processing the input stream", "error", err)
+				slog.Error("error occurred while processing the response stream", "error", err)
 			}
 
-			if !doneLoading {
+			if useSpinner && !doneLoading {
 				done <- true
 				doneLoading = true
 			}
@@ -363,6 +364,50 @@ spice chat --model <model> --cloud
 				))
 			} else {
 				cmd.Print("\n\n")
+			}
+
+			return nil
+		}
+
+		if len(args) > 0 {
+			userMessage := args[0]
+
+			var messages = []Message{
+				{Role: "user", Content: userMessage},
+			}
+
+			err = getChatResponse(messages, false)
+			if err != nil {
+				os.Exit(1)
+			}
+
+			return
+		}
+
+		var messages = []Message{}
+
+		line := liner.NewLiner()
+		line.SetCtrlCAborts(true)
+		defer func() {
+			if err := line.Close(); err != nil {
+				slog.Error("closing line", "error", err)
+			}
+		}()
+		for {
+			message, err := line.Prompt("chat> ")
+			if err == liner.ErrPromptAborted {
+				break
+			} else if err != nil {
+				slog.Error("reading input line", "error", err)
+				continue
+			}
+
+			line.AppendHistory(message)
+			messages = append(messages, Message{Role: "user", Content: message})
+
+			err = getChatResponse(messages, true)
+			if err != nil {
+				continue
 			}
 		}
 	},

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -258,7 +258,7 @@ spice chat --model <model> "What is Spice.ai?"
 			}
 		}
 
-		getChatResponse := func(messages []Message, useSpinner bool) error {
+		getChatResponse := func(messages []Message, useSpinner bool) ([]Message, error) {
 			// Only create these variables if using spinner
 			var done chan bool
 			var doneLoading bool
@@ -282,7 +282,7 @@ spice chat --model <model> "What is Spice.ai?"
 			response, err := sendChatRequest(rtcontext, body)
 			if err != nil {
 				slog.Error("failed to send chat request to spiced", "error", err)
-				return fmt.Errorf("failed to send chat request: %w", err)
+				return messages, fmt.Errorf("failed to send chat request: %w", err)
 			}
 
 			scanner := bufio.NewScanner(response.Body)
@@ -350,7 +350,6 @@ spice chat --model <model> "What is Spice.ai?"
 
 			if useSpinner && !doneLoading {
 				done <- true
-				doneLoading = true
 			}
 
 			if responseMessage != "" {
@@ -366,7 +365,7 @@ spice chat --model <model> "What is Spice.ai?"
 				cmd.Print("\n\n")
 			}
 
-			return nil
+			return messages, nil
 		}
 
 		if len(args) > 0 {
@@ -376,7 +375,7 @@ spice chat --model <model> "What is Spice.ai?"
 				{Role: "user", Content: userMessage},
 			}
 
-			err = getChatResponse(messages, false)
+			_, err = getChatResponse(messages, false)
 			if err != nil {
 				os.Exit(1)
 			}
@@ -405,7 +404,7 @@ spice chat --model <model> "What is Spice.ai?"
 			line.AppendHistory(message)
 			messages = append(messages, Message{Role: "user", Content: message})
 
-			err = getChatResponse(messages, true)
+			messages, err = getChatResponse(messages, true)
 			if err != nil {
 				continue
 			}

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -139,7 +139,7 @@ spice chat --model <model>
 # Start a chat session with spiced instance in spice.ai cloud
 spice chat --model <model> --cloud
 
-# Send a single message and exit
+# Send a single prompt and receive a response
 spice chat --model <model> "What is Spice.ai?"
 `,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -130,8 +130,11 @@ type OpenAIErrorResponse struct {
 }
 
 var chatCmd = &cobra.Command{
-	Use:   "chat",
+	Use:   "chat [flags] [message]",
 	Short: "Chat with the Spice.ai LLM agent",
+	Long: `Chat with the Spice.ai LLM agent.
+	With no message argument: starts an interactive chat session.
+	With one message argument: sends the message and exits.`,
 	Example: `
 # Start a chat session with local spiced instance
 spice chat --model <model>
@@ -142,15 +145,8 @@ spice chat --model <model> --cloud
 # Send a single message and exit
 spice chat --model <model> "What is Spice.ai?"
 `,
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 {
-			slog.Error("too many arguments provided", "expected", "0 or 1", "got", len(args))
-			cmd.Println("Usage: spice chat [message]")
-			cmd.Println("  - With no message: starts an interactive chat")
-			cmd.Println("  - With one message: sends the message and exits")
-			os.Exit(1)
-		}
-
 		cloud, _ := cmd.Flags().GetBool(cloudKeyFlag)
 		rtcontext := context.NewContext().WithCloud(cloud)
 		err := rtcontext.Init()


### PR DESCRIPTION
# 🗣 Description

Enable the `spice chat <message>`, which allows CLI users to send a one-shot chat completion request without initiating an interactive chat REPL.

Usage:
```
spice chat --model ensure_the_physical_plan_is_valid hello
Spice.ai OSS CLI v1.2.0-unstable-build.9922a7e73-dev
{"score":0}

Time: 1.48s (first token 1.44s). Tokens: 1105. Prompt: 1099. Completion: 6 (135.27/s).
# Spice CLI quit
```

### When multiple models are available and --model is not selected: interactive menu for user to choose the model to chat with
![image](https://github.com/user-attachments/assets/564a88fa-adfe-4b74-bca1-1a3827eeadaf)
![image](https://github.com/user-attachments/assets/e3f86916-b993-42dd-a8c1-92529cd9d8d2)

### When only 1 models is available and --model is not selected: use the only one model available:
![image](https://github.com/user-attachments/assets/3f7335a9-dacc-4a5d-a556-750b9a5d683a)

## 🔨 Related Issues

- Close: https://github.com/spiceai/spiceai/issues/5424

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
