### PR TITLE
feat: Add cron scheduler configurations for workers

### DIFF
--- a/bin/spice/cmd/trace.go
+++ b/bin/spice/cmd/trace.go
@@ -48,7 +48,7 @@ var supported_trace_tasks = []string{
 	"ai_chat", "accelerated_refresh", "ai_completion", "eval_run", "nsql", "sql_query",
 	"tool_use::document_similarity", "tool_use::list_datasets", "tool_use::load_memory",
 	"tool_use::sample_data", "tool_use::sql", "tool_use::store_memory",
-	"tool_use::table_schema", "vector_search",
+	"tool_use::table_schema", "vector_search", "scheduler::worker",
 }
 
 func isValidTraceTask(task string) bool {

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -204,4 +204,36 @@ impl Runtime {
 
         Ok(())
     }
+
+    pub async fn remove_worker_schedule(self: Arc<Self>, worker: Worker) -> Result<()> {
+        let scheduler_lock = Arc::clone(&self.schedulers);
+        let schedulers = scheduler_lock.read().await;
+        let worker_name = worker.name.to_string().into();
+
+        if let Some(scheduler) = schedulers.get(WORKER_SCHEDULER_NAME) {
+            if scheduler
+                .schedules()
+                .await
+                .iter()
+                .any(|s| s.name() == worker_name)
+            {
+                tracing::debug!("Removing worker schedule for worker: {worker_name}",);
+                scheduler
+                    .remove_schedule(Arc::clone(&worker_name))
+                    .await
+                    .context(crate::FailedToRemoveScheduleSnafu {
+                        name: worker_name.to_string(),
+                        scheduler: WORKER_SCHEDULER_NAME.to_string(),
+                    })?;
+            } else {
+                tracing::debug!("No worker schedule found for worker: {worker_name}",);
+            }
+        } else {
+            tracing::debug!(
+                "No worker scheduler found, cannot remove schedule for worker: {worker_name}",
+            );
+        }
+
+        Ok(())
+    }
 }

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -120,7 +120,7 @@ impl Runtime {
             }
             (_, Some(v)) => {
                 tracing::warn!(
-                    "Worker '{}' has a 'prompt' but it is not a string: {v}.\nThe worker will not be scheduled to run.\nSpecify a 'start_cron' parameter and try again.",
+                    "Worker '{}' has a 'prompt' but it is not a string: {v}.\nThe worker will not be scheduled to run.\nSpecify a valid 'prompt' parameter and try again.",
                     worker.name,
                 );
                 return Ok(());

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -17,15 +17,23 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use scheduler::{
+    channel::cron::CronRequestChannel,
     schedule::Schedule,
     scheduler::{Running, Scheduler, SchedulerBuilder},
 };
+use serde_json::Value;
 use snafu::ResultExt;
+use spicepod::component::worker::Worker;
 use tokio::sync::RwLock;
 
-use crate::{Result, Runtime, component::dataset::Dataset, scheduling::DatasetRefreshTask};
+use crate::{
+    Result, Runtime,
+    component::dataset::Dataset,
+    scheduling::{DatasetRefreshTask, WorkerPromptTask},
+};
 
 const REFRESH_SCHEDULER_NAME: &str = "refresh_scheduler";
+const WORKER_SCHEDULER_NAME: &str = "worker_scheduler";
 
 pub(crate) type ScheduleRegistry = RwLock<HashMap<Arc<str>, Arc<Scheduler<Running>>>>;
 
@@ -89,6 +97,110 @@ impl Runtime {
         );
 
         schedulers.insert(REFRESH_SCHEDULER_NAME.into(), Arc::clone(&scheduler));
+
+        Ok(())
+    }
+
+    pub async fn create_worker_schedule(self: Arc<Self>, worker: Worker) -> Result<()> {
+        let (start_cron, prompt) = match (worker.start_cron.clone(), worker.params.get("prompt")) {
+            (Some(cron), Some(Value::String(prompt))) => (cron, prompt.clone()),
+            (Some(_), None) => {
+                tracing::warn!(
+                    "Worker '{}' has a 'start_cron' but no prompt is specified.\nThe worker will not be scheduled to run.\nSpecify a 'prompt' parameter and try again.",
+                    worker.name
+                );
+                return Ok(());
+            }
+            (None, Some(Value::String(_))) => {
+                tracing::warn!(
+                    "Worker '{}' has a 'prompt' but no 'start_cron' is specified.\nThe worker will not be scheduled to run.\nSpecify a 'start_cron' parameter and try again.",
+                    worker.name
+                );
+                return Ok(());
+            }
+            (_, Some(v)) => {
+                tracing::warn!(
+                    "Worker '{}' has a 'prompt' but it is not a string: {v}.\nThe worker will not be scheduled to run.\nSpecify a 'start_cron' parameter and try again.",
+                    worker.name,
+                );
+                return Ok(());
+            }
+            (None, None) => {
+                tracing::debug!(
+                    "Worker {} has no start cron or prompt, skipping schedule creation",
+                    worker.name
+                );
+                return Ok(());
+            }
+        };
+
+        let scheduler_lock = Arc::clone(&self.schedulers);
+        let mut schedulers = scheduler_lock.write().await;
+        let worker_name = worker.name.to_string().into();
+
+        let worker_prompt_task = Arc::new(WorkerPromptTask::new(
+            Arc::clone(&self),
+            Arc::new(worker),
+            Arc::from(prompt),
+        ));
+
+        let cron_request_channel = Arc::new(RwLock::new(
+            CronRequestChannel::new(&start_cron.clone().into()).context(
+                crate::FailedToCreateCronChannelSnafu {
+                    cron: start_cron.clone(),
+                },
+            )?,
+        ));
+
+        let schedule = Arc::new(
+            Schedule::new(Arc::clone(&worker_name), worker_prompt_task)
+                .add_trigger(cron_request_channel),
+        );
+
+        tracing::debug!("Creating worker schedule for worker: {worker_name}");
+
+        if let Some(scheduler) = schedulers.get(WORKER_SCHEDULER_NAME) {
+            if scheduler
+                .schedules()
+                .await
+                .iter()
+                .any(|s| s.name() == schedule.name())
+            {
+                tracing::debug!(
+                    "Worker schedule already exists in worker scheduler for worker: {worker_name}",
+                );
+                return Ok(());
+            }
+
+            tracing::debug!(
+                "Adding worker schedule to existing worker scheduler for worker: {worker_name}",
+            );
+            scheduler
+                .add_schedule(schedule)
+                .await
+                .context(crate::FailedToAddScheduleSnafu {
+                    name: worker_name.to_string(),
+                    scheduler: WORKER_SCHEDULER_NAME.to_string(),
+                })?;
+            return Ok(());
+        }
+
+        // create a new 'worker_scheduler' if it doesn't exist
+        tracing::debug!("Creating new worker scheduler for worker schedule: {worker_name}",);
+
+        let scheduler = Arc::new(
+            SchedulerBuilder::new(WORKER_SCHEDULER_NAME.into())
+                .add_schedule(schedule)
+                .build()
+                .context(crate::FailedToBuildSchedulerSnafu)?
+                .start()
+                .await
+                .context(crate::FailedToStartSchedulerSnafu)?,
+        );
+        schedulers.insert(WORKER_SCHEDULER_NAME.into(), Arc::clone(&scheduler));
+        tracing::debug!(
+            "Worker scheduler created for worker '{worker_name}' with cron: {start_cron}",
+        );
 
         Ok(())
     }

--- a/crates/runtime/src/init/worker.rs
+++ b/crates/runtime/src/init/worker.rs
@@ -24,19 +24,21 @@ use snafu::prelude::*;
 pub enum Error {}
 
 impl Runtime {
-    pub(crate) async fn load_workers(&self) {
+    pub(crate) async fn load_workers(self: Arc<Self>) {
         let app_lock = self.app.read().await;
 
         if let Some(app) = app_lock.as_ref() {
             for worker in &app.workers {
-                self.status
+                let runtime = Arc::clone(&self);
+                runtime
+                    .status
                     .update_worker(&worker.name, status::ComponentStatus::Initializing);
-                self.load_worker(worker).await;
+                runtime.load_worker(worker).await;
             }
         }
     }
 
-    async fn load_worker(&self, cfg: &spicepod::component::worker::Worker) {
+    async fn load_worker(self: Arc<Self>, cfg: &spicepod::component::worker::Worker) {
         let _guard = TimeMeasurement::new(
             &metrics::workers::LOAD_DURATION_MS,
             &[KeyValue::new("worker", cfg.name.clone())],
@@ -44,7 +46,7 @@ impl Runtime {
 
         tracing::info!("Loading worker [{}]...", cfg.name);
 
-        let worker = match try_construct_worker(&cfg.r#type, cfg, self) {
+        let worker = match try_construct_worker(&cfg.r#type, cfg, &self) {
             Ok(worker) => worker,
             Err(e) => {
                 tracing::error!("Failed to load worker [{}]: {e}", cfg.name);
@@ -67,9 +69,17 @@ impl Runtime {
         metrics::workers::COUNT.add(1, &[KeyValue::new("worker", cfg.name.clone())]);
         self.status
             .update_worker(&cfg.name, status::ComponentStatus::Ready);
+
+        if let Err(e) = Arc::clone(&self).create_worker_schedule(cfg.clone()).await {
+            tracing::error!("Failed to create scheduler for worker [{}]: {e}", cfg.name);
+            self.status
+                .update_worker(&cfg.name, status::ComponentStatus::Error);
+        } else {
+            tracing::info!("Scheduler for worker [{}] created successfully", cfg.name);
+        }
     }
 
-    async fn remove_worker(&self, cfg: &spicepod::component::worker::Worker) {
+    async fn remove_worker(self: Arc<Self>, cfg: &spicepod::component::worker::Worker) {
         let mut llm_registry = self.llms.write().await;
         llm_registry.remove(&cfg.name);
 
@@ -77,24 +87,26 @@ impl Runtime {
         metrics::workers::COUNT.add(-1, &[KeyValue::new("worker", cfg.name.clone())]);
     }
 
-    async fn update_worker(&self, worker_config: &spicepod::component::worker::Worker) {
+    async fn update_worker(self: Arc<Self>, worker_config: &spicepod::component::worker::Worker) {
         self.status
             .update_worker(&worker_config.name, status::ComponentStatus::Refreshing);
-        self.remove_worker(worker_config).await;
-        self.load_worker(worker_config).await;
+        Arc::clone(&self).remove_worker(worker_config).await;
+        Arc::clone(&self).load_worker(worker_config).await;
     }
 
     pub(crate) async fn apply_worker_diff(
-        &self,
+        self: Arc<Self>,
         current_app: &Arc<app::App>,
         new_app: &Arc<app::App>,
     ) {
         // Remove workers that are no longer in the app
         for worker in &current_app.workers {
             if !new_app.workers.iter().any(|w| w.name == worker.name) {
-                self.status
+                let runtime = Arc::clone(&self);
+                runtime
+                    .status
                     .update_worker(&worker.name, status::ComponentStatus::Disabled);
-                self.remove_worker(worker).await;
+                runtime.remove_worker(worker).await;
             }
         }
 
@@ -102,12 +114,14 @@ impl Runtime {
             if let Some(current_worker) = current_app.workers.iter().find(|w| w.name == worker.name)
             {
                 if current_worker != worker {
-                    self.update_worker(worker).await;
+                    Arc::clone(&self).update_worker(worker).await;
                 }
             } else {
-                self.status
+                let runtime = Arc::clone(&self);
+                runtime
+                    .status
                     .update_worker(&worker.name, status::ComponentStatus::Initializing);
-                self.load_worker(worker).await;
+                runtime.load_worker(worker).await;
             }
         }
     }

--- a/crates/runtime/src/init/worker.rs
+++ b/crates/runtime/src/init/worker.rs
@@ -83,6 +83,13 @@ impl Runtime {
         let mut llm_registry = self.llms.write().await;
         llm_registry.remove(&cfg.name);
 
+        if let Err(e) = Arc::clone(&self).remove_worker_schedule(cfg.clone()).await {
+            tracing::error!("Failed to remove scheduler for worker [{}]: {e}", cfg.name);
+            self.status
+                .update_worker(&cfg.name, status::ComponentStatus::Error);
+            return;
+        }
+
         tracing::info!("Worker [{}] has been unloaded", cfg.name);
         metrics::workers::COUNT.add(-1, &[KeyValue::new("worker", cfg.name.clone())]);
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -368,6 +368,14 @@ pub enum Error {
         scheduler: String,
         name: String,
     },
+
+    #[snafu(display(
+        "Failed to create a cron schedule from the provided expression: '{cron}'\n{source}\nEnsure the cron expression is valid and try again."
+    ))]
+    FailedToCreateCronChannel {
+        cron: String,
+        source: scheduler::Error,
+    },
 }
 
 const HTTP_SERVER: &str = "http_server";
@@ -755,7 +763,7 @@ impl Runtime {
 
                 #[cfg(feature = "models")]
                 {
-                    self_clone.load_workers().await;
+                    Arc::clone(&self_clone).load_workers().await;
                     self_clone.load_eval_scorer().await;
                     let () = self_clone.verify_evals().await;
                     let an_eval_exists = app_lock.as_ref().is_some_and(|app| !app.evals.is_empty());

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -376,6 +376,15 @@ pub enum Error {
         cron: String,
         source: scheduler::Error,
     },
+
+    #[snafu(display(
+        "Failed to remove a schedule '{name}' from the '{scheduler}' scheduler.\n{source}\nReport a bug on GitHub: https://github.com/spiceai/spiceai/issues"
+    ))]
+    FailedToRemoveSchedule {
+        source: scheduler::Error,
+        scheduler: String,
+        name: String,
+    },
 }
 
 const HTTP_SERVER: &str = "http_server";

--- a/crates/runtime/src/scheduling/mod.rs
+++ b/crates/runtime/src/scheduling/mod.rs
@@ -16,10 +16,14 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use async_openai::types::{ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs};
 use scheduler::Result;
 use scheduler::task::ScheduledTask;
+use spicepod::component::worker::Worker;
 use tonic::async_trait;
+use tracing_futures::Instrument;
 
+use crate::Runtime;
 use crate::component::dataset::Dataset;
 
 pub struct DatasetRefreshTask(Arc<Dataset>);
@@ -50,5 +54,89 @@ impl ScheduledTask for DatasetRefreshTask {
         }
 
         Ok(())
+    }
+}
+
+pub struct WorkerPromptTask {
+    runtime: Arc<Runtime>,
+    worker: Arc<Worker>,
+    prompt: Arc<str>,
+}
+
+impl WorkerPromptTask {
+    pub fn new(runtime: Arc<Runtime>, worker: Arc<Worker>, prompt: Arc<str>) -> Self {
+        Self {
+            runtime,
+            worker,
+            prompt,
+        }
+    }
+}
+
+#[async_trait]
+impl ScheduledTask for WorkerPromptTask {
+    async fn execute(&self) -> Result<()> {
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "scheduler::worker", input = %self.prompt, worker = %self.worker.name, prompt = %self.prompt);
+
+        async {
+            let worker = Arc::clone(&self.worker);
+            let prompt = Arc::clone(&self.prompt);
+            let runtime = Arc::clone(&self.runtime);
+
+            let workers_lock = Arc::clone(&runtime.workers);
+            let workers = workers_lock.read().await;
+            let Some(worker) = workers.get(&worker.name) else {
+                tracing::debug!("Worker not found for ScheduledTask: {}", worker.name);
+                return Ok(());
+            };
+
+            tracing::debug!(
+                "Executing worker prompt task for worker: {}, prompt: {}",
+                worker.name(),
+                prompt
+            );
+
+            let Some(model) = Arc::clone(worker).as_model() else {
+                tracing::debug!(
+                    "Worker is not a model worker, skipping prompt execution: {}",
+                    worker.name()
+                );
+                return Ok(());
+            };
+
+            let Ok(message_args) = ChatCompletionRequestUserMessageArgs::default()
+                .content(prompt.to_string())
+                .build()
+            else {
+                tracing::error!(
+                    "Failed to build chat completion request message for worker '{}'",
+                    worker.name()
+                );
+                return Ok(());
+            };
+
+            let Ok(chat_request) = CreateChatCompletionRequestArgs::default()
+                .messages(vec![message_args.into()])
+                .build()
+            else {
+                tracing::error!(
+                    "Failed to build chat completion request for worker '{}'",
+                    worker.name()
+                );
+
+                return Ok(());
+            };
+
+            if let Err(e) = model.chat_request(chat_request).await {
+                tracing::error!(
+                    "Failed to execute worker prompt task for worker '{}': {e}",
+                    worker.name(),
+                );
+            }
+
+            Ok(())
+        }
+        .instrument(span)
+        .await
     }
 }

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -53,6 +53,10 @@ pub enum Error {
         "Failed to determine next cron expression run time.\n{source}\nConfirm the cron expression is valid, and try again."
     ))]
     FailedToDetermineNextCronRunTime { source: croner::errors::CronError },
+    #[snafu(display(
+        "The specified schedule '{name}' does not exist in the scheduler.\nEnsure the schedule is defined, and try again."
+    ))]
+    ScheduleNotFound { name: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -329,6 +329,86 @@ impl Scheduler<Running> {
 
         Ok(())
     }
+
+    /// Removes a running schedule from the scheduler.
+    ///
+    /// # Errors
+    ///
+    /// - If the schedule with the specified name does not exist.
+    pub async fn remove_schedule(&self, schedule_name: Arc<str>) -> Result<()> {
+        let mut schedules = self.state.schedules.write().await;
+        if let Some(index) = schedules.iter().position(|s| s.name() == schedule_name) {
+            schedules.remove(index);
+        } else {
+            return Err(crate::Error::ScheduleNotFound {
+                name: schedule_name.to_string(),
+            });
+        }
+
+        // Remove the request handles for the schedule
+        let handles = self
+            .state
+            .request_handles
+            .write()
+            .await
+            .remove(&schedule_name);
+
+        if let Some(handles) = handles {
+            for handle in handles {
+                handle.abort();
+                match handle.await {
+                    Ok(Ok(())) => {
+                        tracing::debug!("Request channel completed successfully");
+                    }
+                    Ok(Err(e)) => {
+                        tracing::error!("Request channel execution failed: {e}");
+                    }
+                    Err(e) => {
+                        tracing::error!("Request channel join error: {e}");
+                    }
+                }
+            }
+        }
+
+        // Remove the scheduler handles for the schedule
+        let handles = self
+            .state
+            .scheduler_handles
+            .write()
+            .await
+            .remove(&schedule_name);
+
+        if let Some(handles) = handles {
+            for handle in handles {
+                handle.abort();
+                match handle.await {
+                    Ok(Ok(())) => {
+                        tracing::debug!("Scheduler task completed successfully");
+                    }
+                    Ok(Err(e)) => {
+                        tracing::error!("Scheduler task execution failed: {e}");
+                    }
+                    Err(e) => {
+                        tracing::error!("Scheduler task join error: {e}");
+                    }
+                }
+            }
+        }
+
+        // Remove the request and submission channels for the schedule
+        self.state
+            .request_channels
+            .write()
+            .await
+            .remove(&schedule_name);
+        self.state
+            .submission_channels
+            .write()
+            .await
+            .remove(&schedule_name);
+
+        Ok(())
+    }
 }
 
 // ========== Tests ==========
@@ -378,6 +458,7 @@ mod test {
             0,
         );
         map.insert(Arc::from("test_adding_trigger_to_existing_schedule"), 0);
+        map.insert(Arc::from("test_remove_schedule"), 0);
 
         RwLock::new(map)
     });
@@ -752,6 +833,51 @@ mod test {
         let map_lock = TEST_EXECUTION_COUNT.read().await;
         let count = map_lock
             .get("test_adding_trigger_to_existing_schedule")
+            .expect("To get test execution count");
+        assert!(
+            *count == 4 || *count == 5,
+            "Test component should have executed 4 or 5 times, but got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_schedule() {
+        let schedule = Schedule::new(
+            Arc::from("test_remove_schedule"),
+            Arc::new(TestComponent {
+                name: Arc::from("test_remove_schedule"),
+            }),
+        )
+        .add_trigger(Arc::new(RwLock::new(IntervalRequestChannel::new(1))));
+        let scheduler =
+            Scheduler::<NotStarted>::new("test_remove_schedule".into(), vec![Arc::new(schedule)]);
+        let scheduler = scheduler.start().await.expect("Scheduler should start");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        let map_lock = TEST_EXECUTION_COUNT.read().await;
+        let count = map_lock
+            .get("test_remove_schedule")
+            .expect("To get test execution count");
+
+        assert!(
+            *count == 4 || *count == 5,
+            "Test component should have executed 4 or 5 times, but got {count}"
+        );
+
+        drop(map_lock);
+
+        // remove the schedule
+        scheduler
+            .remove_schedule(Arc::from("test_remove_schedule"))
+            .await
+            .expect("To remove schedule");
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        scheduler.stop().await;
+        let map_lock = TEST_EXECUTION_COUNT.read().await;
+        let count = map_lock
+            .get("test_remove_schedule")
             .expect("To get test execution count");
         assert!(
             *count == 4 || *count == 5,

--- a/crates/spicepod/src/component/worker.rs
+++ b/crates/spicepod/src/component/worker.rs
@@ -46,6 +46,9 @@ pub struct Worker {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub load_balance: Option<LoadBalanceParams>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_cron: Option<String>,
 }
 
 impl FromStr for WorkerType {
@@ -81,6 +84,7 @@ impl WithDependsOn<Worker> for Worker {
             description: self.description.clone(),
             params: self.params.clone(),
             load_balance: self.load_balance.clone(),
+            start_cron: self.start_cron.clone(),
         }
     }
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds scheduler configuration for workers based on the UX from #5683
  * Adds `start_cron`, which specifies a cron schedule to execute the worker on
  * Adds a `prompt` parameter, which specifies the prompt that will be used for scheduled execution
* Adds a tracing span for scheduled worker prompt events as `scheduler::worker`

Here's an example of the scheduler in action:

```bash
TREE                          STATUS DURATION   SPANID           INPUT                                                                                                         OUTPUT                                                                                                       
scheduler::worker             ✅      2355.75ms a4cda54e424820eb Using the sql tool, query the customer table and calculate how many customer rec... (15 characters omitted)   <empty>                                                                                                      
  ├── tool_use::list_datasets ✅         0.32ms 0434650df8b11509 <empty>                                                                                                       [{"table":"spice.public.customer","can_search_documents":false,"description":nul... (17 characters omitted)  
  ├── ai_completion           ✅      1018.05ms bd9a5e0b7aed8d00 {"messages":[{"role":"assistant","tool_calls":[{"id":"initial_list_datasets","ty... (4993 characters omitted) [{"content":null,"refusal":null,"tool_calls":[{"id":"call_kR3lU6jPR96sOhaH7v6kQc... (177 characters omitted) 
  ├── tool_use::sql           ✅         7.96ms 4d878a48f81421fc {"query":"SELECT COUNT(*) FROM spice.public.customer"}                                                        <empty>                                                                                                      
  │ └── sql_query             ✅         7.76ms b24aa9071535f741 SELECT COUNT(*) FROM spice.public.customer                                                                    [{"count(*)":150000}]                                                                                        
  └── ai_completion           ✅      1326.98ms d142dc315686398a {"messages":[{"role":"assistant","tool_calls":[{"id":"initial_list_datasets","ty... (5312 characters omitted) [{"content":"There are 150,000 customer records in the customer table.","refusal... (79 characters omitted)
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #5921
* Part of #5683

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

* Worker documentation will require updates for the new parameters: https://github.com/spiceai/docs/issues/1020
