### PR TITLE
Fix Iceberg API returning 404 when schema contains a Dictionary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6072,7 +6072,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=e0a591f76b4b4ab5f3d1a9167961c1586422543f#e0a591f76b4b4ab5f3d1a9167961c1586422543f"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d7a9a31b69afbf6b8f3303b37c4040322a5c7341#d7a9a31b69afbf6b8f3303b37c4040322a5c7341"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=e0a591f76b4b4ab5f3d1a9167961c1586422543f#e0a591f76b4b4ab5f3d1a9167961c1586422543f"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d7a9a31b69afbf6b8f3303b37c4040322a5c7341#d7a9a31b69afbf6b8f3303b37c4040322a5c7341"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6147,7 +6147,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=e0a591f76b4b4ab5f3d1a9167961c1586422543f#e0a591f76b4b4ab5f3d1a9167961c1586422543f"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d7a9a31b69afbf6b8f3303b37c4040322a5c7341#d7a9a31b69afbf6b8f3303b37c4040322a5c7341"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,8 +194,8 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "e0a591f76b4b4ab5f3d1a9167961c1586422543f" }              # spiceai-0.4.0-df-45
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "e0a591f76b4b4ab5f3d1a9167961c1586422543f" } # spiceai-0.4.0-df-45
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "e0a591f76b4b4ab5f3d1a9167961c1586422543f" }   # spiceai-0.4.0-df-45
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d7a9a31b69afbf6b8f3303b37c4040322a5c7341" }              # spiceai-0.4.0-df-45
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d7a9a31b69afbf6b8f3303b37c4040322a5c7341" } # spiceai-0.4.0-df-45
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d7a9a31b69afbf6b8f3303b37c4040322a5c7341" }   # spiceai-0.4.0-df-45
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }

--- a/crates/runtime/tests/iceberg_api/mod.rs
+++ b/crates/runtime/tests/iceberg_api/mod.rs
@@ -1,0 +1,123 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+use rand::Rng;
+use runtime::{Runtime, auth::EndpointAuth, config::Config};
+use spicepod::component::dataset::Dataset;
+
+use crate::{
+    init_tracing,
+    utils::{test_request_context, wait_until_true},
+};
+
+const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+pub fn get_s3_dictionary_dataset(name: &str) -> Dataset {
+    Dataset::new(
+        "s3://spiceai-public-datasets/dictionary_example/dictionary_example.parquet",
+        name,
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+#[tokio::test]
+async fn test_iceberg_api_get_table_schema() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
+    test_request_context()
+        .scope(async {
+            let span = tracing::info_span!("test_iceberg_api_get_table_schema");
+            let _span_guard = span.enter();
+
+            let mut rng = rand::rng();
+            let http_port: u16 = rng.random_range(50000..60000);
+            let flight_port: u16 = http_port + 1;
+            let otel_port: u16 = http_port + 2;
+
+            tracing::debug!(
+                "Iceberg API Ports: http: {http_port}, flight: {flight_port}, otel: {otel_port}"
+            );
+
+            let api_config = Config::new()
+                .with_http_bind_address(SocketAddr::new(LOCALHOST, http_port))
+                .with_flight_bind_address(SocketAddr::new(LOCALHOST, flight_port))
+                .with_open_telemetry_bind_address(SocketAddr::new(LOCALHOST, otel_port));
+
+            let app = app::AppBuilder::new("test_app")
+                .with_dataset(get_s3_dictionary_dataset("dictionary_example"))
+                .build();
+
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            let cloned_rt = Arc::clone(&rt);
+
+            // Start the servers
+            tokio::spawn(async move {
+                Box::pin(cloned_rt.start_servers(api_config, None, EndpointAuth::no_auth()))
+                    .await
+            });
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+            
+            // Connect to the server
+            let http_client = reqwest::Client::builder().build()?;
+
+            tracing::info!("Waiting for servers to start...");
+            wait_until_true(Duration::from_secs(10), || async {
+                http_client
+                    .get(format!("http://127.0.0.1:{http_port}/ready"))
+                    .send()
+                    .await
+                    .is_ok()
+            })
+            .await;
+
+            // Get the table schema
+            let http_url =
+                format!("http://127.0.0.1:{http_port}/v1/namespaces/spice%1Fpublic/tables/dictionary_example");
+            let response = http_client
+                .get(&http_url)
+                .send()
+                .await
+                .expect("valid response");
+            assert!(
+                response.status().is_success(),
+                "HTTP health check failed: {}",
+                response.status()
+            );
+            let dictionary_example_snapshot = response.text().await?;
+            let dictionary_example_snapshot = serde_json::from_str::<serde_json::Value>(&dictionary_example_snapshot)?;
+            assert_eq!(dictionary_example_snapshot["metadata"]["location"], "spice.ai/spice.public.dictionary_example");
+            let schemas = dictionary_example_snapshot["metadata"]["schemas"].as_array().expect("schemas is an array");
+            insta::assert_json_snapshot!(schemas);
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/iceberg_api/mod.rs
+++ b/crates/runtime/tests/iceberg_api/mod.rs
@@ -84,7 +84,7 @@ async fn test_iceberg_api_get_table_schema() -> Result<(), anyhow::Error> {
                 }
                 () = Arc::clone(&rt).load_components() => {}
             }
-            
+
             // Connect to the server
             let http_client = reqwest::Client::builder().build()?;
 

--- a/crates/runtime/tests/iceberg_api/snapshots/integration__iceberg_api__iceberg_api_get_table_schema.snap
+++ b/crates/runtime/tests/iceberg_api/snapshots/integration__iceberg_api__iceberg_api_get_table_schema.snap
@@ -1,0 +1,24 @@
+---
+source: crates/runtime/tests/iceberg_api/mod.rs
+expression: schemas
+---
+[
+  {
+    "schema-id": 0,
+    "type": "struct",
+    "fields": [
+      {
+        "id": 0,
+        "name": "category",
+        "required": false,
+        "type": "string"
+      },
+      {
+        "id": 1,
+        "name": "value",
+        "required": false,
+        "type": "long"
+      }
+    ]
+  }
+]

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -47,6 +47,7 @@ mod flight;
 mod github;
 mod graphql;
 mod iceberg;
+mod iceberg_api;
 #[cfg(feature = "mssql")]
 mod mssql;
 #[cfg(feature = "mysql")]


### PR DESCRIPTION
## 📝 Summary

Brings in this change that fixes the Iceberg API returning 404 when getting the schema for a table that contains a Dictionary type.
- https://github.com/spiceai/iceberg-rust/pull/10

Also adds an integration test that verifies the fix is working.

## 🔗 Related

- #5662
