### PR TITLE
fix: Testoperator dispatch

### DIFF
--- a/.github/actions/setup-spiced/action.yml
+++ b/.github/actions/setup-spiced/action.yml
@@ -28,10 +28,10 @@ runs:
       if: ${{ !inputs.spiced_commit }}
       shell: bash
       run: |
-        git fetch --depth=10 origin refs/remotes/origin/${{ inputs.ref }}
-        echo "Fetching latest 10 commits from refs/remotes/origin/${{ inputs.ref }}"
+        git fetch --depth=10 origin ${{ inputs.ref }}
+        echo "Fetching latest 10 commits from ${{ inputs.ref }}"
 
-        commit_hashes=($(git log refs/remotes/origin/${{ inputs.ref }} --pretty=format:"%H" -n 10))
+        commit_hashes=($(git log ${{ inputs.ref }} --pretty=format:"%H" -n 10))
         
         if [[ "${{ inputs.with_odbc }}" == "true" ]]; then
           features="odbc_models"

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -71,7 +71,7 @@ jobs:
         uses: ./.github/actions/setup-spiced
         id: setup-spiced
         with:
-          ref: ${{ matrix.branch }}
+          ref: refs/remotes/origin/${{ matrix.branch }}
 
       - name: Display spiced commit
         run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Refactor how the setup spiced composite gets the ref. `setup-spiced` expects a fully qualified ref, unlike `actions/checkout` which only uses the branch/tag portion - except `github.event.ref` passes the fully qualified ref 😐
