### PR TITLE
feat: Record memory usage as a metric

### DIFF
--- a/crates/test-framework/src/process/mod.rs
+++ b/crates/test-framework/src/process/mod.rs
@@ -61,7 +61,7 @@ impl Process {
                 };
 
                 readings.push(reading);
-                tokio::time::sleep(Duration::from_secs(5)).await;
+                tokio::time::sleep(Duration::from_secs(1)).await;
             }
 
             Ok(readings)

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -72,7 +72,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let metrics: QueryMetrics<_, NoExtendedMetrics> = test.collect(TestType::Benchmark)?;
     let test_succeeded = test.succeeded();
     let mut spiced_instance = test.end()?;
-    let (max_memory, _) = observe_memory(memory_token, memory_readings).await?;
+    let (max_memory, median_memory) = observe_memory(memory_token, memory_readings).await?;
 
     let commit_sha = metrics.commit_sha.clone();
     let spiced_version = metrics.spiced_version.clone();
@@ -115,6 +115,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     crate::metrics::TEST_DURATION
         .record((metrics.finished_at - metrics.started_at).try_into()?, &[]);
+    crate::metrics::MAX_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
+    crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
 
     telemetry.emit().await?;
 

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -98,3 +98,19 @@ pub static TEST_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .with_unit("ms")
         .build()
 });
+
+pub static MAX_MEMORY_USAGE: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    METER
+        .f64_gauge("max_memory_usage_mb")
+        .with_description("The maximum observed memory usage during the test.")
+        .with_unit("mb")
+        .build()
+});
+
+pub static MEDIAN_MEMORY_USAGE: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    METER
+        .f64_gauge("median_memory_usage_mb")
+        .with_description("The median observed memory usage during the test.")
+        .with_unit("mb")
+        .build()
+});


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Records the memory usage during a benchmark test as metrics, for median and maximum memory usage.
* Updates the memory usage recorder to check every second, instead of every 5 seconds - to better capture memory usage for fast running tests.
