### PR TITLE
refactor: Remove worker type

### DIFF
--- a/crates/runtime/src/http/v1/workers.rs
+++ b/crates/runtime/src/http/v1/workers.rs
@@ -49,7 +49,6 @@ pub(crate) struct WorkerResponse {
 pub(crate) struct WorkerResponseItem {
     name: String,
     description: Option<String>,
-    r#type: String,
     is_llm: bool,
 }
 
@@ -57,7 +56,6 @@ fn worker_details(worker: &Arc<dyn Worker>) -> WorkerResponseItem {
     WorkerResponseItem {
         name: worker.name().to_string(),
         description: worker.description().map(|d| d.to_string()),
-        r#type: worker.role().to_string(),
         is_llm: Arc::clone(worker).as_model().is_some(),
     }
 }
@@ -79,13 +77,11 @@ fn worker_details(worker: &Arc<dyn Worker>) -> WorkerResponseItem {
                     {
                         "name": "round-robin",
                         "description": "Distributes requests between foo and bar models in a round-robin fashion.\n",
-                        "type": "load_balance",
                         "is_llm": true
                     },
                     {
                         "name": "fallback",
                         "description": "Attempts bar first, then foo, then baz if previous models fail.\n",
-                        "type": "load_balance",
                         "is_llm": true
                     }
                 ]

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -102,7 +102,7 @@ impl Runtime {
     }
 
     pub async fn create_worker_schedule(self: Arc<Self>, worker: Worker) -> Result<()> {
-        let (start_cron, prompt) = match (worker.start_cron.clone(), worker.params.get("prompt")) {
+        let (start_cron, prompt) = match (worker.cron.clone(), worker.params.get("prompt")) {
             (Some(cron), Some(Value::String(prompt))) => (cron, prompt.clone()),
             (Some(_), None) => {
                 tracing::warn!(

--- a/crates/runtime/src/init/worker.rs
+++ b/crates/runtime/src/init/worker.rs
@@ -46,7 +46,7 @@ impl Runtime {
 
         tracing::info!("Loading worker [{}]...", cfg.name);
 
-        let worker = match try_construct_worker(&cfg.r#type, cfg, &self) {
+        let worker = match try_construct_worker(cfg, &self) {
             Ok(worker) => worker,
             Err(e) => {
                 tracing::error!("Failed to load worker [{}]: {e}", cfg.name);

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -385,6 +385,11 @@ pub enum Error {
         scheduler: String,
         name: String,
     },
+
+    #[snafu(display(
+        "Failed to infer the worker type for the worker '{name}'.\nEnsure the worker has a valid configuration, and try again.\nFor details, visit: https://spiceai.org/docs/components/workers"
+    ))]
+    FailedToInferWorkerType { name: String },
 }
 
 const HTTP_SERVER: &str = "http_server";

--- a/crates/runtime/src/worker.rs
+++ b/crates/runtime/src/worker.rs
@@ -18,7 +18,7 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use llms::chat::Chat;
-use spicepod::component::worker::{Worker as WorkerComponent, WorkerType};
+use spicepod::component::worker::Worker as WorkerComponent;
 use tokio::sync::RwLock;
 use workers::RouterModel;
 
@@ -26,20 +26,37 @@ use crate::{Result, Runtime};
 
 pub type WorkerRegistry = Arc<RwLock<HashMap<String, Arc<dyn Worker>>>>;
 
-pub fn try_construct_worker(
-    worker_type: &WorkerType,
-    worker: &WorkerComponent,
-    rt: &Runtime,
-) -> Result<Arc<dyn Worker>> {
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum WorkerType {
+    #[default]
+    LoadBalance,
+}
+
+impl std::fmt::Display for WorkerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkerType::LoadBalance => write!(f, "load_balance"),
+        }
+    }
+}
+
+fn infer_worker_type(worker: &WorkerComponent) -> Result<WorkerType> {
+    if worker.load_balance.is_some() {
+        Ok(WorkerType::LoadBalance)
+    } else {
+        Err(super::Error::FailedToInferWorkerType {
+            name: worker.name.clone(),
+        })
+    }
+}
+
+pub fn try_construct_worker(worker: &WorkerComponent, rt: &Runtime) -> Result<Arc<dyn Worker>> {
+    let worker_type = infer_worker_type(worker)?;
+
     match worker_type {
         WorkerType::LoadBalance => {
             let Some(load_balance) = &worker.load_balance else {
-                return Err(crate::Error::UnableToLoadWorker {
-                    source: Box::from(format!(
-                        "Worker '{}' is of 'type: {}', but has no 'load_balance' configuration",
-                        worker.name, worker.r#type
-                    )),
-                });
+                unreachable!("LoadBalance worker must have load_balance defined");
             };
 
             let model = RouterModel::new(
@@ -58,8 +75,6 @@ pub fn try_construct_worker(
 #[async_trait]
 pub trait Worker: Send + Sync {
     fn name(&self) -> Cow<'_, str>;
-
-    fn role(&self) -> WorkerType;
 
     fn description(&self) -> Option<Cow<'_, str>>;
 
@@ -80,10 +95,6 @@ impl LoadBalanceWorker {
 impl Worker for LoadBalanceWorker {
     fn name(&self) -> Cow<'_, str> {
         self.model.router_name.clone().into()
-    }
-
-    fn role(&self) -> WorkerType {
-        WorkerType::LoadBalance
     }
 
     fn description(&self) -> Option<Cow<'_, str>> {

--- a/crates/spicepod/src/component/worker.rs
+++ b/crates/spicepod/src/component/worker.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 use std::collections::HashMap;
-use std::str::FromStr;
 
 use super::{Nameable, WithDependsOn};
 #[cfg(feature = "schemars")]
@@ -24,20 +23,10 @@ use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-pub enum WorkerType {
-    #[default]
-    LoadBalance,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Worker {
     pub name: String,
-
-    pub r#type: WorkerType,
 
     pub description: Option<String>,
 
@@ -48,26 +37,7 @@ pub struct Worker {
     pub load_balance: Option<LoadBalanceParams>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub start_cron: Option<String>,
-}
-
-impl FromStr for WorkerType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "load_balance" => Ok(WorkerType::LoadBalance),
-            _ => Err(format!("Unknown worker type: {s}")),
-        }
-    }
-}
-
-impl std::fmt::Display for WorkerType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            WorkerType::LoadBalance => write!(f, "load_balance"),
-        }
-    }
+    pub cron: Option<String>,
 }
 
 impl Nameable for Worker {
@@ -80,11 +50,10 @@ impl WithDependsOn<Worker> for Worker {
     fn depends_on(&self, _depends_on: &[String]) -> Worker {
         Worker {
             name: self.name.clone(),
-            r#type: self.r#type.clone(),
             description: self.description.clone(),
             params: self.params.clone(),
             load_balance: self.load_balance.clone(),
-            start_cron: self.start_cron.clone(),
+            cron: self.cron.clone(),
         }
     }
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Removes the `type:` parameter from workers, instead inferring it from the specified properties on the worker.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #6036

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

* Will require updates to https://github.com/spiceai/docs/pull/1015
