### PR TITLE
Support unparsing UNION for distinct results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3265,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "log",
  "tokio",
@@ -3320,12 +3320,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 
 [[package]]
 name = "datafusion-execution"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "dashmap",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "chrono",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3474,7 +3474,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3497,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3512,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "chrono",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3624,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=e0e423e9e29a711d076892865d51747b06429d1b#e0e423e9e29a711d076892865d51747b06429d1b"
+source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3265,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "log",
  "tokio",
@@ -3320,12 +3320,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 
 [[package]]
 name = "datafusion-execution"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "dashmap",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "chrono",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3474,7 +3474,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3497,7 +3497,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3512,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "chrono",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3624,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=113ca6dbf7baa96eaf4e58f5d473427b415081ab#113ca6dbf7baa96eaf4e58f5d473427b415081ab"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,10 +162,10 @@ uuid = "1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "e0e423e9e29a711d076892865d51747b06429d1b" } # spiceai-45
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e0e423e9e29a711d076892865d51747b06429d1b" } # spiceai-45
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "e0e423e9e29a711d076892865d51747b06429d1b" } # spiceai-45
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "e0e423e9e29a711d076892865d51747b06429d1b" } # spiceai-45
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "bfde649a9622d1a89172a1ba08b7a66945a030d5" } # spiceai-45
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "bfde649a9622d1a89172a1ba08b7a66945a030d5" } # spiceai-45
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "bfde649a9622d1a89172a1ba08b7a66945a030d5" } # spiceai-45
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "bfde649a9622d1a89172a1ba08b7a66945a030d5" } # spiceai-45
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "1c814422cfbdeb7f7bd2399e3369656710413aa8" } # spiceai-45
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "1713e9af2729f686aac46aef63e8c84545083e29" } # spiceai


### PR DESCRIPTION
## 📝 Summary

Brings in a DataFusion change to fix the unparser for `UNION`.

The DataFusion SQL Unparser does not correctly roundtrip SQL queries that use `UNION` rather than `UNION ALL`. For example the following query:

```sql
SELECT col1 FROM footable
UNION
SELECT col1 FROM bartable
```

Should result in a query that filters out duplicate rows from the final result. DataFusion handles this by adding a `LogicalPlan::Distinct` node as the parent of the `LogicalPlan::Union` node.

```rust
Distinct:
  Union:
    TableScan
    TableScan
```

However, this is currently unparsed to the following SQL:

```sql
SELECT col1 FROM footable
UNION ALL
SELECT col1 FROM bartable
```

That will cause incorrect results when executed, because the duplicate rows will not be filtered out.

## 🔗 Related

- https://github.com/apache/datafusion/issues/15813
- https://github.com/spiceai/datafusion/pull/75
