### PR TITLE
Load request context extensions on every flight incoming call

### DIFF
--- a/crates/runtime/src/flight/middleware/request_context.rs
+++ b/crates/runtime/src/flight/middleware/request_context.rs
@@ -98,7 +98,7 @@ where
             );
 
         Box::pin(async move {
-            request_context.run_extensions().await;
+            request_context.load_extensions().await;
             request_context.scope(inner.call(req)).await
         })
     }

--- a/crates/runtime/src/flight/middleware/request_context.rs
+++ b/crates/runtime/src/flight/middleware/request_context.rs
@@ -97,6 +97,9 @@ where
                 Arc::clone(&request_context) as Arc<dyn AuthRequestContext + Send + Sync>
             );
 
-        Box::pin(async move { request_context.scope(inner.call(req)).await })
+        Box::pin(async move {
+            request_context.run_extensions().await;
+            request_context.scope(inner.call(req)).await
+        })
     }
 }

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -281,7 +281,7 @@ async fn track_metrics(
 
     let response = Arc::clone(&request_context)
         .scope(async move {
-            request_context.run_extensions().await;
+            request_context.load_extensions().await;
             next.run(req).await
         })
         .await;

--- a/crates/runtime/src/request/context.rs
+++ b/crates/runtime/src/request/context.rs
@@ -183,7 +183,7 @@ impl RequestContext {
         }
     }
 
-    pub async fn run_extensions(&self) {
+    pub async fn load_extensions(&self) {
         if let Some(extension) = self.extension::<DatabricksAuthExtension>() {
             extension.load_u2m_components().await;
         }


### PR DESCRIPTION
## 📝 Summary

Renamed `run_extensions` to `load_extensions` for clarity. 

Load request context extensions on every incoming call to the flight API. Same way it is done for http 
https://github.com/spiceai/spiceai/blob/daa91f7bbd9da737802faa783110ad55310d1795/crates/runtime/src/http/routes.rs#L282-L287

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
