### PR TITLE
fix: Use refs in testoperator dispatch instead of commits

### DIFF
--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -12,6 +12,7 @@ inputs:
   ref: # optionally override the branch to fetch latest 10 commits from
     description: 'target ref'
     required: false
+    default: 'refs/heads/trunk'
     type: string
   with_odbc: # whether to download the ODBC-enabled binary
     description: 'download the ODBC-enabled spiced binary'
@@ -30,7 +31,7 @@ runs:
         git fetch --depth=10 origin ${{ inputs.ref }}
         echo "Fetching latest 10 commits from ${{ inputs.ref }}"
 
-        commit_hashes=($(git log origin/${{ inputs.ref }} --pretty=format:"%H" -n 10))
+        commit_hashes=($(git log ${{ inputs.ref }} --pretty=format:"%H" -n 10))
         
         if [[ "${{ inputs.with_odbc }}" == "true" ]]; then
           features="odbc_models"

--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'spiced build commit'
     required: false
     type: string
+  ref: # optionally override the branch to fetch latest 10 commits from
+    description: 'target ref'
+    required: false
+    type: string
   with_odbc: # whether to download the ODBC-enabled binary
     description: 'download the ODBC-enabled spiced binary'
     required: false
@@ -23,8 +27,10 @@ runs:
       if: ${{ !inputs.spiced_commit }}
       shell: bash
       run: |
-        git fetch --depth=10 origin trunk
-        commit_hashes=($(git log origin/trunk --pretty=format:"%H" -n 10))
+        git fetch --depth=10 origin ${{ inputs.ref }}
+        echo "Fetching latest 10 commits from ${{ inputs.ref }}"
+
+        commit_hashes=($(git log origin/${{ inputs.ref }} --pretty=format:"%H" -n 10))
         
         if [[ "${{ inputs.with_odbc }}" == "true" ]]; then
           features="odbc_models"

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -49,16 +49,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        commit:
-          - '' # empty string - find latest built spiced
-          - '9ac1a25bdc849edde0eff5379a5ea212644c66fe' # release/1.1
+        branch:
+          - 'trunk'
+          - 'release/1.1'
     concurrency:
       group: testoperator-dispatch-scheduled
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.commit }}
+          ref: ${{ matrix.branch }}
 
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
@@ -71,7 +71,7 @@ jobs:
         uses: ./.github/actions/setup-spiced
         id: setup-spiced
         with:
-          spiced_commit: ${{ matrix.commit }}
+          ref: ${{ matrix.branch }}
 
       - name: Display spiced commit
         run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
@@ -85,7 +85,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Bench - TPCDS
         run: |
@@ -93,7 +93,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.branch }}
 
       - name: Dispatch Testoperator - Scheduled Bench - ClickBench
         run: |
@@ -101,7 +101,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ matrix.branch }}
 
   dispatch-input:
     name: Dispatch tests - Input
@@ -125,6 +125,7 @@ jobs:
         id: setup-spiced
         with:
           spiced_commit: ${{ github.event.inputs.spiced_commit }}
+          ref: ${{ github.event.ref }}
 
       - name: Display spiced commit
         run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
@@ -143,7 +144,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}
 
       - name: Dispatch Testoperator - Scheduled Bench - TPCH
         if: ${{ github.event.inputs.all_benchmarks == 'true' }}
@@ -152,7 +153,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}
 
       - name: Dispatch Testoperator - Scheduled Bench - TPCDS
         if: ${{ github.event.inputs.all_benchmarks == 'true' }}
@@ -161,7 +162,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}
 
       - name: Dispatch Testoperator - Scheduled Bench - ClickBench
         if: ${{ github.event.inputs.all_benchmarks == 'true' }}
@@ -170,4 +171,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -50,8 +50,8 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - 'trunk'
-          - 'release/1.1'
+          - 'refs/remotes/origin/trunk'
+          - 'refs/remotes/origin/release/1.1'
     concurrency:
       group: testoperator-dispatch-scheduled
       cancel-in-progress: false


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Uses refs instead of commits in testoperator dispatch
* Updates `setup-spiced` to list the latest 10 commits from the specified ref, if one was set. If one is not set, defaults to trunk like usual.
