### PR TITLE
Support retrieving the latest Iceberg table on table scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6026,7 +6026,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d7a9a31b69afbf6b8f3303b37c4040322a5c7341#d7a9a31b69afbf6b8f3303b37c4040322a5c7341"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=2d01d56ffa606022caf4e3b6ce0f5169984ac6ae#2d01d56ffa606022caf4e3b6ce0f5169984ac6ae"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -6075,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d7a9a31b69afbf6b8f3303b37c4040322a5c7341#d7a9a31b69afbf6b8f3303b37c4040322a5c7341"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=2d01d56ffa606022caf4e3b6ce0f5169984ac6ae#2d01d56ffa606022caf4e3b6ce0f5169984ac6ae"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6101,7 +6101,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=d7a9a31b69afbf6b8f3303b37c4040322a5c7341#d7a9a31b69afbf6b8f3303b37c4040322a5c7341"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=2d01d56ffa606022caf4e3b6ce0f5169984ac6ae#2d01d56ffa606022caf4e3b6ce0f5169984ac6ae"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6026,7 +6026,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=2d01d56ffa606022caf4e3b6ce0f5169984ac6ae#2d01d56ffa606022caf4e3b6ce0f5169984ac6ae"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=58308b27bc768f644f32a45dac277bb40984a058#58308b27bc768f644f32a45dac277bb40984a058"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -6075,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=2d01d56ffa606022caf4e3b6ce0f5169984ac6ae#2d01d56ffa606022caf4e3b6ce0f5169984ac6ae"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=58308b27bc768f644f32a45dac277bb40984a058#58308b27bc768f644f32a45dac277bb40984a058"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6101,7 +6101,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.4.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=2d01d56ffa606022caf4e3b6ce0f5169984ac6ae#2d01d56ffa606022caf4e3b6ce0f5169984ac6ae"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=58308b27bc768f644f32a45dac277bb40984a058#58308b27bc768f644f32a45dac277bb40984a058"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,8 +194,8 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d7a9a31b69afbf6b8f3303b37c4040322a5c7341" }              # spiceai-0.4.0-df-45
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d7a9a31b69afbf6b8f3303b37c4040322a5c7341" } # spiceai-0.4.0-df-45
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "d7a9a31b69afbf6b8f3303b37c4040322a5c7341" }   # spiceai-0.4.0-df-45
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "2d01d56ffa606022caf4e3b6ce0f5169984ac6ae" }              # phillip/250501-dynamic-table-df-45
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "2d01d56ffa606022caf4e3b6ce0f5169984ac6ae" } # phillip/250501-dynamic-table-df-45
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "2d01d56ffa606022caf4e3b6ce0f5169984ac6ae" }   # phillip/250501-dynamic-table-df-45
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,8 +194,8 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 # Tracking Issue: https://github.com/allan2/dotenvy/issues/113
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "2d01d56ffa606022caf4e3b6ce0f5169984ac6ae" }              # phillip/250501-dynamic-table-df-45
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "2d01d56ffa606022caf4e3b6ce0f5169984ac6ae" } # phillip/250501-dynamic-table-df-45
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "2d01d56ffa606022caf4e3b6ce0f5169984ac6ae" }   # phillip/250501-dynamic-table-df-45
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "58308b27bc768f644f32a45dac277bb40984a058" }              # spiceai-0.4.0-df-45
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "58308b27bc768f644f32a45dac277bb40984a058" } # spiceai-0.4.0-df-45
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "58308b27bc768f644f32a45dac277bb40984a058" }   # spiceai-0.4.0-df-45
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }

--- a/crates/data_components/src/iceberg/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog.rs
@@ -202,9 +202,12 @@ mod tests {
             .expect("Failed to load table");
         println!("{table:?}");
 
-        let df_table_provider = IcebergTableProvider::try_new_from_table(table)
-            .await
-            .expect("Failed to create table provider");
+        let df_table_provider = IcebergTableProvider::try_new(
+            Arc::new(catalog),
+            TableIdent::new(NamespaceIdent::new("nyc".to_string()), "taxis".to_string()),
+        )
+        .await
+        .expect("Failed to create table provider");
 
         let ctx = SessionContext::new();
         ctx.register_table("ice_ice_baby", Arc::new(df_table_provider))

--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -205,11 +205,11 @@ impl IcebergSchemaProvider {
             .iter()
             .map(|name| {
                 let client_clone = Arc::clone(&client);
-                let name_clone = name.clone();
+                let name_clone = Arc::new(name.clone());
                 let semaphore_clone = Arc::clone(&load_semaphore);
                 async move {
                     // Map the inner Result to include the table name
-                    Self::load_table(client_clone, &name_clone, semaphore_clone)
+                    Self::load_table(client_clone, Arc::clone(&name_clone), semaphore_clone)
                         .await
                         .map(|opt_provider| (name_clone, opt_provider))
                 }
@@ -232,7 +232,7 @@ impl IcebergSchemaProvider {
 
     async fn load_table(
         client: Arc<RestCatalog>,
-        table_name: &TableIdent,
+        table_name: Arc<TableIdent>,
         semaphore: Arc<Semaphore>,
     ) -> Result<Option<Arc<dyn TableProvider>>> {
         // Acquire a permit from the semaphore to limit concurrent table loads
@@ -241,11 +241,14 @@ impl IcebergSchemaProvider {
             .await
             .map_err(|e| Error::SemaphoreError { source: e })?;
 
-        match client.load_table(table_name).await {
-            Ok(table) => match IcebergTableProvider::try_new_from_table(table).await {
-                Ok(provider) => Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>)),
-                Err(e) => Err(handle_iceberg_error(e)),
-            },
+        match client.load_table(&table_name).await {
+            Ok(_table) => {
+                match IcebergTableProvider::try_new(client, Arc::unwrap_or_clone(table_name)).await
+                {
+                    Ok(provider) => Ok(Some(Arc::new(provider) as Arc<dyn TableProvider>)),
+                    Err(e) => Err(handle_iceberg_error(e)),
+                }
+            }
             Err(e) => {
                 // If the table doesn't exist, return None instead of an error
                 let err_msg = e.to_string();

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -21,7 +21,7 @@ use std::{any::Any, future::Future, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
 use datafusion::catalog::TableProvider;
-use iceberg::{Catalog, TableIdent};
+use iceberg::TableIdent;
 use iceberg_catalog_rest::RestCatalog;
 use iceberg_datafusion::IcebergTableProvider;
 use secrecy::ExposeSecret;
@@ -148,17 +148,8 @@ impl DataConnector for IcebergDataConnector {
         let namespace_ident = namespace.name().clone();
         let table_identifier = TableIdent::new(namespace_ident, table_name);
 
-        let iceberg_table = catalog_client
-            .load_table(&table_identifier)
-            .await
-            .map_err(|e| Error::UnableToGetReadProvider {
-                dataconnector: "iceberg".into(),
-                connector_component: ConnectorComponent::from(dataset),
-                source: Box::new(e),
-            })?;
-
         // Create a DataFusion TableProvider from the Iceberg table
-        let table_provider = IcebergTableProvider::try_new_from_table(iceberg_table)
+        let table_provider = IcebergTableProvider::try_new(catalog_client, table_identifier)
             .await
             .map_err(|e| Error::UnableToGetReadProvider {
                 dataconnector: "iceberg".into(),


### PR DESCRIPTION
## 📝 Summary

- Integrates https://github.com/spiceai/iceberg-rust/pull/11 to get dynamic table scans for Iceberg.

## 🔗 Related

- Closes #5697
