### PR TITLE
Add support for on_conflict upsert for Arrow MemTable

### DIFF
--- a/crates/data_components/src/arrow.rs
+++ b/crates/data_components/src/arrow.rs
@@ -19,9 +19,10 @@ use async_trait::async_trait;
 use datafusion::{
     catalog::{Session, TableProviderFactory},
     datasource::TableProvider,
-    error::Result as DataFusionResult,
+    error::{DataFusionError, Result as DataFusionResult},
     logical_expr::CreateExternalTable,
 };
+use datafusion_table_providers::util::on_conflict::OnConflict;
 use std::sync::Arc;
 
 use crate::delete::DeletionTableProviderAdapter;
@@ -55,9 +56,18 @@ impl TableProviderFactory for ArrowFactory {
         cmd: &CreateExternalTable,
     ) -> DataFusionResult<Arc<dyn TableProvider>> {
         let schema: SchemaRef = Arc::new(cmd.schema.as_arrow().clone());
-        let mem_table = MemTable::try_new(schema, vec![])?
+        let mut mem_table = MemTable::try_new(schema, vec![])?
             .try_with_constraints(cmd.constraints.clone())
             .await?;
+
+        if let Some(on_conflict_str) = cmd.options.get("on_conflict") {
+            mem_table = mem_table.with_on_conflict(
+                OnConflict::try_from(on_conflict_str.as_str()).map_err(|e| {
+                    DataFusionError::External(format!("Error parsing on_conflict: {e}").into())
+                })?,
+            );
+        }
+
         let delete_adapter = DeletionTableProviderAdapter::new(Arc::new(mem_table));
         Ok(Arc::new(delete_adapter))
     }

--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -26,6 +26,8 @@ use datafusion::datasource::sink::{DataSink, DataSinkExec};
 use datafusion::datasource::source::DataSourceExec;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::scalar::ScalarValue;
+use datafusion_table_providers::util::column_reference::ColumnReference;
+use datafusion_table_providers::util::on_conflict::OnConflict;
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug};
@@ -64,6 +66,8 @@ pub struct MemTable {
     /// Optional pre-known sort order(s). Must be `SortExpr`s.
     /// inserting data into this table removes the order
     pub sort_order: Arc<Mutex<Vec<Vec<Expr>>>>,
+
+    pub on_conflict: Option<OnConflict>,
 }
 
 impl MemTable {
@@ -96,7 +100,21 @@ impl MemTable {
             constraints: Constraints::empty(),
             column_defaults: HashMap::new(),
             sort_order: Arc::new(Mutex::new(vec![])),
+            on_conflict: None,
         })
+    }
+
+    #[must_use]
+    pub fn with_on_conflict(mut self, on_conflict: OnConflict) -> Self {
+        if !matches!(on_conflict, OnConflict::Upsert(_)) {
+            tracing::warn!(
+                "In-memory tables only support Upsert on_conflict, but got: {on_conflict:?}. Setting will be ignored."
+            );
+            return self;
+        }
+
+        self.on_conflict = Some(on_conflict);
+        self
     }
 
     pub async fn try_with_constraints(mut self, constraints: Constraints) -> Result<Self> {
@@ -155,6 +173,34 @@ impl MemTable {
             }
         }
         Ok(None)
+    }
+
+    fn verify_on_conflict_matches_primary_key(
+        &self,
+        pk: &[usize],
+        on_conflict: &ColumnReference,
+    ) -> Result<()> {
+        let on_conflict_cols: Vec<_> = on_conflict.iter().collect();
+
+        if on_conflict_cols.len() != pk.len() {
+            return Err(DataFusionError::Execution(
+                "Primary key must match the on_conflict definition".to_string(),
+            ));
+        }
+
+        let schema = self.schema();
+
+        if on_conflict_cols
+            .iter()
+            .zip(pk.iter())
+            .any(|(c, pk)| c != schema.field(*pk).name())
+        {
+            return Err(DataFusionError::Execution(
+                "Primary key must match the on_conflict definition".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 
     /// Assign column defaults
@@ -231,11 +277,19 @@ impl TableProvider for MemTable {
 
         let primary_key = self.get_and_ensure_only_primary_keys()?;
 
+        // In-memory tables only support primary keys constraints. Support for `OnConflict` is limited to `Upsert` matching the primary key.
+        // So we verify that the `on_conflict` and  the primary key matches
+        if let (Some(OnConflict::Upsert(on_conflict)), Some(pk)) = (&self.on_conflict, &primary_key)
+        {
+            self.verify_on_conflict_matches_primary_key(pk, on_conflict)?;
+        }
+
         let sink = Arc::new(MemSink::new(
             self.batches.clone(),
             overwrite,
             primary_key,
             self.schema(),
+            self.on_conflict.clone(),
         ));
         Ok(Arc::new(DataSinkExec::new(input, sink, None)))
     }
@@ -254,6 +308,7 @@ struct MemSink {
     /// Optional primary key columns. If present, primary key values must be unique, ordered ascendingly.
     primary_key: Option<Vec<usize>>,
     schema: SchemaRef,
+    on_conflict: Option<OnConflict>,
 }
 
 impl Debug for MemSink {
@@ -283,6 +338,7 @@ impl MemSink {
         overwrite: InsertOp,
         primary_key: Option<Vec<usize>>,
         schema: SchemaRef,
+        on_conflict: Option<OnConflict>,
     ) -> Self {
         Self {
             batches,
@@ -293,6 +349,7 @@ impl MemSink {
                 z
             }),
             schema,
+            on_conflict,
         }
     }
 }
@@ -532,6 +589,12 @@ impl DataSink for MemSink {
                 // Ensure no primary key conflicts between new data that is being appended, and existing data (since we are not replacing).
                 InsertOp::Append => {
                     if let Some(ref pks) = self.primary_key {
+                        // Mem-table only supports on_conflict upsert that matches primary keys, so we
+                        // remove existing data that collides with new primary keys similarly to `InsertOp::Replace`.
+                        if self.on_conflict.is_some() {
+                            filter_existing(&mut *target, &new_key_set, pks)?;
+                        }
+
                         for rb in &**target {
                             let batch_pks = extract_primary_keys_str(rb, pks)?;
                             let _ = check_and_filter_non_null_unique_primary_keys(
@@ -656,7 +719,7 @@ mod tests {
         physical_plan::collect,
         scalar::ScalarValue,
     };
-    use datafusion_table_providers::util::test::MockExec;
+    use datafusion_table_providers::util::{on_conflict::OnConflict, test::MockExec};
 
     use crate::{arrow::write::MemTable, delete::DeletionTableProvider};
 
@@ -1022,6 +1085,83 @@ mod tests {
             "insertion should fail due to primary key conflict"
         );
     }
+
+    #[tokio::test]
+    async fn test_write_all_append_primary_key_on_conflict_upsert() {
+        let (rb, schema) = create_batch_with_string_columns(&[
+            (
+                "primary_key",
+                vec!["1970-01-01", "2012-12-01T11:11:11Z", "2012-12-01T11:11:12Z"],
+            ),
+            ("value", vec!["a", "b", "c"]),
+        ]);
+        let table = MemTable::try_new(schema, vec![vec![rb]])
+            .expect("mem table should be created")
+            .try_with_constraints(Constraints::new_unverified(vec![Constraint::PrimaryKey(
+                vec![0],
+            )]))
+            .await
+            .expect("satisfy primary key constraints")
+            .with_on_conflict(
+                OnConflict::try_from("upsert:primary_key").expect("create on_conflict"),
+            );
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+
+        let (insert_rb, new_schema) = create_batch_with_string_columns(&[
+            ("primary_key", vec!["1970-01-01", "1970-01-02"]),
+            ("value", vec!["x", "y"]),
+        ]);
+        let exec = Arc::new(MockExec::new(vec![Ok(insert_rb)], new_schema));
+        let insertion = table
+            .insert_into(
+                &state,
+                exec,
+                datafusion::logical_expr::dml::InsertOp::Append,
+            )
+            .await
+            .expect("insertion should be successful");
+
+        let result = collect(insertion, ctx.task_ctx())
+            .await
+            .expect("insert successful")
+            .first()
+            .expect("result should have at least one batch")
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("result should be UInt64Array")
+            .value(0)
+            .to_i64()
+            .expect("insert_into result should return i64");
+
+        assert_eq!(result, 2);
+
+        // Ensure new values have changed correctly.
+        let plan = table
+            .scan(&state, None, &[], None)
+            .await
+            .expect("Scan plan can be constructed");
+
+        let result = collect(plan, ctx.task_ctx())
+            .await
+            .expect("Query successful");
+
+        let mut results = vec![];
+        for rb in &result {
+            let values: Vec<_> = rb
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("result should be StringArray")
+                .into_iter()
+                .collect();
+            results.extend(values.clone());
+        }
+
+        assert_eq!(vec![Some("b"), Some("c"), Some("x"), Some("y")], results);
+    }
+
     #[tokio::test]
     async fn test_write_all_append_primary_key() {
         let (rb, schema) = create_batch_with_string_columns(&[


### PR DESCRIPTION
## 📝 Summary

This allows using Arrow acceleration for tables with defined primary key and append mode updates that might have duplicate or updated data.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
