### PR TITLE
Remove HTTP auth from LLM config and simplify Databricks models logic by using static headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,7 +7131,6 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]

--- a/crates/data_components/src/databricks/mod.rs
+++ b/crates/data_components/src/databricks/mod.rs
@@ -17,13 +17,19 @@ limitations under the License.
 pub mod delta;
 pub mod spark_connect;
 
+use std::sync::LazyLock;
+
 pub use delta::DatabricksDelta;
 pub use spark_connect::DatabricksSparkConnect;
 
 const SPICE_USER_AGENT_STRING: &str = "SpiceAI_OSS";
 
-#[must_use]
-pub fn user_agent() -> String {
-    let version = env!("CARGO_PKG_VERSION").to_string();
+static USER_AGENT: LazyLock<String> = LazyLock::new(|| {
+    let version = env!("CARGO_PKG_VERSION");
     format!("{SPICE_USER_AGENT_STRING}/{version}")
+});
+
+#[must_use]
+pub fn user_agent() -> &'static str {
+    &USER_AGENT
 }

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -101,7 +101,7 @@ impl UnityCatalog {
         #[cfg(feature = "databricks")]
         // Include user_agent, if connects to Databricks instance
         if endpoint.0.contains("databricks") {
-            user_agent = Some(crate::databricks::user_agent());
+            user_agent = Some(crate::databricks::user_agent().to_string());
         }
 
         Self {

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -58,7 +58,6 @@ either = "1.15.0"
 indexmap.workspace = true
 tempfile.workspace = true
 token_providers = { path = "../token_providers" }
-url = "2.5.4"
 
 [dev-dependencies]
 anyhow = "1.0.86"

--- a/crates/llms/src/anthropic/mod.rs
+++ b/crates/llms/src/anthropic/mod.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 use async_openai::{Client, error::OpenAIError};
+use reqwest::header::HeaderValue;
 use types::validate_model_variant;
 
 mod chat;
@@ -41,15 +42,12 @@ impl Anthropic {
         api_base: Option<&str>,
         version: Option<&str>,
     ) -> Result<Self, OpenAIError> {
+        let value = HeaderValue::from_str(version.unwrap_or(ANTHROPIC_API_VERSION))
+            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
         let variant = validate_model_variant(model.unwrap_or(DEFAULT_ANTHROPIC_MODEL))?;
         let cfg = HostedModelConfig::from_url(api_base.unwrap_or(ANTHROPIC_API_BASE))
-            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?
             .with_auth(auth)
-            .with_header(
-                "anthropic-version",
-                version.unwrap_or(ANTHROPIC_API_VERSION),
-            )
-            .map_err(|e| OpenAIError::InvalidArgument(e.to_string()))?;
+            .with_header_value("anthropic-version", value);
 
         Ok(Self {
             client: Client::<HostedModelConfig>::with_config(cfg),

--- a/crates/llms/src/config.rs
+++ b/crates/llms/src/config.rs
@@ -16,15 +16,10 @@ limitations under the License.
 #![allow(clippy::missing_errors_doc)]
 
 use async_openai::config::Config;
-use reqwest::header::{
-    AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, InvalidHeaderValue,
-};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use secrecy::SecretString;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use token_providers::{StaticTokenProvider, TokenProvider};
-use url::Url;
-
-static DUMMY_API_KEY: LazyLock<SecretString> = LazyLock::new(|| SecretString::from(String::new()));
 
 /// A generic configuration for any hosted `OpenAI` API client.
 ///
@@ -33,19 +28,19 @@ static DUMMY_API_KEY: LazyLock<SecretString> = LazyLock::new(|| SecretString::fr
 #[derive(Clone, Debug)]
 pub struct HostedModelConfig {
     pub auth: Option<GenericAuthMechanism>,
-    pub base_url: url::Url,
+    pub base_url: String,
     pub default_headers: HeaderMap,
 }
 
 impl HostedModelConfig {
-    pub fn from_url(url: &str) -> Result<Self, url::ParseError> {
+    pub fn from_url(url: &str) -> Self {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        Ok(Self {
+        Self {
             auth: None,
-            base_url: Url::parse(url)?,
+            base_url: url.to_string(),
             default_headers: headers,
-        })
+        }
     }
 
     /// Set the API key for authentication.
@@ -73,15 +68,15 @@ impl HostedModelConfig {
     }
 
     /// Add (or override) a default header.
-    pub fn with_header<V>(mut self, key: &'static str, value: V) -> Result<Self, InvalidHeaderValue>
-    where
-        V: Into<String>,
-    {
-        self.default_headers.insert(
-            HeaderName::from_static(key),
-            HeaderValue::from_str(&value.into())?,
-        );
-        Ok(self)
+    pub fn with_header(mut self, key: &'static str, value: &'static str) -> Self {
+        self = self.with_header_value(key, HeaderValue::from_static(value));
+        self
+    }
+
+    pub fn with_header_value(mut self, key: &'static str, value: HeaderValue) -> Self {
+        self.default_headers
+            .insert(HeaderName::from_static(key), value);
+        self
     }
 }
 
@@ -90,7 +85,6 @@ impl HostedModelConfig {
 pub enum GenericAuthMechanism {
     ApiKey(Arc<dyn TokenProvider>),
     BearerToken(Arc<dyn TokenProvider>),
-    HttpUsername(String, Arc<dyn TokenProvider>),
 }
 
 impl GenericAuthMechanism {
@@ -111,21 +105,6 @@ impl GenericAuthMechanism {
     pub fn from_bearer_token_provider(provider: Arc<dyn TokenProvider>) -> Self {
         Self::BearerToken(provider)
     }
-
-    pub fn from_http_username<S: Into<String>>(username: S, password: S) -> Self {
-        GenericAuthMechanism::from_http_username_provider(
-            username,
-            Arc::new(StaticTokenProvider::new(SecretString::from(
-                password.into(),
-            ))),
-        )
-    }
-    pub fn from_http_username_provider<S: Into<String>>(
-        username: S,
-        provider: Arc<dyn TokenProvider>,
-    ) -> Self {
-        Self::HttpUsername(username.into(), provider)
-    }
 }
 
 impl Config for HostedModelConfig {
@@ -135,7 +114,6 @@ impl Config for HostedModelConfig {
         // Insert authentication header if available.
         if let Some(auth) = &self.auth {
             match auth {
-                GenericAuthMechanism::HttpUsername(_, _) => {}
                 GenericAuthMechanism::ApiKey(prov) => {
                     match HeaderValue::from_str(prov.get_token().as_str()) {
                         Ok(value) => {
@@ -167,18 +145,7 @@ impl Config for HostedModelConfig {
     }
 
     fn url(&self, path: &str) -> String {
-        let base = match &self.auth {
-            Some(GenericAuthMechanism::HttpUsername(username, provider)) => {
-                let mut base = self.base_url.clone();
-                if let Err(()) = base.set_username(username.as_str()) {
-                    tracing::warn!("Failed to set username in URL '{base}'");
-                };
-                let _ = base.set_password(Some(provider.get_token().as_str()));
-                base
-            }
-            _ => self.base_url.clone(),
-        };
-        format!("{base}{path}")
+        format!("{}{path}", self.base_url.as_str())
     }
 
     fn query(&self) -> Vec<(&str, &str)> {
@@ -194,7 +161,7 @@ impl Config for HostedModelConfig {
             Some(GenericAuthMechanism::BearerToken(prov) | GenericAuthMechanism::ApiKey(prov)) => {
                 Arc::new(SecretString::from(prov.get_token()))
             }
-            _ => Arc::new(DUMMY_API_KEY.clone()),
+            _ => Arc::new(SecretString::from(String::new())),
         }
     }
 }

--- a/crates/llms/src/config.rs
+++ b/crates/llms/src/config.rs
@@ -68,11 +68,13 @@ impl HostedModelConfig {
     }
 
     /// Add (or override) a default header.
+    #[must_use]
     pub fn with_header(mut self, key: &'static str, value: &'static str) -> Self {
         self = self.with_header_value(key, HeaderValue::from_static(value));
         self
     }
 
+    #[must_use]
     pub fn with_header_value(mut self, key: &'static str, value: HeaderValue) -> Self {
         self.default_headers
             .insert(HeaderName::from_static(key), value);

--- a/crates/llms/src/databricks.rs
+++ b/crates/llms/src/databricks.rs
@@ -44,7 +44,7 @@ pub struct Databricks {
     client: Client<HostedModelConfig>,
 }
 
-pub fn from_access_token(
+#[must_use] pub fn from_access_token(
     endpoint: &str,
     model: &str,
     access_token: &str,

--- a/crates/llms/src/databricks.rs
+++ b/crates/llms/src/databricks.rs
@@ -44,7 +44,8 @@ pub struct Databricks {
     client: Client<HostedModelConfig>,
 }
 
-#[must_use] pub fn from_access_token(
+#[must_use]
+pub fn from_access_token(
     endpoint: &str,
     model: &str,
     access_token: &str,

--- a/crates/llms/src/databricks.rs
+++ b/crates/llms/src/databricks.rs
@@ -44,58 +44,48 @@ pub struct Databricks {
     client: Client<HostedModelConfig>,
 }
 
-pub fn try_from_access_token(
+pub fn from_access_token(
     endpoint: &str,
     model: &str,
     access_token: &str,
-    user_agent: Option<&str>,
-) -> Result<Databricks, super::chat::Error> {
+    user_agent: Option<&'static str>,
+) -> Databricks {
     let mut cfg = HostedModelConfig::from_url(
         format!("https://token:{access_token}@{endpoint}/serving-endpoints/{model}/invocations")
             .as_str(),
-    )
-    .boxed()
-    .map_err(|e| super::chat::Error::FailedToLoadModel { source: e })?;
+    );
 
     if let Some(user_agent) = user_agent {
-        cfg = cfg
-            .with_header("user-agent", user_agent)
-            .boxed()
-            .map_err(|e| super::chat::Error::FailedToLoadModel { source: e })?;
+        cfg = cfg.with_header("user-agent", user_agent);
     };
 
-    Ok(Databricks {
+    Databricks {
         model: model.to_string(),
         client: Client::with_config(cfg),
-    })
+    }
 }
 
-pub fn try_from_token_provider(
+pub fn from_token_provider(
     endpoint: &str,
     model: &str,
     token_provider: Arc<dyn TokenProvider>,
-    user_agent: Option<&str>,
-) -> Result<Databricks, super::chat::Error> {
+    user_agent: Option<&'static str>,
+) -> Databricks {
     let mut cfg = HostedModelConfig::from_url(
         format!("https://{endpoint}/serving-endpoints/{model}/invocations").as_str(),
     )
-    .boxed()
-    .map_err(|e| super::chat::Error::FailedToLoadModel { source: e })?
     .with_auth(GenericAuthMechanism::from_bearer_token_provider(
         token_provider,
     ));
 
     if let Some(user_agent) = user_agent {
-        cfg = cfg
-            .with_header("user-agent", user_agent)
-            .boxed()
-            .map_err(|e| super::chat::Error::FailedToLoadModel { source: e })?;
+        cfg = cfg.with_header("user-agent", user_agent);
     };
 
-    Ok(Databricks {
+    Databricks {
         model: model.to_string(),
         client: Client::with_config(cfg),
-    })
+    }
 }
 
 #[async_trait]

--- a/crates/llms/src/perplexity/mod.rs
+++ b/crates/llms/src/perplexity/mod.rs
@@ -21,7 +21,6 @@ use async_openai::{Client, error::OpenAIError};
 use futures::{StreamExt, TryStreamExt};
 use reqwest_eventsource::Error as SseError;
 use secrecy::{ExposeSecret, SecretString};
-use snafu::ResultExt;
 use types::{
     PerplexityRequest, PerplexityRequestParameters, PerplexityResponse, PerplexityResponseStream,
     PerplexityStreamResponse,
@@ -64,11 +63,9 @@ impl PerplexitySonar {
             })
             .collect();
 
-        let cfg = HostedModelConfig::from_url(PERPLEXITY_SONAR_API_BASE)
-            .boxed()?
-            .with_auth(GenericAuthMechanism::from_bearer_token(
-                auth_token.expose_secret(),
-            ));
+        let cfg = HostedModelConfig::from_url(PERPLEXITY_SONAR_API_BASE).with_auth(
+            GenericAuthMechanism::from_bearer_token(auth_token.expose_secret()),
+        );
 
         Ok(Self {
             client: Client::<HostedModelConfig>::with_config(cfg),

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -23,7 +23,6 @@ use llms::{
 use llms::{config::GenericAuthMechanism, openai::DEFAULT_LLM_MODEL};
 use secrecy::SecretString;
 use serde_json::Value;
-use snafu::ResultExt;
 use spicepod::component::model::{Model, ModelFileType, ModelSource};
 use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
 use token_providers::databricks::DatabricksM2MTokenProvider;
@@ -271,13 +270,12 @@ async fn databricks(
                 source: "If `databricks_client_id` is provided, `databricks_client_secret` must also be provided.".into(),
             })
         }
-        (Some(token), None, None) => Ok(Arc::new(llms::databricks::try_from_access_token(
+        (Some(token), None, None) => Ok(Arc::new(llms::databricks::from_access_token(
             endpoint,
             model_id.as_str(),
             token,
-            user_agent.as_deref(),
-        ).boxed()
-        .map_err(|e| LlmError::FailedToLoadModel { source: e })?) as Arc<dyn Chat>),
+            user_agent,
+        )) as Arc<dyn Chat>),
         (None, Some(client_id), Some(client_secret)) => {
             let token_provider = DatabricksM2MTokenProvider::try_new(
                 endpoint.to_string(),
@@ -291,14 +289,12 @@ async fn databricks(
                 )),
             })?;
             Ok(Arc::new(
-                llms::databricks::try_from_token_provider(
+                llms::databricks::from_token_provider(
                     endpoint,
                     model_id.as_str(),
                     Arc::new(token_provider),
-                    user_agent.as_deref(),
+                    user_agent,
                 )
-                .boxed()
-                .map_err(|e| LlmError::FailedToLoadModel { source: e })?,
             ) as Arc<dyn Chat>)
         }
     }

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -247,7 +247,7 @@ async fn databricks(
     #[cfg(feature = "databricks")]
     let user_agent = Some(data_components::databricks::user_agent());
     #[cfg(not(feature = "databricks"))]
-    let user_agent: Option<String> = None;
+    let user_agent: Option<&'static str> = None;
 
     match (token_opt, client_id, client_secret) {
         (Some(_), Some(_) | None, Some(_)) | (Some(_), Some(_), None) => {

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #![allow(clippy::implicit_hasher)]
 
+use crate::{get_params_with_secrets, secrets::Secrets};
 use bytes::Bytes;
 use itertools::Itertools;
 use llms::embeddings::{
@@ -34,8 +35,6 @@ use token_providers::databricks::DatabricksM2MTokenProvider;
 use tokio::fs;
 use tokio::sync::RwLock;
 use url::Url;
-
-use crate::{get_params_with_secrets, secrets::Secrets};
 
 pub type EmbeddingModelStore = HashMap<String, Arc<dyn Embed>>;
 
@@ -130,14 +129,12 @@ async fn databricks(
                 source: "If `databricks_client_id` is provided, `databricks_client_secret` must also be provided.".into(),
             })
         }
-        (Some(token), None, None) => Ok(Arc::new(llms::databricks::try_from_access_token(
+        (Some(token), None, None) => Ok(Arc::new(llms::databricks::from_access_token(
             endpoint,
             model_id.as_str(),
             token,
-            user_agent.as_deref(),
-        ).boxed()
-        .map_err(|e| EmbedError::FailedToInstantiateEmbeddingModel { source: e })?
-        ) as Arc<dyn Embed>),
+            user_agent,
+        )) as Arc<dyn Embed>),
         (None, Some(client_id), Some(client_secret)) => {
             let token_provider = DatabricksM2MTokenProvider::try_new(
                 endpoint.to_string(),
@@ -151,15 +148,12 @@ async fn databricks(
                 )),
             })?;
             Ok(Arc::new(
-                llms::databricks::try_from_token_provider(
+                llms::databricks::from_token_provider(
                     endpoint,
                     model_id.as_str(),
                     Arc::new(token_provider),
-                    user_agent.as_deref(),
-                )
-                .boxed()
-                .map_err(|e| EmbedError::FailedToInstantiateEmbeddingModel { source: e })?,
-            ) as Arc<dyn Embed>)
+                    user_agent,
+                )) as Arc<dyn Embed>)
         }
     }
 }

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -106,7 +106,7 @@ async fn databricks(
     #[cfg(feature = "databricks")]
     let user_agent = Some(data_components::databricks::user_agent());
     #[cfg(not(feature = "databricks"))]
-    let user_agent: Option<String> = None;
+    let user_agent: Option<&'static str> = None;
 
     match (token_opt, client_id, client_secret) {
         (Some(_), Some(_) | None, Some(_)) | (Some(_), Some(_), None) => {


### PR DESCRIPTION
## 📝 Summary
- HTTP basic auth is not used by any current provider anymore. It will be removed. 
- Use `&'static str` for databricks header to simplify things. 
