### PR TITLE
Enable federated data refresh support for accelerated views

### DIFF
--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -238,8 +238,7 @@ pub struct Builder {
     cache_provider: Option<Arc<QueryResultsCacheProvider>>,
     changes_stream: Option<ChangesStream>,
     append_stream: Option<ChangesStream>,
-    disable_query_push_down: bool,
-    disable_refresh_federation: bool,
+    disable_federation: bool,
     checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
     synchronize_with: Option<SynchronizedTable>,
     initial_load_complete: bool,
@@ -270,9 +269,8 @@ impl Builder {
             append_stream: None,
             checkpointer: None,
             synchronize_with: None,
-            disable_query_push_down: false,
+            disable_federation: false,
             initial_load_complete: false,
-            disable_refresh_federation: false,
         }
     }
 
@@ -304,13 +302,8 @@ impl Builder {
         self
     }
 
-    pub fn disable_query_push_down(&mut self) -> &mut Self {
-        self.disable_query_push_down = true;
-        self
-    }
-
-    pub fn disable_refresh_federation(&mut self) -> &mut Self {
-        self.disable_refresh_federation = true;
+    pub fn disable_federation(&mut self) -> &mut Self {
+        self.disable_federation = true;
         self
     }
 
@@ -449,7 +442,7 @@ impl Builder {
         refresher.checkpointer(self.checkpointer);
         refresher.refresh_on_startup(self.refresh_on_startup);
         refresher.set_initial_load_completed(self.initial_load_complete);
-        refresher.disable_refresh_federation(self.disable_refresh_federation);
+        refresher.disable_federation(self.disable_federation);
         if let Some(synchronize_with) = &self.synchronize_with {
             refresher.synchronize_with(synchronize_with.clone());
         }
@@ -491,7 +484,7 @@ impl Builder {
                 ready_state: self.ready_state,
                 refresh_params,
                 refresher,
-                disable_query_push_down: self.disable_query_push_down,
+                disable_query_push_down: self.disable_federation,
                 synchronized_with: self.synchronize_with,
             },
             is_ready,

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -185,7 +185,7 @@ pub struct AcceleratedTable {
     ready_state: ReadyState,
     refresh_params: Arc<RwLock<refresh::Refresh>>,
     refresher: Arc<refresh::Refresher>,
-    disable_query_push_down: bool,
+    disable_federation: bool,
     synchronized_with: Option<SynchronizedTable>,
 }
 
@@ -198,7 +198,7 @@ impl std::fmt::Debug for AcceleratedTable {
             .field("zero_results_action", &self.zero_results_action)
             .field("ready_state", &self.ready_state)
             .field("refresh_params", &self.refresh_params)
-            .field("disable_query_push_down", &self.disable_query_push_down)
+            .field("disable_federation", &self.disable_federation)
             .field("synchronized_with", &self.synchronized_with)
             .finish_non_exhaustive()
     }
@@ -484,7 +484,7 @@ impl Builder {
                 ready_state: self.ready_state,
                 refresh_params,
                 refresher,
-                disable_query_push_down: self.disable_federation,
+                disable_federation: self.disable_federation,
                 synchronized_with: self.synchronize_with,
             },
             is_ready,

--- a/crates/runtime/src/accelerated_table.rs
+++ b/crates/runtime/src/accelerated_table.rs
@@ -239,6 +239,7 @@ pub struct Builder {
     changes_stream: Option<ChangesStream>,
     append_stream: Option<ChangesStream>,
     disable_query_push_down: bool,
+    disable_refresh_federation: bool,
     checkpointer: Option<Arc<dyn DatasetCheckpointer>>,
     synchronize_with: Option<SynchronizedTable>,
     initial_load_complete: bool,
@@ -271,6 +272,7 @@ impl Builder {
             synchronize_with: None,
             disable_query_push_down: false,
             initial_load_complete: false,
+            disable_refresh_federation: false,
         }
     }
 
@@ -304,6 +306,11 @@ impl Builder {
 
     pub fn disable_query_push_down(&mut self) -> &mut Self {
         self.disable_query_push_down = true;
+        self
+    }
+
+    pub fn disable_refresh_federation(&mut self) -> &mut Self {
+        self.disable_refresh_federation = true;
         self
     }
 
@@ -442,6 +449,7 @@ impl Builder {
         refresher.checkpointer(self.checkpointer);
         refresher.refresh_on_startup(self.refresh_on_startup);
         refresher.set_initial_load_completed(self.initial_load_complete);
+        refresher.disable_refresh_federation(self.disable_refresh_federation);
         if let Some(synchronize_with) = &self.synchronize_with {
             refresher.synchronize_with(synchronize_with.clone());
         }

--- a/crates/runtime/src/accelerated_table/federation.rs
+++ b/crates/runtime/src/accelerated_table/federation.rs
@@ -44,8 +44,8 @@ impl AcceleratedTable {
         let schema = Arc::clone(&self.schema());
         let accelerated_table_federation_provider = self.get_federation_provider_for_accelerator();
 
-        let enabled = self.zero_results_action != ZeroResultsAction::UseSource
-            && !self.disable_query_push_down;
+        let enabled =
+            self.zero_results_action != ZeroResultsAction::UseSource && !self.disable_federation;
 
         let remote_table_name = accelerated_table_federation_provider
             .as_ref()

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -426,6 +426,7 @@ pub struct Refresher {
     synchronize_with: Option<SynchronizedTable>,
 
     initial_load_completed: Arc<AtomicBool>,
+    disable_refresh_federation: bool,
 }
 
 impl Refresher {
@@ -450,6 +451,7 @@ impl Refresher {
             refresh_on_startup: RefreshOnStartup::default(),
             synchronize_with: None,
             initial_load_completed: Arc::new(AtomicBool::new(false)),
+            disable_refresh_federation: false,
         }
     }
 
@@ -477,6 +479,12 @@ impl Refresher {
     /// Synchronize further refreshes with an existing accelerated table after the initial load completes
     pub fn synchronize_with(&mut self, synchronized_table: SynchronizedTable) -> &mut Self {
         self.synchronize_with = Some(synchronized_table);
+        self
+    }
+
+    /// Disable refresh queries federation for this refresher
+    pub fn disable_refresh_federation(&mut self, disable: bool) -> &mut Self {
+        self.disable_refresh_federation = disable;
         self
     }
 
@@ -560,6 +568,7 @@ impl Refresher {
             self.federated_source.clone(),
             Arc::clone(&self.refresh),
             Arc::clone(&self.accelerator),
+            self.disable_refresh_federation,
         );
 
         let (start_refresh, mut on_refresh_complete) = refresh_task_runner.start();
@@ -694,13 +703,16 @@ impl Refresher {
         &mut self,
         ready_sender: oneshot::Sender<()>,
     ) -> tokio::task::JoinHandle<()> {
-        let refresh_task = Arc::new(RefreshTask::new(
-            Arc::clone(&self.runtime_status),
-            self.dataset_name.clone(),
-            Arc::clone(&self.federated),
-            self.federated_source.clone(),
-            Arc::clone(&self.accelerator),
-        ));
+        let refresh_task = Arc::new(
+            RefreshTask::new(
+                Arc::clone(&self.runtime_status),
+                self.dataset_name.clone(),
+                Arc::clone(&self.federated),
+                self.federated_source.clone(),
+                Arc::clone(&self.accelerator),
+            )
+            .with_disable_refresh_federation(self.disable_refresh_federation),
+        );
 
         let refresh_defaults = Arc::clone(&self.refresh);
 
@@ -727,13 +739,16 @@ impl Refresher {
         changes_stream: ChangesStream,
         ready_sender: oneshot::Sender<()>,
     ) -> tokio::task::JoinHandle<()> {
-        let refresh_task = Arc::new(RefreshTask::new(
-            Arc::clone(&self.runtime_status),
-            self.dataset_name.clone(),
-            Arc::clone(&self.federated),
-            self.federated_source.clone(),
-            Arc::clone(&self.accelerator),
-        ));
+        let refresh_task = Arc::new(
+            RefreshTask::new(
+                Arc::clone(&self.runtime_status),
+                self.dataset_name.clone(),
+                Arc::clone(&self.federated),
+                self.federated_source.clone(),
+                Arc::clone(&self.accelerator),
+            )
+            .with_disable_refresh_federation(self.disable_refresh_federation),
+        );
 
         let cache_provider = self.cache_provider.clone();
         let refresh = Arc::clone(&self.refresh);

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -426,7 +426,7 @@ pub struct Refresher {
     synchronize_with: Option<SynchronizedTable>,
 
     initial_load_completed: Arc<AtomicBool>,
-    disable_refresh_federation: bool,
+    disable_federation: bool,
 }
 
 impl Refresher {
@@ -451,7 +451,7 @@ impl Refresher {
             refresh_on_startup: RefreshOnStartup::default(),
             synchronize_with: None,
             initial_load_completed: Arc::new(AtomicBool::new(false)),
-            disable_refresh_federation: false,
+            disable_federation: false,
         }
     }
 
@@ -483,8 +483,8 @@ impl Refresher {
     }
 
     /// Disable refresh queries federation for this refresher
-    pub fn disable_refresh_federation(&mut self, disable: bool) -> &mut Self {
-        self.disable_refresh_federation = disable;
+    pub fn disable_federation(&mut self, disable: bool) -> &mut Self {
+        self.disable_federation = disable;
         self
     }
 
@@ -568,7 +568,7 @@ impl Refresher {
             self.federated_source.clone(),
             Arc::clone(&self.refresh),
             Arc::clone(&self.accelerator),
-            self.disable_refresh_federation,
+            self.disable_federation,
         );
 
         let (start_refresh, mut on_refresh_complete) = refresh_task_runner.start();
@@ -711,7 +711,7 @@ impl Refresher {
                 self.federated_source.clone(),
                 Arc::clone(&self.accelerator),
             )
-            .with_disable_refresh_federation(self.disable_refresh_federation),
+            .with_disable_federation(self.disable_federation),
         );
 
         let refresh_defaults = Arc::clone(&self.refresh);
@@ -747,7 +747,7 @@ impl Refresher {
                 self.federated_source.clone(),
                 Arc::clone(&self.accelerator),
             )
-            .with_disable_refresh_federation(self.disable_refresh_federation),
+            .with_disable_federation(self.disable_federation),
         );
 
         let cache_provider = self.cache_provider.clone();

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -22,6 +22,7 @@ use arrow::{
 use arrow_schema::SchemaRef;
 use async_stream::stream;
 use datafusion::datasource::TableType;
+use datafusion::execution::SessionStateBuilder;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion_table_providers::util::retriable_error::{
     check_and_mark_retriable_error, is_retriable_error,
@@ -33,8 +34,9 @@ use tracing::{Instrument, Span};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{RetryError, retry};
 
-use crate::datafusion::builder::get_df_default_config;
+use crate::datafusion::builder::{get_analyzer_rules, get_df_default_config};
 use crate::datafusion::error::{SpiceExternalError, find_datafusion_root, get_spice_df_error};
+use crate::datafusion::extension::SpiceQueryPlanner;
 use crate::datafusion::is_spice_internal_dataset;
 use crate::datafusion::schema::BaseSchema;
 use crate::federated_table::FederatedTable;
@@ -87,6 +89,7 @@ pub struct RefreshTask {
     federated_source: Option<String>,
     accelerator: Arc<dyn TableProvider>,
     sink: Arc<RwLock<AccelerationSink>>,
+    disable_refresh_federation: bool,
 }
 
 impl RefreshTask {
@@ -105,7 +108,13 @@ impl RefreshTask {
             federated_source,
             accelerator: Arc::clone(&accelerator),
             sink: Arc::new(RwLock::new(AccelerationSink::new(accelerator))),
+            disable_refresh_federation: false,
         }
+    }
+    /// Sets the `disable_refresh_federation` flag
+    pub fn with_disable_refresh_federation(mut self, disable: bool) -> RefreshTask {
+        self.disable_refresh_federation = disable;
+        self
     }
 
     /// Subscribes a new acceleration table provider to the existing `AccelerationSink` managed by this `RefreshTask`.
@@ -506,8 +515,23 @@ impl RefreshTask {
     }
 
     fn refresh_df_context(&self, federated_provider: Arc<dyn TableProvider>) -> SessionContext {
-        let ctx =
-            SessionContext::new_with_config_rt(get_df_default_config(), default_runtime_env());
+        let ctx = if self.disable_refresh_federation {
+            SessionContext::new_with_config_rt(get_df_default_config(), default_runtime_env())
+        } else {
+            let mut state = SessionStateBuilder::new()
+                .with_config(get_df_default_config())
+                .with_runtime_env(default_runtime_env())
+                .with_default_features()
+                .with_query_planner(Arc::new(SpiceQueryPlanner::new()))
+                .with_analyzer_rules(get_analyzer_rules())
+                .build();
+
+            if let Err(e) = datafusion_functions_json::register_all(&mut state) {
+                tracing::error!("Unable to register JSON functions: {e}");
+            }
+
+            SessionContext::new_with_state(state)
+        };
 
         let ctx_state = ctx.state();
         let default_catalog = &ctx_state.config_options().catalog.default_catalog;

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -89,7 +89,7 @@ pub struct RefreshTask {
     federated_source: Option<String>,
     accelerator: Arc<dyn TableProvider>,
     sink: Arc<RwLock<AccelerationSink>>,
-    disable_refresh_federation: bool,
+    disable_federation: bool,
 }
 
 impl RefreshTask {
@@ -108,12 +108,13 @@ impl RefreshTask {
             federated_source,
             accelerator: Arc::clone(&accelerator),
             sink: Arc::new(RwLock::new(AccelerationSink::new(accelerator))),
-            disable_refresh_federation: false,
+            disable_federation: false,
         }
     }
-    /// Sets the `disable_refresh_federation` flag
-    pub fn with_disable_refresh_federation(mut self, disable: bool) -> RefreshTask {
-        self.disable_refresh_federation = disable;
+    /// Sets the `disable_federation` flag
+    #[must_use]
+    pub fn with_disable_federation(mut self, disable: bool) -> RefreshTask {
+        self.disable_federation = disable;
         self
     }
 
@@ -515,7 +516,7 @@ impl RefreshTask {
     }
 
     fn refresh_df_context(&self, federated_provider: Arc<dyn TableProvider>) -> SessionContext {
-        let ctx = if self.disable_refresh_federation {
+        let ctx = if self.disable_federation {
             SessionContext::new_with_config_rt(get_df_default_config(), default_runtime_env())
         } else {
             let mut state = SessionStateBuilder::new()

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -52,7 +52,7 @@ impl RefreshTaskRunner {
         federated_source: Option<String>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
-        disable_refresh_federation: bool,
+        disable_federation: bool,
     ) -> Self {
         let refresh_task = Arc::new(
             RefreshTask::new(
@@ -62,7 +62,7 @@ impl RefreshTaskRunner {
                 federated_source,
                 accelerator,
             )
-            .with_disable_refresh_federation(disable_refresh_federation),
+            .with_disable_federation(disable_federation),
         );
 
         Self {

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -52,14 +52,18 @@ impl RefreshTaskRunner {
         federated_source: Option<String>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
+        disable_refresh_federation: bool,
     ) -> Self {
-        let refresh_task = Arc::new(RefreshTask::new(
-            runtime_status,
-            dataset_name.clone(),
-            federated,
-            federated_source,
-            accelerator,
-        ));
+        let refresh_task = Arc::new(
+            RefreshTask::new(
+                runtime_status,
+                dataset_name.clone(),
+                federated,
+                federated_source,
+                accelerator,
+            )
+            .with_disable_refresh_federation(disable_refresh_federation),
+        );
 
         Self {
             dataset_name,

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -280,9 +280,7 @@ pub struct Acceleration {
 
     pub on_conflict: HashMap<ColumnReference, OnConflictBehavior>,
 
-    pub disable_query_push_down: bool,
-
-    pub disable_refresh_federation: bool,
+    pub disable_federation: bool,
 }
 
 impl Acceleration {
@@ -296,7 +294,6 @@ impl Acceleration {
 impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
     type Error = crate::Error;
 
-    #[allow(clippy::too_many_lines)]
     fn try_from(
         acceleration: spicepod_acceleration::Acceleration,
     ) -> std::result::Result<Self, Self::Error> {
@@ -361,17 +358,9 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
 
         let mut params = acceleration.params.clone();
 
-        let disable_query_push_down = match params
+        let disable_federation = match params
             .as_mut()
-            .and_then(|x| x.data.remove("disable_query_push_down"))
-        {
-            Some(spicepod::param::ParamValue::Bool(value)) => value,
-            _ => false,
-        };
-
-        let disable_refresh_federation = match params
-            .as_mut()
-            .and_then(|x| x.data.remove("disable_refresh_federation"))
+            .and_then(|x| x.data.remove("disable_federation"))
         {
             Some(spicepod::param::ParamValue::Bool(value)) => value,
             _ => false,
@@ -409,8 +398,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             retention_period: acceleration.retention_period,
             retention_check_interval: acceleration.retention_check_interval,
             retention_check_enabled: acceleration.retention_check_enabled,
-            disable_query_push_down,
-            disable_refresh_federation,
+            disable_federation,
             on_zero_results: ZeroResultsAction::from(acceleration.on_zero_results),
             indexes,
             primary_key,
@@ -442,8 +430,7 @@ impl Default for Acceleration {
             indexes: HashMap::default(),
             primary_key: None,
             on_conflict: HashMap::default(),
-            disable_query_push_down: false,
-            disable_refresh_federation: false,
+            disable_federation: false,
             refresh_on_startup: RefreshOnStartup::default(),
         }
     }

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -281,6 +281,8 @@ pub struct Acceleration {
     pub on_conflict: HashMap<ColumnReference, OnConflictBehavior>,
 
     pub disable_query_push_down: bool,
+
+    pub disable_refresh_federation: bool,
 }
 
 impl Acceleration {
@@ -294,6 +296,7 @@ impl Acceleration {
 impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
     type Error = crate::Error;
 
+    #[allow(clippy::too_many_lines)]
     fn try_from(
         acceleration: spicepod_acceleration::Acceleration,
     ) -> std::result::Result<Self, Self::Error> {
@@ -366,6 +369,14 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             _ => false,
         };
 
+        let disable_refresh_federation = match params
+            .as_mut()
+            .and_then(|x| x.data.remove("disable_refresh_federation"))
+        {
+            Some(spicepod::param::ParamValue::Bool(value)) => value,
+            _ => false,
+        };
+
         let refresh_check_interval = try_parse_duration(
             "refresh_check_interval",
             acceleration.refresh_check_interval,
@@ -399,6 +410,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             retention_check_interval: acceleration.retention_check_interval,
             retention_check_enabled: acceleration.retention_check_enabled,
             disable_query_push_down,
+            disable_refresh_federation,
             on_zero_results: ZeroResultsAction::from(acceleration.on_zero_results),
             indexes,
             primary_key,
@@ -431,6 +443,7 @@ impl Default for Acceleration {
             primary_key: None,
             on_conflict: HashMap::default(),
             disable_query_push_down: false,
+            disable_refresh_federation: false,
             refresh_on_startup: RefreshOnStartup::default(),
         }
     }

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -360,8 +360,12 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
 
         let disable_federation = match params
             .as_mut()
-            .and_then(|x| x.data.remove("disable_federation"))
-        {
+            // support `disable_query_push_down` for backward compatibility
+            .and_then(|x| {
+                x.data
+                    .remove("disable_federation")
+                    .or_else(|| x.data.remove("disable_query_push_down"))
+            }) {
             Some(spicepod::param::ParamValue::Bool(value)) => value,
             _ => false,
         };

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -75,7 +75,7 @@ pub mod query;
 pub mod builder;
 pub mod dialect;
 pub mod error;
-mod extension;
+pub mod extension;
 pub mod filter_converter;
 pub mod param_utils;
 pub mod refresh_sql;
@@ -884,6 +884,9 @@ impl DataFusion {
             accelerated_table_builder.disable_query_push_down();
         }
 
+        // Datasets don't support using federation logic for data refresh yet.
+        accelerated_table_builder.disable_refresh_federation();
+
         if refresh_mode == RefreshMode::Changes {
             let changes_stream = source.changes_stream(Arc::clone(&source_table_provider));
 
@@ -1363,6 +1366,12 @@ impl DataFusion {
         builder.checkpointer_opt(DatasetCheckpoint::try_new(view).await.ok());
         builder.refresh_on_startup(acceleration.refresh_on_startup);
         builder.ready_state(view.ready_state);
+        if acceleration.disable_query_push_down {
+            builder.disable_query_push_down();
+        }
+        if acceleration.disable_refresh_federation {
+            builder.disable_refresh_federation();
+        }
 
         let (accelerated_table, _) =
             builder

--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -880,12 +880,9 @@ impl DataFusion {
 
         accelerated_table_builder.initial_load_complete(initial_load_complete);
 
-        if acceleration_settings.disable_query_push_down {
-            accelerated_table_builder.disable_query_push_down();
+        if acceleration_settings.disable_federation {
+            accelerated_table_builder.disable_federation();
         }
-
-        // Datasets don't support using federation logic for data refresh yet.
-        accelerated_table_builder.disable_refresh_federation();
 
         if refresh_mode == RefreshMode::Changes {
             let changes_stream = source.changes_stream(Arc::clone(&source_table_provider));
@@ -1366,11 +1363,8 @@ impl DataFusion {
         builder.checkpointer_opt(DatasetCheckpoint::try_new(view).await.ok());
         builder.refresh_on_startup(acceleration.refresh_on_startup);
         builder.ready_state(view.ready_state);
-        if acceleration.disable_query_push_down {
-            builder.disable_query_push_down();
-        }
-        if acceleration.disable_refresh_federation {
-            builder.disable_refresh_federation();
+        if acceleration.disable_federation {
+            builder.disable_federation();
         }
 
         let (accelerated_table, _) =

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -221,7 +221,8 @@ impl DataFusionBuilder {
 /// as opposed to when underlying federated query engines will execute the query.
 ///
 /// This list should be kept in sync with the default rules in `Analyzer::new()`, but with the federation analyzer rule added.
-fn get_analyzer_rules() -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
+#[must_use]
+pub fn get_analyzer_rules() -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
     vec![
         Arc::new(InlineTableScan::new()),
         Arc::new(ExpandWildcardRule::new()),

--- a/crates/runtime/src/datafusion/extension/bytes_processed.rs
+++ b/crates/runtime/src/datafusion/extension/bytes_processed.rs
@@ -111,6 +111,7 @@ impl OptimizerRule for BytesProcessedOptimizerRule {
 }
 
 impl BytesProcessedOptimizerRule {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/runtime/src/datafusion/extension/mod.rs
+++ b/crates/runtime/src/datafusion/extension/mod.rs
@@ -32,6 +32,7 @@ pub mod bytes_processed;
 pub struct SpiceQueryPlanner {}
 
 impl SpiceQueryPlanner {
+    #[must_use]
     pub fn new() -> Self {
         SpiceQueryPlanner {}
     }
@@ -58,6 +59,7 @@ impl QueryPlanner for SpiceQueryPlanner {
 pub struct SpiceExtensionPlanner {}
 
 impl SpiceExtensionPlanner {
+    #[must_use]
     pub fn new() -> Self {
         SpiceExtensionPlanner {}
     }

--- a/crates/runtime/tests/acceleration/query_push_down.rs
+++ b/crates/runtime/tests/acceleration/query_push_down.rs
@@ -82,7 +82,7 @@ async fn acceleration_with_and_without_federation() -> Result<(), anyhow::Error>
             );
             federated_acc.params = Some(params.clone());
             params.data.insert(
-                "disable_query_push_down".to_string(),
+                "disable_federation".to_string(),
                 spicepod::param::ParamValue::Bool(false),
             );
 
@@ -107,7 +107,7 @@ async fn acceleration_with_and_without_federation() -> Result<(), anyhow::Error>
             );
             non_federated_acc.params = Some(non_federated_params.clone());
             non_federated_params.data.insert(
-                "disable_query_push_down".to_string(),
+                "disable_federation".to_string(),
                 spicepod::param::ParamValue::Bool(true),
             );
 


### PR DESCRIPTION
## 📝 Summary

Enable federation logic support for accelerated views by default that can be disabled using `disable_federation` param. 
1. We had `disable_query_push_down` undocumented parameter (applied for dataset access query federation) that was generalized to `disable_federation` to cover all federation logic (data refresh/load and queries). `disable_query_push_down` is still supported for backward capability.
2. Datasets load does not involve federation due to a single source, but with this change, the same unparsing mechanism that is used for federated queries will now apply to refresh SQL.

```yaml
views:
  - name: complex_vw
    sql: |
      ...
    acceleration:
      params: 
        disable_federation: true
```

Before 
```
2025-05-02T09:24:49.619891Z  INFO runtime::accelerated_table::refresh_task: Loaded 9,033,323 rows (920.50 GiB) for view test_view in 8m 39s 285ms.
```

After 
```
2025-05-02T06:29:52.585976Z  INFO runtime::accelerated_table::refresh_task: Loaded 9,033,323 rows (7.25 GiB) for view test_view in 2m 48s 800ms.
```

## 🔗 Related

Fixes 
- https://github.com/spiceai/spiceai/issues/5658

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

1. The change must be covered by tests (to be added to this or next PR)
