### PR TITLE
fix: Use SPICED_COMMIT for spiced_commit_sha

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -105,9 +105,13 @@ jobs:
 
       - name: Setup spiced
         uses: ./.github/actions/setup-spiced
+        id: setup-spiced
         with:
           spiced_commit: ${{ github.event.inputs.spiced_commit }}
           with_odbc: ${{ contains(steps.extract_spicepod_filename.outputs.SPICEPOD_FILENAME, 'odbc') }}
+
+      - name: Display spiced commit
+        run: echo "SPICED_COMMIT=${{ steps.setup-spiced.outputs.SPICED_COMMIT }}"
 
       - name: Build Testoperator
         uses: ./.github/actions/build-testoperator
@@ -179,6 +183,7 @@ jobs:
           MSSQL_PASSWORD: S3cretP@ssw0rd
           MSSQL_TPCH_DB: tpch_sf1
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
 
       - name: Run the benchmark test (with overrides) - ${{ steps.extract_spicepod_filename.outputs.SPICEPOD_FILENAME }}
         if: ${{ github.event.inputs.query_overrides != '' }}
@@ -230,6 +235,7 @@ jobs:
           MSSQL_PASSWORD: S3cretP@ssw0rd
           MSSQL_TPCH_DB: tpch_sf1
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
+          SPICED_COMMIT: ${{ steps.setup-spiced.outputs.SPICED_COMMIT }}
 
       - name: Install GH CLI
         if: github.event.inputs.update_snapshots == 'always'

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -75,6 +75,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let (max_memory, median_memory) = observe_memory(memory_token, memory_readings).await?;
 
     let commit_sha = metrics.commit_sha.clone();
+    let spiced_commit_sha = std::env::var("SPICED_COMMIT")?;
     let spiced_version = metrics.spiced_version.clone();
     let app_name = app.name.clone();
     let benchmark_resource = Resource::new(vec![
@@ -83,7 +84,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
         KeyValue::new("name", app_name.clone()),
         KeyValue::new("spiced_version", spiced_version.clone()),
         KeyValue::new("query_set", query_set.to_string()),
-        KeyValue::new("spiced_commit_sha", commit_sha.clone()),
+        KeyValue::new("testoperator_commit_sha", commit_sha.clone()),
+        KeyValue::new("spiced_commit_sha", spiced_commit_sha),
         KeyValue::new("branch_name", metrics.branch_name.clone()),
         KeyValue::new("scale_factor", args.scale_factor.unwrap_or(1.0).to_string()),
     ]);

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -75,7 +75,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let (max_memory, median_memory) = observe_memory(memory_token, memory_readings).await?;
 
     let commit_sha = metrics.commit_sha.clone();
-    let spiced_commit_sha = std::env::var("SPICED_COMMIT")?;
+    let spiced_commit_sha = std::env::var("SPICED_COMMIT").unwrap_or("unknown".to_string());
     let spiced_version = metrics.spiced_version.clone();
     let app_name = app.name.clone();
     let benchmark_resource = Resource::new(vec![


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates testoperator benchmark metrics to omit the actual spiced commit for `spiced_commit_sha` instead of the current HEAD commit SHA. The HEAD commit SHA is renamed to `testoperator_commit_sha`.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5360
