### PR TITLE
Remove the DataFusion reference from the flight service and use the reference from the request context instead

### DIFF
--- a/crates/runtime/src/flight/actions.rs
+++ b/crates/runtime/src/flight/actions.rs
@@ -88,7 +88,6 @@ pub(crate) async fn list() -> Response<<Service as FlightService>::ListActionsSt
 }
 
 pub(crate) async fn do_action(
-    flight_svc: &Service,
     request: Request<Action>,
 ) -> Result<Response<<Service as FlightService>::DoActionStream>, Status> {
     let action_type = ActionType::from_str(request.get_ref().r#type.as_str());
@@ -107,9 +106,7 @@ pub(crate) async fn do_action(
                         "Unable to unpack ActionCreatePreparedStatementRequest.",
                     )
                 })?;
-            let stmt =
-                prepared_statement_query::do_action_create_prepared_statement(flight_svc, cmd)
-                    .await?;
+            let stmt = prepared_statement_query::do_action_create_prepared_statement(cmd).await?;
             futures::stream::iter(vec![Ok(arrow_flight::Result {
                 body: stmt.as_any().encode_to_vec().into(),
             })])

--- a/crates/runtime/src/flight/do_exchange.rs
+++ b/crates/runtime/src/flight/do_exchange.rs
@@ -28,7 +28,9 @@ use futures::{StreamExt, stream};
 use tokio::sync::broadcast;
 use tonic::{Request, Response, Status, Streaming};
 
+use crate::datafusion::request_context_extension::get_current_datafusion;
 use crate::dataupdate::{DataUpdate, UpdateType};
+use crate::request::{AsyncMarker, RequestContext};
 
 use super::{Service, metrics};
 
@@ -70,7 +72,10 @@ pub(crate) async fn handle(
 
     let data_path = TableReference::parse_str(&flight_descriptor.path.join("."));
 
-    let Some(table_provider) = flight_svc.datafusion.get_table(&data_path).await else {
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
+    let Some(table_provider) = datafusion.get_table(&data_path).await else {
         return Err(Status::invalid_argument(format!(
             r#"Unknown dataset: "{data_path}""#,
         )));
@@ -170,7 +175,6 @@ pub(crate) async fn handle(
     })
     .flat_map(|x| x);
 
-    let datafusion = Arc::clone(&flight_svc.datafusion);
     let table_provider = Arc::clone(&table_provider);
     tokio::spawn(async move {
         let Ok(df) = datafusion.ctx.read_table(table_provider) else {

--- a/crates/runtime/src/flight/do_get.rs
+++ b/crates/runtime/src/flight/do_get.rs
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
-
 use arrow_flight::{
     Ticket,
     flight_service_server::FlightService,
@@ -25,42 +23,34 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
     flight::{metrics, util::attach_cache_metadata},
+    request::{AsyncMarker, RequestContext},
     timing::TimedStream,
 };
 
 use super::{Service, flightsql, to_tonic_err};
 
 pub(crate) async fn handle(
-    flight_svc: &Service,
     request: Request<Ticket>,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let msg: Any = match Message::decode(&*request.get_ref().ticket) {
         Ok(msg) => msg,
-        Err(_) => return Box::pin(do_get_simple(flight_svc, request)).await,
+        Err(_) => return Box::pin(do_get_simple(request)).await,
     };
 
     match Command::try_from(msg).map_err(to_tonic_err)? {
         Command::CommandStatementQuery(command) => {
-            Box::pin(flightsql::statement_query::do_get(flight_svc, command)).await
+            Box::pin(flightsql::statement_query::do_get(command)).await
         }
         Command::CommandPreparedStatementQuery(command) => {
-            Box::pin(flightsql::prepared_statement_query::do_get(
-                flight_svc, command,
-            ))
-            .await
+            Box::pin(flightsql::prepared_statement_query::do_get(command)).await
         }
-        Command::CommandGetCatalogs(command) => {
-            flightsql::get_catalogs::do_get(flight_svc, command).await
-        }
-        Command::CommandGetDbSchemas(command) => {
-            flightsql::get_schemas::do_get(flight_svc, command).await
-        }
-        Command::CommandGetTables(command) => {
-            flightsql::get_tables::do_get(flight_svc, command).await
-        }
+        Command::CommandGetCatalogs(command) => flightsql::get_catalogs::do_get(command).await,
+        Command::CommandGetDbSchemas(command) => flightsql::get_schemas::do_get(command).await,
+        Command::CommandGetTables(command) => flightsql::get_tables::do_get(command).await,
         Command::CommandGetPrimaryKeys(command) => {
-            flightsql::get_primary_keys::do_get(flight_svc, &command).await
+            flightsql::get_primary_keys::do_get(&command).await
         }
         Command::CommandGetTableTypes(command) => flightsql::get_table_types::do_get(command).await,
         Command::CommandGetSqlInfo(command) => flightsql::get_sql_info::do_get(command).await,
@@ -72,11 +62,13 @@ pub(crate) async fn handle(
 }
 
 async fn do_get_simple(
-    flight_svc: &Service,
     request: Request<Ticket>,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let start = metrics::track_flight_request("do_get", Some("sql_query")).await;
-    let datafusion = Arc::clone(&flight_svc.datafusion);
+
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     let ticket = request.into_inner();
     tracing::trace!("do_get_simple: {ticket:?}");
     match std::str::from_utf8(&ticket.ticket) {

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -42,9 +42,9 @@ use tonic::{Request, Response, Status, Streaming};
 use async_stream::stream;
 
 use crate::{
-    datafusion::DataFusion,
+    datafusion::{DataFusion, request_context_extension::get_current_datafusion},
     dataupdate::{StreamingDataUpdate, UpdateType},
-    request::RequestContext,
+    request::{AsyncMarker, RequestContext},
     timing::TimedStream,
 };
 
@@ -54,7 +54,6 @@ use super::{
 };
 
 pub(crate) async fn handle(
-    flight_svc: &Service,
     request: Request<Streaming<FlightData>>,
 ) -> Result<Response<<Service as FlightService>::DoPutStream>, Status> {
     let rate_limit_check_fn = request
@@ -78,8 +77,7 @@ pub(crate) async fn handle(
         if let Command::CommandPreparedStatementQuery(query) =
             Command::try_from(message).map_err(|e| Status::internal(format!("{e:?}")))?
         {
-            return prepared_statement_query::do_put_query(flight_svc, query, streaming_flight)
-                .await;
+            return prepared_statement_query::do_put_query(query, streaming_flight).await;
         }
     }
 
@@ -127,7 +125,10 @@ pub(crate) async fn handle(
     // Initializing tracking here so that both counter and duration have consistent path dimensions
     let start = metrics::track_flight_request("do_put", Some(&path.to_string())).await;
 
-    if !flight_svc.datafusion.is_writable(&path) {
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
+    if datafusion.is_writable(&path) {
         return Err(Status::invalid_argument(format!(
             "Path doesn't exist or is not writable: {path}",
         )));
@@ -137,9 +138,7 @@ pub(crate) async fn handle(
         .map_err(|e| Status::internal(format!("Failed to get schema from data header: {e}")))?;
     let schema = Arc::new(schema);
 
-    let df = Arc::clone(&flight_svc.datafusion);
-
-    let target_schema = df
+    let target_schema = datafusion
         .get_arrow_schema(path.clone())
         .await
         .map_err(|e| Status::internal(format!("Failed to get target dataset schema: {e}")))?;
@@ -152,7 +151,7 @@ pub(crate) async fn handle(
 
     let first_message = first_message.clone();
     let response_stream =
-        create_response_stream(path, schema, df, streaming_flight, &first_message);
+        create_response_stream(path, schema, datafusion, streaming_flight, &first_message);
 
     let timed_stream = TimedStream::new(response_stream, move || start);
 

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -128,7 +128,7 @@ pub(crate) async fn handle(
     let context = RequestContext::current(AsyncMarker::new().await);
     let datafusion = get_current_datafusion(&context);
 
-    if datafusion.is_writable(&path) {
+    if !datafusion.is_writable(&path) {
         return Err(Status::invalid_argument(format!(
             "Path doesn't exist or is not writable: {path}",
         )));

--- a/crates/runtime/src/flight/flightsql/get_catalogs.rs
+++ b/crates/runtime/src/flight/flightsql/get_catalogs.rs
@@ -23,10 +23,12 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
     flight::{
         Service, metrics, record_batches_to_flight_stream, to_tonic_err,
         util::set_flightsql_protocol,
     },
+    request::{AsyncMarker, RequestContext},
     timing::TimedStream,
 };
 
@@ -53,16 +55,18 @@ pub(crate) async fn get_flight_info(
 }
 
 pub(crate) async fn do_get(
-    flight_svc: &Service,
     query: sql::CommandGetCatalogs,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let start = metrics::track_flight_request("do_get", Some("get_catalogs")).await;
     set_flightsql_protocol().await;
 
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     tracing::trace!("do_get_catalogs: {query:?}");
     let mut builder = query.into_builder();
 
-    let catalog_names = flight_svc.datafusion.ctx.catalog_names();
+    let catalog_names = datafusion.ctx.catalog_names();
 
     for catalog in catalog_names {
         builder.append(catalog);

--- a/crates/runtime/src/flight/flightsql/get_primary_keys.rs
+++ b/crates/runtime/src/flight/flightsql/get_primary_keys.rs
@@ -58,7 +58,6 @@ pub(crate) async fn get_flight_info(
 ///   `key_sequence`: int32 not null
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) async fn do_get(
-    _flight_svc: &Service,
     query: &sql::CommandGetPrimaryKeys,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let start = metrics::track_flight_request("do_get", Some("get_primary_keys")).await;

--- a/crates/runtime/src/flight/flightsql/get_schemas.rs
+++ b/crates/runtime/src/flight/flightsql/get_schemas.rs
@@ -23,10 +23,12 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
     flight::{
         Service, metrics, record_batches_to_flight_stream, to_tonic_err,
         util::set_flightsql_protocol,
     },
+    request::{AsyncMarker, RequestContext},
     timing::TimedStream,
 };
 
@@ -53,22 +55,24 @@ pub(crate) async fn get_flight_info(
 }
 
 pub(crate) async fn do_get(
-    flight_svc: &Service,
     query: sql::CommandGetDbSchemas,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let start = metrics::track_flight_request("do_get", Some("get_db_schemas")).await;
     set_flightsql_protocol().await;
 
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     let catalog = &query.catalog;
     tracing::trace!("do_get: {query:?}");
     let filtered_catalogs = match catalog {
         Some(catalog) => vec![catalog.to_string()],
-        None => flight_svc.datafusion.ctx.catalog_names(),
+        None => datafusion.ctx.catalog_names(),
     };
     let mut builder = query.into_builder();
 
     for catalog in filtered_catalogs {
-        let catalog_provider = flight_svc.datafusion.ctx.catalog(&catalog).ok_or_else(|| {
+        let catalog_provider = datafusion.ctx.catalog(&catalog).ok_or_else(|| {
             Status::internal(format!("unable to get catalog provider for {catalog}"))
         })?;
         for schema in catalog_provider.schema_names() {

--- a/crates/runtime/src/flight/flightsql/get_tables.rs
+++ b/crates/runtime/src/flight/flightsql/get_tables.rs
@@ -21,10 +21,12 @@ use datafusion::datasource::TableType;
 use tonic::{Request, Response, Status};
 
 use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
     flight::{
         Service, metrics, record_batches_to_flight_stream, to_tonic_err,
         util::set_flightsql_protocol,
     },
+    request::{AsyncMarker, RequestContext},
     timing::TimedStream,
 };
 
@@ -49,28 +51,26 @@ pub(crate) async fn get_flight_info(
 }
 
 pub(crate) async fn do_get(
-    flight_svc: &Service,
     query: sql::CommandGetTables,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let start = metrics::track_flight_request("do_get", Some("get_tables")).await;
     set_flightsql_protocol().await;
 
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     let catalog = &query.catalog;
     tracing::trace!("do_get_tables: {query:?}");
     let filtered_catalogs = match catalog {
         Some(catalog) => vec![catalog.to_string()],
-        None => flight_svc.datafusion.ctx.catalog_names(),
+        None => datafusion.ctx.catalog_names(),
     };
     let mut builder = query.into_builder();
 
     for catalog_name in filtered_catalogs {
-        let catalog_provider = flight_svc
-            .datafusion
-            .ctx
-            .catalog(&catalog_name)
-            .ok_or_else(|| {
-                Status::internal(format!("unable to get catalog provider for {catalog_name}"))
-            })?;
+        let catalog_provider = datafusion.ctx.catalog(&catalog_name).ok_or_else(|| {
+            Status::internal(format!("unable to get catalog provider for {catalog_name}"))
+        })?;
 
         for schema_name in catalog_provider.schema_names() {
             let Some(schema_provider) = catalog_provider.schema(&schema_name) else {

--- a/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{borrow::Cow, ops::ControlFlow, sync::Arc};
+use std::{borrow::Cow, ops::ControlFlow};
 
 use arrow::compute::concat_batches;
 use arrow_flight::{
@@ -43,10 +43,12 @@ use tokio_stream::{StreamExt, adapters::Peekable};
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
     flight::{
         Service, metrics, to_tonic_err,
         util::{attach_cache_metadata, set_flightsql_protocol},
     },
+    request::{AsyncMarker, RequestContext},
     timing::TimedStream,
 };
 
@@ -58,7 +60,6 @@ pub(crate) struct PreparedStatement {
 
 /// Create a prepared statement from given SQL statement.
 pub(crate) async fn do_action_create_prepared_statement(
-    flight_svc: &Service,
     statement: sql::ActionCreatePreparedStatementRequest,
 ) -> Result<sql::ActionCreatePreparedStatementResult, Status> {
     tracing::trace!("do_action_create_prepared_statement: {statement:?}");
@@ -66,10 +67,12 @@ pub(crate) async fn do_action_create_prepared_statement(
 
     let query = convert_jdbc_parameter_placeholders(&statement.query).map_err(error_to_status)?;
 
-    let (dataset_schema, parameter_schema) =
-        Service::get_arrow_schema(Arc::clone(&flight_svc.datafusion), &query)
-            .await
-            .map_err(to_tonic_err)?;
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
+    let (dataset_schema, parameter_schema) = Service::get_arrow_schema(datafusion, &query)
+        .await
+        .map_err(to_tonic_err)?;
 
     let dataset_schema = Service::serialize_schema(&dataset_schema)?;
     let parameter_schema = if let Some(schema) = &parameter_schema {
@@ -93,7 +96,6 @@ pub(crate) async fn do_action_create_prepared_statement(
 }
 
 pub(crate) async fn get_flight_info(
-    _flight_svc: &Service,
     handle: sql::CommandPreparedStatementQuery,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<FlightInfo>, Status> {
@@ -117,13 +119,14 @@ pub(crate) async fn get_flight_info(
 }
 
 pub(crate) async fn do_get(
-    flight_svc: &Service,
     query: sql::CommandPreparedStatementQuery,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let start = metrics::track_flight_request("do_get", Some("prepared_statement_query")).await;
     set_flightsql_protocol().await;
 
-    let datafusion = Arc::clone(&flight_svc.datafusion);
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     tracing::trace!("do_get: {query:?}");
 
     let PreparedStatement {
@@ -147,7 +150,6 @@ pub(crate) async fn do_get(
 ///
 /// See [Sequence Diagrams](https://arrow.apache.org/docs/format/FlightSql.html#sequence-diagrams)
 pub(crate) async fn do_put_query(
-    _flight_svc: &Service,
     query: CommandPreparedStatementQuery,
     streaming_flight: Peekable<Streaming<FlightData>>,
 ) -> Result<Response<<Service as FlightService>::DoPutStream>, Status> {

--- a/crates/runtime/src/flight/flightsql/statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/statement_query.rs
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
-
 use arrow_flight::{
     FlightDescriptor, FlightEndpoint, FlightInfo, Ticket,
     flight_service_server::FlightService,
@@ -25,18 +23,19 @@ use prost::Message;
 use tonic::{Request, Response, Status};
 
 use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
     flight::{
         Service,
         metrics::track_flight_request,
         to_tonic_err,
         util::{attach_cache_metadata, set_flightsql_protocol},
     },
+    request::{AsyncMarker, RequestContext},
     timing::TimedStream,
 };
 
 /// Get a `FlightInfo` for executing a SQL query.
 pub(crate) async fn get_flight_info(
-    flight_svc: &Service,
     query: sql::CommandStatementQuery,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<FlightInfo>, Status> {
@@ -46,7 +45,10 @@ pub(crate) async fn get_flight_info(
 
     let sql = query.query.as_str();
 
-    let (arrow_schema, _) = Service::get_arrow_schema(Arc::clone(&flight_svc.datafusion), sql)
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
+    let (arrow_schema, _) = Service::get_arrow_schema(datafusion, sql)
         .await
         .map_err(to_tonic_err)?;
 
@@ -66,13 +68,14 @@ pub(crate) async fn get_flight_info(
 }
 
 pub(crate) async fn do_get(
-    flight_svc: &Service,
     cmd: sql::CommandStatementQuery,
 ) -> Result<Response<<Service as FlightService>::DoGetStream>, Status> {
     let start = track_flight_request("do_get", Some("statement_query")).await;
     set_flightsql_protocol().await;
 
-    let datafusion = Arc::clone(&flight_svc.datafusion);
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     tracing::trace!("do_get_statement: {cmd:?}");
     let (output, from_cache) =
         Box::pin(Service::sql_to_flight_stream(datafusion, &cmd.query, None)).await?;

--- a/crates/runtime/src/flight/get_flight_info.rs
+++ b/crates/runtime/src/flight/get_flight_info.rs
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
-
 use arrow_flight::{
     FlightDescriptor, FlightEndpoint, FlightInfo, Ticket,
     sql::{Any, Command},
@@ -23,24 +21,27 @@ use arrow_flight::{
 use prost::Message;
 use tonic::{Request, Response, Status};
 
-use crate::flight::metrics;
+use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
+    flight::metrics,
+    request::{AsyncMarker, RequestContext},
+};
 
 use super::{Service, flightsql, to_tonic_err};
 
 pub(crate) async fn handle(
-    flight_svc: &Service,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<FlightInfo>, Status> {
     let Ok(message) = Any::decode(&*request.get_ref().cmd) else {
-        return get_flight_info_simple(flight_svc, request).await;
+        return get_flight_info_simple(request).await;
     };
 
     match Command::try_from(message).map_err(to_tonic_err)? {
         Command::CommandStatementQuery(token) => {
-            flightsql::statement_query::get_flight_info(flight_svc, token, request).await
+            flightsql::statement_query::get_flight_info(token, request).await
         }
         Command::CommandPreparedStatementQuery(handle) => {
-            flightsql::prepared_statement_query::get_flight_info(flight_svc, handle, request).await
+            flightsql::prepared_statement_query::get_flight_info(handle, request).await
         }
         Command::CommandGetCatalogs(token) => {
             Ok(flightsql::get_catalogs::get_flight_info(token, request).await)
@@ -68,7 +69,6 @@ pub(crate) async fn handle(
 }
 
 async fn get_flight_info_simple(
-    flight_svc: &Service,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<FlightInfo>, Status> {
     tracing::trace!("get_flight_info_simple: {request:?}");
@@ -76,8 +76,11 @@ async fn get_flight_info_simple(
 
     let fd = request.into_inner();
 
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     let sql: &str = std::str::from_utf8(&fd.cmd).map_err(to_tonic_err)?;
-    let (arrow_schema, _) = Service::get_arrow_schema(Arc::clone(&flight_svc.datafusion), sql)
+    let (arrow_schema, _) = Service::get_arrow_schema(datafusion, sql)
         .await
         .map_err(to_tonic_err)?;
 

--- a/crates/runtime/src/flight/get_schema.rs
+++ b/crates/runtime/src/flight/get_schema.rs
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
-
 use arrow_flight::{
     FlightDescriptor, IpcMessage, SchemaAsIpc, SchemaResult, flight_descriptor::DescriptorType,
 };
@@ -23,12 +21,15 @@ use arrow_ipc::writer::IpcWriteOptions;
 use datafusion::sql::TableReference;
 use tonic::{Request, Response, Status};
 
-use crate::flight::metrics;
+use crate::{
+    datafusion::request_context_extension::get_current_datafusion,
+    flight::metrics,
+    request::{AsyncMarker, RequestContext},
+};
 
 use super::{Service, to_tonic_err};
 
 pub(crate) async fn handle(
-    flight_svc: &Service,
     request: Request<FlightDescriptor>,
 ) -> Result<Response<SchemaResult>, Status> {
     let _start = metrics::track_flight_request("get_schema", None).await;
@@ -36,13 +37,15 @@ pub(crate) async fn handle(
 
     let fd = request.into_inner();
 
+    let context = RequestContext::current(AsyncMarker::new().await);
+    let datafusion = get_current_datafusion(&context);
+
     match fd.r#type {
         x if x == DescriptorType::Cmd as i32 => {
             let sql: &str = std::str::from_utf8(&fd.cmd).map_err(to_tonic_err)?;
-            let (arrow_schema, _) =
-                Service::get_arrow_schema(Arc::clone(&flight_svc.datafusion), sql)
-                    .await
-                    .map_err(to_tonic_err)?;
+            let (arrow_schema, _) = Service::get_arrow_schema(datafusion, sql)
+                .await
+                .map_err(to_tonic_err)?;
             let options = IpcWriteOptions::default();
             let IpcMessage(schema) = SchemaAsIpc::new(&arrow_schema, &options)
                 .try_into()
@@ -56,7 +59,7 @@ pub(crate) async fn handle(
             let path = fd.path.join(".");
             let table_reference = TableReference::from(path);
             tracing::debug!("get_schema: table_reference: {:?}", table_reference);
-            let Some(table) = flight_svc.datafusion.get_table(&table_reference).await else {
+            let Some(table) = datafusion.get_table(&table_reference).await else {
                 return Err(Status::not_found("Table not found"));
             };
             let schema = table.schema();

--- a/crates/runtime/src/flight/middleware/request_context.rs
+++ b/crates/runtime/src/flight/middleware/request_context.rs
@@ -21,7 +21,10 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::request::{Protocol, RequestContext};
+use crate::{
+    datafusion::{DataFusion, request_context_extension::DataFusionContextExtension},
+    request::{Protocol, RequestContext},
+};
 use app::App;
 
 use runtime_auth::AuthRequestContext;
@@ -31,12 +34,13 @@ use tower::{Layer, Service};
 #[derive(Clone)]
 pub struct RequestContextLayer {
     app: Option<Arc<App>>,
+    df: Arc<DataFusion>,
 }
 
 impl RequestContextLayer {
     #[must_use]
-    pub fn new(app: Option<Arc<App>>) -> Self {
-        Self { app }
+    pub fn new(app: Option<Arc<App>>, df: Arc<DataFusion>) -> Self {
+        Self { app, df }
     }
 }
 
@@ -47,6 +51,7 @@ impl<S> Layer<S> for RequestContextLayer {
         RequestContextMiddleware {
             inner,
             app: self.app.clone(),
+            df: Arc::clone(&self.df),
         }
     }
 }
@@ -55,6 +60,7 @@ impl<S> Layer<S> for RequestContextLayer {
 pub struct RequestContextMiddleware<S> {
     inner: S,
     app: Option<Arc<App>>,
+    df: Arc<DataFusion>,
 }
 
 impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for RequestContextMiddleware<S>
@@ -83,6 +89,8 @@ where
                 .from_headers(headers)
                 .build(),
         );
+
+        request_context.insert_extension(DataFusionContextExtension::new(Arc::clone(&self.df)));
 
         req.extensions_mut()
             .insert::<Arc<dyn AuthRequestContext + Send + Sync>>(

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -69,7 +69,6 @@ mod middleware;
 mod util;
 
 pub struct Service {
-    datafusion: Arc<DataFusion>,
     channel_map: Arc<RwLock<HashMap<TableReference, Arc<Sender<DataUpdate>>>>>,
     basic_auth: Option<Arc<dyn FlightBasicAuth + Send + Sync>>,
 }
@@ -105,7 +104,7 @@ impl FlightService for Service {
         &self,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
-        Box::pin(get_flight_info::handle(self, request)).await
+        Box::pin(get_flight_info::handle(request)).await
     }
 
     async fn poll_flight_info(
@@ -121,7 +120,7 @@ impl FlightService for Service {
         request: Request<FlightDescriptor>,
     ) -> Result<Response<SchemaResult>, Status> {
         let _start = track_flight_request("get_schema", None).await;
-        get_schema::handle(self, request).await
+        get_schema::handle(request).await
     }
 
     async fn do_get(
@@ -129,7 +128,7 @@ impl FlightService for Service {
         request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
         let _start = track_flight_request("do_get", None).await;
-        Box::pin(do_get::handle(self, request)).await
+        Box::pin(do_get::handle(request)).await
     }
 
     async fn do_put(
@@ -137,7 +136,7 @@ impl FlightService for Service {
         request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
         let _start = track_flight_request("do_put", None).await;
-        do_put::handle(self, request).await
+        do_put::handle(request).await
     }
 
     async fn do_exchange(
@@ -153,7 +152,7 @@ impl FlightService for Service {
         request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
         let _start = track_flight_request("do_action", None).await;
-        Box::pin(actions::do_action(self, request)).await
+        Box::pin(actions::do_action(request)).await
     }
 
     async fn list_actions(
@@ -342,7 +341,6 @@ pub async fn start(
     shutdown_signal: Option<CancellationToken>,
 ) -> Result<()> {
     let service = Service {
-        datafusion: rt.datafusion(),
         channel_map: Arc::new(RwLock::new(HashMap::new())),
         basic_auth: endpoint_auth.flight_basic_auth.as_ref().map(Arc::clone),
     };
@@ -368,7 +366,7 @@ pub async fn start(
         .into_inner();
 
     let server = server
-        .layer(RequestContextLayer::new(app))
+        .layer(RequestContextLayer::new(app, Arc::clone(&rt.df)))
         .layer(TokenProviderLayer::new(rt.token_provider_registry()))
         .layer(WriteRateLimitLayer::new(RateLimiter::direct(
             rate_limits.flight_write_limit,

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -366,7 +366,7 @@ pub async fn start(
         .into_inner();
 
     let server = server
-        .layer(RequestContextLayer::new(app, Arc::clone(&rt.df)))
+        .layer(RequestContextLayer::new(app, rt.datafusion()))
         .layer(TokenProviderLayer::new(rt.token_provider_registry()))
         .layer(WriteRateLimitLayer::new(RateLimiter::direct(
             rate_limits.flight_write_limit,


### PR DESCRIPTION
## 📝 Summary

Following the change in the HTTP server in #5807, this PR moves the Arc<DataFusion> reference from the flight service to the request context. All references to DataFusion in flight handlers have been updated to use the current request context.

## 🔗 Related

closes #5804 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
