### PR TITLE
feat: Testoperator reports benchmark failure summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12448,6 +12448,7 @@ dependencies = [
 name = "test-framework"
 version = "1.4.0-unstable"
 dependencies = [
+ "ahash 0.8.12",
  "anyhow",
  "app",
  "arrow",

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+ahash.workspace = true
 anyhow = "1.0.95"
 app = { path = "../app" }
 arrow = { workspace = true, features = ["prettyprint"] }

--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -49,15 +49,14 @@ pub fn to_i32(value: usize) -> i32 {
 pub enum QueryStatus {
     #[default]
     Passed,
-    Failed,
-    FailedWithReason(Arc<str>),
+    Failed(Option<Arc<str>>),
 }
 
 impl Display for QueryStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             QueryStatus::Passed => write!(f, "passed"),
-            QueryStatus::Failed | QueryStatus::FailedWithReason(_) => write!(f, "failed"),
+            QueryStatus::Failed(_) => write!(f, "failed"),
         }
     }
 }
@@ -109,10 +108,10 @@ impl<T: ExtendedMetrics> QueryMetric<T> {
 
     #[must_use]
     pub fn failed_with_status(mut self, query_status: QueryStatus) -> Self {
-        if matches!(query_status, QueryStatus::FailedWithReason(_)) {
+        if matches!(query_status, QueryStatus::Failed(_)) {
             self.query_status = query_status;
         } else {
-            self.query_status = QueryStatus::Failed;
+            self.query_status = QueryStatus::Failed(None);
         }
 
         self
@@ -662,7 +661,7 @@ impl<T: ExtendedMetrics, R: ExtendedMetrics> QueryMetrics<T, R> {
             {
                 QueryStatus::Passed
             } else {
-                QueryStatus::Failed
+                QueryStatus::Failed(None)
             },
         ];
 

--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -45,24 +45,25 @@ pub fn to_i32(value: usize) -> i32 {
     value as i32
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub enum QueryStatus {
     #[default]
     Passed,
     Failed,
+    FailedWithReason(Arc<str>),
 }
 
 impl Display for QueryStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             QueryStatus::Passed => write!(f, "passed"),
-            QueryStatus::Failed => write!(f, "failed"),
+            QueryStatus::Failed | QueryStatus::FailedWithReason(_) => write!(f, "failed"),
         }
     }
 }
 
 pub struct QueryMetric<T: ExtendedMetrics> {
-    pub query_name: String,
+    pub query_name: Arc<str>,
     pub query_status: QueryStatus,
     pub started_at: usize,
     pub finished_at: usize,
@@ -78,20 +79,20 @@ pub struct QueryMetric<T: ExtendedMetrics> {
 
 impl<T: ExtendedMetrics> QueryMetric<T> {
     pub fn new_from_durations(
-        name: &str,
+        name: Arc<str>,
         durations: &Vec<Duration>,
         query_status: QueryStatus,
         started_at: usize,
         finished_at: usize,
     ) -> Result<Self> {
         if durations.is_empty() {
-            return Ok(Self::new(name).failed());
+            return Ok(Self::new(Arc::clone(&name)).failed_with_status(query_status));
         }
 
         let iterations = durations.len();
         let durations = durations.statistical_set()?;
         Ok(Self {
-            query_name: name.to_string(),
+            query_name: name,
             query_status,
             started_at,
             finished_at,
@@ -107,15 +108,20 @@ impl<T: ExtendedMetrics> QueryMetric<T> {
     }
 
     #[must_use]
-    pub fn failed(mut self) -> Self {
-        self.query_status = QueryStatus::Failed;
+    pub fn failed_with_status(mut self, query_status: QueryStatus) -> Self {
+        if matches!(query_status, QueryStatus::FailedWithReason(_)) {
+            self.query_status = query_status;
+        } else {
+            self.query_status = QueryStatus::Failed;
+        }
+
         self
     }
 
     #[must_use]
-    pub fn new(name: &str) -> Self {
+    pub fn new(name: Arc<str>) -> Self {
         Self {
-            query_name: name.to_string(),
+            query_name: name,
             query_status: QueryStatus::Passed,
             started_at: 0,
             finished_at: 0,
@@ -221,6 +227,65 @@ impl StatisticsCollector<Duration, Vec<Duration>> for Vec<Duration> {
         } else {
             sorted_durations
         })
+    }
+}
+
+impl StatisticsCollector<BTreeMap<Arc<str>, Duration>, BTreeMap<Arc<str>, Vec<Duration>>>
+    for BTreeMap<Arc<str>, Vec<Duration>>
+{
+    fn percentile(&self, percentile: f64) -> Result<BTreeMap<Arc<str>, Duration>> {
+        let mut percentiles = BTreeMap::new();
+        for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
+            percentiles.insert(Arc::clone(query), durations.percentile(percentile)?);
+        }
+        Ok(percentiles)
+    }
+
+    fn median(&self) -> Result<BTreeMap<Arc<str>, Duration>> {
+        let mut medians = BTreeMap::new();
+        for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
+            medians.insert(Arc::clone(query), durations.median()?);
+        }
+        Ok(medians)
+    }
+
+    fn min_duration(&self) -> Result<BTreeMap<Arc<str>, Duration>> {
+        let mut mins = BTreeMap::new();
+        for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
+            mins.insert(Arc::clone(query), durations.min_duration()?);
+        }
+        Ok(mins)
+    }
+
+    fn max_duration(&self) -> Result<BTreeMap<Arc<str>, Duration>> {
+        let mut maxes = BTreeMap::new();
+        for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
+            maxes.insert(Arc::clone(query), durations.max_duration()?);
+        }
+        Ok(maxes)
+    }
+
+    fn statistical_set(&self) -> Result<BTreeMap<Arc<str>, Vec<Duration>>> {
+        let mut statistical_sets = BTreeMap::new();
+        for (query, durations) in self {
+            if durations.is_empty() {
+                continue;
+            }
+            statistical_sets.insert(Arc::clone(query), durations.statistical_set()?);
+        }
+        Ok(statistical_sets)
     }
 }
 
@@ -531,7 +596,12 @@ impl<T: ExtendedMetrics, R: ExtendedMetrics> QueryMetrics<T, R> {
             Arc::new(StringArray::from(spiced_version)),
             Arc::new(UInt64Array::from(started_at)),
             Arc::new(UInt64Array::from(finished_at)),
-            Arc::new(StringArray::from(query_name)),
+            Arc::new(StringArray::from(
+                query_name
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>(),
+            )),
             Arc::new(StringArray::from(query_status)),
             Arc::new(UInt64Array::from(min_duration_ms)),
             Arc::new(UInt64Array::from(max_duration_ms)),
@@ -573,7 +643,7 @@ impl<T: ExtendedMetrics, R: ExtendedMetrics> QueryMetrics<T, R> {
 
     /// Builds record batches for the test run
     /// The record batch is a single row, representing the run as a whole - which can pass or fail separately from individual queries
-    pub fn build_run(&self, status: QueryStatus) -> Result<Vec<RecordBatch>> {
+    pub fn build_run(&self, status: &QueryStatus) -> Result<Vec<RecordBatch>> {
         let run_id = vec![self.run_id.to_string()];
         let spiced_version = vec![self.spiced_version.to_string()];
         let run_name = vec![self.run_name.clone()];
@@ -588,7 +658,7 @@ impl<T: ExtendedMetrics, R: ExtendedMetrics> QueryMetrics<T, R> {
                 .metrics
                 .iter()
                 .all(|m| m.query_status == QueryStatus::Passed)
-                && status == QueryStatus::Passed
+                && status.clone() == QueryStatus::Passed
             {
                 QueryStatus::Passed
             } else {
@@ -648,7 +718,7 @@ impl<T: ExtendedMetrics, R: ExtendedMetrics> QueryMetrics<T, R> {
     }
 
     pub fn show_run(&self, status: Option<QueryStatus>) -> Result<()> {
-        print_batches(&self.build_run(status.unwrap_or_default())?)?;
+        print_batches(&self.build_run(&status.unwrap_or_default())?)?;
 
         Ok(())
     }

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -246,14 +246,11 @@ impl SpiceTest<Running> {
                     .entry(query)
                     .and_modify(|existing_status| {
                         // If the worker reports failure, update the status to Failed
-                        if matches!(existing_status, QueryStatus::FailedWithReason(_)) {
+                        if matches!(existing_status, QueryStatus::Failed(_)) {
                             return; // don't update any existing status message
                         }
 
-                        if matches!(
-                            worker_status,
-                            QueryStatus::Failed | QueryStatus::FailedWithReason(_)
-                        ) {
+                        if matches!(worker_status, QueryStatus::Failed(_)) {
                             *existing_status = worker_status.clone();
                         }
                     })
@@ -414,7 +411,7 @@ impl MetricCollector<DatasetMetrics, NoExtendedMetrics> for SpiceTest<Completed>
                     .state
                     .query_statuses
                     .get(query)
-                    .unwrap_or(&QueryStatus::Failed)
+                    .unwrap_or(&QueryStatus::Failed(None))
                     .to_owned();
 
                 let metric = QueryMetric::new_from_durations(
@@ -468,7 +465,7 @@ impl MetricCollector<NoExtendedMetrics, ThroughputMetrics> for SpiceTest<Complet
                     .state
                     .query_statuses
                     .get(query)
-                    .unwrap_or(&QueryStatus::Failed)
+                    .unwrap_or(&QueryStatus::Failed(None))
                     .to_owned();
 
                 QueryMetric::new_from_durations(

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::{
     collections::BTreeMap,
+    sync::Arc,
     time::{Duration, Instant, SystemTime},
 };
 
@@ -109,10 +110,10 @@ pub struct Running {
     end_condition: EndCondition,
 }
 pub struct Completed {
-    pub(crate) query_durations: BTreeMap<String, Vec<Duration>>,
-    pub(crate) query_iteration_durations: BTreeMap<String, (SystemTime, SystemTime)>,
-    pub(crate) row_counts: BTreeMap<String, Vec<usize>>,
-    pub(crate) query_statuses: BTreeMap<String, QueryStatus>,
+    pub(crate) query_durations: BTreeMap<Arc<str>, Vec<Duration>>,
+    pub(crate) query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)>,
+    pub(crate) row_counts: BTreeMap<Arc<str>, Vec<usize>>,
+    pub(crate) query_statuses: BTreeMap<Arc<str>, QueryStatus>,
     pub(crate) test_duration: Duration,
     pub(crate) end_time: SystemTime,
     pub(crate) query_count: usize,
@@ -245,8 +246,15 @@ impl SpiceTest<Running> {
                     .entry(query)
                     .and_modify(|existing_status| {
                         // If the worker reports failure, update the status to Failed
-                        if worker_status == QueryStatus::Failed {
-                            *existing_status = QueryStatus::Failed;
+                        if matches!(existing_status, QueryStatus::FailedWithReason(_)) {
+                            return; // don't update any existing status message
+                        }
+
+                        if matches!(
+                            worker_status,
+                            QueryStatus::Failed | QueryStatus::FailedWithReason(_)
+                        ) {
+                            *existing_status = worker_status.clone();
                         }
                     })
                     .or_insert(worker_status);
@@ -282,7 +290,7 @@ impl SpiceTest<Running> {
 
 impl SpiceTest<Completed> {
     #[must_use]
-    pub fn get_query_durations(&self) -> &BTreeMap<String, Vec<Duration>> {
+    pub fn get_query_durations(&self) -> &BTreeMap<Arc<str>, Vec<Duration>> {
         &self.state.query_durations
     }
 
@@ -290,7 +298,7 @@ impl SpiceTest<Completed> {
     ///
     /// Only valid when the `EndCondition` is `QuerySetCompleted`.
     #[must_use]
-    pub fn get_query_iteration_durations(&self) -> &BTreeMap<String, (SystemTime, SystemTime)> {
+    pub fn get_query_iteration_durations(&self) -> &BTreeMap<Arc<str>, (SystemTime, SystemTime)> {
         &self.state.query_iteration_durations
     }
 
@@ -329,7 +337,7 @@ impl SpiceTest<Completed> {
 
     /// Validates that row counts are consistent across queries
     /// Each query should return the same number of rows
-    pub fn validate_returned_row_counts(&self) -> Result<BTreeMap<String, usize>> {
+    pub fn validate_returned_row_counts(&self) -> Result<BTreeMap<Arc<str>, usize>> {
         // validate that row counts are consistent across queries - each query should return the same number of rows
         let mut returned_row_counts = BTreeMap::new();
         for (query, counts) in &self.state.row_counts {
@@ -343,7 +351,7 @@ impl SpiceTest<Completed> {
                 ));
             }
 
-            returned_row_counts.insert(query.clone(), *first);
+            returned_row_counts.insert(Arc::clone(query), *first);
         }
 
         Ok(returned_row_counts)
@@ -410,7 +418,7 @@ impl MetricCollector<DatasetMetrics, NoExtendedMetrics> for SpiceTest<Completed>
                     .to_owned();
 
                 let metric = QueryMetric::new_from_durations(
-                    query,
+                    Arc::clone(query),
                     durations,
                     query_status,
                     system_time_to_unix_epoch_ms(query_start_time)?,
@@ -464,7 +472,7 @@ impl MetricCollector<NoExtendedMetrics, ThroughputMetrics> for SpiceTest<Complet
                     .to_owned();
 
                 QueryMetric::new_from_durations(
-                    query,
+                    Arc::clone(query),
                     durations,
                     query_status,
                     system_time_to_unix_epoch_ms(query_start_time)?,

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -52,20 +52,25 @@ pub(crate) struct SpiceTestQueryWorker {
 }
 
 pub struct SpiceTestQueryWorkerResult {
-    pub query_durations: BTreeMap<String, Vec<Duration>>,
-    pub query_iteration_durations: BTreeMap<String, (SystemTime, SystemTime)>,
-    pub query_statuses: BTreeMap<String, QueryStatus>,
+    pub query_durations: BTreeMap<Arc<str>, Vec<Duration>>,
+    pub query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)>,
+    pub query_statuses: BTreeMap<Arc<str>, QueryStatus>,
     pub connection_failed: bool,
-    pub row_counts: BTreeMap<String, Vec<usize>>,
+    pub row_counts: BTreeMap<Arc<str>, Vec<usize>>,
+}
+
+struct QueryRunResult {
+    connection_failed: bool,
+    query_failure: Option<String>,
 }
 
 impl SpiceTestQueryWorkerResult {
     pub fn new(
-        query_durations: BTreeMap<String, Vec<Duration>>,
-        query_iteration_durations: BTreeMap<String, (SystemTime, SystemTime)>,
-        query_statuses: BTreeMap<String, QueryStatus>,
+        query_durations: BTreeMap<Arc<str>, Vec<Duration>>,
+        query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)>,
+        query_statuses: BTreeMap<Arc<str>, QueryStatus>,
         connection_failed: bool,
-        row_counts: BTreeMap<String, Vec<usize>>,
+        row_counts: BTreeMap<Arc<str>, Vec<usize>>,
     ) -> Self {
         Self {
             query_durations,
@@ -124,14 +129,14 @@ impl SpiceTestQueryWorker {
     #[allow(clippy::too_many_lines)]
     pub fn start(self) -> JoinHandle<Result<SpiceTestQueryWorkerResult>> {
         tokio::spawn(async move {
-            let mut query_durations: BTreeMap<String, Vec<Duration>> = BTreeMap::new();
+            let mut query_durations: BTreeMap<Arc<str>, Vec<Duration>> = BTreeMap::new();
 
             // Keeps track of the start and end time of each query iteration
-            let mut query_iteration_durations: BTreeMap<String, (SystemTime, SystemTime)> =
+            let mut query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)> =
                 BTreeMap::new();
 
-            let mut query_statuses: BTreeMap<String, QueryStatus> = BTreeMap::new();
-            let mut row_counts: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+            let mut query_statuses: BTreeMap<Arc<str>, QueryStatus> = BTreeMap::new();
+            let mut row_counts: BTreeMap<Arc<str>, Vec<usize>> = BTreeMap::new();
             let mut query_set_count = 0;
             let start = Instant::now();
 
@@ -187,7 +192,9 @@ impl SpiceTestQueryWorker {
                         // Additional round of query run before recording results.
                         // To discard the abnormal results caused by: establishing initial connection / spark cluster startup time
 
-                        let (connection_succeed, _) = self
+                        let QueryRunResult {
+                            connection_failed, ..
+                        } = self
                             .run_single_query(
                                 query,
                                 &mut BTreeMap::new(),
@@ -196,7 +203,7 @@ impl SpiceTestQueryWorker {
                                 false,
                             )
                             .await?;
-                        if !connection_succeed {
+                        if connection_failed {
                             return Ok(SpiceTestQueryWorkerResult::new(
                                 query_durations,
                                 query_iteration_durations,
@@ -217,7 +224,9 @@ impl SpiceTestQueryWorker {
                                     self.id, query.name, e
                                 );
 
-                                query_status = QueryStatus::Failed;
+                                query_status = QueryStatus::FailedWithReason(
+                                    "Explain plan snapshot assertion failed".into(),
+                                );
                             }
                         }
 
@@ -236,7 +245,10 @@ impl SpiceTestQueryWorker {
                                 );
                             }
 
-                            let (connection_succeed, query_succeed) = self
+                            let QueryRunResult {
+                                connection_failed,
+                                query_failure,
+                            } = self
                                 .run_single_query(
                                     query,
                                     &mut query_durations,
@@ -246,7 +258,7 @@ impl SpiceTestQueryWorker {
                                 )
                                 .await?;
 
-                            if !connection_succeed {
+                            if connection_failed {
                                 return Ok(SpiceTestQueryWorkerResult::new(
                                     query_durations,
                                     query_iteration_durations,
@@ -256,16 +268,16 @@ impl SpiceTestQueryWorker {
                                 ));
                             }
 
-                            if !query_succeed {
-                                query_status = QueryStatus::Failed;
+                            if let Some(query_failure) = query_failure {
+                                query_status = QueryStatus::FailedWithReason(query_failure.into());
                             }
 
                             current_query_count += 1;
                         }
                         let end = SystemTime::now();
                         query_iteration_durations
-                            .insert(query.name.to_string(), (query_start, end));
-                        query_statuses.insert(query.name.to_string(), query_status);
+                            .insert(Arc::clone(&query.name), (query_start, end));
+                        query_statuses.insert(Arc::clone(&query.name), query_status);
                     }
                 }
             }
@@ -283,30 +295,36 @@ impl SpiceTestQueryWorker {
     // run queries as a duration-based test
     async fn run_query_set(
         &self,
-        query_durations: &mut BTreeMap<String, Vec<Duration>>,
-        query_statuses: &mut BTreeMap<String, QueryStatus>,
-        row_counts: &mut BTreeMap<String, Vec<usize>>,
+        query_durations: &mut BTreeMap<Arc<str>, Vec<Duration>>,
+        query_statuses: &mut BTreeMap<Arc<str>, QueryStatus>,
+        row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
     ) -> Result<bool> {
         for query in &self.query_set {
-            let (connection_succeed, query_succeed) = self
+            let QueryRunResult {
+                connection_failed,
+                query_failure,
+            } = self
                 .run_single_query(query, query_durations, row_counts, false, false)
                 .await?;
-            if !connection_succeed {
+            if connection_failed {
                 return Ok(false);
             }
 
-            let worker_status = if query_succeed {
-                QueryStatus::Passed
+            let worker_status = if let Some(query_failure) = query_failure {
+                QueryStatus::FailedWithReason(query_failure.into())
             } else {
-                QueryStatus::Failed
+                QueryStatus::Passed
             };
 
             query_statuses
-                .entry(query.name.to_string())
+                .entry(Arc::clone(&query.name))
                 .and_modify(|existing_status| {
                     // If the worker reports failure, update the status to Failed
-                    if worker_status == QueryStatus::Failed {
-                        *existing_status = QueryStatus::Failed;
+                    if matches!(
+                        worker_status,
+                        QueryStatus::FailedWithReason(_) | QueryStatus::Failed
+                    ) {
+                        *existing_status = worker_status.clone();
                     }
                 })
                 .or_insert(worker_status);
@@ -318,11 +336,11 @@ impl SpiceTestQueryWorker {
     async fn run_single_query(
         &self,
         query: &Query,
-        query_durations: &mut BTreeMap<String, Vec<Duration>>,
-        row_counts: &mut BTreeMap<String, Vec<usize>>,
+        query_durations: &mut BTreeMap<Arc<str>, Vec<Duration>>,
+        row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
         results_snapshot: bool,
         validate: bool,
-    ) -> Result<(bool, bool)> {
+    ) -> Result<QueryRunResult> {
         match self
             .execute_query(
                 query,
@@ -333,7 +351,10 @@ impl SpiceTestQueryWorker {
             )
             .await
         {
-            Ok(()) => Ok((true, true)),
+            Ok(()) => Ok(QueryRunResult {
+                connection_failed: false,
+                query_failure: None,
+            }),
             Err(e) => {
                 let flight_error = e.downcast_ref::<flight_client::Error>();
                 if let Some(
@@ -345,14 +366,20 @@ impl SpiceTestQueryWorker {
                         "FAIL - EARLY EXIT - Worker {} - Query '{}' failed: {}",
                         self.id, query.name, e
                     );
-                    Ok((false, false))
+                    Ok(QueryRunResult {
+                        connection_failed: true,
+                        query_failure: None,
+                    })
                 } else {
                     eprintln!(
                         "FAIL - Worker {} - Query '{}' failed: {}",
                         self.id, query.name, e
                     );
-                    query_durations.entry(query.name.to_string()).or_default();
-                    Ok((true, false))
+                    query_durations.entry(Arc::clone(&query.name)).or_default();
+                    Ok(QueryRunResult {
+                        connection_failed: false,
+                        query_failure: Some(format!("{e}")),
+                    })
                 }
             }
         }
@@ -361,8 +388,8 @@ impl SpiceTestQueryWorker {
     async fn execute_query(
         &self,
         query: &Query,
-        query_durations: &mut BTreeMap<String, Vec<Duration>>,
-        row_counts: &mut BTreeMap<String, Vec<usize>>,
+        query_durations: &mut BTreeMap<Arc<str>, Vec<Duration>>,
+        row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
         results_snapshot: bool,
         validate: bool,
     ) -> Result<()> {
@@ -384,7 +411,7 @@ impl SpiceTestQueryWorker {
                         "FAIL - Worker {} - Query '{}' failed: {}",
                         self.id, query.name, e
                     );
-                    query_durations.entry(query.name.to_string()).or_default();
+                    query_durations.entry(Arc::clone(&query.name)).or_default();
                     return Err(e.into());
                 }
                 Ok(Some(batch)) => {
@@ -425,7 +452,9 @@ impl SpiceTestQueryWorker {
                     "FAIL - Worker {} - Query '{}' validation failed: {validation_reason:?}",
                     self.id, query.name
                 );
-                return Err(anyhow::anyhow!("Query validation failed"));
+                return Err(anyhow::anyhow!(
+                    "Query validation failed: {validation_reason:?}"
+                ));
             }
         }
 
@@ -453,12 +482,12 @@ impl SpiceTestQueryWorker {
 
         let duration = query_start.elapsed();
         query_durations
-            .entry(query.name.to_string())
+            .entry(Arc::clone(&query.name))
             .or_default()
             .push(duration);
 
         row_counts
-            .entry(query.name.to_string())
+            .entry(Arc::clone(&query.name))
             .or_default()
             .push(row_count);
 

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -224,9 +224,9 @@ impl SpiceTestQueryWorker {
                                     self.id, query.name, e
                                 );
 
-                                query_status = QueryStatus::FailedWithReason(
+                                query_status = QueryStatus::Failed(Some(
                                     "Explain plan snapshot assertion failed".into(),
-                                );
+                                ));
                             }
                         }
 
@@ -269,7 +269,7 @@ impl SpiceTestQueryWorker {
                             }
 
                             if let Some(query_failure) = query_failure {
-                                query_status = QueryStatus::FailedWithReason(query_failure.into());
+                                query_status = QueryStatus::Failed(Some(query_failure.into()));
                             }
 
                             current_query_count += 1;
@@ -311,7 +311,7 @@ impl SpiceTestQueryWorker {
             }
 
             let worker_status = if let Some(query_failure) = query_failure {
-                QueryStatus::FailedWithReason(query_failure.into())
+                QueryStatus::Failed(Some(query_failure.into()))
             } else {
                 QueryStatus::Passed
             };
@@ -320,10 +320,7 @@ impl SpiceTestQueryWorker {
                 .entry(Arc::clone(&query.name))
                 .and_modify(|existing_status| {
                     // If the worker reports failure, update the status to Failed
-                    if matches!(
-                        worker_status,
-                        QueryStatus::FailedWithReason(_) | QueryStatus::Failed
-                    ) {
+                    if matches!(worker_status, QueryStatus::Failed(_)) {
                         *existing_status = worker_status.clone();
                     }
                 })

--- a/crates/test-framework/src/spicetest/http/consistency.rs
+++ b/crates/test-framework/src/spicetest/http/consistency.rs
@@ -229,7 +229,7 @@ impl MetricCollector<NoExtendedMetrics, NoExtendedMetrics> for SpiceTest<Complet
             .enumerate()
             .map(|(i, durations)| {
                 QueryMetric::new_from_durations(
-                    format!("{i}").as_str(),
+                    format!("{i}").into(),
                     durations,
                     QueryStatus::Passed,
                     system_time_to_unix_epoch_ms(self.start_time)?,

--- a/crates/test-framework/src/spicetest/http/overhead.rs
+++ b/crates/test-framework/src/spicetest/http/overhead.rs
@@ -204,14 +204,14 @@ impl MetricCollector<NoExtendedMetrics, NoExtendedMetrics> for SpiceTest<Complet
 
     fn metrics(&self) -> Result<Vec<QueryMetric<NoExtendedMetrics>>> {
         let baseline = QueryMetric::new_from_durations(
-            "baseline",
+            "baseline".into(),
             &self.state.baseline_results.durations,
             QueryStatus::Passed,
             system_time_to_unix_epoch_ms(self.start_time)?,
             system_time_to_unix_epoch_ms(self.state.end_time)?,
         )?;
         let spice = QueryMetric::new_from_durations(
-            "spice",
+            "spice".into(),
             &self.state.spice_results.durations,
             QueryStatus::Passed,
             system_time_to_unix_epoch_ms(self.start_time)?,

--- a/crates/test-framework/src/spicetest/vector_search/mod.rs
+++ b/crates/test-framework/src/spicetest/vector_search/mod.rs
@@ -167,7 +167,7 @@ impl MetricCollector<SearchScoreMetric, NoExtendedMetrics> for SpiceTest<Complet
             .iter()
             .map(|(id, result)| {
                 QueryMetric::new_from_durations(
-                    id,
+                    id.as_str().into(),
                     &vec![result.duration],
                     QueryStatus::Passed,
                     system_time_to_unix_epoch_ms(self.start_time)?,

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -92,14 +92,22 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
 
+    let mut failures = Vec::new();
     for query in &metrics.metrics {
-        let query_name = query.query_name.clone();
-        let row_count = row_counts.get(&query_name).unwrap_or(&0);
-        let attributes = vec![KeyValue::new("query_name", query_name)];
+        let query_name = &query.query_name;
+        let row_count = row_counts.get(query_name).unwrap_or(&0);
+        let attributes = vec![KeyValue::new("query_name", query_name.to_string())];
 
-        let status: u64 = u64::from(match query.query_status {
+        let status: u64 = u64::from(match &query.query_status {
             QueryStatus::Passed => true,
-            QueryStatus::Failed => false,
+            QueryStatus::Failed => {
+                failures.push(format!("{query_name}: failed with an undetermined error"));
+                false
+            }
+            QueryStatus::FailedWithReason(reason) => {
+                failures.push(format!("{query_name}: {reason}"));
+                false
+            }
         });
 
         crate::metrics::QUERY_STATUS.record(status, &attributes);
@@ -126,7 +134,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     if !test_succeeded {
         return Err(anyhow::anyhow!(
-            "Benchmark test failed due to failed queries"
+            "Benchmark test failed due to failed queries:\n{}",
+            failures.join("\n")
         ));
     }
 

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -100,12 +100,12 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
         let status: u64 = u64::from(match &query.query_status {
             QueryStatus::Passed => true,
-            QueryStatus::Failed => {
-                failures.push(format!("{query_name}: failed with an undetermined error"));
-                false
-            }
-            QueryStatus::FailedWithReason(reason) => {
-                failures.push(format!("{query_name}: {reason}"));
+            QueryStatus::Failed(reason) => {
+                if let Some(reason) = reason {
+                    failures.push(format!("{query_name}: {reason}"));
+                } else {
+                    failures.push(format!("{query_name}: failed with an undetermined error"));
+                }
                 false
             }
         });

--- a/tools/testoperator/src/commands/http/overhead.rs
+++ b/tools/testoperator/src/commands/http/overhead.rs
@@ -81,10 +81,18 @@ pub(crate) async fn overhead_run(args: &HttpOverheadTestArgs) -> anyhow::Result<
     let mut spiced_instance = test.end()?;
     spiced_instance.stop()?;
 
-    let Some(baseline) = results.metrics.iter().find(|q| q.query_name == "baseline") else {
+    let Some(baseline) = results
+        .metrics
+        .iter()
+        .find(|q| q.query_name == "baseline".into())
+    else {
         return Err(anyhow::anyhow!("Baseline results not found"));
     };
-    let Some(spice) = results.metrics.iter().find(|q| q.query_name == "spice") else {
+    let Some(spice) = results
+        .metrics
+        .iter()
+        .find(|q| q.query_name == "spice".into())
+    else {
         return Err(anyhow::anyhow!("Spice results not found"));
     };
 

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -116,12 +116,12 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     let mut test_passed = true;
     let mut yellow_measurements = 0;
     for query in queries {
-        let Some(baseline_percentile) = baseline_percentiles.get(&query.name.to_string()) else {
+        let Some(baseline_percentile) = baseline_percentiles.get(&query.name) else {
             // Query Failed, no percentile statistics recorded
             continue;
         };
 
-        let Some(duration) = test_durations.get(&query.name.to_string()) else {
+        let Some(duration) = test_durations.get(&query.name) else {
             return Err(anyhow::anyhow!(
                 "Query {} not found in test durations",
                 query.name

--- a/tools/testoperator/src/commands/mod.rs
+++ b/tools/testoperator/src/commands/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 use crate::args::CommonArgs;
 use test_framework::{
@@ -32,7 +32,7 @@ pub(crate) mod load;
 pub(crate) mod throughput;
 mod util;
 pub(crate) mod vector_search;
-pub(crate) type RowCounts = BTreeMap<String, usize>;
+pub(crate) type RowCounts = BTreeMap<Arc<str>, usize>;
 
 pub(crate) fn get_app_and_start_request(args: &CommonArgs) -> anyhow::Result<(App, StartRequest)> {
     if !args.metrics {


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates `QueryStatus` for testoperator to include a `FailedWithReason(Arc<str>)`. This allows individual queries to report a specific failure reason, if one is available. The failure reasons are then collected and displayed at the end of benchmark runs. An example output with some induced validation errors:

```console
[... rest of table ...]
| 17c3689c-7a14-4744-b89b-131d6781a3e5 | v1.3.0         | 0             | 0             | tpch_q9    | failed | 0               | 0               | 0          | b6522ed7d-dirty | trunk       | 0                  | 0                         | 0                         | 0                         | testing |
+--------------------------------------+----------------+---------------+---------------+------------+--------+-----------------+-----------------+------------+-----------------+-------------+--------------------+---------------------------+---------------------------+---------------------------+---------+
2025-05-19T09:52:12.452513Z  INFO runtime: Shutdown initiated; waiting up to 30s for connections to drain
2025-05-19T09:52:12.452986Z  INFO spiced: Goodbye!
Error: Benchmark test failed due to failed queries:
tpch_q1: Query validation failed: DataMismatch { column: "sum_qty", row_number: 1, expected: "\"37734107\"", actual: "\"3774200.00\"" }
tpch_q10: Query validation failed: DataMismatch { column: "c_custkey", row_number: 1, expected: "\"57040\"", actual: "\"3226\"" }
tpch_q11: Query validation failed: NoAnswer
tpch_q12: Query validation failed: DataMismatch { column: "high_line_count", row_number: 1, expected: "\"6202\"", actual: "\"647\"" }
```

* Updates all of the `BTreeMap<String, ...>` inside the datasets testoperator test to use `BTreeMap<Arc<str>, ...` instead, reducing CPU usage from memory clones and freeing up more capacity for the runtime under test instead. This is more noticeable during throughput or load tests.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5399
