### PR TITLE
Fix public '.model' name for router workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14849,6 +14849,7 @@ dependencies = [
  "arrow",
  "async-openai",
  "async-trait",
+ "futures",
  "llms",
  "rand 0.9.0",
  "secrecy",

--- a/crates/workers/Cargo.toml
+++ b/crates/workers/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 arrow.workspace = true
 async-openai.workspace = true
 async-trait.workspace = true
+futures.workspace = true
 llms = { path = "../llms" }
 rand = { version = "0.9.0" }
 secrecy.workspace = true

--- a/crates/workers/src/router.rs
+++ b/crates/workers/src/router.rs
@@ -20,6 +20,7 @@ use async_openai::{
         ChatCompletionResponseStream, CreateChatCompletionRequest, CreateChatCompletionResponse,
     },
 };
+use futures::TryStreamExt;
 use llms::chat::{Chat, nsql::SqlGeneration};
 use rand::{
     distr::{Distribution, weighted::WeightedIndex},
@@ -84,7 +85,8 @@ impl Chat for RouterModel {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
-        match self.models_cfg.first() {
+        let public_name = self.router_name.clone();
+        Ok(Box::pin(match self.models_cfg.first() {
             Some(worker::RouterConfig::RoundRobin { .. }) => {
                 // This cannot be `None` as by this point, there is at least one model.
                 let name = self.select_from_round_robin().unwrap_or_default();
@@ -140,7 +142,11 @@ impl Chat for RouterModel {
                 param: None,
                 code: None,
             })),
-        }
+        }?
+        .map_ok(move |mut ss| {
+            ss.model = public_name.clone();
+            ss
+        })))
     }
 
     #[allow(deprecated)]
@@ -205,6 +211,10 @@ impl Chat for RouterModel {
                 code: None,
             })),
         }
+        .map(|mut r| {
+            r.model = self.router_name.clone();
+            r
+        })
     }
 
     fn as_sql(&self) -> Option<&dyn SqlGeneration> {

--- a/crates/workers/src/router.rs
+++ b/crates/workers/src/router.rs
@@ -144,7 +144,7 @@ impl Chat for RouterModel {
             })),
         }?
         .map_ok(move |mut ss| {
-            ss.model = public_name.clone();
+            ss.model.clone_from(&public_name);
             ss
         })))
     }
@@ -212,7 +212,7 @@ impl Chat for RouterModel {
             })),
         }
         .map(|mut r| {
-            r.model = self.router_name.clone();
+            r.model.clone_from(&self.router_name);
             r
         })
     }


### PR DESCRIPTION
## 📝 Summary
 - When using a router worker, the `.model` field in the response was from the underlying model. This PR addresses that by using the worker name.