### PR TITLE
Don't fail if cargo-deny is already installed (license check)

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -49,7 +49,7 @@ jobs:
           os: macos
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        run: cargo install cargo-deny || true
 
       - name: Check Rust Licenses
         run: cargo deny check licenses


### PR DESCRIPTION
## 📝 Summary

For some runs I see the following error. This does not happen always if cargo-deny already installed.
https://github.com/spiceai/spiceai/actions/runs/15295478735/job/43023733649

```
Run cargo install cargo-deny
    Updating crates.io index
error: binary `cargo-deny` already exists in destination
Add --force to overwrite
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
