### PR TITLE
Make Spice properly Iceberg Catalog API compatible for load table API

### DIFF
--- a/crates/runtime/src/http/v1/iceberg/tables.rs
+++ b/crates/runtime/src/http/v1/iceberg/tables.rs
@@ -31,7 +31,10 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use datafusion::sql::TableReference;
-use iceberg::{arrow::arrow_schema_to_schema, spec::Schema};
+use iceberg::{
+    arrow::arrow_schema_to_schema,
+    spec::{PartitionSpec, Schema, SortOrder},
+};
 use serde::{Serialize, Serializer};
 use uuid::Uuid;
 
@@ -89,6 +92,7 @@ impl Serialize for TableFormatVersion {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 struct TableMetadata {
     format_version: TableFormatVersion,
@@ -97,8 +101,21 @@ struct TableMetadata {
     location: String,
 
     /// Iceberg schemas, see `<https://apache.github.io/iceberg/spec/#schemas>`.
-    #[cfg_attr(feature = "openapi", schema(value_type=Type::Object, example="2b9da507-2c07-4bb3-9f0b-8df66a5e9e53"))]
+    #[cfg_attr(feature = "openapi", schema(value_type=Type::Object))]
     schemas: Vec<Schema>,
+
+    // The following fields are part of the Iceberg Table Metadata V2 spec - but we don't do anything with them yet
+    last_updated_ms: i64,
+    last_column_id: u32,
+    last_sequence_number: u64,
+    current_schema_id: u32,
+    #[cfg_attr(feature = "openapi", schema(value_type=Type::Object))]
+    partition_specs: Vec<PartitionSpec>,
+    default_spec_id: u32,
+    last_partition_id: u32,
+    #[cfg_attr(feature = "openapi", schema(value_type=Type::Object))]
+    sort_orders: Vec<SortOrder>,
+    default_sort_order_id: u32,
 }
 
 /// Get a table.
@@ -128,6 +145,7 @@ struct TableMetadata {
         )))
     )
 ))]
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) async fn get(
     Extension(datafusion): Extension<Arc<DataFusion>>,
     Path((namespace, table)): Path<(NamespacePath, String)>,
@@ -154,11 +172,31 @@ pub(crate) async fn get(
         }
     };
 
+    let last_updated_ms = chrono::Utc::now().timestamp_millis();
+
+    let partition_specs = if let Ok(partition_spec) = PartitionSpec::builder(iceberg_schema.clone())
+        .with_spec_id(0)
+        .build()
+    {
+        vec![partition_spec]
+    } else {
+        vec![]
+    };
+
     let metadata = TableMetadata {
         format_version: TableFormatVersion::V2,
         table_uuid: Uuid::new_v4(),
         location: format!("spice.ai/{table_reference}"),
         schemas: vec![iceberg_schema],
+        last_column_id: arrow_schema.fields.len() as u32,
+        last_updated_ms,
+        last_sequence_number: 0,
+        current_schema_id: 0,
+        partition_specs,
+        default_spec_id: 0,
+        last_partition_id: 1000,
+        sort_orders: vec![SortOrder::unsorted_order()],
+        default_sort_order_id: 0,
     };
 
     let response = LoadTableResponse { metadata };


### PR DESCRIPTION
## 📝 Summary

Allows `pyiceberg` and other Iceberg reader to read from the Spice API.

Create the following file in a clean directory.

`.pyiceberg.yaml`
```yaml
catalog:
  default:
    type: rest
    uri: http://localhost:8090
```

Now run the following commands in that same directory. Assumes [`uv`](https://docs.astral.sh/uv/getting-started/installation/) is installed.

```bash
uv init
uv add pyiceberg
uv run pyiceberg list
uv run pyiceberg describe spice.public.<table>
```
