### PR TITLE
fix: Properly publish binaries to dev on push

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -359,7 +359,7 @@ jobs:
     name: Upload artifacts to MinIO
     needs: build
     runs-on: spiceai-dev-runners
-    if: inputs.platform_option == 'Linux x64' || inputs.platform_option == 'all'
+    if: inputs.platform_option == 'Linux x64' || inputs.platform_option == 'all' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
       - name: Setup MinIO


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Ensure binaries are publish to dev on `push` events, as well as `workflow_dispatch` events.
