### PR TITLE
fix: update dispatcher to run all benchmarks, rename metric, update spicepods, add scale factor

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -12,7 +12,7 @@ on:
         type: string
       test_files_path:
         description: 'path to load test files to dispatch'
-        required: true
+        required: false
         type: string
       workflow_type:
         description: 'the workflow to execute (bench, throughput, load, etc)'
@@ -31,6 +31,11 @@ on:
         default: false
       validate:
         description: 'Validate results?'
+        required: false
+        type: boolean
+        default: false
+      all_benchmarks:
+        description: 'Run all benchmarks?'
         required: false
         type: boolean
         default: false
@@ -62,7 +67,7 @@ jobs:
         uses: ./.github/actions/build-testoperator
       
       - name: Dispatch Testoperator - Input
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_files_path != '' }}
         run: |
           testoperator dispatch \
             ${{ github.event.inputs.test_files_path }} \
@@ -75,7 +80,7 @@ jobs:
           WORKFLOW_COMMIT: ${{ github.ref }}
 
       - name: Dispatch Testoperator - Scheduled Bench - TPCH
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.all_benchmarks == 'true' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch --workflow bench
         env:
@@ -83,7 +88,7 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
 
       - name: Dispatch Testoperator - Scheduled Bench - TPCDS
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.all_benchmarks == 'true'  }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpcds --workflow bench
         env:
@@ -91,7 +96,7 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
 
       - name: Dispatch Testoperator - Scheduled Bench - ClickBench
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.all_benchmarks == 'true'  }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/clickbench --workflow bench
         env:

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -53,6 +53,11 @@ on:
         options:
           - 'spiceai-runners'
           - 'spiceai-large-runners'
+      scale_factor:
+        description: 'Scale factor for the benchmark'
+        required: false
+        type: string
+        default: '1'
       update_snapshots:
         description: 'Update the snapshots?'
         required: false
@@ -66,11 +71,6 @@ on:
         required: false
         type: boolean
         default: false
-      scale_factor:
-        description: 'Scale factor for the benchmark'
-        required: false
-        type: string
-        default: '1'
 
 jobs:
   run-bench:

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -66,6 +66,11 @@ on:
         required: false
         type: boolean
         default: false
+      scale_factor:
+        description: 'Scale factor for the benchmark'
+        required: false
+        type: string
+        default: '1'
 
 jobs:
   run-bench:
@@ -135,7 +140,8 @@ jobs:
             --ready-wait ${{ github.event.inputs.ready_wait }} \
             --disable-progress-bars \
             --validate=${{ github.event.inputs.validate_results }} \
-            --metrics
+            --metrics \
+            --scale-factor ${{ github.event.inputs.scale_factor }}
         env:
           S3_ENDPOINT: ${{ secrets.MINIO_ENDPOINT}}
           S3_KEY: ${{ secrets.MINIO_ACCESS_KEY}}
@@ -185,7 +191,8 @@ jobs:
             --ready-wait ${{ github.event.inputs.ready_wait }} \
             --disable-progress-bars \
             --validate=${{ github.event.inputs.validate_results }} \
-            --metrics
+            --metrics \
+            --scale-factor ${{ github.event.inputs.scale_factor }}
         env:
           S3_ENDPOINT: ${{ secrets.MINIO_ENDPOINT}}
           S3_KEY: ${{ secrets.MINIO_ACCESS_KEY}}

--- a/test/spicepods/README.md
+++ b/test/spicepods/README.md
@@ -27,6 +27,7 @@ When a connector does not use acceleration, the `{accelerator[variant]}` value *
 Examples of full spicepod names:
 
 * `s3[parquet]-federated` - a non-accelerator S3 connector using Parquet.
+* `duckdb-federated` - a DuckDB connector using no acceleration.
 * `spicecloud-arrow` - a Spicecloud connector using Arrow acceleration.
 * `mysql-duckdb[file]-on_zero_results` - a MySQL connector using file-mode DuckDB acceleration, testing the behavior of on-zero-results action.
 * `file[parquet]-duckdb[file]-on_zero_results` - a File connector using Parquet data with DuckDB file-mode acceleration, testing the behavior of on-zero-results action.

--- a/test/spicepods/README.md
+++ b/test/spicepods/README.md
@@ -1,0 +1,35 @@
+# Test Spicepods
+
+## Naming
+
+Test spicepod names should be formatted according to the following template:
+
+```console
+{connector[variant]}-{accelerator[variant]}-{test variant}
+```
+
+`[variant]` refers to the connector or accelerator specific information about the connector setup. For example:
+
+* `s3[parquet]` - a S3 connector using Parquet data
+* `file[csv]` - a File connector using CSV data
+* `odbc[athena]` - an ODBC connector using AWS Athena
+* `spark[databricks]` - a Spark connector using databricks
+* `duckdb[file]` - a DuckDB accelerator using file-mode acceleration.
+
+Variants can be nested, up to 2 levels. For example, `odbc[s3[parquet]]` is an ODBC connector using an S3 source with Parquet data.
+
+`{test variant}` refers to specific test information about the case under test. For example, `on_zero_results` is a test validating the behavior of the accelerator on-zero-results action.
+
+Do not include scale factor formation in the `{test variant}`. This information is supplied as a query metric dimension/attribute.
+
+When a connector does not use acceleration, the `{accelerator[variant]}` value **must** be `federated`.
+
+Examples of full spicepod names:
+
+* `s3[parquet]-federated` - a non-accelerator S3 connector using Parquet.
+* `spicecloud-arrow` - a Spicecloud connector using Arrow acceleration.
+* `mysql-duckdb[file]-on_zero_results` - a MySQL connector using file-mode DuckDB acceleration, testing the behavior of on-zero-results action.
+* `file[parquet]-duckdb[file]-on_zero_results` - a File connector using Parquet data with DuckDB file-mode acceleration, testing the behavior of on-zero-results action.
+* `file[parquet]-duckdb[memory]-on_zero_results` - a File connector using Parquet data with DuckDB memory-mode acceleration, testing the behavior of on-zero-results action.
+* `s3[parquet]-duckdb[memory]-on_zero_results` - an S3 connector using Parquet data with DuckDB memory-mode acceleration, testing on-zero-results action.
+* `s3[parquet]-duckdb[file]-on_zero_results` - an S3 connector using Parquet data with DuckDB file-mode acceleration, testing on-zero-results action.

--- a/test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_file.yaml
+++ b/test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_clickbench_duckdb_file_on_zero_results
+name: file[parquet]-duckdb[file]-on_zero_results_small
 datasets:
   - from: file:data/hits_0.parquet
     name: hits

--- a/test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_memory.yaml
+++ b/test/spicepods/clickbench/accelerated/on_zero_results/file_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_clickbench_duckdb_memory_on_zero_results
+name: file[parquet]-duckdb[memory]-on_zero_results_small
 datasets:
   - from: file:data/hits_0.parquet
     name: hits

--- a/test/spicepods/clickbench/accelerated/s3_arrow.yaml
+++ b/test/spicepods/clickbench/accelerated/s3_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_arrow
+name: s3[parquet]-arrow
 datasets:
   - from: s3://benchmarks/clickbench/hits/
     name: hits

--- a/test/spicepods/clickbench/accelerated/s3_duckdb_file.yaml
+++ b/test/spicepods/clickbench/accelerated/s3_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_duckdb_file
+name: s3[parquet]-duckdb[file]
 datasets:
   - from: s3://benchmarks/clickbench/hits/
     name: hits

--- a/test/spicepods/clickbench/accelerated/s3_duckdb_memory.yaml
+++ b/test/spicepods/clickbench/accelerated/s3_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_duckdb_memory
+name: s3[parquet]-duckdb[memory]
 datasets:
   - from: s3://benchmarks/clickbench/hits/
     name: hits

--- a/test/spicepods/clickbench/accelerated/s3_postgres.yaml
+++ b/test/spicepods/clickbench/accelerated/s3_postgres.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_postgres
+name: s3[parquet]-postgres
 datasets:
   - from: s3://benchmarks/clickbench/hits/
     name: hits

--- a/test/spicepods/clickbench/accelerated/s3_sqlite_file.yaml
+++ b/test/spicepods/clickbench/accelerated/s3_sqlite_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sqlite_file
+name: s3[parquet]-sqlite[file]
 datasets:
   - from: s3://benchmarks/clickbench/hits/
     name: hits

--- a/test/spicepods/clickbench/accelerated/s3_sqlite_memory.yaml
+++ b/test/spicepods/clickbench/accelerated/s3_sqlite_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sqlite_memory
+name: s3[parquet]-sqlite[memory]
 datasets:
   - from: s3://benchmarks/clickbench/hits/
     name: hits

--- a/test/spicepods/clickbench/file_small.yaml
+++ b/test/spicepods/clickbench/file_small.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_small
+name: file[parquet]-federated-small
 datasets:
   - from: file:data/hits_0.parquet
     name: hits

--- a/test/spicepods/clickbench/postgres.yaml
+++ b/test/spicepods/clickbench/postgres.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres
+name: postgres-federated
 datasets:
   - from: postgres:hits
     name: hits

--- a/test/spicepods/clickbench/s3.yaml
+++ b/test/spicepods/clickbench/s3.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3
+name: s3[parquet]-federated
 datasets:
   - from: s3://benchmarks/clickbench/hits/
     name: hits

--- a/test/spicepods/clickbench/spicecloud.yaml
+++ b/test/spicepods/clickbench/spicecloud.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: spicecloud
+name: spicecloud-federated
 datasets:
   - from: spice.ai:spiceai/benchmarks-clickbench/datasets/clickbench.hits
     name: hits

--- a/test/spicepods/tpcds/abfs.yaml
+++ b/test/spicepods/tpcds/abfs.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: abfs
+name: abfs[parquet]-federated
 datasets:
   - from: abfs://data/tpcds/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/file_arrow.yaml
+++ b/test/spicepods/tpcds/accelerated/file_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_arrow
+name: file[parquet]-arrow
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/file_duckdb_file.yaml
+++ b/test/spicepods/tpcds/accelerated/file_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_duckdb_file
+name: file[parquet]-duckdb[file]
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/file_duckdb_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/file_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_duckdb_memory
+name: file[parquet]-duckdb[memory]
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/file_postgres.yaml
+++ b/test/spicepods/tpcds/accelerated/file_postgres.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_postgres
+name: file[parquet]-postgres
 datasets:
   - from: file:data/catalog_returns.parquet
     name: catalog_returns

--- a/test/spicepods/tpcds/accelerated/file_sqlite_file.yaml
+++ b/test/spicepods/tpcds/accelerated/file_sqlite_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_sqlite_file
+name: file[parquet]-sqlite[file]
 datasets:
   - from: file:data/sf0_01/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/file_sqlite_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/file_sqlite_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_sqlite_memory
+name: file[parquet]-sqlite[memory]
 datasets:
   - from: file:data/sf0_01/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/on_zero_results/file_duckdb_file.yaml
+++ b/test/spicepods/tpcds/accelerated/on_zero_results/file_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_duckdb_file_on_zero_results
+name: file[parquet]-duckdb[file]-on_zero_results
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/on_zero_results/file_duckdb_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/on_zero_results/file_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_duckdb_file_on_zero_results
+name: file[parquet]-duckdb[memory]-on_zero_results
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/on_zero_results/s3_duckdb_file.yaml
+++ b/test/spicepods/tpcds/accelerated/on_zero_results/s3_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_duckdb_file_on_zero_results
+name: s3[parquet]-duckdb[file]-on_zero_results
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/on_zero_results/s3_duckdb_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/on_zero_results/s3_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_duckdb_memory_on_zero_results
+name: s3[parquet]-duckdb[memory]-on_zero_results
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/postgres_arrow.yaml
+++ b/test/spicepods/tpcds/accelerated/postgres_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres_arrow
+name: postgres-arrow
 datasets:
   - from: postgres:catalog_sales
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/postgres_duckdb_file.yaml
+++ b/test/spicepods/tpcds/accelerated/postgres_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres_duckdb_file
+name: postgres-duckdb[file]
 datasets:
   - from: postgres:catalog_sales
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/postgres_duckdb_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/postgres_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres_duckdb_memory
+name: postgres-duckdb[file]
 datasets:
   - from: postgres:catalog_sales
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/s3_arrow.yaml
+++ b/test/spicepods/tpcds/accelerated/s3_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_arrow
+name: s3[parquet]-arrow
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/s3_duckdb_file.yaml
+++ b/test/spicepods/tpcds/accelerated/s3_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_duckdb_file
+name: s3[parquet]-duckdb[file]
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/s3_duckdb_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/s3_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_duckdb_memory
+name: s3[parquet]-duckdb[memory]
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/s3_postgres.yaml
+++ b/test/spicepods/tpcds/accelerated/s3_postgres.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sqlite_file
+name: s3[parquet]-postgres
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/s3_sqlite_file.yaml
+++ b/test/spicepods/tpcds/accelerated/s3_sqlite_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sqlite_file
+name: s3[parquet]-sqlite[file]
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/accelerated/s3_sqlite_memory.yaml
+++ b/test/spicepods/tpcds/accelerated/s3_sqlite_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sqlite_memory
+name: s3[parquet]-sqlite[memory]
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/databricks_delta.yaml
+++ b/test/spicepods/tpcds/databricks_delta.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: databricks_delta
+name: databricks[delta_lake]-federated
 datasets:
   - from: databricks:spiceai_sandbox.tpcds.item
     name: item

--- a/test/spicepods/tpcds/dremio.yaml
+++ b/test/spicepods/tpcds/dremio.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: dremio
+name: dremio-federated
 datasets:
   - from: dremio:tpcds.call_center
     name: call_center

--- a/test/spicepods/tpcds/duckdb.yaml
+++ b/test/spicepods/tpcds/duckdb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: duckdb
+name: duckdb-federated
 datasets:
   - from: duckdb:catalog_sales
     name: catalog_sales

--- a/test/spicepods/tpcds/file.yaml
+++ b/test/spicepods/tpcds/file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file
+name: file[parquet]-federated
 datasets:
   - from: file:data/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/mysql.yaml
+++ b/test/spicepods/tpcds/mysql.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql
+name: mysql-federated
 
 # Define common anchors
 definitions:

--- a/test/spicepods/tpcds/odbc-databricks.yaml
+++ b/test/spicepods/tpcds/odbc-databricks.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: odbc_databricks
+name: odbc[databricks]-federated
 datasets:
   - from: odbc:spiceai_sandbox.tpcds.catalog_sales
     name: catalog_sales

--- a/test/spicepods/tpcds/postgres.yaml
+++ b/test/spicepods/tpcds/postgres.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres
+name: postgres-federated
 datasets:
   - from: postgres:catalog_sales
     name: catalog_sales

--- a/test/spicepods/tpcds/s3.yaml
+++ b/test/spicepods/tpcds/s3.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3
+name: s3[parquet]-federated
 datasets:
   - from: s3://benchmarks/tpcds_sf1/catalog_sales/
     name: catalog_sales

--- a/test/spicepods/tpcds/s3_sf5.yaml
+++ b/test/spicepods/tpcds/s3_sf5.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3
+name: s3[parquet]-federated
 datasets:
   - from: s3://benchmarks/tpcds_sf5/catalog_sales.parquet
     name: catalog_sales

--- a/test/spicepods/tpcds/spark.yaml
+++ b/test/spicepods/tpcds/spark.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: spark
+name: spark[databricks]-federated
 datasets:
   - from: spark:spiceai_sandbox.tpcds.catalog_sales
     name: catalog_sales

--- a/test/spicepods/tpcds/spicecloud.yaml
+++ b/test/spicepods/tpcds/spicecloud.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: spicecloud
+name: spicecloud-federated
 datasets:
   - from: spice.ai:spiceai/benchmarks-tpcds/datasets/tpcds.catalog_sales
     name: catalog_sales

--- a/test/spicepods/tpch/abfs.yaml
+++ b/test/spicepods/tpch/abfs.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: abfs-federated
+name: abfs[parquet]-federated
 datasets:
   - from: abfs://data/tpch/customer/
     name: customer

--- a/test/spicepods/tpch/abfs.yaml
+++ b/test/spicepods/tpch/abfs.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: abfs
+name: abfs-federated
 datasets:
   - from: abfs://data/tpch/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/abfs_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/abfs_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: abfs-arrow
+name: abfs[parquet]-arrow
 datasets:
   - from: abfs://data/tpch/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/abfs_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/abfs_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: abfs_arrow
+name: abfs-arrow
 datasets:
   - from: abfs://data/tpch/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/databricks_delta_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/databricks_delta_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: databricks[delta]-arrow
+name: databricks[delta_lake]-arrow
 datasets:
   - from: databricks:spiceai_sandbox.tpch.partsupp
     name: partsupp

--- a/test/spicepods/tpch/accelerated/databricks_delta_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/databricks_delta_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: databricks_delta_arrow
+name: databricks[delta]-arrow
 datasets:
   - from: databricks:spiceai_sandbox.tpch.partsupp
     name: partsupp

--- a/test/spicepods/tpch/accelerated/dremio_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/dremio_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: dremio_arrow
+name: dremio-arrow
 datasets:
   - from: dremio:tpch.customer
     name: customer

--- a/test/spicepods/tpch/accelerated/duckdb_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/duckdb_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: duckdb_arrow
+name: duckdb-arrow
 datasets:
   - from: duckdb:customer
     name: customer

--- a/test/spicepods/tpch/accelerated/file_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/file_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_arrow
+name: file[parquet]-arrow
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/file_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_duckdb_file
+name: file[parquet]-duckdb[file]
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/file_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_duckdb_memory
+name: file[parquet]-duckdb[memory]
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_mixed_acceleration.yaml
+++ b/test/spicepods/tpch/accelerated/file_mixed_acceleration.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_mixed_acceleration
+name: file[parquet]-mixed
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_mixed_acceleration.yaml
+++ b/test/spicepods/tpch/accelerated/file_mixed_acceleration.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file[parquet]-mixed
+name: file[parquet]-mixed[duckdb[file]+sqlite[file]]
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_postgres.yaml
+++ b/test/spicepods/tpch/accelerated/file_postgres.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_postgres
+name: file[parquet]-postgres
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_sqlite_file.yaml
+++ b/test/spicepods/tpch/accelerated/file_sqlite_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_sqlite_file
+name: file[parquet]-sqlite[file]
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/file_sqlite_memory.yaml
+++ b/test/spicepods/tpch/accelerated/file_sqlite_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_sqlite_memory
+name: file[parquet]-sqlite[memory]
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/mysql_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/mysql_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql_arrow
+name: mysql-arrow
 
 # Define common anchors
 definitions:

--- a/test/spicepods/tpch/accelerated/odbc_athena_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/odbc_athena_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: odbc_athena_arrow
+name: odbc[athena]-arrow
 datasets:
   - from: odbc:tpch.customer
     name: customer

--- a/test/spicepods/tpch/accelerated/odbc_databricks_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/odbc_databricks_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: odbc_databricks_arrow
+name: odbc[databricks]-arrow
 datasets:
   - from: odbc:spiceai_sandbox.tpch.customer
     name: customer

--- a/test/spicepods/tpch/accelerated/on_zero_results/file_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/on_zero_results/file_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_duckdb_file_on_zero_results
+name: file[parquet]-duckdb[file]-on_zero_results
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/on_zero_results/file_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/on_zero_results/file_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file_duckdb_memory_on_zero_results
+name: file[parquet]-duckdb[memory]-on_zero_results
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/accelerated/postgres_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/postgres_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres_arrow
+name: postgres-arrow
 datasets:
   - from: postgres:customer
     name: customer

--- a/test/spicepods/tpch/accelerated/postgres_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/postgres_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres_duckdb_file
+name: postgres-duckdb[file]
 datasets:
   - from: postgres:customer
     name: customer

--- a/test/spicepods/tpch/accelerated/postgres_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/postgres_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres_duckdb_memory
+name: postgres-duckdb[memory]
 datasets:
   - from: postgres:customer
     name: customer

--- a/test/spicepods/tpch/accelerated/postgres_sqlite_file.yaml
+++ b/test/spicepods/tpch/accelerated/postgres_sqlite_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres_sqlite_file
+name: postgres-sqlite[file]
 datasets:
   - from: postgres:customer
     name: customer

--- a/test/spicepods/tpch/accelerated/postgres_sqlite_memory.yaml
+++ b/test/spicepods/tpch/accelerated/postgres_sqlite_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres_sqlite_memory
+name: postgres-sqlite[memory]
 datasets:
   - from: postgres:customer
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/s3_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_arrow
+name: s3[parquet]-arrow
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/s3_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_duckdb_file
+name: s3[parquet]-duckdb[file]
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/s3_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_duckdb_memory
+name: s3[parquet]-duckdb[memory]
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_postgres.yaml
+++ b/test/spicepods/tpch/accelerated/s3_postgres.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_postgres
+name: s3[parquet]-postgres
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_sf5_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sf5_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_arrow
+name: s3[parquet]-arrow
 datasets:
   - from: s3://benchmarks/tpch_sf5/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_sf5_duckdb_file.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sf5_duckdb_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_file
+name: s3[parquet]-duckdb[file]
 datasets:
   - from: s3://benchmarks/tpch_sf5/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_sf5_duckdb_memory.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sf5_duckdb_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_memory
+name: s3[parquet]-duckdb[memory]
 datasets:
   - from: s3://benchmarks/tpch_sf5/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_sqlite_file.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sqlite_file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sqlite_file
+name: s3[parquet]-sqlite[file]
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/s3_sqlite_memory.yaml
+++ b/test/spicepods/tpch/accelerated/s3_sqlite_memory.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sqlite_memory
+name: s3[parquet]-sqlite[memory]
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/accelerated/snowflake_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/snowflake_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: snowflake_arrow
+name: snowflake-arrow
 datasets:
   - from: snowflake:SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.CUSTOMER
     name: customer

--- a/test/spicepods/tpch/accelerated/spark_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/spark_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: spark_arrow
+name: spark[databricks]-arrow
 datasets:
   - from: spark:spiceai_sandbox.tpch.customer
     name: customer

--- a/test/spicepods/tpch/accelerated/spicecloud_arrow.yaml
+++ b/test/spicepods/tpch/accelerated/spicecloud_arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: spicecloud_arrow
+name: spicecloud-arrow
 datasets:
   - from: spice.ai:spiceai/tpch/datasets/tpch.customer
     name: customer

--- a/test/spicepods/tpch/cache/mysql_1gb.yaml
+++ b/test/spicepods/tpch/cache/mysql_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql_cache_1gb
+name: mysql-federated-cache_1gb
 
 runtime:
   results_cache:

--- a/test/spicepods/tpch/cache/mysql_4gb.yaml
+++ b/test/spicepods/tpch/cache/mysql_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql_cache_4gb
+name: mysql-federated-cache_4gb
 
 runtime:
   results_cache:

--- a/test/spicepods/tpch/cache/mysql_ttl.yaml
+++ b/test/spicepods/tpch/cache/mysql_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql_cache_ttl
+name: mysql-federated-cache_ttl
 
 runtime:
   results_cache:

--- a/test/spicepods/tpch/cache/s3_arrow_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_arrow_cache_1gb
+name: s3[parquet]-arrow-cache_1gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_arrow_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_arrow_cache_4gb
+name: s3[parquet]-arrow-cache_4gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_arrow_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_arrow_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_arrow_cache_ttl
+name: s3[parquet]-arrow-cache_ttl
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_cache_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_cache_1gb
+name: s3[parquet]-federated-cache_1gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_cache_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_cache_4gb
+name: s3[parquet]-federated-cache_4gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_cache_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_cache_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_cache_ttl
+name: s3[parquet]-federated-cache_ttl
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_file_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_file_cache_1gb
+name: s3[parquet]-duckdb[file]-cache_1gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_file_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_file_cache_4gb
+name: s3[parquet]-duckdb[file]-cache_4gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_file_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_file_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_file_cache_ttl
+name: s3[parquet]-duckdb[file]-cache_ttl
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_1gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_1gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_memory_cache_1gb
+name: s3[parquet]-duckdb[memory]-cache_1gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_4gb.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_4gb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_memory_cache_4gb
+name: s3[parquet]-duckdb[memory]-cache_4gb
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/cache/s3_duckdb_memory_ttl.yaml
+++ b/test/spicepods/tpch/cache/s3_duckdb_memory_ttl.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5_duckdb_memory_cache_ttl
+name: s3[parquet]-duckdb[memory]-cache_ttl
 runtime:
   results_cache:
     enabled: true

--- a/test/spicepods/tpch/databricks_delta.yaml
+++ b/test/spicepods/tpch/databricks_delta.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: databricks_delta
+name: databricks[delta]-federated
 datasets:
   - from: databricks:spiceai_sandbox.tpch.partsupp
     name: partsupp

--- a/test/spicepods/tpch/dremio.yaml
+++ b/test/spicepods/tpch/dremio.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: dremio
+name: dremio-federated
 datasets:
   - from: dremio:tpch.customer
     name: customer

--- a/test/spicepods/tpch/duckdb.yaml
+++ b/test/spicepods/tpch/duckdb.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: duckdb
+name: duckdb-federated
 datasets:
   - from: duckdb:customer
     name: customer

--- a/test/spicepods/tpch/file.yaml
+++ b/test/spicepods/tpch/file.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: file
+name: file[parquet]-federated
 datasets:
   - from: file:data/customer.parquet
     name: customer

--- a/test/spicepods/tpch/iceberg_catalog.yaml
+++ b/test/spicepods/tpch/iceberg_catalog.yaml
@@ -1,6 +1,6 @@
 version: v1beta1
 kind: Spicepod
-name: iceberg_catalog
+name: iceberg[catalog]-federated
 
 catalogs:
   - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces

--- a/test/spicepods/tpch/mssql.yaml
+++ b/test/spicepods/tpch/mssql.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mssql
+name: mssql-federated
 datasets:
   - from: mssql:customer
     name: customer

--- a/test/spicepods/tpch/mysql.yaml
+++ b/test/spicepods/tpch/mysql.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mysql
+name: mysql-federated
 
 # Define common anchors
 definitions:

--- a/test/spicepods/tpch/odbc_athena.yaml
+++ b/test/spicepods/tpch/odbc_athena.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: odbc_athena
+name: odbc[athena]-federated
 datasets:
   - from: odbc:tpch.customer
     name: customer

--- a/test/spicepods/tpch/odbc_databricks.yaml
+++ b/test/spicepods/tpch/odbc_databricks.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: odbc_databricks
+name: odbc[databricks]-federated
 datasets:
   - from: odbc:spiceai_sandbox.tpch.customer
     name: customer

--- a/test/spicepods/tpch/postgres.yaml
+++ b/test/spicepods/tpch/postgres.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: postgres
+name: postgres-federated
 datasets:
   - from: postgres:customer
     name: customer

--- a/test/spicepods/tpch/s3.yaml
+++ b/test/spicepods/tpch/s3.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3
+name: s3-federated
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/s3.yaml
+++ b/test/spicepods/tpch/s3.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3-federated
+name: s3[parquet]-federated
 datasets:
   - from: s3://benchmarks/tpch_sf1/customer/
     name: customer

--- a/test/spicepods/tpch/s3_sf5.yaml
+++ b/test/spicepods/tpch/s3_sf5.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3-federated
+name: s3[parquet]-federated
 datasets:
   - from: s3://benchmarks/tpch_sf5/customer/
     name: customer

--- a/test/spicepods/tpch/s3_sf5.yaml
+++ b/test/spicepods/tpch/s3_sf5.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: s3_sf5
+name: s3-federated
 datasets:
   - from: s3://benchmarks/tpch_sf5/customer/
     name: customer

--- a/test/spicepods/tpch/snowflake_sf1.yaml
+++ b/test/spicepods/tpch/snowflake_sf1.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: snowflake
+name: snowflake-federated
 datasets:
   - from: snowflake:SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.CUSTOMER
     name: customer

--- a/test/spicepods/tpch/snowflake_sf100.yaml
+++ b/test/spicepods/tpch/snowflake_sf100.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: snowflake
+name: snowflake-federated
 datasets:
   - from: snowflake:SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.CUSTOMER
     name: customer

--- a/test/spicepods/tpch/spark.yaml
+++ b/test/spicepods/tpch/spark.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: spark
+name: spark[databricks]-federated
 datasets:
   - from: spark:spiceai_sandbox.tpch.customer
     name: customer

--- a/test/spicepods/tpch/spicecloud.yaml
+++ b/test/spicepods/tpch/spicecloud.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: spicecloud
+name: spicecloud-federated
 datasets:
   - from: spice.ai:spiceai/tpch/datasets/tpch.customer
     name: customer

--- a/test/spicepods/tpch/spicecloud_catalog.yaml
+++ b/test/spicepods/tpch/spicecloud_catalog.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: spicecloud_catalog
+name: spicecloud[catalog]-federated
 catalogs:
   - from: spice.ai:spiceai/tpch
     name: tpch

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -102,6 +102,8 @@ pub struct BenchArgs {
     pub update_snapshots: Option<UpdateSnapshots>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub validate_results: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scale_factor: Option<f64>,
 }
 
 impl BenchArgs {

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -83,6 +83,10 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
         KeyValue::new("benchmark.spiced_version", spiced_version.clone()),
         KeyValue::new("benchmark.query_set", query_set.to_string()),
         KeyValue::new("benchmark.spiced_commit_sha", commit_sha.clone()),
+        KeyValue::new(
+            "benchmark.scale_factor",
+            args.scale_factor.unwrap_or(1.0).to_string(),
+        ),
     ]);
 
     let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -119,7 +119,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     crate::metrics::TEST_DURATION
         .record((metrics.finished_at - metrics.started_at).try_into()?, &[]);
-    crate::metrics::MAX_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
+    crate::metrics::PEAK_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
     crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
 
     telemetry.emit().await?;

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -99,9 +99,9 @@ pub static TEST_DURATION: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .build()
 });
 
-pub static MAX_MEMORY_USAGE: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+pub static PEAK_MEMORY_USAGE: LazyLock<Gauge<f64>> = LazyLock::new(|| {
     METER
-        .f64_gauge("max_memory_usage_mb")
+        .f64_gauge("peak_memory_usage_mb")
         .with_description("The maximum observed memory usage during the test.")
         .with_unit("mb")
         .build()


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* A quality of life update to the dispatcher, specifies a checkbox to run the standard set of benchmarks (clickbench, tpch, tpcds) in a single workflow
* Renames the max memory usage metric to `peak_memory_usage_mb`
* Updates the spicepod names for the TPC-H, TPC-DS and Clickbench spicepods to the new naming convention. Also, documents this naming convention in a readme in `./test/spicepods/README.md`
* Adds a `scale_factor` input to the `testoperator_run_bench` workflow to allow for scaling the benchmark workload
* Updates the benchmark metric attributes to include the scale factor
