### PR TITLE
fix: Run PR checks for tools/ changes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,7 @@ jobs:
               - 'crates/**'
               - 'bin/**'
               - 'test/**'
+              - 'tools/**'
               - 'install/**'
               - '.github/workflows/**'
               - 'Cargo.toml'


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Ensures PR checks run for changes under `tools/`, primarily to capture PRs which have only changed the testoperator.
