### PR TITLE
Fix `content-type: application/json` in NSQL testing

### DIFF
--- a/crates/runtime/tests/models/mod.rs
+++ b/crates/runtime/tests/models/mod.rs
@@ -88,7 +88,7 @@ mod nsql {
         // Check task_history table for expected rows.
         let mut headers = HeaderMap::new();
         headers.insert(ACCEPT, HeaderValue::from_static("text/plain"));
-        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
 
         // With `sample_data_enabled`, tools run concurrently, so for deterministic results, order by task and input for verification instead of start time.
         let query = if ts


### PR DESCRIPTION
## 📝 Summary
 - With the introduction of parameterised queries, `v1/sql` POST body can now take a JSON payload. Currently, the `content-type` header is set to `application/json` in the NSQL integration tests which causes deserialisation errors. 

## 🔗 Related
 - Fixes https://github.com/spiceai/spiceai/actions/runs/14627825368/job/41043761900?pr=5509