### PR TITLE
Tweak default log to ignore aws_config::imds::region

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -69,8 +69,7 @@ const INTERNAL_COMPONENTS: &[&str] = &[
     "workers",
 ];
 
-const OFF_FILTERS: &str =
-    "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off";
+const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off,aws_config::imds::region=off";
 
 impl From<LogVerbosity> for EnvFilter {
     fn from(v: LogVerbosity) -> Self {


### PR DESCRIPTION
## 📝 Summary

Tweaks the default logging in Spice to ignore `aws_config::imds::region` to suppress the following warning that doesn't require any user action:

<img width="1277" alt="Screenshot 2025-05-05 at 4 45 07 PM" src="https://github.com/user-attachments/assets/b7a19564-a4a1-4cad-9425-d84ecedd7414" />