### PR TITLE
Fix deferred loading for datasets with embeddings

### DIFF
--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -173,4 +173,8 @@ impl DataConnector for EmbeddingConnector {
     ) -> Option<DataConnectorResult<Arc<dyn TableProvider>>> {
         self.inner_connector.metadata_provider(dataset).await
     }
+
+    fn deferred_load(&self) -> bool {
+        self.inner_connector.deferred_load()
+    }
 }

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -577,19 +577,19 @@ impl Runtime {
             return Ok(Arc::new(LocalPodConnector::new(Arc::clone(&self.df))));
         }
 
-        let mut data_connector = match dataconnector::create_new_connector(source, params).await {
-            Some(dc) => dc.context(UnableToInitializeDataConnectorSnafu {})?,
-            None => {
+        let mut data_connector =
+            if let Some(dc) = dataconnector::create_new_connector(source, params).await {
+                dc.context(UnableToInitializeDataConnectorSnafu {})?
+            } else {
                 if source == ODBC_DATACONNECTOR {
                     return Err(OdbcNotInstalledSnafu.build());
-                } else {
-                    return Err(UnknownDataConnectorSnafu {
-                        data_connector: source,
-                    }
-                    .build());
                 }
-            }
-        };
+
+                return Err(UnknownDataConnectorSnafu {
+                    data_connector: source,
+                }
+                .build());
+            };
 
         if ds.has_embeddings() {
             data_connector = Arc::new(EmbeddingConnector::new(
@@ -603,31 +603,6 @@ impl Runtime {
         }
 
         Ok(data_connector)
-    }
-
-    pub(crate) async fn get_dataconnector_from_source(
-        &self,
-        source: &str,
-        params: ConnectorParams,
-    ) -> Result<Arc<dyn DataConnector>> {
-        // Unlike most other data connectors, the localpod connector needs a reference to the current DataFusion instance.
-        if source == LOCALPOD_DATACONNECTOR {
-            return Ok(Arc::new(LocalPodConnector::new(Arc::clone(&self.df))));
-        }
-
-        match dataconnector::create_new_connector(source, params).await {
-            Some(dc) => dc.context(UnableToInitializeDataConnectorSnafu {}),
-            None => {
-                if source == ODBC_DATACONNECTOR {
-                    OdbcNotInstalledSnafu.fail()
-                } else {
-                    UnknownDataConnectorSnafu {
-                        data_connector: source,
-                    }
-                    .fail()
-                }
-            }
-        }
     }
 
     async fn register_dataset(

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -30,8 +30,8 @@ use crate::{
         builder::DatasetBuilder,
     },
     dataconnector::{
-        self, ConnectorComponent, ConnectorParams, ConnectorParamsBuilder, DataConnector,
-        DataConnectorError, ODBC_DATACONNECTOR,
+        self, ConnectorComponent, ConnectorParamsBuilder, DataConnector, DataConnectorError,
+        ODBC_DATACONNECTOR,
         deferred::DeferredConnector,
         localpod::{LOCALPOD_DATACONNECTOR, LocalPodConnector},
     },
@@ -201,16 +201,10 @@ impl Runtime {
 
     async fn load_dataset_connector(&self, ds: Arc<Dataset>) -> Result<Arc<dyn DataConnector>> {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
-
         let source = ds.source();
-        let params = ConnectorParamsBuilder::new(source.into(), (&ds).into())
-            .build(self.secrets())
-            .await
-            .context(UnableToInitializeDataConnectorSnafu)?;
 
         let data_connector: Arc<dyn DataConnector> = match self
-            .get_dataconnector_from_dataset(Arc::clone(&ds), params)
-            // .get_dataconnector_from_source(source, params)
+            .get_dataconnector_from_dataset(Arc::clone(&ds))
             .await
         {
             Ok(data_connector) => data_connector,
@@ -568,9 +562,13 @@ impl Runtime {
     pub(crate) async fn get_dataconnector_from_dataset(
         &self,
         ds: Arc<Dataset>,
-        params: ConnectorParams,
     ) -> Result<Arc<dyn DataConnector>> {
         let source = ds.source();
+
+        let params = ConnectorParamsBuilder::new(source.into(), (&ds).into())
+            .build(self.secrets())
+            .await
+            .context(UnableToInitializeDataConnectorSnafu)?;
 
         // Unlike most other data connectors, the localpod connector needs a reference to the current DataFusion instance.
         if source == LOCALPOD_DATACONNECTOR {

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -215,7 +215,15 @@ impl Runtime {
             Ok(data_connector) => {
                 // if connector marked as deferred, replace it with stub DeferredConnector
                 if data_connector.deferred_load() {
-                    Arc::new(DeferredConnector::new(data_connector)) as Arc<dyn DataConnector>
+                    // If the dataset has embeddings, datafusion needs to load the wrapped connector when it is ready
+                    if ds.has_embeddings() {
+                        let connector =
+                            EmbeddingConnector::new(data_connector, Arc::clone(&self.embeds));
+                        Arc::new(DeferredConnector::new(Arc::new(connector)))
+                            as Arc<dyn DataConnector>
+                    } else {
+                        Arc::new(DeferredConnector::new(data_connector)) as Arc<dyn DataConnector>
+                    }
                 } else {
                     data_connector
                 }
@@ -329,7 +337,7 @@ impl Runtime {
         }
 
         // Only wrap data connector when necessary.
-        let connector = if ds.has_embeddings() {
+        let connector = if ds.has_embeddings() && !data_connector.deferred_load() {
             let connector = EmbeddingConnector::new(data_connector, Arc::clone(&self.embeds));
             Arc::new(connector) as Arc<dyn DataConnector>
         } else {

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -209,25 +209,11 @@ impl Runtime {
             .context(UnableToInitializeDataConnectorSnafu)?;
 
         let data_connector: Arc<dyn DataConnector> = match self
-            .get_dataconnector_from_source(source, params)
+            .get_dataconnector_from_dataset(Arc::clone(&ds), params)
+            // .get_dataconnector_from_source(source, params)
             .await
         {
-            Ok(data_connector) => {
-                // if connector marked as deferred, replace it with stub DeferredConnector
-                if data_connector.deferred_load() {
-                    // If the dataset has embeddings, datafusion needs to load the wrapped connector when it is ready
-                    if ds.has_embeddings() {
-                        let connector =
-                            EmbeddingConnector::new(data_connector, Arc::clone(&self.embeds));
-                        Arc::new(DeferredConnector::new(Arc::new(connector)))
-                            as Arc<dyn DataConnector>
-                    } else {
-                        Arc::new(DeferredConnector::new(data_connector)) as Arc<dyn DataConnector>
-                    }
-                } else {
-                    data_connector
-                }
-            }
+            Ok(data_connector) => data_connector,
             Err(err) => {
                 let ds_name = &ds.name;
                 self.status
@@ -336,24 +322,16 @@ impl Runtime {
             }
         }
 
-        // Only wrap data connector when necessary.
-        let connector = if ds.has_embeddings() && !data_connector.deferred_load() {
-            let connector = EmbeddingConnector::new(data_connector, Arc::clone(&self.embeds));
-            Arc::new(connector) as Arc<dyn DataConnector>
-        } else {
-            data_connector
-        };
-
         // Test dataset connectivity by attempting to get a read provider.
-        let federated_table = match connector.read_provider(&ds).await {
+        let federated_table = match data_connector.read_provider(&ds).await {
             Ok(provider) => {
-                FederatedTable::new(Arc::clone(&ds), provider, Arc::clone(&connector)).await
+                FederatedTable::new(Arc::clone(&ds), provider, Arc::clone(&data_connector)).await
             }
             Err(err) => {
                 // We couldn't connect to the federated table. If the dataset has an existing
                 // accelerated table, we can defer the federated table creation.
                 if let Some(federated_table) =
-                    FederatedTable::new_deferred(Arc::clone(&ds), Arc::clone(&connector)).await
+                    FederatedTable::new_deferred(Arc::clone(&ds), Arc::clone(&data_connector)).await
                 {
                     tracing::warn!(
                         "Unable to connect to the remote source for {}. Data will be served from the pre-existing accelerated table for {} while attempting to establish the connection.\n\n{err}",
@@ -382,7 +360,7 @@ impl Runtime {
             .register_dataset(
                 Arc::clone(&ds),
                 RegisterDatasetContext {
-                    data_connector: Arc::clone(&connector),
+                    data_connector: Arc::clone(&data_connector),
                     federated_read_table: federated_table,
                     source: source.to_string(),
                     accelerated_table,
@@ -394,12 +372,12 @@ impl Runtime {
                 tracing::info!(
                     "{}",
                     dataset_registered_trace(
-                        connector.as_ref(),
+                        data_connector.as_ref(),
                         &ds,
                         self.df.results_cache_provider().is_some()
                     )
                 );
-                if !connector.deferred_load() {
+                if !data_connector.deferred_load() {
                     if let Some(datasets_health_monitor) = &self.datasets_health_monitor {
                         if let Err(err) = datasets_health_monitor.register_dataset(&ds).await {
                             tracing::warn!(
@@ -585,6 +563,46 @@ impl Runtime {
             .await?;
 
         Ok(())
+    }
+
+    pub(crate) async fn get_dataconnector_from_dataset(
+        &self,
+        ds: Arc<Dataset>,
+        params: ConnectorParams,
+    ) -> Result<Arc<dyn DataConnector>> {
+        let source = ds.source();
+
+        // Unlike most other data connectors, the localpod connector needs a reference to the current DataFusion instance.
+        if source == LOCALPOD_DATACONNECTOR {
+            return Ok(Arc::new(LocalPodConnector::new(Arc::clone(&self.df))));
+        }
+
+        let mut data_connector = match dataconnector::create_new_connector(source, params).await {
+            Some(dc) => dc.context(UnableToInitializeDataConnectorSnafu {})?,
+            None => {
+                if source == ODBC_DATACONNECTOR {
+                    return Err(OdbcNotInstalledSnafu.build());
+                } else {
+                    return Err(UnknownDataConnectorSnafu {
+                        data_connector: source,
+                    }
+                    .build());
+                }
+            }
+        };
+
+        if ds.has_embeddings() {
+            data_connector = Arc::new(EmbeddingConnector::new(
+                data_connector,
+                Arc::clone(&self.embeds),
+            ));
+        }
+
+        if data_connector.deferred_load() {
+            data_connector = Arc::new(DeferredConnector::new(data_connector));
+        }
+
+        Ok(data_connector)
     }
 
     pub(crate) async fn get_dataconnector_from_source(


### PR DESCRIPTION
## 📝 Summary

If dataset is configured with embeddings, its connector is wrapped with `EmbeddingConnector`. If source data connector is deferred (e.g. Databricks with U2M auth), embedding wrapping should be applied only when the connector is ready.

## 🔗 Related

part of #5738 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
