### PR TITLE
Use Utf8 for listing table (i.e. S3) partition columns

### DIFF
--- a/crates/runtime/src/dataconnector/listing/infer.rs
+++ b/crates/runtime/src/dataconnector/listing/infer.rs
@@ -63,12 +63,7 @@ pub(crate) fn infer_partitions_with_types_from_files(
 ) -> Result<Vec<(String, DataType)>> {
     Ok(infer_partitions(table_path_prefix, files)?
         .into_iter()
-        .map(|col_name| {
-            (
-                col_name,
-                DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
-            )
-        })
+        .map(|col_name| (col_name, DataType::Utf8))
         .collect::<Vec<_>>())
 }
 
@@ -177,8 +172,8 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].0, "year");
         assert_eq!(result[1].0, "month");
-        assert!(matches!(result[0].1, DataType::Dictionary(_, _)));
-        assert!(matches!(result[1].1, DataType::Dictionary(_, _)));
+        assert!(matches!(result[0].1, DataType::Utf8));
+        assert!(matches!(result[1].1, DataType::Utf8));
     }
 
     #[test]

--- a/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_source_path_authenticated_parts.snap
+++ b/crates/runtime/tests/s3/snapshots/integration__s3__s3_schema_source_path_authenticated_parts.snap
@@ -2,10 +2,10 @@
 source: crates/runtime/tests/s3/mod.rs
 expression: schema
 ---
-+-------------+--------------------------+-------------+
-| column_name | data_type                | is_nullable |
-+-------------+--------------------------+-------------+
-| id          | Int64                    | NO          |
-| value       | Float64                  | NO          |
-| part_key    | Dictionary(UInt16, Utf8) | NO          |
-+-------------+--------------------------+-------------+
++-------------+-----------+-------------+
+| column_name | data_type | is_nullable |
++-------------+-----------+-------------+
+| id          | Int64     | NO          |
+| value       | Float64   | NO          |
+| part_key    | Utf8      | NO          |
++-------------+-----------+-------------+


### PR DESCRIPTION
## 📝 Summary

Report the schema for listing table providers (i.e. S3) as Utf8 instead of a Dictionary of Utf8 values. The Java FlightSQL implementation cannot handle the dictionary dataset, failing with:

```bash
Unhandled java.lang.IllegalArgumentException
   Could not find dictionary with ID 0
```

With this change, that is now working. I verified using a test Scala app that loaded the FlightSQL driver.