### PR TITLE
Fix Delta Lake bug for: Found unmasked nulls for non-nullable StructArray field "predicate"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,46 +325,32 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-arith 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-cast 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-csv 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-data 54.2.1",
- "arrow-ipc 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-json 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-ord 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-row 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-schema 54.2.1",
- "arrow-select 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-string 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
 name = "arrow-arith"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "num",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "num",
 ]
@@ -372,43 +358,16 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
  "ahash 0.8.11",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz 0.10.1",
  "half",
  "hashbrown 0.15.2",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "ahash 0.8.11",
- "arrow-buffer 54.2.1",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
- "chrono",
- "chrono-tz 0.10.1",
- "half",
- "hashbrown 0.15.2",
- "num",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "bytes",
- "half",
  "num",
 ]
 
@@ -426,33 +385,13 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "atoi",
- "base64 0.22.1",
- "chrono",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
- "arrow-select 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -466,43 +405,16 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d3cb0914486a3cae19a5cad2598e44e225d53157926d0ada03c20521191a65"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
  "lazy_static",
  "regex",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-cast 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-schema 54.2.1",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "regex",
-]
-
-[[package]]
-name = "arrow-data"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-buffer 54.2.1",
- "arrow-schema 54.2.1",
- "half",
- "num",
 ]
 
 [[package]]
@@ -511,8 +423,8 @@ version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
 dependencies = [
- "arrow-buffer 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-buffer",
+ "arrow-schema",
  "half",
  "num",
 ]
@@ -523,17 +435,17 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7408f2bf3b978eddda272c7699f439760ebc4ac70feca25fefa82c5b8ce808d"
 dependencies = [
- "arrow-arith 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-data 54.3.1",
- "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-ord 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-row 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-string 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
  "base64 0.22.1",
  "bytes",
  "futures",
@@ -547,59 +459,26 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "flatbuffers",
  "lz4_flex",
 ]
 
 [[package]]
-name = "arrow-ipc"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
- "flatbuffers",
-]
-
-[[package]]
 name = "arrow-json"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b9340013413eb84868682ace00a1098c81a5ebc96d279f7ebf9a4cac3c0fd"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "half",
- "indexmap 2.9.0",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "arrow-json"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-cast 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.9.0",
@@ -625,59 +504,25 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
- "arrow-select 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
 ]
 
 [[package]]
 name = "arrow-row"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "half",
-]
-
-[[package]]
-name = "arrow-row"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
- "half",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -686,63 +531,33 @@ version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 dependencies = [
+ "bitflags 2.8.0",
  "serde",
 ]
 
 [[package]]
 name = "arrow-select"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "num",
-]
-
-[[package]]
-name = "arrow-select"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "ahash 0.8.11",
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "num",
 ]
 
 [[package]]
 name = "arrow-string"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=3e6fcbcb0e94c411c5e480c77bc830a273f292df#3e6fcbcb0e94c411c5e480c77bc830a273f292df"
 dependencies = [
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr",
- "num",
- "regex",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "arrow-string"
-version = "54.2.1"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
-dependencies = [
- "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
- "arrow-buffer 54.2.1",
- "arrow-data 54.2.1",
- "arrow-schema 54.2.1",
- "arrow-select 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "memchr",
  "num",
  "regex",
@@ -768,8 +583,8 @@ name = "arrow_tools"
 version = "1.2.0-unstable"
 dependencies = [
  "arrow",
- "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-cast",
+ "arrow-schema",
  "datafusion",
  "insta",
  "snafu",
@@ -3331,7 +3146,7 @@ name = "data_components"
 version = "1.2.0-unstable"
 dependencies = [
  "arrow",
- "arrow-buffer 54.3.1",
+ "arrow-buffer",
  "arrow-flight",
  "async-stream",
  "async-trait",
@@ -3389,12 +3204,12 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes",
@@ -3439,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3459,14 +3274,14 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-schema",
  "base64 0.22.1",
  "half",
  "hashbrown 0.14.5",
@@ -3485,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "log",
  "tokio",
@@ -3494,12 +3309,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 
 [[package]]
 name = "datafusion-execution"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
  "dashmap",
@@ -3517,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
  "chrono",
@@ -3537,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3550,7 +3365,7 @@ name = "datafusion-federation"
 version = "0.1.6"
 source = "git+https://github.com/spiceai/datafusion-federation.git?rev=1c814422cfbdeb7f7bd2399e3369656710413aa8#1c814422cfbdeb7f7bd2399e3369656710413aa8"
 dependencies = [
- "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-json",
  "async-stream",
  "async-trait",
  "datafusion",
@@ -3573,10 +3388,10 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
- "arrow-buffer 54.3.1",
+ "arrow-buffer",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -3602,12 +3417,12 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-buffer 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-buffer",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -3624,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3648,13 +3463,13 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-ord 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -3671,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3686,7 +3501,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -3702,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3711,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -3721,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
  "chrono",
@@ -3739,13 +3554,13 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -3763,11 +3578,11 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-buffer 54.3.1",
+ "arrow-buffer",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
@@ -3777,10 +3592,10 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
- "arrow-schema 54.3.1",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -3798,14 +3613,14 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-ord 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -3829,11 +3644,11 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
 dependencies = [
  "arrow",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-schema",
  "bigdecimal",
  "datafusion-common",
  "datafusion-expr",
@@ -3850,8 +3665,8 @@ version = "0.1.0"
 source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=1713e9af2729f686aac46aef63e8c84545083e29#1713e9af2729f686aac46aef63e8c84545083e29"
 dependencies = [
  "arrow",
- "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-json",
+ "arrow-schema",
  "async-stream",
  "async-trait",
  "bb8",
@@ -4723,7 +4538,7 @@ version = "1.2.0-unstable"
 dependencies = [
  "ansi_term",
  "arrow-flight",
- "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-json",
  "clap",
  "datafusion",
  "flight_client",
@@ -6186,13 +6001,13 @@ dependencies = [
  "anyhow",
  "apache-avro",
  "array-init",
- "arrow-arith 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-ord 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-string 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
  "async-trait",
  "bimap",
  "bitvec",
@@ -9100,7 +8915,7 @@ name = "otel-arrow"
 version = "1.2.0-unstable"
 dependencies = [
  "arrow",
- "arrow-buffer 54.3.1",
+ "arrow-buffer",
  "async-trait",
  "opentelemetry 0.27.1",
  "opentelemetry_sdk 0.27.1",
@@ -9239,13 +9054,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88838dca3b84d41444a0341b19f347e8098a3898b0f21536654b8b799e11abd"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-data 54.3.1",
- "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -10926,11 +10741,11 @@ dependencies = [
  "anyhow",
  "app",
  "arrow",
- "arrow-csv 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-csv",
  "arrow-flight",
- "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrow-schema 54.3.1",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-schema",
  "arrow_sql_gen",
  "arrow_tools",
  "async-graphql",
@@ -12063,7 +11878,7 @@ version = "0.0.1-beta.4"
 source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=f6e07191d1432184c4f447f4f1ab187d8abd33df#f6e07191d1432184c4f447f4f1ab187d8abd33df"
 dependencies = [
  "arrow",
- "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-ipc",
  "chrono",
  "parking_lot 0.12.3",
  "prost 0.13.4",
@@ -12753,7 +12568,7 @@ dependencies = [
 name = "testoperator"
 version = "1.2.0-unstable"
 dependencies = [
- "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-json",
  "clap",
  "reqwest 0.12.12",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,22 +325,21 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-cast 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-csv 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-data 54.2.1",
+ "arrow-ipc 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-json 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-ord 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-row 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-string 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
 ]
 
 [[package]]
@@ -349,10 +348,23 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "chrono",
  "num",
 ]
@@ -364,13 +376,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
 dependencies = [
  "ahash 0.8.11",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
  "chrono",
  "chrono-tz 0.10.1",
  "half",
  "hashbrown 0.15.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "chrono",
+ "chrono-tz 0.10.1",
+ "half",
+ "hashbrown 0.15.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "bytes",
+ "half",
  "num",
 ]
 
@@ -391,11 +429,30 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -412,9 +469,24 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d3cb0914486a3cae19a5cad2598e44e225d53157926d0ada03c20521191a65"
 dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-cast 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-schema 54.2.1",
  "chrono",
  "csv",
  "csv-core",
@@ -424,12 +496,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-buffer 54.2.1",
+ "arrow-schema 54.2.1",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
 version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 54.3.1",
+ "arrow-schema 54.3.1",
  "half",
  "num",
 ]
@@ -440,17 +523,17 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7408f2bf3b978eddda272c7699f439760ebc4ac70feca25fefa82c5b8ce808d"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-data 54.3.1",
+ "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-ord 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-row 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-string 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.22.1",
  "bytes",
  "futures",
@@ -467,12 +550,24 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
  "flatbuffers",
  "lz4_flex",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -481,11 +576,30 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d03b9340013413eb84868682ace00a1098c81a5ebc96d279f7ebf9a4cac3c0fd"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "half",
+ "indexmap 2.9.0",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-json"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-cast 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "chrono",
  "half",
  "indexmap 2.9.0",
@@ -514,11 +628,23 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
 ]
 
 [[package]]
@@ -527,11 +653,31 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
  "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -540,7 +686,6 @@ version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 dependencies = [
- "bitflags 2.8.0",
  "serde",
 ]
 
@@ -551,10 +696,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "num",
 ]
 
@@ -564,11 +722,27 @@ version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "arrow-string"
+version = "54.2.1"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8#b9f9a4950ac6a2029b63d68acfba5f530da09bd8"
+dependencies = [
+ "arrow-array 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1 (git+https://github.com/spiceai/arrow-rs.git?rev=b9f9a4950ac6a2029b63d68acfba5f530da09bd8)",
  "memchr",
  "num",
  "regex",
@@ -594,8 +768,8 @@ name = "arrow_tools"
 version = "1.2.0-unstable"
 dependencies = [
  "arrow",
- "arrow-cast",
- "arrow-schema",
+ "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
  "datafusion",
  "insta",
  "snafu",
@@ -3157,7 +3331,7 @@ name = "data_components"
 version = "1.2.0-unstable"
 dependencies = [
  "arrow",
- "arrow-buffer",
+ "arrow-buffer 54.3.1",
  "arrow-flight",
  "async-stream",
  "async-trait",
@@ -3215,12 +3389,12 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
  "async-compression",
  "async-trait",
  "bytes",
@@ -3265,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3285,14 +3459,14 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ipc",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
  "base64 0.22.1",
  "half",
  "hashbrown 0.14.5",
@@ -3311,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "log",
  "tokio",
@@ -3320,12 +3494,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 
 [[package]]
 name = "datafusion-execution"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "dashmap",
@@ -3343,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "chrono",
@@ -3363,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3376,7 +3550,7 @@ name = "datafusion-federation"
 version = "0.1.6"
 source = "git+https://github.com/spiceai/datafusion-federation.git?rev=1c814422cfbdeb7f7bd2399e3369656710413aa8#1c814422cfbdeb7f7bd2399e3369656710413aa8"
 dependencies = [
- "arrow-json",
+ "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-stream",
  "async-trait",
  "datafusion",
@@ -3399,10 +3573,10 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
- "arrow-buffer",
+ "arrow-buffer 54.3.1",
  "base64 0.22.1",
  "blake2",
  "blake3",
@@ -3428,12 +3602,12 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 54.3.1",
+ "arrow-schema 54.3.1",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -3450,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3474,13 +3648,13 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-ord 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -3497,7 +3671,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3512,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -3528,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3537,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -3547,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
  "chrono",
@@ -3565,13 +3739,13 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-schema 54.3.1",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -3589,11 +3763,11 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-buffer",
+ "arrow-buffer 54.3.1",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
@@ -3603,10 +3777,10 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
- "arrow-schema",
+ "arrow-schema 54.3.1",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -3624,14 +3798,14 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-ord 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -3655,11 +3829,11 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "45.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=a31aef39aea666f2150c8568f8f5737addc81996#a31aef39aea666f2150c8568f8f5737addc81996"
+source = "git+https://github.com/spiceai/datafusion.git?rev=bfde649a9622d1a89172a1ba08b7a66945a030d5#bfde649a9622d1a89172a1ba08b7a66945a030d5"
 dependencies = [
  "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
  "bigdecimal",
  "datafusion-common",
  "datafusion-expr",
@@ -3676,8 +3850,8 @@ version = "0.1.0"
 source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=1713e9af2729f686aac46aef63e8c84545083e29#1713e9af2729f686aac46aef63e8c84545083e29"
 dependencies = [
  "arrow",
- "arrow-json",
- "arrow-schema",
+ "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
  "async-stream",
  "async-trait",
  "bb8",
@@ -4549,7 +4723,7 @@ version = "1.2.0-unstable"
 dependencies = [
  "ansi_term",
  "arrow-flight",
- "arrow-json",
+ "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
  "datafusion",
  "flight_client",
@@ -6012,13 +6186,13 @@ dependencies = [
  "anyhow",
  "apache-avro",
  "array-init",
- "arrow-arith",
- "arrow-array",
- "arrow-cast",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-ord 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-string 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "bimap",
  "bitvec",
@@ -8926,7 +9100,7 @@ name = "otel-arrow"
 version = "1.2.0-unstable"
 dependencies = [
  "arrow",
- "arrow-buffer",
+ "arrow-buffer 54.3.1",
  "async-trait",
  "opentelemetry 0.27.1",
  "opentelemetry_sdk 0.27.1",
@@ -9065,13 +9239,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88838dca3b84d41444a0341b19f347e8098a3898b0f21536654b8b799e11abd"
 dependencies = [
  "ahash 0.8.11",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-data 54.3.1",
+ "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -10752,11 +10926,11 @@ dependencies = [
  "anyhow",
  "app",
  "arrow",
- "arrow-csv",
+ "arrow-csv 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-flight",
- "arrow-ipc",
- "arrow-json",
- "arrow-schema",
+ "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-schema 54.3.1",
  "arrow_sql_gen",
  "arrow_tools",
  "async-graphql",
@@ -11889,7 +12063,7 @@ version = "0.0.1-beta.4"
 source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=f6e07191d1432184c4f447f4f1ab187d8abd33df#f6e07191d1432184c4f447f4f1ab187d8abd33df"
 dependencies = [
  "arrow",
- "arrow-ipc",
+ "arrow-ipc 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "parking_lot 0.12.3",
  "prost 0.13.4",
@@ -12579,7 +12753,7 @@ dependencies = [
 name = "testoperator"
 version = "1.2.0-unstable"
 dependencies = [
- "arrow-json",
+ "arrow-json 54.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
  "reqwest 0.12.12",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,8 @@ rust-version = "1.85"
 version = "1.2.0-unstable"
 
 [workspace.dependencies]
-arrow = { version = "54", features = ["prettyprint"] }
+arrow = { version = "=54.2.1", features = ["prettyprint"] }
+arrow-array = "=54.2.1"
 arrow-buffer = "54"
 arrow-flight = "54"
 arrow-cast = "54"
@@ -161,7 +162,17 @@ uuid = "1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
-arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b9f9a4950ac6a2029b63d68acfba5f530da09bd8" } # spiceai-54
+arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-arith = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-csv = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-row = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
+arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "3e6fcbcb0e94c411c5e480c77bc830a273f292df" } # spiceai-54.2.1
 
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "a31aef39aea666f2150c8568f8f5737addc81996" } # spiceai-45
 datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a31aef39aea666f2150c8568f8f5737addc81996" } # spiceai-45

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ version = "1.2.0-unstable"
 arrow = { version = "54", features = ["prettyprint"] }
 arrow-buffer = "54"
 arrow-flight = "54"
-# Use published version once https://github.com/apache/arrow-rs/pull/6606 is released
 arrow-cast = "54"
 arrow-csv = "54"
 arrow-ipc = "54"
@@ -162,6 +161,8 @@ uuid = "1"
 x509-certificate = "0.23.1"
 
 [patch.crates-io]
+arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "b9f9a4950ac6a2029b63d68acfba5f530da09bd8" } # spiceai-54
+
 datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "a31aef39aea666f2150c8568f8f5737addc81996" } # spiceai-45
 datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a31aef39aea666f2150c8568f8f5737addc81996" } # spiceai-45
 datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "a31aef39aea666f2150c8568f8f5737addc81996" } # spiceai-45


### PR DESCRIPTION
## 📝 Summary

Brings in a fix for `arrow-rs` that tweaks the validation logic for StructArray::try_new() to allow for arrays that have a `logical_nulls()` array with 0 null values to be considered valid.

Relevant arrow-rs commit (one-line change): https://github.com/spiceai/arrow-rs/commit/e3f2210f5dfe61833cd2b169ce76d629d35ed1de

<img width="1172" alt="Screenshot 2025-04-23 at 11 17 25 PM" src="https://github.com/user-attachments/assets/42c88b44-93cc-49e8-ae2f-e449182c7ba8" />

## 🔗 Related

Closes #5501
