### PR TITLE
Adapt to Arrow 54 changes in Dict IDs preserving (Arrow IPC)

### DIFF
--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -33,6 +33,7 @@ use arrow_flight::{
     Ticket, flight_service_server::FlightServiceServer,
 };
 use arrow_ipc::writer::IpcWriteOptions;
+use async_stream::try_stream;
 use bytes::Bytes;
 use cache::QueryResultsCacheStatus;
 use datafusion::common::ParamValues;
@@ -205,47 +206,50 @@ impl Service {
 
         let query_result = query.run().await.map_err(handle_query_error)?;
 
-        let schema = query_result.data.schema();
         let options = datafusion::arrow::ipc::writer::IpcWriteOptions::default();
-        let schema_as_ipc = SchemaAsIpc::new(&schema, &options);
-        let schema_flight_data = FlightData::from(schema_as_ipc);
 
-        let batches_stream = query_result
-            .data
-            .then(move |batch_result| {
-                let options_clone = options.clone();
-                async move {
-                    let encoder = IpcDataGenerator::default();
-                    let mut tracker = DictionaryTracker::new(false);
+        let mut dict_tracker = DictionaryTracker::new(false);
+        let encoder = IpcDataGenerator::default();
+        let data = IpcMessage(
+            encoder
+                .schema_to_bytes_with_dictionary_tracker(
+                    query_result.data.schema().as_ref(),
+                    &mut dict_tracker,
+                    &options,
+                )
+                .ipc_message
+                .into(),
+        );
+        let schema_flight_data = FlightData {
+            data_header: data.0,
+            ..Default::default()
+        };
 
-                    match batch_result {
-                        Ok(batch) => {
-                            let (flight_dictionaries, flight_batch) = encoder
-                                .encoded_batch(&batch, &mut tracker, &options_clone)
-                                .map_err(|e| Status::internal(e.to_string()))?;
+        let data_stream = query_result.data;
+        let flights_stream = try_stream! {
+            yield schema_flight_data;
 
-                            let mut flights: Vec<FlightData> =
-                                flight_dictionaries.into_iter().map(Into::into).collect();
-                            flights.push(flight_batch.into());
-                            Ok(flights)
+            futures::pin_mut!(data_stream); // needed to use `.next()` on stream
+
+            while let Some(batch_result) = data_stream.next().await {
+                match batch_result {
+                    Ok(batch) => {
+                        let (dicts, batch_data) = encoder
+                            .encoded_batch(&batch, &mut dict_tracker, &options)
+                            .map_err(|e| Status::internal(e.to_string()))?;
+
+                        for dict in dicts {
+                            yield dict.into();
                         }
-                        Err(e) => {
-                            let e = find_datafusion_root(e);
-                            Err(handle_datafusion_error(e))
-                        }
+                        yield batch_data.into();
+                    }
+                    Err(e) => {
+                        let e = find_datafusion_root(e);
+                        Err(handle_datafusion_error(e))?;
                     }
                 }
-            })
-            .map(|result| {
-                // Convert Result<Vec<FlightData>, Status> into Stream of Result<FlightData, Status>
-                match result {
-                    Ok(flights) => stream::iter(flights.into_iter().map(Ok)).left_stream(),
-                    Err(e) => stream::once(async { Err(e) }).right_stream(),
-                }
-            })
-            .flatten();
-
-        let flights_stream = stream::once(async { Ok(schema_flight_data) }).chain(batches_stream);
+            }
+        };
 
         Ok((flights_stream.boxed(), query_result.results_cache_status))
     }

--- a/crates/runtime/tests/flight/do_get.rs
+++ b/crates/runtime/tests/flight/do_get.rs
@@ -1,0 +1,54 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow::array::RecordBatch;
+use futures::TryStreamExt;
+use spicepod::component::dataset::Dataset;
+
+use crate::{
+    flight::{create_flight_client, start_spice_test_app},
+    init_tracing,
+    utils::test_request_context,
+};
+
+#[tokio::test]
+async fn test_flight_do_get_dict_types() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let ds = Dataset::new(
+                "s3://spiceai-public-datasets/test_different_formats/dictionaries.parquet",
+                "test_table_dict_types",
+            );
+
+            let (channel, _) = start_spice_test_app(None, None, Some(ds)).await?;
+            let mut client = create_flight_client(channel, None)?;
+
+            let ticket = arrow_flight::Ticket::new(
+                "select * from test_table_dict_types".as_bytes().to_vec(),
+            );
+            let stream = client.do_get(ticket).await?;
+
+            let data: Vec<RecordBatch> = stream.try_collect().await?;
+            let result_str = arrow::util::pretty::pretty_format_batches(&data)?;
+
+            insta::assert_snapshot!("dict_types", result_str);
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/flight/do_put.rs
+++ b/crates/runtime/tests/flight/do_put.rs
@@ -46,7 +46,7 @@ async fn test_flight_do_put_basic() -> Result<(), anyhow::Error> {
             let auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid:rw")]))
                 as Arc<dyn FlightBasicAuth + Send + Sync>;
 
-            let (channel, df) = start_spice_test_app(Some(auth), None).await?;
+            let (channel, df) = start_spice_test_app(Some(auth), None, None).await?;
 
             let mut client = create_flight_client(channel, Some("valid"))?;
 
@@ -83,7 +83,7 @@ async fn test_do_put_stream_error() -> Result<(), Box<dyn std::error::Error>> {
     let auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid:rw")]))
         as Arc<dyn FlightBasicAuth + Send + Sync>;
 
-    let (channel, df) = start_spice_test_app(Some(auth), None).await?;
+    let (channel, df) = start_spice_test_app(Some(auth), None, None).await?;
 
     let mut client = create_flight_client(channel, Some("valid"))?;
 
@@ -141,7 +141,7 @@ async fn test_flight_do_put_no_auth() -> Result<(), anyhow::Error> {
 
     test_request_context()
         .scope_retry(3, || async {
-            let (channel, _df) = start_spice_test_app(None, None).await?;
+            let (channel, _df) = start_spice_test_app(None, None, None).await?;
 
             let mut client = create_flight_client(channel, None)?;
 
@@ -167,7 +167,7 @@ async fn test_flight_do_put_ro_key() -> Result<(), anyhow::Error> {
             let auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid")]))
                 as Arc<dyn FlightBasicAuth + Send + Sync>;
 
-            let (channel, _df) = start_spice_test_app(Some(auth), None).await?;
+            let (channel, _df) = start_spice_test_app(Some(auth), None, None).await?;
 
             let mut client = create_flight_client(channel, Some("valid"))?;
 
@@ -200,6 +200,7 @@ async fn test_flight_do_put_rate_limit() -> Result<(), anyhow::Error> {
             let (channel, df) = start_spice_test_app(
                 Some(auth),
                 Some(RateLimits::new().with_flight_write_limit(write_quota)),
+                None,
             )
             .await?;
 
@@ -253,7 +254,7 @@ async fn test_flight_do_put_max_rows_allowed() -> Result<(), anyhow::Error> {
             let auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid:rw")]))
                 as Arc<dyn FlightBasicAuth + Send + Sync>;
 
-            let (channel, df) = start_spice_test_app(Some(auth), None).await?;
+            let (channel, df) = start_spice_test_app(Some(auth), None, None).await?;
 
             let mut client = create_flight_client(channel, Some("valid"))?;
 
@@ -294,7 +295,7 @@ async fn test_do_put_read_timeout() -> Result<(), Box<dyn std::error::Error>> {
     let auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid:rw")]))
         as Arc<dyn FlightBasicAuth + Send + Sync>;
 
-    let (channel, df) = start_spice_test_app(Some(auth), None).await?;
+    let (channel, df) = start_spice_test_app(Some(auth), None, None).await?;
 
     let mut client = create_flight_client(channel, Some("valid"))?;
 

--- a/crates/runtime/tests/flight/mod.rs
+++ b/crates/runtime/tests/flight/mod.rs
@@ -36,19 +36,25 @@ use runtime::{
     flight::RateLimits, internal_table::create_internal_accelerated_table, secrets::Secrets,
 };
 use runtime_auth::FlightBasicAuth;
+use spicepod::component::dataset::Dataset;
 use tokio::{sync::RwLock, time::sleep};
 use tonic::transport::Channel;
 
-use crate::{configure_test_datafusion, utils::wait_until_true};
+use crate::{
+    configure_test_datafusion,
+    utils::{runtime_ready_check, wait_until_true},
+};
 
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
+mod do_get;
 mod do_put;
 mod prepared_statements;
 
 async fn start_spice_test_app(
     flight_auth: Option<Arc<dyn FlightBasicAuth + Send + Sync>>,
     rate_limits: Option<RateLimits>,
+    test_dataset: Option<Dataset>,
 ) -> Result<(Channel, Arc<DataFusion>), anyhow::Error> {
     let mut rng = rand::rng();
     let http_port: u16 = rng.random_range(50000..60000);
@@ -75,8 +81,24 @@ async fn start_spice_test_app(
         rt_builder = rt_builder.with_rate_limits(rate_limits);
     }
 
-    let app = app::AppBuilder::new("test_app").build();
+    let app = if let Some(dataset) = test_dataset {
+        app::AppBuilder::new("test_app")
+            .with_dataset(dataset)
+            .build()
+    } else {
+        app::AppBuilder::new("test_app").build()
+    };
     let rt = Arc::new(rt_builder.with_app(app).build().await);
+
+    let cloned_rt = Arc::clone(&rt);
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+            return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+        }
+        () = cloned_rt.load_components() => {}
+    };
+
+    runtime_ready_check(&rt).await;
 
     let df = rt.datafusion();
 

--- a/crates/runtime/tests/flight/prepared_statements.rs
+++ b/crates/runtime/tests/flight/prepared_statements.rs
@@ -19,7 +19,7 @@ async fn test_basic_binding() -> Result<(), anyhow::Error> {
 
     test_request_context()
         .scope(async {
-            let (channel, _df) = start_spice_test_app(None, None).await?;
+            let (channel, _df) = start_spice_test_app(None, None, None).await?;
 
             let mut client = FlightSqlServiceClient::new(channel);
             let param_batch = create_param_batch(
@@ -46,7 +46,7 @@ async fn test_question_mark_placeholder() -> Result<(), anyhow::Error> {
 
     test_request_context()
         .scope(async {
-            let (channel, _df) = start_spice_test_app(None, None).await?;
+            let (channel, _df) = start_spice_test_app(None, None, None).await?;
 
             let mut client = FlightSqlServiceClient::new(channel);
             let param_batch = create_param_batch(
@@ -75,7 +75,7 @@ async fn test_multiple_parameters() -> Result<(), anyhow::Error> {
         .scope(async {
             let auth = Arc::new(ApiKeyAuth::new(vec![ApiKey::parse_str("valid:rw")]))
                 as Arc<dyn FlightBasicAuth + Send + Sync>;
-            let (channel, _df) = start_spice_test_app(Some(auth), None).await?;
+            let (channel, _df) = start_spice_test_app(Some(auth), None, None).await?;
 
             let test_record_batch = test_record_batch()?;
 

--- a/crates/runtime/tests/flight/snapshots/integration__flight__do_get__dict_types.snap
+++ b/crates/runtime/tests/flight/snapshots/integration__flight__do_get__dict_types.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/flight/do_get.rs
+expression: result_str
+---
++----+------+------+
+| id | col1 | col2 |
++----+------+------+
+| 1  | A    | X    |
+| 2  | B    | Y    |
+| 3  | A    | X    |
+| 4  | C    | Z    |
+| 5  | B    | X    |
+| 6  | A    | Y    |
+| 7  | C    | Z    |
+| 8  | C    | X    |
+| 9  | B    | Y    |
+| 10 | A    | Z    |
++----+------+------+


### PR DESCRIPTION
## 📝 Summary

Arrow 54 introduced a [breaking change](https://github.com/apache/arrow-rs/issues/5981) where IPC serialization no longer preserves dictionary IDs by default (`preserve_dict_ids = false`). This impacts consumers like Arrow Flight that rely on consistent `dict_id`s for decoding.

To ensure compatibility, this PR switches to using a shared `DictionaryTracker` for both schema and all record batches serialization. This aligns with the [recommended approach](https://github.com/apache/arrow-rs/pull/6788) and [similar to arrow-rs changes](https://github.com/apache/arrow-rs/pull/6788/commits/206f7f4624f222e81b675011e6efe36534fae46a#diff-5d13ec34052a1792f00c5d0029a71fd4b9b748966d35567312d1f550b1925d0b)

Details could be found here:
 - https://github.com/apache/arrow-rs/issues/5981

## 🔗 Related

Fixes https://github.com/spiceai/spiceai/issues/5863

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Alternative approach I tried and it worked as well is to use deprecated api to force-enable `preserve_dict_ids = true` and apply DictionaryTracker with enabled preserve_dict_ids setting for schema and batches separately maintaining original code w/o updating streaming logic. Selected current approach as  `preserve_dict_ids` is deprecated and a subject for removal

