### PR TITLE
feat: Add a CronRequestChannel for `scheduler`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,6 +2911,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "croner"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fd53511eaf0b00a185613875fee58b208dfce016577d0ad4bb548e1c4fb3ee"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11152,6 +11161,8 @@ version = "1.4.0-unstable"
 dependencies = [
  "arrow",
  "async-trait",
+ "chrono",
+ "croner",
  "futures",
  "snafu",
  "tokio",

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -11,6 +11,8 @@ version.workspace = true
 [dependencies]
 arrow.workspace = true
 async-trait.workspace = true
+chrono.workspace = true
+croner = "2.0.6"
 futures.workspace = true
 snafu.workspace = true
 tokio = { workspace = true, features = ["time"] }

--- a/crates/scheduler/README.md
+++ b/crates/scheduler/README.md
@@ -11,7 +11,7 @@ The `scheduler` crate provides a flexible, asynchronous task scheduling framewor
 - **Async/Await:** Fully asynchronous, leveraging Tokio for concurrency.
 - **Extensible:** Easily add new types of channels or scheduled tasks.
 
-## Packaged Triggers
+## Included Triggers
 
 - **Manual:** Passthrough task requests from a managed channel, or send `None` to generate requests which interrupt in-progress tasks.
 - **Interval:** Run tasks on a set interval, determined at the last completion time of the task.
@@ -37,6 +37,7 @@ use scheduler::{
     schedule::Schedule,
     scheduler::Scheduler,
     channel::interval::IntervalRequestChannel,
+    channel::cron::CronRequestChannel,
     task::ScheduledTask,
 };
 use std::sync::Arc;
@@ -56,7 +57,8 @@ impl ScheduledTask for MyTask {
 #[tokio::main]
 async fn main() {
     let schedule = Schedule::new(Arc::new(MyTask))
-        .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(5)))); // every 5 seconds
+        .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(5)))) // every 5 seconds
+        .add_trigger(Arc::new(RwLock::new(CronRequestChannel::new("0 * * * *").expect("Should parse cron expression")))); // on the hour, every hour
 
     let scheduler = Scheduler::new("example_scheduler".into(), vec![Arc::new(schedule)]);
     let running_scheduler = scheduler.start().await.expect("Scheduler should start");

--- a/crates/scheduler/README.md
+++ b/crates/scheduler/README.md
@@ -11,6 +11,12 @@ The `scheduler` crate provides a flexible, asynchronous task scheduling framewor
 - **Async/Await:** Fully asynchronous, leveraging Tokio for concurrency.
 - **Extensible:** Easily add new types of channels or scheduled tasks.
 
+## Packaged Triggers
+
+- **Manual:** Passthrough task requests from a managed channel, or send `None` to generate requests which interrupt in-progress tasks.
+- **Interval:** Run tasks on a set interval, determined at the last completion time of the task.
+- **Cron:** Run tasks based on cron expressions, based on the seconds-optional cron expression format (like `*/5 * * * * *` for at every 5th second).
+
 ## Concepts
 
 - **Schedule:** A collection of tasks and channels (triggers).
@@ -76,4 +82,3 @@ The following features are planned:
 
 - **Retry Mechanisms:** Support for automatic retries of failed tasks, with configurable backoff strategies and retry limits.
 - **Parallelism Controls:** Ability to limit the number of concurrently running tasks per schedule or globally, to better manage resource usage.
-- **Cron Scheduling:** Native support for cron-like scheduling expressions, enabling more flexible and calendar-based task triggers.

--- a/crates/scheduler/src/channel/cron.rs
+++ b/crates/scheduler/src/channel/cron.rs
@@ -193,9 +193,9 @@ mod tests {
             .await
             .expect("Should receive another task request");
         let next_now = Local::now();
-        let elapsed = next_now.signed_duration_since(now).num_seconds();
-        assert_eq!(
-            elapsed, 5,
+        let elapsed = next_now.signed_duration_since(now).num_milliseconds();
+        assert!(
+            elapsed >= 4950 && elapsed <= 5050,
             "The next request should be sent after 5 seconds"
         );
         assert!(

--- a/crates/scheduler/src/channel/cron.rs
+++ b/crates/scheduler/src/channel/cron.rs
@@ -1,0 +1,346 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Local;
+use croner::Cron;
+use snafu::{OptionExt, ResultExt};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::Result;
+use crate::task::TaskRequest;
+
+use super::TaskRequestChannel;
+
+pub struct CronRequestChannel {
+    cancellation: Option<Arc<CancellationToken>>,
+    task_completion: Option<Arc<tokio::sync::Notify>>,
+    reset: Option<Arc<tokio::sync::Notify>>,
+    tx: Option<Arc<tokio::sync::mpsc::Sender<Arc<TaskRequest>>>>,
+    cron: Arc<Cron>,
+}
+
+impl CronRequestChannel {
+    /// Creates a new `CronRequestChannel` with the given cron expression.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the cron expression is invalid or cannot be parsed.
+    pub fn new(cron: &Arc<str>) -> Result<Self> {
+        Ok(Self {
+            cancellation: None,
+            task_completion: None,
+            reset: None,
+            tx: None,
+            cron: Arc::new(
+                Cron::new(cron)
+                    .with_seconds_optional()
+                    .parse()
+                    .context(crate::FailedToParseCronSnafu)?,
+            ),
+        })
+    }
+}
+
+impl TaskRequestChannel for CronRequestChannel {
+    fn set_cancellation_token(&mut self, cancellation: Arc<CancellationToken>) {
+        self.cancellation = Some(cancellation);
+    }
+
+    fn set_task_completion_notification(&mut self, notify: Arc<tokio::sync::Notify>) {
+        self.task_completion = Some(notify);
+    }
+
+    fn set_reset_notification(&mut self, notify: Arc<tokio::sync::Notify>) {
+        self.reset = Some(notify);
+    }
+
+    fn set_submission_channel(&mut self, tx: Arc<tokio::sync::mpsc::Sender<Arc<TaskRequest>>>) {
+        self.tx = Some(tx);
+    }
+
+    fn start(&self) -> Result<JoinHandle<Result<()>>> {
+        // cancellation token to cancel the background task
+        let cancellation = self
+            .cancellation
+            .clone()
+            .context(crate::CancellationTokenRequiredSnafu)?;
+        // reset channel to advise the requestor to reset and wait for the next notification
+        // e.g. another requestor has started a task, and the task is currently running
+        let reset = self
+            .reset
+            .clone()
+            .context(crate::NotificationChannelRequiredSnafu)?;
+        // notification channel to notify the requestor that a task has been completed
+        let task_completion = self
+            .task_completion
+            .clone()
+            .context(crate::NotificationChannelRequiredSnafu)?;
+        // request submission channel to send the request
+        let tx = self
+            .tx
+            .clone()
+            .context(crate::SubmissionChannelRequiredSnafu)?;
+        let cron = Arc::clone(&self.cron);
+
+        Ok(tokio::spawn(async move {
+            let mut first_run = true;
+            loop {
+                if first_run {
+                    first_run = false;
+                } else {
+                    tokio::select! {
+                        () = cancellation.cancelled() => {
+                            tracing::debug!("Cron evaluator cancelled");
+                            return Ok(());
+                        }
+                        () = reset.notified() => {
+                            tracing::debug!("Cron evaluator reset");
+                            continue;
+                        }
+                        () = task_completion.notified() => {
+                            tracing::debug!("Cron evaluator notified");
+                        }
+                    }
+                }
+
+                let time = Local::now();
+                let next = cron
+                    .find_next_occurrence(&time, false)
+                    .context(crate::FailedToDetermineNextCronRunTimeSnafu)?;
+
+                let duration_till = next.signed_duration_since(time);
+                // .to_std() errors when the duration is less than zero - the next expression time is in the past
+                let interval = duration_till.to_std().unwrap_or(Duration::from_secs(1));
+
+                tokio::select! {
+                    () = cancellation.cancelled() => {
+                        tracing::debug!("Cron evaluator cancelled");
+                        return Ok(());
+                    }
+                    () = reset.notified() => {
+                        tracing::debug!("Cron evaluator reset");
+                        continue;
+                    }
+                    () = tokio::time::sleep(interval) => {
+                        tracing::debug!("Cron evaluator time elapsed");
+                    }
+                }
+
+                tx.send(Arc::new(TaskRequest::default()))
+                    .await
+                    .context(crate::ChannelSendSnafu)?;
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Timelike;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cron_request_channel() {
+        let cron_expression = "*/5 * * * * *".into();
+        let mut channel =
+            CronRequestChannel::new(&cron_expression).expect("Cron expression should be valid");
+
+        let cancellation_token = Arc::new(CancellationToken::new());
+        channel.set_cancellation_token(Arc::clone(&cancellation_token));
+
+        let task_completion = Arc::new(tokio::sync::Notify::new());
+        channel.set_task_completion_notification(Arc::clone(&task_completion));
+
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
+        channel.set_reset_notification(Arc::clone(&reset_notify));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(5);
+        channel.set_submission_channel(Arc::new(tx));
+
+        let handle = channel.start().expect("Cron channel should start");
+
+        let request = rx.recv().await.expect("Should receive a task request");
+        let now = Local::now();
+        assert!(
+            now.second() % 5 == 0,
+            "The request should be sent at a 5-second interval"
+        );
+        assert!(!request.cancel_running);
+        assert!(!request.clear_queue);
+
+        task_completion.notify_waiters();
+
+        let request = rx
+            .recv()
+            .await
+            .expect("Should receive another task request");
+        let next_now = Local::now();
+        let elapsed = next_now.signed_duration_since(now).num_seconds();
+        assert_eq!(
+            elapsed, 5,
+            "The next request should be sent after 5 seconds"
+        );
+        assert!(
+            next_now.second() % 5 == 0,
+            "The request should be sent at a 5-second interval"
+        );
+        assert!(!request.cancel_running);
+        assert!(!request.clear_queue);
+
+        cancellation_token.cancel();
+        handle
+            .await
+            .expect("Should join handle")
+            .expect("Handle should end successfully");
+    }
+
+    #[tokio::test]
+    async fn test_cron_resets_to_next() {
+        // resetting while in-between a schedule should evaluate to the same next instance again
+        let cron_expression = "*/5 * * * * *".into();
+        let mut channel =
+            CronRequestChannel::new(&cron_expression).expect("Cron expression should be valid");
+
+        let cancellation_token = Arc::new(CancellationToken::new());
+        channel.set_cancellation_token(Arc::clone(&cancellation_token));
+
+        let task_completion = Arc::new(tokio::sync::Notify::new());
+        channel.set_task_completion_notification(Arc::clone(&task_completion));
+
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
+        channel.set_reset_notification(Arc::clone(&reset_notify));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(5);
+        channel.set_submission_channel(Arc::new(tx));
+
+        let handle = channel.start().expect("Cron channel should start");
+
+        // Wait for the first request to peg to the interval
+        let request = rx.recv().await.expect("Should receive a task request");
+        let last_now = Local::now();
+        assert!(
+            last_now.second() % 5 == 0,
+            "The request should be sent at a 5-second interval"
+        );
+        assert!(!request.cancel_running);
+        assert!(!request.clear_queue);
+
+        task_completion.notify_waiters();
+
+        tokio::select! {
+            request = rx.recv() => {
+                panic!("Should not receive a task request yet, got: {request:?}");
+            }
+            () = tokio::time::sleep(Duration::from_secs(2)) => {
+                reset_notify.notify_waiters();
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        task_completion.notify_waiters();
+        let now = Local::now();
+
+        let request = rx
+            .recv()
+            .await
+            .expect("Should receive another task request");
+        let next_now = Local::now();
+        let elapsed = next_now.signed_duration_since(now).num_seconds();
+        let original_elapsed = next_now.signed_duration_since(last_now).num_seconds();
+        assert!(
+            elapsed == 3 || elapsed == 2,
+            "The next request should be sent after 2  or 3 seconds"
+        );
+        assert_eq!(
+            original_elapsed, 5,
+            "The next request should be sent after 5 seconds from the last request"
+        );
+        assert!(
+            next_now.second() % 5 == 0,
+            "The request should be sent at a 5-second interval"
+        );
+        assert!(!request.cancel_running);
+        assert!(!request.clear_queue);
+
+        cancellation_token.cancel();
+        handle
+            .await
+            .expect("Should join handle")
+            .expect("Handle should end successfully");
+    }
+
+    #[tokio::test]
+    async fn test_cron_seconds_optional() {
+        let cron_expression = "* * * * *".into(); // every minute
+        let mut channel =
+            CronRequestChannel::new(&cron_expression).expect("Cron expression should be valid");
+
+        let cancellation_token = Arc::new(CancellationToken::new());
+        channel.set_cancellation_token(Arc::clone(&cancellation_token));
+
+        let task_completion = Arc::new(tokio::sync::Notify::new());
+        channel.set_task_completion_notification(Arc::clone(&task_completion));
+
+        let reset_notify = Arc::new(tokio::sync::Notify::new());
+        channel.set_reset_notification(Arc::clone(&reset_notify));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(5);
+        channel.set_submission_channel(Arc::new(tx));
+
+        let handle = channel.start().expect("Cron channel should start");
+
+        let request = rx.recv().await.expect("Should receive a task request");
+        let now = Local::now();
+        assert_eq!(
+            now.second(),
+            0,
+            "The request should be sent at a minute interval"
+        );
+        assert!(!request.cancel_running);
+        assert!(!request.clear_queue);
+
+        task_completion.notify_waiters();
+
+        let request = rx
+            .recv()
+            .await
+            .expect("Should receive another task request");
+        let next_now = Local::now();
+        let elapsed = next_now.signed_duration_since(now).num_milliseconds();
+        assert!(
+            elapsed >= 5950 || elapsed <= 6050,
+            "The next request should be sent around the minute mark"
+        );
+        assert_eq!(
+            next_now.second(),
+            0,
+            "The request should be sent at a 0-second interval"
+        );
+        assert!(!request.cancel_running);
+        assert!(!request.clear_queue);
+
+        cancellation_token.cancel();
+        handle
+            .await
+            .expect("Should join handle")
+            .expect("Handle should end successfully");
+    }
+}

--- a/crates/scheduler/src/channel/cron.rs
+++ b/crates/scheduler/src/channel/cron.rs
@@ -195,7 +195,7 @@ mod tests {
         let next_now = Local::now();
         let elapsed = next_now.signed_duration_since(now).num_milliseconds();
         assert!(
-            elapsed >= 4950 && elapsed <= 5050,
+            (4950..=5050).contains(&elapsed),
             "The next request should be sent after 5 seconds"
         );
         assert!(
@@ -326,7 +326,7 @@ mod tests {
         let next_now = Local::now();
         let elapsed = next_now.signed_duration_since(now).num_milliseconds();
         assert!(
-            elapsed >= 5950 || elapsed <= 6050,
+            (59900..=60100).contains(&elapsed),
             "The next request should be sent around the minute mark"
         );
         assert_eq!(

--- a/crates/scheduler/src/channel/mod.rs
+++ b/crates/scheduler/src/channel/mod.rs
@@ -22,6 +22,7 @@ use tokio_util::sync::CancellationToken;
 use crate::Result;
 use crate::task::TaskRequest;
 
+pub mod cron;
 pub mod interval;
 pub mod manual;
 

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -21,19 +21,31 @@ use task::TaskRequest;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("A cancellation token is required"))]
+    #[snafu(display(
+        "A cancellation token is required.\nThis is likely an internal error, if builtin task request triggers are used.\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
+    ))]
     CancellationTokenRequired,
-    #[snafu(display("A notification channel is required"))]
+    #[snafu(display(
+        "A notification channel is required.\nThis is likely an internal error, if builtin task request triggers are used.\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
+    ))]
     NotificationChannelRequired,
-    #[snafu(display("A submission channel is required"))]
+    #[snafu(display(
+        "A submission channel is required.\nThis is likely an internal error, if builtin task request triggers are used.\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
+    ))]
     SubmissionChannelRequired,
-    #[snafu(display("A channel send error occurred: {source}"))]
+    #[snafu(display(
+        "A channel send error occurred.\n{source}\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
+    ))]
     ChannelSendError {
         source: tokio::sync::mpsc::error::SendError<Arc<TaskRequest>>,
     },
-    #[snafu(display("Failed to parse cron expression: {source}"))]
+    #[snafu(display(
+        "Failed to parse cron expression.\n{source}\nValidate the cron expression is valid, and try again."
+    ))]
     FailedToParseCron { source: croner::errors::CronError },
-    #[snafu(display("Failed to determine next cron expression run time: {source}"))]
+    #[snafu(display(
+        "Failed to determine next cron expression run time.\n{source}\nValidate the cron expression is valid, and try again."
+    ))]
     FailedToDetermineNextCronRunTime { source: croner::errors::CronError },
 }
 

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -31,6 +31,10 @@ pub enum Error {
     ChannelSendError {
         source: tokio::sync::mpsc::error::SendError<Arc<TaskRequest>>,
     },
+    #[snafu(display("Failed to parse cron expression: {source}"))]
+    FailedToParseCron { source: croner::errors::CronError },
+    #[snafu(display("Failed to determine next cron expression run time: {source}"))]
+    FailedToDetermineNextCronRunTime { source: croner::errors::CronError },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds a `CronRequestChannel` to parse cron expressions, and send task requests based on cron schedules
* The cron expressions are evaluated against the Local timezone of the system it runs on. For example, in helm deployments, ensure the pods are configured with the correct timezone for the configured schedules.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5918
* Part of #5683
