### PR TITLE
Add TokenProviderRegistry to the runtime

### DIFF
--- a/crates/data_components/src/token_provider.rs
+++ b/crates/data_components/src/token_provider.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use snafu::prelude::*;
+use tokio::sync::watch;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -33,6 +34,13 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[async_trait]
 pub trait TokenProvider: Send + Sync + Debug {
     async fn get_token(&self) -> Result<String>;
+
+    /// Returns a `watch::Receiver` of new tokens, if the provider supports refresh.
+    ///
+    /// The default implementation gives no updates.
+    fn subscribe(&self) -> Option<watch::Receiver<String>> {
+        None
+    }
 }
 
 pub struct StaticTokenProvider {

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -28,6 +28,7 @@ use crate::{
     extension::{Extension, ExtensionFactory},
     flight::RateLimits,
     metrics, podswatcher,
+    registry::token_provider::TokenProviderRegistry,
     secrets::{self, Secrets},
     status,
     timing::TimeMeasurement,
@@ -48,6 +49,7 @@ pub struct RuntimeBuilder {
     rate_limits: Option<Arc<RateLimits>>,
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     datafusion_configuration_fn: Option<DatafusionConfigurationCallback>,
+    token_provider_registry: Arc<TokenProviderRegistry>,
 }
 
 impl RuntimeBuilder {
@@ -64,6 +66,7 @@ impl RuntimeBuilder {
             rate_limits: None,
             accelerator_engine_registry: Arc::new(AcceleratorEngineRegistry::new()),
             datafusion_configuration_fn: None,
+            token_provider_registry: Arc::new(TokenProviderRegistry::new()),
         }
     }
 
@@ -208,6 +211,7 @@ impl RuntimeBuilder {
             status: self.runtime_status,
             runtime_tasks: Arc::new(RwLock::new(HashMap::new())),
             accelerator_engine_registry: self.accelerator_engine_registry,
+            token_provider_registry: self.token_provider_registry,
         };
 
         let mut extensions: HashMap<String, Arc<dyn Extension>> = HashMap::new();

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -18,6 +18,7 @@ limitations under the License.
 use ::tools::SpiceModelTool;
 use ::tools::rename::with_name;
 use async_stream::stream;
+use registry::token_provider::TokenProviderRegistry;
 use std::collections::HashSet;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -92,6 +93,7 @@ pub mod objectstore;
 mod opentelemetry;
 pub mod parameters;
 pub mod podswatcher;
+mod registry;
 pub mod request;
 pub mod secrets;
 pub mod spice_metrics;
@@ -371,6 +373,7 @@ pub struct Runtime {
     status: Arc<status::RuntimeStatus>,
     runtime_tasks: Arc<RwLock<HashMap<String, CancellableTaskHandle>>>,
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
+    token_provider_registry: Arc<TokenProviderRegistry>,
 }
 
 impl Runtime {
@@ -412,6 +415,11 @@ impl Runtime {
     #[must_use]
     pub fn accelerator_engine_registry(&self) -> Arc<AcceleratorEngineRegistry> {
         Arc::clone(&self.accelerator_engine_registry)
+    }
+
+    #[must_use]
+    pub fn token_provider_registry(&self) -> Arc<TokenProviderRegistry> {
+        Arc::clone(&self.token_provider_registry)
     }
 
     /// Requests a loaded extension, or will attempt to load it if part of the autoloaded extensions.

--- a/crates/runtime/src/registry/mod.rs
+++ b/crates/runtime/src/registry/mod.rs
@@ -1,0 +1,17 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+pub mod token_provider;

--- a/crates/runtime/src/registry/token_provider.rs
+++ b/crates/runtime/src/registry/token_provider.rs
@@ -38,7 +38,6 @@ impl TokenProviderRegistry {
     /// # Arguments
     ///
     /// * `key` - The key to use for the token provider.
-    /// * `provider_type` - The type of token provider to create.
     /// * `factory` - The factory function to use to create the token provider.
     ///
     /// # Returns
@@ -47,7 +46,6 @@ impl TokenProviderRegistry {
     pub async fn get_or_create_provider<P, E, F, Fut>(
         &self,
         key: String,
-        provider_type: &str,
         factory: F,
     ) -> Result<Arc<dyn TokenProvider>, E>
     where
@@ -55,41 +53,27 @@ impl TokenProviderRegistry {
         Fut: std::future::Future<Output = Result<P, E>> + Send,
         F: FnOnce() -> Fut + Send,
     {
-        let registry_key = format!("{provider_type}:{key}");
-
         {
             let registry = self.token_provider_registry.read().await;
-            if let Some(provider) = registry.get(&registry_key) {
-                tracing::debug!(
-                    "Using existing {} token provider for key: {}",
-                    provider_type,
-                    key
-                );
+            if let Some(provider) = registry.get(&key) {
+                tracing::debug!("Using existing token provider for key: {key}",);
                 return Ok(Arc::clone(provider));
             }
         }
 
         let mut registry = self.token_provider_registry.write().await;
 
-        if let Some(provider) = registry.get(&registry_key) {
-            tracing::debug!(
-                "Using existing {} token provider for key: {}",
-                provider_type,
-                key
-            );
+        if let Some(provider) = registry.get(&key) {
+            tracing::debug!("Using existing token provider for key: {key}",);
             return Ok(Arc::clone(provider));
         }
 
-        tracing::debug!(
-            "Creating new {} token provider for key: {}",
-            provider_type,
-            key
-        );
+        tracing::debug!("Creating new token provider for key: {key}",);
 
         let provider = factory().await?;
         let provider_arc = Arc::new(provider) as Arc<dyn TokenProvider>;
 
-        registry.insert(registry_key, Arc::clone(&provider_arc));
+        registry.insert(key, Arc::clone(&provider_arc));
 
         Ok(provider_arc)
     }

--- a/crates/runtime/src/registry/token_provider.rs
+++ b/crates/runtime/src/registry/token_provider.rs
@@ -1,0 +1,96 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use data_components::token_provider::TokenProvider;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
+
+#[derive(Default, Clone)]
+pub struct TokenProviderRegistry {
+    pub token_provider_registry: Arc<RwLock<HashMap<String, Arc<dyn TokenProvider>>>>,
+}
+
+impl TokenProviderRegistry {
+    pub fn new() -> Self {
+        Self {
+            token_provider_registry: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get or create a token provider for the given key and provider type.
+    ///
+    /// If the provider already exists, it will be returned.
+    /// If the provider does not exist, it will be created using the provided factory function.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to use for the token provider.
+    /// * `provider_type` - The type of token provider to create.
+    /// * `factory` - The factory function to use to create the token provider.
+    ///
+    /// # Returns
+    ///
+    /// A token provider, or an error if the provider could not be created.
+    pub async fn get_or_create_provider<P, E, F, Fut>(
+        &self,
+        key: String,
+        provider_type: &str,
+        factory: F,
+    ) -> Result<Arc<dyn TokenProvider>, E>
+    where
+        P: TokenProvider + 'static,
+        Fut: std::future::Future<Output = Result<P, E>> + Send,
+        F: FnOnce() -> Fut + Send,
+    {
+        let registry_key = format!("{provider_type}:{key}");
+
+        {
+            let registry = self.token_provider_registry.read().await;
+            if let Some(provider) = registry.get(&registry_key) {
+                tracing::debug!(
+                    "Using existing {} token provider for key: {}",
+                    provider_type,
+                    key
+                );
+                return Ok(Arc::clone(provider));
+            }
+        }
+
+        let mut registry = self.token_provider_registry.write().await;
+
+        if let Some(provider) = registry.get(&registry_key) {
+            tracing::debug!(
+                "Using existing {} token provider for key: {}",
+                provider_type,
+                key
+            );
+            return Ok(Arc::clone(provider));
+        }
+
+        tracing::debug!(
+            "Creating new {} token provider for key: {}",
+            provider_type,
+            key
+        );
+
+        let provider = factory().await?;
+        let provider_arc = Arc::new(provider) as Arc<dyn TokenProvider>;
+
+        registry.insert(registry_key, Arc::clone(&provider_arc));
+
+        Ok(provider_arc)
+    }
+}


### PR DESCRIPTION
## 📝 Summary

Added a new `subscribe` method to the `TokenProvider` trait, allowing providers to optionally return a `watch::Receiver` for token updates. The default implementation returns `None`.

Added a `TokenProviderRegistry` to manage and share instances of token providers among runtime components. Main goal is to allow having multiple connectors (e.g. Databricks data connector, catalog connector and model provider) to share a single token provider instance.

Registry not used anywhere yet, will be applied for #5468

Usage example:

```rs
let token_provider = rt.token_provider_registry
    .get_or_create_provider(format!("databricks_m2m_{}", client_id.to_string()), || async {
        DatabricksM2MTokenProvider::try_new(
            endpoint.to_string(),
            client_id.to_string(),
            client_secret.clone(),
        )
        .await
    })
    .await?
```

## 🔗 Related

- #5468
- decoupled from #5542

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
