### PR TITLE
Helm chart: enable service ports customization 

### DIFF
--- a/deploy/chart/templates/service.yaml
+++ b/deploy/chart/templates/service.yaml
@@ -19,6 +19,9 @@ spec:
   loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
+    {{- if .Values.service.ports }}
+    {{- toYaml .Values.service.ports | nindent 4 }}
+    {{- else }}
     - port: 8090
       name: http
     - port: 9090
@@ -27,6 +30,7 @@ spec:
       name: flight
     - port: 50052
       name: otel
+    {{- end }}
   selector:
     {{- if .Values.service.selector }}
     {{- toYaml .Values.service.selector | nindent 4 }}


### PR DESCRIPTION
## 📝 Summary

Add support for defining service ports via Helm chart. This is especially useful when predictable NodePorts are needed; otherwise, Kubernetes will assign them dynamically.

```
service:
  type: NodePort
  ports:
    - port: 8090
      name: http
      nodePort: 30001
    - port: 9090
      name: metrics
      nodePort: 30002
    - port: 50051
      name: flight
      nodePort: 30003
    - port: 50052
      name: otel
      nodePort: 30004
```

**Before**

```
Name:                     spiceai-dev
Namespace:                default
Labels:                   app=spiceai-dev
                          app.kubernetes.io/component=controller
                          app.kubernetes.io/instance=spiceai-dev
                          app.kubernetes.io/managed-by=Helm
                          app.kubernetes.io/name=spiceai
                          app.kubernetes.io/part-of=spiceai
                          app.kubernetes.io/version=1.2.1
                          helm.sh/chart=spiceai-1.2.1
Annotations:              meta.helm.sh/release-name: spiceai-dev
                          meta.helm.sh/release-namespace: default
Selector:                 app=spiceai
Type:                     NodePort
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       10.96.60.186
IPs:                      10.96.60.186
Port:                     http  8090/TCP
TargetPort:               8090/TCP
NodePort:                 http  32465/TCP
Endpoints:                
Port:                     metrics  9090/TCP
TargetPort:               9090/TCP
NodePort:                 metrics  32031/TCP
Endpoints:                
Port:                     flight  50051/TCP
TargetPort:               50051/TCP
NodePort:                 flight  30377/TCP
Endpoints:                
Port:                     otel  50052/TCP
TargetPort:               50052/TCP
NodePort:                 otel  30336/TCP
Endpoints:                
Session Affinity:         None
External Traffic Policy:  Cluster
Internal Traffic Policy:  Cluster
Events:                   <none>
```

**After**

```
Name:                     spiceai-dev
Namespace:                default
Labels:                   app=spiceai-dev
                          app.kubernetes.io/component=controller
                          app.kubernetes.io/instance=spiceai-dev
                          app.kubernetes.io/managed-by=Helm
                          app.kubernetes.io/name=spiceai
                          app.kubernetes.io/part-of=spiceai
                          app.kubernetes.io/version=1.2.1
                          helm.sh/chart=spiceai-1.2.1
Annotations:              meta.helm.sh/release-name: spiceai-dev
                          meta.helm.sh/release-namespace: default
Selector:                 app=spiceai
Type:                     NodePort
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       10.96.60.186
IPs:                      10.96.60.186
Port:                     http  8090/TCP
TargetPort:               8090/TCP
NodePort:                 http  30001/TCP
Endpoints:                
Port:                     metrics  9090/TCP
TargetPort:               9090/TCP
NodePort:                 metrics  30002/TCP
Endpoints:                
Port:                     flight  50051/TCP
TargetPort:               50051/TCP
NodePort:                 flight  30003/TCP
Endpoints:                
Port:                     otel  50052/TCP
TargetPort:               50052/TCP
NodePort:                 otel  30004/TCP
Endpoints:                
Session Affinity:         None
External Traffic Policy:  Cluster
Internal Traffic Policy:  Cluster
Events:                   <none>

```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
