### PR TITLE
Add additional test scenarios for benchmarks

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: spiceai-runners
     if: ${{ github.event_name == 'workflow_dispatch' }}
     concurrency:
-      group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}
+      group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}-${{ github.event.ref }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4

--- a/test/spicepods/tpch/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
+++ b/test/spicepods/tpch/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
@@ -1,0 +1,45 @@
+version: v1
+kind: Spicepod
+name: databricks[delta_lake]-duckdb[file]
+datasets:
+  - from: databricks:spiceai_sandbox.tpch.partsupp
+    name: partsupp
+    params: &databricks_delta_params
+      mode: delta_lake
+      client_timeout: 600s
+      databricks_aws_access_key_id: ${ secrets:AWS_DATABRICKS_DELTA_ACCESS_KEY_ID }
+      databricks_aws_secret_access_key: ${ secrets:AWS_DATABRICKS_DELTA_SECRET_ACCESS_KEY }
+      databricks_token: ${ secrets:DATABRICKS_TOKEN }
+      databricks_endpoint: ${ secrets:DATABRICKS_HOST }
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: databricks:spiceai_sandbox.tpch.customer
+    name: customer
+    params: *databricks_delta_params
+    acceleration: *acceleration
+  - from: databricks:spiceai_sandbox.tpch.lineitem
+    name: lineitem
+    params: *databricks_delta_params
+    acceleration: *acceleration
+  - from: databricks:spiceai_sandbox.tpch.nation
+    name: nation
+    params: *databricks_delta_params
+    acceleration: *acceleration
+  - from: databricks:spiceai_sandbox.tpch.orders
+    name: orders
+    params: *databricks_delta_params
+    acceleration: *acceleration
+  - from: databricks:spiceai_sandbox.tpch.region
+    name: region
+    params: *databricks_delta_params
+    acceleration: *acceleration
+  - from: databricks:spiceai_sandbox.tpch.supplier
+    name: supplier
+    params: *databricks_delta_params
+    acceleration: *acceleration
+  - from: databricks:spiceai_sandbox.tpch.part
+    name: part
+    params: *databricks_delta_params
+    acceleration: *acceleration

--- a/test/spicepods/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
+++ b/test/spicepods/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
@@ -1,0 +1,44 @@
+version: v1beta1
+kind: Spicepod
+name: iceberg-duckdb[file]
+
+datasets:
+  - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces/tpch_sf1/tables/partsupp
+    name: partsupp
+    params: &iceberg_params
+      iceberg_s3_endpoint: ${secrets:S3_ENDPOINT}
+      iceberg_s3_access_key_id: ${secrets:S3_KEY}
+      iceberg_s3_secret_access_key: ${secrets:S3_SECRET}
+      iceberg_s3_region: us-east-1
+    acceleration: &acceleration
+      enabled: true
+      engine: duckdb
+      mode: file
+  - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces/tpch_sf1/tables/customer
+    name: customer
+    params: *iceberg_params
+    acceleration: *acceleration
+  - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces/tpch_sf1/tables/lineitem
+    name: lineitem
+    params: *iceberg_params
+    acceleration: *acceleration
+  - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces/tpch_sf1/tables/nation
+    name: nation
+    params: *iceberg_params
+    acceleration: *acceleration
+  - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces/tpch_sf1/tables/orders
+    name: orders
+    params: *iceberg_params
+    acceleration: *acceleration
+  - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces/tpch_sf1/tables/region
+    name: region
+    params: *iceberg_params
+    acceleration: *acceleration
+  - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces/tpch_sf1/tables/supplier
+    name: supplier
+    params: *iceberg_params
+    acceleration: *acceleration
+  - from: iceberg:http://iceberg-rest.dataplatform.svc.cluster.local:8181/v1/namespaces/tpch_sf1/tables/part
+    name: part
+    params: *iceberg_params
+    acceleration: *acceleration

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
@@ -1,0 +1,15 @@
+tests:
+  bench:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+  throughput:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+  load:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/databricks[delta_lake]-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    duration: 28800
+    ready_wait: 600

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
@@ -1,0 +1,15 @@
+tests:
+  bench:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+  throughput:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+  load:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/iceberg-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    duration: 28800
+    ready_wait: 600

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/mysql-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/mysql-duckdb[file].yaml
@@ -1,0 +1,17 @@
+tests:
+  bench:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/mysql-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    ready_wait: 600
+  throughput:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/mysql-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    ready_wait: 600
+  load:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/mysql-duckdb[file].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    duration: 28800
+    ready_wait: 600


### PR DESCRIPTION
## 📝 Summary

Adds the following benchmark test Spicepods and enables them in the scheduled runs:
- `databricks[delta_lake]-duckdb[file].yaml`
- `iceberg-duckdb[file].yaml`
- `mysql-duckdb[file].yaml`

Also allows running the testoperator dispatch from multiple branches at once.