### PR TITLE
Define SearchPipeline and use in `runtime/vector_search.rs`.

### DIFF
--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -162,9 +162,7 @@ pub(crate) async fn post(
             let error_type = match e {
                 VectorSearchError::NoTablesWithEmbeddingsFound {}
                 | VectorSearchError::CannotVectorSearchDataset { .. } => StatusCode::BAD_REQUEST,
-                VectorSearchError::CandidateAggregationError { ref source }
-                    if source.is_user_error() =>
-                {
+                VectorSearchError::SearchPipelineError { ref source } if source.is_user_error() => {
                     StatusCode::BAD_REQUEST
                 }
                 _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/runtime/src/search/mod.rs
+++ b/crates/runtime/src/search/mod.rs
@@ -45,12 +45,6 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Error occurred retrieving candidate search results: {source}"))]
-    CandidateGenerationError { source: search::generation::Error },
-
-    #[snafu(display("Error occurred aggregating candidate search results: {source}"))]
-    CandidateAggregationError { source: search::aggregation::Error },
-
     #[snafu(display("Error occurred in search pipeline: {source}"))]
     SearchPipelineError { source: search::pipeline::Error },
 

--- a/crates/runtime/src/search/mod.rs
+++ b/crates/runtime/src/search/mod.rs
@@ -22,6 +22,7 @@ pub mod vector_search;
 use arrow_schema::ArrowError;
 use datafusion::sql::TableReference;
 use itertools::Itertools;
+use search::aggregation;
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
@@ -47,6 +48,9 @@ pub enum Error {
 
     #[snafu(display("Error occurred in search pipeline: {source}"))]
     SearchPipelineError { source: search::pipeline::Error },
+
+    #[snafu(display("Error occurred aggregating candidate search results: {source}"))]
+    SearchAggregationError { source: aggregation::Error },
 
     #[snafu(display("Error occurred processing Arrow records: {source}"))]
     RecordProcessingError { source: ArrowError },

--- a/crates/runtime/src/search/mod.rs
+++ b/crates/runtime/src/search/mod.rs
@@ -51,6 +51,9 @@ pub enum Error {
     #[snafu(display("Error occurred aggregating candidate search results: {source}"))]
     CandidateAggregationError { source: search::aggregation::Error },
 
+    #[snafu(display("Error occurred in search pipeline: {source}"))]
+    SearchPipelineError { source: search::pipeline::Error },
+
     #[snafu(display("Error occurred processing Arrow records: {source}"))]
     RecordProcessingError { source: ArrowError },
 

--- a/crates/runtime/src/search/request.rs
+++ b/crates/runtime/src/search/request.rs
@@ -23,6 +23,7 @@ use datafusion::sql::sqlparser::keywords::Keyword;
 use datafusion::sql::sqlparser::parser::Parser;
 use datafusion::sql::sqlparser::tokenizer::Token;
 use schemars::JsonSchema;
+use search::pipeline::valid_keywords;
 use serde::{Deserialize, Serialize};
 
 use super::{Error, Result};
@@ -101,7 +102,7 @@ impl TryFrom<SearchRequestAIJson> for SearchRequest {
                 .transpose()?,
             SearchRequest::parse_additional_columns(&req.base.additional_columns)
                 .map_err(|e| e.to_string())?,
-            SearchRequest::parse_keywords(&req.keywords).map_err(|e| e.to_string())?,
+            valid_keywords(&req.keywords).map_err(|e| e.to_string())?,
         ))
     }
 }
@@ -355,16 +356,6 @@ impl SearchRequest {
 
         Ok(ilike_expr)
     }
-
-    pub fn parse_keywords(keywords: &[String]) -> Result<Vec<String>> {
-        keywords
-            .iter()
-            .map(|k| {
-                Self::validate_keyword_to_ilike(k.as_str(), "target_column")?; // emulate the use of the keyword in the query.
-                Ok(k.clone())
-            })
-            .collect::<Result<Vec<String>>>()
-    }
 }
 
 #[cfg(test)]
@@ -523,28 +514,6 @@ pub(crate) mod tests {
         // Test escaping column name
         let additional_columns = vec!["1; DROP TABLE testing; --".to_string()]; // would result in SELECT 1; DROP TABLE testing; -- FROM testing;
         let result = SearchRequest::parse_additional_columns(&additional_columns);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_search_request_parse_keywords() {
-        let keywords = vec!["keyword1".to_string(), "keyword2".to_string()];
-        let result = SearchRequest::parse_keywords(&keywords);
-        assert!(result.is_ok());
-
-        // Test keyword with a space
-        let keywords = vec!["keyword 1".to_string()];
-        let result = SearchRequest::parse_keywords(&keywords);
-        assert!(result.is_ok());
-
-        // Test empty keyword
-        let keywords = vec![String::new()];
-        let result = SearchRequest::parse_keywords(&keywords);
-        assert!(result.is_ok());
-
-        // Test escaping keyword
-        let keywords = vec!["'); DROP TABLE testing;".to_string()];
-        let result = SearchRequest::parse_keywords(&keywords);
         assert!(result.is_err());
     }
 }

--- a/crates/runtime/src/search/types.rs
+++ b/crates/runtime/src/search/types.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::ResultExt;
 
-use super::{CandidateAggregationSnafu, Result};
+use super::{Result, SearchAggregationSnafu};
 
 pub type ModelKey = String;
 pub type VectorSearchResult = HashMap<TableReference, AggregationResult>;
@@ -138,7 +138,7 @@ pub async fn to_pretty(agg: AggregationResult) -> Result<impl Display, ArrowErro
 pub async fn to_matches_sorted(result: VectorSearchResult, limit: usize) -> Result<Vec<Match>> {
     let mut matches: Vec<Match> = Vec::new();
     for (a, b) in result {
-        let mut o = to_matches(&a, b).await.context(CandidateAggregationSnafu)?;
+        let mut o = to_matches(&a, b).await.context(SearchAggregationSnafu)?;
         matches.append(&mut o);
     }
 

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -170,7 +170,7 @@ impl VectorSearch {
                         );
                     };
 
-                    let agg_result = SearchPipeline::new(generators, Box::new(ReciprocalRankFusion)).run(
+                    let agg_result = SearchPipeline::new(generators, ReciprocalRankFusion).run(
                          query.clone(),
                          where_cond.as_ref().map(|e| vec![e.clone()]).unwrap_or_default(),
                           additional_columns.iter().map(|s| Expr::Identifier(Ident::new(s))).collect(),

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -18,16 +18,23 @@ use std::{collections::HashMap, sync::Arc};
 
 use super::request::SearchRequest;
 use super::util::{get_embedding_table, user_tables_with_embeddings};
-use super::{CandidateAggregationSnafu, Error, Result};
-use crate::search::candidate::vector::VectorGeneration;
-use crate::search::util::{embedding_columns_from_table, get_primary_keys_with_overrides};
+use super::{Error, Result};
+use crate::search::{
+    SearchPipelineSnafu,
+    candidate::vector::VectorGeneration,
+    util::{embedding_columns_from_table, get_primary_keys_with_overrides},
+};
 use crate::{datafusion::DataFusion, model::EmbeddingModelStore};
-use datafusion::sql::TableReference;
-use datafusion::sql::sqlparser::ast::{Expr, Ident};
+use datafusion::sql::{
+    TableReference,
+    sqlparser::ast::{Expr, Ident},
+};
 use itertools::Itertools;
-use search::aggregation::CandidateAggregation;
-use search::{VectorSearchGenerationResult, VectorSearchGenerationTableResult};
-use search::{aggregation::reciprocal_rank::ReciprocalRankFusion, generation::CandidateGeneration};
+use search::{
+    aggregation::{AggregationResult, reciprocal_rank::ReciprocalRankFusion},
+    generation::CandidateGeneration,
+    pipeline::SearchPipeline,
+};
 use snafu::ResultExt;
 use tokio::sync::RwLock;
 use tracing::{Instrument, Span};
@@ -58,21 +65,13 @@ impl VectorSearch {
         }
     }
 
-    // Prepare an individual [`impl search::CandidateGeneration`] (specifically a [`VectorGeneration`]) based on the [`TableReference`], and use it to generate search candidates based on the provided query and additional parameters.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn individual_vector_search(
+    // Prepare an individual [`impl search::CandidateGeneration`] (specifically a [`VectorGeneration`]) based on the [`TableReference`].
+    pub async fn vector_search_generator(
         &self,
         tbl: &TableReference,
         embedding_column: &str,
-        query: &str,
         primary_keys: &[String],
-        additional_columns: &[String],
-        where_cond: Option<&Expr>,
-        keywords: Vec<String>,
-        limit: usize,
-    ) -> Result<VectorSearchGenerationResult> {
-        tracing::debug!("Running vector search for table {:#?}", tbl);
-
+    ) -> Result<VectorGeneration> {
         let table_provider = self
             .df
             .get_table(tbl)
@@ -110,49 +109,14 @@ impl VectorSearch {
             });
         };
 
-        let filters = keywords
-            .iter()
-            .map(|k| SearchRequest::validate_keyword_to_ilike(k, embedding_column))
-            .collect::<Result<Vec<Expr>>>()?;
-        let mut filter_refs: Vec<&Expr> = filters.iter().collect();
-
-        if let Some(filter_expr) = where_cond {
-            filter_refs.push(filter_expr);
-        }
-
-        let additional_columns: Vec<Expr> = additional_columns
-            .iter()
-            .map(|s| Expr::Identifier(Ident::new(s)))
-            .collect();
-        let col_refs: Vec<&Expr> = additional_columns.iter().collect();
-
-        let generator = VectorGeneration::new(
+        Ok(VectorGeneration::new(
             &self.df,
             tbl,
             &embed,
             primary_keys,
             embedding_column,
             embedding_table.is_chunked(embedding_column),
-        );
-
-        let data = generator
-            .search(
-                query.to_string(),
-                filter_refs.as_slice(),
-                col_refs.as_slice(),
-                limit,
-            )
-            .await
-            .map_err(|e| Error::CandidateGenerationError { source: e })?;
-
-        Ok(VectorSearchGenerationResult {
-            data,
-            derived_from: embedding_column.to_string(),
-        })
-
-        // TODO: Filter results after the fact for filters that aren't supported by [`CandidateGeneration::supports_filter_pushdown`]. https://github.com/spiceai/spiceai/issues/5849
-
-        // TODO: Retrieve columns from projection that aren't provided by candidate generator (see [`CandidateGeneration::supports_columns`]) https://github.com/spiceai/spiceai/issues/5850
+        ))
     }
 
     pub async fn search(&self, req: &SearchRequest) -> Result<VectorSearchResult> {
@@ -189,34 +153,37 @@ impl VectorSearch {
                 .await?;
 
             // Search for each table is independent, but done in parallel.
-            let response: HashMap<TableReference, VectorSearchGenerationTableResult> = futures::future::try_join_all(tables.into_iter().map(|tbl| {
+            let response: HashMap<TableReference, AggregationResult> = futures::future::try_join_all(tables.into_iter().map(|tbl| {
                 let keywords = keywords.clone();
                 let primary_keys = table_primary_keys.get(&tbl).map_or(&[] as &[String], |v| v.as_slice());
 
                 async move {
                     let embedding_columns = embedding_columns_from_table(&self.df, &tbl).await?;
-                    let mut results: Vec<VectorSearchGenerationResult> = Vec::with_capacity(embedding_columns.len());
+                    let mut generators: Vec<Box<dyn CandidateGeneration>> = Vec::with_capacity(embedding_columns.len());
 
                     for (i, col) in embedding_columns.iter().enumerate() {
-                        results.insert(i, self.individual_vector_search(
+                        generators.insert(i, Box::new(self.vector_search_generator(
                                 &tbl,
                                 col.as_str(),
-                                query.as_str(),
                                 primary_keys,
-                                additional_columns.as_slice(),
-                                where_cond.as_ref(),
-                                keywords.clone(),
-                                1000
-                                // *limit
-                            ).await?
+                            ).await?)
                         );
-                    }
+                    };
 
-                    Ok((tbl.clone(), VectorSearchGenerationTableResult{data: results, primary_keys: primary_keys.to_vec()}))
+                    let agg_result = SearchPipeline::new(generators, Box::new(ReciprocalRankFusion)).run(
+                         query.clone(),
+                         where_cond.as_ref().map(|e| vec![e.clone()]).unwrap_or_default(),
+                          additional_columns.iter().map(|s| Expr::Identifier(Ident::new(s))).collect(),
+                          primary_keys.to_vec(),
+                          keywords,
+                          *limit
+                    ).await.context(SearchPipelineSnafu)?;
+
+                    Ok((tbl.clone(), agg_result))
                 }
             }).collect::<Vec<_>>()).await?.into_iter().collect();
 
-            self.aggregate_per_table(response, ReciprocalRankFusion, *limit).await
+            Ok(response)
 
         }.instrument(span.clone()).await;
 
@@ -230,32 +197,5 @@ impl VectorSearch {
                 Err(e)
             }
         }
-    }
-
-    /// For each [`TableReference`] combine & order results from multiple [`CandidateGeneration::search`]s via a [`CandidateAggregation`] algorithm.
-    async fn aggregate_per_table(
-        &self,
-        generation_results: HashMap<TableReference, VectorSearchGenerationTableResult>,
-        aggregation: impl CandidateAggregation,
-        limit: usize,
-    ) -> Result<VectorSearchResult> {
-        let mut result: VectorSearchResult = HashMap::with_capacity(generation_results.len());
-
-        for (
-            tbl,
-            VectorSearchGenerationTableResult {
-                data,
-                ref primary_keys,
-            },
-        ) in generation_results
-        {
-            let aggregated = aggregation
-                .aggregate(data, primary_keys.clone(), limit)
-                .await
-                .context(CandidateAggregationSnafu)?;
-            result.insert(tbl, aggregated);
-        }
-
-        Ok(result)
     }
 }

--- a/crates/runtime/src/tools/builtin/document_similarity.rs
+++ b/crates/runtime/src/tools/builtin/document_similarity.rs
@@ -78,6 +78,7 @@ impl SpiceModelTool for DocumentSimilarityTool {
             let search_request = SearchRequest::try_from(req)?;
 
             let result = vs.search(&search_request).await.boxed()?;
+
             let mut formatted = serde_json::Map::with_capacity(result.len());
             for (tbl, result) in result {
                 let displayed = to_pretty(result).await?;

--- a/crates/runtime/src/tools/builtin/document_similarity.rs
+++ b/crates/runtime/src/tools/builtin/document_similarity.rs
@@ -78,7 +78,6 @@ impl SpiceModelTool for DocumentSimilarityTool {
             let search_request = SearchRequest::try_from(req)?;
 
             let result = vs.search(&search_request).await.boxed()?;
-
             let mut formatted = serde_json::Map::with_capacity(result.len());
             for (tbl, result) in result {
                 let displayed = to_pretty(result).await?;

--- a/crates/search/src/lib.rs
+++ b/crates/search/src/lib.rs
@@ -21,6 +21,7 @@ use datafusion::{error::DataFusionError, execution::SendableRecordBatchStream};
 use futures::StreamExt;
 pub mod aggregation;
 pub mod generation;
+pub mod pipeline;
 
 pub static SEARCH_SCORE_COLUMN_NAME: &str = "score";
 pub static SEARCH_VALUE_COLUMN_NAME: &str = "value";

--- a/crates/search/src/pipeline.rs
+++ b/crates/search/src/pipeline.rs
@@ -40,6 +40,13 @@ pub enum Error {
     InvalidKeyword { keyword: String },
 }
 
+impl Error {
+    #[must_use]
+    pub fn is_user_error(&self) -> bool {
+        matches!(self, Error::CandidateAggregationError { source } if source.is_user_error())
+    }
+}
+
 pub struct SearchPipeline {
     generators: Vec<Box<dyn CandidateGeneration>>,
     aggregator: Box<dyn CandidateAggregation>,

--- a/crates/search/src/pipeline.rs
+++ b/crates/search/src/pipeline.rs
@@ -47,17 +47,17 @@ impl Error {
     }
 }
 
-pub struct SearchPipeline {
+pub struct SearchPipeline<A>
+where
+    A: CandidateAggregation,
+{
     generators: Vec<Box<dyn CandidateGeneration>>,
-    aggregator: Box<dyn CandidateAggregation>,
+    aggregator: A,
 }
 
-impl SearchPipeline {
+impl<A: CandidateAggregation> SearchPipeline<A> {
     #[must_use]
-    pub fn new(
-        generators: Vec<Box<dyn CandidateGeneration>>,
-        aggregator: Box<dyn CandidateAggregation>,
-    ) -> Self {
+    pub fn new(generators: Vec<Box<dyn CandidateGeneration>>, aggregator: A) -> Self {
         SearchPipeline {
             generators,
             aggregator,
@@ -125,7 +125,18 @@ fn prepare_keywords(keywords: &[String], column: &str) -> Result<Vec<Expr>, Erro
         .collect::<Result<Vec<Expr>, Error>>()
 }
 
-fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, Error> {
+/// Ensure the provided keywords are valid string literal, useable as a keyword in an ILIKE expression (i.e. no SQL injection).
+pub fn valid_keywords(keywords: &[String]) -> Result<Vec<String>, Error> {
+    keywords
+        .iter()
+        .map(|k| {
+            validate_keyword_to_ilike(k.as_str(), "target_column")?; // emulate the use of the keyword in the query.
+            Ok(k.clone())
+        })
+        .collect::<Result<Vec<String>, _>>()
+}
+
+pub fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, Error> {
     let expression = format!("{target_column} ILIKE '%{}%'", k.to_lowercase());
     let parser = Parser::new(&GenericDialect {});
     let mut parser = parser.try_with_sql(&expression).map_err(|err| {
@@ -162,7 +173,7 @@ fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, Error
     {
         if id.value.to_lowercase() != target_column {
             tracing::trace!(
-                "vector_search keyword parsing failed. expected 'target_column', but got {}",
+                "vector_search keyword parsing failed. expected {target_column}, but got {}",
                 id.value
             );
             return Err(Error::InvalidKeyword {
@@ -201,4 +212,31 @@ fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, Error
     }
 
     Ok(ilike_expr)
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search_request_parse_keywords() {
+        let keywords = vec!["keyword1".to_string(), "keyword2".to_string()];
+        let result = valid_keywords(&keywords);
+        assert!(result.is_ok());
+
+        // Test keyword with a space
+        let keywords = vec!["keyword 1".to_string()];
+        let result = valid_keywords(&keywords);
+        assert!(result.is_ok());
+
+        // Test empty keyword
+        let keywords = vec![String::new()];
+        let result = valid_keywords(&keywords);
+        assert!(result.is_ok());
+
+        // Test escaping keyword
+        let keywords = vec!["'); DROP TABLE testing;".to_string()];
+        let result = valid_keywords(&keywords);
+        assert!(result.is_err());
+    }
 }

--- a/crates/search/src/pipeline.rs
+++ b/crates/search/src/pipeline.rs
@@ -30,10 +30,10 @@ use crate::{
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display(""))]
+    #[snafu(display("Error occurred retrieving candidate search results: {source}"))]
     CandidateGenerationError { source: generation::Error },
 
-    #[snafu(display(""))]
+    #[snafu(display("Error occurred aggregating candidate search results: {source}"))]
     CandidateAggregationError { source: aggregation::Error },
 
     #[snafu(display("An invalid keyword was specified: {keyword}"))]
@@ -72,6 +72,9 @@ impl SearchPipeline {
         let generation_results: Vec<VectorSearchGenerationResult> =
             futures::future::try_join_all(self.generators.iter().map(|g| async {
                 let content_col = g.value_derived_from();
+
+                // The column name for each `.generator` will be different, and therefore the
+                // keyword filter [`Expr`] must be made differently.
                 let filters = [
                     prepare_keywords(&keywords.clone(), &content_col)?,
                     opt_filters.clone(),
@@ -105,6 +108,9 @@ impl SearchPipeline {
     }
 }
 
+/// Convert each keyword into an `ILIKE %keyword%` [`Expr`].
+///
+/// Also validates keywords against being SQL injections.
 fn prepare_keywords(keywords: &[String], column: &str) -> Result<Vec<Expr>, Error> {
     keywords
         .iter()

--- a/crates/search/src/pipeline.rs
+++ b/crates/search/src/pipeline.rs
@@ -1,0 +1,191 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use datafusion::{
+    logical_expr::sqlparser::ast::Expr,
+    sql::sqlparser::{
+        ast::{Value, ValueWithSpan},
+        dialect::GenericDialect,
+        parser::Parser,
+        tokenizer::Token,
+    },
+};
+use snafu::{ResultExt, Snafu};
+
+use crate::{
+    VectorSearchGenerationResult,
+    aggregation::{self, AggregationResult, CandidateAggregation},
+    generation::{self, CandidateGeneration},
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(""))]
+    CandidateGenerationError { source: generation::Error },
+
+    #[snafu(display(""))]
+    CandidateAggregationError { source: aggregation::Error },
+
+    #[snafu(display("An invalid keyword was specified: {keyword}"))]
+    InvalidKeyword { keyword: String },
+}
+
+pub struct SearchPipeline {
+    generators: Vec<Box<dyn CandidateGeneration>>,
+    aggregator: Box<dyn CandidateAggregation>,
+}
+
+impl SearchPipeline {
+    #[must_use]
+    pub fn new(
+        generators: Vec<Box<dyn CandidateGeneration>>,
+        aggregator: Box<dyn CandidateAggregation>,
+    ) -> Self {
+        SearchPipeline {
+            generators,
+            aggregator,
+        }
+    }
+
+    /// Runs the search pipeline with the provided parameters.
+    pub async fn run(
+        &self,
+        query: String,
+        opt_filters: Vec<Expr>,
+        addition_projection: Vec<Expr>,
+        primary_keys: Vec<String>,
+        keywords: Vec<String>,
+        limit: usize,
+    ) -> std::result::Result<AggregationResult, Error> {
+        let proj_ref: &[&Expr] = &addition_projection.iter().collect::<Vec<_>>();
+
+        let generation_results: Vec<VectorSearchGenerationResult> =
+            futures::future::try_join_all(self.generators.iter().map(|g| async {
+                let content_col = g.value_derived_from();
+                let filters = [
+                    prepare_keywords(&keywords.clone(), &content_col)?,
+                    opt_filters.clone(),
+                ]
+                .concat();
+
+                let data = g
+                    .search(
+                        query.clone(),
+                        &filters.iter().collect::<Vec<_>>(),
+                        proj_ref,
+                        limit,
+                    )
+                    .await
+                    .context(CandidateGenerationSnafu)?;
+
+                // TODO: Filter results after the fact for filters that aren't supported by [`CandidateGeneration::supports_filter_pushdown`]. https://github.com/spiceai/spiceai/issues/5849
+
+                // TODO: Retrieve columns from projection that aren't provided by candidate generator (see [`CandidateGeneration::supports_columns`]) https://github.com/spiceai/spiceai/issues/5850
+                Ok(VectorSearchGenerationResult {
+                    data,
+                    derived_from: content_col,
+                })
+            }))
+            .await?;
+
+        self.aggregator
+            .aggregate(generation_results, primary_keys, limit)
+            .await
+            .context(CandidateAggregationSnafu)
+    }
+}
+
+fn prepare_keywords(keywords: &[String], column: &str) -> Result<Vec<Expr>, Error> {
+    keywords
+        .iter()
+        .map(|k| validate_keyword_to_ilike(k, column))
+        .collect::<Result<Vec<Expr>, Error>>()
+}
+
+fn validate_keyword_to_ilike(k: &str, target_column: &str) -> Result<Expr, Error> {
+    let expression = format!("{target_column} ILIKE '%{}%'", k.to_lowercase());
+    let parser = Parser::new(&GenericDialect {});
+    let mut parser = parser.try_with_sql(&expression).map_err(|err| {
+        tracing::trace!("vector_search keyword parsing failed. {err}");
+        Error::InvalidKeyword {
+            keyword: k.to_string(),
+        }
+    })?;
+
+    // The keyword will exist on its own if nothing else is present.
+    let ilike_expr = parser.parse_expr().map_err(|err| {
+        tracing::trace!("vector_search keyword parsing failed. {err}");
+        Error::InvalidKeyword {
+            keyword: k.to_string(),
+        }
+    })?;
+
+    let Expr::ILike { expr, pattern, .. } = &ilike_expr else {
+        tracing::trace!(
+            "vector_search keyword parsing failed. expected ILIKE, but got {ilike_expr:?}"
+        );
+        return Err(Error::InvalidKeyword {
+            keyword: k.to_string(),
+        });
+    };
+
+    if let (
+        Expr::Identifier(id),
+        Expr::Value(ValueWithSpan {
+            value: Value::SingleQuotedString(v),
+            ..
+        }),
+    ) = (*expr.clone(), *pattern.clone())
+    {
+        if id.value.to_lowercase() != target_column {
+            tracing::trace!(
+                "vector_search keyword parsing failed. expected 'target_column', but got {}",
+                id.value
+            );
+            return Err(Error::InvalidKeyword {
+                keyword: k.to_string(),
+            });
+        }
+
+        if v != format!("%{}%", k.to_lowercase()) {
+            tracing::trace!(
+                "vector_search keyword parsing failed. expected '%{}%', but got {}",
+                k.to_lowercase(),
+                v
+            );
+            return Err(Error::InvalidKeyword {
+                keyword: k.to_string(),
+            });
+        }
+    } else {
+        tracing::trace!(
+            "vector_search keyword parsing failed. expected identifiers, but got {expr:?} - {pattern:?}"
+        );
+        return Err(Error::InvalidKeyword {
+            keyword: k.to_string(),
+        });
+    }
+
+    // Ensure the expression is the last token.
+    let next_token = parser.next_token();
+    if next_token != Token::EOF {
+        tracing::trace!(
+            "vector_search keyword parsing failed. expected EOF, but got {next_token:?}"
+        );
+        return Err(Error::InvalidKeyword {
+            keyword: k.to_string(),
+        });
+    }
+
+    Ok(ilike_expr)
+}


### PR DESCRIPTION
## 📝 Summary
Remove logic from vector search in runtime to the `search` crate to handle calling `CandidateGeneration` implementations and combing them via a `CandidateAggregation`. 

This looks like
```rust
pub struct SearchPipeline {
    generators: Vec<Box<dyn CandidateGeneration>>,
    aggregator: Box<dyn CandidateAggregation>,
}
impl SearchPipeline {
    pub async fn run(
        &self,
        query: String,
        opt_filters: Vec<Expr>,
        addition_projection: Vec<Expr>,
        primary_keys: Vec<String>,
        keywords: Vec<String>,
        limit: usize,
    ) -> std::result::Result<AggregationResult, Error> {
```

- [Code Link](https://github.com/spiceai/spiceai/blob/jeadie/25-05-28/search-combine/crates/search/src/pipeline.rs#L43-L46)

## 🔗 Related
This will be needed for #3015
