### PR TITLE
fix: Split scheduled dispatch into a separate job

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -45,12 +45,12 @@ jobs:
   dispatch-scheduled:
     name: Dispatch tests - Scheduled
     runs-on: spiceai-runners
-    if: ${{ github.event_name == 'schedule' || github.event.inputs.all_benchmarks == 'true' }}
+    if: ${{ github.event_name == 'schedule' }}
     strategy:
       fail-fast: false
       matrix:
         commit:
-          - '' # empty string - find latest
+          - '' # empty string - find latest built spiced
           - '9ac1a25bdc849edde0eff5379a5ea212644c66fe' # release/1.1
     concurrency:
       group: testoperator-dispatch-scheduled
@@ -106,7 +106,7 @@ jobs:
   dispatch-input:
     name: Dispatch tests - Input
     runs-on: spiceai-runners
-    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_files_path != '' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     concurrency:
       group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}
       cancel-in-progress: false
@@ -133,13 +133,40 @@ jobs:
         uses: ./.github/actions/build-testoperator
 
       - name: Dispatch Testoperator - Input
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_files_path != '' }}
+        if: ${{ github.event.inputs.test_files_path != '' }}
         run: |
           testoperator dispatch \
             ${{ github.event.inputs.test_files_path }} \
             --workflow ${{ github.event.inputs.workflow_type }} \
             --update-snapshots ${{ github.event.inputs.update_snapshots }} \
             --validate=${{ github.event.inputs.validate }} \
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.inputs.spiced_commit }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - TPCH
+        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.inputs.spiced_commit }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - TPCDS
+        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.inputs.spiced_commit }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - ClickBench
+        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 --workflow bench
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -42,20 +42,19 @@ on:
         default: false
 
 jobs:
-  dispatch-tests:
-    name: Dispatch tests
+  dispatch-scheduled:
+    name: Dispatch tests - Scheduled
     runs-on: spiceai-runners
-    concurrency:
-      group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'scheduled' }}
-      cancel-in-progress: false
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.all_benchmarks == 'true' }}
     strategy:
+      fail-fast: false
       matrix:
         commit:
-          - ${{ github.event.inputs.spiced_commit || '' }}
+          - '' # empty string - find latest
           - '00e9d7d671ca9dd28eac1e78ba1253b1ae33fe76' # release/1.1
-        exclude:
-          - commit: '00e9d7d671ca9dd28eac1e78ba1253b1ae33fe76'
-            if: ${{ github.event_name != 'schedule' }}
+    concurrency:
+      group: testoperator-dispatch-scheduled
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,6 +79,59 @@ jobs:
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
 
+      - name: Dispatch Testoperator - Scheduled Bench - TPCH
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.commit }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - TPCDS
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.commit }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - ClickBench
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 --workflow bench
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.commit }}
+
+  dispatch-input:
+    name: Dispatch tests - Input
+    runs-on: spiceai-runners
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_files_path != '' }}
+    concurrency:
+      group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install MinIO
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.MINIO_SECRET_KEY }}
+
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        id: setup-spiced
+        with:
+          spiced_commit: ${{ github.event.inputs.spiced_commit }}
+
+      - name: Display spiced commit
+        run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
+
+      - name: Build Testoperator
+        uses: ./.github/actions/build-testoperator
+
       - name: Dispatch Testoperator - Input
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_files_path != '' }}
         run: |
@@ -91,31 +143,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ matrix.commit }}
-
-      - name: Dispatch Testoperator - Scheduled Bench - TPCH
-        if: ${{ github.event_name == 'schedule' || github.event.inputs.all_benchmarks == 'true' }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 --workflow bench
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ matrix.commit }}
-
-      - name: Dispatch Testoperator - Scheduled Bench - TPCDS
-        if: ${{ github.event_name == 'schedule' || github.event.inputs.all_benchmarks == 'true'  }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 --workflow bench
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ matrix.commit }}
-
-      - name: Dispatch Testoperator - Scheduled Bench - ClickBench
-        if: ${{ github.event_name == 'schedule' || github.event.inputs.all_benchmarks == 'true'  }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 --workflow bench
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ matrix.commit }}
+          WORKFLOW_COMMIT: ${{ github.event.inputs.spiced_commit }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         commit:
           - '' # empty string - find latest
-          - '00e9d7d671ca9dd28eac1e78ba1253b1ae33fe76' # release/1.1
+          - '9ac1a25bdc849edde0eff5379a5ea212644c66fe' # release/1.1
     concurrency:
       group: testoperator-dispatch-scheduled
       cancel-in-progress: false


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Splits the testoperator dispatch workflow into 2 jobs, one for triggered from input and one for from schedule. This makes it easier to manage each job type, instead of trying to manage the matrix within the same job