### PR TITLE
fix: Testoperator dispatch

### DIFF
--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -28,10 +28,10 @@ runs:
       if: ${{ !inputs.spiced_commit }}
       shell: bash
       run: |
-        git fetch --depth=10 origin ${{ inputs.ref }}
-        echo "Fetching latest 10 commits from ${{ inputs.ref }}"
+        git fetch --depth=10 origin refs/remotes/origin/${{ inputs.ref }}
+        echo "Fetching latest 10 commits from refs/remotes/origin/${{ inputs.ref }}"
 
-        commit_hashes=($(git log ${{ inputs.ref }} --pretty=format:"%H" -n 10))
+        commit_hashes=($(git log refs/remotes/origin/${{ inputs.ref }} --pretty=format:"%H" -n 10))
         
         if [[ "${{ inputs.with_odbc }}" == "true" ]]; then
           features="odbc_models"

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -50,8 +50,8 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - 'refs/remotes/origin/trunk'
-          - 'refs/remotes/origin/release/1.1'
+          - 'trunk'
+          - 'release/1.1'
     concurrency:
       group: testoperator-dispatch-scheduled
       cancel-in-progress: false


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Fixes the testoperator dispatch scheduled run by removing the full ref and using only the branch name. `ref:` in `actions/checkout` cannot actually be the full ref (`refs/remotes/origin/trunk`) because it prefixes the origin information to the branch you supply.