### PR TITLE
Add initial support for Spice Cloud Platform management

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -137,7 +137,7 @@ impl AppBuilder {
         self.runtime = spicepod.runtime.clone();
         self.secrets.extend(spicepod.secrets.clone());
         self.extensions.extend(spicepod.extensions.clone());
-        self.management = spicepod.management.clone();
+        self.management.clone_from(&spicepod.management);
         self.catalogs.extend(spicepod.catalogs.clone());
         self.datasets.extend(spicepod.datasets.clone());
         self.views.extend(spicepod.views.clone());

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -28,6 +28,7 @@ use spicepod::{
         dataset::Dataset,
         embeddings::Embeddings,
         eval::Eval,
+        management::Management,
         model::Model,
         runtime::{CorsConfig, Runtime, TlsConfig},
         secret::Secret,
@@ -67,6 +68,8 @@ pub struct App {
     pub spicepods: Vec<Spicepod>,
 
     pub runtime: Runtime,
+
+    pub management: Option<Management>,
 }
 
 impl App {
@@ -106,6 +109,7 @@ pub struct AppBuilder {
     workers: Vec<Worker>,
     spicepods: Vec<Spicepod>,
     runtime: Runtime,
+    management: Option<Management>,
 }
 
 impl AppBuilder {
@@ -124,6 +128,7 @@ impl AppBuilder {
             workers: vec![],
             spicepods: vec![],
             runtime: Runtime::default(),
+            management: None,
         }
     }
 
@@ -132,6 +137,7 @@ impl AppBuilder {
         self.runtime = spicepod.runtime.clone();
         self.secrets.extend(spicepod.secrets.clone());
         self.extensions.extend(spicepod.extensions.clone());
+        self.management = spicepod.management.clone();
         self.catalogs.extend(spicepod.catalogs.clone());
         self.datasets.extend(spicepod.datasets.clone());
         self.views.extend(spicepod.views.clone());
@@ -241,6 +247,12 @@ impl AppBuilder {
     }
 
     #[must_use]
+    pub fn with_management(mut self, management: Management) -> AppBuilder {
+        self.management = Some(management);
+        self
+    }
+
+    #[must_use]
     pub fn build(self) -> App {
         App {
             name: self.name,
@@ -256,6 +268,7 @@ impl AppBuilder {
             workers: self.workers,
             spicepods: self.spicepods,
             runtime: self.runtime,
+            management: self.management,
         }
     }
 
@@ -272,6 +285,7 @@ impl AppBuilder {
         let secrets = spicepod.secrets.clone();
         let runtime = spicepod.runtime.clone();
         let extensions = spicepod.extensions.clone();
+        let management = spicepod.management.clone();
         let mut catalogs: Vec<Catalog> = vec![];
         let mut datasets: Vec<Dataset> = vec![];
         let mut views: Vec<View> = vec![];
@@ -369,6 +383,7 @@ impl AppBuilder {
             workers,
             spicepods,
             runtime,
+            management,
         })
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -808,8 +808,8 @@ impl Runtime {
             .as_ref()
             .and_then(|app| app.management.as_ref())
         {
-            if let Err(err) = management::init_cloud_management(Arc::clone(&self), cfg).await {
-                tracing::error!("Failed to initialize Spice Cloud management: {err}");
+            if let Err(err) = management::init_management(Arc::clone(&self), cfg).await {
+                tracing::error!("Failed to initialize management of the Spice runtime: {err}");
             }
         }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -88,6 +88,7 @@ pub mod flight;
 mod http;
 mod init;
 pub mod internal_table;
+mod management;
 mod metrics;
 mod metrics_server;
 pub mod model;
@@ -799,6 +800,18 @@ impl Runtime {
                 }
             }
         });
+
+        if let Some(cfg) = self
+            .app
+            .read()
+            .await
+            .as_ref()
+            .and_then(|app| app.management.as_ref())
+        {
+            if let Err(err) = management::init_cloud_management(Arc::clone(&self), cfg).await {
+                tracing::error!("Failed to initialize Spice Cloud management: {err}");
+            }
+        }
 
         let components = vec![task_history, datasets, catalogs, models_and_evals];
 

--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -1,0 +1,372 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const TASK_HISTORY_SINK_REMOTE_TABLE: &str = "runtime.task_history";
+const TASK_HISTORY_SINK_TABLE: &str = "runtime.task_history_cloud";
+const DEFAULT_EXPORT_INTERVAL_SECS: u64 = 5;
+
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use arrow::array::RecordBatch;
+use chrono::{DateTime, Utc};
+use datafusion::{
+    catalog::TableProvider,
+    datasource::DefaultTableSource,
+    error::DataFusionError,
+    execution::SessionStateBuilder,
+    logical_expr::LogicalPlanBuilder,
+    prelude::{DataFrame, SessionContext, col, lit},
+    sql::TableReference,
+};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
+use snafu::{OptionExt, ResultExt, Snafu};
+use spicepod::component::management::Management as spicepod_management;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    Runtime,
+    component::dataset::{Mode, builder::DatasetBuilder},
+    dataconnector::{ConnectorParamsBuilder, DataConnectorError, create_new_connector},
+    datafusion::{
+        DataFusion, SPICE_RUNTIME_SCHEMA, builder::get_df_default_config, error::SpiceExternalError,
+    },
+    dataupdate::{DataUpdate, UpdateType},
+    get_params_with_secrets,
+    task_history::DEFAULT_TASK_HISTORY_TABLE,
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Missing required secret: {name}. Specify a value."))]
+    MissingRequiredSecret { name: String },
+
+    #[snafu(display("Table provider does not support read_write mode"))]
+    NoReadWriteProvider {},
+
+    #[snafu(display(
+        "Unable to create data connector: {source}\nReport a bug to request support: https://github.com/spiceai/spiceai/issues"
+    ))]
+    UnableToCreateDataConnector {
+        source: Box<dyn std::error::Error + Sync + Send>,
+    },
+
+    #[snafu(display("{source}"))]
+    UnableToCreateCloudTableProvider { source: DataConnectorError },
+
+    #[snafu(display("Error exporting task_history records: {source}"))]
+    UnableToExportTaskHistoryData {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+pub(crate) async fn init_cloud_management(
+    runtime: Arc<Runtime>,
+    config: &spicepod_management,
+) -> Result<(), Error> {
+    if !config.enabled {
+        return Ok(());
+    }
+
+    match Management::try_from(config, runtime).await {
+        Ok(management) => management.start().await,
+        Err(e) => Err(e),
+    }
+}
+
+/// Spice Cloud Management
+///
+/// Implements runtime management and observability for Spice instances running
+/// outside of the Spice Cloud Platform, enabling monitoring and troubleshooting capabilities
+/// across on-premises and cluster environments.
+pub(crate) struct Management {
+    runtime: Arc<Runtime>,
+    api_key: String,
+    params: HashMap<String, SecretString>,
+}
+
+impl Management {
+    pub async fn try_from(
+        config: &spicepod_management,
+        runtime: Arc<Runtime>,
+    ) -> Result<Self, Error> {
+        let params = get_params_with_secrets(runtime.secrets(), &config.params).await;
+
+        let api_key = params
+            .get("api_key")
+            .map(SecretBox::expose_secret)
+            .context(MissingRequiredSecretSnafu { name: "api_key" })?;
+
+        Ok(Self {
+            api_key: api_key.to_string(),
+            runtime,
+            params,
+        })
+    }
+
+    pub async fn start(&self) -> Result<(), Error> {
+        self.start_task_history_export().await?;
+        tracing::info!("Initialized Spice Cloud management");
+        Ok(())
+    }
+
+    async fn start_task_history_export(&self) -> Result<(), Error> {
+        let app_ref = self.runtime.app();
+        let app_lock = app_ref.read().await;
+        if let Some(app) = app_lock.as_ref() {
+            if !app.runtime.task_history.enabled {
+                tracing::debug!("Task history is disabled via configuration.");
+                return Ok(());
+            }
+        }
+        drop(app_lock);
+
+        self.init_task_history_sink_table().await?;
+
+        let cancellation_token = CancellationToken::new();
+        let df = self.runtime.datafusion();
+
+        let _task = self
+            .runtime
+            .start_runtime_task(
+                "task_history_export",
+                Some(cancellation_token.clone()),
+                async move {
+                    let mut interval =
+                        tokio::time::interval(Duration::from_secs(DEFAULT_EXPORT_INTERVAL_SECS));
+
+                    loop {
+                        tokio::select! {
+                            _ = interval.tick() => {
+                            }
+                            () = cancellation_token.cancelled() => {
+                                // Runtime shutdown requested, write latest available data and stop exporting
+                                let since = Self::calculate_export_since_time();
+                                let _= Self::export_task_history_records(&df, since).await;
+                                tracing::debug!("Task history data export stopped");
+                                break;
+                            }
+                        };
+
+                        let since = Self::calculate_export_since_time();
+                        let _ = Self::export_task_history_records(&df, since).await;
+                    }
+
+                    Ok(())
+                },
+            )
+            .await;
+
+        tracing::debug!("Enabled task history data export to Spice Cloud");
+
+        Ok(())
+    }
+
+    async fn init_task_history_sink_table(&self) -> Result<(), Error> {
+        let mut params = HashMap::new();
+        params.insert("spiceai_api_key".to_string(), self.api_key.to_string());
+
+        if let Some(flight_endpoint) = self.params.get("flight_endpoint") {
+            params.insert(
+                "spiceai_endpoint".to_string(),
+                flight_endpoint.expose_secret().to_string(),
+            );
+        }
+
+        let sink = get_spiceai_table_provider(
+            TASK_HISTORY_SINK_TABLE,
+            TASK_HISTORY_SINK_REMOTE_TABLE,
+            params,
+            Arc::clone(&self.runtime),
+        )
+        .await?;
+
+        self.runtime
+            .datafusion()
+            .register_table_as_writable_and_with_schema(TASK_HISTORY_SINK_TABLE.into(), sink)
+            .boxed()
+            .context(UnableToCreateDataConnectorSnafu)
+    }
+
+    // Calculate the timestamp for 3 days ago from now
+    fn calculate_export_since_time() -> SystemTime {
+        SystemTime::now()
+            .checked_sub(Duration::from_secs(3 * 24 * 60 * 60))
+            .unwrap_or(SystemTime::UNIX_EPOCH)
+    }
+
+    // Export task history records to Spice Cloud, returning true if any records were exported
+    async fn export_task_history_records(df: &Arc<DataFusion>, since: SystemTime) -> bool {
+        let data = match get_task_history_records(df, since).await {
+            Ok(records) => records,
+            Err(e) => {
+                if is_table_not_ready_error(&e) {
+                    tracing::debug!("Task history table is not ready yet, retrying later");
+                    return false;
+                }
+
+                tracing::warn!(
+                    "{}. Retrying in {DEFAULT_EXPORT_INTERVAL_SECS} seconds",
+                    Error::UnableToExportTaskHistoryData {
+                        source: Box::new(e)
+                    }
+                );
+                return false;
+            }
+        };
+
+        if data.is_empty() {
+            tracing::trace!("No task history records to export");
+            return false;
+        }
+
+        if let Err(e) = write_task_history_records_to_remote(df, data).await {
+            tracing::warn!("{e}. Retrying in {DEFAULT_EXPORT_INTERVAL_SECS} seconds");
+            return false;
+        }
+
+        true
+    }
+}
+
+async fn get_spiceai_table_provider(
+    name: &str,
+    cloud_dataset_path: &str,
+    params: HashMap<String, String>,
+    runtime: Arc<Runtime>,
+) -> Result<Arc<dyn TableProvider>, Error> {
+    let app_ref = runtime.app();
+    let app_lock = app_ref.read().await;
+    let Some(app) = app_lock.as_ref() else {
+        return Err(Error::UnableToCreateDataConnector {
+            source: "Missing App From Runtime".into(),
+        });
+    };
+
+    let secrets = runtime.secrets();
+
+    let mut dataset = DatasetBuilder::try_new(format!("spice.ai/{cloud_dataset_path}"), name)
+        .boxed()
+        .context(UnableToCreateDataConnectorSnafu)?
+        .with_app(Arc::clone(app))
+        .with_runtime(runtime)
+        .build()
+        .boxed()
+        .context(UnableToCreateDataConnectorSnafu)?
+        .with_params(params);
+
+    dataset.mode = Mode::ReadWrite;
+
+    let params = ConnectorParamsBuilder::new("spice.ai".into(), (&dataset).into())
+        .build(secrets)
+        .await
+        .context(UnableToCreateDataConnectorSnafu)?;
+
+    let data_connector = create_new_connector("spice.ai", params)
+        .await
+        .ok_or_else(|| NoReadWriteProviderSnafu {}.build())?
+        .context(UnableToCreateDataConnectorSnafu)?;
+
+    let source_table_provider = data_connector
+        .read_write_provider(&dataset)
+        .await
+        .ok_or_else(|| NoReadWriteProviderSnafu {}.build())?
+        .context(UnableToCreateCloudTableProviderSnafu)?;
+
+    Ok(source_table_provider)
+}
+
+async fn write_task_history_records_to_remote(
+    df: &Arc<DataFusion>,
+    data: Vec<RecordBatch>,
+) -> Result<(), Error> {
+    let Some(schema) = data.first().map(RecordBatch::schema) else {
+        tracing::trace!("No records to export for task history");
+        return Ok(());
+    };
+
+    let num_records: usize = data
+        .iter()
+        .map(datafusion::arrow::array::RecordBatch::num_rows)
+        .sum();
+
+    let data_update = DataUpdate {
+        schema,
+        data,
+        update_type: UpdateType::Append,
+    };
+
+    df.write_data(&TASK_HISTORY_SINK_TABLE.into(), data_update)
+        .await
+        .boxed()
+        .context(UnableToExportTaskHistoryDataSnafu)?;
+
+    tracing::debug!("Exported {num_records} task history records");
+
+    Ok(())
+}
+
+async fn get_task_history_records(
+    df: &Arc<DataFusion>,
+    since: SystemTime,
+) -> Result<Vec<RecordBatch>, datafusion::error::DataFusionError> {
+    let state = SessionStateBuilder::new()
+        .with_config(get_df_default_config())
+        .build();
+
+    let ctx = SessionContext::new_with_state(state);
+
+    let Ok(table_provider) = df
+        .get_accelerated_table_provider("runtime.task_history")
+        .await
+    else {
+        // If the table provider is not available, it means task history is not registered or ready yet
+        tracing::debug!("Task history table is not registered or ready yet.");
+        return Ok(vec![]);
+    };
+
+    // Build filter expression: end_time >= since
+    let since_dt = Into::<DateTime<Utc>>::into(since).to_rfc3339();
+    let filter_expr = col("end_time").gt_eq(lit(since_dt));
+
+    let table_source = Arc::new(DefaultTableSource::new(Arc::clone(&table_provider)));
+
+    let logical_plan = LogicalPlanBuilder::scan(
+        TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE),
+        table_source,
+        None,
+    )?
+    .filter(filter_expr)?
+    .build()?;
+
+    let df = DataFrame::new(ctx.state(), logical_plan);
+
+    df.collect().await
+}
+
+fn is_table_not_ready_error(e: &DataFusionError) -> bool {
+    if let DataFusionError::External(e) = e {
+        if let Some(e) = e.downcast_ref::<SpiceExternalError>() {
+            match e {
+                SpiceExternalError::AccelerationNotReady { .. } => return true,
+            }
+        }
+    }
+    false
+}

--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -35,9 +35,9 @@ use datafusion::{
     prelude::{DataFrame, SessionContext, col, lit},
     sql::TableReference,
 };
-use secrecy::{ExposeSecret, SecretBox, SecretString};
+use secrecy::{ExposeSecret, SecretString};
 use snafu::{OptionExt, ResultExt, Snafu};
-use spicepod::component::management::Management as spicepod_management;
+use spicepod::component::management::Management as SpicepodManagement;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -76,9 +76,9 @@ pub enum Error {
     },
 }
 
-pub(crate) async fn init_cloud_management(
+pub(crate) async fn init_management(
     runtime: Arc<Runtime>,
-    config: &spicepod_management,
+    config: &SpicepodManagement,
 ) -> Result<(), Error> {
     if !config.enabled {
         return Ok(());
@@ -97,24 +97,23 @@ pub(crate) async fn init_cloud_management(
 /// across on-premises and cluster environments.
 pub(crate) struct Management {
     runtime: Arc<Runtime>,
-    api_key: String,
+    api_key: SecretString,
     params: HashMap<String, SecretString>,
 }
 
 impl Management {
     pub async fn try_from(
-        config: &spicepod_management,
+        config: &SpicepodManagement,
         runtime: Arc<Runtime>,
     ) -> Result<Self, Error> {
         let params = get_params_with_secrets(runtime.secrets(), &config.params).await;
 
         let api_key = params
             .get("api_key")
-            .map(SecretBox::expose_secret)
             .context(MissingRequiredSecretSnafu { name: "api_key" })?;
 
         Ok(Self {
-            api_key: api_key.to_string(),
+            api_key: api_key.clone(),
             runtime,
             params,
         })
@@ -122,7 +121,7 @@ impl Management {
 
     pub async fn start(&self) -> Result<(), Error> {
         self.start_task_history_export().await?;
-        tracing::info!("Initialized Spice Cloud management");
+        tracing::info!("Initialized management of the Spice runtime");
         Ok(())
     }
 
@@ -173,14 +172,17 @@ impl Management {
             )
             .await;
 
-        tracing::debug!("Enabled task history data export to Spice Cloud");
+        tracing::debug!("Enabled task history data export");
 
         Ok(())
     }
 
     async fn init_task_history_sink_table(&self) -> Result<(), Error> {
         let mut params = HashMap::new();
-        params.insert("spiceai_api_key".to_string(), self.api_key.to_string());
+        params.insert(
+            "spiceai_api_key".to_string(),
+            self.api_key.expose_secret().to_string(),
+        );
 
         if let Some(flight_endpoint) = self.params.get("flight_endpoint") {
             params.insert(

--- a/crates/spicepod/src/component.rs
+++ b/crates/spicepod/src/component.rs
@@ -31,6 +31,7 @@ pub mod catalog;
 pub mod dataset;
 pub mod embeddings;
 pub mod eval;
+pub mod management;
 pub mod model;
 pub mod runtime;
 pub mod secret;

--- a/crates/spicepod/src/component/management.rs
+++ b/crates/spicepod/src/component/management.rs
@@ -1,0 +1,40 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::collections::HashMap;
+
+use crate::component::default_true;
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+pub struct Management {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub params: HashMap<String, String>,
+}
+
+impl Default for Management {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            params: HashMap::new(),
+        }
+    }
+}

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 #![allow(clippy::missing_errors_doc)]
 
+use component::management::Management;
 use extension::Extension;
 use reader::ReadableYaml;
 use serde::{Deserialize, Serialize};
@@ -88,6 +89,8 @@ pub struct Spicepod {
     pub workers: Vec<Worker>,
 
     pub runtime: Runtime,
+
+    pub management: Option<Management>,
 }
 
 fn detect_duplicate_component_names(
@@ -266,5 +269,6 @@ fn from_definition(
         workers,
         dependencies: spicepod_definition.dependencies,
         runtime: spicepod_definition.runtime,
+        management: spicepod_definition.management,
     }
 }

--- a/crates/spicepod/src/spec.rs
+++ b/crates/spicepod/src/spec.rs
@@ -25,6 +25,7 @@ use crate::component::catalog::Catalog;
 use crate::component::embeddings::Embeddings;
 use crate::component::eval::Eval;
 use crate::component::is_default;
+use crate::component::management::Management;
 use crate::component::runtime::Runtime;
 use crate::component::secret::Secret;
 use crate::component::tool::Tool;
@@ -66,6 +67,10 @@ pub struct SpicepodDefinition {
     /// Optional runtime configuration
     #[serde(default, skip_serializing_if = "is_default")]
     pub runtime: Runtime,
+
+    /// Optional management configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub management: Option<Management>,
 
     /// Optional extensions configuration
     #[serde(skip_serializing_if = "HashMap::is_empty")]

--- a/crates/test-framework/src/spicepod_utils/mod.rs
+++ b/crates/test-framework/src/spicepod_utils/mod.rs
@@ -40,6 +40,7 @@ pub fn from_app(app: App) -> SpicepodDefinition {
         name: app.name,
         runtime: app.runtime,
         extensions: app.extensions,
+        management: app.management,
         secrets: app.secrets,
         views: app
             .views

--- a/tools/evalconverter/src/main.rs
+++ b/tools/evalconverter/src/main.rs
@@ -134,6 +134,7 @@ fn spicepod_definition(datasets: Vec<Dataset>, evals: Vec<Eval>) -> SpicepodDefi
             .map(ComponentOrReference::Component)
             .collect(),
         runtime: spicepod::component::runtime::Runtime::default(),
+        management: None,
         extensions: HashMap::default(),
         secrets: Vec::default(),
         metadata: HashMap::default(),


### PR DESCRIPTION
## 📝 Summary

PR adds initial support for Spice.ai Cloud Platform management, enabling observability based on task history records for Spice instances running outside the Spice.ai Cloud Platform. This allows monitoring and troubleshooting capabilities for on-premises and cluster environments.

```yaml
management:
  enabled: true
  params:
    api_key: ... # Spice.ai Cloud Platform api-key
    flight_endpoint: https://dev-flight.spiceai.io
```

1. Records are exported every 5 seconds and include data from the past 3 days.
2. If the management module fails to initialize or start, an error message is logged, but it does not block the runtime from starting.

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/5269

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

We might consider moving functionality to own crate/module. Keeping directly in runtime currently for simplicity.
