### PR TITLE
Fix search bench

### DIFF
--- a/crates/runtime/benches/vector_search.rs
+++ b/crates/runtime/benches/vector_search.rs
@@ -303,7 +303,7 @@ async fn run_search_queries(
                         Some(vec!["data".to_string()]),
                         search_limit,
                         None,
-                        vec!["_id".to_string()],
+                        vec![],
                         vec![],
                     );
 
@@ -356,8 +356,8 @@ async fn to_search_result(result: VectorSearchResult) -> Result<HashMap<String, 
         match to_matches(&table_ref, agg_result).await {
             Ok(matches) => {
                 for m in matches {
-                    let id = m.metadata().get("_id").ok_or_else(|| {
-                        "Missing '_id' key value in search result metadata".to_string()
+                    let id = m.primary_key().get("_id").ok_or_else(|| {
+                        "Missing '_id' primary key value in search result".to_string()
                     })?;
 
                     let id = id

--- a/crates/runtime/src/search/request.rs
+++ b/crates/runtime/src/search/request.rs
@@ -47,7 +47,8 @@ pub struct SearchRequestBaseJson {
     #[serde(rename = "where", default)]
     pub where_cond: Option<String>,
 
-    /// Additional columns to return from the dataset.
+    /// Additional columns to return from the dataset. If the column is a primary key, it will be
+    /// returned within the response under `.primary_key`, not `.data`.
     #[serde(default)]
     pub additional_columns: Vec<String>,
 }

--- a/crates/runtime/src/search/types.rs
+++ b/crates/runtime/src/search/types.rs
@@ -97,11 +97,6 @@ impl Match {
     pub fn metadata(&self) -> &HashMap<String, serde_json::Value> {
         &self.metadata
     }
-
-    #[must_use]
-    pub fn data(&self) -> &HashMap<String, serde_json::Value> {
-        &self.data
-    }
 }
 
 pub async fn to_pretty(agg: AggregationResult) -> Result<impl Display, ArrowError> {

--- a/crates/runtime/src/search/types.rs
+++ b/crates/runtime/src/search/types.rs
@@ -97,6 +97,11 @@ impl Match {
     pub fn metadata(&self) -> &HashMap<String, serde_json::Value> {
         &self.metadata
     }
+
+    #[must_use]
+    pub fn data(&self) -> &HashMap<String, serde_json::Value> {
+        &self.data
+    }
 }
 
 pub async fn to_pretty(agg: AggregationResult) -> Result<impl Display, ArrowError> {

--- a/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_1_ai_completion_input.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__openai__chat_1_ai_completion_input.snap
@@ -46,7 +46,7 @@ expression: "serde_json::to_string_pretty(&task_input).expect(\"Failed to serial
           "properties": {
             "additional_columns": {
               "default": [],
-              "description": "Additional columns to return from the dataset.",
+              "description": "Additional columns to return from the dataset. If the column is a primary key, it will be returned within the response under `.primary_key`, not `.data`.",
               "items": {
                 "type": "string"
               },


### PR DESCRIPTION
## 📝 Summary
 - `_id` is a primary key for search benchmark. 
 - Investigating why it was coming as `.metadata`, not `.primary_key` originally.