### PR TITLE
Make `spill_to_disk_and_rehydration` test more robust

### DIFF
--- a/crates/runtime/tests/docker/mod.rs
+++ b/crates/runtime/tests/docker/mod.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+};
 
 use bollard::{
     Docker,
@@ -29,9 +32,17 @@ use bollard::{
     },
 };
 use futures::StreamExt;
+use tokio::sync::Semaphore;
+
+// Limit the number of concurrent container operations to avoid overwhelming the Docker daemon and containers stopping due to OOM
+static CONTAINER_SEMAPHORE: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(3)));
+
 pub struct RunningContainer<'a> {
     name: &'a str,
     docker: Docker,
+    // Store the permit to release it when the container is dropped
+    _permit: tokio::sync::OwnedSemaphorePermit,
 }
 
 impl RunningContainer<'_> {
@@ -139,6 +150,14 @@ impl<'a> ContainerRunner<'a> {
             remove(&self.docker, self.name).await?;
         }
 
+        let permit = tokio::time::timeout(
+            std::time::Duration::from_secs(300), // Timeout after 5min
+            CONTAINER_SEMAPHORE.clone().acquire_owned(),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("Timed out waiting for available container slot"))?
+        .map_err(|_| anyhow::anyhow!("Failed to acquire container permit"))?;
+
         self.pull_image().await?;
 
         let options = CreateContainerOptions {
@@ -219,6 +238,7 @@ impl<'a> ContainerRunner<'a> {
         Ok(RunningContainer::<'a> {
             name: self.name,
             docker: self.docker,
+            _permit: permit,
         })
     }
 

--- a/crates/runtime/tests/mysql/common.rs
+++ b/crates/runtime/tests/mysql/common.rs
@@ -45,12 +45,14 @@ pub fn make_mysql_dataset(path: &str, name: &str, port: u16, accelerated: bool) 
 }
 
 const MYSQL_ROOT_PASSWORD: &str = "integration-test-pw";
+const MYSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-mysql";
 
 #[instrument]
 pub async fn start_mysql_docker_container(
-    container_name: &'static str,
     port: u16,
 ) -> Result<RunningContainer<'static>, anyhow::Error> {
+    let container_name = format!("{MYSQL_DOCKER_CONTAINER}-{port}");
+    let container_name: &'static str = Box::leak(container_name.into_boxed_str());
     let running_container = ContainerRunnerBuilder::new(container_name)
         .image(format!("{}mysql:latest", container_registry()))
         .add_port_binding(3306, port)

--- a/crates/runtime/tests/mysql/federation.rs
+++ b/crates/runtime/tests/mysql/federation.rs
@@ -34,8 +34,8 @@ use runtime::Runtime;
 use tracing::instrument;
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
 
-const MYSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-federation-mysql";
-const MYSQL_PORT: u16 = 13306;
+const MYSQL_PORT1: u16 = 13306;
+const MYSQL_PORT2: u16 = 13308;
 
 #[instrument]
 async fn init_mysql_db(port: u16) -> Result<(), anyhow::Error> {
@@ -73,7 +73,7 @@ async fn mysql_federation_push_down() -> Result<(), String> {
     test_request_context()
         .scope(async {
             let running_container =
-                start_mysql_docker_container(MYSQL_DOCKER_CONTAINER, MYSQL_PORT)
+                start_mysql_docker_container(MYSQL_PORT1)
                     .await
                     .map_err(|e| {
                         tracing::error!("start_mysql_docker_container: {e}");
@@ -82,7 +82,7 @@ async fn mysql_federation_push_down() -> Result<(), String> {
             tracing::debug!("Container started");
             let retry_strategy = FibonacciBackoffBuilder::new().max_retries(Some(10)).build();
             retry(retry_strategy, || async {
-                init_mysql_db(MYSQL_PORT)
+                init_mysql_db(MYSQL_PORT1)
                     .await
                     .map_err(RetryError::transient)
             })
@@ -92,7 +92,7 @@ async fn mysql_federation_push_down() -> Result<(), String> {
                 e.to_string()
             })?;
             let app = AppBuilder::new("mysql_federation_push_down")
-                .with_dataset(make_mysql_dataset("lineitem", "line", MYSQL_PORT, false))
+                .with_dataset(make_mysql_dataset("lineitem", "line", MYSQL_PORT1, false))
                 .build();
 
             let mut rt = Runtime::builder()
@@ -170,12 +170,10 @@ async fn mysql_federation_push_down() -> Result<(), String> {
 async fn mysql_federation_inner_join_with_acc() -> Result<(), String> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _tracing = init_tracing(Some("integration=debug,info"));
-    let mysql_port = 13308;
 
     test_request_context().scope_retry(3, || async {
         let running_container = start_mysql_docker_container(
-            "runtime-integration-test-federation-inner-join-mysql",
-            mysql_port,
+            MYSQL_PORT2,
         )
         .await
         .map_err(|e| {
@@ -185,7 +183,7 @@ async fn mysql_federation_inner_join_with_acc() -> Result<(), String> {
         tracing::debug!("Container started");
         let retry_strategy = FibonacciBackoffBuilder::new().max_retries(Some(10)).build();
         retry(retry_strategy, || async {
-            init_mysql_db(mysql_port)
+            init_mysql_db(MYSQL_PORT2)
                 .await
                 .map_err(RetryError::transient)
         })
@@ -195,8 +193,8 @@ async fn mysql_federation_inner_join_with_acc() -> Result<(), String> {
             e.to_string()
         })?;
         let app = AppBuilder::new("mysql_federation_inner_join_with_accelerated_dataset")
-            .with_dataset(make_mysql_dataset("lineitem", "line", mysql_port, false))
-            .with_dataset(make_mysql_dataset("lineitem", "acc_line", mysql_port, true))
+            .with_dataset(make_mysql_dataset("lineitem", "line", MYSQL_PORT2, false))
+            .with_dataset(make_mysql_dataset("lineitem", "acc_line", MYSQL_PORT2, true))
             .build();
 
         let mut rt =

--- a/crates/runtime/tests/mysql/mod.rs
+++ b/crates/runtime/tests/mysql/mod.rs
@@ -34,8 +34,8 @@ use mysql_async::{Params, Row};
 use runtime::Runtime;
 use tracing::instrument;
 
-const MYSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-types-mysql";
-const MYSQL_PORT: u16 = 13316;
+const MYSQL_PORT1: u16 = 13316;
+const MYSQL_PORT2: u16 = 13317;
 
 #[instrument]
 async fn init_mysql_db(port: u16) -> Result<(), anyhow::Error> {
@@ -222,7 +222,7 @@ async fn mysql_integration_test() -> Result<(), String> {
     test_request_context()
         .scope(async {
             let running_container =
-                start_mysql_docker_container(MYSQL_DOCKER_CONTAINER, MYSQL_PORT)
+                start_mysql_docker_container(MYSQL_PORT1)
                     .await
                     .map_err(|e| {
                         tracing::error!("start_mysql_docker_container: {e}");
@@ -231,7 +231,7 @@ async fn mysql_integration_test() -> Result<(), String> {
             tracing::debug!("Container started");
             let retry_strategy = FibonacciBackoffBuilder::new().max_retries(Some(10)).build();
             retry(retry_strategy, || async {
-                init_mysql_db(MYSQL_PORT)
+                init_mysql_db(MYSQL_PORT1)
                     .await
                     .map_err(RetryError::transient)
             })
@@ -241,7 +241,7 @@ async fn mysql_integration_test() -> Result<(), String> {
                 e.to_string()
             })?;
             let app = AppBuilder::new("mysql_integration_test")
-                .with_dataset(make_mysql_dataset("test", "test", MYSQL_PORT, false))
+                .with_dataset(make_mysql_dataset("test", "test", MYSQL_PORT1, false))
                 .build();
 
             let mut rt = Runtime::builder()
@@ -311,7 +311,7 @@ async fn mysql_character_set_results_test() -> Result<(), String> {
     test_request_context()
         .scope(async {
             let running_container =
-                start_mysql_docker_container(MYSQL_DOCKER_CONTAINER, MYSQL_PORT)
+                start_mysql_docker_container(MYSQL_PORT2)
                     .await
                     .map_err(|e| {
                         tracing::error!("start_mysql_docker_container: {e}");
@@ -320,7 +320,7 @@ async fn mysql_character_set_results_test() -> Result<(), String> {
             tracing::debug!("Container started");
             let retry_strategy = FibonacciBackoffBuilder::new().max_retries(Some(10)).build();
             retry(retry_strategy, || async {
-                init_mysql_utf8mb4_db(MYSQL_PORT)
+                init_mysql_utf8mb4_db(MYSQL_PORT2)
                     .await
                     .map_err(RetryError::transient)
             })
@@ -334,7 +334,7 @@ async fn mysql_character_set_results_test() -> Result<(), String> {
                 .with_dataset(make_mysql_dataset(
                     "test_utf8mb4",
                     "test_default",
-                    MYSQL_PORT,
+                    MYSQL_PORT2,
                     false,
                 ))
                 .build();

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -43,8 +43,7 @@ use tokio::time;
 use tracing::instrument;
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
 
-const MYSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-refresh-retry-mysql";
-const MYSQL_PORT: u16 = 13307;
+const MYSQL_PORT: u16 = 13327;
 
 #[instrument]
 async fn init_mysql_db() -> Result<(), anyhow::Error> {
@@ -77,7 +76,7 @@ async fn init_mysql_db() -> Result<(), anyhow::Error> {
 #[instrument]
 async fn prepare_test_environment() -> Result<RunningContainer<'static>, String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
-    let running_container = start_mysql_docker_container(MYSQL_DOCKER_CONTAINER, MYSQL_PORT)
+    let running_container = start_mysql_docker_container(MYSQL_PORT)
         .await
         .map_err(|e| {
             tracing::error!("start_mysql_docker_container: {e}");

--- a/crates/runtime/tests/rehydration/mod.rs
+++ b/crates/runtime/tests/rehydration/mod.rs
@@ -63,13 +63,9 @@ async fn spill_to_disk_and_rehydration() -> Result<(), anyhow::Error> {
 
         let config = vec![
             #[cfg(feature = "duckdb")]
-            ("duckdb", None),
-            #[cfg(feature = "duckdb")]
-            ("duckdb", Some("./.spice/my_duckdb.db")),
+            ("duckdb", Some("spill_to_disk_duckdb.db")),
             #[cfg(feature = "sqlite")]
-            ("sqlite", None),
-            #[cfg(feature = "sqlite")]
-            ("sqlite", Some("./.spice/my_sqlite.db")),
+            ("sqlite", Some("spill_to_disk_sqlite.db")),
         ];
 
         for (idx, (engine, db_file_path)) in config.into_iter().enumerate() {
@@ -132,6 +128,7 @@ async fn execute_spill_to_disk_and_rehydration(
     for file_path in [
         accelerated_db_file_path.clone(),
         format!("{accelerated_db_file_path}-wal"),
+        format!("{accelerated_db_file_path}.wal"),
         format!("{accelerated_db_file_path}-shm"),
     ] {
         if std::fs::metadata(&file_path).is_ok() {
@@ -162,6 +159,7 @@ async fn execute_spill_to_disk_and_rehydration(
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     rt.shutdown().await;
+    drop(rt);
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let retry_strategy = FibonacciBackoffBuilder::new().max_retries(Some(10)).build();
@@ -189,8 +187,10 @@ async fn execute_spill_to_disk_and_rehydration(
     let restart1_items_pretty =
         arrow::util::pretty::pretty_format_batches(&restart1_items).expect("pretty format");
     insta::assert_snapshot!("records", restart1_items_pretty);
-
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    rt.shutdown().await;
     drop(rt);
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // Restart the runtime with updated app definition that includes primary key and indexes
     let rt = init_spice_app(engine, db_file_path, true).await?;
@@ -333,7 +333,6 @@ fn create_test_dataset(
     ds
 }
 
-const MYSQL_DOCKER_CONTAINER: &str = "runtime-integration-test-rehydration-retry-mysql";
 const MYSQL_PORT: u16 = 13337;
 
 #[instrument]
@@ -366,7 +365,7 @@ async fn init_mysql_db() -> Result<(), anyhow::Error> {
 
 #[instrument]
 async fn prepare_test_environment() -> Result<RunningContainer<'static>, String> {
-    let running_container = start_mysql_docker_container(MYSQL_DOCKER_CONTAINER, MYSQL_PORT)
+    let running_container = start_mysql_docker_container(MYSQL_PORT)
         .await
         .map_err(|e| {
             tracing::error!("Failed to start MySQL Docker container: {e}");

--- a/crates/runtime/tests/rehydration/mod.rs
+++ b/crates/runtime/tests/rehydration/mod.rs
@@ -52,8 +52,6 @@ mod duckdb;
 mod sqlite;
 
 #[tokio::test]
-// Temporarily disabled until test robustness is improved: https://github.com/spiceai/spiceai/issues/5803
-#[ignore]
 async fn spill_to_disk_and_rehydration() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 


### PR DESCRIPTION
## 📝 Summary

1. Limit number of running Docker containers to 3 to prevent containers stopped due to OOM (`"OOMKilled": true`)
2. Don't use default acceleration folder (`.spice/data/accelerated_duckdb.db`) to avoid conflicts with other tests using the same default folder.
3. Unified mysql container naming based on port to avoid naming conflicts (for example recently added `mysql_character_set_results_test` conflicted with `mysql_integration_test`)

This should also improve `mysql_refresh_retries` (I previously saw the test failing time to time)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
