### PR TITLE
E2E test for spice chat <message> behavior

### DIFF
--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -541,6 +541,10 @@ jobs:
         run: |
           brew install expect
 
+      - name: Make expect scripts executable
+        run: |
+          chmod +x ./test/cli/*.exp
+
       - name: Test `spice chat` error
         run: |
           ./test/cli/spice_chat_error.exp

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -104,384 +104,384 @@ jobs:
           path: |
             spice.exe
 
-  test_spice_upgrade_with_runtime:
-    name: 'Test spice upgrade (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-    continue-on-error: true
-    runs-on: ${{ matrix.target.runner }}
-    env:
-      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs:
-      - build
-      - setup-matrix
-    timeout-minutes: 5
+  # test_spice_upgrade_with_runtime:
+  #   name: 'Test spice upgrade (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+  #   continue-on-error: true
+  #   runs-on: ${{ matrix.target.runner }}
+  #   env:
+  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   needs:
+  #     - build
+  #     - setup-matrix
+  #   timeout-minutes: 5
 
-    strategy:
-      matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+  #   strategy:
+  #     matrix:
+  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-        if: github.event.inputs.build_cli != 'false'
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          path: ./build
+  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #       if: github.event.inputs.build_cli != 'false'
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #         path: ./build
 
-      - name: download spice cli released version
-        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
-        run: |
-          mkdir -p ./build
-          cd ./build
-          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-          output="spice.tar.gz"
-          curl -L -o "$output" "$url"
-          tar -xzf "$output"
-          rm "$output"
-          chmod +x spice
+  #     - name: download spice cli released version
+  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
+  #       run: |
+  #         mkdir -p ./build
+  #         cd ./build
+  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+  #         output="spice.tar.gz"
+  #         curl -L -o "$output" "$url"
+  #         tar -xzf "$output"
+  #         rm "$output"
+  #         chmod +x spice
 
-      - name: download spice cli released version
-        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
-        run: |
-          New-Item -ItemType Directory -Force -Path "./build" > $null
-          Set-Location "./build"
-          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
-          $output = "spice.exe_windows_x86_64.tar.gz"
-          Invoke-WebRequest -Uri $url -OutFile $output
-          tar -xzf $output
-          Remove-Item $output
+  #     - name: download spice cli released version
+  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
+  #       run: |
+  #         New-Item -ItemType Directory -Force -Path "./build" > $null
+  #         Set-Location "./build"
+  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
+  #         $output = "spice.exe_windows_x86_64.tar.gz"
+  #         Invoke-WebRequest -Uri $url -OutFile $output
+  #         tar -xzf $output
+  #         Remove-Item $output
 
-      - name: Download a older spiced
-        shell: pwsh
-        if: matrix.target.target_os == 'windows'
-        run: |
-          Set-Location "./build"
-          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spiced.exe_windows_x86_64.tar.gz"
-          $output = "spiced.exe_windows_x86_64.tar.gz"
-          Invoke-WebRequest -Uri $url -OutFile $output
-          tar -xzf $output
-          Remove-Item $output
+  #     - name: Download a older spiced
+  #       shell: pwsh
+  #       if: matrix.target.target_os == 'windows'
+  #       run: |
+  #         Set-Location "./build"
+  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spiced.exe_windows_x86_64.tar.gz"
+  #         $output = "spiced.exe_windows_x86_64.tar.gz"
+  #         Invoke-WebRequest -Uri $url -OutFile $output
+  #         tar -xzf $output
+  #         Remove-Item $output
 
-      - name: Download older spiced
-        if: matrix.target.target_os != 'windows'
-        run: |
-          cd ./build
-          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spiced_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-          output="spiced.tar.gz"
-          curl -L -o "$output" "$url"
-          tar -xzf "$output"
-          rm "$output"
-          chmod +x spiced
+  #     - name: Download older spiced
+  #       if: matrix.target.target_os != 'windows'
+  #       run: |
+  #         cd ./build
+  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spiced_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+  #         output="spiced.tar.gz"
+  #         curl -L -o "$output" "$url"
+  #         tar -xzf "$output"
+  #         rm "$output"
+  #         chmod +x spiced
 
-      - name: Install spice
-        uses: ./.github/actions/install-spice
-        with:
-          build-path: ./build
+  #     - name: Install spice
+  #       uses: ./.github/actions/install-spice
+  #       with:
+  #         build-path: ./build
 
-      - name: Run spice upgrade
-        run: |
-          spice upgrade
+  #     - name: Run spice upgrade
+  #       run: |
+  #         spice upgrade
 
-      - name: Check the temp directory (Windows)
-        if: matrix.target.target_os == 'windows'
-        run: |
-          Write-Host "System temp directory: $env:TEMP"
-          Get-ChildItem -Path $env:TEMP -Recurse |
-              Where-Object { $_.Name -like "spice*" } |
-              Select-Object FullName, Length, LastWriteTime |
-              Format-Table -AutoSize
+  #     - name: Check the temp directory (Windows)
+  #       if: matrix.target.target_os == 'windows'
+  #       run: |
+  #         Write-Host "System temp directory: $env:TEMP"
+  #         Get-ChildItem -Path $env:TEMP -Recurse |
+  #             Where-Object { $_.Name -like "spice*" } |
+  #             Select-Object FullName, Length, LastWriteTime |
+  #             Format-Table -AutoSize
 
-      - name: Run spice upgrade again
-        if: matrix.target.target_os == 'windows'
-        run: |
-          spice upgrade
+  #     - name: Run spice upgrade again
+  #       if: matrix.target.target_os == 'windows'
+  #       run: |
+  #         spice upgrade
 
-      - name: Check the temp directory (Windows)
-        if: matrix.target.target_os == 'windows'
-        run: |
-          Write-Host "System temp directory: $env:TEMP"
-          Get-ChildItem -Path $env:TEMP -Recurse |
-              Where-Object { $_.Name -like "spice*" } |
-              Select-Object FullName, Length, LastWriteTime |
-              Format-Table -AutoSize
+  #     - name: Check the temp directory (Windows)
+  #       if: matrix.target.target_os == 'windows'
+  #       run: |
+  #         Write-Host "System temp directory: $env:TEMP"
+  #         Get-ChildItem -Path $env:TEMP -Recurse |
+  #             Where-Object { $_.Name -like "spice*" } |
+  #             Select-Object FullName, Length, LastWriteTime |
+  #             Format-Table -AutoSize
 
-  test_spice_upgrade_without_runtime:
-    name: 'Test spice upgrade without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-    continue-on-error: true
-    runs-on: ${{ matrix.target.runner }}
-    env:
-      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs:
-      - build
-      - setup-matrix
-    timeout-minutes: 5
+  # test_spice_upgrade_without_runtime:
+  #   name: 'Test spice upgrade without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+  #   continue-on-error: true
+  #   runs-on: ${{ matrix.target.runner }}
+  #   env:
+  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   needs:
+  #     - build
+  #     - setup-matrix
+  #   timeout-minutes: 5
 
-    strategy:
-      matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+  #   strategy:
+  #     matrix:
+  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-        if: github.event.inputs.build_cli != 'false'
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          path: ./build
+  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #       if: github.event.inputs.build_cli != 'false'
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #         path: ./build
 
-      - name: download spice cli released version
-        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
-        run: |
-          mkdir -p ./build
-          cd ./build
-          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-          output="spice.tar.gz"
-          curl -L -o "$output" "$url"
-          tar -xzf "$output"
-          rm "$output"
-          chmod +x spice
+  #     - name: download spice cli released version
+  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
+  #       run: |
+  #         mkdir -p ./build
+  #         cd ./build
+  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+  #         output="spice.tar.gz"
+  #         curl -L -o "$output" "$url"
+  #         tar -xzf "$output"
+  #         rm "$output"
+  #         chmod +x spice
 
-      - name: download spice cli released version
-        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
-        run: |
-          New-Item -ItemType Directory -Force -Path "./build" > $null
-          Set-Location "./build"
-          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
-          $output = "spice.exe_windows_x86_64.tar.gz"
-          Invoke-WebRequest -Uri $url -OutFile $output
-          tar -xzf $output
-          Remove-Item $output
+  #     - name: download spice cli released version
+  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
+  #       run: |
+  #         New-Item -ItemType Directory -Force -Path "./build" > $null
+  #         Set-Location "./build"
+  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
+  #         $output = "spice.exe_windows_x86_64.tar.gz"
+  #         Invoke-WebRequest -Uri $url -OutFile $output
+  #         tar -xzf $output
+  #         Remove-Item $output
 
-      - name: Install Spice CLI
-        uses: ./.github/actions/install-spice-cli
-        with:
-          build-path: ./build
+  #     - name: Install Spice CLI
+  #       uses: ./.github/actions/install-spice-cli
+  #       with:
+  #         build-path: ./build
 
-      - name: Run spice upgrade
-        run: |
-          spice upgrade
+  #     - name: Run spice upgrade
+  #       run: |
+  #         spice upgrade
 
-      - name: Check the temp directory (Windows)
-        if: matrix.target.target_os == 'windows'
-        run: |
-          Write-Host "System temp directory: $env:TEMP"
-          Get-ChildItem -Path $env:TEMP -Recurse |
-              Where-Object { $_.Name -like "spice*" } |
-              Select-Object FullName, Length, LastWriteTime |
-              Format-Table -AutoSize
+  #     - name: Check the temp directory (Windows)
+  #       if: matrix.target.target_os == 'windows'
+  #       run: |
+  #         Write-Host "System temp directory: $env:TEMP"
+  #         Get-ChildItem -Path $env:TEMP -Recurse |
+  #             Where-Object { $_.Name -like "spice*" } |
+  #             Select-Object FullName, Length, LastWriteTime |
+  #             Format-Table -AutoSize
 
-      - name: Run spice upgrade again
-        if: matrix.target.target_os == 'windows'
-        run: |
-          spice upgrade
+  #     - name: Run spice upgrade again
+  #       if: matrix.target.target_os == 'windows'
+  #       run: |
+  #         spice upgrade
 
-      - name: Check the temp directory (Windows)
-        if: matrix.target.target_os == 'windows'
-        run: |
-          Write-Host "System temp directory: $env:TEMP"
-          Get-ChildItem -Path $env:TEMP -Recurse |
-              Where-Object { $_.Name -like "spice*" } |
-              Select-Object FullName, Length, LastWriteTime |
-              Format-Table -AutoSize
+  #     - name: Check the temp directory (Windows)
+  #       if: matrix.target.target_os == 'windows'
+  #       run: |
+  #         Write-Host "System temp directory: $env:TEMP"
+  #         Get-ChildItem -Path $env:TEMP -Recurse |
+  #             Where-Object { $_.Name -like "spice*" } |
+  #             Select-Object FullName, Length, LastWriteTime |
+  #             Format-Table -AutoSize
 
-  test_spice_install_without_runtime:
-    name: 'Test spice install without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-    continue-on-error: true
-    runs-on: ${{ matrix.target.runner }}
-    env:
-      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs:
-      - build
-      - setup-matrix
-    timeout-minutes: 5
+  # test_spice_install_without_runtime:
+  #   name: 'Test spice install without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+  #   continue-on-error: true
+  #   runs-on: ${{ matrix.target.runner }}
+  #   env:
+  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   needs:
+  #     - build
+  #     - setup-matrix
+  #   timeout-minutes: 5
 
-    strategy:
-      matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+  #   strategy:
+  #     matrix:
+  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-        if: github.event.inputs.build_cli != 'false'
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          path: ./build
+  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #       if: github.event.inputs.build_cli != 'false'
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #         path: ./build
 
-      - name: download spice cli released version
-        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
-        run: |
-          mkdir -p ./build
-          cd ./build
-          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-          output="spice.tar.gz"
-          curl -L -o "$output" "$url"
-          tar -xzf "$output"
-          rm "$output"
-          chmod +x spice
+  #     - name: download spice cli released version
+  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
+  #       run: |
+  #         mkdir -p ./build
+  #         cd ./build
+  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+  #         output="spice.tar.gz"
+  #         curl -L -o "$output" "$url"
+  #         tar -xzf "$output"
+  #         rm "$output"
+  #         chmod +x spice
 
-      - name: download spice cli released version
-        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
-        run: |
-          New-Item -ItemType Directory -Force -Path "./build" > $null
-          Set-Location "./build"
-          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
-          $output = "spice.exe_windows_x86_64.tar.gz"
-          Invoke-WebRequest -Uri $url -OutFile $output
-          tar -xzf $output
-          Remove-Item $output
+  #     - name: download spice cli released version
+  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
+  #       run: |
+  #         New-Item -ItemType Directory -Force -Path "./build" > $null
+  #         Set-Location "./build"
+  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
+  #         $output = "spice.exe_windows_x86_64.tar.gz"
+  #         Invoke-WebRequest -Uri $url -OutFile $output
+  #         tar -xzf $output
+  #         Remove-Item $output
 
-      - name: Install Spice CLI
-        uses: ./.github/actions/install-spice-cli
-        with:
-          build-path: ./build
+  #     - name: Install Spice CLI
+  #       uses: ./.github/actions/install-spice-cli
+  #       with:
+  #         build-path: ./build
 
-      - name: Run spice install
-        run: |
-          spice install
+  #     - name: Run spice install
+  #       run: |
+  #         spice install
 
-      - name: Run spice version
-        run: |
-          spice version
+  #     - name: Run spice version
+  #       run: |
+  #         spice version
 
-  test_spice_run_without_runtime:
-    name: 'Test spice run without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-    continue-on-error: true
-    runs-on: ${{ matrix.target.runner }}
-    env:
-      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs:
-      - build
-      - setup-matrix
-    timeout-minutes: 5
+  # test_spice_run_without_runtime:
+  #   name: 'Test spice run without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+  #   continue-on-error: true
+  #   runs-on: ${{ matrix.target.runner }}
+  #   env:
+  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   needs:
+  #     - build
+  #     - setup-matrix
+  #   timeout-minutes: 5
 
-    strategy:
-      matrix:
-        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+  #   strategy:
+  #     matrix:
+  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-        if: github.event.inputs.build_cli != 'false'
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          path: ./build
+  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #       if: github.event.inputs.build_cli != 'false'
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #         path: ./build
 
-      - name: download spice cli released version
-        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
-        run: |
-          mkdir -p ./build
-          cd ./build
-          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-          output="spice.tar.gz"
-          curl -L -o "$output" "$url"
-          tar -xzf "$output"
-          rm "$output"
-          chmod +x spice
+  #     - name: download spice cli released version
+  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
+  #       run: |
+  #         mkdir -p ./build
+  #         cd ./build
+  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+  #         output="spice.tar.gz"
+  #         curl -L -o "$output" "$url"
+  #         tar -xzf "$output"
+  #         rm "$output"
+  #         chmod +x spice
 
-      - name: download spice cli released version
-        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
-        run: |
-          New-Item -ItemType Directory -Force -Path "./build" > $null
-          Set-Location "./build"
-          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
-          $output = "spice.exe_windows_x86_64.tar.gz"
-          Invoke-WebRequest -Uri $url -OutFile $output
-          tar -xzf $output
-          Remove-Item $output
+  #     - name: download spice cli released version
+  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
+  #       run: |
+  #         New-Item -ItemType Directory -Force -Path "./build" > $null
+  #         Set-Location "./build"
+  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
+  #         $output = "spice.exe_windows_x86_64.tar.gz"
+  #         Invoke-WebRequest -Uri $url -OutFile $output
+  #         tar -xzf $output
+  #         Remove-Item $output
 
-      - name: Install Spice CLI
-        uses: ./.github/actions/install-spice-cli
-        with:
-          build-path: ./build
+  #     - name: Install Spice CLI
+  #       uses: ./.github/actions/install-spice-cli
+  #       with:
+  #         build-path: ./build
 
-      - name: Start spice runtime
-        if: matrix.target.target_os != 'windows'
-        run: |
-          spice run &> spice.log &
-          # time to download runtime
-          sleep 60
+  #     - name: Start spice runtime
+  #       if: matrix.target.target_os != 'windows'
+  #       run: |
+  #         spice run &> spice.log &
+  #         # time to download runtime
+  #         sleep 60
 
-      - name: Start spice runtime
-        if: matrix.target.target_os == 'windows'
-        run: |
-          Start-Process spice -ArgumentList "run" -NoNewWindow -RedirectStandardOutput "spice.stdout.log" -RedirectStandardError "spice.stderr.log"
-          # time to download runtime
-          Start-Sleep -Seconds 60
+  #     - name: Start spice runtime
+  #       if: matrix.target.target_os == 'windows'
+  #       run: |
+  #         Start-Process spice -ArgumentList "run" -NoNewWindow -RedirectStandardOutput "spice.stdout.log" -RedirectStandardError "spice.stderr.log"
+  #         # time to download runtime
+  #         Start-Sleep -Seconds 60
 
-      - name: Stop spice and check logs
-        if: always() && matrix.target.target_os != 'windows'
-        run: |
-          killall spice || true
-          cat spice.log
+  #     - name: Stop spice and check logs
+  #       if: always() && matrix.target.target_os != 'windows'
+  #       run: |
+  #         killall spice || true
+  #         cat spice.log
 
-      - name: Stop spice and check logs
-        if: always() && matrix.target.target_os == 'windows'
-        shell: pwsh
-        run: |
-          Get-Process -Name spice -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-          Get-Content spice.stdout.log, spice.stderr.log
+  #     - name: Stop spice and check logs
+  #       if: always() && matrix.target.target_os == 'windows'
+  #       shell: pwsh
+  #       run: |
+  #         Get-Process -Name spice -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+  #         Get-Content spice.stdout.log, spice.stderr.log
 
-      - name: Run spice version
-        run: |
-          spice version
+  #     - name: Run spice version
+  #       run: |
+  #         spice version
 
-  test_spice_upgrade_from_brew:
-    name: 'Test spice upgrade from a homebrew spice cli'
-    if: github.event.inputs.build_cli == 'true'
-    continue-on-error: true
-    runs-on: ${{ matrix.target.runner }}
-    env:
-      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs:
-      - build
-    timeout-minutes: 5
+  # test_spice_upgrade_from_brew:
+  #   name: 'Test spice upgrade from a homebrew spice cli'
+  #   if: github.event.inputs.build_cli == 'true'
+  #   continue-on-error: true
+  #   runs-on: ${{ matrix.target.runner }}
+  #   env:
+  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   needs:
+  #     - build
+  #   timeout-minutes: 5
 
-    strategy:
-      matrix:
-        target:
-          - name: "macOS aarch64 (Apple Silicon)"
-            runner: "macos-14"
-            target_os: "darwin"
-            target_arch: "aarch64"
-            target_arch_go: "arm64"
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         - name: "macOS aarch64 (Apple Silicon)"
+  #           runner: "macos-14"
+  #           target_os: "darwin"
+  #           target_arch: "aarch64"
+  #           target_arch_go: "arm64"
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-        if: github.event.inputs.build_cli != 'false'
-        uses: actions/download-artifact@v4
-        with:
-          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-          path: ./build
+  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #       if: github.event.inputs.build_cli != 'false'
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+  #         path: ./build
 
-      - name: download spice cli from homebrew
-        run: |
-          brew install spiceai/spiceai/spice
-          spice version
-          which spice
+  #     - name: download spice cli from homebrew
+  #       run: |
+  #         brew install spiceai/spiceai/spice
+  #         spice version
+  #         which spice
 
-      - name: move the built spice cli to brew directory
-        run: |
-          sudo mv ./build/spice /opt/homebrew/bin
-          sudo chmod +x /opt/homebrew/bin/spice
-          which spice
-          spice version
+  #     - name: move the built spice cli to brew directory
+  #       run: |
+  #         sudo mv ./build/spice /opt/homebrew/bin
+  #         sudo chmod +x /opt/homebrew/bin/spice
+  #         which spice
+  #         spice version
 
-      - name: run spice upgrade
-        run: |
-          spice upgrade
+  #     - name: run spice upgrade
+  #       run: |
+  #         spice upgrade
 
   test_spice_chat:
     name: 'Test spice chat'

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -547,11 +547,11 @@ jobs:
 
       - name: Test `spice chat` error
         run: |
-          ./test/cli/spice_chat_error.exp
+          expect ./test/cli/spice_chat_error.exp
 
       - name: Test `spice chat <message>`
         run: |
-          ./test/cli/spice_chat_message.exp
+          expect ./test/cli/spice_chat_message.exp
 
       - name: Stop spice and check logs
         if: always()

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -104,384 +104,384 @@ jobs:
           path: |
             spice.exe
 
-  # test_spice_upgrade_with_runtime:
-  #   name: 'Test spice upgrade (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-  #   continue-on-error: true
-  #   runs-on: ${{ matrix.target.runner }}
-  #   env:
-  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   needs:
-  #     - build
-  #     - setup-matrix
-  #   timeout-minutes: 5
+  test_spice_upgrade_with_runtime:
+    name: 'Test spice upgrade (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+    continue-on-error: true
+    runs-on: ${{ matrix.target.runner }}
+    env:
+      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs:
+      - build
+      - setup-matrix
+    timeout-minutes: 5
 
-  #   strategy:
-  #     matrix:
-  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #       if: github.event.inputs.build_cli != 'false'
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #         path: ./build
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+        if: github.event.inputs.build_cli != 'false'
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: ./build
 
-  #     - name: download spice cli released version
-  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
-  #       run: |
-  #         mkdir -p ./build
-  #         cd ./build
-  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-  #         output="spice.tar.gz"
-  #         curl -L -o "$output" "$url"
-  #         tar -xzf "$output"
-  #         rm "$output"
-  #         chmod +x spice
+      - name: download spice cli released version
+        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
+        run: |
+          mkdir -p ./build
+          cd ./build
+          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+          output="spice.tar.gz"
+          curl -L -o "$output" "$url"
+          tar -xzf "$output"
+          rm "$output"
+          chmod +x spice
 
-  #     - name: download spice cli released version
-  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
-  #       run: |
-  #         New-Item -ItemType Directory -Force -Path "./build" > $null
-  #         Set-Location "./build"
-  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
-  #         $output = "spice.exe_windows_x86_64.tar.gz"
-  #         Invoke-WebRequest -Uri $url -OutFile $output
-  #         tar -xzf $output
-  #         Remove-Item $output
+      - name: download spice cli released version
+        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
+        run: |
+          New-Item -ItemType Directory -Force -Path "./build" > $null
+          Set-Location "./build"
+          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
+          $output = "spice.exe_windows_x86_64.tar.gz"
+          Invoke-WebRequest -Uri $url -OutFile $output
+          tar -xzf $output
+          Remove-Item $output
 
-  #     - name: Download a older spiced
-  #       shell: pwsh
-  #       if: matrix.target.target_os == 'windows'
-  #       run: |
-  #         Set-Location "./build"
-  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spiced.exe_windows_x86_64.tar.gz"
-  #         $output = "spiced.exe_windows_x86_64.tar.gz"
-  #         Invoke-WebRequest -Uri $url -OutFile $output
-  #         tar -xzf $output
-  #         Remove-Item $output
+      - name: Download a older spiced
+        shell: pwsh
+        if: matrix.target.target_os == 'windows'
+        run: |
+          Set-Location "./build"
+          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spiced.exe_windows_x86_64.tar.gz"
+          $output = "spiced.exe_windows_x86_64.tar.gz"
+          Invoke-WebRequest -Uri $url -OutFile $output
+          tar -xzf $output
+          Remove-Item $output
 
-  #     - name: Download older spiced
-  #       if: matrix.target.target_os != 'windows'
-  #       run: |
-  #         cd ./build
-  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spiced_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-  #         output="spiced.tar.gz"
-  #         curl -L -o "$output" "$url"
-  #         tar -xzf "$output"
-  #         rm "$output"
-  #         chmod +x spiced
+      - name: Download older spiced
+        if: matrix.target.target_os != 'windows'
+        run: |
+          cd ./build
+          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spiced_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+          output="spiced.tar.gz"
+          curl -L -o "$output" "$url"
+          tar -xzf "$output"
+          rm "$output"
+          chmod +x spiced
 
-  #     - name: Install spice
-  #       uses: ./.github/actions/install-spice
-  #       with:
-  #         build-path: ./build
+      - name: Install spice
+        uses: ./.github/actions/install-spice
+        with:
+          build-path: ./build
 
-  #     - name: Run spice upgrade
-  #       run: |
-  #         spice upgrade
+      - name: Run spice upgrade
+        run: |
+          spice upgrade
 
-  #     - name: Check the temp directory (Windows)
-  #       if: matrix.target.target_os == 'windows'
-  #       run: |
-  #         Write-Host "System temp directory: $env:TEMP"
-  #         Get-ChildItem -Path $env:TEMP -Recurse |
-  #             Where-Object { $_.Name -like "spice*" } |
-  #             Select-Object FullName, Length, LastWriteTime |
-  #             Format-Table -AutoSize
+      - name: Check the temp directory (Windows)
+        if: matrix.target.target_os == 'windows'
+        run: |
+          Write-Host "System temp directory: $env:TEMP"
+          Get-ChildItem -Path $env:TEMP -Recurse |
+              Where-Object { $_.Name -like "spice*" } |
+              Select-Object FullName, Length, LastWriteTime |
+              Format-Table -AutoSize
 
-  #     - name: Run spice upgrade again
-  #       if: matrix.target.target_os == 'windows'
-  #       run: |
-  #         spice upgrade
+      - name: Run spice upgrade again
+        if: matrix.target.target_os == 'windows'
+        run: |
+          spice upgrade
 
-  #     - name: Check the temp directory (Windows)
-  #       if: matrix.target.target_os == 'windows'
-  #       run: |
-  #         Write-Host "System temp directory: $env:TEMP"
-  #         Get-ChildItem -Path $env:TEMP -Recurse |
-  #             Where-Object { $_.Name -like "spice*" } |
-  #             Select-Object FullName, Length, LastWriteTime |
-  #             Format-Table -AutoSize
+      - name: Check the temp directory (Windows)
+        if: matrix.target.target_os == 'windows'
+        run: |
+          Write-Host "System temp directory: $env:TEMP"
+          Get-ChildItem -Path $env:TEMP -Recurse |
+              Where-Object { $_.Name -like "spice*" } |
+              Select-Object FullName, Length, LastWriteTime |
+              Format-Table -AutoSize
 
-  # test_spice_upgrade_without_runtime:
-  #   name: 'Test spice upgrade without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-  #   continue-on-error: true
-  #   runs-on: ${{ matrix.target.runner }}
-  #   env:
-  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   needs:
-  #     - build
-  #     - setup-matrix
-  #   timeout-minutes: 5
+  test_spice_upgrade_without_runtime:
+    name: 'Test spice upgrade without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+    continue-on-error: true
+    runs-on: ${{ matrix.target.runner }}
+    env:
+      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs:
+      - build
+      - setup-matrix
+    timeout-minutes: 5
 
-  #   strategy:
-  #     matrix:
-  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #       if: github.event.inputs.build_cli != 'false'
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #         path: ./build
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+        if: github.event.inputs.build_cli != 'false'
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: ./build
 
-  #     - name: download spice cli released version
-  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
-  #       run: |
-  #         mkdir -p ./build
-  #         cd ./build
-  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-  #         output="spice.tar.gz"
-  #         curl -L -o "$output" "$url"
-  #         tar -xzf "$output"
-  #         rm "$output"
-  #         chmod +x spice
+      - name: download spice cli released version
+        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
+        run: |
+          mkdir -p ./build
+          cd ./build
+          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+          output="spice.tar.gz"
+          curl -L -o "$output" "$url"
+          tar -xzf "$output"
+          rm "$output"
+          chmod +x spice
 
-  #     - name: download spice cli released version
-  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
-  #       run: |
-  #         New-Item -ItemType Directory -Force -Path "./build" > $null
-  #         Set-Location "./build"
-  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
-  #         $output = "spice.exe_windows_x86_64.tar.gz"
-  #         Invoke-WebRequest -Uri $url -OutFile $output
-  #         tar -xzf $output
-  #         Remove-Item $output
+      - name: download spice cli released version
+        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
+        run: |
+          New-Item -ItemType Directory -Force -Path "./build" > $null
+          Set-Location "./build"
+          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
+          $output = "spice.exe_windows_x86_64.tar.gz"
+          Invoke-WebRequest -Uri $url -OutFile $output
+          tar -xzf $output
+          Remove-Item $output
 
-  #     - name: Install Spice CLI
-  #       uses: ./.github/actions/install-spice-cli
-  #       with:
-  #         build-path: ./build
+      - name: Install Spice CLI
+        uses: ./.github/actions/install-spice-cli
+        with:
+          build-path: ./build
 
-  #     - name: Run spice upgrade
-  #       run: |
-  #         spice upgrade
+      - name: Run spice upgrade
+        run: |
+          spice upgrade
 
-  #     - name: Check the temp directory (Windows)
-  #       if: matrix.target.target_os == 'windows'
-  #       run: |
-  #         Write-Host "System temp directory: $env:TEMP"
-  #         Get-ChildItem -Path $env:TEMP -Recurse |
-  #             Where-Object { $_.Name -like "spice*" } |
-  #             Select-Object FullName, Length, LastWriteTime |
-  #             Format-Table -AutoSize
+      - name: Check the temp directory (Windows)
+        if: matrix.target.target_os == 'windows'
+        run: |
+          Write-Host "System temp directory: $env:TEMP"
+          Get-ChildItem -Path $env:TEMP -Recurse |
+              Where-Object { $_.Name -like "spice*" } |
+              Select-Object FullName, Length, LastWriteTime |
+              Format-Table -AutoSize
 
-  #     - name: Run spice upgrade again
-  #       if: matrix.target.target_os == 'windows'
-  #       run: |
-  #         spice upgrade
+      - name: Run spice upgrade again
+        if: matrix.target.target_os == 'windows'
+        run: |
+          spice upgrade
 
-  #     - name: Check the temp directory (Windows)
-  #       if: matrix.target.target_os == 'windows'
-  #       run: |
-  #         Write-Host "System temp directory: $env:TEMP"
-  #         Get-ChildItem -Path $env:TEMP -Recurse |
-  #             Where-Object { $_.Name -like "spice*" } |
-  #             Select-Object FullName, Length, LastWriteTime |
-  #             Format-Table -AutoSize
+      - name: Check the temp directory (Windows)
+        if: matrix.target.target_os == 'windows'
+        run: |
+          Write-Host "System temp directory: $env:TEMP"
+          Get-ChildItem -Path $env:TEMP -Recurse |
+              Where-Object { $_.Name -like "spice*" } |
+              Select-Object FullName, Length, LastWriteTime |
+              Format-Table -AutoSize
 
-  # test_spice_install_without_runtime:
-  #   name: 'Test spice install without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-  #   continue-on-error: true
-  #   runs-on: ${{ matrix.target.runner }}
-  #   env:
-  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   needs:
-  #     - build
-  #     - setup-matrix
-  #   timeout-minutes: 5
+  test_spice_install_without_runtime:
+    name: 'Test spice install without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+    continue-on-error: true
+    runs-on: ${{ matrix.target.runner }}
+    env:
+      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs:
+      - build
+      - setup-matrix
+    timeout-minutes: 5
 
-  #   strategy:
-  #     matrix:
-  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #       if: github.event.inputs.build_cli != 'false'
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #         path: ./build
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+        if: github.event.inputs.build_cli != 'false'
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: ./build
 
-  #     - name: download spice cli released version
-  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
-  #       run: |
-  #         mkdir -p ./build
-  #         cd ./build
-  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-  #         output="spice.tar.gz"
-  #         curl -L -o "$output" "$url"
-  #         tar -xzf "$output"
-  #         rm "$output"
-  #         chmod +x spice
+      - name: download spice cli released version
+        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
+        run: |
+          mkdir -p ./build
+          cd ./build
+          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+          output="spice.tar.gz"
+          curl -L -o "$output" "$url"
+          tar -xzf "$output"
+          rm "$output"
+          chmod +x spice
 
-  #     - name: download spice cli released version
-  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
-  #       run: |
-  #         New-Item -ItemType Directory -Force -Path "./build" > $null
-  #         Set-Location "./build"
-  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
-  #         $output = "spice.exe_windows_x86_64.tar.gz"
-  #         Invoke-WebRequest -Uri $url -OutFile $output
-  #         tar -xzf $output
-  #         Remove-Item $output
+      - name: download spice cli released version
+        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
+        run: |
+          New-Item -ItemType Directory -Force -Path "./build" > $null
+          Set-Location "./build"
+          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
+          $output = "spice.exe_windows_x86_64.tar.gz"
+          Invoke-WebRequest -Uri $url -OutFile $output
+          tar -xzf $output
+          Remove-Item $output
 
-  #     - name: Install Spice CLI
-  #       uses: ./.github/actions/install-spice-cli
-  #       with:
-  #         build-path: ./build
+      - name: Install Spice CLI
+        uses: ./.github/actions/install-spice-cli
+        with:
+          build-path: ./build
 
-  #     - name: Run spice install
-  #       run: |
-  #         spice install
+      - name: Run spice install
+        run: |
+          spice install
 
-  #     - name: Run spice version
-  #       run: |
-  #         spice version
+      - name: Run spice version
+        run: |
+          spice version
 
-  # test_spice_run_without_runtime:
-  #   name: 'Test spice run without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-  #   continue-on-error: true
-  #   runs-on: ${{ matrix.target.runner }}
-  #   env:
-  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   needs:
-  #     - build
-  #     - setup-matrix
-  #   timeout-minutes: 5
+  test_spice_run_without_runtime:
+    name: 'Test spice run without runtime (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
+    continue-on-error: true
+    runs-on: ${{ matrix.target.runner }}
+    env:
+      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs:
+      - build
+      - setup-matrix
+    timeout-minutes: 5
 
-  #   strategy:
-  #     matrix:
-  #       target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #       if: github.event.inputs.build_cli != 'false'
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #         path: ./build
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+        if: github.event.inputs.build_cli != 'false'
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: ./build
 
-  #     - name: download spice cli released version
-  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
-  #       run: |
-  #         mkdir -p ./build
-  #         cd ./build
-  #         url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
-  #         output="spice.tar.gz"
-  #         curl -L -o "$output" "$url"
-  #         tar -xzf "$output"
-  #         rm "$output"
-  #         chmod +x spice
+      - name: download spice cli released version
+        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os != 'windows'
+        run: |
+          mkdir -p ./build
+          cd ./build
+          url="https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}.tar.gz"
+          output="spice.tar.gz"
+          curl -L -o "$output" "$url"
+          tar -xzf "$output"
+          rm "$output"
+          chmod +x spice
 
-  #     - name: download spice cli released version
-  #       if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
-  #       run: |
-  #         New-Item -ItemType Directory -Force -Path "./build" > $null
-  #         Set-Location "./build"
-  #         $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
-  #         $output = "spice.exe_windows_x86_64.tar.gz"
-  #         Invoke-WebRequest -Uri $url -OutFile $output
-  #         tar -xzf $output
-  #         Remove-Item $output
+      - name: download spice cli released version
+        if: github.event.inputs.build_cli == 'false' && matrix.target.target_os == 'windows'
+        run: |
+          New-Item -ItemType Directory -Force -Path "./build" > $null
+          Set-Location "./build"
+          $url = "https://github.com/spiceai/spiceai/releases/download/v${{ env.REL_VERSION }}/spice.exe_windows_x86_64.tar.gz"
+          $output = "spice.exe_windows_x86_64.tar.gz"
+          Invoke-WebRequest -Uri $url -OutFile $output
+          tar -xzf $output
+          Remove-Item $output
 
-  #     - name: Install Spice CLI
-  #       uses: ./.github/actions/install-spice-cli
-  #       with:
-  #         build-path: ./build
+      - name: Install Spice CLI
+        uses: ./.github/actions/install-spice-cli
+        with:
+          build-path: ./build
 
-  #     - name: Start spice runtime
-  #       if: matrix.target.target_os != 'windows'
-  #       run: |
-  #         spice run &> spice.log &
-  #         # time to download runtime
-  #         sleep 60
+      - name: Start spice runtime
+        if: matrix.target.target_os != 'windows'
+        run: |
+          spice run &> spice.log &
+          # time to download runtime
+          sleep 60
 
-  #     - name: Start spice runtime
-  #       if: matrix.target.target_os == 'windows'
-  #       run: |
-  #         Start-Process spice -ArgumentList "run" -NoNewWindow -RedirectStandardOutput "spice.stdout.log" -RedirectStandardError "spice.stderr.log"
-  #         # time to download runtime
-  #         Start-Sleep -Seconds 60
+      - name: Start spice runtime
+        if: matrix.target.target_os == 'windows'
+        run: |
+          Start-Process spice -ArgumentList "run" -NoNewWindow -RedirectStandardOutput "spice.stdout.log" -RedirectStandardError "spice.stderr.log"
+          # time to download runtime
+          Start-Sleep -Seconds 60
 
-  #     - name: Stop spice and check logs
-  #       if: always() && matrix.target.target_os != 'windows'
-  #       run: |
-  #         killall spice || true
-  #         cat spice.log
+      - name: Stop spice and check logs
+        if: always() && matrix.target.target_os != 'windows'
+        run: |
+          killall spice || true
+          cat spice.log
 
-  #     - name: Stop spice and check logs
-  #       if: always() && matrix.target.target_os == 'windows'
-  #       shell: pwsh
-  #       run: |
-  #         Get-Process -Name spice -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-  #         Get-Content spice.stdout.log, spice.stderr.log
+      - name: Stop spice and check logs
+        if: always() && matrix.target.target_os == 'windows'
+        shell: pwsh
+        run: |
+          Get-Process -Name spice -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+          Get-Content spice.stdout.log, spice.stderr.log
 
-  #     - name: Run spice version
-  #       run: |
-  #         spice version
+      - name: Run spice version
+        run: |
+          spice version
 
-  # test_spice_upgrade_from_brew:
-  #   name: 'Test spice upgrade from a homebrew spice cli'
-  #   if: github.event.inputs.build_cli == 'true'
-  #   continue-on-error: true
-  #   runs-on: ${{ matrix.target.runner }}
-  #   env:
-  #     REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   needs:
-  #     - build
-  #   timeout-minutes: 5
+  test_spice_upgrade_from_brew:
+    name: 'Test spice upgrade from a homebrew spice cli'
+    if: github.event.inputs.build_cli == 'true'
+    continue-on-error: true
+    runs-on: ${{ matrix.target.runner }}
+    env:
+      REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs:
+      - build
+    timeout-minutes: 5
 
-  #   strategy:
-  #     matrix:
-  #       target:
-  #         - name: "macOS aarch64 (Apple Silicon)"
-  #           runner: "macos-14"
-  #           target_os: "darwin"
-  #           target_arch: "aarch64"
-  #           target_arch_go: "arm64"
+    strategy:
+      matrix:
+        target:
+          - name: "macOS aarch64 (Apple Silicon)"
+            runner: "macos-14"
+            target_os: "darwin"
+            target_arch: "aarch64"
+            target_arch_go: "arm64"
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #       if: github.event.inputs.build_cli != 'false'
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
-  #         path: ./build
+      - name: download artifacts - build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+        if: github.event.inputs.build_cli != 'false'
+        uses: actions/download-artifact@v4
+        with:
+          name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          path: ./build
 
-  #     - name: download spice cli from homebrew
-  #       run: |
-  #         brew install spiceai/spiceai/spice
-  #         spice version
-  #         which spice
+      - name: download spice cli from homebrew
+        run: |
+          brew install spiceai/spiceai/spice
+          spice version
+          which spice
 
-  #     - name: move the built spice cli to brew directory
-  #       run: |
-  #         sudo mv ./build/spice /opt/homebrew/bin
-  #         sudo chmod +x /opt/homebrew/bin/spice
-  #         which spice
-  #         spice version
+      - name: move the built spice cli to brew directory
+        run: |
+          sudo mv ./build/spice /opt/homebrew/bin
+          sudo chmod +x /opt/homebrew/bin/spice
+          which spice
+          spice version
 
-  #     - name: run spice upgrade
-  #       run: |
-  #         spice upgrade
+      - name: run spice upgrade
+        run: |
+          spice upgrade
 
   test_spice_chat:
     name: 'Test spice chat'

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -521,7 +521,7 @@ jobs:
 
       - name: Init spice app
         run: |
-          cp ./test/models/spicepod_openai.yml ./spicepod.yaml
+          cp ./test/cli/spicepod_openai.yml ./spicepod.yaml
           cat ./spicepod.yaml
 
       - name: Start spice runtime

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -545,6 +545,10 @@ jobs:
         run: |
           ./test/cli/spice_chat_error.exp
 
+      - name: Test `spice chat <message>`
+        run: |
+          ./test/cli/spice_chat_message.exp
+
       - name: Stop spice and check logs
         if: always()
         run: |

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -138,8 +138,19 @@ spice chat --model <model>
 
 # Start a chat session with spiced instance in spice.ai cloud
 spice chat --model <model> --cloud
+
+# Send a single message and exit
+spice chat --model <model> "What is Spice.ai?"
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 1 {
+			slog.Error("too many arguments provided", "expected", "0 or 1", "got", len(args))
+			cmd.Println("Usage: spice chat [message]")
+			cmd.Println("  - With no message: starts an interactive chat")
+			cmd.Println("  - With one message: sends the message and exits")
+			os.Exit(1)
+		}
+
 		cloud, _ := cmd.Flags().GetBool(cloudKeyFlag)
 		rtcontext := context.NewContext().WithCloud(cloud)
 		err := rtcontext.Init()
@@ -247,31 +258,18 @@ spice chat --model <model> --cloud
 			}
 		}
 
-		var messages = []Message{}
+		getChatResponse := func(messages []Message, useSpinner bool) error {
+			// Only create these variables if using spinner
+			var done chan bool
+			var doneLoading bool
 
-		line := liner.NewLiner()
-		line.SetCtrlCAborts(true)
-		defer func() {
-			if err := line.Close(); err != nil {
-				slog.Error("closing line", "error", err)
+			if useSpinner {
+				done = make(chan bool)
+				doneLoading = false
+				go func() {
+					util.ShowSpinner(done)
+				}()
 			}
-		}()
-		for {
-			message, err := line.Prompt("chat> ")
-			if err == liner.ErrPromptAborted {
-				break
-			} else if err != nil {
-				slog.Error("reading input line", "error", err)
-				continue
-			}
-
-			line.AppendHistory(message)
-			messages = append(messages, Message{Role: "user", Content: message})
-
-			done := make(chan bool)
-			go func() {
-				util.ShowSpinner(done)
-			}()
 
 			body := NewChatRequestBody(messages, model, true, &StreamOptions{
 				IncludeUsage: true,
@@ -284,7 +282,7 @@ spice chat --model <model> --cloud
 			response, err := sendChatRequest(rtcontext, body)
 			if err != nil {
 				slog.Error("failed to send chat request to spiced", "error", err)
-				continue
+				return fmt.Errorf("failed to send chat request: %w", err)
 			}
 
 			scanner := bufio.NewScanner(response.Body)
@@ -292,7 +290,10 @@ spice chat --model <model> --cloud
 
 			/// Usage for the entire stream, and related timing.
 			var usage Usage
-			doneLoading := false
+
+			if useSpinner {
+				doneLoading = false
+			}
 
 			for scanner.Scan() {
 				chunk := scanner.Text()
@@ -324,7 +325,7 @@ spice chat --model <model> --cloud
 					continue
 				}
 
-				if !doneLoading {
+				if useSpinner && !doneLoading {
 					done <- true
 					doneLoading = true
 				}
@@ -344,10 +345,10 @@ spice chat --model <model> --cloud
 			}
 
 			if err := scanner.Err(); err != nil {
-				slog.Error("error occurred while processing the input stream", "error", err)
+				slog.Error("error occurred while processing the response stream", "error", err)
 			}
 
-			if !doneLoading {
+			if useSpinner && !doneLoading {
 				done <- true
 				doneLoading = true
 			}
@@ -363,6 +364,50 @@ spice chat --model <model> --cloud
 				))
 			} else {
 				cmd.Print("\n\n")
+			}
+
+			return nil
+		}
+
+		if len(args) > 0 {
+			userMessage := args[0]
+
+			var messages = []Message{
+				{Role: "user", Content: userMessage},
+			}
+
+			err = getChatResponse(messages, false)
+			if err != nil {
+				os.Exit(1)
+			}
+
+			return
+		}
+
+		var messages = []Message{}
+
+		line := liner.NewLiner()
+		line.SetCtrlCAborts(true)
+		defer func() {
+			if err := line.Close(); err != nil {
+				slog.Error("closing line", "error", err)
+			}
+		}()
+		for {
+			message, err := line.Prompt("chat> ")
+			if err == liner.ErrPromptAborted {
+				break
+			} else if err != nil {
+				slog.Error("reading input line", "error", err)
+				continue
+			}
+
+			line.AppendHistory(message)
+			messages = append(messages, Message{Role: "user", Content: message})
+
+			err = getChatResponse(messages, true)
+			if err != nil {
+				continue
 			}
 		}
 	},

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -258,7 +258,7 @@ spice chat --model <model> "What is Spice.ai?"
 			}
 		}
 
-		getChatResponse := func(messages []Message, useSpinner bool) error {
+		getChatResponse := func(messages []Message, useSpinner bool) ([]Message, error) {
 			// Only create these variables if using spinner
 			var done chan bool
 			var doneLoading bool
@@ -282,7 +282,7 @@ spice chat --model <model> "What is Spice.ai?"
 			response, err := sendChatRequest(rtcontext, body)
 			if err != nil {
 				slog.Error("failed to send chat request to spiced", "error", err)
-				return fmt.Errorf("failed to send chat request: %w", err)
+				return messages, fmt.Errorf("failed to send chat request: %w", err)
 			}
 
 			scanner := bufio.NewScanner(response.Body)
@@ -350,7 +350,6 @@ spice chat --model <model> "What is Spice.ai?"
 
 			if useSpinner && !doneLoading {
 				done <- true
-				doneLoading = true
 			}
 
 			if responseMessage != "" {
@@ -366,7 +365,7 @@ spice chat --model <model> "What is Spice.ai?"
 				cmd.Print("\n\n")
 			}
 
-			return nil
+			return messages, nil
 		}
 
 		if len(args) > 0 {
@@ -376,7 +375,7 @@ spice chat --model <model> "What is Spice.ai?"
 				{Role: "user", Content: userMessage},
 			}
 
-			err = getChatResponse(messages, false)
+			_, err = getChatResponse(messages, false)
 			if err != nil {
 				os.Exit(1)
 			}
@@ -405,7 +404,7 @@ spice chat --model <model> "What is Spice.ai?"
 			line.AppendHistory(message)
 			messages = append(messages, Message{Role: "user", Content: message})
 
-			err = getChatResponse(messages, true)
+			messages, err = getChatResponse(messages, true)
 			if err != nil {
 				continue
 			}

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -139,7 +139,7 @@ spice chat --model <model>
 # Start a chat session with spiced instance in spice.ai cloud
 spice chat --model <model> --cloud
 
-# Send a single message and exit
+# Send a single prompt and receive a response
 spice chat --model <model> "What is Spice.ai?"
 `,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/bin/spice/cmd/chat.go
+++ b/bin/spice/cmd/chat.go
@@ -130,8 +130,11 @@ type OpenAIErrorResponse struct {
 }
 
 var chatCmd = &cobra.Command{
-	Use:   "chat",
+	Use:   "chat [flags] [message]",
 	Short: "Chat with the Spice.ai LLM agent",
+	Long: `Chat with the Spice.ai LLM agent.
+	With no message argument: starts an interactive chat session.
+	With one message argument: sends the message and exits.`,
 	Example: `
 # Start a chat session with local spiced instance
 spice chat --model <model>
@@ -142,15 +145,8 @@ spice chat --model <model> --cloud
 # Send a single message and exit
 spice chat --model <model> "What is Spice.ai?"
 `,
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 {
-			slog.Error("too many arguments provided", "expected", "0 or 1", "got", len(args))
-			cmd.Println("Usage: spice chat [message]")
-			cmd.Println("  - With no message: starts an interactive chat")
-			cmd.Println("  - With one message: sends the message and exits")
-			os.Exit(1)
-		}
-
 		cloud, _ := cmd.Flags().GetBool(cloudKeyFlag)
 		rtcontext := context.NewContext().WithCloud(cloud)
 		err := rtcontext.Init()

--- a/test/cli/spice_chat_error.exp
+++ b/test/cli/spice_chat_error.exp
@@ -24,10 +24,10 @@ proc test_invalid_model {} {
     }
 
     # Check that expected models are in the list
-    if {[regexp {openai-gpt} $output]} {
-        puts "✓ Found expected model 'openai-gpt' in the list"
+    if {[regexp {model1} $output]} {
+        puts "✓ Found expected model 'model1' in the list"
     } else {
-        puts "✗ Expected model 'openai-gpt' not found in the list"
+        puts "✗ Expected model 'model1' not found in the list"
         exit 1
     }
 

--- a/test/cli/spice_chat_message.exp
+++ b/test/cli/spice_chat_message.exp
@@ -1,0 +1,111 @@
+# Test single message mode (non-interactive)
+proc test_spice_chat_message {} {
+    set command "spice chat \"hello\" --model model1"
+
+    puts "Testing single message mode..."
+
+    # Use spawn instead of exec to observe process behavior
+    spawn {*}[split $command]
+
+    set timeout 30
+
+    # Look for either completion or chat prompt
+    expect {
+        "Spice.ai OSS CLI" {
+            exp_continue
+        }
+        "chat>" {
+            puts "✗ Command entered interactive mode when it shouldn't have"
+            exit 1
+        }
+        eof {
+            # Command terminated, this is the expected behavior of `spice chat <message>`
+            puts "✓ Command completed without entering interactive mode"
+        }
+    }
+
+    set output $expect_out(buffer)
+
+    if {[string length $output] > 1} {
+        puts "✓ Command produced output of reasonable length"
+    } else {
+        puts "✗ Command produced insufficient output"
+        exit 1
+    }
+
+    puts "✓ spice chat <message> test passed"
+}
+
+# Test selection of model when running spice chat with a message
+proc test_spice_chat_model_select {} {
+    set command "spice chat \"hello\""
+    puts "Testing spice chat <message> with model selection..."
+
+    spawn {*}[split $command]
+
+    set full_output ""
+
+    # Wait for the model selection prompt
+    expect {
+        "Spice.ai OSS CLI" {
+            append full_output $expect_out(buffer)
+            exp_continue
+        }
+        "Use the arrow keys to navigate:" {
+            puts "✓ Model selection prompt appeared"
+            append full_output $expect_out(buffer)
+        }
+        timeout {
+            puts "✗ Model selection prompt did not appear"
+            exit 1
+        }
+    }
+
+    # Press Enter to select the first model
+    send "\r"
+
+    # Check model confirmation
+    expect {
+        "Using model:" {
+            puts "✓ Model selection confirmed"
+            append full_output $expect_out(buffer)
+        }
+        timeout {
+            puts "✗ Model selection confirmation not shown"
+            exit 1
+        }
+    }
+
+    set timeout 30
+    expect {
+        -re {Time:.*Tokens:.*\n} {
+            puts "✓ Complete response with usage statistics received"
+            append full_output $expect_out(buffer)
+        }
+        timeout {
+            puts "✗ Usage statistics not shown within timeout"
+            exit 1
+        }
+        eof {
+            puts "✗ Command terminated unexpectedly"
+            exit 1
+        }
+    }
+
+    puts "Full output captured:\n$full_output"
+
+    if {[regexp {Using model:} $full_output] &&
+        [regexp {Time:.*Tokens:} $full_output] &&
+        [string length $full_output] > 1} {
+        puts "✓ Complete response cycle verified"
+    } else {
+        puts "✗ Incomplete response cycle"
+        exit 1
+    }
+
+    puts "✓ Model selection test passed"
+}
+
+test_spice_chat_message
+test_spice_chat_model_select
+exit 0

--- a/test/cli/spicepod_openai.yml
+++ b/test/cli/spicepod_openai.yml
@@ -4,6 +4,11 @@ name: ai-test-spicepod
 
 models:
   - from: openai:gpt-4o-mini
-    name: openai-gpt
+    name: model1
+    params:
+      openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
+
+  - from: openai:gpt-4o-mini
+    name: model2
     params:
       openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }


### PR DESCRIPTION
# 🗣 Description

Implement an E2E test to cover the new `spice chat <message>` feature with multiple being available in spice runtime. Test scenarios include:
- `spice chat --model model1 "some_message"`, the response should be directly returned without initiating any interactive selector / chat REPL
- `spice chat "some_message"`, a interactive model selector should first pop up, and after the model selection the the response should be directly returned without initiating any interactive chat REPL

Branch based on top of the `spice chat message` change. All tests passed in CI: https://github.com/spiceai/spiceai/actions/runs/14568803132/job/40862274610

## 🔨 Related Issues

- Close: https://github.com/spiceai/spiceai/issues/5446

## ⛓️‍💥 Breaking Change

<!-- Remove this block is this PR is not a breaking change -->

* [ ] "Breaking Change" label added if this PR is a breaking change

## 📄 Documentation Updates

<!-- list any documentation related issues, cookbook recipes or video content related to this PR -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
