### PR TITLE
Update Models Benchmarks to report unsuccessful evals as errors

### DIFF
--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -146,7 +146,7 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     println!("Result:\n{}\n", pretty_format_batches(&eval_result)?);
 
     // Extract metrics from the evaluation result. If the evaluation run was not successful (EvalStatus::Failed),
-    // we will return an error at the end after prining statistics and cleaning up.
+    // we will return an error at the end after printing statistics and cleaning up.
     let metrics = EvalMetrics::from_record_batch(&eval_result)?;
 
     let tasks_calls = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_TASKS).await?;

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -145,7 +145,8 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     let eval_result = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_MAIN_METRICS).await?;
     println!("Result:\n{}\n", pretty_format_batches(&eval_result)?);
 
-    // Extract metrics from the evaluation result
+    // Extract metrics from the evaluation result. If the evaluation run was not successful (EvalStatus::Failed),
+    // we will return an error at the end after prining statistics and cleaning up.
     let metrics = EvalMetrics::from_record_batch(&eval_result)?;
 
     let tasks_calls = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_TASKS).await?;
@@ -189,7 +190,12 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
 
     spiced_instance.stop()?;
 
-    println!("Benchmark completed");
+    // Report unsuccessful evaluation run as an error
+    if matches!(metrics.status, EvalStatus::Failed) {
+        return Err(anyhow::anyhow!("Evaluation run failed"));
+    }
+
+    println!("Benchmark completed successfully!");
 
     Ok(())
 }


### PR DESCRIPTION
## 📝 Summary

Currently, if a model benchmark fails, the metric correctly indicates the error, but Testoperator and the GitHub Workflow still report the benchmark as successfully completed. This PR updates the behavior to correctly report errors.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
