### PR TITLE
fix: Allow dev runners in dispatch files

### DIFF
--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -152,6 +152,10 @@ pub enum RunnerType {
     SelfHosted,
     #[serde(rename = "spiceai-large-runners")]
     LargeSelfHosted,
+    #[serde(rename = "spiceai-dev-runners")]
+    Dev,
+    #[serde(rename = "spiceai-dev-large-runners")]
+    DevLarge,
 }
 
 /// Payload sent to the GitHub Actions workflow request for HTTP consistency tests


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Allows specifying the dev runners in testoperator dispatch files.