### PR TITLE
Clear plan cache when dataset updates

### DIFF
--- a/crates/runtime/src/datafusion.rs
+++ b/crates/runtime/src/datafusion.rs
@@ -1497,6 +1497,11 @@ impl DataFusion {
 
         Ok(plan)
     }
+
+    pub(crate) fn clear_cached_plans(&self) {
+        tracing::trace!("clearing cached logical plans");
+        self.cached_plans.invalidate_all();
+    }
 }
 
 #[must_use]

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -453,6 +453,11 @@ impl Runtime {
     async fn update_dataset(&self, ds: Arc<Dataset>) {
         self.status
             .update_dataset(&ds.name, status::ComponentStatus::Refreshing);
+
+        // Updating a dataset may cause the cached LogicalPlans to be
+        // obsolete, so we remove them
+        self.df.clear_cached_plans();
+
         match self.load_dataset_connector(Arc::clone(&ds)).await {
             Ok(connector) => {
                 // File accelerated datasets don't support hot reload.


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

Clears the plan cache when a dataset is updated in the SpicePod in case the update causes the cached logical plans to be obsolete.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->
- Closes https://github.com/spiceai/spiceai/issues/5698

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
