### PR TITLE
Add tools enabled to MCP server capabilities

### DIFF
--- a/crates/runtime/src/tools/mcp/catalog.rs
+++ b/crates/runtime/src/tools/mcp/catalog.rs
@@ -114,7 +114,7 @@ impl McpToolCatalog {
                     protocol_version: ProtocolVersion::default(),
                     capabilities: ClientCapabilities::default(),
                     client_info: Implementation {
-                        name: "Spice.ai".to_string(),
+                        name: "Spice OSS".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),
                     },
                 };

--- a/crates/runtime/src/tools/mcp/catalog.rs
+++ b/crates/runtime/src/tools/mcp/catalog.rs
@@ -114,7 +114,7 @@ impl McpToolCatalog {
                     protocol_version: ProtocolVersion::default(),
                     capabilities: ClientCapabilities::default(),
                     client_info: Implementation {
-                        name: "Spice OSS".to_string(),
+                        name: "Spice.ai Open Source".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),
                     },
                 };

--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -50,7 +50,7 @@ impl ServerHandler for RuntimeServer {
             instructions: None,
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation {
-                name: "Spice OSS".to_string(),
+                name: "Spice.ai Open Source".to_string(),
                 version: env!("CARGO_PKG_VERSION").to_string(),
             },
             protocol_version: ProtocolVersion::LATEST,

--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -50,7 +50,7 @@ impl ServerHandler for RuntimeServer {
             instructions: None,
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation {
-                name: "Spice.ai".to_string(),
+                name: "Spice OSS".to_string(),
                 version: env!("CARGO_PKG_VERSION").to_string(),
             },
             protocol_version: ProtocolVersion::LATEST,

--- a/crates/runtime/src/tools/mcp/server.rs
+++ b/crates/runtime/src/tools/mcp/server.rs
@@ -20,8 +20,8 @@ use futures::StreamExt;
 use rmcp::{
     Error as McpError, RoleServer, ServerHandler,
     model::{
-        CallToolRequestMethod, CallToolRequestParam, CallToolResult, Content, ListToolsResult,
-        PaginatedRequestParam,
+        CallToolRequestMethod, CallToolRequestParam, CallToolResult, Content, Implementation,
+        ListToolsResult, PaginatedRequestParam, ProtocolVersion, ServerCapabilities, ServerInfo,
     },
     service::RequestContext,
 };
@@ -45,6 +45,18 @@ impl From<&Arc<Runtime>> for RuntimeServer {
 }
 
 impl ServerHandler for RuntimeServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: None,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation {
+                name: "Spice.ai".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            protocol_version: ProtocolVersion::LATEST,
+        }
+    }
+
     fn call_tool(
         &self,
         request: CallToolRequestParam,


### PR DESCRIPTION
## 📝 Summary
 - Some consumers of MCP servers (e.g. `npx @modelcontextprotocol/inspector`) will check capabilities before enabling other features. 
 - Add tools capabilities to custom `get_info` route. 