### PR TITLE
fix: Use HTTPS ubuntu sources (#6034)

### DIFF
--- a/.github/actions/update-http-sources/action.yml
+++ b/.github/actions/update-http-sources/action.yml
@@ -1,0 +1,11 @@
+name: Update HTTP to HTTPS sources
+description: 'composite action'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Use HTTPS in apt sources
+      shell: bash
+      run: |
+        sudo sed -i 's|http://|https://|g' /etc/apt/sources.list
+        sudo apt-get update

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -103,6 +103,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update HTTP sources to HTTPS
+        if: matrix.target.builder == 'spiceai-runners'
+        uses: ./.github/actions/update-http-sources
+
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -79,6 +79,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update HTTP sources to HTTPS
+        if: matrix.target.builder == 'spiceai-runners'
+        uses: ./.github/actions/update-http-sources
+
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,6 +55,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update HTTP sources to HTTPS
+        uses: ./.github/actions/update-http-sources
+
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -43,6 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update HTTP sources to HTTPS
+        uses: ./.github/actions/update-http-sources
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,6 +63,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Update HTTP sources to HTTPS
+        uses: ./.github/actions/update-http-sources
+        if: needs.check_changes.outputs.relevant_changes == 'true'
+
       - name: Set up Go
         if: needs.check_changes.outputs.relevant_changes == 'true'
         uses: actions/setup-go@v5
@@ -143,6 +147,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Update HTTP sources to HTTPS
+        uses: ./.github/actions/update-http-sources
+        if: needs.check_changes.outputs.relevant_changes == 'true'
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Cherry-picks to release/1.3 the fix to use HTTPS ubuntu sources so testoperator dispatch can run
