### PR TITLE
Include multiple duckdb files acceleration scenarios into testoperator dispatch

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-duckdb[file-many].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/file[parquet]-duckdb[file-many].yaml
@@ -1,0 +1,15 @@
+tests:
+  bench:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file-many].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    validate_results: true
+  throughput:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file-many].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+  load:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/file[parquet]-duckdb[file-many].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    duration: 28800

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-mixed[duckdb[ds]+duckdb[view]].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-mixed[duckdb[ds]+duckdb[view]].yaml
@@ -1,0 +1,15 @@
+tests:
+  bench:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/s3[parquet]-mixed[duckdb[ds]+duckdb[view]].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    validate_results: true
+  throughput:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/s3[parquet]-mixed[duckdb[ds]+duckdb[view]].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+  load:
+    spicepod_path: ./test/spicepods/tpch/sf1/accelerated/s3[parquet]-mixed[duckdb[ds]+duckdb[view]].yaml
+    query_set: tpch
+    runner_type: spiceai-runners
+    duration: 28800


### PR DESCRIPTION
## 📝 Summary

Include the following configurations into benchmark testing:
1. `file[parquet]-duckdb[file-many]` -  multiple DuckDB target acceleration files (datasets only)
2. `s3[parquet]-mixed[duckdb[ds]+duckdb[view]]` - contains mix of accelerated datasets and views (multiple DuckDB files) 

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/5688

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
