### PR TITLE
Set application_name when connecting to Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d45f16cb8cec4009179a6e0e5979c6af15c8ad64#d45f16cb8cec4009179a6e0e5979c6af15c8ad64"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=c8b6ea36266bd2d9a062796c88ae4c178a0177f9#c8b6ea36266bd2d9a062796c88ae4c178a0177f9"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=15d2c7ce1e071eef86733f0d2971cab779203874#15d2c7ce1e071eef86733f0d2971cab779203874"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=d45f16cb8cec4009179a6e0e5979c6af15c8ad64#d45f16cb8cec4009179a6e0e5979c6af15c8ad64"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "a898971e2c2652abf924d9d60e4d9d0a12620cd9" }      # spiceai-45
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "1c814422cfbdeb7f7bd2399e3369656710413aa8" }                      # spiceai-45
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "15d2c7ce1e071eef86733f0d2971cab779203874" } # spiceai
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d45f16cb8cec4009179a6e0e5979c6af15c8ad64" } # phillip/250511-app-name
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "2e24b958e44ec7419290249e27a15f1a19703fff" } # spiceai-1.1.3-backported-arrow-54
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "a898971e2c2652abf924d9d60e4d9d0a12620cd9" }      # spiceai-45
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "1c814422cfbdeb7f7bd2399e3369656710413aa8" }                      # spiceai-45
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d45f16cb8cec4009179a6e0e5979c6af15c8ad64" } # phillip/250511-app-name
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "c8b6ea36266bd2d9a062796c88ae4c178a0177f9" } # spiceai
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "2e24b958e44ec7419290249e27a15f1a19703fff" } # spiceai-1.1.3-backported-arrow-54
 

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -61,11 +61,11 @@ impl DataAccelerator for ArrowAccelerator {
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
     async fn create_external_table(
         &self,
-        cmd: &CreateExternalTable,
+        cmd: CreateExternalTable,
         _source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         let ctx = SessionContext::new();
-        TableProviderFactory::create(&self.arrow_factory, &ctx.state(), cmd)
+        TableProviderFactory::create(&self.arrow_factory, &ctx.state(), &cmd)
             .await
             .boxed()
     }

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -290,10 +290,9 @@ impl DataAccelerator for DuckDBAccelerator {
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
     async fn create_external_table(
         &self,
-        cmd: &CreateExternalTable,
+        mut cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
-        let mut cmd = cmd.clone();
         if let Some(duckdb_file) = cmd.options.remove("file") {
             cmd.options
                 .insert("open".to_string(), duckdb_file.to_string());
@@ -438,7 +437,7 @@ mod tests {
         let duckdb_accelerator = DuckDBAccelerator::new();
         let ctx = SessionContext::new();
         let table = duckdb_accelerator
-            .create_external_table(&external_table, None)
+            .create_external_table(external_table, None)
             .await
             .expect("table should be created");
 

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -228,7 +228,7 @@ impl AcceleratorEngineRegistry {
         let external_table = external_table_builder.build()?;
 
         let table_provider = accelerator
-            .create_external_table(&external_table, source)
+            .create_external_table(external_table, source)
             .await
             .context(AccelerationCreationFailedSnafu)?;
 
@@ -244,7 +244,7 @@ pub trait DataAccelerator: Send + Sync {
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
     async fn create_external_table(
         &self,
-        cmd: &CreateExternalTable,
+        cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
 

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -86,12 +86,18 @@ impl DataAccelerator for PostgresAccelerator {
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
     async fn create_external_table(
         &self,
-        cmd: &CreateExternalTable,
+        mut cmd: CreateExternalTable,
         _source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
         let ctx = SessionContext::new();
+
+        cmd.options.insert(
+            "application_name".to_string(),
+            format!("Spice.ai {}", env!("CARGO_PKG_VERSION")),
+        );
+
         let table_provider =
-            TableProviderFactory::create(&self.postgres_factory, &ctx.state(), cmd)
+            TableProviderFactory::create(&self.postgres_factory, &ctx.state(), &cmd)
                 .await
                 .context(UnableToCreateTableSnafu)
                 .boxed()?;

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -245,11 +245,9 @@ impl DataAccelerator for SqliteAccelerator {
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
     async fn create_external_table(
         &self,
-        cmd: &CreateExternalTable,
+        mut cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
-        let mut cmd = cmd.clone();
-
         if let Some(source) = source {
             if source.is_file_accelerated() {
                 // If the user didn't specify a SQLite file and this is a file-mode SQLite,
@@ -371,7 +369,7 @@ mod tests {
         };
         let ctx = SessionContext::new();
         let table = SqliteAccelerator::new()
-            .create_external_table(&external_table, None)
+            .create_external_table(external_table, None)
             .await
             .expect("table should be created");
 

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -26,6 +26,7 @@ use datafusion_table_providers::sql::db_connection_pool::{
     Error as DbConnectionPoolError,
     postgrespool::{self, PostgresConnectionPool},
 };
+use secrecy::SecretBox;
 use snafu::prelude::*;
 use std::any::Any;
 use std::future::Future;
@@ -92,7 +93,14 @@ impl DataConnectorFactory for PostgresFactory {
         params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
-            match PostgresConnectionPool::new(params.parameters.to_secret_map()).await {
+            let mut param_map = params.parameters.to_secret_map();
+
+            param_map.insert(
+                "application_name".to_string(),
+                SecretBox::from(format!("Spice.ai {}", env!("CARGO_PKG_VERSION"))),
+            );
+
+            match PostgresConnectionPool::new(param_map).await {
                 Ok(mut pool) => {
                     if let Some(unsupported_type_action) = params.unsupported_type_action {
                         pool = pool.with_unsupported_type_action(unsupported_type_action);


### PR DESCRIPTION
## 📝 Summary

Set the `application_name` parameter when connecting to Postgres, so that tools that visualize the connection can see which session belongs to Spice vs other applications.

e.g. pgAdmin
<img width="1128" alt="Screenshot 2025-05-11 at 2 38 12 PM" src="https://github.com/user-attachments/assets/cf2d6b65-342e-43a2-939e-c2725855ba84" />

Requires https://github.com/datafusion-contrib/datafusion-table-providers/pull/335