### PR TITLE
Lru cache: limit single cached record size to u32::MAX (4GB)

### DIFF
--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -42,7 +42,8 @@ pub fn to_cached_record_batch_stream(
     let cached_result_stream = stream! {
         let mut records: Vec<RecordBatch> = Vec::new();
         let mut records_size: usize = 0;
-        let cache_max_size: usize = cache_provider.max_size().try_into().unwrap_or(usize::MAX);
+        // moka-rs operates by `u32` for records size, so max single record size is `u32::MAX` / 4 GB
+        let cache_max_size = usize::try_from(cache_provider.max_size().min(u64::from(u32::MAX))).unwrap_or_default();
 
         while let Some(batch_result) = stream.next().await {
             if records_size < cache_max_size {


### PR DESCRIPTION
## 📝 Summary

[Moka-rs library](https://github.com/moka-rs/moka/blob/8dbc8e5c6ee804470b1144960f4065959658232a/src/sync/builder.rs#L418) we use for caching has a limitation on the single record size function, which returns the size as a `u32`. Therefore, we need to limit the size of a single cached record to `u32::MAX` (4 GB) to avoid conversion issues. Currently, records larger than 4 GB are counted as exactly 4 GB, which incorrectly skews the cache size calculation and results in warning traces.

The change in Moka-rs from using u64 to u32 for the weigher function was made to prevent overflow issues.

## 🔗 Related

Fixes https://github.com/spiceai/spiceai/issues/5652

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Another approach considered was using a kilobyte scale for cache size calculations (i.e., converting sizes from bytes to kilobytes). However, simple query result record batches are often smaller than 1 KB—for example, the following record batch is only 160 bytes. As a result, we would need to round such records to either 0 KB or 1 KB, leading to inaccurate size tracking and inefficient cache usage.
```
fn create_test_record_batch() -> RecordBatch {
        let schema = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
        let array = Int32Array::from(vec![1, 2, 3]);
        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])
            .expect("Failed to create record batch")
    }
```
