### PR TITLE
Upgrade `pulls-with-spice` to require a milestone on PRs

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -15,10 +15,12 @@ jobs:
   enforce-pull-with-spice:
     runs-on: spiceai-macos
     steps:
-      - uses: spiceai/pulls-with-spice-action@v1.0.6
+      - uses: spiceai/pulls-with-spice-action@v1.0.7
         if: github.event_name == 'pull_request'
         with:
           require_title_min_length: '10'
           required_labels_any: 'kind/refactor,kind/bug,kind/enhancement,kind/documentation,kind/optimization,kind/dependencies,kind/endgame'
           banned_labels: 'invalid,wontfix,nomerge,duplicate'
           require_assignee: 'true'
+          require_milestone: 'true'
+          custom_error_messages: '{"no_milestone": "Add a milestone to the PR. Use the milestone that corresponds to issue tracking this work."}'


### PR DESCRIPTION
## 📝 Summary

Update the `pulls-with-spice` action to require a milestone on each PR.

This will be used to ensure that all changes required for a patch release are cherry-picked appropriately.
