### PR TITLE
Update trunk to 1.4.0-unstable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "app"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "snafu",
  "spicepod",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_sql_gen"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_tools"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3184,7 +3184,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data_components"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "db_connection_pool"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "arrow-odbc",
@@ -4097,7 +4097,7 @@ checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "document_parse"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "bytes",
  "docx-rs",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "event_stream"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "futures",
  "futures-util",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "flight_client"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "flightpublisher"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "flightrepl"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "ansi_term",
  "arrow-flight",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "flightsubscriber"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow-flight",
  "clap",
@@ -6972,7 +6972,7 @@ dependencies = [
 
 [[package]]
 name = "llms"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -7642,7 +7642,7 @@ dependencies = [
 
 [[package]]
 name = "model_components"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7969,7 +7969,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "ns_lookup"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "snafu",
  "tracing",
@@ -8774,7 +8774,7 @@ dependencies = [
 
 [[package]]
 name = "otel-arrow"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "otelpublisher"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "clap",
  "futures",
@@ -8832,7 +8832,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "package"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "bytes",
  "futures",
@@ -10621,7 +10621,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -10770,7 +10770,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-auth"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "app",
  "axum 0.8.3",
@@ -11818,7 +11818,7 @@ dependencies = [
 
 [[package]]
 name = "spice-cloud"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -11835,7 +11835,7 @@ dependencies = [
 
 [[package]]
 name = "spiced"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "app",
  "clap",
@@ -11871,7 +11871,7 @@ dependencies = [
 
 [[package]]
 name = "spicepod"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "byte-unit",
  "fundu",
@@ -11887,7 +11887,7 @@ dependencies = [
 
 [[package]]
 name = "spicepodschema"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "schemars",
  "serde_json",
@@ -11896,7 +11896,7 @@ dependencies = [
 
 [[package]]
 name = "spiceschema"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "clap",
  "runtime",
@@ -12363,7 +12363,7 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "telemetry"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
@@ -12446,7 +12446,7 @@ dependencies = [
 
 [[package]]
 name = "test-framework"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "anyhow",
  "app",
@@ -12487,7 +12487,7 @@ dependencies = [
 
 [[package]]
 name = "testoperator"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow-json",
  "clap",
@@ -12788,7 +12788,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token_provider"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "reqwest 0.12.15",
  "secrecy",
@@ -13096,7 +13096,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "async-trait",
  "rmcp",
@@ -13173,7 +13173,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tpc-extension"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -13900,7 +13900,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "util"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "backoff",
  "ctrlc",
@@ -14813,7 +14813,7 @@ dependencies = [
 
 [[package]]
 name = "workers"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ homepage = "https://spice.ai"
 license = "Apache-2.0"
 repository = "https://github.com/spiceai/spiceai"
 rust-version = "1.85"
-version = "1.3.0-unstable"
+version = "1.4.0-unstable"
 
 [workspace.dependencies]
 ahash = "0.8.12"

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-1.3.0-unstable
+1.4.0-unstable


### PR DESCRIPTION
## 📝 Summary

Updates `trunk` to the next minor release, `1.4.0-unstable`
