### PR TITLE
Enable Upsert OnConflictBehavior for runtime.task_history table

### DIFF
--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -291,6 +291,15 @@ impl Acceleration {
         self.primary_key = Some(primary_key);
         self
     }
+
+    #[must_use]
+    pub fn with_on_conflict(
+        mut self,
+        on_conflict: HashMap<ColumnReference, OnConflictBehavior>,
+    ) -> Self {
+        self.on_conflict = on_conflict;
+        self
+    }
 }
 
 impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {

--- a/crates/runtime/src/task_history/mod.rs
+++ b/crates/runtime/src/task_history/mod.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use crate::accelerated_table::refresh::Refresh;
+use crate::component::dataset::acceleration::OnConflictBehavior;
 use crate::datafusion::DataFusion;
 use crate::dataupdate::{DataUpdate, UpdateType};
 use crate::internal_table::create_internal_accelerated_table;
@@ -26,6 +27,7 @@ use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow_schema::ArrowError;
 use data_components::arrow::struct_builder::StructBuilder;
 use datafusion::sql::TableReference;
+use datafusion_table_providers::util::column_reference::ColumnReference;
 use futures::TryStreamExt;
 use snafu::prelude::*;
 use snafu::{ResultExt, Snafu};
@@ -102,12 +104,20 @@ impl TaskSpan {
         let tbl_reference =
             TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE);
 
+        let acceleration_settings = Acceleration::default().with_on_conflict(
+            [(
+                ColumnReference::new(vec!["span_id".to_string()]),
+                OnConflictBehavior::Upsert,
+            )]
+            .into(),
+        );
+
         create_internal_accelerated_table(
             status,
             tbl_reference,
             Arc::new(TaskSpan::table_schema()),
             Some(vec!["span_id".to_string()]),
-            Acceleration::default(),
+            acceleration_settings,
             Refresh::default(),
             retention,
             Arc::new(RwLock::new(Secrets::default())),


### PR DESCRIPTION
## 📝 Summary

Enable upserting records with the same `span_id` into the `runtime.task_history` table by adding the `on_conflict` `upsert:span_id` configuration. 

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/5269

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
