### PR TITLE
Enable parallel data sampling for NSQL

### DIFF
--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -38,6 +38,7 @@ use axum::{
 };
 use axum_extra::TypedHeader;
 use datafusion::sql::TableReference;
+use futures::future::try_join_all;
 use headers_accept::Accept;
 
 use itertools::Itertools;
@@ -52,6 +53,9 @@ use super::accept_header_types;
 
 // Default number of retries for NSQL queries if the generated query fails to execute
 const DEFAULT_NSQL_RETRIES: u8 = 10;
+
+// Maximum number of parallel tables for sampling
+const DATA_SAMPLING_MAX_PARALLEL_TABLES: usize = 5;
 
 fn clean_model_based_sql(input: &str) -> String {
     let no_dashes = match input.strip_prefix("--") {
@@ -76,29 +80,40 @@ async fn sample_messages(
 ) -> Result<Vec<ChatCompletionRequestMessage>, Box<dyn std::error::Error + Send + Sync>> {
     let mut messages = Vec::new();
 
-    for dataset in sample_from {
-        for params in [
-            SampleTableParams::DistinctColumns(DistinctColumnsParams {
-                tbl: dataset.to_string(),
-                limit: 3,
-                cols: None,
-            }),
-            SampleTableParams::RandomSample(RandomSampleParams {
-                tbl: dataset.to_string(),
-                limit: 3,
-            }),
-        ] {
-            let method = SampleTableMethod::from(&params);
-            let msgs = create_tool_use_messages(
-                Arc::clone(&rt),
-                &SampleDataTool::new(method.clone()),
-                format!("sample-{method:?}").as_str(),
-                &params,
-            )
-            .instrument(Span::current())
-            .await?;
-            messages.extend(msgs);
-        }
+    for datasets_chunk in sample_from.chunks(DATA_SAMPLING_MAX_PARALLEL_TABLES) {
+        let message_futures = datasets_chunk.iter().flat_map(|dataset| {
+            [
+                SampleTableParams::DistinctColumns(DistinctColumnsParams {
+                    tbl: dataset.to_string(),
+                    limit: 3,
+                    cols: None,
+                }),
+                SampleTableParams::RandomSample(RandomSampleParams {
+                    tbl: dataset.to_string(),
+                    limit: 3,
+                }),
+            ]
+            .into_iter()
+            .map(|params| {
+                let rt = Arc::clone(&rt);
+                let method = SampleTableMethod::from(&params);
+                async move {
+                    create_tool_use_messages(
+                        rt,
+                        &SampleDataTool::new(method.clone()),
+                        format!("sample-{method:?}").as_str(),
+                        &params,
+                    )
+                    .instrument(Span::current())
+                    .await
+                }
+            })
+        });
+
+        // Execute samples in parallel and collect results
+        let chunk_messages: Vec<Vec<ChatCompletionRequestMessage>> =
+            try_join_all(message_futures).await?;
+        messages.extend(chunk_messages.into_iter().flatten());
     }
     Ok(messages)
 }

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -38,7 +38,7 @@ use axum::{
 };
 use axum_extra::TypedHeader;
 use datafusion::sql::TableReference;
-use futures::future::try_join_all;
+use futures::{StreamExt, TryStreamExt};
 use headers_accept::Accept;
 
 use itertools::Itertools;
@@ -54,8 +54,8 @@ use super::accept_header_types;
 // Default number of retries for NSQL queries if the generated query fails to execute
 const DEFAULT_NSQL_RETRIES: u8 = 10;
 
-// Maximum number of parallel tables for sampling
-const DATA_SAMPLING_MAX_PARALLEL_TABLES: usize = 5;
+// Maximum number of concurrent sampling tools executions for NSQL
+const DATA_SAMPLING_MAX_CONCURRENT: usize = 10;
 
 fn clean_model_based_sql(input: &str) -> String {
     let no_dashes = match input.strip_prefix("--") {
@@ -80,41 +80,42 @@ async fn sample_messages(
 ) -> Result<Vec<ChatCompletionRequestMessage>, Box<dyn std::error::Error + Send + Sync>> {
     let mut messages = Vec::new();
 
-    for datasets_chunk in sample_from.chunks(DATA_SAMPLING_MAX_PARALLEL_TABLES) {
-        let message_futures = datasets_chunk.iter().flat_map(|dataset| {
-            [
-                SampleTableParams::DistinctColumns(DistinctColumnsParams {
-                    tbl: dataset.to_string(),
-                    limit: 3,
-                    cols: None,
-                }),
-                SampleTableParams::RandomSample(RandomSampleParams {
-                    tbl: dataset.to_string(),
-                    limit: 3,
-                }),
-            ]
-            .into_iter()
-            .map(|params| {
-                let rt = Arc::clone(&rt);
+    let message_futures = sample_from.iter().flat_map(|dataset| {
+        [
+            SampleTableParams::DistinctColumns(DistinctColumnsParams {
+                tbl: dataset.to_string(),
+                limit: 3,
+                cols: None,
+            }),
+            SampleTableParams::RandomSample(RandomSampleParams {
+                tbl: dataset.to_string(),
+                limit: 3,
+            }),
+        ]
+        .into_iter()
+        .map(|params| {
+            let rt = Arc::clone(&rt);
+            async move {
                 let method = SampleTableMethod::from(&params);
-                async move {
-                    create_tool_use_messages(
-                        rt,
-                        &SampleDataTool::new(method.clone()),
-                        format!("sample-{method:?}").as_str(),
-                        &params,
-                    )
-                    .instrument(Span::current())
-                    .await
-                }
-            })
-        });
+                create_tool_use_messages(
+                    rt,
+                    &SampleDataTool::new(method.clone()),
+                    format!("sample-{method:?}").as_str(),
+                    &params,
+                )
+                .instrument(Span::current())
+                .await
+            }
+        })
+    });
 
-        // Execute samples in parallel and collect results
-        let chunk_messages: Vec<Vec<ChatCompletionRequestMessage>> =
-            try_join_all(message_futures).await?;
-        messages.extend(chunk_messages.into_iter().flatten());
-    }
+    let tool_call_messages = futures::stream::iter(message_futures)
+        .boxed()
+        .buffer_unordered(DATA_SAMPLING_MAX_CONCURRENT)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    messages.extend(tool_call_messages.into_iter().flatten());
     Ok(messages)
 }
 

--- a/crates/runtime/src/http/v1/nsql.rs
+++ b/crates/runtime/src/http/v1/nsql.rs
@@ -78,8 +78,6 @@ async fn sample_messages(
     sample_from: &[TableReference],
     rt: Arc<Runtime>,
 ) -> Result<Vec<ChatCompletionRequestMessage>, Box<dyn std::error::Error + Send + Sync>> {
-    let mut messages = Vec::new();
-
     let message_futures = sample_from.iter().flat_map(|dataset| {
         [
             SampleTableParams::DistinctColumns(DistinctColumnsParams {
@@ -115,8 +113,7 @@ async fn sample_messages(
         .try_collect::<Vec<_>>()
         .await?;
 
-    messages.extend(tool_call_messages.into_iter().flatten());
-    Ok(messages)
+    Ok(tool_call_messages.into_iter().flatten().collect())
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/runtime/src/tools/builtin/sample/distinct.rs
+++ b/crates/runtime/src/tools/builtin/sample/distinct.rs
@@ -24,12 +24,18 @@ use std::{
 
 use crate::datafusion::DataFusion;
 use arrow::compute::concat;
-use futures::TryStreamExt;
+use futures::{
+    TryStreamExt,
+    future::{BoxFuture, try_join_all},
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
 use super::SampleFrom;
+
+// Max columns for parallel distinct sampling per table
+const MAX_PARALLEL_DISTINCT_COLUMN_SCANS_PER_TABLE: usize = 10;
 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -135,27 +141,45 @@ impl SampleFrom for DistinctColumnsParams {
 
         let mut result: Vec<ArrayRef> = Vec::with_capacity(columns.len());
 
+        for columns_chunk in columns.chunks(MAX_PARALLEL_DISTINCT_COLUMN_SCANS_PER_TABLE) {
+            let data_sample_futures: Vec<_> = columns_chunk
+                .iter()
+                .map(|column| {
+                    let fut: BoxFuture<'_, _> = if column_supports_distinct_sampling(column)
+                        // Only sample distinctly from columns that are specified in the `cols` field, if `cols` is None and distinct sampling is supported
+                        && (self.cols.is_none()
+                            || self
+                                .cols
+                                .as_ref()
+                                .is_some_and(|cols| cols.contains(column.name())))
+                    {
+                        Box::pin(Self::sample_distinct_from_column(
+                            Arc::clone(&df),
+                            &tbl,
+                            column.name(),
+                            self.limit,
+                        ))
+                    } else {
+                        Box::pin(Self::sample_from_column(
+                            Arc::clone(&df),
+                            &tbl,
+                            column.name(),
+                            self.limit,
+                        ))
+                    };
+
+                    fut
+                })
+                .collect();
+
+            let data_samples = try_join_all(data_sample_futures).await?;
+            result.extend(data_samples);
+        }
+
         // Sampling data will return at most `limit` rows, but may return fewer if the table has fewer rows or empty
         let mut min_sample_rows_count = self.limit;
-
-        for (i, column) in columns.iter().enumerate() {
-            // Only sample distinctly from columns that are specified in the `cols` field, if `cols` is None and distinct sampling is supported
-            let column_data = if column_supports_distinct_sampling(column)
-                && (self.cols.is_none()
-                    || self
-                        .cols
-                        .as_ref()
-                        .is_some_and(|cols| cols.contains(column.name())))
-            {
-                Self::sample_distinct_from_column(Arc::clone(&df), &tbl, column.name(), self.limit)
-                    .await?
-            } else {
-                Self::sample_from_column(Arc::clone(&df), &tbl, column.name(), self.limit).await?
-            };
-
+        for column_data in &result {
             min_sample_rows_count = min_sample_rows_count.min(column_data.len());
-
-            result.insert(i, column_data);
         }
 
         // If the number of rows sampled is less than the limit, ensure that all columns have the same length

--- a/crates/runtime/src/tools/builtin/sample/distinct.rs
+++ b/crates/runtime/src/tools/builtin/sample/distinct.rs
@@ -24,18 +24,15 @@ use std::{
 
 use crate::datafusion::DataFusion;
 use arrow::compute::concat;
-use futures::{
-    TryStreamExt,
-    future::{BoxFuture, try_join_all},
-};
+use futures::{StreamExt, TryStreamExt};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
 use super::SampleFrom;
 
-// Max columns for parallel distinct sampling per table
-const MAX_PARALLEL_DISTINCT_COLUMN_SCANS_PER_TABLE: usize = 5;
+// Max columns for parallel distinct sampling per tool call
+const MAX_CONCURRENT_COLUMNS_SCANS: usize = 5;
 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -141,40 +138,33 @@ impl SampleFrom for DistinctColumnsParams {
 
         let mut result: Vec<ArrayRef> = Vec::with_capacity(columns.len());
 
-        for columns_chunk in columns.chunks(MAX_PARALLEL_DISTINCT_COLUMN_SCANS_PER_TABLE) {
-            let data_sample_futures: Vec<_> = columns_chunk
-                .iter()
-                .map(|column| {
-                    let fut: BoxFuture<'_, _> = if column_supports_distinct_sampling(column)
-                        // Only sample distinctly from columns that are specified in the `cols` field, if `cols` is None and distinct sampling is supported
-                        && (self.cols.is_none()
-                            || self
-                                .cols
-                                .as_ref()
-                                .is_some_and(|cols| cols.contains(column.name())))
-                    {
-                        Box::pin(Self::sample_distinct_from_column(
-                            Arc::clone(&df),
-                            &tbl,
-                            column.name(),
-                            self.limit,
-                        ))
-                    } else {
-                        Box::pin(Self::sample_from_column(
-                            Arc::clone(&df),
-                            &tbl,
-                            column.name(),
-                            self.limit,
-                        ))
-                    };
+        let data_sample_futures = columns.iter().map(|column| {
+            let tbl = tbl.clone();
+            let df = Arc::clone(&df);
+            async move {
+                // Only sample distinctly from columns that are specified in the `cols` field, if `cols` is None and distinct sampling is supported
+                if column_supports_distinct_sampling(column)
+                    && (self.cols.is_none()
+                        || self
+                            .cols
+                            .as_ref()
+                            .is_some_and(|cols| cols.contains(column.name())))
+                {
+                    Self::sample_distinct_from_column(df, &tbl, column.name(), self.limit).await
+                } else {
+                    Self::sample_from_column(df, &tbl, column.name(), self.limit).await
+                }
+            }
+        });
 
-                    fut
-                })
-                .collect();
+        let data_samples = futures::stream::iter(data_sample_futures)
+            .boxed()
+            // Use `buffered` (ordered) to preserve column order to match the schema.
+            .buffered(MAX_CONCURRENT_COLUMNS_SCANS)
+            .try_collect::<Vec<_>>()
+            .await?;
 
-            let data_samples = try_join_all(data_sample_futures).await?;
-            result.extend(data_samples);
-        }
+        result.extend(data_samples);
 
         // Sampling data will return at most `limit` rows, but may return fewer if the table has fewer rows or empty
         let mut min_sample_rows_count = self.limit;

--- a/crates/runtime/src/tools/builtin/sample/distinct.rs
+++ b/crates/runtime/src/tools/builtin/sample/distinct.rs
@@ -35,7 +35,7 @@ use snafu::ResultExt;
 use super::SampleFrom;
 
 // Max columns for parallel distinct sampling per table
-const MAX_PARALLEL_DISTINCT_COLUMN_SCANS_PER_TABLE: usize = 10;
+const MAX_PARALLEL_DISTINCT_COLUMN_SCANS_PER_TABLE: usize = 5;
 
 #[derive(Debug, Clone, JsonSchema, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -90,17 +90,35 @@ mod nsql {
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
-        let response = http_post(
-            format!("{base_url}/v1/sql").as_str(),
+        // With `sample_data_enabled`, tools run concurrently, so for deterministic results, order by task and input for verification instead of start time.
+        let query = if ts
+            .body
+            .get("sample_data_enabled")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+        {
             format!(
                 "SELECT task, input
-                        FROM runtime.task_history
-                        WHERE task NOT IN ('ai_completion', 'health', 'accelerated_refresh')
-                        AND start_time > '{}'
-                        ORDER BY start_time, task;",
+                FROM runtime.task_history
+                WHERE task NOT IN ('ai_completion', 'health', 'accelerated_refresh')
+                AND start_time > '{}'
+                ORDER BY task, input;",
                 Into::<DateTime<Utc>>::into(task_start_time).to_rfc3339()
             )
-            .as_str(),
+        } else {
+            format!(
+                "SELECT task, input
+                FROM runtime.task_history
+                WHERE task NOT IN ('ai_completion', 'health', 'accelerated_refresh')
+                AND start_time > '{}'
+                ORDER BY start_time, task;",
+                Into::<DateTime<Utc>>::into(task_start_time).to_rfc3339()
+            )
+        };
+
+        let response = http_post(
+            format!("{base_url}/v1/sql").as_str(),
+            query.as_str(),
             headers,
         )
         .await

--- a/crates/runtime/tests/models/snapshots/integration_models__models__nsql__openai_with_sample_data_enabled_tasks.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__nsql__openai_with_sample_data_enabled_tasks.snap
@@ -6,79 +6,14 @@ expression: response
 | task                   | input                                                                                     |
 +------------------------+-------------------------------------------------------------------------------------------+
 | nsql                   | how many records (as 'total_records') are in taxi_trips dataset?                          |
-| tool_use::table_schema | {"tables":["spice.public.taxi_trips"],"output":"full"}                                    |
-| tool_use::sample_data  | DistinctColumns({"dataset":"spice.public.taxi_trips","limit":3,"cols":null})              |
-| sql_query              | SELECT "VendorID" FROM (                                                                  |
-|                        |                 SELECT "VendorID", 1 as priority                                          |
-|                        |                 FROM (SELECT DISTINCT "VendorID" FROM spice.public.taxi_trips)            |
+| sql_query              | SELECT "Airport_fee" FROM (                                                               |
+|                        |                 SELECT "Airport_fee", 1 as priority                                       |
+|                        |                 FROM (SELECT DISTINCT "Airport_fee" FROM spice.public.taxi_trips)         |
 |                        |                 UNION ALL                                                                 |
-|                        |                 SELECT "VendorID", 2 as priority                                          |
+|                        |                 SELECT "Airport_fee", 2 as priority                                       |
 |                        |                 FROM spice.public.taxi_trips                                              |
 |                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, "VendorID"                                                 |
-|                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT tpep_pickup_datetime FROM (                                                        |
-|                        |                 SELECT tpep_pickup_datetime, 1 as priority                                |
-|                        |                 FROM (SELECT DISTINCT tpep_pickup_datetime FROM spice.public.taxi_trips)  |
-|                        |                 UNION ALL                                                                 |
-|                        |                 SELECT tpep_pickup_datetime, 2 as priority                                |
-|                        |                 FROM spice.public.taxi_trips                                              |
-|                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, tpep_pickup_datetime                                       |
-|                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT tpep_dropoff_datetime FROM (                                                       |
-|                        |                 SELECT tpep_dropoff_datetime, 1 as priority                               |
-|                        |                 FROM (SELECT DISTINCT tpep_dropoff_datetime FROM spice.public.taxi_trips) |
-|                        |                 UNION ALL                                                                 |
-|                        |                 SELECT tpep_dropoff_datetime, 2 as priority                               |
-|                        |                 FROM spice.public.taxi_trips                                              |
-|                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, tpep_dropoff_datetime                                      |
-|                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT passenger_count FROM (                                                             |
-|                        |                 SELECT passenger_count, 1 as priority                                     |
-|                        |                 FROM (SELECT DISTINCT passenger_count FROM spice.public.taxi_trips)       |
-|                        |                 UNION ALL                                                                 |
-|                        |                 SELECT passenger_count, 2 as priority                                     |
-|                        |                 FROM spice.public.taxi_trips                                              |
-|                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, passenger_count                                            |
-|                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT trip_distance FROM (                                                               |
-|                        |                 SELECT trip_distance, 1 as priority                                       |
-|                        |                 FROM (SELECT DISTINCT trip_distance FROM spice.public.taxi_trips)         |
-|                        |                 UNION ALL                                                                 |
-|                        |                 SELECT trip_distance, 2 as priority                                       |
-|                        |                 FROM spice.public.taxi_trips                                              |
-|                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, trip_distance                                              |
-|                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT "RatecodeID" FROM (                                                                |
-|                        |                 SELECT "RatecodeID", 1 as priority                                        |
-|                        |                 FROM (SELECT DISTINCT "RatecodeID" FROM spice.public.taxi_trips)          |
-|                        |                 UNION ALL                                                                 |
-|                        |                 SELECT "RatecodeID", 2 as priority                                        |
-|                        |                 FROM spice.public.taxi_trips                                              |
-|                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, "RatecodeID"                                               |
-|                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT store_and_fwd_flag FROM (                                                          |
-|                        |                 SELECT store_and_fwd_flag, 1 as priority                                  |
-|                        |                 FROM (SELECT DISTINCT store_and_fwd_flag FROM spice.public.taxi_trips)    |
-|                        |                 UNION ALL                                                                 |
-|                        |                 SELECT store_and_fwd_flag, 2 as priority                                  |
-|                        |                 FROM spice.public.taxi_trips                                              |
-|                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, store_and_fwd_flag                                         |
-|                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT "PULocationID" FROM (                                                              |
-|                        |                 SELECT "PULocationID", 1 as priority                                      |
-|                        |                 FROM (SELECT DISTINCT "PULocationID" FROM spice.public.taxi_trips)        |
-|                        |                 UNION ALL                                                                 |
-|                        |                 SELECT "PULocationID", 2 as priority                                      |
-|                        |                 FROM spice.public.taxi_trips                                              |
-|                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, "PULocationID"                                             |
+|                        |             ORDER BY priority, "Airport_fee"                                              |
 |                        |             LIMIT 3                                                                       |
 | sql_query              | SELECT "DOLocationID" FROM (                                                              |
 |                        |                 SELECT "DOLocationID", 1 as priority                                      |
@@ -89,23 +24,43 @@ expression: response
 |                        |             ) combined                                                                    |
 |                        |             ORDER BY priority, "DOLocationID"                                             |
 |                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT payment_type FROM (                                                                |
-|                        |                 SELECT payment_type, 1 as priority                                        |
-|                        |                 FROM (SELECT DISTINCT payment_type FROM spice.public.taxi_trips)          |
+| sql_query              | SELECT "PULocationID" FROM (                                                              |
+|                        |                 SELECT "PULocationID", 1 as priority                                      |
+|                        |                 FROM (SELECT DISTINCT "PULocationID" FROM spice.public.taxi_trips)        |
 |                        |                 UNION ALL                                                                 |
-|                        |                 SELECT payment_type, 2 as priority                                        |
+|                        |                 SELECT "PULocationID", 2 as priority                                      |
 |                        |                 FROM spice.public.taxi_trips                                              |
 |                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, payment_type                                               |
+|                        |             ORDER BY priority, "PULocationID"                                             |
 |                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT fare_amount FROM (                                                                 |
-|                        |                 SELECT fare_amount, 1 as priority                                         |
-|                        |                 FROM (SELECT DISTINCT fare_amount FROM spice.public.taxi_trips)           |
+| sql_query              | SELECT "RatecodeID" FROM (                                                                |
+|                        |                 SELECT "RatecodeID", 1 as priority                                        |
+|                        |                 FROM (SELECT DISTINCT "RatecodeID" FROM spice.public.taxi_trips)          |
 |                        |                 UNION ALL                                                                 |
-|                        |                 SELECT fare_amount, 2 as priority                                         |
+|                        |                 SELECT "RatecodeID", 2 as priority                                        |
 |                        |                 FROM spice.public.taxi_trips                                              |
 |                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, fare_amount                                                |
+|                        |             ORDER BY priority, "RatecodeID"                                               |
+|                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT "VendorID" FROM (                                                                  |
+|                        |                 SELECT "VendorID", 1 as priority                                          |
+|                        |                 FROM (SELECT DISTINCT "VendorID" FROM spice.public.taxi_trips)            |
+|                        |                 UNION ALL                                                                 |
+|                        |                 SELECT "VendorID", 2 as priority                                          |
+|                        |                 FROM spice.public.taxi_trips                                              |
+|                        |             ) combined                                                                    |
+|                        |             ORDER BY priority, "VendorID"                                                 |
+|                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT * FROM spice.public.taxi_trips LIMIT 3                                             |
+| sql_query              | SELECT COUNT(*) AS "total_records" FROM "spice"."public"."taxi_trips"                     |
+| sql_query              | SELECT congestion_surcharge FROM (                                                        |
+|                        |                 SELECT congestion_surcharge, 1 as priority                                |
+|                        |                 FROM (SELECT DISTINCT congestion_surcharge FROM spice.public.taxi_trips)  |
+|                        |                 UNION ALL                                                                 |
+|                        |                 SELECT congestion_surcharge, 2 as priority                                |
+|                        |                 FROM spice.public.taxi_trips                                              |
+|                        |             ) combined                                                                    |
+|                        |             ORDER BY priority, congestion_surcharge                                       |
 |                        |             LIMIT 3                                                                       |
 | sql_query              | SELECT extra FROM (                                                                       |
 |                        |                 SELECT extra, 1 as priority                                               |
@@ -116,6 +71,24 @@ expression: response
 |                        |             ) combined                                                                    |
 |                        |             ORDER BY priority, extra                                                      |
 |                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT fare_amount FROM (                                                                 |
+|                        |                 SELECT fare_amount, 1 as priority                                         |
+|                        |                 FROM (SELECT DISTINCT fare_amount FROM spice.public.taxi_trips)           |
+|                        |                 UNION ALL                                                                 |
+|                        |                 SELECT fare_amount, 2 as priority                                         |
+|                        |                 FROM spice.public.taxi_trips                                              |
+|                        |             ) combined                                                                    |
+|                        |             ORDER BY priority, fare_amount                                                |
+|                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT improvement_surcharge FROM (                                                       |
+|                        |                 SELECT improvement_surcharge, 1 as priority                               |
+|                        |                 FROM (SELECT DISTINCT improvement_surcharge FROM spice.public.taxi_trips) |
+|                        |                 UNION ALL                                                                 |
+|                        |                 SELECT improvement_surcharge, 2 as priority                               |
+|                        |                 FROM spice.public.taxi_trips                                              |
+|                        |             ) combined                                                                    |
+|                        |             ORDER BY priority, improvement_surcharge                                      |
+|                        |             LIMIT 3                                                                       |
 | sql_query              | SELECT mta_tax FROM (                                                                     |
 |                        |                 SELECT mta_tax, 1 as priority                                             |
 |                        |                 FROM (SELECT DISTINCT mta_tax FROM spice.public.taxi_trips)               |
@@ -125,6 +98,34 @@ expression: response
 |                        |             ) combined                                                                    |
 |                        |             ORDER BY priority, mta_tax                                                    |
 |                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT passenger_count FROM (                                                             |
+|                        |                 SELECT passenger_count, 1 as priority                                     |
+|                        |                 FROM (SELECT DISTINCT passenger_count FROM spice.public.taxi_trips)       |
+|                        |                 UNION ALL                                                                 |
+|                        |                 SELECT passenger_count, 2 as priority                                     |
+|                        |                 FROM spice.public.taxi_trips                                              |
+|                        |             ) combined                                                                    |
+|                        |             ORDER BY priority, passenger_count                                            |
+|                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT payment_type FROM (                                                                |
+|                        |                 SELECT payment_type, 1 as priority                                        |
+|                        |                 FROM (SELECT DISTINCT payment_type FROM spice.public.taxi_trips)          |
+|                        |                 UNION ALL                                                                 |
+|                        |                 SELECT payment_type, 2 as priority                                        |
+|                        |                 FROM spice.public.taxi_trips                                              |
+|                        |             ) combined                                                                    |
+|                        |             ORDER BY priority, payment_type                                               |
+|                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT store_and_fwd_flag FROM (                                                          |
+|                        |                 SELECT store_and_fwd_flag, 1 as priority                                  |
+|                        |                 FROM (SELECT DISTINCT store_and_fwd_flag FROM spice.public.taxi_trips)    |
+|                        |                 UNION ALL                                                                 |
+|                        |                 SELECT store_and_fwd_flag, 2 as priority                                  |
+|                        |                 FROM spice.public.taxi_trips                                              |
+|                        |             ) combined                                                                    |
+|                        |             ORDER BY priority, store_and_fwd_flag                                         |
+|                        |             LIMIT 3                                                                       |
+| sql_query              | SELECT store_and_fwd_flag_embedding FROM spice.public.taxi_trips LIMIT 3                  |
 | sql_query              | SELECT tip_amount FROM (                                                                  |
 |                        |                 SELECT tip_amount, 1 as priority                                          |
 |                        |                 FROM (SELECT DISTINCT tip_amount FROM spice.public.taxi_trips)            |
@@ -143,15 +144,6 @@ expression: response
 |                        |             ) combined                                                                    |
 |                        |             ORDER BY priority, tolls_amount                                               |
 |                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT improvement_surcharge FROM (                                                       |
-|                        |                 SELECT improvement_surcharge, 1 as priority                               |
-|                        |                 FROM (SELECT DISTINCT improvement_surcharge FROM spice.public.taxi_trips) |
-|                        |                 UNION ALL                                                                 |
-|                        |                 SELECT improvement_surcharge, 2 as priority                               |
-|                        |                 FROM spice.public.taxi_trips                                              |
-|                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, improvement_surcharge                                      |
-|                        |             LIMIT 3                                                                       |
 | sql_query              | SELECT total_amount FROM (                                                                |
 |                        |                 SELECT total_amount, 1 as priority                                        |
 |                        |                 FROM (SELECT DISTINCT total_amount FROM spice.public.taxi_trips)          |
@@ -161,26 +153,34 @@ expression: response
 |                        |             ) combined                                                                    |
 |                        |             ORDER BY priority, total_amount                                               |
 |                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT congestion_surcharge FROM (                                                        |
-|                        |                 SELECT congestion_surcharge, 1 as priority                                |
-|                        |                 FROM (SELECT DISTINCT congestion_surcharge FROM spice.public.taxi_trips)  |
+| sql_query              | SELECT tpep_dropoff_datetime FROM (                                                       |
+|                        |                 SELECT tpep_dropoff_datetime, 1 as priority                               |
+|                        |                 FROM (SELECT DISTINCT tpep_dropoff_datetime FROM spice.public.taxi_trips) |
 |                        |                 UNION ALL                                                                 |
-|                        |                 SELECT congestion_surcharge, 2 as priority                                |
+|                        |                 SELECT tpep_dropoff_datetime, 2 as priority                               |
 |                        |                 FROM spice.public.taxi_trips                                              |
 |                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, congestion_surcharge                                       |
+|                        |             ORDER BY priority, tpep_dropoff_datetime                                      |
 |                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT "Airport_fee" FROM (                                                               |
-|                        |                 SELECT "Airport_fee", 1 as priority                                       |
-|                        |                 FROM (SELECT DISTINCT "Airport_fee" FROM spice.public.taxi_trips)         |
+| sql_query              | SELECT tpep_pickup_datetime FROM (                                                        |
+|                        |                 SELECT tpep_pickup_datetime, 1 as priority                                |
+|                        |                 FROM (SELECT DISTINCT tpep_pickup_datetime FROM spice.public.taxi_trips)  |
 |                        |                 UNION ALL                                                                 |
-|                        |                 SELECT "Airport_fee", 2 as priority                                       |
+|                        |                 SELECT tpep_pickup_datetime, 2 as priority                                |
 |                        |                 FROM spice.public.taxi_trips                                              |
 |                        |             ) combined                                                                    |
-|                        |             ORDER BY priority, "Airport_fee"                                              |
+|                        |             ORDER BY priority, tpep_pickup_datetime                                       |
 |                        |             LIMIT 3                                                                       |
-| sql_query              | SELECT store_and_fwd_flag_embedding FROM spice.public.taxi_trips LIMIT 3                  |
+| sql_query              | SELECT trip_distance FROM (                                                               |
+|                        |                 SELECT trip_distance, 1 as priority                                       |
+|                        |                 FROM (SELECT DISTINCT trip_distance FROM spice.public.taxi_trips)         |
+|                        |                 UNION ALL                                                                 |
+|                        |                 SELECT trip_distance, 2 as priority                                       |
+|                        |                 FROM spice.public.taxi_trips                                              |
+|                        |             ) combined                                                                    |
+|                        |             ORDER BY priority, trip_distance                                              |
+|                        |             LIMIT 3                                                                       |
+| tool_use::sample_data  | DistinctColumns({"dataset":"spice.public.taxi_trips","limit":3,"cols":null})              |
 | tool_use::sample_data  | RandomSample({"dataset":"spice.public.taxi_trips","limit":3})                             |
-| sql_query              | SELECT * FROM spice.public.taxi_trips LIMIT 3                                             |
-| sql_query              | SELECT COUNT(*) AS "total_records" FROM "spice"."public"."taxi_trips"                     |
+| tool_use::table_schema | {"tables":["spice.public.taxi_trips"],"output":"full"}                                    |
 +------------------------+-------------------------------------------------------------------------------------------+


### PR DESCRIPTION
# 🗣 Description

1. Run data sampling tools (DistinctColumns, RandomSample) in parallel (max 10 concurrent tool calls).
1. Run separate queries (column data) of DistinctColumns tool in parallel (max 5 columns in parallel)

## 🔨 Related Issues

Fixes https://github.com/spiceai/spiceai/issues/5440

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

