### PR TITLE
Set fsGroup on PodSpec to force volumes to be mounted with permission to docker image

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -30,6 +30,11 @@ spec:
       annotations:
         checksum/spicepod: {{ toYaml .Values.spicepod | sha256sum }}
     spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        runAsNonRoot: true
       {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "spiceai.serviceAccountName" . }}
       {{- end }}
@@ -104,11 +109,8 @@ spec:
           resources: {{ toYaml .Values.resources | nindent 12 }}
           {{- end }}
           securityContext:
-            runAsUser: 65534
-            runAsGroup: 65534
             allowPrivilegeEscalation: false
             privileged: false
-            runAsNonRoot: true
       volumes:
         {{- if .Values.volumes }}
         {{- .Values.volumes | toYaml | nindent 8 }}


### PR DESCRIPTION
## 📝 Summary

Adds the securityContext option `fsGroup` which forces volumes mounted via Kubernetes to have their group set to the ID specified in `fsGroup`. This allows the container process to have permission to mounted volumes.

Notably this doesn't work for `hostPath` because that volume type doesn't respect the `fsGroup` option. There are workarounds we could do (i.e. see https://github.com/bitpoke/mysql-operator/pull/734 for one option), but we can enable that later if necessary.

- Closes #5851