### PR TITLE
Update spark-connect-rs to override user agent string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11944,7 +11944,7 @@ dependencies = [
 [[package]]
 name = "spark-connect-core"
 version = "0.0.1-beta.4"
-source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=3dc74fef6ca2c5f90d646e2be3889a2f00114a61#3dc74fef6ca2c5f90d646e2be3889a2f00114a61"
+source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=8f0473271de9ea611969dbdd88d76816976ce429#8f0473271de9ea611969dbdd88d76816976ce429"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -11964,7 +11964,7 @@ dependencies = [
 [[package]]
 name = "spark-connect-rs"
 version = "0.0.1-beta.4"
-source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=3dc74fef6ca2c5f90d646e2be3889a2f00114a61#3dc74fef6ca2c5f90d646e2be3889a2f00114a61"
+source = "git+https://github.com/spiceai/spark-connect-rs.git?rev=8f0473271de9ea611969dbdd88d76816976ce429#8f0473271de9ea611969dbdd88d76816976ce429"
 dependencies = [
  "spark-connect-core",
 ]

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -65,7 +65,7 @@ serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
-spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "3dc74fef6ca2c5f90d646e2be3889a2f00114a61", features = [
+spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "8f0473271de9ea611969dbdd88d76816976ce429", features = [
     "tls",
 ], optional = true } # spiceai
 tiberius = { workspace = true, optional = true }


### PR DESCRIPTION
## 📝 Summary

spark-connect-rs change
- https://github.com/spiceai/spark-connect-rs/pull/10

Fully override user agent string for Databricks spark, to keep only Spice name and version

Before:

![CleanShot 2025-05-13 at 09 53 36@2x](https://github.com/user-attachments/assets/ae8c525a-a685-4359-80f8-3c0a049df61e)

After:

![CleanShot 2025-05-13 at 09 51 31@2x](https://github.com/user-attachments/assets/507547fb-20d3-43af-b54a-b6a73f9186d0)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
