### PR TITLE
chore: Upgrade to Rust 1.86

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -36,12 +36,12 @@ runs:
       if: inputs.os != 'windows'
       shell: bash
       run: |
-        rustup toolchain install 1.85
-        rustup default 1.85
+        rustup toolchain install 1.86
+        rustup default 1.86
 
     - name: Install latest Rust stable toolchain (Windows)
       if: inputs.os == 'windows'
       shell: pwsh
       run: |
-        rustup toolchain install 1.85
-        rustup default 1.85
+        rustup toolchain install 1.86
+        rustup default 1.86

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ exclude = [".github/"]
 homepage = "https://spice.ai"
 license = "Apache-2.0"
 repository = "https://github.com/spiceai/spiceai"
-rust-version = "1.85"
+rust-version = "1.86"
 version = "1.4.0-unstable"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.85
+ARG RUST_VERSION=1.86
 FROM rust:${RUST_VERSION}-slim-bookworm as build
 
 # cache mounts below may already exist and owned by root

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.85
+ARG RUST_VERSION=1.86
 
 FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04 AS build
 

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -266,7 +266,7 @@ pub async fn run(args: Args) -> Result<()> {
 
     let result = match server_thread.await {
         // Don't treat force terminated as an error
-        Ok(Err(runtime::Error::ForceTerminated { .. })) => Ok(()),
+        Ok(Err(runtime::Error::ForceTerminated)) => Ok(()),
         Ok(ok) => ok.context(UnableToStartServersSnafu),
         Err(_) => Err(Error::GenericError {
             reason: "Unable to start spiced".into(),

--- a/crates/data_components/src/databricks/delta.rs
+++ b/crates/data_components/src/databricks/delta.rs
@@ -67,9 +67,7 @@ impl DatabricksDelta {
         let mut storage_options = HashMap::new();
         for (key, value) in &self.storage_options {
             match key.as_ref() {
-                "token" | "endpoint" => {
-                    continue;
-                }
+                "token" | "endpoint" => {}
                 "client_timeout" => {
                     storage_options.insert("timeout".into(), value.clone());
                 }

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -124,9 +124,7 @@ impl DeltaTable {
         let mut storage_options: HashMap<String, String> = HashMap::new();
         for (key, value) in options {
             match key.as_ref() {
-                "token" | "endpoint" => {
-                    continue;
-                }
+                "token" | "endpoint" => {}
                 "client_timeout" => {
                     storage_options.insert("timeout".into(), value.expose_secret().to_string());
                 }

--- a/crates/data_components/src/flight/stream.rs
+++ b/crates/data_components/src/flight/stream.rs
@@ -227,8 +227,8 @@ fn subscribe_to_stream(
                 while let Some(decoded_data) = stream.next().await {
                     match decoded_data {
                         Ok(decoded_data) => match decoded_data.payload {
-                          DecodedPayload::None => continue,
-                          DecodedPayload::Schema(_) => continue,
+                          DecodedPayload::None => {},
+                          DecodedPayload::Schema(_) => {},
                           DecodedPayload::RecordBatch(batch) => yield Ok(batch),
                         },
                         Err(error) => {

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -377,7 +377,7 @@ impl PaginationParameters {
         tracing::trace!("For PaginationParameters, searching json_pointer path: {current_path}");
         for selection in selections {
             match selection {
-                graphql_parser::query::Selection::FragmentSpread(_) => continue,
+                graphql_parser::query::Selection::FragmentSpread(_) => {}
                 graphql_parser::query::Selection::InlineFragment(InlineFragment {
                     selection_set,
                     ..

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -97,7 +97,7 @@ impl GraphQLTableProviderBuilder {
                     self.context.clone().and_then(|o| o.error_checker()),
                 )
                 .await?;
-        };
+        }
 
         let result = self
             .client

--- a/crates/data_components/src/unity_catalog.rs
+++ b/crates/data_components/src/unity_catalog.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use datafusion::sql::TableReference;
 use serde::Deserialize;
 use snafu::prelude::*;
+use std::fmt::Write;
 use url::Url;
 
 use token_provider::TokenProvider;
@@ -138,7 +139,7 @@ impl UnityCatalog {
         );
 
         if let Some(port) = parsed_url.port() {
-            endpoint.push_str(&format!(":{port}"));
+            let _ = write!(endpoint, ":{port}");
         }
 
         tracing::debug!("parse_catalog_url: endpoint: {}", endpoint);

--- a/crates/data_components/src/unity_catalog/provider.rs
+++ b/crates/data_components/src/unity_catalog/provider.rs
@@ -27,6 +27,7 @@ use snafu::prelude::*;
 use std::{
     any::Any,
     collections::HashMap,
+    fmt::Write,
     sync::{Arc, RwLock},
 };
 
@@ -249,13 +250,15 @@ impl UnityCatalogSchemaProvider {
                 self.schema.catalog_name, self.schema.name
             );
             if !removed_tables.is_empty() {
-                message.push_str(&format!("Tables removed: {}.", removed_tables.join(", ")));
+                let _ = write!(message, "Tables removed: {}.", removed_tables.join(", "));
             }
             if !new_table_providers.is_empty() {
                 if !removed_tables.is_empty() {
                     message.push(' ');
                 }
-                message.push_str(&format!(
+
+                let _ = write!(
+                    message,
                     "Tables added: {}.",
                     new_table_providers
                         .keys()
@@ -263,7 +266,7 @@ impl UnityCatalogSchemaProvider {
                         .collect::<Vec<_>>()
                         .as_slice()
                         .join(", ")
-                ));
+                );
             }
             tracing::info!("{}", message);
         }

--- a/crates/db_connection_pool/src/odbcpool.rs
+++ b/crates/db_connection_pool/src/odbcpool.rs
@@ -24,6 +24,7 @@ use sha2::{Digest, Sha256};
 use snafu::prelude::*;
 use std::{
     collections::HashMap,
+    fmt::Write,
     sync::{Arc, LazyLock},
 };
 
@@ -63,7 +64,7 @@ fn hash_string(val: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(val);
     hasher.finalize().iter().fold(String::new(), |mut hash, b| {
-        hash.push_str(&format!("{b:02x}"));
+        let _ = write!(hash, "{b:02x}");
         hash
     })
 }

--- a/crates/db_connection_pool/src/snowflakepool.rs
+++ b/crates/db_connection_pool/src/snowflakepool.rs
@@ -22,7 +22,7 @@ use pkcs8::{LineEnding, SecretDocument};
 use secrecy::{ExposeSecret, SecretBox, SecretString};
 use snafu::prelude::*;
 use snowflake_api::{SnowflakeApi, SnowflakeApiError};
-use std::{collections::HashMap, fs, sync::Arc};
+use std::{collections::HashMap, fmt::Write, fs, sync::Arc};
 
 use crate::dbconnection::snowflakeconn::SnowflakeConnection;
 
@@ -169,10 +169,10 @@ impl SnowflakeConnectionPool {
 
         let mut join_push_context_str = format!("username={username},account={account}");
         if let Some(warehouse) = warehouse {
-            join_push_context_str.push_str(&format!(",warehouse={warehouse}"));
+            let _ = write!(join_push_context_str, ",warehouse={warehouse}");
         }
         if let Some(role) = role {
-            join_push_context_str.push_str(&format!(",role={role}"));
+            let _ = write!(join_push_context_str, ",role={role}");
         }
 
         Ok(Self {

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -340,7 +340,6 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
             Err(FlightError::Tonic(status)) => {
                 display_grpc_error(&status);
                 last_error = Some(status);
-                continue;
             }
             Err(e) => {
                 println!(

--- a/crates/llms/src/chat/nsql/mod.rs
+++ b/crates/llms/src/chat/nsql/mod.rs
@@ -16,6 +16,8 @@ use async_openai::{
     types::{CreateChatCompletionRequest, CreateChatCompletionResponse},
 };
 
+use std::fmt::Write;
+
 pub mod default;
 pub(crate) mod json;
 pub(crate) mod structured_output;
@@ -76,10 +78,11 @@ pub fn create_prompt(query: &str, ctx: &QueryGenerationContext) -> String {
 fn failed_attempts_formatted(attempts: &Vec<FailedAttempt>) -> String {
     let mut previous_attempts = String::new();
     for attempt in attempts {
-        previous_attempts.push_str(&format!(
+        let _ = write!(
+            previous_attempts,
             "sql: `{}`\nerror: `{}`\n\n",
             attempt.attempted_query, attempt.error_message
-        ));
+        );
     }
     previous_attempts
 }

--- a/crates/llms/src/databricks.rs
+++ b/crates/llms/src/databricks.rs
@@ -60,7 +60,7 @@ pub fn from_access_token(
 
     if let Some(user_agent) = user_agent {
         cfg = cfg.with_header("user-agent", user_agent);
-    };
+    }
 
     Databricks {
         model: model.to_string(),
@@ -85,7 +85,7 @@ pub fn from_token_provider(
 
     if let Some(user_agent) = user_agent {
         cfg = cfg.with_header("user-agent", user_agent);
-    };
+    }
 
     Databricks {
         model: model.to_string(),

--- a/crates/model_components/src/modelsource/spiceai.rs
+++ b/crates/model_components/src/modelsource/spiceai.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::prelude::*;
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::io::Cursor;
 use std::string::ToString;
 use std::sync::Arc;
@@ -96,7 +97,7 @@ impl ModelSource for SpiceAI {
         match version.as_str() {
             "latest" => {}
             _ => {
-                url.push_str(&format!("?training_run_id={version}"));
+                let _ = write!(url, "?training_run_id={version}");
             }
         }
 

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -29,6 +29,7 @@ use iceberg_catalog_rest::RestCatalogConfig;
 use ns_lookup::verify_ns_lookup_and_tcp_connect;
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
+use std::fmt::Write;
 use std::{any::Any, collections::HashMap, sync::Arc};
 use url::Url;
 
@@ -367,7 +368,7 @@ fn parse_iceberg_url(url: &str) -> Result<(String, HashMap<String, String>, Iceb
     // Add any path segments before v1 to the base URI
     if v1_idx > 0 {
         let prefix_path = segments[..v1_idx].join("/");
-        base_uri.push_str(&format!("/{prefix_path}"));
+        let _ = write!(base_uri, "/{prefix_path}");
     }
 
     // Find the "namespaces" segment

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -997,7 +997,7 @@ where
                     .iter_mut()
                     .for_each(|item| all_selections.push(item));
             }
-            graphql_parser::query::Selection::FragmentSpread(_) => continue,
+            graphql_parser::query::Selection::FragmentSpread(_) => {}
         }
     }
 

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -414,7 +414,7 @@ pub fn subscribe_to_append_stream(
                 while let Some(decoded_data) = stream.next().await {
                     match decoded_data {
                         Ok(decoded_data) => match decoded_data.payload {
-                            DecodedPayload::None | DecodedPayload::Schema(_) => continue,
+                            DecodedPayload::None | DecodedPayload::Schema(_) => {},
                             DecodedPayload::RecordBatch(batch) => {
                                 match ChangeBatch::try_new(batch).map(|rb| {
                                     ChangeEnvelope::new(Box::new(SpiceAIChangeCommiter {}), rb)

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1349,7 +1349,7 @@ impl DataFusion {
                 tracing::error!("Failed to create view: {e}");
                 status.update_view(table, status::ComponentStatus::Error);
                 return;
-            };
+            }
             tracing::info!("{}", view_registered_trace(table, None));
             status.update_view(table, status::ComponentStatus::Ready);
         });

--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -84,7 +84,7 @@ pub(crate) async fn handle(
     // Check if the request should be rate limited.
     if let Some(rate_limit_check) = rate_limit_check_fn {
         rate_limit_check()?;
-    };
+    }
 
     match RequestContext::current(crate::request::AsyncMarker::new().await).auth_principal() {
         Some(principal) => {

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -135,7 +135,6 @@ impl Runtime {
                 );
                 self.status
                     .update_dataset(&ds.name, status::ComponentStatus::Error);
-                continue;
             }
         }
 

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -130,7 +130,7 @@ impl Runtime {
                     metrics::views::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", view_name.table());
                 }
-            };
+            }
         }
     }
 

--- a/crates/runtime/src/model/tool_use.rs
+++ b/crates/runtime/src/model/tool_use.rs
@@ -196,9 +196,9 @@ impl ToolUsingChat {
     ///
     /// Returns
     /// - `None` if no spiced runtime tools were used. Note: external tools may still have been
-    ///     requested.
+    ///   requested.
     /// - `Some(messages)` if spiced runtime tools were used. The returned messages are ready to be
-    ///     reprocessed by the model.
+    ///   reprocessed by the model.
     async fn process_tool_calls_and_run_spice_tools(
         &self,
         original_messages: Vec<ChatCompletionRequestMessage>,

--- a/crates/runtime/src/search/request.rs
+++ b/crates/runtime/src/search/request.rs
@@ -364,7 +364,7 @@ pub(crate) mod tests {
         match SearchRequest::parse_where_cond("column = 'value'".to_string()) {
             Ok(r) => assert_eq!(r.to_string(), "column = 'value'"),
             Err(e) => panic!("{}", e),
-        };
+        }
 
         // Test with WHERE keyword
         let result = SearchRequest::parse_where_cond("WHERE column = 'value'".to_string());

--- a/crates/runtime/src/secrets/mod.rs
+++ b/crates/runtime/src/secrets/mod.rs
@@ -156,7 +156,7 @@ impl Secrets {
         for store in self.stores.values() {
             match store.get_secret(key).await {
                 Ok(Some(secret)) => return Ok(Some(secret)),
-                Ok(None) => continue,
+                Ok(None) => {}
                 Err(e) => return Err(e),
             }
         }

--- a/crates/runtime/src/tools/mod.rs
+++ b/crates/runtime/src/tools/mod.rs
@@ -45,7 +45,7 @@ impl Tooling {
                 let catalog_name = c.name();
                 if default_catalog_names().contains(&catalog_name) {
                     return c.all().await;
-                };
+                }
 
                 // If non-default catalog, tool name must be prefixed by catalog.
                 c.all()

--- a/crates/runtime/src/tracing_util.rs
+++ b/crates/runtime/src/tracing_util.rs
@@ -105,7 +105,7 @@ fn acceleration_info(
     }
     if let Some(retention_check_interval) = &acceleration.retention_check_interval {
         if acceleration.retention_check_enabled {
-            let _ = write!(info, ", {retention_check_interval:#?} retention");
+            let _ = write!(info, ", {retention_check_interval} retention");
         }
     }
     if acceleration.on_zero_results == ZeroResultsAction::UseSource {

--- a/crates/runtime/src/tracing_util.rs
+++ b/crates/runtime/src/tracing_util.rs
@@ -26,6 +26,8 @@ use crate::{
     dataconnector::DataConnector,
 };
 
+use std::fmt::Write;
+
 // Format: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb), results cache enabled.
 pub fn dataset_registered_trace(
     data_connector: &dyn DataConnector,
@@ -35,10 +37,11 @@ pub fn dataset_registered_trace(
     let mut info = format!("Dataset {} registered ({})", &ds.name, &ds.from);
     if let Some(acceleration) = &ds.acceleration {
         if acceleration.enabled {
-            info.push_str(&format!(
+            let _ = write!(
+                info,
                 ", acceleration ({})",
                 acceleration_info(Some(data_connector), acceleration)
-            ));
+            );
         }
     }
 
@@ -58,10 +61,11 @@ pub fn view_registered_trace(
     let mut info = format!("View {table} registered");
     if let Some(acceleration) = acceleration {
         if acceleration.enabled {
-            info.push_str(&format!(
+            let _ = write!(
+                info,
                 ", acceleration ({})",
                 acceleration_info(None, acceleration)
-            ));
+            );
         }
     }
 
@@ -97,11 +101,11 @@ fn acceleration_info(
     }
 
     if let Some(refresh_interval) = &acceleration.refresh_check_interval {
-        info.push_str(&format!(", {refresh_interval:#?} refresh"));
+        let _ = write!(info, ", {refresh_interval:#?} refresh");
     }
     if let Some(retention_check_interval) = &acceleration.retention_check_interval {
         if acceleration.retention_check_enabled {
-            info.push_str(&format!(", {retention_check_interval} retention"));
+            let _ = write!(info, ", {retention_check_interval:#?} retention");
         }
     }
     if acceleration.on_zero_results == ZeroResultsAction::UseSource {

--- a/crates/runtime/tests/flight/mod.rs
+++ b/crates/runtime/tests/flight/mod.rs
@@ -185,7 +185,7 @@ fn create_flight_client(
         client
             .add_header("authorization", &format!("Bearer {api_key}"))
             .map_err(anyhow::Error::from)?;
-    };
+    }
 
     Ok(client)
 }

--- a/crates/test-framework/src/spicetest/http/consistency.rs
+++ b/crates/test-framework/src/spicetest/http/consistency.rs
@@ -326,11 +326,9 @@ impl ConsistencyWorker {
                     Ok(Err(e)) => {
                         eprintln!("Worker {} - Request failed: {}", self.id, e);
                         error_count += 1;
-                        continue;
                     }
                     Err(_) => {
                         eprintln!("Worker {} - Request timed out.", self.id);
-                        continue;
                     }
                 }
             }

--- a/crates/test-framework/src/spicetest/http/overhead.rs
+++ b/crates/test-framework/src/spicetest/http/overhead.rs
@@ -269,7 +269,6 @@ impl OverHeadWorker {
                     Err(e) => {
                         eprintln!("Worker {} - Request failed: {}", self.id, e);
                         error_count += 1;
-                        continue;
                     }
                 }
             }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -88,7 +88,7 @@ pub async fn force_shutdown_signal() {
     }) {
         tracing::error!("Failed to set listener for Ctrl-C: {err}");
         // do not exit; otherwise, it will be interpreted as a force shutdown signal
-    };
+    }
     on_second_ctrl_c.await.ok();
 }
 

--- a/crates/workers/src/router.rs
+++ b/crates/workers/src/router.rs
@@ -167,7 +167,6 @@ impl Chat for RouterModel {
                                 .content(e.to_string())
                                 .to_jsonl(),
                             );
-                            continue
                         },
 
                         // Check if first item in stream is `Err` since this is a common error by providers.
@@ -184,7 +183,6 @@ impl Chat for RouterModel {
                                         .content(e.to_string())
                                         .to_jsonl(),
                                     );
-                                    continue
                                 },
                                 None | Some(Ok(_)) => return Ok(peekable),
                             }
@@ -254,7 +252,6 @@ impl Chat for RouterModel {
                                 .content(e.to_string())
                                 .to_jsonl(),
                             );
-                            continue
                         },
 
                         Ok(resp) => return Ok(resp),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"
 components = ["rustc", "cargo", "rustfmt", "clippy"] 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Upgrades to Rust 1.86, while solving the following new clippy pedantic rules:
  * https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
    * Replaces with `let _ = write!()`, because `write!` returns a `Result` while `push_str` does not. However, when used in the manner we use it, it never returns an error so the result can be discarded.
  * https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
  * https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5944 
