### PR TITLE
refactor: Deprecate results_cache for caching.sql_results

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -36,14 +36,13 @@ use runtime::config::Config as RuntimeConfig;
 use runtime::datafusion::DataFusion;
 use runtime::podswatcher::PodsWatcher;
 use runtime::spice_metrics;
-use runtime::{Runtime, auth::EndpointAuth, extension::ExtensionFactory};
+use runtime::{Runtime, auth::EndpointAuth, extension::ExtensionFactory, in_tracing_context};
 use serde_yaml::Value;
 use snafu::prelude::*;
 use spice_cloud::SpiceExtensionFactory;
 use spiced_tracing::LogVerbosity;
 #[cfg(feature = "tpc-extension")]
 use tpc_extension::TpcExtensionFactory;
-use tracing::subscriber;
 
 #[path = "tracing.rs"]
 mod spiced_tracing;
@@ -444,14 +443,4 @@ fn apply_override(
     }
 
     Ok(())
-}
-
-pub fn in_tracing_context<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_ansi(true)
-        .finish();
-    subscriber::with_default(subscriber, f)
 }

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
     }
 
     if let Err(err) = tokio_runtime.block_on(start_runtime(args)) {
-        spiced::in_tracing_context(|| {
+        runtime::in_tracing_context(|| {
             tracing::error!("{err}");
         });
     }
@@ -93,7 +93,7 @@ fn main() {
 }
 
 async fn start_runtime(args: spiced::Args) -> Result<(), Box<dyn std::error::Error>> {
-    spiced::in_tracing_context(|| {
+    runtime::in_tracing_context(|| {
         if let Some(allocator_name) = get_allocator_name() {
             tracing::info!(
                 "Starting runtime {version} (allocator: {allocator_name})",

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -205,7 +205,7 @@ impl AppBuilder {
 
     #[must_use]
     pub fn with_results_cache(mut self, results_cache: ResultsCache) -> AppBuilder {
-        self.runtime.results_cache = results_cache;
+        self.runtime.results_cache = Some(results_cache);
         self
     }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -43,7 +43,6 @@ use futures::task::{Context, Poll};
 use lru_cache::LruCache;
 use snafu::{ResultExt, Snafu};
 use spicepod::component::runtime::HashingAlgorithm;
-use spicepod::component::runtime::ResultsCache;
 
 mod lru_cache;
 mod metrics;
@@ -51,6 +50,7 @@ mod simple_cache;
 mod utils;
 
 pub use simple_cache::SimpleCache;
+use spicepod::component::runtime::SQLResultsCacheConfig;
 pub use utils::get_logical_plan_input_tables;
 pub use utils::to_cached_record_batch_stream;
 
@@ -324,21 +324,24 @@ impl QueryResultsCacheProvider {
     /// # Errors
     ///
     /// Will return `Err` if method fails to parse cache params or to create the cache
-    pub fn try_new(config: &ResultsCache, ignore_schemas: Box<[Box<str>]>) -> Result<Self> {
-        let cache_max_size: u64 = match &config.cache_max_size {
+    pub fn try_new(
+        config: &SQLResultsCacheConfig,
+        ignore_schemas: Box<[Box<str>]>,
+    ) -> Result<Self> {
+        let cache_max_size: u64 = match &config.inner.max_size {
             Some(cache_max_size) => Byte::parse_str(cache_max_size, true)
                 .context(FailedToParseCacheMaxSizeSnafu)?
                 .as_u64(),
             None => 128 * 1024 * 1024, // 128 MiB
         };
 
-        let ttl = match &config.item_ttl {
+        let ttl = match &config.inner.item_ttl {
             Some(item_ttl) => fundu::parse_duration(item_ttl).context(FailedToParseItemTtlSnafu)?,
             None => std::time::Duration::from_secs(1),
         };
 
         let cache_provider = QueryResultsCacheProvider {
-            cache: match config.hashing_algorithm {
+            cache: match config.inner.hashing_algorithm {
                 HashingAlgorithm::Ahash => Arc::new(LruCache::new(
                     cache_max_size,
                     ttl,
@@ -503,7 +506,7 @@ mod tests {
         let logical_plan = parse_sql_to_logical_plan(sql).await;
 
         let cache_provider =
-            QueryResultsCacheProvider::try_new(&ResultsCache::default(), Box::new([]))
+            QueryResultsCacheProvider::try_new(&SQLResultsCacheConfig::default(), Box::new([]))
                 .expect("valid cache provider");
 
         assert!(!cache_provider.cache_is_enabled_for_plan(&logical_plan));
@@ -515,7 +518,7 @@ mod tests {
         let logical_plan = parse_sql_to_logical_plan(sql).await;
 
         let cache_provider = QueryResultsCacheProvider::try_new(
-            &ResultsCache::default(),
+            &SQLResultsCacheConfig::default(),
             Box::new(["information_schema".into()]),
         )
         .expect("valid cache provider");
@@ -529,7 +532,7 @@ mod tests {
         let logical_plan = parse_sql_to_logical_plan(sql).await;
 
         let cache_provider =
-            QueryResultsCacheProvider::try_new(&ResultsCache::default(), Box::new([]))
+            QueryResultsCacheProvider::try_new(&SQLResultsCacheConfig::default(), Box::new([]))
                 .expect("valid cache provider");
 
         assert!(cache_provider.cache_is_enabled_for_plan(&logical_plan));

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -31,6 +31,7 @@ use crate::{
     tracers,
 };
 use app::App;
+use spicepod::component::runtime::Caching;
 use token_provider::registry::TokenProviderRegistry;
 use tokio::sync::{Mutex, RwLock};
 
@@ -137,6 +138,7 @@ impl RuntimeBuilder {
         self
     }
 
+    #[allow(clippy::too_many_lines)]
     pub async fn build(self) -> Runtime {
         self.accelerator_engine_registry.register_all().await;
         dataconnector::register_all().await;
@@ -163,8 +165,24 @@ impl RuntimeBuilder {
             .as_ref()
             .is_none_or(|app| app.runtime.task_history.enabled);
 
-        let caching =
-            Runtime::init_caching(self.app.as_ref().map(|app| &app.runtime.results_cache));
+        let mut caching_config = self
+            .app
+            .as_ref()
+            .map_or(Caching::default(), |app| app.runtime.caching.clone());
+        if let Some(results_cache) = self
+            .app
+            .as_ref()
+            .and_then(|app| app.runtime.results_cache.clone())
+        {
+            crate::in_tracing_context(|| {
+                tracing::warn!(
+                    "The `results_cache` Runtime parameter is deprecated and will be removed in a future release.\nUse `caching.sql_results` instead.\nFor more information, visit: https://spiceai.org/docs/features/caching"
+                );
+            });
+            caching_config.sql_results = results_cache.into();
+        }
+
+        let caching = Runtime::init_caching(self.app.as_ref().map(|app| &app.runtime.caching));
 
         let mut df_builder = DataFusion::builder(
             Arc::clone(&self.runtime_status),
@@ -279,16 +297,19 @@ fn parse_memory_limit(memory_limit: Option<String>) -> Option<u64> {
         .map(|v| v.get_adjusted_unit(byte_unit::Unit::B).get_value() as u64);
 
     if memory_limit.is_none() {
-        tracing::warn!(
-            "An invalid Runtime memory limit was specified: {original_memory_limit}\n A memory limit must be specified as an integer in GB, MB, or KB size."
-        );
+        crate::in_tracing_context(|| {
+            tracing::warn!(
+                "An invalid Runtime memory limit was specified: {original_memory_limit}\n A memory limit must be specified as an integer in GB, MB, or KB size."
+            );
+        });
     }
 
     if memory_limit == Some(0) {
-        tracing::warn!(
-            "A Runtime memory limit of 0 was specified: {original_memory_limit}\n A memory limit must be greater than 0."
-        );
-
+        crate::in_tracing_context(|| {
+            tracing::warn!(
+                "A Runtime memory limit of 0 was specified: {original_memory_limit}\n A memory limit must be greater than 0."
+            );
+        });
         None
     } else {
         memory_limit

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -430,7 +430,7 @@ mod tests {
     use ::cache::{Caching, QueryResultsCacheProvider, QueryResultsCacheStatus};
     use arrow::array::Int64Array;
     use serde_json::json;
-    use spicepod::component::runtime::ResultsCache;
+    use spicepod::component::runtime::SQLResultsCacheConfig;
 
     use crate::{
         dataaccelerator::AcceleratorEngineRegistry,
@@ -443,7 +443,7 @@ mod tests {
     #[tokio::test]
     async fn parameterized_query() {
         let parameters = convert_json_to_param_values(json!([41])).expect("json to paramvalues");
-        let config = ResultsCache::default();
+        let config = SQLResultsCacheConfig::default();
         let cache_provider = Arc::new(
             QueryResultsCacheProvider::try_new(&config, Box::new([])).expect("cache provider new"),
         );

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -261,7 +261,7 @@ mod tests {
     use cache::{
         CacheKey, Caching, QueryResultsCacheProvider, QueryResultsCacheStatus, SimpleCache,
     };
-    use spicepod::component::runtime::{HashingAlgorithm, ResultsCache};
+    use spicepod::component::runtime::{CacheConfig, SQLResultsCacheConfig};
 
     use crate::{
         builder::RuntimeBuilder,
@@ -292,13 +292,12 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn test_get_plan_or_cached_cache_miss_and_hit() {
-        let results_cache_config = ResultsCache {
-            enabled: true,
-            cache_max_size: None,
-            item_ttl: Some("10m".to_string()),
-            eviction_policy: None,
+        let results_cache_config = SQLResultsCacheConfig {
+            inner: CacheConfig {
+                item_ttl: Some("10m".to_string()),
+                ..Default::default()
+            },
             cache_key_type: spicepod::component::runtime::CacheKeyType::Sql,
-            hashing_algorithm: HashingAlgorithm::default(),
         };
         let cache_provider =
             QueryResultsCacheProvider::try_new(&results_cache_config, Box::new([]))
@@ -424,13 +423,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_plan_or_cached_sql_cached_prepared_statements() {
-        let results_cache_config = ResultsCache {
-            enabled: true,
-            cache_max_size: None,
-            item_ttl: Some("10m".to_string()),
-            eviction_policy: None,
+        let results_cache_config = SQLResultsCacheConfig {
+            inner: CacheConfig {
+                item_ttl: Some("10m".to_string()),
+                ..Default::default()
+            },
             cache_key_type: spicepod::component::runtime::CacheKeyType::Sql,
-            hashing_algorithm: HashingAlgorithm::default(),
         };
         let cache_provider =
             QueryResultsCacheProvider::try_new(&results_cache_config, Box::new([]))
@@ -495,13 +493,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_plan_or_cached_plan_cached_prepared_statements() {
-        let results_cache_config = ResultsCache {
-            enabled: true,
-            cache_max_size: None,
-            item_ttl: Some("10m".to_string()),
-            eviction_policy: None,
+        let results_cache_config = SQLResultsCacheConfig {
+            inner: CacheConfig {
+                item_ttl: Some("10m".to_string()),
+                ..Default::default()
+            },
             cache_key_type: spicepod::component::runtime::CacheKeyType::Plan,
-            hashing_algorithm: HashingAlgorithm::default(),
         };
         let cache_provider =
             QueryResultsCacheProvider::try_new(&results_cache_config, Box::new([]))

--- a/crates/runtime/src/init/caching.rs
+++ b/crates/runtime/src/init/caching.rs
@@ -18,40 +18,43 @@ use std::{sync::Arc, time::Duration};
 
 use cache::{CacheProvider, Caching, QueryResultsCacheProvider, SimpleCache};
 use datafusion::logical_expr::LogicalPlan;
-use spicepod::component::runtime::{HashingAlgorithm, ResultsCache};
+use spicepod::component::runtime::{Caching as CachingConfig, HashingAlgorithm};
 
 use crate::{Runtime, datafusion::SPICE_RUNTIME_SCHEMA};
 
 const DEFAULT_CACHED_PLANS_MAX_CAPACITY: u64 = 512;
 
 impl Runtime {
-    pub fn init_caching(cache_config: Option<&ResultsCache>) -> Arc<Caching> {
+    #[must_use]
+    pub fn init_caching(cache_config: Option<&CachingConfig>) -> Arc<Caching> {
         let Some(cache_config) = cache_config else {
             return Arc::new(Caching::new());
         };
 
-        if !cache_config.enabled {
-            return Arc::new(Caching::new());
-        }
-
         let mut caching = Caching::new();
 
-        match QueryResultsCacheProvider::try_new(
-            cache_config,
-            Box::new([SPICE_RUNTIME_SCHEMA.into(), "information_schema".into()]),
-        ) {
-            Ok(cache_provider) => {
-                tracing::info!("Initialized results cache; {cache_provider}");
-                caching = caching.with_results_cache(Arc::new(cache_provider));
-            }
-            Err(e) => {
-                tracing::warn!("Failed to initialize results cache: {e}");
+        if cache_config.sql_results.inner.enabled {
+            match QueryResultsCacheProvider::try_new(
+                &cache_config.sql_results,
+                Box::new([SPICE_RUNTIME_SCHEMA.into(), "information_schema".into()]),
+            ) {
+                Ok(cache_provider) => {
+                    crate::in_tracing_context(|| {
+                        tracing::info!("Initialized results cache; {cache_provider}");
+                    });
+                    caching = caching.with_results_cache(Arc::new(cache_provider));
+                }
+                Err(e) => {
+                    crate::in_tracing_context(|| {
+                        tracing::error!("Failed to initialize results cache: {e}");
+                    });
+                }
             }
         }
 
         // TODO: logical plan cache needs its own configuration?
         let plan_cache_provider: Arc<dyn CacheProvider<LogicalPlan> + Send + Sync> =
-            match cache_config.hashing_algorithm {
+            match cache_config.sql_results.inner.hashing_algorithm {
                 HashingAlgorithm::Siphash => Arc::new(SimpleCache::new(
                     DEFAULT_CACHED_PLANS_MAX_CAPACITY,
                     Duration::from_secs(3600),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -26,6 +26,7 @@ use std::{collections::HashMap, sync::Arc};
 use token_provider::registry::TokenProviderRegistry;
 use tokio::{sync::Mutex, task::JoinHandle, time::Instant};
 use tools::factory::{ToolFactory, default_catalog_names};
+use tracing::subscriber;
 use util::force_shutdown_signal;
 
 use crate::dataaccelerator::AcceleratorEngineRegistry;
@@ -979,4 +980,14 @@ pub fn spice_data_base_path() -> String {
 pub(crate) fn make_spice_data_directory() -> Result<()> {
     let base_folder = spice_data_base_path();
     std::fs::create_dir_all(base_folder).context(UnableToCreateDirectorySnafu)
+}
+
+pub fn in_tracing_context<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_ansi(true)
+        .finish();
+    subscriber::with_default(subscriber, f)
 }

--- a/crates/runtime/src/request/cache_control.rs
+++ b/crates/runtime/src/request/cache_control.rs
@@ -36,7 +36,10 @@ impl CacheKeyType {
         };
 
         // Mapping from the user-facing `CacheKeyType` to the internal `CacheKeyType`.
-        match app.runtime.results_cache.cache_key_type {
+        match app.runtime.results_cache.as_ref().map_or_else(
+            || app.runtime.caching.sql_results.cache_key_type,
+            |c| c.cache_key_type,
+        ) {
             spicepod::component::runtime::CacheKeyType::Plan => Self::Default,
             spicepod::component::runtime::CacheKeyType::Sql => Self::Raw,
         }
@@ -92,20 +95,20 @@ mod tests {
         // Create test App instances
         let app_with_plan = AppBuilder::new("app_with_plan")
             .with_runtime(spicepod::component::runtime::Runtime {
-                results_cache: spicepod::component::runtime::ResultsCache {
+                results_cache: Some(spicepod::component::runtime::ResultsCache {
                     cache_key_type: spicepod::component::runtime::CacheKeyType::Plan,
                     ..Default::default()
-                },
+                }),
                 ..Default::default()
             })
             .build();
 
         let app_with_sql = AppBuilder::new("app_with_sql")
             .with_runtime(spicepod::component::runtime::Runtime {
-                results_cache: spicepod::component::runtime::ResultsCache {
+                results_cache: Some(spicepod::component::runtime::ResultsCache {
                     cache_key_type: spicepod::component::runtime::CacheKeyType::Sql,
                     ..Default::default()
-                },
+                }),
                 ..Default::default()
             })
             .build();

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -169,3 +169,11 @@ where
 pub(super) fn is_default<T: Default + PartialEq>(value: &T) -> bool {
     *value == T::default()
 }
+
+#[allow(clippy::ref_option)] // &Option<T> is required for serde
+pub(super) fn is_default_or_none<T: Default + PartialEq>(value: &Option<T>) -> bool {
+    match value {
+        Some(v) => is_default(v),
+        None => true,
+    }
+}

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::{collections::HashMap, error::Error, sync::Arc, time::Duration};
 
-use super::is_default;
+use super::{is_default, is_default_or_none};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -27,8 +27,10 @@ const TASK_HISTORY_RETENTION_MINIMUM: u64 = 60; // 1 minute
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Runtime {
+    #[serde(default, skip_serializing_if = "is_default_or_none")]
+    pub results_cache: Option<ResultsCache>,
     #[serde(default, skip_serializing_if = "is_default")]
-    pub results_cache: ResultsCache,
+    pub caching: Caching,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dataset_load_parallelism: Option<usize>,
@@ -112,6 +114,50 @@ pub enum HashingAlgorithm {
     Ahash,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct Caching {
+    #[serde(skip_serializing_if = "is_default")]
+    pub sql_results: SQLResultsCacheConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct CacheConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub max_size: Option<String>,
+    pub item_ttl: Option<String>,
+    pub eviction_policy: Option<String>,
+    #[serde(default)]
+    pub hashing_algorithm: HashingAlgorithm,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_size: None,
+            item_ttl: None,
+            eviction_policy: None,
+            hashing_algorithm: HashingAlgorithm::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct SQLResultsCacheConfig {
+    #[serde(flatten)]
+    pub inner: CacheConfig,
+    #[serde(default)]
+    pub cache_key_type: CacheKeyType,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ResultsCache {
@@ -126,10 +172,6 @@ pub struct ResultsCache {
     pub hashing_algorithm: HashingAlgorithm,
 }
 
-const fn default_true() -> bool {
-    true
-}
-
 impl Default for ResultsCache {
     fn default() -> Self {
         Self {
@@ -139,6 +181,21 @@ impl Default for ResultsCache {
             eviction_policy: None,
             cache_key_type: CacheKeyType::default(),
             hashing_algorithm: HashingAlgorithm::default(),
+        }
+    }
+}
+
+impl From<ResultsCache> for SQLResultsCacheConfig {
+    fn from(val: ResultsCache) -> Self {
+        SQLResultsCacheConfig {
+            inner: CacheConfig {
+                enabled: val.enabled,
+                max_size: val.cache_max_size,
+                item_ttl: val.item_ttl,
+                eviction_policy: val.eviction_policy,
+                hashing_algorithm: val.hashing_algorithm,
+            },
+            cache_key_type: val.cache_key_type,
         }
     }
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Deprecates the `runtime.results_cache` parameter in favor of the new `runtime.caching.sql_results`
* Future tracking task for parameter removal: #6007

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5996
* Part of #3018

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

* Caching documentation will require updating, and a note for deprecation.