### PR TITLE
Enable metrics reporting for models benchmarks (evals)

### DIFF
--- a/.github/workflows/ai_benchmark_nsql.yml
+++ b/.github/workflows/ai_benchmark_nsql.yml
@@ -178,6 +178,7 @@ jobs:
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
           SPICE_ANTHROPIC_API_KEY: ${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}
           SPICE_XAI_API_KEY: ${{ secrets.SPICE_SECRET_XAI_API_KEY }}
+          SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
         run: |
           ./testoperator run evals \
             -s $GITHUB_WORKSPACE/spiced \

--- a/.github/workflows/ai_benchmark_nsql.yml
+++ b/.github/workflows/ai_benchmark_nsql.yml
@@ -184,4 +184,5 @@ jobs:
             -s $GITHUB_WORKSPACE/spiced \
             -p ${{ matrix.target.spicepod }} \
             -d $GITHUB_WORKSPACE/${{ matrix.target.data }} \
-            --ready-wait 180
+            --ready-wait 180 \
+            --metrics

--- a/.github/workflows/financebench.yml
+++ b/.github/workflows/financebench.yml
@@ -167,5 +167,6 @@ jobs:
             -s $GITHUB_WORKSPACE/spiced \
             -p ${{ matrix.target.spicepod }} \
             --model ${{ matrix.target.name }} \
-            --ready-wait 180
+            --ready-wait 180 \
+            --metrics
   

--- a/.github/workflows/financebench.yml
+++ b/.github/workflows/financebench.yml
@@ -161,6 +161,7 @@ jobs:
         env:
           SPICEAI_FINANCEBENCH_API_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_FINANCEBENCH_API_KEY}}
           OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
+          SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
         run: |
           ./testoperator run evals \
             -s $GITHUB_WORKSPACE/spiced \

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -18,14 +18,80 @@ use crate::args::EvalsTestArgs;
 
 use super::get_app_and_start_request;
 use serde_json::json;
-use std::time::Duration;
+use std::{
+    env,
+    time::{Duration, SystemTime},
+};
 use test_framework::{
     anyhow,
-    arrow::{array::RecordBatch, util::pretty::pretty_format_batches},
+    arrow::{
+        array::{Float64Array, RecordBatch, StringArray},
+        util::pretty::pretty_format_batches,
+    },
     flight_client::FlightClient,
     futures::TryStreamExt,
+    git,
+    opentelemetry::KeyValue,
+    opentelemetry_sdk::Resource,
     spiced::SpicedInstance,
+    telemetry::Telemetry,
 };
+
+/// Status of an evaluation run
+#[derive(Debug, Clone, PartialEq)]
+pub enum EvalStatus {
+    Finished,
+    Failed,
+}
+
+impl EvalStatus {
+    /// Convert a status string to `EvalStatus`
+    pub fn from_str(status: &str) -> Self {
+        match status.to_lowercase().as_str() {
+            "completed" => EvalStatus::Finished,
+            _ => EvalStatus::Failed,
+        }
+    }
+
+    /// Convert `EvalStatus` to a boolean value for metrics recording
+    pub fn to_u64(&self) -> u64 {
+        match self {
+            EvalStatus::Finished => 1,
+            EvalStatus::Failed => 0,
+        }
+    }
+}
+
+/// Metrics from an evaluation run
+#[derive(Debug, Clone)]
+pub struct EvalMetrics {
+    pub status: EvalStatus,
+    pub score: f64,
+}
+
+impl EvalMetrics {
+    pub fn from_record_batch(batch: &[RecordBatch]) -> anyhow::Result<Self> {
+        if batch.is_empty() || batch[0].num_rows() == 0 {
+            return Err(anyhow::anyhow!("No evaluation metrics found"));
+        }
+        let record = &batch[0];
+
+        let status_str = record
+            .column_by_name("status")
+            .and_then(|col| col.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| anyhow::anyhow!("Failed to extract status"))?
+            .value(0);
+        let status = EvalStatus::from_str(status_str);
+
+        let score = record
+            .column_by_name("score")
+            .and_then(|col| col.as_any().downcast_ref::<Float64Array>())
+            .ok_or_else(|| anyhow::anyhow!("Failed to extract score"))?
+            .value(0);
+
+        Ok(EvalMetrics { status, score })
+    }
+}
 
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
@@ -55,12 +121,16 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     let url = format!("http://localhost:8090/v1/evals/{eval}");
     let body = json!({"model": model}).to_string();
 
+    let started_at = SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
+
     let response = http_client
         .post(&url)
         .header("Content-Type", "application/json")
         .body(body)
         .send()
         .await?;
+
+    let finished_at = SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
 
     let response_status = response.status();
     let response_msq = response.text().await?;
@@ -78,6 +148,9 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     let eval_result = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_MAIN_METRICS).await?;
     println!("Result:\n{}\n", pretty_format_batches(&eval_result)?);
 
+    // Extract metrics from the evaluation result
+    let metrics = EvalMetrics::from_record_batch(&eval_result)?;
+
     let tasks_calls = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_TASKS).await?;
     println!(
         "Executed tasks:\n{}\n",
@@ -91,6 +164,31 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     let top_errors = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_TOP_ERRORS).await?;
     // json format is easier to read as table could be too wide
     println!("Top errors:\n{}\n", arrow_to_json(&top_errors)?);
+
+    // Record benchamrk results
+    let benchmark_resource = Resource::new(vec![
+        KeyValue::new("service.name", "testoperator"),
+        KeyValue::new("type", "model_eval"),
+        KeyValue::new("spiced_version", spiced_instance.version().to_string()),
+        KeyValue::new("spiced_commit_sha", git::get_commit_sha()),
+        KeyValue::new("testoperator_commit_sha", git::get_commit_sha()),
+        KeyValue::new("branch_name", git::get_branch_name()),
+    ]);
+
+    let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
+
+    let attributes = vec![
+        KeyValue::new("model_name", model.to_string()),
+        KeyValue::new("eval_name", eval.to_string()),
+    ];
+    crate::metrics::STATUS.record(metrics.status.to_u64(), &attributes);
+    crate::metrics::SCORE.record(metrics.score, &attributes);
+    crate::metrics::TEST_DURATION.record(
+        u64::try_from((finished_at - started_at).as_millis())?,
+        &attributes,
+    );
+
+    telemetry.emit().await?;
 
     spiced_instance.stop()?;
 

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -18,10 +18,7 @@ use crate::args::EvalsTestArgs;
 
 use super::get_app_and_start_request;
 use serde_json::json;
-use std::{
-    env,
-    time::{Duration, SystemTime},
-};
+use std::time::{Duration, SystemTime};
 use test_framework::{
     anyhow,
     arrow::{
@@ -168,7 +165,7 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     // Record benchamrk results
     let benchmark_resource = Resource::new(vec![
         KeyValue::new("service.name", "testoperator"),
-        KeyValue::new("type", "model_eval"),
+        KeyValue::new("type", "model_benchmark"),
         KeyValue::new("spiced_version", spiced_instance.version().to_string()),
         KeyValue::new("spiced_commit_sha", git::get_commit_sha()),
         KeyValue::new("testoperator_commit_sha", git::get_commit_sha()),
@@ -179,7 +176,7 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
 
     let attributes = vec![
         KeyValue::new("model_name", model.to_string()),
-        KeyValue::new("eval_name", eval.to_string()),
+        KeyValue::new("benchmark_name", eval.to_string()),
     ];
     crate::metrics::STATUS.record(metrics.status.to_u64(), &attributes);
     crate::metrics::SCORE.record(metrics.score, &attributes);

--- a/tools/testoperator/src/metrics.rs
+++ b/tools/testoperator/src/metrics.rs
@@ -114,3 +114,19 @@ pub static MEDIAN_MEMORY_USAGE: LazyLock<Gauge<f64>> = LazyLock::new(|| {
         .with_unit("mb")
         .build()
 });
+
+pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    METER
+        .u64_gauge("status")
+        .with_description("Test execution status.")
+        .with_unit("status")
+        .build()
+});
+
+pub static SCORE: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    METER
+        .f64_gauge("score")
+        .with_description("Test score.")
+        .with_unit("score")
+        .build()
+});


### PR DESCRIPTION
## 📝 Summary

Report evals benchmark metrics (score, duration, status) under `model_benchmark` type. Metrics include `model_name` and `benchmark_name` (tpch_nsql, financebench)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
