### PR TITLE
fix: Disable the query tracker when task history is disabled

### DIFF
--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -158,12 +158,18 @@ impl RuntimeBuilder {
             .as_ref()
             .and_then(|app| app.runtime.dataset_load_parallelism);
 
+        let task_history = self
+            .app
+            .as_ref()
+            .is_none_or(|app| app.runtime.task_history.enabled);
+
         let mut df_builder = DataFusion::builder(
             Arc::clone(&self.runtime_status),
             Arc::clone(&self.accelerator_engine_registry),
         )
         .memory_limit(memory_limit)
-        .temp_directory(temp_directory);
+        .temp_directory(temp_directory)
+        .with_task_history(task_history);
 
         if let Some(dataset_parallelism) = dataset_parallelism {
             df_builder = df_builder.max_parallel_accelerated_refreshes(dataset_parallelism);

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -64,6 +64,7 @@ pub struct DataFusionBuilder {
     memory_limit: Option<u64>,
     temp_directory: Option<String>,
     accelerated_refresh_semaphore: Option<Arc<Semaphore>>,
+    task_history_enabled: bool,
 }
 
 pub(crate) fn get_df_default_config() -> SessionConfig {
@@ -115,7 +116,14 @@ impl DataFusionBuilder {
             memory_limit: None,
             temp_directory: None,
             accelerated_refresh_semaphore: None,
+            task_history_enabled: true,
         }
+    }
+
+    #[must_use]
+    pub fn with_task_history(mut self, task_history: bool) -> Self {
+        self.task_history_enabled = task_history;
+        self
     }
 
     #[must_use]
@@ -226,6 +234,7 @@ impl DataFusionBuilder {
             accelerated_tables: TokioRwLock::new(HashSet::new()),
             accelerator_engine_registry: self.accelerator_engine_registry,
             acceleration_refresh_semaphore: self.accelerated_refresh_semaphore,
+            task_history_enabled: self.task_history_enabled,
         }
     }
 }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -273,6 +273,7 @@ pub struct DataFusion {
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     // Controls the parallelism of accelerated table refreshes
     acceleration_refresh_semaphore: Option<Arc<Semaphore>>,
+    pub task_history_enabled: bool,
 }
 
 impl std::fmt::Debug for DataFusion {

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -273,7 +273,7 @@ pub struct DataFusion {
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     // Controls the parallelism of accelerated table refreshes
     acceleration_refresh_semaphore: Option<Arc<Semaphore>>,
-    pub task_history_enabled: bool,
+    pub(crate) task_history_enabled: bool,
 }
 
 impl std::fmt::Debug for DataFusion {

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -90,13 +90,13 @@ pub struct Query {
     df: Arc<crate::datafusion::DataFusion>,
     sql: Arc<str>,
     parameters: Option<ParamValues>,
-    tracker: QueryTracker,
+    tracker: Option<QueryTracker>,
 }
 
 macro_rules! handle_error {
     ($self:expr, $request_context:expr, $error_code:expr, $error:expr, $target_error:ident) => {{
         let snafu_error = Error::$target_error { source: $error };
-        $self.finish_with_error($request_context, snafu_error.to_string(), $error_code);
+        $self.map(|t| t.finish_with_error($request_context, snafu_error.to_string(), $error_code));
         return Err(snafu_error);
     }};
 }
@@ -171,13 +171,20 @@ impl Query {
                 }
             }
             if is_accelerated {
-                tracker.is_accelerated = Some(true);
+                tracker = tracker.map(|mut t| {
+                    t.is_accelerated = Some(true);
+                    t
+                });
             }
 
-            tracker = tracker.datasets(Arc::new(input_tables));
+            let datasets = Arc::new(input_tables);
+            tracker = tracker.map(|t| t.datasets(Arc::clone(&datasets)));
 
             // Start the timer for the query execution
-            tracker.query_execution_duration_timer = Instant::now();
+            tracker = tracker.map(|mut t| {
+                t.query_execution_duration_timer = Instant::now();
+                t
+            });
 
             let df = DataFrame::new(session, plan);
 
@@ -215,7 +222,7 @@ impl Query {
                     &ctx.df,
                     res_stream,
                     cache_manager.raw_cache_key,
-                    Arc::clone(&tracker.datasets),
+                    datasets,
                 )
             } else {
                 res_stream
@@ -249,8 +256,9 @@ impl Query {
         error_message: String,
         error_code: ErrorCode,
     ) {
-        self.tracker
-            .finish_with_error(request_context, error_message, error_code);
+        if let Some(t) = self.tracker {
+            t.finish_with_error(request_context, error_message, error_code);
+        }
     }
 
     /// Return the schema for the data and (possibly) the parameters of a [`Query`].
@@ -327,9 +335,13 @@ fn parameter_schema_for_plan(plan: &LogicalPlan) -> Result<Option<Schema>, DataF
 fn attach_query_tracker_to_stream(
     span: Span,
     request_context: Arc<RequestContext>,
-    tracker: QueryTracker,
+    tracker: Option<QueryTracker>,
     mut stream: SendableRecordBatchStream,
 ) -> SendableRecordBatchStream {
+    let Some(tracker) = tracker else {
+        return stream;
+    };
+
     let schema = stream.schema();
     let schema_copy = Arc::clone(&schema);
 

--- a/crates/runtime/src/datafusion/query/builder.rs
+++ b/crates/runtime/src/datafusion/query/builder.rs
@@ -56,11 +56,8 @@ impl<'a> QueryBuilder<'a> {
     #[must_use]
     pub fn build(self) -> Query {
         let sql: Arc<str> = self.sql.into();
-        Query {
-            df: Arc::clone(&self.df),
-            sql: Arc::clone(&sql),
-            parameters: self.parameters,
-            tracker: QueryTracker {
+        let tracker = if self.df.task_history_enabled {
+            Some(QueryTracker {
                 schema: None,
                 query_duration_secs: None,
                 query_execution_duration_secs: None,
@@ -72,7 +69,16 @@ impl<'a> QueryBuilder<'a> {
                 query_duration_timer: Instant::now(),
                 query_execution_duration_timer: Instant::now(),
                 datasets: Arc::new(HashSet::default()),
-            },
+            })
+        } else {
+            None
+        };
+
+        Query {
+            df: Arc::clone(&self.df),
+            sql: Arc::clone(&sql),
+            parameters: self.parameters,
+            tracker,
         }
     }
 }

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -38,7 +38,7 @@ use super::{
 
 /// Returns `Plan` if the result is not cached and needs to be executed, otherwise returns `Cached`
 pub(super) enum PlanOrCached {
-    Plan(LogicalPlan, QueryTracker, RequestCacheManager),
+    Plan(LogicalPlan, Option<QueryTracker>, RequestCacheManager),
     Cached(QueryResult),
 }
 
@@ -62,8 +62,8 @@ impl RequestCacheManager {
 
 enum CacheResult {
     Hit(QueryResult),
-    MissOrSkipped(QueryTracker, QueryResultsCacheStatus),
-    WrongCacheKeyType(QueryTracker),
+    MissOrSkipped(Option<QueryTracker>, QueryResultsCacheStatus),
+    WrongCacheKeyType(Option<QueryTracker>),
 }
 
 impl Query {
@@ -74,7 +74,7 @@ impl Query {
         request_context: Arc<RequestContext>,
         sql: &str,
         parameters: Option<ParamValues>,
-        tracker: QueryTracker,
+        tracker: Option<QueryTracker>,
     ) -> super::Result<PlanOrCached> {
         // Try to get cached results first from sql
         let sql_cache_key = CacheKey::Query(sql, parameters.as_ref());
@@ -106,7 +106,9 @@ impl Query {
                 let e = find_datafusion_root(e);
                 let error_code = ErrorCode::from(&e);
                 let snafu_error = super::Error::UnableToExecuteQuery { source: e };
-                tracker.finish_with_error(&request_context, snafu_error.to_string(), error_code);
+                if let Some(t) = tracker {
+                    t.finish_with_error(&request_context, snafu_error.to_string(), error_code);
+                }
                 return Err(snafu_error);
             }
         };
@@ -142,7 +144,7 @@ impl Query {
         let raw_cache_key = plan_cache_key.unwrap_or(sql_raw_cache_key);
 
         let cache_status = Self::should_cache_results(df, &plan, cache_status);
-        tracker = tracker.results_cache_hit(false);
+        tracker = tracker.map(|t| t.results_cache_hit(false));
 
         Ok(PlanOrCached::Plan(
             plan,
@@ -154,7 +156,7 @@ impl Query {
     async fn try_get_cached_result(
         df: &DataFusion,
         request_context: Arc<RequestContext>,
-        mut tracker: QueryTracker,
+        mut tracker: Option<QueryTracker>,
         key: &CacheKey<'_>,
     ) -> super::Result<(CacheResult, Option<RawCacheKey>)> {
         let Some(cache_provider) = df.cache_provider() else {
@@ -194,9 +196,10 @@ impl Query {
             Err(e) => return Err(super::Error::FailedToAccessCache { source: e }),
         };
 
-        tracker = tracker
-            .datasets(cached_result.input_tables)
-            .results_cache_hit(true);
+        tracker = tracker.map(|t| {
+            t.datasets(cached_result.input_tables)
+                .results_cache_hit(true)
+        });
 
         let record_batch_stream =
             match MemoryStream::try_new(cached_result.records.to_vec(), cached_result.schema, None)


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates the `QueryTracker` on `Query` to be an `Option<QueryTracker>`
* When `task_history.enabled == false`, disables the `Option<QueryTracker>` by setting it to `None`

Benchmark results of an aggregation with low compute (`SELECT COUNT(*) FROM customer`) when task history is disabled:

* **Before:** 208k req/s, 0.0018 secs P99
* **After:** 228k req/s (+9.6%), 0.0016 secs P99 (-11%)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #5832
