### PR TITLE
Fix dispatch spicepod reference for `file[parquet]-duckdb[file]-indexes` and `file[parquet]-duckdb[memory]-indexes`

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[file]-indexes.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[file]-indexes.yaml
@@ -1,15 +1,15 @@
 tests:
   bench:
-    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file]-indexes.yaml
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[file]-indexes.yaml
     query_set: tpch
     runner_type: spiceai-runners
     validate_results: true
   throughput:
-    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file]-indexes.yaml
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[file]-indexes.yaml
     query_set: tpch
     runner_type: spiceai-runners
   load:
-    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file]-indexes.yaml
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[file]-indexes.yaml
     query_set: tpch
     runner_type: spiceai-runners
     duration: 28800

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[memory]-indexes.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[memory]-indexes.yaml
@@ -1,15 +1,15 @@
 tests:
   bench:
-    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[memory]-indexes.yaml
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[memory]-indexes.yaml
     query_set: tpch
     runner_type: spiceai-runners
     validate_results: true
   throughput:
-    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[memory]-indexes.yaml
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[memory]-indexes.yaml
     query_set: tpch
     runner_type: spiceai-runners
   load:
-    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[memory]-indexes.yaml
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/indexes/file[parquet]-duckdb[memory]-indexes.yaml
     query_set: tpch
     runner_type: spiceai-runners
     duration: 28800


### PR DESCRIPTION
## 📝 Summary

Fixes a bug where the dispatch file referenced an incorrect path for the `file[parquet]-duckdb[file]-indexes` and `file[parquet]-duckdb[memory]-indexes` spicepods.
