### PR TITLE
fix: Add option to run dispatch schedule

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -57,7 +57,6 @@ assignees: ''
    - [ ] Verify [Test Operator Benchmarks](https://github.com/spiceai/spiceai/actions/workflows/testoperator_run_bench.yml) is green on `trunk` and the release branch.
      - Use the [Test Operator Dispatch](https://github.com/spiceai/spiceai/actions/workflows/testoperator_dispatch.yml) workflow to execute a new benchmark run. Specify `trunk` as the branch source, with the following parameters:
        - Workflow to execute: `bench`
-       - Run Schedule: Yes
        - All other values left empty.
    - [ ] Verify [E2E Test CLI](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_spice_cli.yml) is green on `trunk` and the release branch.
      - Parameters: Branch: `trunk`
@@ -65,7 +64,6 @@ assignees: ''
    - [ ] Verify [Throughput Tests](https://github.com/spiceai/spiceai/actions/workflows/testoperator_run_throughput.yml) is green on `trunk` and the release branch.
      - Use the [Test Operator Dispatch](https://github.com/spiceai/spiceai/actions/workflows/testoperator_dispatch.yml) workflow to execute a new throughput run. Specify `trunk` as the branch source, with the following parameters:
        - Workflow to execute: `throughput`
-       - Run Schedule: Yes
        - All other values left empty.
 
 1. **Documentation Review**

--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -55,18 +55,18 @@ assignees: ''
    - [ ] Verify [E2E Test CI (core)](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_ci.yml) is green on `trunk` and the release branch.
    - [ ] Verify [E2E Test CI (models)](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_ci_models.yml) is green on `trunk` and the release branch.
    - [ ] Verify [Test Operator Benchmarks](https://github.com/spiceai/spiceai/actions/workflows/testoperator_run_bench.yml) is green on `trunk` and the release branch.
-     - Use the [Test Operator Dispatch](https://github.com/spiceai/spiceai/actions/workflows/testoperator_dispatch.yml) workflow to execute a new benchmark run. Specify `trunk` as the branch source, but input the spiced commit SHA for the release branch.
-       - Branch: `trunk`
-       - Commit Hash: latest built spiced commit SHA from release branch
-       - Path to load test files: Run a workflow for each of `./tools/testoperator/dispatch/tpch`, `./tools/testoperator/dispatch/tpcds`, and `./tools/testoperator/dispatch/clickbench`
-       - The workflow to execute: `bench`
-       - Update snapshots: No
+     - Use the [Test Operator Dispatch](https://github.com/spiceai/spiceai/actions/workflows/testoperator_dispatch.yml) workflow to execute a new benchmark run. Specify `trunk` as the branch source, with the following parameters:
+       - Workflow to execute: `bench`
+       - Run Schedule: Yes
+       - All other values left empty.
    - [ ] Verify [E2E Test CLI](https://github.com/spiceai/spiceai/actions/workflows/e2e_test_spice_cli.yml) is green on `trunk` and the release branch.
      - Parameters: Branch: `trunk`
      - Build CLI: `true`
    - [ ] Verify [Throughput Tests](https://github.com/spiceai/spiceai/actions/workflows/testoperator_run_throughput.yml) is green on `trunk` and the release branch.
-     - Use the [Test Operator Dispatch](https://github.com/spiceai/spiceai/actions/workflows/testoperator_dispatch.yml) workflow.
-     - Use the same parameters from the benchmark test, but specify the `throughput` workflow. Throughput tests are only supported for `./tools/testoperator/dispatch/tpch` and `./tools/testoperator/dispatch/tpcds`.
+     - Use the [Test Operator Dispatch](https://github.com/spiceai/spiceai/actions/workflows/testoperator_dispatch.yml) workflow to execute a new throughput run. Specify `trunk` as the branch source, with the following parameters:
+       - Workflow to execute: `throughput`
+       - Run Schedule: Yes
+       - All other values left empty.
 
 1. **Documentation Review**
 

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -115,8 +115,6 @@ jobs:
     concurrency:
       group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}-${{ github.event.ref }}
       cancel-in-progress: false
-    outputs:
-      matrix: ${{ steps.setup-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v4
 
@@ -140,105 +138,50 @@ jobs:
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
 
-      - name: Generate Dispatch Matrix
-        id: setup-matrix
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const all_benchmarks = ${{ github.event.inputs.all_benchmarks }}
-            const test_files_path = ${{ github.event.inputs.test_files_path }}
-            const workflow_type = ${{ github.event.inputs.workflow_type }}
-            const update_snapshots = ${{ github.event.inputs.update_snapshots }}
-            const validate = ${{ github.event.inputs.validate }}
-            const spiced_commit = ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-            const ref = ${{ github.event.ref }}
-
-            if (all_benchmarks) {
-              return [
-                {
-                  name: "TPCH",
-                  workflow_type,
-                  update_snapshots,
-                  validate,
-                  test_files_path: "./tools/testoperator/dispatch/tpch/sf1",
-                  spiced_commit,
-                  ref
-                },
-                {
-                  name: "TPCDS",
-                  workflow_type,
-                  update_snapshots,
-                  validate,
-                  test_files_path: "./tools/testoperator/dispatch/tpcds/sf1",
-                  spiced_commit,
-                  ref
-                },
-                {
-                  name: "ClickBench",
-                  workflow_type,
-                  update_snapshots,
-                  validate,
-                  test_files_path: "./tools/testoperator/dispatch/clickbench/sf1",
-                  spiced_commit,
-                  ref
-                }
-              ]
-            } else {
-              return [
-                {
-                  name: "Input",
-                  workflow_type,
-                  update_snapshots,
-                  validate,
-                  test_files_path,
-                  spiced_commit,
-                  ref
-                }
-              ]
-            }
-      
-  dispatch-matrix:
-    needs: dispatch-input
-    name: Dispatch Test - ${{ matrix.name }}
-    runs-on: spiceai-runners
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        include: ${{ fromJson(needs.dispatch-input.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.ref }}
-
-      - name: Install MinIO
-        uses: ./.github/actions/setup-minio
-        with:
-          minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}
-          minio_access_key: ${{ secrets.MINIO_ACCESS_KEY }}
-          minio_secret_key: ${{ secrets.MINIO_SECRET_KEY }}
-
-      - name: Setup spiced
-        uses: ./.github/actions/setup-spiced
-        id: setup-spiced
-        with:
-          spiced_commit: ${{ matrix.spiced_commit }}
-          ref: ${{ github.event.ref }}
-
-      - name: Display spiced commit
-        run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
-
-      - name: Build Testoperator
-        uses: ./.github/actions/build-testoperator
-
       - name: Dispatch Testoperator - Input
-        if: ${{ matrix.test_files_path != '' }}
+        if: ${{ github.event.inputs.test_files_path != '' }}
         run: |
           testoperator dispatch \
-            ${{ matrix.test_files_path }} \
-            --workflow ${{ matrix.workflow_type }} \
-            --update-snapshots ${{ matrix.update_snapshots }} \
-            --validate=${{ matrix.validate }} \
+            ${{ github.event.inputs.test_files_path }} \
+            --workflow ${{ github.event.inputs.workflow_type }} \
+            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
+            --validate=${{ github.event.inputs.validate }} \
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - TPCH
+        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 \
+            --workflow bench \
+            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
+            --validate=${{ github.event.inputs.validate }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - TPCDS
+        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 \
+            --workflow bench \
+            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
+            --validate=${{ github.event.inputs.validate }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+          WORKFLOW_COMMIT: ${{ github.event.ref }}
+
+      - name: Dispatch Testoperator - Scheduled Bench - ClickBench
+        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
+        run: |
+          testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 \
+            --workflow bench \
+            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
+            --validate=${{ github.event.inputs.validate }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -145,13 +145,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const all_benchmarks = ${{ github.event.inputs.all_benchmarks }};
-            const test_files_path = "${{ github.event.inputs.test_files_path }}";
-            const workflow_type = "${{ github.event.inputs.workflow_type }}";
-            const update_snapshots = ${{ github.event.inputs.update_snapshots }};
-            const validate = ${{ github.event.inputs.validate }};
-            const spiced_commit = "${{ steps.setup-spiced.outputs.SPICED_COMMIT }}";
-            const ref = "${{ github.event.ref }}";
+            const all_benchmarks = ${{ github.event.inputs.all_benchmarks }}
+            const test_files_path = ${{ github.event.inputs.test_files_path }}
+            const workflow_type = ${{ github.event.inputs.workflow_type }}
+            const update_snapshots = ${{ github.event.inputs.update_snapshots }}
+            const validate = ${{ github.event.inputs.validate }}
+            const spiced_commit = ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+            const ref = ${{ github.event.ref }}
 
             if (all_benchmarks) {
               return [
@@ -182,7 +182,7 @@ jobs:
                   spiced_commit,
                   ref
                 }
-              ];
+              ]
             } else {
               return [
                 {
@@ -194,7 +194,7 @@ jobs:
                   spiced_commit,
                   ref
                 }
-              ];
+              ]
             }
       
   dispatch-matrix:

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -145,13 +145,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const all_benchmarks = ${{ github.event.inputs.all_benchmarks }}
-            const test_files_path = ${{ github.event.inputs.test_files_path }}
-            const workflow_type = ${{ github.event.inputs.workflow_type }}
-            const update_snapshots = ${{ github.event.inputs.update_snapshots }}
-            const validate = ${{ github.event.inputs.validate }}
-            const spiced_commit = ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-            const ref = ${{ github.event.ref }}
+            const all_benchmarks = ${{ github.event.inputs.all_benchmarks }};
+            const test_files_path = "${{ github.event.inputs.test_files_path }}";
+            const workflow_type = "${{ github.event.inputs.workflow_type }}";
+            const update_snapshots = ${{ github.event.inputs.update_snapshots }};
+            const validate = ${{ github.event.inputs.validate }};
+            const spiced_commit = "${{ steps.setup-spiced.outputs.SPICED_COMMIT }}";
+            const ref = "${{ github.event.ref }}";
 
             if (all_benchmarks) {
               return [
@@ -182,7 +182,7 @@ jobs:
                   spiced_commit,
                   ref
                 }
-              ]
+              ];
             } else {
               return [
                 {
@@ -194,7 +194,7 @@ jobs:
                   spiced_commit,
                   ref
                 }
-              ]
+              ];
             }
       
   dispatch-matrix:

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -30,11 +30,6 @@ on:
         required: false
         type: boolean
         default: false
-      validate:
-        description: 'Validate results?'
-        required: false
-        type: boolean
-        default: false
       all_benchmarks:
         description: 'Run all benchmarks?'
         required: false
@@ -144,8 +139,7 @@ jobs:
           testoperator dispatch \
             ${{ github.event.inputs.test_files_path }} \
             --workflow ${{ github.event.inputs.workflow_type }} \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
-            --validate=${{ github.event.inputs.validate }} \
+            --update-snapshots ${{ github.event.inputs.update_snapshots }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
@@ -156,8 +150,7 @@ jobs:
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 \
             --workflow ${{ github.event.inputs.workflow_type }} \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
-            --validate=${{ github.event.inputs.validate }}
+            --update-snapshots ${{ github.event.inputs.update_snapshots }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
@@ -168,8 +161,7 @@ jobs:
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 \
             --workflow ${{ github.event.inputs.workflow_type }} \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
-            --validate=${{ github.event.inputs.validate }}
+            --update-snapshots ${{ github.event.inputs.update_snapshots }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
@@ -180,8 +172,7 @@ jobs:
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 \
             --workflow ${{ github.event.inputs.workflow_type }} \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
-            --validate=${{ github.event.inputs.validate }}
+            --update-snapshots ${{ github.event.inputs.update_snapshots }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -115,6 +115,8 @@ jobs:
     concurrency:
       group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}-${{ github.event.ref }}
       cancel-in-progress: false
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v4
 
@@ -138,50 +140,105 @@ jobs:
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
 
+      - name: Generate Dispatch Matrix
+        id: setup-matrix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const all_benchmarks = ${{ github.event.inputs.all_benchmarks }}
+            const test_files_path = ${{ github.event.inputs.test_files_path }}
+            const workflow_type = ${{ github.event.inputs.workflow_type }}
+            const update_snapshots = ${{ github.event.inputs.update_snapshots }}
+            const validate = ${{ github.event.inputs.validate }}
+            const spiced_commit = ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
+            const ref = ${{ github.event.ref }}
+
+            if (all_benchmarks) {
+              return [
+                {
+                  name: "TPCH",
+                  workflow_type,
+                  update_snapshots,
+                  validate,
+                  test_files_path: "./tools/testoperator/dispatch/tpch/sf1",
+                  spiced_commit,
+                  ref
+                },
+                {
+                  name: "TPCDS",
+                  workflow_type,
+                  update_snapshots,
+                  validate,
+                  test_files_path: "./tools/testoperator/dispatch/tpcds/sf1",
+                  spiced_commit,
+                  ref
+                },
+                {
+                  name: "ClickBench",
+                  workflow_type,
+                  update_snapshots,
+                  validate,
+                  test_files_path: "./tools/testoperator/dispatch/clickbench/sf1",
+                  spiced_commit,
+                  ref
+                }
+              ]
+            } else {
+              return [
+                {
+                  name: "Input",
+                  workflow_type,
+                  update_snapshots,
+                  validate,
+                  test_files_path,
+                  spiced_commit,
+                  ref
+                }
+              ]
+            }
+      
+  dispatch-matrix:
+    needs: dispatch-input
+    name: Dispatch Test - ${{ matrix.name }}
+    runs-on: spiceai-runners
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include: ${{ fromJson(needs.dispatch-input.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.ref }}
+
+      - name: Install MinIO
+        uses: ./.github/actions/setup-minio
+        with:
+          minio_endpoint: ${{ secrets.MINIO_ENDPOINT }}
+          minio_access_key: ${{ secrets.MINIO_ACCESS_KEY }}
+          minio_secret_key: ${{ secrets.MINIO_SECRET_KEY }}
+
+      - name: Setup spiced
+        uses: ./.github/actions/setup-spiced
+        id: setup-spiced
+        with:
+          spiced_commit: ${{ matrix.spiced_commit }}
+          ref: ${{ github.event.ref }}
+
+      - name: Display spiced commit
+        run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
+
+      - name: Build Testoperator
+        uses: ./.github/actions/build-testoperator
+
       - name: Dispatch Testoperator - Input
-        if: ${{ github.event.inputs.test_files_path != '' }}
+        if: ${{ matrix.test_files_path != '' }}
         run: |
           testoperator dispatch \
-            ${{ github.event.inputs.test_files_path }} \
-            --workflow ${{ github.event.inputs.workflow_type }} \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
-            --validate=${{ github.event.inputs.validate }} \
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ github.event.ref }}
-
-      - name: Dispatch Testoperator - Scheduled Bench - TPCH
-        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 \
-            --workflow bench \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
-            --validate=${{ github.event.inputs.validate }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ github.event.ref }}
-
-      - name: Dispatch Testoperator - Scheduled Bench - TPCDS
-        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 \
-            --workflow bench \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
-            --validate=${{ github.event.inputs.validate }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ github.event.ref }}
-
-      - name: Dispatch Testoperator - Scheduled Bench - ClickBench
-        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
-        run: |
-          testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 \
-            --workflow bench \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }} \
-            --validate=${{ github.event.inputs.validate }}
+            ${{ matrix.test_files_path }} \
+            --workflow ${{ matrix.workflow_type }} \
+            --update-snapshots ${{ matrix.update_snapshots }} \
+            --validate=${{ matrix.validate }} \
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -111,7 +111,7 @@ jobs:
   dispatch-input:
     name: Dispatch tests - Input
     runs-on: spiceai-runners
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.test_files_path || github.event.inputs.all_benchmarks) }}
+    if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.test_files_path != '' || github.event.inputs.all_benchmarks == 'true') }}
     concurrency:
       group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}-${{ github.event.ref }}
       cancel-in-progress: false

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -11,10 +11,6 @@ on:
         description: 'An optional commit hash to use for spiced'
         required: false
         type: string
-      test_files_path:
-        description: 'path to load test files to dispatch'
-        required: false
-        type: string
       workflow_type:
         description: 'the workflow to execute (bench, throughput, load, etc)'
         required: true
@@ -27,11 +23,6 @@ on:
           - 'http-consistency'
       update_snapshots:
         description: 'Update snapshots?'
-        required: false
-        type: boolean
-        default: false
-      all_benchmarks:
-        description: 'Run all benchmarks?'
         required: false
         type: boolean
         default: false
@@ -106,9 +97,9 @@ jobs:
   dispatch-input:
     name: Dispatch tests - Input
     runs-on: spiceai-runners
-    if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.test_files_path != '' || github.event.inputs.all_benchmarks == 'true') }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     concurrency:
-      group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}-${{ github.event.ref }}
+      group: testoperator-dispatch-${{ github.event.ref }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
@@ -133,20 +124,7 @@ jobs:
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
 
-      - name: Dispatch Testoperator - Input
-        if: ${{ github.event.inputs.test_files_path != '' }}
-        run: |
-          testoperator dispatch \
-            ${{ github.event.inputs.test_files_path }} \
-            --workflow ${{ github.event.inputs.workflow_type }} \
-            --update-snapshots ${{ github.event.inputs.update_snapshots }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
-          WORKFLOW_COMMIT: ${{ github.event.ref }}
-
       - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - TPCH
-        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 \
             --workflow ${{ github.event.inputs.workflow_type }} \
@@ -157,7 +135,6 @@ jobs:
           WORKFLOW_COMMIT: ${{ github.event.ref }}
 
       - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - TPCDS
-        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 \
             --workflow ${{ github.event.inputs.workflow_type }} \
@@ -168,7 +145,6 @@ jobs:
           WORKFLOW_COMMIT: ${{ github.event.ref }}
 
       - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - ClickBench
-        if: ${{ github.event.inputs.all_benchmarks == 'true' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 \
             --workflow ${{ github.event.inputs.workflow_type }} \

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         branch:
           - 'trunk'
-          - 'release/1.1'
+          - 'release/1.2'
     concurrency:
       group: testoperator-dispatch-scheduled
       cancel-in-progress: false

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/actions/setup-spiced
         id: setup-spiced
         with:
-          ref: refs/remotes/origin/${{ matrix.branch }}
+          ref: refs/heads/${{ matrix.branch }}
 
       - name: Display spiced commit
         run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -151,11 +151,11 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ github.event.ref }}
 
-      - name: Dispatch Testoperator - Scheduled Bench - TPCH
+      - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - TPCH
         if: ${{ github.event.inputs.all_benchmarks == 'true' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpch/sf1 \
-            --workflow bench \
+            --workflow ${{ github.event.inputs.workflow_type }} \
             --update-snapshots ${{ github.event.inputs.update_snapshots }} \
             --validate=${{ github.event.inputs.validate }}
         env:
@@ -163,11 +163,11 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ github.event.ref }}
 
-      - name: Dispatch Testoperator - Scheduled Bench - TPCDS
+      - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - TPCDS
         if: ${{ github.event.inputs.all_benchmarks == 'true' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/tpcds/sf1 \
-            --workflow bench \
+            --workflow ${{ github.event.inputs.workflow_type }} \
             --update-snapshots ${{ github.event.inputs.update_snapshots }} \
             --validate=${{ github.event.inputs.validate }}
         env:
@@ -175,11 +175,11 @@ jobs:
           SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
           WORKFLOW_COMMIT: ${{ github.event.ref }}
 
-      - name: Dispatch Testoperator - Scheduled Bench - ClickBench
+      - name: Dispatch Testoperator - ${{ github.event.inputs.workflow_type }} - ClickBench
         if: ${{ github.event.inputs.all_benchmarks == 'true' }}
         run: |
           testoperator dispatch ./tools/testoperator/dispatch/clickbench/sf1 \
-            --workflow bench \
+            --workflow ${{ github.event.inputs.workflow_type }} \
             --update-snapshots ${{ github.event.inputs.update_snapshots }} \
             --validate=${{ github.event.inputs.validate }}
         env:

--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -40,12 +40,17 @@ on:
         required: false
         type: boolean
         default: false
+      scheduled:
+        description: 'Run schedule?'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   dispatch-scheduled:
     name: Dispatch tests - Scheduled
     runs-on: spiceai-runners
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.scheduled == 'true') }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +111,7 @@ jobs:
   dispatch-input:
     name: Dispatch tests - Input
     runs-on: spiceai-runners
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.test_files_path || github.event.inputs.all_benchmarks) }}
     concurrency:
       group: testoperator-dispatch-${{ github.event.inputs.test_files_path || 'unset' }}-${{ github.event.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds a checkbox option to easily to the schedule for the testoperator dispatch
* Updates the dispatch workflow to passthrough the selected `workflow_type` when `Run all benchmarks` is selected

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5629 