### PR TITLE
Update JSON to ScalarValue type conversion to match DataFusion behavior

### DIFF
--- a/crates/runtime/src/datafusion/param_utils.rs
+++ b/crates/runtime/src/datafusion/param_utils.rs
@@ -71,12 +71,10 @@ fn json_to_scalar(json: &Value) -> Result<ScalarValue, Error> {
         Value::Null => Ok(ScalarValue::Utf8(None)),
         Value::Bool(b) => Ok(ScalarValue::Boolean(Some(*b))),
         Value::Number(n) => {
-            if let Some(i) = n.as_u64() {
-                Ok(ScalarValue::UInt64(Some(i)))
+            if let Some(i) = n.as_i64() {
+                Ok(ScalarValue::Int64(Some(i)))
             } else if let Some(f) = n.as_f64() {
                 Ok(ScalarValue::Float64(Some(f)))
-            } else if let Some(i) = n.as_i64() {
-                Ok(ScalarValue::Int64(Some(i)))
             } else {
                 Err(Error::UnsupportedJsonNumberFormat)
             }
@@ -115,7 +113,7 @@ mod tests {
         let json = json!([1, "hello", true, null]);
         let got = convert_json_to_param_values(json).expect("convert to param values");
         let want = ParamValues::List(vec![
-            ScalarValue::UInt64(Some(1)),
+            ScalarValue::Int64(Some(1)),
             ScalarValue::Utf8(Some("hello".to_string())),
             ScalarValue::Boolean(Some(true)),
             ScalarValue::Utf8(None),
@@ -129,7 +127,7 @@ mod tests {
         let json = json!({"x": 42, "y": "world", "z": false});
         let got = convert_json_to_param_values(json).expect("convert to param values");
         let mut want = HashMap::new();
-        want.insert("x".to_string(), ScalarValue::UInt64(Some(42)));
+        want.insert("x".to_string(), ScalarValue::Int64(Some(42)));
         want.insert(
             "y".to_string(),
             ScalarValue::Utf8(Some("world".to_string())),


### PR DESCRIPTION
## 📝 Summary

Update scalar value type inference logic for numeric values to use Int64 instead of UInt64 (for positive numerics) and Float64 (for negative numerics; this is because Float64 was before Int64 so always used) to match DataFusion value conversion logic.

Below is example DataFusion behavior.


```
datafusion-cli
DataFusion CLI v47.0.0

> CREATE VIEW temp_literals AS
SELECT
    1             AS int_pos_one,
    0             AS int_zero,
    -1            AS int_neg_one,
    1.0           AS float_one,
    true          AS bool_true,
    'foo'         AS str_foo,
    NULL          AS null_val
;
0 row(s) fetched. 
Elapsed 0.002 seconds.

> DESCRIBE temp_literals;
+-------------+-----------+-------------+
| column_name | data_type | is_nullable |
+-------------+-----------+-------------+
| int_pos_one | Int64     | NO          |
| int_zero    | Int64     | NO          |
| int_neg_one | Int64     | NO          |
| float_one   | Float64   | NO          |
| bool_true   | Boolean   | NO          |
| str_foo     | Utf8      | NO          |
| null_val    | Null      | YES         |
+-------------+-----------+-------------+
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
