### PR TITLE
feat: Add branch name to metric dimensions in testoperator

### DIFF
--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -83,6 +83,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
         KeyValue::new("benchmark.spiced_version", spiced_version.clone()),
         KeyValue::new("benchmark.query_set", query_set.to_string()),
         KeyValue::new("benchmark.spiced_commit_sha", commit_sha.clone()),
+        KeyValue::new("benchmark.branch_name", metrics.branch_name.clone()),
         KeyValue::new(
             "benchmark.scale_factor",
             args.scale_factor.unwrap_or(1.0).to_string(),


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds `benchmark.branch_name` as a metric dimension for testoperator benchmarks