### PR TITLE
Apply Spice advanced acceleration logic and params support to accelerated views 

### DIFF
--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use super::{find_first_delimiter, validate_identifier};
-use crate::{dataaccelerator::AccelerationSource, Runtime};
+use crate::{Runtime, dataaccelerator::AccelerationSource};
 use acceleration::{Acceleration, Engine};
 use app::App;
 use arrow::datatypes::SchemaRef;
@@ -767,7 +767,6 @@ impl AccelerationSource for Dataset {
         &self.name
     }
 }
-
 
 pub mod acceleration;
 

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 use super::{find_first_delimiter, validate_identifier};
-use crate::Runtime;
-use acceleration::Engine;
+use crate::{dataaccelerator::AccelerationSource, Runtime};
+use acceleration::{Acceleration, Engine};
 use app::App;
 use arrow::datatypes::SchemaRef;
 use datafusion::sql::{
@@ -745,6 +745,30 @@ impl Dataset {
         !self.embeddings.is_empty() || self.columns.iter().any(|c| !c.embeddings.is_empty())
     }
 }
+
+impl AccelerationSource for Dataset {
+    fn is_file_accelerated(&self) -> bool {
+        self.is_file_accelerated()
+    }
+
+    fn app(&self) -> Arc<app::App> {
+        self.app()
+    }
+
+    fn runtime(&self) -> Arc<Runtime> {
+        self.runtime()
+    }
+
+    fn acceleration(&self) -> Option<&Acceleration> {
+        self.acceleration.as_ref()
+    }
+
+    fn name(&self) -> &TableReference {
+        &self.name
+    }
+}
+
+
 pub mod acceleration;
 
 pub mod replication {

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -14,58 +14,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use app::App;
 use datafusion::sql::TableReference;
 use serde_json::Value;
 use snafu::prelude::*;
 use spicepod::component::view as spicepod_view;
-use std::{collections::HashMap, fs};
+use std::{collections::HashMap, fs, sync::Arc};
+
+use crate::{Runtime, dataaccelerator::AccelerationSource};
 
 use super::{
-    dataset::{Dataset, acceleration},
+    dataset::{
+        Dataset,
+        acceleration::{self, Acceleration},
+    },
     validate_identifier,
 };
 use spicepod::semantic::Column;
 
 /// [`View`] is the internal representation of the [`spicepod_view::View`] spicepod component.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone)]
 pub struct View {
     pub name: TableReference,
     pub sql: String,
     pub metadata: HashMap<String, Value>,
     pub columns: Vec<Column>,
     pub acceleration: Option<acceleration::Acceleration>,
+    pub runtime: Arc<Runtime>,
+    pub app: Arc<App>,
 }
 
-impl TryFrom<spicepod_view::View> for View {
-    type Error = crate::Error;
+impl PartialEq for View {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.sql == other.sql
+            && self.metadata == other.metadata
+            && self.columns == other.columns
+            && self.acceleration == other.acceleration
+    }
+}
 
-    fn try_from(view: spicepod_view::View) -> Result<Self, Self::Error> {
-        validate_identifier(&view.name).context(crate::ComponentSnafu)?;
-
-        let table_reference = Dataset::parse_table_reference(&view.name)?;
-
-        let sql = if let Some(view_sql) = &view.sql {
-            view_sql.to_string()
-        } else if let Some(sql_ref) = &view.sql_ref {
-            Self::load_sql_ref(sql_ref)?
-        } else {
-            return Err(crate::Error::NeedToSpecifySQLView {
-                name: table_reference.to_string(),
-            });
-        };
-
-        let acceleration = view
-            .acceleration
-            .map(acceleration::Acceleration::try_from)
-            .transpose()?;
-
-        Ok(View {
-            name: table_reference,
-            sql,
-            metadata: view.metadata,
-            columns: view.columns,
-            acceleration,
-        })
+impl std::fmt::Debug for View {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("View")
+            .field("name", &self.name)
+            .field("sql", &self.sql)
+            .field("metadata", &self.metadata)
+            .field("columns", &self.columns)
+            .field("acceleration", &self.acceleration)
+            .finish_non_exhaustive()
     }
 }
 
@@ -83,5 +80,125 @@ impl View {
         }
 
         false
+    }
+}
+
+pub struct ViewBuilder {
+    pub name: TableReference,
+    pub sql: String,
+    pub metadata: HashMap<String, Value>,
+    pub columns: Vec<Column>,
+    pub acceleration: Option<acceleration::Acceleration>,
+    pub runtime: Option<Arc<Runtime>>,
+    pub app: Option<Arc<App>>,
+}
+
+impl TryFrom<spicepod_view::View> for ViewBuilder {
+    type Error = crate::Error;
+
+    fn try_from(view: spicepod_view::View) -> Result<Self, Self::Error> {
+        validate_identifier(&view.name).context(crate::ComponentSnafu)?;
+
+        let table_reference = Dataset::parse_table_reference(&view.name)?;
+
+        let sql = if let Some(view_sql) = &view.sql {
+            view_sql.to_string()
+        } else if let Some(sql_ref) = &view.sql_ref {
+            View::load_sql_ref(sql_ref)?
+        } else {
+            return Err(crate::Error::NeedToSpecifySQLView {
+                name: table_reference.to_string(),
+            });
+        };
+
+        let acceleration = view
+            .acceleration
+            .map(acceleration::Acceleration::try_from)
+            .transpose()?;
+
+        Ok(ViewBuilder {
+            name: table_reference,
+            sql,
+            metadata: view.metadata,
+            columns: view.columns,
+            acceleration,
+            runtime: None,
+            app: None,
+        })
+    }
+}
+
+impl AccelerationSource for View {
+    fn is_file_accelerated(&self) -> bool {
+        if let Some(acceleration) = &self.acceleration {
+            if acceleration.engine == acceleration::Engine::PostgreSQL {
+                return false;
+            }
+            return acceleration.enabled && acceleration.mode == acceleration::Mode::File;
+        }
+        false
+    }
+
+    fn app(&self) -> Arc<app::App> {
+        Arc::clone(&self.app)
+    }
+
+    fn runtime(&self) -> Arc<Runtime> {
+        Arc::clone(&self.runtime)
+    }
+
+    fn acceleration(&self) -> Option<&Acceleration> {
+        self.acceleration.as_ref()
+    }
+
+    fn name(&self) -> &TableReference {
+        &self.name
+    }
+}
+
+impl ViewBuilder {
+    #[must_use]
+    pub fn new(name: TableReference, sql: String) -> Self {
+        Self {
+            name,
+            sql,
+            metadata: HashMap::default(),
+            columns: vec![],
+            acceleration: None,
+            runtime: None,
+            app: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_runtime(mut self, runtime: Arc<Runtime>) -> Self {
+        self.runtime = Some(runtime);
+        self
+    }
+
+    #[must_use]
+    pub fn with_app(mut self, app: Arc<App>) -> Self {
+        self.app = Some(app);
+        self
+    }
+
+    pub fn build(self) -> crate::Result<View> {
+        let runtime = self.runtime.context(crate::UnableToCreateViewSnafu {
+            reason: "Runtime is not set.\nAn unexpected error occurred. Report a bug to request support: https://github.com/spiceai/spiceai/issues".to_string()
+        })?;
+
+        let app = self.app.context(crate::UnableToCreateViewSnafu {
+            reason: "App is not set.\nAn unexpected error occurred. Report a bug to request support: https://github.com/spiceai/spiceai/issues".to_string()
+        })?;
+
+        Ok(View {
+            name: self.name,
+            sql: self.sql,
+            metadata: self.metadata,
+            columns: self.columns,
+            acceleration: self.acceleration,
+            runtime,
+            app,
+        })
     }
 }

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -33,7 +33,6 @@ use super::{
 use spicepod::semantic::Column;
 
 /// [`View`] is the internal representation of the [`spicepod_view::View`] spicepod component.
-#[derive(Clone)]
 pub struct View {
     pub name: TableReference,
     pub sql: Arc<str>,

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -36,7 +36,7 @@ use spicepod::semantic::Column;
 #[derive(Clone)]
 pub struct View {
     pub name: TableReference,
-    pub sql: String,
+    pub sql: Arc<str>,
     pub metadata: HashMap<String, Value>,
     pub columns: Vec<Column>,
     pub acceleration: Option<acceleration::Acceleration>,
@@ -168,7 +168,7 @@ impl ViewBuilder {
     pub fn build_with(self, runtime: Arc<Runtime>, app: Arc<App>) -> View {
         View {
             name: self.name,
-            sql: self.sql,
+            sql: Arc::from(self.sql),
             metadata: self.metadata,
             columns: self.columns,
             acceleration: self.acceleration,

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -89,8 +89,6 @@ pub struct ViewBuilder {
     pub metadata: HashMap<String, Value>,
     pub columns: Vec<Column>,
     pub acceleration: Option<acceleration::Acceleration>,
-    pub runtime: Option<Arc<Runtime>>,
-    pub app: Option<Arc<App>>,
 }
 
 impl TryFrom<spicepod_view::View> for ViewBuilder {
@@ -122,8 +120,6 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
             metadata: view.metadata,
             columns: view.columns,
             acceleration,
-            runtime: None,
-            app: None,
         })
     }
 }
@@ -165,33 +161,12 @@ impl ViewBuilder {
             metadata: HashMap::default(),
             columns: vec![],
             acceleration: None,
-            runtime: None,
-            app: None,
         }
     }
 
     #[must_use]
-    pub fn with_runtime(mut self, runtime: Arc<Runtime>) -> Self {
-        self.runtime = Some(runtime);
-        self
-    }
-
-    #[must_use]
-    pub fn with_app(mut self, app: Arc<App>) -> Self {
-        self.app = Some(app);
-        self
-    }
-
-    pub fn build(self) -> crate::Result<View> {
-        let runtime = self.runtime.context(crate::UnableToCreateViewSnafu {
-            reason: "Runtime is not set.\nAn unexpected error occurred. Report a bug to request support: https://github.com/spiceai/spiceai/issues".to_string()
-        })?;
-
-        let app = self.app.context(crate::UnableToCreateViewSnafu {
-            reason: "App is not set.\nAn unexpected error occurred. Report a bug to request support: https://github.com/spiceai/spiceai/issues".to_string()
-        })?;
-
-        Ok(View {
+    pub fn build_with(self, runtime: Arc<Runtime>, app: Arc<App>) -> View {
+        View {
             name: self.name,
             sql: self.sql,
             metadata: self.metadata,
@@ -199,6 +174,6 @@ impl ViewBuilder {
             acceleration: self.acceleration,
             runtime,
             app,
-        })
+        }
     }
 }

--- a/crates/runtime/src/dataaccelerator.rs
+++ b/crates/runtime/src/dataaccelerator.rs
@@ -19,7 +19,7 @@ use crate::component::dataset::acceleration::{self, Acceleration, Engine, IndexT
 use crate::parameters::ParameterSpec;
 use crate::parameters::Parameters;
 use crate::secrets::{ExposeSecret, ParamStr, Secrets};
-use crate::spice_data_base_path;
+use crate::{Runtime, spice_data_base_path};
 use ::arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::common::Constraint;
@@ -131,7 +131,7 @@ impl AcceleratorEngineRegistry {
         constraints: Option<&Constraints>,
         acceleration_settings: &acceleration::Acceleration,
         secrets: Arc<RwLock<Secrets>>,
-        dataset: Option<&Dataset>,
+        source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>> {
         let engine = acceleration_settings.engine;
 
@@ -229,7 +229,7 @@ impl AcceleratorEngineRegistry {
         let external_table = external_table_builder.build()?;
 
         let table_provider = accelerator
-            .create_external_table(&external_table, dataset)
+            .create_external_table(&external_table, source)
             .await
             .context(AccelerationCreationFailedSnafu)?;
 
@@ -246,7 +246,7 @@ pub trait DataAccelerator: Send + Sync {
     async fn create_external_table(
         &self,
         cmd: &CreateExternalTable,
-        dataset: Option<&Dataset>,
+        source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
 
     /// The name of the accelerator
@@ -258,7 +258,7 @@ pub trait DataAccelerator: Send + Sync {
     /// The parameters of the accelerator
     fn parameters(&self) -> &'static [ParameterSpec];
 
-    /// Initialize the accelerator for a dataset
+    /// Initialize the accelerator for a component
     async fn init(
         &self,
         _dataset: &Dataset,
@@ -266,7 +266,7 @@ pub trait DataAccelerator: Send + Sync {
         Ok(())
     }
 
-    /// Check if the accelerator is initialized for a dataset
+    /// Check if the accelerator is initialized for a component
     fn is_initialized(&self, _dataset: &Dataset) -> bool {
         true
     }
@@ -278,7 +278,7 @@ pub trait DataAccelerator: Send + Sync {
 
     /// For file-based accelerators, return the file path
     /// For any other accelerator, return None
-    fn file_path(&self, _dataset: &Dataset) -> Result<String> {
+    fn file_path(&self, _source: &dyn AccelerationSource) -> Result<String> {
         Err(Error::FileModeUnsupported {})
     }
 
@@ -297,8 +297,8 @@ pub trait DataAccelerator: Send + Sync {
     }
 
     /// Check if the file path exists
-    fn has_existing_file(&self, dataset: &Dataset) -> bool {
-        if let Ok(path) = self.file_path(dataset) {
+    fn has_existing_file(&self, source: &dyn AccelerationSource) -> bool {
+        if let Ok(path) = self.file_path(source) {
             let path = std::path::Path::new(&path);
             path.is_file()
         } else {
@@ -437,6 +437,25 @@ impl AcceleratorExternalTableBuilder {
 
         Ok(external_table)
     }
+}
+
+/// Represents acceleration source component, such as a dataset or a view.
+/// Provides additional information about the source, such as its name and associated runtime information.
+pub trait AccelerationSource: Sync {
+    /// Returns true if the source uses file-based acceleration
+    fn is_file_accelerated(&self) -> bool;
+
+    /// Returns the application associated with this source
+    fn app(&self) -> Arc<app::App>;
+
+    /// Returns the runtime associated with this source
+    fn runtime(&self) -> Arc<Runtime>;
+
+    /// Returns the acceleration configuration if it exists
+    fn acceleration(&self) -> Option<&Acceleration>;
+
+    /// Returns the name of this source
+    fn name(&self) -> &TableReference;
 }
 
 fn get_primary_keys_from_constraints(constraints: &Constraints, schema: &SchemaRef) -> Vec<String> {

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -23,9 +23,9 @@ use datafusion::{
 use snafu::ResultExt;
 use std::{any::Any, sync::Arc};
 
-use crate::{component::dataset::Dataset, parameters::ParameterSpec};
+use crate::parameters::ParameterSpec;
 
-use super::DataAccelerator;
+use super::{AccelerationSource, DataAccelerator};
 
 pub struct ArrowAccelerator {
     arrow_factory: ArrowFactory,
@@ -62,7 +62,7 @@ impl DataAccelerator for ArrowAccelerator {
     async fn create_external_table(
         &self,
         cmd: &CreateExternalTable,
-        _dataset: Option<&Dataset>,
+        _source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         let ctx = SessionContext::new();
         TableProviderFactory::create(&self.arrow_factory, &ctx.state(), cmd)

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -39,7 +39,7 @@ use duckdb::AccessMode;
 use snafu::prelude::*;
 use std::{any::Any, cmp::max, ffi::OsStr, sync::Arc};
 
-use super::{DataAccelerator, Error as DataAcceleratorError};
+use super::{AccelerationSource, DataAccelerator, Error as DataAcceleratorError};
 
 const DEFAULT_MIN_IDLE_CONNECTIONS: u32 = 10;
 
@@ -93,12 +93,12 @@ impl DuckDBAccelerator {
     }
 
     /// Returns the `DuckDB` file path that would be used for a file-based `DuckDB` accelerator from this dataset
-    pub fn duckdb_file_path(&self, dataset: &Dataset) -> Result<String> {
-        if !dataset.is_file_accelerated() {
+    pub fn duckdb_file_path(&self, source: &dyn AccelerationSource) -> Result<String> {
+        if !source.is_file_accelerated() {
             Err(Error::InvalidConfiguration {
                 detail: Arc::from("Dataset is not file accelerated"),
             })
-        } else if let Some(acceleration) = dataset.acceleration.as_ref() {
+        } else if let Some(acceleration) = source.acceleration().as_ref() {
             let mut params = acceleration.params.clone();
             params.insert("data_directory".to_string(), spice_data_base_path());
 
@@ -185,7 +185,7 @@ impl DuckDBAccelerator {
                 // If the path is Some, we're counting the number of file instances
                 if let Some(this_file_path) = path {
                     if acceleration.mode == Mode::File {
-                        if let Ok(file_path) = self.file_path(&ds) {
+                        if let Ok(file_path) = self.file_path(ds.as_ref()) {
                             if this_file_path == file_path {
                                 instance_usage += 1;
                             }
@@ -235,8 +235,8 @@ impl DataAccelerator for DuckDBAccelerator {
         vec!["db", "ddb", "duckdb"]
     }
 
-    fn file_path(&self, dataset: &Dataset) -> Result<String, DataAcceleratorError> {
-        self.duckdb_file_path(dataset)
+    fn file_path(&self, source: &dyn AccelerationSource) -> Result<String, DataAcceleratorError> {
+        self.duckdb_file_path(source)
             .map_err(|e| DataAcceleratorError::InvalidConfiguration { msg: e.to_string() })
     }
 
@@ -291,7 +291,7 @@ impl DataAccelerator for DuckDBAccelerator {
     async fn create_external_table(
         &self,
         cmd: &CreateExternalTable,
-        dataset: Option<&Dataset>,
+        source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         let mut cmd = cmd.clone();
         if let Some(duckdb_file) = cmd.options.remove("file") {
@@ -299,24 +299,24 @@ impl DataAccelerator for DuckDBAccelerator {
                 .insert("open".to_string(), duckdb_file.to_string());
         }
 
-        if let Some(this_dataset) = dataset {
-            if let Some(temp_directory) = &this_dataset.app.runtime.temp_directory.clone() {
+        if let Some(source) = source {
+            if let Some(temp_directory) = &source.app().runtime.temp_directory.clone() {
                 cmd.options
                     .insert("temp_directory".to_string(), temp_directory.to_string());
             }
 
-            if this_dataset.is_file_accelerated() {
+            if source.is_file_accelerated() {
                 // If the user didn't specify a DuckDB file and this is a file-mode DuckDB,
                 // then use the shared DuckDB file `accelerated_duckdb.db`
                 if !cmd.options.contains_key("open") {
-                    let duckdb_file = self.duckdb_file_path(this_dataset)?;
+                    let duckdb_file = self.duckdb_file_path(source)?;
                     cmd.options.insert("open".to_string(), duckdb_file);
                 }
 
-                let datasets = Arc::clone(&this_dataset.runtime)
-                    .get_initialized_datasets(&this_dataset.app, crate::LogErrors(false))
+                let datasets: Vec<Arc<Dataset>> = Arc::clone(&source.runtime())
+                    .get_initialized_datasets(&source.app(), crate::LogErrors(false))
                     .await;
-                let self_path = self.file_path(this_dataset)?;
+                let self_path = self.file_path(source)?;
                 let attach_databases = datasets
                     .iter()
                     .filter_map(|other_dataset| {
@@ -325,10 +325,10 @@ impl DataAccelerator for DuckDBAccelerator {
                             .as_ref()
                             .is_some_and(|a| a.engine == Engine::DuckDB && a.mode == Mode::File)
                         {
-                            if **other_dataset == *this_dataset {
+                            if other_dataset.name() == source.name() {
                                 None
                             } else {
-                                let other_path = self.file_path(other_dataset);
+                                let other_path = self.file_path(other_dataset.as_ref());
                                 other_path.ok().filter(|p| p != &self_path)
                             }
                         } else {

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -26,9 +26,9 @@ use datafusion_table_providers::postgres::{
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
-use crate::{component::dataset::Dataset, parameters::ParameterSpec};
+use crate::parameters::ParameterSpec;
 
-use super::DataAccelerator;
+use super::{AccelerationSource, DataAccelerator};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -87,7 +87,7 @@ impl DataAccelerator for PostgresAccelerator {
     async fn create_external_table(
         &self,
         cmd: &CreateExternalTable,
-        _dataset: Option<&Dataset>,
+        _source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         let ctx = SessionContext::new();
         let table_provider =

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -38,7 +38,7 @@ use crate::{
     spice_data_base_path,
 };
 
-use super::{DataAccelerator, Error as DataAcceleratorError};
+use super::{AccelerationSource, DataAccelerator, Error as DataAcceleratorError};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -107,12 +107,12 @@ impl SqliteAccelerator {
     }
 
     /// Returns the `Sqlite` file path that would be used for a file-based `Sqlite` accelerator from this dataset
-    pub fn sqlite_file_path(&self, dataset: &Dataset) -> Result<String> {
-        if !dataset.is_file_accelerated() {
+    pub fn sqlite_file_path(&self, source: &dyn AccelerationSource) -> Result<String> {
+        if !source.is_file_accelerated() {
             Err(Error::InvalidConfiguration {
                 detail: Arc::from("Dataset is not file accelerated"),
             })
-        } else if let Some(acceleration) = dataset.acceleration.as_ref() {
+        } else if let Some(acceleration) = source.acceleration() {
             let mut acceleration_params = acceleration.params.clone();
 
             acceleration_params.insert("data_directory".to_string(), spice_data_base_path());
@@ -188,8 +188,8 @@ impl DataAccelerator for SqliteAccelerator {
         vec!["sqlite", "db"]
     }
 
-    fn file_path(&self, dataset: &Dataset) -> Result<String, DataAcceleratorError> {
-        self.sqlite_file_path(dataset)
+    fn file_path(&self, source: &dyn AccelerationSource) -> Result<String, DataAcceleratorError> {
+        self.sqlite_file_path(source)
             .map_err(|err| DataAcceleratorError::InvalidConfiguration {
                 msg: err.to_string(),
             })
@@ -249,23 +249,24 @@ impl DataAccelerator for SqliteAccelerator {
     async fn create_external_table(
         &self,
         cmd: &CreateExternalTable,
-        dataset: Option<&Dataset>,
+        source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         let mut cmd = cmd.clone();
 
-        if let Some(this_dataset) = dataset {
-            if this_dataset.is_file_accelerated() {
+        if let Some(source) = source {
+            if source.is_file_accelerated() {
                 // If the user didn't specify a SQLite file and this is a file-mode SQLite,
                 // then use the shared SQLite file `accelerated_sqlite.db`
                 if !cmd.options.contains_key("file") {
-                    let sqlite_file = self.sqlite_file_path(this_dataset)?;
+                    let sqlite_file = self.sqlite_file_path(source)?;
                     cmd.options.insert("file".to_string(), sqlite_file);
                 }
 
-                let datasets = Arc::clone(&this_dataset.runtime)
-                    .get_initialized_datasets(&this_dataset.app, crate::LogErrors(false))
+                let datasets = source
+                    .runtime()
+                    .get_initialized_datasets(&source.app(), crate::LogErrors(false))
                     .await;
-                let self_path = self.file_path(this_dataset)?;
+                let self_path = self.file_path(source)?;
                 let attach_databases = datasets
                     .iter()
                     .filter_map(|other_dataset| {
@@ -274,10 +275,10 @@ impl DataAccelerator for SqliteAccelerator {
                             .as_ref()
                             .is_some_and(|a| a.engine == Engine::Sqlite && a.mode == Mode::File)
                         {
-                            if **other_dataset == *this_dataset {
+                            if other_dataset.name() == source.name() {
                                 None
                             } else {
-                                let other_path = self.file_path(other_dataset);
+                                let other_path = self.file_path(other_dataset.as_ref());
                                 other_path.ok().filter(|p| p != &self_path)
                             }
                         } else {

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -21,8 +21,9 @@ use std::time::Duration;
 use crate::accelerated_table::refresh::{self, RefreshOverrides};
 use crate::accelerated_table::{self, AcceleratedTableBuilderError};
 use crate::accelerated_table::{AcceleratedTable, Retention, refresh::Refresh};
-use crate::component::dataset::acceleration::{self, RefreshMode};
+use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::{Dataset, Mode};
+use crate::component::view::View;
 use crate::dataaccelerator::AcceleratorEngineRegistry;
 use crate::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
 use crate::dataaccelerator::{self};
@@ -1172,20 +1173,18 @@ impl DataFusion {
 
     pub(crate) fn register_view(
         self: &Arc<Self>,
-        table: TableReference,
-        view: String,
-        acceleration: Option<acceleration::Acceleration>,
+        view: View,
         secrets: Arc<TokioRwLock<Secrets>>,
     ) -> Result<()> {
-        tracing::info!("Initializing view {table}");
+        tracing::info!("Initializing view {}", &view.name);
 
-        let table_exists = self.ctx.table_exist(table.clone()).unwrap_or(false);
+        let table_exists = self.ctx.table_exist(view.name.clone()).unwrap_or(false);
         if table_exists {
             return TableAlreadyExistsSnafu.fail();
         }
-        ensure_schema_exists(&self.ctx, SPICE_DEFAULT_CATALOG, &table)?;
+        ensure_schema_exists(&self.ctx, SPICE_DEFAULT_CATALOG, &view.name)?;
 
-        let statements = DFParser::parse_sql_with_dialect(view.as_str(), &PostgreSqlDialect {})
+        let statements = DFParser::parse_sql_with_dialect(&view.sql, &PostgreSqlDialect {})
             .context(UnableToParseSqlSnafu)?;
         if statements.len() != 1 {
             return UnableToCreateViewSnafu {
@@ -1210,6 +1209,8 @@ impl DataFusion {
 
             let deadline = Instant::now() + Duration::from_secs(60);
             let mut unresolved_dependent_table: Option<TableReference> = None;
+
+            let table = &view.name;
 
             for dependent_table_name in &dependent_table_names {
                 let mut attempts = 0;
@@ -1245,33 +1246,27 @@ impl DataFusion {
                 tracing::error!(
                     "Failed to create view {table}. Dependent table {missing_table} does not exist."
                 );
-                status.update_view(&table, status::ComponentStatus::Error);
+                status.update_view(table, status::ComponentStatus::Error);
                 return;
             }
 
-            let view_table = match create_view_table(&ctx, &statements[0], view).await {
+            let view_table = match create_view_table(&ctx, &statements[0], &view.sql).await {
                 Ok(view_table) => view_table,
                 Err(e) => {
                     tracing::error!("Failed to create view: {e}");
-                    status.update_view(&table, status::ComponentStatus::Error);
+                    status.update_view(table, status::ComponentStatus::Error);
                     return;
                 }
             };
 
-            if let Some(acceleration) = acceleration {
+            if let Some(acceleration) = &view.acceleration {
                 if acceleration.enabled {
                     if let Err(e) = df_ref
-                        .create_accelerated_view(
-                            &table,
-                            view_table,
-                            acceleration,
-                            &dependent_table_names,
-                            secrets,
-                        )
+                        .create_accelerated_view(&view, view_table, &dependent_table_names, secrets)
                         .await
                     {
                         tracing::error!("Failed to create view: {e}");
-                        status.update_view(&table, status::ComponentStatus::Error);
+                        status.update_view(table, status::ComponentStatus::Error);
                     }
                     return;
                 }
@@ -1280,11 +1275,11 @@ impl DataFusion {
             // non-accelerated view
             if let Err(e) = ctx.register_table(table.clone(), Arc::new(view_table)) {
                 tracing::error!("Failed to create view: {e}");
-                status.update_view(&table, status::ComponentStatus::Error);
+                status.update_view(table, status::ComponentStatus::Error);
                 return;
             };
-            tracing::info!("{}", view_registered_trace(&table, None));
-            status.update_view(&table, status::ComponentStatus::Ready);
+            tracing::info!("{}", view_registered_trace(table, None));
+            status.update_view(table, status::ComponentStatus::Ready);
         });
 
         Ok(())
@@ -1292,15 +1287,23 @@ impl DataFusion {
 
     pub async fn create_accelerated_view(
         self: &Arc<Self>,
-        table: &TableReference,
+        view: &View,
         view_table: ViewTable,
-        acceleration: acceleration::Acceleration,
         dependent_tables: &[TableReference],
         secrets: Arc<TokioRwLock<Secrets>>,
     ) -> Result<()> {
+        let table = &view.name;
+
         tracing::debug!(
-            "Creating accelerated view {table:?} with dependent tables {dependent_tables:?}"
+            "Creating accelerated view {table} with dependent tables {dependent_tables:?}"
         );
+
+        let acceleration =
+            view.acceleration
+                .as_ref()
+                .ok_or_else(|| Error::ExpectedAccelerationSettings {
+                    name: table.to_string(),
+                })?;
 
         // If accelerated view depends on other tables, wait until they are ready; this is required to complete
         // initial data load and avoid errors indicating that the load can't be completed because tables are still loading or connecting
@@ -1343,7 +1346,14 @@ impl DataFusion {
 
         let accelerated_table_provider = self
             .accelerator_engine_registry()
-            .create_accelerator_table(table.clone(), schema, None, &acceleration, secrets, None)
+            .create_accelerator_table(
+                table.clone(),
+                schema,
+                None,
+                acceleration,
+                secrets,
+                Some(view),
+            )
             .await
             .map_err(|e| Error::UnableToCreateView {
                 reason: format!("Failed to create view acceleration: {e}"),
@@ -1382,7 +1392,7 @@ impl DataFusion {
             })?;
 
         // ready status will be updated by the accelerated dataset
-        tracing::info!("{}", view_registered_trace(table, Some(&acceleration)));
+        tracing::info!("{}", view_registered_trace(table, Some(acceleration)));
 
         Ok(())
     }

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -1173,7 +1173,7 @@ impl DataFusion {
 
     pub(crate) fn register_view(
         self: &Arc<Self>,
-        view: View,
+        view: Arc<View>,
         secrets: Arc<TokioRwLock<Secrets>>,
     ) -> Result<()> {
         tracing::info!("Initializing view {}", &view.name);

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -1250,7 +1250,8 @@ impl DataFusion {
                 return;
             }
 
-            let view_table = match create_view_table(&ctx, &statements[0], &view.sql).await {
+            let view_table = match create_view_table(&ctx, &statements[0], view.sql.as_ref()).await
+            {
                 Ok(view_table) => view_table,
                 Err(e) => {
                     tracing::error!("Failed to create view: {e}");

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -17,8 +17,13 @@ limitations under the License.
 use std::{collections::HashMap, collections::HashSet, sync::Arc};
 
 use crate::{
-    LogErrors, Result, Runtime, UnableToAttachViewSnafu, component::view::View, metrics,
-    secrets::Secrets, status, topological_ordering::construct_effected_in_topological_order, view,
+    LogErrors, Result, Runtime, UnableToAttachViewSnafu,
+    component::view::{View, ViewBuilder},
+    metrics,
+    secrets::Secrets,
+    status,
+    topological_ordering::construct_effected_in_topological_order,
+    view,
 };
 use app::App;
 use datafusion::sql::{TableReference, parser::DFParser, sqlparser::dialect::PostgreSqlDialect};
@@ -43,6 +48,8 @@ impl Runtime {
         app: &Arc<App>,
         log_errors: LogErrors,
     ) -> Vec<View> {
+        let rt_ref = Arc::clone(&self);
+
         let datasets = self
             .get_valid_datasets(app, log_errors)
             .iter()
@@ -52,7 +59,12 @@ impl Runtime {
         app.views
             .iter()
             .cloned()
-            .map(View::try_from)
+            .map(|spicepod_view| {
+                ViewBuilder::try_from(spicepod_view)?
+                    .with_app(Arc::clone(app))
+                    .with_runtime(Arc::clone(&rt_ref))
+                    .build()
+            })
             .zip(&app.views)
             .filter_map(|(view, spicepod_view)| match view {
                 Ok(view) => {
@@ -83,34 +95,29 @@ impl Runtime {
 
     fn load_view(&self, view: &View, secrets: Arc<RwLock<Secrets>>) -> Result<()> {
         let df = Arc::clone(&self.df);
-        df.register_view(
-            view.name.clone(),
-            view.sql.clone(),
-            view.acceleration.clone(),
-            secrets,
-        )
-        .context(UnableToAttachViewSnafu)
-        .inspect_err(|_| {
-            self.status
-                .update_view(&view.name, status::ComponentStatus::Error);
-        })?;
+        df.register_view(view.clone(), secrets)
+            .context(UnableToAttachViewSnafu)
+            .inspect_err(|_| {
+                self.status
+                    .update_view(&view.name, status::ComponentStatus::Error);
+            })?;
         Ok(())
     }
 
-    fn remove_view(&self, view: &View) {
-        if self.df.table_exists(view.name.clone()) {
-            if let Err(e) = self.df.remove_view(&view.name) {
-                tracing::warn!("Unable to unload view {}: {}", &view.name, e);
+    fn remove_view(&self, name: &TableReference) {
+        if self.df.table_exists(name.clone()) {
+            if let Err(e) = self.df.remove_view(name) {
+                tracing::warn!("Unable to unload view {}: {}", name, e);
                 return;
             }
         }
-        tracing::info!("Unloaded view {}", &view.name);
+        tracing::info!("Unloaded view {}", name);
     }
 
     fn update_view(&self, view: &View) {
         self.status
             .update_view(&view.name, status::ComponentStatus::Refreshing);
-        self.remove_view(view);
+        self.remove_view(&view.name);
         let _ = self.load_view(view, self.secrets());
     }
 
@@ -140,7 +147,7 @@ impl Runtime {
         // Remove views that are no longer in the app
         for view in &current_app.views {
             if !new_app.views.iter().any(|v| v.name == view.name) {
-                let view = match View::try_from(view.clone()) {
+                let view_builder = match ViewBuilder::try_from(view.clone()) {
                     Ok(v) => v,
                     Err(e) => {
                         tracing::error!("Could not remove view {}: {e}", view.name);
@@ -148,8 +155,8 @@ impl Runtime {
                     }
                 };
                 self.status
-                    .update_view(&view.name, status::ComponentStatus::Disabled);
-                self.remove_view(&view);
+                    .update_view(&view_builder.name, status::ComponentStatus::Disabled);
+                self.remove_view(&view_builder.name);
             }
         }
 

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -164,7 +164,7 @@ impl Runtime {
             .iter()
             .map(|v| {
                 let Some(statement) =
-                    DFParser::parse_sql_with_dialect(v.sql.as_str(), &PostgreSqlDialect {})
+                    DFParser::parse_sql_with_dialect(v.sql.as_ref(), &PostgreSqlDialect {})
                         .boxed()?.pop_front() else {
                             return Err(Box::<dyn std::error::Error + Send + Sync>::from(format!("no statements found in view {}", v.name)));
                         };

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -33,10 +33,10 @@ use tokio::sync::RwLock;
 
 impl Runtime {
     pub(crate) fn load_views(self: Arc<Self>, app: &Arc<App>) {
-        let views: Vec<View> = Arc::clone(&self).get_valid_views(app, LogErrors(true));
+        let views = Arc::clone(&self).get_valid_views(app, LogErrors(true));
 
-        for view in &views {
-            if let Err(e) = self.load_view(view, self.secrets()) {
+        for view in views {
+            if let Err(e) = self.load_view(&view, self.secrets()) {
                 tracing::error!("Unable to load view: {e}");
             };
         }
@@ -47,7 +47,7 @@ impl Runtime {
         self: Arc<Self>,
         app: &Arc<App>,
         log_errors: LogErrors,
-    ) -> Vec<View> {
+    ) -> Vec<Arc<View>> {
         let rt_ref = Arc::clone(&self);
 
         let datasets = self
@@ -77,7 +77,7 @@ impl Runtime {
                         }
                         None
                     } else {
-                        Some(view)
+                        Some(Arc::new(view))
                     }
                 }
                 Err(e) => {
@@ -91,9 +91,9 @@ impl Runtime {
             .collect()
     }
 
-    fn load_view(&self, view: &View, secrets: Arc<RwLock<Secrets>>) -> Result<()> {
+    fn load_view(&self, view: &Arc<View>, secrets: Arc<RwLock<Secrets>>) -> Result<()> {
         let df = Arc::clone(&self.df);
-        df.register_view(view.clone(), secrets)
+        df.register_view(Arc::clone(view), secrets)
             .context(UnableToAttachViewSnafu)
             .inspect_err(|_| {
                 self.status
@@ -112,7 +112,7 @@ impl Runtime {
         tracing::info!("Unloaded view {}", name);
     }
 
-    fn update_view(&self, view: &View) {
+    fn update_view(&self, view: &Arc<View>) {
         self.status
             .update_view(&view.name, status::ComponentStatus::Refreshing);
         self.remove_view(&view.name);

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -60,10 +60,8 @@ impl Runtime {
             .iter()
             .cloned()
             .map(|spicepod_view| {
-                ViewBuilder::try_from(spicepod_view)?
-                    .with_app(Arc::clone(app))
-                    .with_runtime(Arc::clone(&rt_ref))
-                    .build()
+                ViewBuilder::try_from(spicepod_view)
+                    .map(|builder| builder.build_with(Arc::clone(&rt_ref), Arc::clone(app)))
             })
             .zip(&app.views)
             .filter_map(|(view, spicepod_view)| match view {


### PR DESCRIPTION
## 📝 Summary

Apply common acceleration logic for both Datasets and Views by introducing `AccelerationSource` abstraction Data Accelerators can operate by. This apply Spice advanced acceleration logic and params support to accelerated views:
 - shared default acceleration file (`accelerated_duckdb.db`) for full federation
 - temp_directory

Note: this is first iteration to add most important functionality/logic support, the following item was created to make datasets attachment logic to include views to have full federation when accelerated datasets and views define custom acceleration file path.
- https://github.com/spiceai/spiceai/issues/5530

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/5490

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Some `DataAccelerator` methods still use Dataset as param instead of `AccelerationSource`, this is to be addressed in follow-up PR to enabling checkpointing support for accelerated views.

```
fn is_initialized(&self, _dataset: &Dataset) -> bool {
..
}
```
