### PR TITLE
Fix LLMs calling nested MCP tools

### DIFF
--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -133,21 +133,18 @@ impl ToolUsingChat {
     }
 
     /// Check if a tool call is a spiced runtime tool.
-    fn is_spiced_tool(&self, t: &ChatCompletionMessageToolCall) -> bool {
+    fn as_spiced_tool(&self, t: &ChatCompletionMessageToolCall) -> Option<Arc<dyn SpiceModelTool>> {
         self.tools
             .iter()
-            .any(|tool| encode_tool_name(tool.name().as_ref()) == t.function.name)
+            .find(|tool| encode_tool_name(tool.name().as_ref()) == t.function.name)
+            .cloned()
     }
 
     /// Call a spiced runtime tool.
     ///
     /// Return the result as a JSON value.
     async fn call_tool(&self, tool_call: &ChatCompletionMessageToolCall) -> Value {
-        match self
-            .tools
-            .iter()
-            .find(|t| t.name() == tool_call.function.name)
-        {
+        match self.as_spiced_tool(tool_call) {
             Some(t) => match t.call(&tool_call.function.arguments).await {
                 Ok(v) => {
                     tracing::info!(
@@ -175,7 +172,21 @@ impl ToolUsingChat {
                     ))
                 }
             },
-            None => Value::Null,
+            None => {
+                // All calls to `call_tool` should have previously checked that `tool_call` has an associated tool.
+                if cfg!(feature = "dev") {
+                    panic!(
+                        "Tool '{}' was provided to LLM, but now no longer exists. This should not be possible.",
+                        tool_call.function.name
+                    );
+                } else {
+                    tracing::warn!(
+                        "Tool '{}' was provided to LLM, but now no longer exists. This should not be possible.",
+                        tool_call.function.name
+                    );
+                    Value::Null
+                }
+            }
         }
     }
 
@@ -195,7 +206,7 @@ impl ToolUsingChat {
     ) -> Result<Option<Vec<ChatCompletionRequestMessage>>, OpenAIError> {
         let spiced_tools = requested_tools
             .iter()
-            .filter(|&t| self.is_spiced_tool(t))
+            .filter(|&t| self.as_spiced_tool(t).is_some())
             .cloned()
             .collect_vec();
 

--- a/crates/runtime/src/tools/mcp/tool.rs
+++ b/crates/runtime/src/tools/mcp/tool.rs
@@ -103,7 +103,11 @@ impl SpiceModelTool for McpToolWrapper {
         .await;
 
         match tool_use_result {
-            Ok(value) => Ok(value),
+            Ok(value) => {
+                let captured_output_json = serde_json::to_string(&value).boxed()?;
+                tracing::info!(target: "task_history", parent: &span, captured_output = %captured_output_json);
+                Ok(value)
+            }
             Err(e) => {
                 tracing::error!(target: "task_history", parent: &span, "{e}");
                 Err(e)

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -51,7 +51,7 @@ impl Tooling {
                 c.all()
                     .await
                     .iter()
-                    .map(|t| with_name(&t, format!("{catalog_name}/{}", t.name()).as_str()))
+                    .map(|t| with_name(t, format!("{catalog_name}/{}", t.name()).as_str()))
                     .collect()
             }
         }

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -15,8 +15,9 @@ limitations under the License.
 */
 
 use catalog::SpiceToolCatalog;
+use factory::default_catalog_names;
 use std::{borrow::Cow, sync::Arc};
-use tools::SpiceModelTool;
+use tools::{SpiceModelTool, rename::with_name};
 
 pub mod builtin;
 pub mod catalog;
@@ -40,7 +41,19 @@ impl Tooling {
     pub async fn tools(&self) -> Vec<Arc<dyn SpiceModelTool>> {
         match self {
             Tooling::Tool(t) => vec![Arc::clone(t)],
-            Tooling::Catalog(c) => c.all().await,
+            Tooling::Catalog(c) => {
+                let catalog_name = c.name();
+                if default_catalog_names().contains(&catalog_name) {
+                    return c.all().await;
+                };
+
+                // If non-default catalog, tool name must be prefixed by catalog.
+                c.all()
+                    .await
+                    .iter()
+                    .map(|t| with_name(&t, format!("{catalog_name}/{}", t.name()).as_str()))
+                    .collect()
+            }
         }
     }
 

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -77,3 +77,98 @@ impl From<Arc<dyn SpiceToolCatalog>> for Tooling {
         Tooling::Catalog(catalog)
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use std::borrow::Cow;
+    use std::sync::Arc;
+
+    struct MockTool {
+        name: String,
+    }
+
+    #[async_trait]
+    impl SpiceModelTool for MockTool {
+        fn name(&self) -> Cow<'_, str> {
+            self.name.clone().into()
+        }
+        fn description(&self) -> Option<Cow<'_, str>> {
+            None
+        }
+        fn parameters(&self) -> Option<Value> {
+            None
+        }
+        async fn call(&self, _: &str) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(Value::Null)
+        }
+    }
+
+    struct MockCatalog {
+        name: String,
+    }
+
+    #[async_trait]
+    impl SpiceToolCatalog for MockCatalog {
+        fn name(&self) -> &str {
+            self.name.as_str()
+        }
+
+        async fn all(&self) -> Vec<Arc<dyn SpiceModelTool>> {
+            vec![
+                Arc::new(MockTool {
+                    name: "foo".to_string(),
+                }),
+                Arc::new(MockTool {
+                    name: "bar".to_string(),
+                }),
+                Arc::new(MockTool {
+                    name: "baz".to_string(),
+                }),
+            ]
+        }
+
+        async fn get(&self, name: &str) -> Option<Arc<dyn SpiceModelTool>> {
+            Some(Arc::new(MockTool {
+                name: name.to_string(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_non_default_catalog() {
+        let t = Tooling::Catalog(Arc::new(MockCatalog {
+            name: "not_in_default_catalogs".to_string(),
+        }));
+        assert_eq!(
+            t.tools()
+                .await
+                .iter()
+                .map(|tt| tt.name().to_string())
+                .collect::<Vec<String>>(),
+            vec![
+                "not_in_default_catalogs/foo",
+                "not_in_default_catalogs/bar",
+                "not_in_default_catalogs/baz",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_catalog() {
+        let t = Tooling::Catalog(Arc::new(MockCatalog {
+            name: default_catalog_names()[0].to_string(),
+        }));
+        assert_eq!(
+            t.tools()
+                .await
+                .iter()
+                .map(|tt| tt.name().to_string())
+                .collect::<Vec<String>>(),
+            vec!["foo", "bar", "baz",]
+        );
+    }
+}

--- a/crates/runtime/src/tools/utils.rs
+++ b/crates/runtime/src/tools/utils.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use crate::Runtime;
 
 use super::{Tooling, options::SpiceToolsOptions};
-use tools::SpiceModelTool;
+use tools::{SpiceModelTool, rename::with_name};
 
 /// Creates the messages that would be sent and received if a language model were to request the `tool`
 /// to be called (via an assistant message), with defined `arg`, and the response from running the
@@ -92,7 +92,10 @@ pub async fn get_tools(rt: Arc<Runtime>, opts: &SpiceToolsOptions) -> Vec<Arc<dy
         if let Some((catalog_name, catalog_tool)) = tt.split_once(':') {
             if let Some(Tooling::Catalog(catalog)) = all_tools.get(catalog_name) {
                 if let Some(t) = catalog.get(catalog_tool).await {
-                    tools.push(t);
+                    tools.push(with_name(
+                        &t,
+                        format!("{}/{}", catalog_name, t.name()).as_str(),
+                    ));
                 } else {
                     tracing::warn!("Tool '{catalog_tool}' is not found in '{catalog_name}'.");
                     missing_tools.push(tt);


### PR DESCRIPTION
## 📝 Summary

#### LLM calling MCP tool bug
- [`self.call_tool`](https://github.com/spiceai/spiceai/blob/bdf0dedd1e6165c49b7e5e9c052be9253ab1b123/crates/runtime/src/model/tool_use.rs#L145) fails to find MCP encoded tool names. This results in all 
  - This was introduced in #5116 
  - This resulted in the tool not being called and a `null` response returned.
     ```shell
      Ran tools, and retrieved responses: [
        (ChatCompletionMessageToolCall {
            id: "call_IeaIhvu8Qdw7ah91ZvWNu6c7",
            type: Function,
            function: FunctionCall {
                  name: "spice__mcp_fs_list__directory",
                  arguments: "{\"path\":\"/Users/jeadie/Github/cookbook/mcp\"}" 
            }
      }, Null)] # This is the null response.
     ```

#### Improve nested MCP names
When tools are provided to model with non-default catalog, they will be provided with the catalog name prefixed. For example:
```yaml
models:
  - name: openai-with-spice
    from: openai:gpt-4o-mini
    params:
      openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
      tools: spice_mcp
```
Will produce:
```json
["spice_mcp/random_sample", "spice_mcp/list_datasets", "spice_mcp/document_similarity", "spice_mcp/sample_distinct_columns", "spice_mcp/sql", "spice_mcp/store_memory", "spice_mcp/get_readiness", "spice_mcp/fs/read_file", "spice_mcp/fs/read_multiple_files", "spice_mcp/fs/write_file", "spice_mcp/fs/edit_file", "spice_mcp/fs/create_directory", "spice_mcp/fs/list_directory", "spice_mcp/fs/directory_tree", "spice_mcp/fs/move_file", "spice_mcp/fs/search_files", "spice_mcp/fs/get_file_info", "spice_mcp/fs/list_allowed_directories", "spice_mcp/load_memory", "spice_mcp/table_schema", "spice_mcp/top_n_sample"]
```