### PR TITLE
feat: Add cron evaluator parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,6 +2911,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11151,6 +11162,8 @@ version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
+ "chrono",
+ "cron",
  "futures",
  "snafu",
  "tokio",
@@ -13061,7 +13074,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.7.2",
 ]
 
 [[package]]
@@ -14802,6 +14815,15 @@ dependencies = [
  "web-time",
  "windows-sys 0.52.0",
  "xkbcommon-dl",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -11,6 +11,8 @@ version.workspace = true
 [dependencies]
 arrow.workspace = true
 async-trait.workspace = true
+chrono.workspace = true
+cron = "0.15.0"
 futures.workspace = true
 snafu.workspace = true
 tokio = { workspace = true, features = ["time"] }

--- a/crates/scheduler/src/evaluators.rs
+++ b/crates/scheduler/src/evaluators.rs
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::any::Any;
 use std::sync::Arc;
+use std::{any::Any, str::FromStr};
 
-use crate::TaskRequest;
+use snafu::ResultExt;
+
+use crate::{Result, TaskRequest};
 
 pub trait ScheduleEvaluator: Iterator<Item = Arc<TaskRequest>> + Any + Send + Sync {
     /// Whether this schedule evaluator can deliver a task request with a delivery policy of ``TaskDelivery::Immediate``.
@@ -28,17 +30,52 @@ pub trait ScheduleEvaluator: Iterator<Item = Arc<TaskRequest>> + Any + Send + Sy
 }
 
 #[allow(dead_code)]
-pub struct CronSchedule(Arc<str>);
+pub struct CronSchedule<Z: chrono::offset::TimeZone + Send + Sync + 'static> {
+    schedule: cron::Schedule,
+    tz: Z,
+}
 
-impl Iterator for CronSchedule {
+impl<Z: chrono::offset::TimeZone + Send + Sync + 'static> CronSchedule<Z> {
+    /// Creates a new `CronSchedule` from a cron expression.
+    ///
+    /// # Errors
+    ///
+    /// If the provided cron expression is invalid.
+    pub fn new(cron: &Arc<str>, timezone: Z) -> Result<Self> {
+        let schedule = cron::Schedule::from_str(cron).context(super::UnableToParseCronSnafu {
+            cron: cron.to_string(),
+        })?;
+
+        Ok(CronSchedule {
+            schedule,
+            tz: timezone,
+        })
+    }
+}
+
+impl<Z: chrono::offset::TimeZone + Send + Sync + 'static> Iterator for CronSchedule<Z> {
     type Item = Arc<TaskRequest>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: implement cron schedule evaluation
-        Some(Arc::new(TaskRequest::now()))
+        let now = chrono::Utc::now().timestamp();
+        let next_cron = self.schedule.upcoming(self.tz.clone()).next();
+        match next_cron {
+            Some(next) => {
+                let ts = next.timestamp();
+                let duration = ts - now;
+                if duration < 0 {
+                    Some(Arc::new(TaskRequest::now()))
+                } else {
+                    #[allow(clippy::cast_sign_loss)] // safety: duration is always positive
+                    Some(Arc::new(TaskRequest::from_secs(duration as u64)))
+                }
+            }
+            None => None,
+        }
     }
 }
-impl ScheduleEvaluator for CronSchedule {}
+
+impl<Z: chrono::offset::TimeZone + Send + Sync + 'static> ScheduleEvaluator for CronSchedule<Z> {}
 
 pub struct IntervalSchedule(u64);
 
@@ -80,5 +117,126 @@ impl Iterator for ManualInterrupt {
 impl ScheduleEvaluator for ManualInterrupt {
     fn can_deliver_immediate_task(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use chrono::Timelike;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_manual_interrupt() {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        let mut manual_interrupt = ManualInterrupt::new(rx);
+
+        // Send an interrupt
+        let request = Arc::new(TaskRequest::now());
+
+        tx.send(Some(Arc::clone(&request)))
+            .await
+            .expect("To send interrupt");
+
+        // Receive the interrupt
+        let interrupt = manual_interrupt.next().expect("To get interrupt");
+        // Check that the interrupt is delivered
+        assert_eq!(interrupt, request);
+
+        // Check that the next call to next() returns None
+        assert!(manual_interrupt.next().is_none());
+
+        // Send a None interrupt
+        tx.send(None).await.expect("To send None interrupt");
+
+        // Receive the interrupt which is an automatic Immediate at current time
+        let now = Instant::now();
+        let interrupt = manual_interrupt.next().expect("To get None interrupt");
+        // Check that the interrupt is delivered
+        assert!(interrupt.at.duration_since(now) <= Duration::from_nanos(10000));
+    }
+
+    #[tokio::test]
+    async fn test_interval_schedule() {
+        let interval = 5;
+        let mut schedule = IntervalSchedule(interval);
+
+        let task = schedule.next().expect("To get task");
+        assert!(
+            (Instant::now() + Duration::from_secs(interval)).duration_since(task.at)
+                <= Duration::from_nanos(10000)
+        );
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let task = schedule.next().expect("To get task");
+        assert!(
+            (Instant::now() + Duration::from_secs(interval)).duration_since(task.at)
+                <= Duration::from_nanos(10000)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cron_evaluator_every_5_seconds() {
+        let cron = "*/5 * * * * ? *".into();
+        let timezone = chrono::Utc;
+        let mut schedule = CronSchedule::new(&cron, timezone).expect("To create cron schedule");
+        let now = Instant::now();
+        let chrono_now = chrono::Utc::now();
+        let task = schedule.next().expect("To get task");
+        let time_till = task.at.duration_since(now);
+        let time = chrono_now + time_till;
+
+        assert!(
+            time.second() % 5 == 0 && task.at.duration_since(now) > Duration::from_secs(0),
+            "Expected task to be scheduled in the future on the 5th second, but got: {:?}",
+            time.second()
+        );
+
+        let last_duration = task.at.duration_since(now);
+
+        // cron returns the next schedule in the series, so the .next() item will be the next schedule point
+        let task = schedule.next().expect("To get task");
+        let time_till = task.at.duration_since(now);
+        let time = chrono_now + time_till;
+
+        assert!(
+            time.second() % 5 == 0 && task.at.duration_since(now) > last_duration,
+            "Expected task to be scheduled in the future on the 5th second, but got: {:?}",
+            time.second()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cron_evaluator_every_13_seconds() {
+        let cron = "*/13 * * * * ? *".into();
+        let timezone = chrono::Utc;
+        let mut schedule = CronSchedule::new(&cron, timezone).expect("To create cron schedule");
+        let now = Instant::now();
+        let chrono_now = chrono::Utc::now();
+        let task = schedule.next().expect("To get task");
+        let time_till = task.at.duration_since(now);
+        let time = chrono_now + time_till;
+
+        assert!(
+            time.second() % 13 == 0 && task.at.duration_since(now) > Duration::from_secs(0),
+            "Expected task to be scheduled in the future on the 5th second, but got: {:?}",
+            time.second()
+        );
+
+        let last_duration = task.at.duration_since(now);
+
+        // cron returns the next schedule in the series, so the .next() item will be the next schedule point
+        let task = schedule.next().expect("To get task");
+        let time_till = task.at.duration_since(now);
+        let time = chrono_now + time_till;
+
+        assert!(
+            time.second() % 13 == 0 && task.at.duration_since(now) > last_duration,
+            "Expected task to be scheduled in the future on the 5th second, but got: {:?}",
+            time.second()
+        );
     }
 }

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -27,7 +27,15 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Snafu)]
-pub enum Error {}
+pub enum Error {
+    #[snafu(display(
+        "Failed to parse the provided cron expression: {cron}\n{source}\nEnsure the cron expression is valid, and try again."
+    ))]
+    UnableToParseCron {
+        source: cron::error::Error,
+        cron: String,
+    },
+}
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Uses the popular `cron` crate for parsing the cron expression. With a given timezone, evaluates cron expressions out to their next possible expression time on each `.next()`.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5918 
* Part of #5683
