### PR TITLE
Implement CatalogBuilder, add app and runtime references to catalog component, add runtime reference to connector params

### DIFF
--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -14,12 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use app::App;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use snafu::prelude::*;
 use spicepod::{component::catalog as spicepod_catalog, param::Params};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use super::{find_first_delimiter, validate_identifier};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "Failed to build catalog '{catalog}': required component '{missing_component}' is missing.\nAn unexpected error occurred. Report a bug to request support: https://github.com/spiceai/spiceai/issues"
+    ))]
+    UnableToBuildCatalog {
+        catalog: String,
+        missing_component: String,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone)]
 pub struct Catalog {
@@ -27,10 +41,11 @@ pub struct Catalog {
     pub catalog_id: Option<String>,
     pub from: String,
     pub name: String,
-    orig_include: Vec<String>,
+    pub(crate) orig_include: Vec<String>,
     pub include: Option<GlobSet>,
     pub params: HashMap<String, String>,
     pub dataset_params: HashMap<String, String>,
+    pub app: Arc<App>,
 }
 
 impl PartialEq for Catalog {
@@ -43,65 +58,10 @@ impl PartialEq for Catalog {
     }
 }
 
-impl TryFrom<spicepod_catalog::Catalog> for Catalog {
-    type Error = crate::Error;
-
-    fn try_from(catalog: spicepod_catalog::Catalog) -> std::result::Result<Self, Self::Error> {
-        let provider = Catalog::provider(&catalog.from);
-        let catalog_id = Catalog::catalog_id(&catalog.from).map(String::from);
-
-        let mut globset_opt: Option<GlobSet> = None;
-        if !catalog.include.is_empty() {
-            let mut globset_builder = GlobSetBuilder::new();
-            let include_iter = catalog.include.iter().map(|pattern| {
-                Glob::new(pattern).context(crate::InvalidGlobPatternSnafu { pattern })
-            });
-            for glob in include_iter {
-                globset_builder.add(glob?);
-            }
-
-            globset_opt = Some(
-                globset_builder
-                    .build()
-                    .context(crate::ErrorConvertingGlobSetToRegexSnafu)?,
-            );
-        }
-
-        validate_identifier(&catalog.name).context(crate::ComponentSnafu)?;
-
-        Ok(Catalog {
-            provider: provider.to_string(),
-            catalog_id,
-            from: catalog.from.clone(),
-            name: catalog.name,
-            orig_include: catalog.include.clone(),
-            include: globset_opt,
-            params: catalog
-                .params
-                .as_ref()
-                .map(Params::as_string_map)
-                .unwrap_or_default(),
-            dataset_params: catalog
-                .dataset_params
-                .as_ref()
-                .map(Params::as_string_map)
-                .unwrap_or_default(),
-        })
-    }
-}
-
 impl Catalog {
-    pub fn new(from: &str, name: &str) -> Self {
-        Catalog {
-            provider: Catalog::provider(from).to_string(),
-            catalog_id: Catalog::catalog_id(from).map(String::from),
-            from: from.into(),
-            name: name.into(),
-            orig_include: Vec::default(),
-            include: None,
-            params: HashMap::default(),
-            dataset_params: HashMap::default(),
-        }
+    #[must_use]
+    pub fn app(&self) -> Arc<App> {
+        Arc::clone(&self.app)
     }
 
     /// Returns the catalog provider - the first part of the `from` field before the first '://', ':', or '/'.
@@ -157,5 +117,113 @@ impl Catalog {
             Some((pos, len)) => Some(&from[pos + len..]),
             None => None,
         }
+    }
+}
+
+pub struct CatalogBuilder {
+    pub provider: String,
+    pub catalog_id: Option<String>,
+    pub from: String,
+    pub name: String,
+    orig_include: Vec<String>,
+    pub include: Option<GlobSet>,
+    pub params: HashMap<String, String>,
+    pub dataset_params: HashMap<String, String>,
+    pub app: Option<Arc<App>>,
+}
+
+impl TryFrom<spicepod_catalog::Catalog> for CatalogBuilder {
+    type Error = crate::Error;
+
+    fn try_from(catalog: spicepod_catalog::Catalog) -> std::result::Result<Self, Self::Error> {
+        let provider = Catalog::provider(&catalog.from);
+        let catalog_id = Catalog::catalog_id(&catalog.from).map(String::from);
+
+        let mut globset_opt: Option<GlobSet> = None;
+        if !catalog.include.is_empty() {
+            let mut globset_builder = GlobSetBuilder::new();
+            let include_iter = catalog.include.iter().map(|pattern| {
+                Glob::new(pattern).context(crate::InvalidGlobPatternSnafu { pattern })
+            });
+            for glob in include_iter {
+                globset_builder.add(glob?);
+            }
+
+            globset_opt = Some(
+                globset_builder
+                    .build()
+                    .context(crate::ErrorConvertingGlobSetToRegexSnafu)?,
+            );
+        }
+
+        validate_identifier(&catalog.name).context(crate::ComponentSnafu)?;
+
+        Ok(CatalogBuilder {
+            provider: provider.to_string(),
+            catalog_id,
+            from: catalog.from.clone(),
+            name: catalog.name,
+            orig_include: catalog.include.clone(),
+            include: globset_opt,
+            params: catalog
+                .params
+                .as_ref()
+                .map(Params::as_string_map)
+                .unwrap_or_default(),
+            dataset_params: catalog
+                .dataset_params
+                .as_ref()
+                .map(Params::as_string_map)
+                .unwrap_or_default(),
+            app: None,
+        })
+    }
+}
+
+impl CatalogBuilder {
+    pub fn try_new(from: String, name: &str) -> std::result::Result<Self, crate::Error> {
+        validate_identifier(name).context(crate::ComponentSnafu)?;
+
+        let provider = Catalog::provider(from.as_str());
+        let catalog_id = Catalog::catalog_id(from.as_str()).map(String::from);
+
+        Ok(CatalogBuilder {
+            provider: provider.to_string(),
+            catalog_id,
+            from,
+            name: name.to_string(),
+            orig_include: Vec::default(),
+            include: None,
+            params: HashMap::default(),
+            dataset_params: HashMap::default(),
+            app: None,
+        })
+    }
+
+    #[must_use]
+    pub fn with_app(mut self, app: Arc<App>) -> Self {
+        self.app = Some(app);
+        self
+    }
+
+    pub fn build(self) -> Result<Catalog> {
+        let app = self.app.ok_or(Error::UnableToBuildCatalog {
+            catalog: self.name.to_string(),
+            missing_component: "app".to_string(),
+        })?;
+
+        let catalog = Catalog {
+            provider: self.provider,
+            catalog_id: self.catalog_id,
+            from: self.from,
+            name: self.name,
+            orig_include: self.orig_include,
+            include: self.include,
+            params: self.params,
+            dataset_params: self.dataset_params,
+            app,
+        };
+
+        Ok(catalog)
     }
 }

--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -21,6 +21,7 @@ use spicepod::{component::catalog as spicepod_catalog, param::Params};
 use std::{collections::HashMap, sync::Arc};
 
 use super::{find_first_delimiter, validate_identifier};
+use crate::Runtime;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -35,7 +36,7 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Catalog {
     pub provider: String,
     pub catalog_id: Option<String>,
@@ -46,6 +47,23 @@ pub struct Catalog {
     pub params: HashMap<String, String>,
     pub dataset_params: HashMap<String, String>,
     pub app: Arc<App>,
+    pub runtime: Arc<Runtime>,
+}
+
+impl std::fmt::Debug for Catalog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Catalog")
+            .field("provider", &self.provider)
+            .field("catalog_id", &self.catalog_id)
+            .field("from", &self.from)
+            .field("name", &self.name)
+            .field("orig_include", &self.orig_include)
+            .field("include", &self.include)
+            .field("params", &self.params)
+            .field("dataset_params", &self.dataset_params)
+            .field("app", &self.app)
+            .finish_non_exhaustive()
+    }
 }
 
 impl PartialEq for Catalog {
@@ -62,6 +80,11 @@ impl Catalog {
     #[must_use]
     pub fn app(&self) -> Arc<App> {
         Arc::clone(&self.app)
+    }
+
+    #[must_use]
+    pub fn runtime(&self) -> Arc<Runtime> {
+        Arc::clone(&self.runtime)
     }
 
     /// Returns the catalog provider - the first part of the `from` field before the first '://', ':', or '/'.
@@ -130,6 +153,7 @@ pub struct CatalogBuilder {
     pub params: HashMap<String, String>,
     pub dataset_params: HashMap<String, String>,
     pub app: Option<Arc<App>>,
+    pub runtime: Option<Arc<Runtime>>,
 }
 
 impl TryFrom<spicepod_catalog::Catalog> for CatalogBuilder {
@@ -176,6 +200,7 @@ impl TryFrom<spicepod_catalog::Catalog> for CatalogBuilder {
                 .map(Params::as_string_map)
                 .unwrap_or_default(),
             app: None,
+            runtime: None,
         })
     }
 }
@@ -197,6 +222,7 @@ impl CatalogBuilder {
             params: HashMap::default(),
             dataset_params: HashMap::default(),
             app: None,
+            runtime: None,
         })
     }
 
@@ -206,10 +232,20 @@ impl CatalogBuilder {
         self
     }
 
+    #[must_use]
+    pub fn with_runtime(mut self, runtime: Arc<Runtime>) -> Self {
+        self.runtime = Some(runtime);
+        self
+    }
+
     pub fn build(self) -> Result<Catalog> {
         let app = self.app.ok_or(Error::UnableToBuildCatalog {
             catalog: self.name.to_string(),
             missing_component: "app".to_string(),
+        })?;
+        let runtime = self.runtime.ok_or(Error::UnableToBuildCatalog {
+            catalog: self.name.to_string(),
+            missing_component: "runtime".to_string(),
         })?;
 
         let catalog = Catalog {
@@ -222,6 +258,7 @@ impl CatalogBuilder {
             params: self.params,
             dataset_params: self.dataset_params,
             app,
+            runtime,
         };
 
         Ok(catalog)

--- a/crates/runtime/src/component/dataset.rs
+++ b/crates/runtime/src/component/dataset.rs
@@ -85,7 +85,7 @@ pub enum Error {
     UnableToParseTableReferenceFromPath { path: String, source: ParserError },
 
     #[snafu(display(
-        "Fail to build dataset '{dataset}': required component '{missing_component}' is missing.\nAn unexpected error occurred. Report a bug to request support: https://github.com/spiceai/spiceai/issues"
+        "Failed to build dataset '{dataset}': required component '{missing_component}' is missing.\nAn unexpected error occurred. Report a bug to request support: https://github.com/spiceai/spiceai/issues"
     ))]
     UnableToBuildDataset {
         dataset: String,

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::Runtime;
 use crate::accelerated_table::AcceleratedTable;
 use crate::catalogconnector::CATALOG_CONNECTOR_FACTORY_REGISTRY;
 use crate::component::catalog::Catalog;
@@ -581,6 +582,8 @@ pub struct ConnectorParams {
     pub(crate) unsupported_type_action: Option<UnsupportedTypeAction>,
     pub(crate) component: ConnectorComponent,
     pub(crate) app: Option<Arc<App>>,
+    #[allow(dead_code)] // will be utilized in https://github.com/spiceai/spiceai/pull/5542
+    pub(crate) runtime: Option<Arc<Runtime>>,
 }
 
 pub struct ConnectorParamsBuilder {
@@ -603,7 +606,7 @@ impl ConnectorParamsBuilder {
     ) -> Result<ConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
         let name = self.connector.to_string();
         let mut unsupported_type_action = None;
-        let (params, prefix, parameters, app) = match &self.component {
+        let (params, prefix, parameters, app, runtime) = match &self.component {
             ConnectorComponent::Catalog(catalog) => {
                 let guard = CATALOG_CONNECTOR_FACTORY_REGISTRY.lock().await;
                 let connector_factory = guard.get(&name);
@@ -618,7 +621,8 @@ impl ConnectorParamsBuilder {
                     get_params_with_secrets(Arc::clone(&secrets), &catalog.params).await,
                     factory.prefix(),
                     factory.parameters(),
-                    Some(Arc::clone(&catalog.app)),
+                    Some(catalog.app()),
+                    Some(catalog.runtime()),
                 )
             }
             ConnectorComponent::Dataset(dataset) => {
@@ -646,7 +650,8 @@ impl ConnectorParamsBuilder {
                     params,
                     factory.prefix(),
                     factory.parameters(),
-                    Some(Arc::clone(&dataset.app)),
+                    Some(dataset.app()),
+                    Some(dataset.runtime()),
                 )
             }
         };
@@ -665,6 +670,7 @@ impl ConnectorParamsBuilder {
             unsupported_type_action: unsupported_type_action.map(UnsupportedTypeAction::from),
             component: self.component,
             app,
+            runtime,
         })
     }
 }

--- a/crates/runtime/src/dataconnector.rs
+++ b/crates/runtime/src/dataconnector.rs
@@ -618,7 +618,7 @@ impl ConnectorParamsBuilder {
                     get_params_with_secrets(Arc::clone(&secrets), &catalog.params).await,
                     factory.prefix(),
                     factory.parameters(),
-                    None,
+                    Some(Arc::clone(&catalog.app)),
                 )
             }
             ConnectorComponent::Dataset(dataset) => {

--- a/crates/runtime/src/http/v1/catalogs.rs
+++ b/crates/runtime/src/http/v1/catalogs.rs
@@ -87,6 +87,7 @@ spiceai,spiceai
 ))]
 pub(crate) async fn get(
     Extension(app): Extension<Arc<RwLock<Option<Arc<App>>>>>,
+    Extension(rt): Extension<Arc<Runtime>>,
     Query(filter): Query<CatalogFilter>,
     accept: Option<TypedHeader<Accept>>,
 ) -> Response {
@@ -99,7 +100,7 @@ pub(crate) async fn get(
             .into_response();
     };
 
-    let valid_catalogs = Runtime::get_valid_catalogs(readable_app, LogErrors(false));
+    let valid_catalogs = rt.get_valid_catalogs(readable_app, LogErrors(false));
     let catalogs: Vec<Catalog> = match filter.from {
         Some(provider) => valid_catalogs
             .into_iter()

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -36,7 +36,7 @@ impl Runtime {
             return;
         };
 
-        let valid_catalogs = Self::get_valid_catalogs(app, LogErrors(true));
+        let valid_catalogs = Arc::clone(&self).get_valid_catalogs(app, LogErrors(true));
         drop(app_lock);
         let mut futures = vec![];
         for catalog in &valid_catalogs {
@@ -105,7 +105,10 @@ impl Runtime {
         Ok(catalog_connector)
     }
 
-    fn catalogs_iter(app: &Arc<App>) -> impl Iterator<Item = Result<Catalog>> + '_ {
+    fn catalogs_iter(
+        self: Arc<Self>,
+        app: &Arc<App>,
+    ) -> impl Iterator<Item = Result<Catalog>> + '_ {
         app.catalogs
             .clone()
             .into_iter()
@@ -113,18 +116,24 @@ impl Runtime {
             .map(move |catalog_builder_result| {
                 catalog_builder_result.and_then(|catalog_builder| {
                     let catalog_name = catalog_builder.name.to_string();
-                    catalog_builder.with_app(Arc::clone(app)).build().context(
-                        UnableToBuildCatalogSnafu {
+                    catalog_builder
+                        .with_app(Arc::clone(app))
+                        .with_runtime(Arc::clone(&self))
+                        .build()
+                        .context(UnableToBuildCatalogSnafu {
                             catalog: catalog_name,
-                        },
-                    )
+                        })
                 })
             })
     }
 
     /// Returns a list of valid catalogs from the given App, skipping any that fail to parse and logging an error for them.
-    pub(crate) fn get_valid_catalogs(app: &Arc<App>, log_errors: LogErrors) -> Vec<Catalog> {
-        Self::catalogs_iter(app)
+    pub(crate) fn get_valid_catalogs(
+        self: Arc<Self>,
+        app: &Arc<App>,
+        log_errors: LogErrors,
+    ) -> Vec<Catalog> {
+        self.catalogs_iter(app)
             .zip(&app.catalogs)
             .filter_map(|(catalog, spicepod_catalog)| match catalog {
                 Ok(catalog) => Some(catalog),
@@ -193,8 +202,8 @@ impl Runtime {
         current_app: &Arc<App>,
         new_app: &Arc<App>,
     ) {
-        let valid_catalogs = Self::get_valid_catalogs(new_app, LogErrors(true));
-        let existing_catalogs = Self::get_valid_catalogs(current_app, LogErrors(false));
+        let valid_catalogs = Arc::clone(&self).get_valid_catalogs(new_app, LogErrors(true));
+        let existing_catalogs = Arc::clone(&self).get_valid_catalogs(current_app, LogErrors(false));
 
         for catalog in &valid_catalogs {
             if let Some(current_catalog) = existing_catalogs.iter().find(|c| c.name == catalog.name)

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -17,10 +17,10 @@ limitations under the License.
 use std::sync::Arc;
 
 use crate::{
-    LogErrors, Result, Runtime, UnableToInitializeCatalogConnectorSnafu,
+    LogErrors, Result, Runtime, UnableToBuildCatalogSnafu, UnableToInitializeCatalogConnectorSnafu,
     UnableToLoadCatalogConnectorSnafu,
     catalogconnector::{self, CatalogConnector, get_catalog_provider},
-    component::catalog::Catalog,
+    component::catalog::{Catalog, CatalogBuilder},
     dataconnector::ConnectorParamsBuilder,
     metrics, status, warn_spaced,
 };
@@ -105,8 +105,21 @@ impl Runtime {
         Ok(catalog_connector)
     }
 
-    fn catalogs_iter<'a>(app: &Arc<App>) -> impl Iterator<Item = Result<Catalog>> + 'a {
-        app.catalogs.clone().into_iter().map(Catalog::try_from)
+    fn catalogs_iter(app: &Arc<App>) -> impl Iterator<Item = Result<Catalog>> + '_ {
+        app.catalogs
+            .clone()
+            .into_iter()
+            .map(CatalogBuilder::try_from)
+            .map(move |catalog_builder_result| {
+                catalog_builder_result.and_then(|catalog_builder| {
+                    let catalog_name = catalog_builder.name.to_string();
+                    catalog_builder.with_app(Arc::clone(app)).build().context(
+                        UnableToBuildCatalogSnafu {
+                            catalog: catalog_name,
+                        },
+                    )
+                })
+            })
     }
 
     /// Returns a list of valid catalogs from the given App, skipping any that fail to parse and logging an error for them.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -307,6 +307,12 @@ pub enum Error {
         source: crate::component::dataset::Error,
     },
 
+    #[snafu(display("Unable to build catalog: {catalog}: {source}"))]
+    UnableToBuildCatalog {
+        catalog: String,
+        source: crate::component::catalog::Error,
+    },
+
     #[snafu(display("{source}"))]
     ComponentError { source: component::Error },
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -630,7 +630,7 @@ impl Runtime {
             }
         }
 
-        let valid_catalogs = Self::get_valid_catalogs(app, LogErrors(false));
+        let valid_catalogs = Arc::clone(&self).get_valid_catalogs(app, LogErrors(false));
         for catalog in valid_catalogs {
             self.status
                 .update_catalog(&catalog.name, ComponentStatus::Initializing);


### PR DESCRIPTION
## 📝 Summary

Refactored catalogs to use builder pattern - that is needed to have consistent init logic with dataconnectors, and pass down app reference to each catalog provider. Later that will be used to access token providers registry for Databricks.


<!-- What does this PR change? Why is it necessary? Keep it concise. -->

## 🔗 Related

part of #5468 
<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
