### PR TITLE
Add `--http-endpoint` to `spice trace`

### DIFF
--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -195,6 +195,7 @@ func ToRowInterface(treePrefix string, t *taskhistory.TaskHistory, includeInput 
 func init() {
 	RootCmd.AddCommand(traceCmd)
 	traceCmd.Flags().StringVar(&id, "id", "", "Return the trace with the given id")
+	traceCmd.Flags().String(httpEndpointKeyFlag, "", "HTTP endpoint for chat (default: http://localhost:8090)")
 	traceCmd.Flags().StringVar(&trace_id, "trace-id", "", "Return the trace with the given trace id")
 	traceCmd.Flags().BoolVar(&include_input, "include-input", false, "Include input data in the trace")
 	traceCmd.Flags().BoolVar(&include_output, "include-output", false, "Include output data in the trace")


### PR DESCRIPTION
## 📝 Summary
```shell
>> spice trace --help

        Available operations:
          ai_chat, accelerated_refresh, ai_completion, eval_run, nsql, sql_query, tool_use::document_similarity, tool_use::list_datasets, tool_use::load_memory, tool_use::sample_data, tool_use::sql, tool_use::store_memory, tool_use::table_schema, vector_search

Usage:
  spice trace [flags]

Examples:

# returns the last trace
$ spice trace ai_chat

# returns the trace for the given id
$ spice trace ai_chat --id chatcmpl-At6ZmDE8iAYRPeuQLA0FLlWxGKNnM

Include the input and truncate to 120 characters (default is 80).
$ spice trace ai_chat --include-input --truncate=120


Flags:
      --http-endpoint string   HTTP endpoint for chat (default: http://localhost:8090)
      --id string              Return the trace with the given id
      --include-input          Include input data in the trace
      --include-output         Include output data in the trace
      --trace-id string        Return the trace with the given trace id
      --truncate int[=80]      Truncates the input/output data to 80 when set, or to the given length
```