### PR TITLE
Databricks U2M Spark data connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,6 +3228,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2",
  "snafu",
  "snowflake-api",
  "spark-connect-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ secrecy = "0.10.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.30"
+sha2 = { version = "0.10.8" }
 snafu = "0.8.5"
 snowflake-api = { git = "https://github.com/spiceai/snowflake-rs.git", rev = "ca5c06a6dcb25c7507e110d0a6cd3e0a9ebcbf3b" } # spiceai
 ssh2 = { version = "0.9.5" }

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -59,6 +59,7 @@ rusqlite = { workspace = true, optional = true }
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2 = { workspace = true, optional = true }
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 spark-connect-rs = { git = "https://github.com/spiceai/spark-connect-rs.git", rev = "8f0473271de9ea611969dbdd88d76816976ce429", features = [
@@ -82,7 +83,7 @@ rdkafka = { version = "0.37.0", features = ["cmake-build"], optional = true }
 
 [features]
 clickhouse = ["dep:clickhouse-rs"]
-databricks = ["delta_lake", "spark_connect"]
+databricks = ["delta_lake", "spark_connect", "dep:sha2"]
 debezium = ["dep:rdkafka"]
 delta_lake = ["dep:delta_kernel"]
 duckdb = [

--- a/crates/data_components/src/databricks/mod.rs
+++ b/crates/data_components/src/databricks/mod.rs
@@ -16,12 +16,14 @@ limitations under the License.
 
 pub mod delta;
 pub mod spark_connect;
+pub mod spark_connect_u2m;
 pub mod sql_warehouse;
 
 use std::sync::LazyLock;
 
 pub use delta::DatabricksDelta;
 pub use spark_connect::DatabricksSparkConnect;
+pub use spark_connect_u2m::DatabricksSparkConnectU2M;
 pub use sql_warehouse::DatabricksSqlWarehouse;
 
 const SPICE_USER_AGENT_PREFIX: &str = "SpiceAI_";

--- a/crates/data_components/src/databricks/spark_connect_u2m.rs
+++ b/crates/data_components/src/databricks/spark_connect_u2m.rs
@@ -1,0 +1,127 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow::datatypes::SchemaRef;
+use async_trait::async_trait;
+use datafusion::{datasource::TableProvider, sql::TableReference};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::Duration;
+use std::{collections::HashMap, time::Instant};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use crate::{Read, spark_connect::SparkConnect};
+use token_provider::TokenProvider;
+
+const SESSION_TTL: Duration = Duration::from_secs(10);
+
+struct SessionEntry {
+    session: Arc<RwLock<SparkConnect>>,
+    created_at: Instant,
+}
+
+#[derive(Clone)]
+pub struct DatabricksSparkConnectU2M {
+    /// Base connection string without access token
+    base_connection: String,
+
+    session_pool: Arc<RwLock<HashMap<String, SessionEntry>>>,
+
+    token_provider: Arc<dyn TokenProvider>,
+}
+
+impl DatabricksSparkConnectU2M {
+    pub fn from_token_provider(
+        endpoint: &str,
+        cluster_id: &str,
+        databricks_use_ssl: bool,
+        token_provider: Arc<dyn TokenProvider>,
+    ) -> Self {
+        let user_agent = super::user_agent();
+        let base_connection = format!(
+            "sc://{endpoint}:443/;use_ssl={databricks_use_ssl};user_id=spice.ai;x-databricks-cluster-id={cluster_id};user_agent={user_agent};"
+        );
+        Self {
+            base_connection,
+            session_pool: Arc::new(RwLock::new(HashMap::new())),
+            token_provider,
+        }
+    }
+
+    async fn get_session(
+        &self,
+    ) -> Result<Arc<RwLock<SparkConnect>>, Box<dyn std::error::Error + Send + Sync>> {
+        let access_token = self.token_provider.get_token();
+        let key = hash_string(&access_token);
+
+        {
+            let pool = self.session_pool.read().await;
+            if let Some(entry) = pool.get(&key) {
+                if entry.created_at.elapsed() < SESSION_TTL {
+                    return Ok(Arc::clone(&entry.session));
+                }
+            }
+        }
+
+        let mut pool = self.session_pool.write().await;
+
+        // Clean up expired sessions
+        pool.retain(|_, entry| entry.created_at.elapsed() < SESSION_TTL);
+
+        let session_id = Uuid::new_v4();
+        let connection = format!(
+            "{}token={};session_id={};",
+            self.base_connection, access_token, session_id
+        );
+
+        let spark_connect = SparkConnect::from_connection(connection.as_str()).await?;
+        let session = Arc::new(RwLock::new(spark_connect));
+        pool.insert(
+            key,
+            SessionEntry {
+                session: Arc::clone(&session),
+                created_at: Instant::now(),
+            },
+        );
+
+        Ok(session)
+    }
+}
+
+#[async_trait]
+impl Read for DatabricksSparkConnectU2M {
+    async fn table_provider(
+        &self,
+        table_reference: TableReference,
+        schema: Option<SchemaRef>,
+    ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
+        let session = self.get_session().await?;
+        let spark_connect = session.read().await;
+        Ok(spark_connect
+            .table_provider(table_reference, schema)
+            .await?)
+    }
+}
+
+fn hash_string(val: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(val);
+    hasher.finalize().iter().fold(String::new(), |mut hash, b| {
+        hash.push_str(&format!("{b:02x}"));
+        hash
+    })
+}

--- a/crates/db_connection_pool/Cargo.toml
+++ b/crates/db_connection_pool/Cargo.toml
@@ -27,7 +27,7 @@ pkcs8 = { version = "0.10.2", features = [
 ], optional = true }
 secrecy.workspace = true
 serde_json = { workspace = true, optional = true }
-sha2 = { version = "0.10.8", optional = true }
+sha2 = { workspace = true, optional = true }
 snafu.workspace = true
 snowflake-api = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt"] }

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -21,7 +21,8 @@ use crate::token_providers::databricks::{
 use async_trait::async_trait;
 use data_components::Read;
 use data_components::databricks::{
-    DatabricksDelta, DatabricksSparkConnect, DatabricksSqlWarehouse, sql_warehouse,
+    DatabricksDelta, DatabricksSparkConnect, DatabricksSparkConnectU2M, DatabricksSqlWarehouse,
+    sql_warehouse,
 };
 use data_components::unity_catalog::Endpoint;
 use datafusion::datasource::TableProvider;
@@ -315,16 +316,12 @@ impl Databricks {
                         .await?;
 
                 (
-                    Arc::new(
-                        DatabricksSparkConnect::from_token_provider(
-                            endpoint.to_string(),
-                            cluster_id.expose_secret().to_string(),
-                            databricks_use_ssl,
-                            token_provider,
-                        )
-                        .await
-                        .context(UnableToConstructDatabricksSparkSnafu)?,
-                    ),
+                    Arc::new(DatabricksSparkConnectU2M::from_token_provider(
+                        endpoint,
+                        cluster_id.expose_secret(),
+                        databricks_use_ssl,
+                        token_provider,
+                    )),
                     true,
                 )
             }


### PR DESCRIPTION
## 📝 Summary

Added the `DatabricksSparkConnectU2M` data connector. The main difference from the default `DatabricksSparkConnect` is that it creates a new Spark connection for each incoming request if user authentication is extracted from the headers and no existing session is stored in the session pool.

## 🔗 Related

closes #5816 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
