### PR TITLE
Fix DataFusion dependency loading in Databricks request context extension

### DIFF
--- a/crates/runtime/src/flight/middleware/request_context.rs
+++ b/crates/runtime/src/flight/middleware/request_context.rs
@@ -86,6 +86,7 @@ where
         let request_context = Arc::new(
             RequestContext::builder(Protocol::Flight)
                 .with_app_opt(self.app.clone())
+                .with_df_opt(Some(self.df.clone()))
                 .from_headers(headers)
                 .build(),
         );

--- a/crates/runtime/src/flight/middleware/request_context.rs
+++ b/crates/runtime/src/flight/middleware/request_context.rs
@@ -86,7 +86,7 @@ where
         let request_context = Arc::new(
             RequestContext::builder(Protocol::Flight)
                 .with_app_opt(self.app.clone())
-                .with_df_opt(Some(self.df.clone()))
+                .with_df_opt(Some(Arc::clone(&self.df)))
                 .from_headers(headers)
                 .build(),
         );

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -263,6 +263,7 @@ async fn track_metrics(
     let request_context = Arc::new(
         RequestContext::builder(Protocol::Http)
             .with_app_opt(app_lock.as_ref().map(Arc::clone))
+            .with_df_opt(Some(df.clone()))
             .from_headers(&headers)
             .build(),
     );

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -263,7 +263,7 @@ async fn track_metrics(
     let request_context = Arc::new(
         RequestContext::builder(Protocol::Http)
             .with_app_opt(app_lock.as_ref().map(Arc::clone))
-            .with_df_opt(Some(df.clone()))
+            .with_df_opt(Some(Arc::clone(&df)))
             .from_headers(&headers)
             .build(),
     );

--- a/crates/runtime/src/request/context.rs
+++ b/crates/runtime/src/request/context.rs
@@ -28,6 +28,8 @@ use opentelemetry::KeyValue;
 use runtime_auth::{AuthPrincipalRef, AuthRequestContext};
 use spicepod::component::runtime::UserAgentCollection;
 
+use crate::datafusion::DataFusion;
+
 use super::{CacheControl, CacheKeyType, DatabricksAuthExtension, Protocol, UserAgent, baggage};
 
 type Extensions = HashMap<TypeId, Arc<dyn Any + Send + Sync>>;
@@ -210,6 +212,7 @@ pub struct RequestContextBuilder {
     protocol: Protocol,
     cache_control: CacheControl,
     app: Option<Arc<App>>,
+    df: Option<Arc<DataFusion>>,
     user_agent: UserAgent,
     baggage: Vec<KeyValue>,
     extensions: Extensions,
@@ -222,6 +225,7 @@ impl RequestContextBuilder {
             protocol,
             cache_control: CacheControl::Cache(CacheKeyType::Default),
             app: None,
+            df: None,
             user_agent: UserAgent::Absent,
             baggage: vec![],
             extensions: Extensions::default(),
@@ -231,6 +235,12 @@ impl RequestContextBuilder {
     #[must_use]
     pub fn with_app_opt(mut self, app: Option<Arc<App>>) -> Self {
         self.app = app;
+        self
+    }
+
+    #[must_use]
+    pub fn with_df_opt(mut self, df: Option<Arc<DataFusion>>) -> Self {
+        self.df = df;
         self
     }
 
@@ -250,7 +260,8 @@ impl RequestContextBuilder {
         self.baggage.extend(baggage::from_headers(headers));
 
         let app = self.app.as_ref().map(Arc::clone);
-        if let Some(extension) = DatabricksAuthExtension::from_headers(&app, headers) {
+        let df = self.df.as_ref().map(Arc::clone);
+        if let Some(extension) = DatabricksAuthExtension::from_headers(&app, &df, headers) {
             self.extensions
                 .insert(TypeId::of::<DatabricksAuthExtension>(), Arc::new(extension));
         }

--- a/crates/runtime/src/request/databricks.rs
+++ b/crates/runtime/src/request/databricks.rs
@@ -26,14 +26,12 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::{
-    datafusion::request_context_extension::DataFusionContextExtension,
-    request::{AsyncMarker, RequestContext},
-};
+use crate::datafusion::DataFusion;
 
 #[derive(Clone)]
 pub struct DatabricksAuthExtension {
     app: Option<Arc<App>>,
+    df: Option<Arc<DataFusion>>,
     tokens: Arc<HashMap<String, SecretString>>,
 }
 
@@ -41,6 +39,7 @@ impl Default for DatabricksAuthExtension {
     fn default() -> Self {
         Self {
             app: None,
+            df: None,
             tokens: Arc::new(HashMap::new()),
         }
     }
@@ -48,7 +47,11 @@ impl Default for DatabricksAuthExtension {
 
 impl DatabricksAuthExtension {
     #[must_use]
-    pub fn from_headers(app: &Option<Arc<App>>, headers: &HeaderMap) -> Option<Self> {
+    pub fn from_headers(
+        app: &Option<Arc<App>>,
+        df: &Option<Arc<DataFusion>>,
+        headers: &HeaderMap,
+    ) -> Option<Self> {
         let databricks_headers = headers.get_all("Spice-Databricks-Auth");
         let values = databricks_headers.iter();
 
@@ -73,6 +76,7 @@ impl DatabricksAuthExtension {
         } else {
             Some(Self {
                 app: app.as_ref().map(Arc::clone),
+                df: df.as_ref().map(Arc::clone),
                 tokens: Arc::new(auth_map),
             })
         }
@@ -84,12 +88,7 @@ impl DatabricksAuthExtension {
     }
 
     pub async fn load_u2m_components(&self) {
-        let context = RequestContext::current(AsyncMarker::new().await);
-        if let (Some(app), Some(df)) = (
-            self.app.clone(),
-            context.extension::<DataFusionContextExtension>(),
-        ) {
-            let df = df.datafusion();
+        if let (Some(app), Some(df)) = (self.app.clone(), self.df.clone()) {
             let client_ids = self.tokens.keys().cloned().collect::<Vec<_>>();
             let databricks_u2m_datasets: Vec<Dataset> = app
                 .datasets


### PR DESCRIPTION
## 📝 Summary

Fixed the initialization of the Databricks request context extension. Previously, it relied on the DataFusion extension, which was not guaranteed to load before Databricks.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
