### PR TITLE
Update license check to allow dual license crates

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -34,7 +34,7 @@ on:
 
 env:
   FORBIDDEN_LICENSE_CHECK: |
-    grep -B 1 -E "GPL|CC-BY-SA|CC-BY-NC|CC-BY-NC-SA|CC-BY-NC-ND|APSL|CPAL|EUPL|NPOSL|OSL|SSPL|Parity|RPL|QPL|Sleepycat|copyleft|CDDL|CPL|EPL|ErlPL|IPL|MS-RL|SPL|Facebook|Commons-Clause" | grep . && exit 1 || echo "ok"
+    grep -v 'Apache-2.0' | grep -B 1 -E "GPL|CC-BY-SA|CC-BY-NC|CC-BY-NC-SA|CC-BY-NC-ND|APSL|CPAL|EUPL|NPOSL|OSL|SSPL|Parity|RPL|QPL|Sleepycat|copyleft|CDDL|CPL|EPL|ErlPL|IPL|MS-RL|SPL|Facebook|Commons-Clause" | grep . && exit 1 || echo "ok"
 
 jobs:
   license-check-rust:

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -34,7 +34,7 @@ on:
 
 env:
   FORBIDDEN_LICENSE_CHECK: |
-    grep -v 'Apache-2.0' | grep -B 1 -E "GPL|CC-BY-SA|CC-BY-NC|CC-BY-NC-SA|CC-BY-NC-ND|APSL|CPAL|EUPL|NPOSL|OSL|SSPL|Parity|RPL|QPL|Sleepycat|copyleft|CDDL|CPL|EPL|ErlPL|IPL|MS-RL|SPL|Facebook|Commons-Clause" | grep . && exit 1 || echo "ok"
+    grep -B 1 -E "GPL|CC-BY-SA|CC-BY-NC|CC-BY-NC-SA|CC-BY-NC-ND|APSL|CPAL|EUPL|NPOSL|OSL|SSPL|Parity|RPL|QPL|Sleepycat|copyleft|CDDL|CPL|EPL|ErlPL|IPL|MS-RL|SPL|Facebook|Commons-Clause" | grep . && exit 1 || echo "ok"
 
 jobs:
   license-check-rust:
@@ -43,13 +43,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up make
-        uses: ./.github/actions/setup-make
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
         with:
           os: macos
 
+      - name: Install cargo-deny
+        run: cargo install cargo-deny
+
       - name: Check Rust Licenses
-        run: make dep-licenses 2>&1 | ${{ env.FORBIDDEN_LICENSE_CHECK }}
+        run: cargo deny check licenses
 
   license-check-go:
     name: Check Golang Licenses

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,59 @@
+[graph]
+# Cargo deny will check dependencies via `--all-features`
+all-features = true
+
+[advisories]
+ignore = [
+]
+yanked = "deny"
+
+[bans]
+allow-wildcard-paths = false
+multiple-versions    = "allow"
+
+[licenses]
+
+allow = [
+  "Apache-2.0 WITH LLVM-exception",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "BlueOak-1.0.0",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "Unicode-3.0",
+  "Zlib",
+  "OpenSSL",
+  "0BSD"
+]
+private = { ignore = false }
+unused-allowed-license = "deny"
+
+[sources]
+unknown-git      = "deny"
+unknown-registry = "deny"
+
+# text-embeddings-* have empty license but belongs to the text-embeddings-inference / Apache-2.0 license
+[[licenses.clarify]]
+name = "text-embeddings-core"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "text-embeddings-backend"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "text-embeddings-backend-core"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+name = "text-embeddings-backend-candle"
+expression = "Apache-2.0"
+license-files = []
+

--- a/tools/evalconverter/Cargo.toml
+++ b/tools/evalconverter/Cargo.toml
@@ -3,6 +3,7 @@ description = "Converts https://github.com/openai/evals into SpiceAI compatible 
 edition = "2021"
 name = "evalconverter"
 version = "0.1.0"
+license.workspace = true
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Use `cargo-deny` to verify Rust licenses instead of regular expressions. This approach is more robust for handling dual licenses, such as r-efi 5.2.0, which is licensed under "Apache-2.0 OR LGPL-2.1-or-later OR MIT."

## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
