### PR TITLE
fix: Avoid mistaken ILike to string equality optimization (DataFusion / Arrow)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3360,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "log",
  "tokio",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3402,12 +3402,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 
 [[package]]
 name = "datafusion-execution"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "dashmap",
@@ -3425,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "chrono",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3530,7 +3530,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3589,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -3605,7 +3605,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3614,7 +3614,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -3624,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "chrono",
@@ -3642,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3676,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3694,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "46.0.1"
-source = "git+https://github.com/spiceai/datafusion.git?rev=987d143985657065c8fc4d3d347a2010fbf36fe4#987d143985657065c8fc4d3d347a2010fbf36fe4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=a34b49cfc4f8afafe58793bc4784179be265e25b#a34b49cfc4f8afafe58793bc4784179be265e25b"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,11 +186,11 @@ arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "0aa49f3
 arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "0aa49f3e9f245eb529a5a1db8f2af606c40a8b9a" } # spiceai-54.3.1
 arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "0aa49f3e9f245eb529a5a1db8f2af606c40a8b9a" } # spiceai-54.3.1
 
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "987d143985657065c8fc4d3d347a2010fbf36fe4" }            # spiceai-46
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "987d143985657065c8fc4d3d347a2010fbf36fe4" }     # spiceai-46
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "987d143985657065c8fc4d3d347a2010fbf36fe4" }  # spiceai-46
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "987d143985657065c8fc4d3d347a2010fbf36fe4" }       # spiceai-46
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "987d143985657065c8fc4d3d347a2010fbf36fe4" } # spiceai-46
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "a34b49cfc4f8afafe58793bc4784179be265e25b" }            # spiceai-46
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "a34b49cfc4f8afafe58793bc4784179be265e25b" }     # spiceai-46
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "a34b49cfc4f8afafe58793bc4784179be265e25b" }  # spiceai-46
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "a34b49cfc4f8afafe58793bc4784179be265e25b" }       # spiceai-46
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "a34b49cfc4f8afafe58793bc4784179be265e25b" } # spiceai-46
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "a4c752a172904a0c214fc37ab2d62e907eb16c8f" } # spiceai-46
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "dddeb8cf1c0b12968cb599aa22497920b3eadfdc" } # spiceai


### PR DESCRIPTION
## 📝 Summary

Update `datafusion` version to include the following fix:
- https://github.com/spiceai/datafusion/pull/84

```
sql> select store_and_fwd_flag from taxi_trips limit 5;
+--------------------+
| store_and_fwd_flag |
+--------------------+
| N                  |
| N                  |
| N                  |
| N                  |
| N                  |
+--------------------+

Time: 0.004951917 seconds. 5 rows.
```
Before:

```
sql> select store_and_fwd_flag from taxi_trips where store_and_fwd_flag ILIKE 'n' limit 10;
No results.
```

After

```
sql> select store_and_fwd_flag from taxi_trips where store_and_fwd_flag ILIKE 'n' limit 5;
+--------------------+
| store_and_fwd_flag |
+--------------------+
| N                  |
| N                  |
| N                  |
| N                  |
| N                  |
+--------------------+

Time: 0.018415292 seconds. 5 rows.
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
