### PR TITLE
Fix flaky DataBricks M2M integration tests

### DIFF
--- a/crates/runtime/tests/databricks_spark_catalog_m2m/mod.rs
+++ b/crates/runtime/tests/databricks_spark_catalog_m2m/mod.rs
@@ -53,10 +53,11 @@ async fn databricks_spark_connect_m2m_integration_test_catalog() -> Result<(), a
             let cloned_rt = Arc::new(rt.clone());
 
             tokio::select! {
-                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                // We may need to wait for the cluster to startup and become ready, so wait for up to 10 minutes
+                () = tokio::time::sleep(std::time::Duration::from_secs(600)) => {
                     panic!("Timeout waiting for components to load");
                 }
-() = cloned_rt.load_components() => {}
+                () = cloned_rt.load_components() => {}
             }
 
             runtime_ready_check(&rt).await;

--- a/crates/runtime/tests/databricks_spark_m2m/mod.rs
+++ b/crates/runtime/tests/databricks_spark_m2m/mod.rs
@@ -95,7 +95,8 @@ async fn databricks_spark_m2m_integration_test() -> Result<(), anyhow::Error> {
             let cloned_rt = Arc::new(rt.clone());
             // Set a timeout for the test
             tokio::select! {
-                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                // We may need to wait for the cluster to startup and become ready, so wait for up to 10 minutes
+                () = tokio::time::sleep(std::time::Duration::from_secs(600)) => {
                     return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
                 }
                 () = cloned_rt.load_components() => {}


### PR DESCRIPTION
## 📝 Summary

The databricks M2M tests currently fail quite a bit and re-running them immediately usually resolves the problem. The reason is that the databricks Spark compute cluster is configured to go to sleep after not being used for a while, and it takes several minutes for it to startup again after getting a request.

This causes the integration tests to fail because they only wait for a couple of minutes. Bump the wait timeout to 10 minutes to give the cluster more time to startup.