### PR TITLE
feat: Add refresh_cron acceleration parameter, start scheduler on table load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11158,7 +11158,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "uuid 1.16.0",
 ]
 
 [[package]]

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -249,7 +249,7 @@ impl RuntimeBuilder {
             runtime_tasks: Arc::new(RwLock::new(HashMap::new())),
             accelerator_engine_registry: self.accelerator_engine_registry,
             token_provider_registry: self.token_provider_registry,
-            schedulers: Arc::new(RwLock::new(Vec::new())),
+            schedulers: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let mut extensions: HashMap<String, Arc<dyn Extension>> = HashMap::new();

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -249,6 +249,7 @@ impl RuntimeBuilder {
             runtime_tasks: Arc::new(RwLock::new(HashMap::new())),
             accelerator_engine_registry: self.accelerator_engine_registry,
             token_provider_registry: self.token_provider_registry,
+            schedulers: Arc::new(RwLock::new(Vec::new())),
         };
 
         let mut extensions: HashMap<String, Arc<dyn Extension>> = HashMap::new();

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use datafusion_table_providers::util::column_reference::ColumnReference;
 use serde::{Deserialize, Serialize};
 use spicepod::{acceleration as spicepod_acceleration, param::Params};
-use std::{collections::HashMap, fmt::Display, time::Duration};
+use std::{collections::HashMap, fmt::Display, sync::Arc, time::Duration};
 
 pub mod constraints;
 pub mod on_conflict;
@@ -250,6 +250,8 @@ pub struct Acceleration {
 
     pub refresh_check_interval: Option<Duration>,
 
+    pub refresh_cron: Option<Arc<str>>,
+
     pub refresh_sql: Option<String>,
 
     pub refresh_data_window: Option<String>,
@@ -365,6 +367,13 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             acceleration.refresh_check_interval,
         )?;
 
+        let refresh_cron = acceleration.refresh_cron.map(Into::into);
+        if refresh_cron.is_some() && refresh_check_interval.is_some() {
+            return Err(crate::Error::InvalidSpicepodDataset {
+                source: super::Error::MultipleRefreshExpressionSpecified,
+            });
+        }
+
         let refresh_jitter_max =
             try_parse_duration("refresh_jitter_max", acceleration.refresh_jitter_max)?;
 
@@ -375,6 +384,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
             refresh_mode: acceleration.refresh_mode.map(RefreshMode::from),
             refresh_on_startup: RefreshOnStartup::from(acceleration.refresh_on_startup),
             refresh_check_interval,
+            refresh_cron,
             refresh_sql: acceleration.refresh_sql,
             refresh_data_window: acceleration.refresh_data_window,
             refresh_append_overlap: try_parse_duration(
@@ -409,6 +419,7 @@ impl Default for Acceleration {
             engine: Engine::default(),
             refresh_mode: None,
             refresh_check_interval: None,
+            refresh_cron: None,
             refresh_sql: None,
             refresh_data_window: None,
             refresh_append_overlap: None,

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -97,7 +97,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Both a 'refresh_cron' and 'refresh_check_interval' were specified.\nOnly one of these options can be specified at a time.\nFor details, visit: https://spiceai.org/docs/features/data-acceleration/data-refresh"
+        "Both a 'refresh_cron' and 'refresh_check_interval' were specified.\nOnly one of these options can be specified for a given dataset.\nFor details, visit: https://spiceai.org/docs/features/data-acceleration/data-refresh"
     ))]
     MultipleRefreshExpressionSpecified,
 }

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -95,6 +95,11 @@ pub enum Error {
         dataset: String,
         missing_component: String,
     },
+
+    #[snafu(display(
+        "Both a 'refresh_cron' and 'refresh_check_interval' were specified.\nOnly one of these options can be specified at a time.\nFor details, visit: https://spiceai.org/docs/features/data-acceleration/data-refresh"
+    ))]
+    MultipleRefreshExpressionSpecified,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -401,6 +406,14 @@ impl Dataset {
     pub fn refresh_check_interval(&self) -> Option<Duration> {
         if let Some(acceleration) = &self.acceleration {
             return acceleration.refresh_check_interval;
+        }
+        None
+    }
+
+    #[must_use]
+    pub fn refresh_cron(&self) -> Option<Arc<str>> {
+        if let Some(acceleration) = &self.acceleration {
+            return acceleration.refresh_cron.clone();
         }
         None
     }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -405,13 +405,18 @@ impl DataFusion {
         Ok(())
     }
 
-    pub async fn register_table(&self, dataset: Arc<Dataset>, table: Table) -> Result<()> {
+    // Returns a oneshot::Receiver if the table supports notifying the runtime when the table is ready.
+    pub async fn register_table(
+        &self,
+        dataset: Arc<Dataset>,
+        table: Table,
+    ) -> Result<Option<oneshot::Receiver<()>>> {
         schema::ensure_schema_exists(&self.ctx, SPICE_DEFAULT_CATALOG, &dataset.name)?;
 
         let dataset_mode = dataset.mode();
         let dataset_table_ref = dataset.name.clone();
 
-        match table {
+        let is_ready = match table {
             Table::Accelerated {
                 source,
                 federated_read_table,
@@ -430,6 +435,7 @@ impl DataFusion {
                         )
                         .map_err(find_datafusion_root)
                         .context(UnableToRegisterTableToDataFusionSnafu)?;
+                    None
                 } else if source.as_any().downcast_ref::<SinkConnector>().is_some() {
                     // Sink connectors don't know their schema until the first data is received. Park this registration until the schema is known via the first write.
                     self.runtime_status
@@ -441,9 +447,17 @@ impl DataFusion {
                             dataset: Arc::clone(&dataset),
                             secrets: Arc::clone(&secrets),
                         });
+                    None
                 } else {
-                    self.register_accelerated_table(dataset, source, federated_read_table, secrets)
-                        .await?;
+                    Some(
+                        self.register_accelerated_table(
+                            dataset,
+                            source,
+                            federated_read_table,
+                            secrets,
+                        )
+                        .await?,
+                    )
                 }
             }
             Table::Federated {
@@ -467,8 +481,10 @@ impl DataFusion {
                     self.register_federated_table(&dataset, data_connector, federated_read_table)
                         .await?;
                 }
+
+                None
             }
-        }
+        };
 
         if matches!(dataset_mode, Mode::ReadWrite) {
             self.data_writers
@@ -477,7 +493,7 @@ impl DataFusion {
                 .insert(dataset_table_ref.clone());
         }
 
-        Ok(())
+        Ok(is_ready)
     }
 
     #[must_use]
@@ -1064,8 +1080,8 @@ impl DataFusion {
         source: Arc<dyn DataConnector>,
         federated_read_table: FederatedTable,
         secrets: Arc<TokioRwLock<Secrets>>,
-    ) -> Result<()> {
-        let (mut accelerated_table, _) = self
+    ) -> Result<oneshot::Receiver<()>> {
+        let (mut accelerated_table, is_ready) = self
             .create_accelerated_table(&dataset, Arc::clone(&source), federated_read_table, secrets)
             .await?;
 
@@ -1090,7 +1106,7 @@ impl DataFusion {
             .await
             .insert(dataset.name.clone());
 
-        Ok(())
+        Ok(is_ready)
     }
 
     pub async fn refresh_table(

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -253,22 +253,27 @@ impl Runtime {
     }
 
     /// Caller must set `status::update_dataset(...` before calling `load_dataset`. This function will set error/ready statuses appropriately.
-    async fn load_dataset(&self, ds: Arc<Dataset>) {
+    async fn load_dataset(self: Arc<Self>, ds: Arc<Dataset>) {
         let spaced_tracer = Arc::clone(&self.spaced_tracer);
 
         let retry_strategy = FibonacciBackoffBuilder::new().max_retries(None).build();
 
+        let runtime = Arc::clone(&self);
         let _ = retry(retry_strategy, || async {
-            let connector = match self.load_dataset_connector(Arc::clone(&ds)).await {
+            let connector = match Arc::clone(&runtime)
+                .load_dataset_connector(Arc::clone(&ds))
+                .await
+            {
                 Ok(connector) => connector,
                 Err(err) => {
-                    if self.status.is_shutdown() {
+                    if runtime.status.is_shutdown() {
                         // should not retry or trace error if runtime is shutting down
                         return Err(RetryError::permanent(err));
                     }
 
                     let ds_name = &ds.name;
-                    self.status
+                    runtime
+                        .status
                         .update_dataset(ds_name, status::ComponentStatus::Error);
                     metrics::datasets::LOAD_ERROR.add(1, &[]);
                     warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
@@ -276,11 +281,11 @@ impl Runtime {
                 }
             };
 
-            if let Err(err) = self
+            if let Err(err) = Arc::clone(&runtime)
                 .register_loaded_dataset(Arc::clone(&ds), connector, None)
                 .await
             {
-                if self.status.is_shutdown() {
+                if runtime.status.is_shutdown() {
                     // should not retry if runtime is shutting down
                     return Err(RetryError::permanent(err));
                 }
@@ -294,7 +299,7 @@ impl Runtime {
 
     #[allow(clippy::too_many_lines)]
     async fn register_loaded_dataset(
-        &self,
+        self: Arc<Self>,
         ds: Arc<Dataset>,
         data_connector: Arc<dyn DataConnector>,
         accelerated_table: Option<AcceleratedTable>,
@@ -349,7 +354,7 @@ impl Runtime {
             }
         };
 
-        match self
+        match Arc::clone(&self)
             .register_dataset(
                 Arc::clone(&ds),
                 RegisterDatasetContext {
@@ -446,7 +451,7 @@ impl Runtime {
         metrics::datasets::COUNT.add(-1, &[KeyValue::new("engine", engine)]);
     }
 
-    async fn update_dataset(&self, ds: Arc<Dataset>) {
+    async fn update_dataset(self: Arc<Self>, ds: Arc<Dataset>) {
         self.status
             .update_dataset(&ds.name, status::ComponentStatus::Refreshing);
 
@@ -454,12 +459,15 @@ impl Runtime {
         // obsolete, so we remove them
         self.df.clear_cached_plans();
 
-        match self.load_dataset_connector(Arc::clone(&ds)).await {
+        match Arc::clone(&self)
+            .load_dataset_connector(Arc::clone(&ds))
+            .await
+        {
             Ok(connector) => {
                 // File accelerated datasets don't support hot reload.
                 if Self::accelerated_dataset_supports_hot_reload(&ds, &*connector) {
                     tracing::info!("Updating accelerated dataset {}...", &ds.name);
-                    if let Ok(()) = &self
+                    if let Ok(()) = Arc::clone(&self)
                         .reload_accelerated_dataset(Arc::clone(&ds), Arc::clone(&connector))
                         .await
                     {
@@ -476,7 +484,7 @@ impl Runtime {
                 self.remove_dataset(ds.name.clone(), ds.acceleration.as_ref())
                     .await;
 
-                if self
+                if Arc::clone(&self)
                     .register_loaded_dataset(Arc::clone(&ds), Arc::clone(&connector), None)
                     .await
                     .is_err()
@@ -523,7 +531,7 @@ impl Runtime {
     }
 
     async fn reload_accelerated_dataset(
-        &self,
+        self: Arc<Self>,
         ds: Arc<Dataset>,
         connector: Arc<dyn DataConnector>,
     ) -> Result<()> {
@@ -603,7 +611,7 @@ impl Runtime {
     }
 
     async fn register_dataset(
-        &self,
+        self: Arc<Self>,
         ds: Arc<Dataset>,
         register_dataset_ctx: RegisterDatasetContext,
     ) -> Result<()> {
@@ -660,7 +668,8 @@ impl Runtime {
         // The accelerated refresh task will set the dataset status to `Ready` once it finishes loading.
         self.status
             .update_dataset(&ds.name, status::ComponentStatus::Refreshing);
-        self.df
+        let is_ready = self
+            .df
             .register_table(
                 Arc::clone(&ds),
                 crate::datafusion::Table::Accelerated {
@@ -674,7 +683,26 @@ impl Runtime {
             .context(UnableToAttachDataConnectorSnafu {
                 data_connector: source,
                 connector_component: ConnectorComponent::from(&ds),
-            })
+            })?;
+
+        if let Some(is_ready) = is_ready {
+            // spawn a background task to wait for the accelerated table to be ready before creating schedules
+            let runtime = Arc::clone(&self);
+            let ds = Arc::clone(&ds);
+            let dataset_name = ds.name.to_string();
+            tokio::task::spawn(async move {
+                if let Ok(()) = is_ready.await {
+                    if let Err(e) = runtime.create_dataset_scheduler_if_required(ds).await {
+                        tracing::error!(
+                            "Failed to create dataset schedule for '{}': {e}",
+                            dataset_name
+                        );
+                    }
+                }
+            });
+        }
+
+        Ok(())
     }
 
     pub(crate) async fn apply_dataset_diff(
@@ -689,12 +717,12 @@ impl Runtime {
         for ds in initialized_datasets {
             if let Some(current_ds) = existing_datasets.iter().find(|d| d.name == ds.name) {
                 if ds != *current_ds {
-                    self.update_dataset(ds).await;
+                    Arc::clone(&self).update_dataset(ds).await;
                 }
             } else {
                 self.status
                     .update_dataset(&ds.name, status::ComponentStatus::Initializing);
-                self.load_dataset(ds).await;
+                Arc::clone(&self).load_dataset(ds).await;
             }
         }
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -692,7 +692,7 @@ impl Runtime {
             let dataset_name = ds.name.to_string();
             tokio::task::spawn(async move {
                 if let Ok(()) = is_ready.await {
-                    if let Err(e) = runtime.create_dataset_scheduler_if_required(ds).await {
+                    if let Err(e) = runtime.create_dataset_schedule(ds).await {
                         tracing::error!(
                             "Failed to create dataset schedule for '{}': {e}",
                             dataset_name

--- a/crates/runtime/src/init/mod.rs
+++ b/crates/runtime/src/init/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod llm;
 pub(crate) mod metrics;
 pub(crate) mod model;
 pub(crate) mod pods_watcher;
+pub(crate) mod scheduler;
 pub(crate) mod task_history;
 pub(crate) mod tool;
 pub(crate) mod view;

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -14,51 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use scheduler::{schedule::Schedule, scheduler::SchedulerBuilder};
+use scheduler::{
+    schedule::Schedule,
+    scheduler::{Running, Scheduler, SchedulerBuilder},
+};
 use snafu::ResultExt;
+use tokio::sync::RwLock;
 
 use crate::{Result, Runtime, component::dataset::Dataset, scheduling::DatasetRefreshTask};
 
 const REFRESH_SCHEDULER_NAME: &str = "refresh_scheduler";
 
+pub(crate) type ScheduleRegistry = RwLock<HashMap<Arc<str>, Arc<Scheduler<Running>>>>;
+
 impl Runtime {
-    pub async fn create_dataset_scheduler_if_required(
-        self: Arc<Self>,
-        dataset: Arc<Dataset>,
-    ) -> Result<()> {
+    pub async fn create_dataset_schedule(self: Arc<Self>, dataset: Arc<Dataset>) -> Result<()> {
         // TODO: Actually schedule the refresh task for cron - https://github.com/spiceai/spiceai/issues/6015
-        let Some(_refresh_cron) = dataset.refresh_cron() else {
+        if dataset.refresh_cron().is_none() {
             return Ok(());
-        };
+        }
 
         tracing::debug!("Creating dataset scheduler for dataset: {}", dataset.name);
         let scheduler_lock = Arc::clone(&self.schedulers);
         let mut schedulers = scheduler_lock.write().await;
         let dataset_name = dataset.name.to_string().into();
-        for scheduler in schedulers.iter() {
-            if scheduler
-                .schedules()
-                .await
-                .iter()
-                .any(|schedule| schedule.name() == dataset_name)
-            {
-                // Schedule already exists for this dataset
-                return Ok(());
-            }
-        }
 
         let refresh_task = Arc::new(DatasetRefreshTask::from(Arc::clone(&dataset)));
         let schedule = Arc::new(Schedule::new(Arc::clone(&dataset_name), refresh_task));
 
         // a `refresh_scheduler` exists but does not contain this dataset's schedule
-        if let Some(scheduler) = schedulers
-            .iter()
-            .find(|s| s.name() == REFRESH_SCHEDULER_NAME.into())
-        {
+        if let Some(scheduler) = schedulers.get(REFRESH_SCHEDULER_NAME) {
             tracing::debug!(
-                "Adding schedule to existing refresh scheduler for dataset: {}",
+                "Adding dataset schedule to existing refresh scheduler for dataset: {}",
                 dataset.name
             );
             scheduler
@@ -73,7 +62,7 @@ impl Runtime {
 
         // no `refresh_scheduler` exists, create a new one
         tracing::debug!(
-            "Creating new refresh scheduler for dataset: {}",
+            "Creating new refresh scheduler for dataset schedule: {}",
             dataset.name
         );
         let scheduler = Arc::new(
@@ -85,7 +74,8 @@ impl Runtime {
                 .await
                 .context(crate::FailedToStartSchedulerSnafu)?,
         );
-        schedulers.push(scheduler);
+
+        schedulers.insert(REFRESH_SCHEDULER_NAME.into(), Arc::clone(&scheduler));
 
         Ok(())
     }

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -1,0 +1,92 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use scheduler::{schedule::Schedule, scheduler::SchedulerBuilder};
+use snafu::ResultExt;
+
+use crate::{Result, Runtime, component::dataset::Dataset, scheduling::DatasetRefreshTask};
+
+const REFRESH_SCHEDULER_NAME: &str = "refresh_scheduler";
+
+impl Runtime {
+    pub async fn create_dataset_scheduler_if_required(
+        self: Arc<Self>,
+        dataset: Arc<Dataset>,
+    ) -> Result<()> {
+        // TODO: Actually schedule the refresh task for cron - https://github.com/spiceai/spiceai/issues/6015
+        let Some(_refresh_cron) = dataset.refresh_cron() else {
+            return Ok(());
+        };
+
+        tracing::debug!("Creating dataset scheduler for dataset: {}", dataset.name);
+        let scheduler_lock = Arc::clone(&self.schedulers);
+        let mut schedulers = scheduler_lock.write().await;
+        let dataset_name = dataset.name.to_string().into();
+        for scheduler in schedulers.iter() {
+            if scheduler
+                .schedules()
+                .await
+                .iter()
+                .any(|schedule| schedule.name() == dataset_name)
+            {
+                // Schedule already exists for this dataset
+                return Ok(());
+            }
+        }
+
+        let refresh_task = Arc::new(DatasetRefreshTask::from(Arc::clone(&dataset)));
+        let schedule = Arc::new(Schedule::new(Arc::clone(&dataset_name), refresh_task));
+
+        // a `refresh_scheduler` exists but does not contain this dataset's schedule
+        if let Some(scheduler) = schedulers
+            .iter()
+            .find(|s| s.name() == REFRESH_SCHEDULER_NAME.into())
+        {
+            tracing::debug!(
+                "Adding schedule to existing refresh scheduler for dataset: {}",
+                dataset.name
+            );
+            scheduler
+                .add_schedule(schedule)
+                .await
+                .context(crate::FailedToAddScheduleSnafu {
+                    name: dataset_name.to_string(),
+                    scheduler: REFRESH_SCHEDULER_NAME.to_string(),
+                })?;
+            return Ok(());
+        }
+
+        // no `refresh_scheduler` exists, create a new one
+        tracing::debug!(
+            "Creating new refresh scheduler for dataset: {}",
+            dataset.name
+        );
+        let scheduler = Arc::new(
+            SchedulerBuilder::new(REFRESH_SCHEDULER_NAME.into())
+                .add_schedule(schedule)
+                .build()
+                .context(crate::FailedToBuildSchedulerSnafu)?
+                .start()
+                .await
+                .context(crate::FailedToStartSchedulerSnafu)?,
+        );
+        schedulers.push(scheduler);
+
+        Ok(())
+    }
+}

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -46,6 +46,19 @@ impl Runtime {
 
         // a `refresh_scheduler` exists but does not contain this dataset's schedule
         if let Some(scheduler) = schedulers.get(REFRESH_SCHEDULER_NAME) {
+            if scheduler
+                .schedules()
+                .await
+                .iter()
+                .any(|s| s.name() == schedule.name())
+            {
+                tracing::debug!(
+                    "Dataset schedule already exists in refresh scheduler for dataset: {}",
+                    dataset.name
+                );
+                return Ok(());
+            }
+
             tracing::debug!(
                 "Adding dataset schedule to existing refresh scheduler for dataset: {}",
                 dataset.name

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -18,6 +18,7 @@ limitations under the License.
 use ::tools::SpiceModelTool;
 use ::tools::rename::with_name;
 use async_stream::stream;
+use scheduler::scheduler::{Running, Scheduler};
 use std::collections::HashSet;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -341,6 +342,25 @@ pub enum Error {
         "Configuration of '{view_name}' view is invalid: {reason}.\nUpdate the configuration and retry. For details, visit: https://spiceai.org/docs/components/views"
     ))]
     AcceleratedViewInvalidConfiguration { view_name: String, reason: String },
+
+    #[snafu(display(
+        "Failed to start scheduler.\n{source}\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
+    ))]
+    FailedToStartScheduler { source: scheduler::Error },
+
+    #[snafu(display(
+        "Failed to build scheduler.\n{source}\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
+    ))]
+    FailedToBuildScheduler { source: scheduler::Error },
+
+    #[snafu(display(
+        "Failed to add schedule '{name}' to the '{scheduler}' scheduler.\n{source}\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
+    ))]
+    FailedToAddSchedule {
+        source: scheduler::Error,
+        scheduler: String,
+        name: String,
+    },
 }
 
 const HTTP_SERVER: &str = "http_server";
@@ -384,6 +404,8 @@ pub struct Runtime {
     runtime_tasks: Arc<RwLock<HashMap<String, CancellableTaskHandle>>>,
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     token_provider_registry: Arc<TokenProviderRegistry>,
+
+    schedulers: Arc<RwLock<Vec<Arc<Scheduler<Running>>>>>,
 }
 
 impl Runtime {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -18,7 +18,7 @@ limitations under the License.
 use ::tools::SpiceModelTool;
 use ::tools::rename::with_name;
 use async_stream::stream;
-use scheduler::scheduler::{Running, Scheduler};
+use init::scheduler::ScheduleRegistry;
 use std::collections::HashSet;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -405,7 +405,7 @@ pub struct Runtime {
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     token_provider_registry: Arc<TokenProviderRegistry>,
 
-    schedulers: Arc<RwLock<Vec<Arc<Scheduler<Running>>>>>,
+    schedulers: Arc<ScheduleRegistry>,
 }
 
 impl Runtime {

--- a/crates/runtime/src/scheduling/mod.rs
+++ b/crates/runtime/src/scheduling/mod.rs
@@ -14,19 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::sync::Arc;
+
 use scheduler::Result;
 use scheduler::task::ScheduledTask;
 use tonic::async_trait;
 
 use crate::component::dataset::Dataset;
 
+pub struct DatasetRefreshTask(Arc<Dataset>);
+
+impl From<Arc<Dataset>> for DatasetRefreshTask {
+    fn from(dataset: Arc<Dataset>) -> Self {
+        Self(dataset)
+    }
+}
+
 #[async_trait]
-impl ScheduledTask for Dataset {
+impl ScheduledTask for DatasetRefreshTask {
     async fn execute(&self) -> Result<()> {
-        match self
+        let dataset = Arc::clone(&self.0);
+        match dataset
             .runtime()
             .datafusion()
-            .refresh_table(&self.name, None)
+            .refresh_table(&dataset.name, None)
             .await
         {
             Ok(()) => {

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -16,7 +16,6 @@ snafu.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tokio-util.workspace = true
 tracing.workspace = true
-uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/scheduler/src/channel/cron.rs
+++ b/crates/scheduler/src/channel/cron.rs
@@ -263,15 +263,15 @@ mod tests {
             .await
             .expect("Should receive another task request");
         let next_now = Local::now();
-        let elapsed = next_now.signed_duration_since(now).num_seconds();
-        let original_elapsed = next_now.signed_duration_since(last_now).num_seconds();
+        let elapsed = next_now.signed_duration_since(now).num_milliseconds();
+        let original_elapsed = next_now.signed_duration_since(last_now).num_milliseconds();
         assert!(
-            elapsed == 3 || elapsed == 2,
+            (2950..=3050).contains(&elapsed),
             "The next request should be sent after 2  or 3 seconds"
         );
-        assert_eq!(
-            original_elapsed, 5,
-            "The next request should be sent after 5 seconds from the last request"
+        assert!(
+            (4950..=5050).contains(&original_elapsed),
+            "The next request should be sent after 5 seconds"
         );
         assert!(
             next_now.second() % 5 == 0,

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -31,6 +31,12 @@ pub enum Error {
     ChannelSendError {
         source: tokio::sync::mpsc::error::SendError<Arc<TaskRequest>>,
     },
+    #[snafu(display(
+        "The names of the schedules must be unique, but the name '{name}' is already in use"
+    ))]
+    DuplicateScheduleName { name: String },
+    #[snafu(display("Not schedules were specified for the scheduler '{name}'"))]
+    NoSchedulesSpecified { name: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -35,7 +35,7 @@ pub enum Error {
         "The names of the schedules must be unique, but the name '{name}' is already in use"
     ))]
     DuplicateScheduleName { name: String },
-    #[snafu(display("Not schedules were specified for the scheduler '{name}'"))]
+    #[snafu(display("No schedules were specified for the scheduler '{name}'"))]
     NoSchedulesSpecified { name: String },
 }
 

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -46,11 +46,11 @@ pub enum Error {
     #[snafu(display("No schedules were specified for the scheduler '{name}'"))]
     NoSchedulesSpecified { name: String },
     #[snafu(display(
-        "Failed to parse cron expression.\n{source}\nValidate the cron expression is valid, and try again."
+        "Failed to parse cron expression.\n{source}\nConfirm the cron expression is valid, and try again."
     ))]
     FailedToParseCron { source: croner::errors::CronError },
     #[snafu(display(
-        "Failed to determine next cron expression run time.\n{source}\nValidate the cron expression is valid, and try again."
+        "Failed to determine next cron expression run time.\n{source}\nConfirm the cron expression is valid, and try again."
     ))]
     FailedToDetermineNextCronRunTime { source: croner::errors::CronError },
 }

--- a/crates/scheduler/src/schedule.rs
+++ b/crates/scheduler/src/schedule.rs
@@ -17,7 +17,6 @@ limitations under the License.
 use std::sync::Arc;
 
 use tokio::sync::{Notify, RwLock};
-use uuid::Uuid;
 
 use crate::{
     channel::TaskRequestChannel,
@@ -26,21 +25,21 @@ use crate::{
 };
 
 pub struct Schedule {
-    id: Arc<str>,
+    name: Arc<str>,
     triggers: Vec<Arc<RwLock<dyn TaskRequestChannel>>>,
     task: Arc<dyn ScheduledTask>,
 }
 
 impl Schedule {
     #[must_use]
-    pub fn id(&self) -> Arc<str> {
-        Arc::clone(&self.id)
+    pub fn name(&self) -> Arc<str> {
+        Arc::clone(&self.name)
     }
 
     #[must_use]
-    pub fn new(task: Arc<dyn ScheduledTask>) -> Self {
+    pub fn new(name: Arc<str>, task: Arc<dyn ScheduledTask>) -> Self {
         Self {
-            id: Uuid::new_v4().to_string().into(),
+            name,
             triggers: Vec::new(),
             task,
         }
@@ -94,11 +93,11 @@ impl Schedule {
         notification_channels: Arc<NotificationChannels>,
         cancellation_token: Arc<tokio_util::sync::CancellationToken>,
     ) -> tokio::task::JoinHandle<crate::Result<()>> {
-        let schedule_id = self.id();
+        let schedule_name = self.name();
         tokio::spawn(async move {
             let rx_lock = {
                 let channels = request_channels.read().await;
-                channels.get(&schedule_id).cloned()
+                channels.get(&schedule_name).cloned()
             };
 
             if let Some(rx_lock) = rx_lock {

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -17,12 +17,15 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use tokio::{
-    sync::{Notify, RwLock, mpsc::Receiver},
+    sync::{
+        Notify, RwLock,
+        mpsc::{Receiver, Sender},
+    },
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::{Result, schedule::Schedule, task::TaskRequest};
+use crate::{Result, channel::TaskRequestChannel, schedule::Schedule, task::TaskRequest};
 
 pub struct NotStarted {
     schedules: Vec<Arc<Schedule>>,
@@ -36,16 +39,70 @@ pub struct NotificationChannels {
 type TaskRequestHandles = Arc<RwLock<HashMap<Arc<str>, Vec<JoinHandle<Result<()>>>>>>;
 pub(crate) type TaskRequestChannels =
     Arc<RwLock<HashMap<Arc<str>, Arc<RwLock<Receiver<Arc<TaskRequest>>>>>>>;
+pub(crate) type TaskSubmissionChannels =
+    Arc<RwLock<HashMap<Arc<str>, Arc<Sender<Arc<TaskRequest>>>>>>;
 
 type SchedulerHandles = Arc<RwLock<HashMap<Arc<str>, Vec<JoinHandle<Result<()>>>>>>;
 
 pub struct Running {
-    schedules: Vec<Arc<Schedule>>,
+    schedules: Arc<RwLock<Vec<Arc<Schedule>>>>,
     request_handles: TaskRequestHandles,
     request_channels: TaskRequestChannels,
+    submission_channels: TaskSubmissionChannels,
     cancellation_token: Arc<CancellationToken>,
     notification_channels: Arc<NotificationChannels>,
     scheduler_handles: SchedulerHandles,
+}
+
+pub struct SchedulerBuilder {
+    name: Arc<str>,
+    schedules: Vec<Arc<Schedule>>,
+}
+
+impl SchedulerBuilder {
+    #[must_use]
+    pub fn new(name: Arc<str>) -> Self {
+        Self {
+            name,
+            schedules: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn add_schedule(mut self, schedule: Arc<Schedule>) -> Self {
+        self.schedules.push(schedule);
+        self
+    }
+
+    /// Builds a new scheduler that has not yet started.
+    ///
+    /// # Errors
+    ///
+    /// - If no schedules are specified, or if there are duplicate schedule names.
+    pub fn build(self) -> Result<Scheduler<NotStarted>> {
+        if self.schedules.is_empty() {
+            return Err(crate::Error::NoSchedulesSpecified {
+                name: self.name.to_string(),
+            });
+        }
+
+        self.schedules.iter().try_for_each(|schedule| {
+            if self
+                .schedules
+                .iter()
+                .filter(|s| s.name() == schedule.name())
+                .count()
+                > 1
+            {
+                return Err(crate::Error::DuplicateScheduleName {
+                    name: schedule.name().to_string(),
+                });
+            }
+            Ok(())
+        })?;
+
+        Ok(Scheduler::<NotStarted>::new(self.name, self.schedules))
+    }
 }
 
 pub struct Scheduler<T> {
@@ -55,7 +112,7 @@ pub struct Scheduler<T> {
 
 impl Scheduler<NotStarted> {
     #[must_use]
-    pub fn new(name: Arc<str>, schedules: Vec<Arc<Schedule>>) -> Self {
+    pub(crate) fn new(name: Arc<str>, schedules: Vec<Arc<Schedule>>) -> Self {
         Self {
             state: Arc::new(NotStarted { schedules }),
             name,
@@ -70,59 +127,43 @@ impl Scheduler<NotStarted> {
     pub async fn start(self) -> Result<Scheduler<Running>> {
         let cancellation_token = Arc::new(CancellationToken::new());
 
-        let schedules = self.state.schedules.clone();
-        let mut request_handles = HashMap::new();
-        let mut request_channels = HashMap::new();
-
         let notification_channels = Arc::new(NotificationChannels {
             completion: Arc::new(Notify::default()),
             reset: Arc::new(Notify::default()),
         });
 
-        for schedule in &schedules {
-            // Initialize the request channels for each schedule
-            let (tx, rx) = tokio::sync::mpsc::channel::<Arc<TaskRequest>>(5);
-            let tx = Arc::new(tx);
-            let schedule_id = schedule.id();
-
-            for channel_lock in schedule.triggers() {
-                let mut channel = channel_lock.write().await;
-                channel.set_task_completion_notification(Arc::clone(
-                    &notification_channels.completion,
-                ));
-                channel.set_cancellation_token(Arc::clone(&cancellation_token));
-                channel.set_reset_notification(Arc::clone(&notification_channels.reset));
-                channel.set_submission_channel(Arc::clone(&tx));
-                let handle = channel.start()?;
-                let entry = request_handles
-                    .entry(Arc::clone(&schedule_id))
-                    .or_insert(Vec::new());
-                entry.push(handle);
-            }
-
-            request_channels.insert(Arc::clone(&schedule_id), Arc::new(RwLock::new(rx)));
-        }
-
-        let request_handles = Arc::new(RwLock::new(request_handles));
-        let request_channels = Arc::new(RwLock::new(request_channels));
-
-        Ok(Scheduler {
+        let scheduler = Scheduler {
             state: Arc::new(Running {
-                schedules: self.state.schedules.clone(),
-                cancellation_token,
-                request_handles,
-                request_channels,
+                schedules: Arc::new(RwLock::new(Vec::new())),
+                cancellation_token: Arc::clone(&cancellation_token),
+                request_handles: Arc::new(RwLock::new(HashMap::new())),
+                request_channels: Arc::new(RwLock::new(HashMap::new())),
+                submission_channels: Arc::new(RwLock::new(HashMap::new())),
                 notification_channels: Arc::clone(&notification_channels),
                 scheduler_handles: Arc::new(RwLock::new(HashMap::new())),
             }),
             name: self.name,
+        };
+
+        for schedule in &self.state.schedules.clone() {
+            scheduler.add_schedule(Arc::clone(schedule)).await?;
         }
-        .start()
-        .await)
+
+        Ok(scheduler)
     }
 }
 
 impl Scheduler<Running> {
+    #[must_use]
+    pub fn name(&self) -> Arc<str> {
+        Arc::clone(&self.name)
+    }
+
+    #[must_use]
+    pub async fn schedules(&self) -> Vec<Arc<Schedule>> {
+        self.state.schedules.read().await.clone()
+    }
+
     pub async fn stop(self) {
         let cancellation_token = Arc::clone(&self.state.cancellation_token);
         cancellation_token.cancel();
@@ -173,32 +214,120 @@ impl Scheduler<Running> {
         scheduler_handles.clear();
     }
 
-    pub async fn start(self) -> Self {
-        let state = Arc::clone(&self.state);
-        let cancellation_token = Arc::clone(&self.state.cancellation_token);
-        let schedules = self.state.schedules.clone();
+    /// Adds another trigger to an existing schedule, and starts up the request channel.
+    ///
+    /// # Errors
+    ///
+    /// - If the schedule with the specified name does not exist.
+    /// - If the request channel fails to start.
+    /// - If a submission channel is not found for the schedule.
+    pub async fn add_trigger_for_schedule(
+        &self,
+        schedule_name: Arc<str>,
+        request_channel: Arc<RwLock<dyn TaskRequestChannel>>,
+    ) -> Result<()> {
+        self.schedules()
+            .await
+            .iter()
+            .find(|s| s.name() == schedule_name)
+            .ok_or_else(|| crate::Error::DuplicateScheduleName {
+                name: schedule_name.to_string(),
+            })?;
 
-        // For each schedule, spawn a task that listens for task requests and executes them
-        let scheduler_handles = Arc::clone(&self.state.scheduler_handles);
-        let mut scheduler_handles = scheduler_handles.write().await;
-        for schedule in &schedules {
-            let schedule = Arc::clone(schedule);
-            let schedule_id = schedule.id();
+        let mut channel = request_channel.write().await;
+        channel.set_task_completion_notification(Arc::clone(
+            &self.state.notification_channels.completion,
+        ));
+        channel.set_cancellation_token(Arc::clone(&self.state.cancellation_token));
+        channel.set_reset_notification(Arc::clone(&self.state.notification_channels.reset));
 
-            let handle = schedule.start(
-                Arc::clone(&state.request_channels),
-                Arc::clone(&state.notification_channels),
-                Arc::clone(&cancellation_token),
-            );
+        let submission_channels_lock = Arc::clone(&self.state.submission_channels);
+        let submission_channels = submission_channels_lock.read().await;
+        let submission_channel = submission_channels
+            .get(&schedule_name)
+            .ok_or(crate::Error::SubmissionChannelRequired)?;
 
-            scheduler_handles
-                .entry(schedule_id)
-                .or_insert_with(Vec::new)
-                .push(handle);
+        channel.set_submission_channel(Arc::clone(submission_channel));
+        let handle = channel.start()?;
+        let mut request_handles = self.state.request_handles.write().await;
+        let entry = request_handles
+            .entry(schedule_name)
+            .or_insert_with(Vec::new);
+        entry.push(handle);
+        Ok(())
+    }
+
+    /// Adds a new schedule to the running scheduler.
+    ///
+    /// # Errors
+    ///
+    /// - If a schedule with the same name already exists.
+    pub async fn add_schedule(&self, schedule: Arc<Schedule>) -> Result<()> {
+        let schedule_name = schedule.name();
+        if self
+            .schedules()
+            .await
+            .iter()
+            .any(|s| s.name() == schedule_name)
+        {
+            return Err(crate::Error::DuplicateScheduleName {
+                name: schedule_name.to_string(),
+            });
         }
 
-        drop(scheduler_handles);
-        self
+        let mut schedules = self.state.schedules.write().await;
+        schedules.push(Arc::clone(&schedule));
+        drop(schedules);
+
+        // Create the submission and request channels for the new schedule
+        let (tx, rx) = tokio::sync::mpsc::channel::<Arc<TaskRequest>>(5);
+        let tx = Arc::new(tx);
+        let schedule_name = schedule.name();
+        self.state
+            .submission_channels
+            .write()
+            .await
+            .insert(Arc::clone(&schedule_name), Arc::clone(&tx));
+        let rx_lock = Arc::new(RwLock::new(rx));
+        self.state
+            .request_channels
+            .write()
+            .await
+            .insert(Arc::clone(&schedule_name), Arc::clone(&rx_lock));
+
+        // Start the request channels for the new schedule
+        let cancellation_token = Arc::clone(&self.state.cancellation_token);
+        let notification_channels = Arc::clone(&self.state.notification_channels);
+
+        for trigger_lock in schedule.triggers() {
+            let mut trigger = trigger_lock.write().await;
+            trigger.set_task_completion_notification(Arc::clone(&notification_channels.completion));
+            trigger.set_cancellation_token(Arc::clone(&cancellation_token));
+            trigger.set_reset_notification(Arc::clone(&notification_channels.reset));
+
+            trigger.set_submission_channel(Arc::clone(&tx));
+            let handle = trigger.start()?;
+            let mut request_handles = self.state.request_handles.write().await;
+            let entry = request_handles
+                .entry(Arc::clone(&schedule_name))
+                .or_insert_with(Vec::new);
+            entry.push(handle);
+        }
+
+        // With request channels set up, we can now start the schedule
+        let scheduler_handles = Arc::clone(&self.state.scheduler_handles);
+        let mut scheduler_handles = scheduler_handles.write().await;
+        let handle = schedule.start(
+            Arc::clone(&self.state.request_channels),
+            Arc::clone(&self.state.notification_channels),
+            Arc::clone(&cancellation_token),
+        );
+        scheduler_handles
+            .entry(schedule_name)
+            .or_insert_with(Vec::new)
+            .push(handle);
+
+        Ok(())
     }
 }
 
@@ -240,6 +369,15 @@ mod test {
         map.insert(Arc::from("test_manual_interrupts"), 0);
         map.insert(Arc::from("test_manual_queued_with_interrupt"), 0);
         map.insert(Arc::from("test_manual_queue_clears_after_immediate"), 0);
+        map.insert(
+            Arc::from("test_adding_schedule_while_running_starts_existing"),
+            0,
+        );
+        map.insert(
+            Arc::from("test_adding_schedule_while_running_starts_new"),
+            0,
+        );
+        map.insert(Arc::from("test_adding_trigger_to_existing_schedule"), 0);
 
         RwLock::new(map)
     });
@@ -304,9 +442,12 @@ mod test {
 
     #[tokio::test]
     async fn test_scheduler() {
-        let schedule = Schedule::new(Arc::new(TestComponent {
-            name: Arc::from("test_scheduler"),
-        }))
+        let schedule = Schedule::new(
+            Arc::from("test_scheduler"),
+            Arc::new(TestComponent {
+                name: Arc::from("test_scheduler"),
+            }),
+        )
         .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))));
         let scheduler =
             Scheduler::<NotStarted>::new("test_scheduler".into(), vec![Arc::new(schedule)]);
@@ -326,9 +467,12 @@ mod test {
     #[tokio::test]
     async fn test_scheduler_timing() {
         init_tracing(None);
-        let schedule = Schedule::new(Arc::new(TimedComponent {
-            name: "test_scheduler_timing".into(),
-        }))
+        let schedule = Schedule::new(
+            Arc::from("test_scheduler_timing"),
+            Arc::new(TimedComponent {
+                name: "test_scheduler_timing".into(),
+            }),
+        )
         .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))));
         let scheduler = Scheduler::new("test_scheduler_timing".into(), vec![Arc::new(schedule)]);
         let scheduler = scheduler.start().await.expect("Scheduler should start");
@@ -357,13 +501,19 @@ mod test {
 
     #[tokio::test]
     async fn test_multi_schedule() {
-        let schedule_one = Schedule::new(Arc::new(TestComponent {
-            name: Arc::from("test_multi_schedule"),
-        }))
+        let schedule_one = Schedule::new(
+            Arc::from("test_multi_schedule_one"),
+            Arc::new(TestComponent {
+                name: Arc::from("test_multi_schedule"),
+            }),
+        )
         .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))));
-        let schedule_two = Schedule::new(Arc::new(TestComponent {
-            name: Arc::from("test_multi_schedule"),
-        }))
+        let schedule_two = Schedule::new(
+            Arc::from("test_multi_schedule_two"),
+            Arc::new(TestComponent {
+                name: Arc::from("test_multi_schedule"),
+            }),
+        )
         .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))));
         let scheduler = Scheduler::<NotStarted>::new(
             "test_multi_schedule".into(),
@@ -387,9 +537,12 @@ mod test {
         let (tx, rx) = tokio::sync::mpsc::channel::<Option<Arc<TaskRequest>>>(1);
         let manual_channel = ManualRequestChannel::new(rx);
         let manual_channel_lock = Arc::new(RwLock::new(manual_channel));
-        let schedule = Schedule::new(Arc::new(TestComponent {
-            name: "test_multi_evaluator".into(),
-        }))
+        let schedule = Schedule::new(
+            Arc::from("test_multi_evaluator"),
+            Arc::new(TestComponent {
+                name: "test_multi_evaluator".into(),
+            }),
+        )
         .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))))
         .add_trigger(manual_channel_lock);
         let scheduler = Scheduler::new("test_multi_evaluator".into(), vec![Arc::new(schedule)]);
@@ -415,9 +568,12 @@ mod test {
         let (tx, rx) = tokio::sync::mpsc::channel::<Option<Arc<TaskRequest>>>(1);
         let manual_channel = ManualRequestChannel::new(rx);
         let manual_channel_lock = Arc::new(RwLock::new(manual_channel));
-        let schedule = Schedule::new(Arc::new(TestComponent {
-            name: "test_manual_interrupts".into(),
-        }))
+        let schedule = Schedule::new(
+            Arc::from("test_manual_interrupts"),
+            Arc::new(TestComponent {
+                name: "test_manual_interrupts".into(),
+            }),
+        )
         .add_trigger(manual_channel_lock);
         let scheduler = Scheduler::new("test_manual_interrupts".into(), vec![Arc::new(schedule)]);
         let scheduler = scheduler.start().await.expect("Scheduler should start");
@@ -443,9 +599,12 @@ mod test {
         let (tx, rx) = tokio::sync::mpsc::channel::<Option<Arc<TaskRequest>>>(1);
         let manual_channel = ManualRequestChannel::new(rx);
         let manual_channel_lock = Arc::new(RwLock::new(manual_channel));
-        let schedule = Schedule::new(Arc::new(TestComponent {
-            name: "test_manual_queued_with_interrupt".into(),
-        }))
+        let schedule = Schedule::new(
+            Arc::from("test_manual_queued_with_interrupt"),
+            Arc::new(TestComponent {
+                name: "test_manual_queued_with_interrupt".into(),
+            }),
+        )
         .add_trigger(manual_channel_lock);
         let scheduler = Scheduler::new(
             "test_manual_queued_with_interrupt".into(),
@@ -474,10 +633,13 @@ mod test {
         let (tx, rx) = tokio::sync::mpsc::channel::<Option<Arc<TaskRequest>>>(1);
         let manual_channel = ManualRequestChannel::new(rx);
         let manual_channel_lock = Arc::new(RwLock::new(manual_channel));
-        let schedule = Schedule::new(Arc::new(LongComponent {
-            name: "test_manual_queue_clears_after_immediate".into(),
-            wait: 5,
-        }))
+        let schedule = Schedule::new(
+            Arc::from("test_manual_queue_clears_after_immediate"),
+            Arc::new(LongComponent {
+                name: "test_manual_queue_clears_after_immediate".into(),
+                wait: 5,
+            }),
+        )
         .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))))
         .add_trigger(manual_channel_lock);
         let scheduler = Scheduler::new(
@@ -498,6 +660,102 @@ mod test {
         assert!(
             *count == 1,
             "Test component should have executed 1 times, but got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_adding_schedule_while_running_starts() {
+        let schedule = Schedule::new(
+            Arc::from("test_adding_schedule_while_running_starts_existing"),
+            Arc::new(TestComponent {
+                name: Arc::from("test_adding_schedule_while_running_starts_existing"),
+            }),
+        )
+        .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))));
+        let scheduler = Scheduler::<NotStarted>::new(
+            "test_adding_schedule_while_running_starts".into(),
+            vec![Arc::new(schedule)],
+        );
+        let scheduler = scheduler.start().await.expect("Scheduler should start");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        // add a new schedule while the scheduler has been running for some time
+        let new_schedule = Schedule::new(
+            Arc::from("test_adding_schedule_while_running_starts_new"),
+            Arc::new(TestComponent {
+                name: Arc::from("test_adding_schedule_while_running_starts_new"),
+            }),
+        )
+        .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))));
+
+        scheduler
+            .add_schedule(Arc::new(new_schedule))
+            .await
+            .expect("To add new schedule");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        scheduler.stop().await;
+        let map_lock = TEST_EXECUTION_COUNT.read().await;
+        let count = map_lock
+            .get("test_adding_schedule_while_running_starts_existing")
+            .expect("To get test execution count");
+        assert!(
+            *count == 9 || *count == 10,
+            "Test component should have executed 9 or 10 times, but got {count}"
+        );
+        let count = map_lock
+            .get("test_adding_schedule_while_running_starts_new")
+            .expect("To get test execution count");
+        assert!(
+            *count == 4 || *count == 5,
+            "Test component should have executed 4 or 5 times, but got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_adding_trigger_to_existing_schedule() {
+        let schedule = Schedule::new(
+            Arc::from("test_adding_trigger_to_existing_schedule"),
+            Arc::new(TestComponent {
+                name: Arc::from("test_adding_trigger_to_existing_schedule"),
+            }),
+        );
+        let scheduler = Scheduler::<NotStarted>::new(
+            "test_adding_trigger_to_existing_schedule".into(),
+            vec![Arc::new(schedule)],
+        );
+        let scheduler = scheduler.start().await.expect("Scheduler should start");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        let map_lock = TEST_EXECUTION_COUNT.read().await;
+        let count = map_lock
+            .get("test_adding_trigger_to_existing_schedule")
+            .expect("To get test execution count");
+        assert!(
+            *count == 0,
+            "Test component should have executed 0 times, but got {count}"
+        );
+        drop(map_lock);
+
+        // add a new trigger to the existing schedule
+        let new_trigger = Arc::new(RwLock::new(IntervalRequestChannel::new(1)));
+        scheduler
+            .add_trigger_for_schedule(
+                Arc::from("test_adding_trigger_to_existing_schedule"),
+                new_trigger,
+            )
+            .await
+            .expect("To add new trigger");
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        scheduler.stop().await;
+        let map_lock = TEST_EXECUTION_COUNT.read().await;
+        let count = map_lock
+            .get("test_adding_trigger_to_existing_schedule")
+            .expect("To get test execution count");
+        assert!(
+            *count == 4 || *count == 5,
+            "Test component should have executed 4 or 5 times, but got {count}"
         );
     }
 }

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -149,6 +149,9 @@ pub struct Acceleration {
     pub refresh_check_interval: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_cron: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refresh_sql: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -220,6 +223,7 @@ impl Default for Acceleration {
             engine: None,
             refresh_mode: None,
             refresh_check_interval: None,
+            refresh_cron: None,
             refresh_sql: None,
             refresh_data_window: None,
             refresh_append_overlap: None,


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds the `refresh_cron` acceleration parameter for specifying a cron schedule. Currently does not parse the schedule, as it depends on #6005 
* Adds support for starting a `Scheduler` on runtime startup. Schedulers are stored in a vec on the runtime, to support adding schedules for other components as well (like future workers schedules, in #5921)
* Updates the `df.register_table()` function to return a `oneshot::Receiver<()>` to signal when the underlying table is ready. At the moment, this is only passed up from the `create_accelerated_table` call. In #6015 this will be updated to include a signal for when an accelerated table is loaded from a checkpoint.
* Refactors the `Scheduler` to support dynamically adding new schedules and triggers to a running scheduler. This refactor also made the code slightly cleaner/more separated for initialising new schedules and their associated channels.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5922
* Closes #5920
* Part of #5683

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

* Will need to add docs for the `refresh_cron` parameter, and the supported cron expression formats. Also, needs a note for exclusivity of `refresh_cron` and `refresh_check_interval` parameters.
