### PR TITLE
fix: Publish binaries to dev when platform option is all

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -359,7 +359,7 @@ jobs:
     name: Upload artifacts to MinIO
     needs: build
     runs-on: spiceai-dev-runners
-    if: inputs.platform_option == 'Linux x64'
+    if: inputs.platform_option == 'Linux x64' || inputs.platform_option == 'all'
     steps:
       - uses: actions/checkout@v4
       - name: Setup MinIO


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* The default trigger for build and release on merge to `trunk` is `all`, not `Linux x64`. This change makes sure the binaries publish on merges to trunk.
