### PR TITLE
fix: Prevent excessively copying RawCacheKey

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -123,8 +123,15 @@ impl CacheKey<'_> {
     }
 }
 
-#[derive(Hash, Clone, Copy, Eq, PartialEq)]
+#[derive(Hash, Eq, PartialEq)]
 pub struct RawCacheKey(u64);
+
+impl RawCacheKey {
+    #[must_use]
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
 
 impl QueryResult {
     #[must_use]
@@ -149,9 +156,9 @@ pub struct CachedQueryResult {
 #[async_trait]
 pub trait QueryResultCache {
     async fn get<'a>(&self, key: CacheKey<'a>) -> Result<Option<CachedQueryResult>>;
-    async fn get_raw_key(&self, raw_key: RawCacheKey) -> Result<Option<CachedQueryResult>>;
+    async fn get_raw_key(&self, raw_key: &RawCacheKey) -> Result<Option<CachedQueryResult>>;
     async fn put<'a>(&self, key: CacheKey<'a>, result: CachedQueryResult) -> Result<()>;
-    async fn put_raw_key(&self, raw_key: RawCacheKey, result: CachedQueryResult) -> Result<()>;
+    async fn put_raw_key(&self, raw_key: &RawCacheKey, result: CachedQueryResult) -> Result<()>;
     async fn invalidate_for_table(&self, table_name: TableReference) -> Result<()>;
     fn size_bytes(&self) -> u64;
     fn item_count(&self) -> u64;
@@ -215,13 +222,13 @@ impl QueryResultsCacheProvider {
     /// Will return `Err` if method fails to access the cache
     pub async fn get(&self, key: CacheKey<'_>) -> Result<Option<CachedQueryResult>> {
         let raw_key = key.as_raw_key();
-        self.get_raw_key(raw_key).await
+        self.get_raw_key(&raw_key).await
     }
 
     /// # Errors
     ///
     /// Will return `Err` if method fails to access the cache
-    pub async fn get_raw_key(&self, raw_key: RawCacheKey) -> Result<Option<CachedQueryResult>> {
+    pub async fn get_raw_key(&self, raw_key: &RawCacheKey) -> Result<Option<CachedQueryResult>> {
         metrics::REQUESTS.add(1, &[]);
         match self.cache.get_raw_key(raw_key).await {
             Ok(Some(cached_result)) => {
@@ -245,7 +252,11 @@ impl QueryResultsCacheProvider {
     /// # Errors
     ///
     /// Will return `Err` if method fails to access the cache
-    pub async fn put_raw_key(&self, raw_key: RawCacheKey, result: CachedQueryResult) -> Result<()> {
+    pub async fn put_raw_key(
+        &self,
+        raw_key: &RawCacheKey,
+        result: CachedQueryResult,
+    ) -> Result<()> {
         let res = self.cache.put_raw_key(raw_key, result).await;
         self.report_size_metrics();
         res

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -68,10 +68,10 @@ impl LruCache {
 impl QueryResultCache for LruCache {
     async fn get<'a>(&self, key: CacheKey<'a>) -> Result<Option<CachedQueryResult>> {
         let raw_key = key.as_raw_key();
-        self.get_raw_key(raw_key).await
+        self.get_raw_key(&raw_key).await
     }
 
-    async fn get_raw_key(&self, raw_key: RawCacheKey) -> Result<Option<CachedQueryResult>> {
+    async fn get_raw_key(&self, raw_key: &RawCacheKey) -> Result<Option<CachedQueryResult>> {
         match self.cache.get(&raw_key.0).await {
             Some(value) => Ok(Some(value)),
             None => Ok(None),
@@ -83,7 +83,7 @@ impl QueryResultCache for LruCache {
         Ok(())
     }
 
-    async fn put_raw_key(&self, raw_key: RawCacheKey, result: CachedQueryResult) -> Result<()> {
+    async fn put_raw_key(&self, raw_key: &RawCacheKey, result: CachedQueryResult) -> Result<()> {
         self.cache.insert(raw_key.0, result).await;
         Ok(())
     }
@@ -181,7 +181,7 @@ mod tests {
 
         // Put a value with a raw key
         cache
-            .put_raw_key(raw_key, result.clone())
+            .put_raw_key(&raw_key, result.clone())
             .await
             .expect("Failed to put with raw key");
 

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -63,7 +63,7 @@ pub fn to_cached_record_batch_stream(
                 input_tables,
             };
 
-            if let Err(e) = cache_provider.put_raw_key(raw_cache_key, cached_result).await {
+            if let Err(e) = cache_provider.put_raw_key(&raw_cache_key, cached_result).await {
                 tracing::error!("Failed to cache query results: {e}");
             }
         }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -43,7 +43,7 @@ use arrow::datatypes::{Schema, SchemaRef};
 use arrow::error::ArrowError;
 use arrow_tools::schema::verify_schema;
 use builder::DataFusionBuilder;
-use cache::{CacheKey, QueryResultsCacheProvider, RawCacheKey};
+use cache::{QueryResultsCacheProvider, RawCacheKey};
 use datafusion::catalog::CatalogProvider;
 use datafusion::catalog::SchemaProvider;
 use datafusion::datasource::{TableProvider, ViewTable};
@@ -261,15 +261,13 @@ struct PendingSinkRegistration {
     secrets: Arc<TokioRwLock<Secrets>>,
 }
 
-type SqlHash = RawCacheKey;
-
 pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     runtime_status: Arc<status::RuntimeStatus>,
     data_writers: RwLock<HashSet<TableReference>>,
     accelerated_tables: TokioRwLock<HashSet<TableReference>>,
     cache_provider: RwLock<Option<Arc<QueryResultsCacheProvider>>>,
-    cached_plans: Cache<SqlHash, LogicalPlan>,
+    cached_plans: Cache<u64, LogicalPlan>,
 
     pending_sink_tables: TokioRwLock<Vec<PendingSinkRegistration>>,
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
@@ -1492,11 +1490,10 @@ impl DataFusion {
     async fn get_or_create_logical_plan(
         &self,
         session: &SessionState,
+        key: &RawCacheKey,
         sql: &str,
     ) -> Result<LogicalPlan, DataFusionError> {
-        let key = CacheKey::Query(sql, None).as_raw_key();
-
-        if let Some(plan) = self.cached_plans.get(&key).await {
+        if let Some(plan) = self.cached_plans.get(&key.as_u64()).await {
             tracing::trace!("using cached plan for {sql}");
             return Ok(plan);
         }
@@ -1504,7 +1501,7 @@ impl DataFusion {
         let plan = session.create_logical_plan(sql).await?;
 
         tracing::trace!("caching plan for {sql}");
-        self.cached_plans.insert(key, plan.clone()).await;
+        self.cached_plans.insert(key.as_u64(), plan.clone()).await;
 
         Ok(plan)
     }
@@ -1583,6 +1580,8 @@ async fn wait_until_dependent_tables_are_ready(
 
 #[cfg(test)]
 mod tests {
+    use cache::CacheKey;
+
     use crate::builder::RuntimeBuilder;
 
     use super::*;
@@ -1590,6 +1589,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_or_create_logical_plan() {
         static SQL: &str = "SELECT 1";
+        let raw_cache_key = CacheKey::Query(SQL, None).as_raw_key();
 
         let runtime = RuntimeBuilder::new().build().await;
         let df = Arc::new(
@@ -1602,7 +1602,7 @@ mod tests {
 
         let session = df.ctx.state();
 
-        df.get_or_create_logical_plan(&session, SQL)
+        df.get_or_create_logical_plan(&session, &raw_cache_key, SQL)
             .await
             .expect("logical plan");
 
@@ -1610,7 +1610,7 @@ mod tests {
         assert_eq!(df.cached_plans.entry_count(), 1);
 
         // Reusing the same query should no longer at to the cache
-        df.get_or_create_logical_plan(&session, SQL)
+        df.get_or_create_logical_plan(&session, &raw_cache_key, SQL)
             .await
             .expect("logical plan");
 

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -211,21 +211,12 @@ impl Query {
             }
 
             let final_stream = if cache_manager.should_cache_results() {
-                if let Some(raw_cache_key) = cache_manager.raw_cache_key {
-                    Self::wrap_stream_with_cache(
-                        &ctx.df,
-                        res_stream,
-                        raw_cache_key,
-                        Arc::clone(&tracker.datasets),
-                    )
-                } else {
-                    // It's not a good idea to log in the query path, and especially at a `warn!` level,
-                    // but this should never happen if the cache manager is implemented correctly, and its better
-                    // to let the query succeed and pollute the logs than to panic.
-                    tracing::warn!("No cache key computed for query, skipping caching");
-                    debug_assert!(false, "No cache key computed for query");
-                    res_stream
-                }
+                Self::wrap_stream_with_cache(
+                    &ctx.df,
+                    res_stream,
+                    cache_manager.raw_cache_key,
+                    Arc::clone(&tracker.datasets),
+                )
             } else {
                 res_stream
             };

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -44,11 +44,11 @@ pub(super) enum PlanOrCached {
 
 pub(super) struct RequestCacheManager {
     pub(super) cache_status: QueryResultsCacheStatus,
-    pub(super) raw_cache_key: Option<RawCacheKey>,
+    pub(super) raw_cache_key: RawCacheKey,
 }
 
 impl RequestCacheManager {
-    fn new(cache_status: QueryResultsCacheStatus, raw_cache_key: Option<RawCacheKey>) -> Self {
+    fn new(cache_status: QueryResultsCacheStatus, raw_cache_key: RawCacheKey) -> Self {
         Self {
             cache_status,
             raw_cache_key,
@@ -147,7 +147,7 @@ impl Query {
         Ok(PlanOrCached::Plan(
             plan,
             tracker,
-            RequestCacheManager::new(cache_status, Some(raw_cache_key)),
+            RequestCacheManager::new(cache_status, raw_cache_key),
         ))
     }
 
@@ -276,12 +276,8 @@ mod tests {
         let cache_status = QueryResultsCacheStatus::CacheHit;
         let raw_cache_key = CacheKey::Query("test-key", None).as_raw_key();
 
-        let manager = RequestCacheManager::new(cache_status, Some(raw_cache_key));
+        let manager = RequestCacheManager::new(cache_status, raw_cache_key);
         assert!(manager.should_cache_results());
-
-        let disabled_manager =
-            RequestCacheManager::new(QueryResultsCacheStatus::CacheDisabled, None);
-        assert!(!disabled_manager.should_cache_results());
     }
 
     #[tokio::test]

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -77,24 +77,30 @@ impl Query {
         tracker: QueryTracker,
     ) -> super::Result<PlanOrCached> {
         // Try to get cached results first from sql
-        let (tracker, cache_status, sql_cache_key) = match Self::try_get_cached_result(
+        let sql_cache_key = CacheKey::Query(sql, parameters.as_ref());
+        let (tracker, cache_status, sql_raw_cache_key) = match Self::try_get_cached_result(
             df,
             Arc::clone(&request_context),
             tracker,
-            CacheKey::Query(sql, parameters.as_ref()),
+            &sql_cache_key,
         )
         .await?
         {
             (CacheResult::Hit(result), _) => return Ok(PlanOrCached::Cached(result)),
-            (CacheResult::MissOrSkipped(tracker, status), sql_cache_key) => {
-                (tracker, Some(status), sql_cache_key)
+            (CacheResult::MissOrSkipped(tracker, status), sql_raw_cache_key) => {
+                (tracker, Some(status), sql_raw_cache_key)
             }
-            (CacheResult::WrongCacheKeyType(tracker), sql_cache_key) => {
-                (tracker, None, sql_cache_key)
+            (CacheResult::WrongCacheKeyType(tracker), sql_raw_cache_key) => {
+                (tracker, None, sql_raw_cache_key)
             }
         };
 
-        let plan = match df.get_or_create_logical_plan(session, sql).await {
+        let sql_raw_cache_key = sql_raw_cache_key.unwrap_or_else(|| sql_cache_key.as_raw_key());
+
+        let plan = match df
+            .get_or_create_logical_plan(session, &sql_raw_cache_key, sql)
+            .await
+        {
             Ok(plan) => plan,
             Err(e) => {
                 let e = find_datafusion_root(e);
@@ -118,7 +124,7 @@ impl Query {
             df,
             Arc::clone(&request_context),
             tracker,
-            CacheKey::LogicalPlan(&plan),
+            &CacheKey::LogicalPlan(&plan),
         )
         .await?
         {
@@ -133,7 +139,7 @@ impl Query {
             ),
         };
 
-        let raw_cache_key = plan_cache_key.or(sql_cache_key);
+        let raw_cache_key = plan_cache_key.unwrap_or(sql_raw_cache_key);
 
         let cache_status = Self::should_cache_results(df, &plan, cache_status);
         tracker = tracker.results_cache_hit(false);
@@ -141,7 +147,7 @@ impl Query {
         Ok(PlanOrCached::Plan(
             plan,
             tracker,
-            RequestCacheManager::new(cache_status, raw_cache_key),
+            RequestCacheManager::new(cache_status, Some(raw_cache_key)),
         ))
     }
 
@@ -149,7 +155,7 @@ impl Query {
         df: &DataFusion,
         request_context: Arc<RequestContext>,
         mut tracker: QueryTracker,
-        key: CacheKey<'_>,
+        key: &CacheKey<'_>,
     ) -> super::Result<(CacheResult, Option<RawCacheKey>)> {
         let Some(cache_provider) = df.cache_provider() else {
             return Ok((
@@ -177,7 +183,7 @@ impl Query {
 
         let raw_key = key.as_raw_key();
 
-        let cached_result = match cache_provider.get_raw_key(raw_key).await {
+        let cached_result = match cache_provider.get_raw_key(&raw_key).await {
             Ok(Some(result)) => result,
             Ok(None) => {
                 return Ok((

--- a/docs/dev/style_guide.md
+++ b/docs/dev/style_guide.md
@@ -215,6 +215,39 @@ pub enum Error {
 }
 ```
 
+### Avoid using `Clone` or `Copy` on Newtypes
+
+*Good:*
+
+Accessing the newtype value via a borrow:
+
+```rust
+struct MyStruct(u64);
+
+impl MyStruct {
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+```
+
+*Bad:*
+
+Accessing the newtype value directly through a `Copy`:
+
+```rust
+#[derive(Clone, Copy)]
+struct MyStruct(u64);
+
+fn consumes_value(v: MyStruct) -> {
+    v.0;
+}
+```
+
+**Why?**
+
+Rust can make some compiler optimisations that result in more stack operations with implicit copies than register operations would use for borrows that result in a copy. Related reading: [When Zero Cost Abstractions Aren't Zero Cost](https://blog.polybdenum.com/2021/08/09/when-zero-cost-abstractions-aren-t-zero-cost.html).
+
 ### Notes
 
 **Code linting**: [Clippy](https://doc.rust-lang.org/stable/clippy/index.html) is used for code linting to enhance idiomatic Rust usage. All warnings are treated as errors, with several non-standard lints enabled. Disabling lints using `#[allow(...)]` is acceptable when the lint is not applicable in certain contexts.

--- a/docs/dev/style_guide.md
+++ b/docs/dev/style_guide.md
@@ -242,6 +242,10 @@ struct MyStruct(u64);
 fn consumes_value(v: MyStruct) -> {
     v.0;
 }
+
+let a = MyStruct(0);
+consumes_value(a);
+consumes_value(a);
 ```
 
 **Why?**


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

1. Remove the `Clone` and `Copy` implementations from `RawCacheKey`. This is a newtype that wraps a `u64` - the `u64` can be accessed directly through a borrow on `&self`, as `u64` itself implements `Copy`. This prevents a situation where a `RawCacheKey` is copied, only for the underlying `u64` to also be copied out of the newtype (e.g. when the newtype is hashed, etc).
    * Also includes associated updates to trait bounds for `QueryResultCache` and `QueryResultsCacheProvider` to accept borrowed values of `RawCacheKey` instead of owned values.
2. Prevent calculating the `RawCacheKey` inside `get_or_create_logical_plan` - if a cache miss occurs, the `RawCacheKey` will already be computed, so there is no reason to re-compute.
3. Updates the logical plan cache to use keys of `u64`, instead of keys of `RawCacheKey`. This aligns with existing behavior for the `LruCache`, which uses the `u64` value from the `RawCacheKey`.

Performing testing with `oha`, some headline metrics are observed:

* Before:
    * `cache_key_type: plan` - 153,438 req/s, P99 @ 0.0011
    * `cache_key_type: sql` - 160,441 req/s, P99 @ 0.0010
* After:
    * `cache_key_type: plan` - 184,764 req/s, P99 @ 0.0009
    * `cache_key_type: sql` - 199,520 req/s, P99 @ 0.0009

Translates to a roughly 20% improvement in query throughput, and reduction in P99 query latency.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #5832 
