### PR TITLE
Override the same queries for SQL Warehouse as Spark

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf1/federated/databricks[sql_warehouse].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/federated/databricks[sql_warehouse].yaml
@@ -2,14 +2,17 @@ tests:
   bench:
     spicepod_path: ./test/spicepods/tpch/sf1/federated/databricks[sql_warehouse].yaml
     query_set: tpch
+    query_overrides: spark
     runner_type: spiceai-runners
     validate_results: true
   throughput:
     spicepod_path: ./test/spicepods/tpch/sf1/federated/databricks[sql_warehouse].yaml
     query_set: tpch
+    query_overrides: spark
     runner_type: spiceai-large-runners
   load:
     spicepod_path: ./test/spicepods/tpch/sf1/federated/databricks[sql_warehouse].yaml
     query_set: tpch
+    query_overrides: spark
     runner_type: spiceai-large-runners
     duration: 28800


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

exclude the same queries in TPCH for SQL Warehouse as we do for Spark. 

https://github.com/spiceai/spiceai/blob/trunk/crates/test-framework/src/queries/README.md#tpc-h

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
