### PR TITLE
feat: Connect search caching for HTTP and tools

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -23,7 +23,7 @@ pub use spicepod;
 use spicepod::{
     Spicepod,
     component::{
-        caching::ResultsCache,
+        caching::{CacheConfig, ResultsCache},
         catalog::Catalog,
         dataset::Dataset,
         embeddings::Embeddings,
@@ -213,6 +213,12 @@ impl AppBuilder {
     #[must_use]
     pub fn with_results_cache(mut self, results_cache: ResultsCache) -> AppBuilder {
         self.runtime.results_cache = Some(results_cache);
+        self
+    }
+
+    #[must_use]
+    pub fn with_search_cache(mut self, search_cache: CacheConfig) -> AppBuilder {
+        self.runtime.caching.search_results = search_cache;
         self
     }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -86,6 +86,7 @@ pub trait CacheProvider<V: Clone + Send + Sync + 'static>: HashProvider + std::f
     fn invalidate_all(&self);
     fn size_bytes(&self) -> u64;
     fn item_count(&self) -> u64;
+    fn max_size(&self) -> usize;
     async fn checkpoint(&self);
 }
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -40,6 +40,7 @@ pub struct LruCache<
 > {
     cache: Cache<u64, V, T>,
     hasher: T,
+    max_size: u64,
 }
 
 impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
@@ -117,7 +118,11 @@ impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send 
             .support_invalidation_closures()
             .build_with_hasher(hasher.clone());
 
-        LruCache { cache, hasher }
+        LruCache {
+            cache,
+            hasher,
+            max_size: cache_max_size,
+        }
     }
 }
 
@@ -169,6 +174,10 @@ impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send 
 
     fn item_count(&self) -> u64 {
         self.cache.entry_count()
+    }
+
+    fn max_size(&self) -> usize {
+        usize::try_from(self.max_size).unwrap_or_default()
     }
 
     async fn checkpoint(&self) {

--- a/crates/cache/src/result/query.rs
+++ b/crates/cache/src/result/query.rs
@@ -58,7 +58,7 @@ pub struct CachedStream {
 
 impl CachedStream {
     #[must_use]
-    pub fn try_new(data: Arc<Vec<RecordBatch>>, schema: SchemaRef) -> Self {
+    pub fn new(data: Arc<Vec<RecordBatch>>, schema: SchemaRef) -> Self {
         Self {
             data,
             schema,

--- a/crates/cache/src/result/search.rs
+++ b/crates/cache/src/result/search.rs
@@ -18,35 +18,35 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
 use datafusion::sql::TableReference;
 
 use crate::Sizeable;
 
-use super::CacheStatus;
-
-// TODO: Move VectorSearchResult into the `search` crate to prevent circular dependency, to reuse here?
-// https://github.com/spiceai/spiceai/issues/6018
 #[derive(Clone)]
 pub struct CachedAggregationResult {
     pub records: Arc<Vec<RecordBatch>>,
-    pub primary_keys: Vec<Arc<str>>,
-    pub data_columns: Vec<Arc<str>>,
-    pub matches: Arc<HashMap<String, Vec<String>>>,
+    pub primary_keys: Vec<String>,
+    pub data_columns: Vec<String>,
+    pub matches: HashMap<String, Vec<String>>,
+    pub schema: SchemaRef,
 }
 
 impl CachedAggregationResult {
     #[must_use]
     pub fn new(
         records: Arc<Vec<RecordBatch>>,
-        primary_keys: Vec<Arc<str>>,
-        data_columns: Vec<Arc<str>>,
-        matches: Arc<HashMap<String, Vec<String>>>,
+        primary_keys: Vec<String>,
+        data_columns: Vec<String>,
+        matches: HashMap<String, Vec<String>>,
+        schema: SchemaRef,
     ) -> Self {
         Self {
             records,
             primary_keys,
             data_columns,
             matches,
+            schema,
         }
     }
 }
@@ -54,7 +54,6 @@ impl CachedAggregationResult {
 #[derive(Clone)]
 pub struct CachedSearchResult {
     pub results: Arc<HashMap<TableReference, CachedAggregationResult>>,
-    pub cache_status: CacheStatus,
 }
 
 impl Sizeable for CachedSearchResult {
@@ -67,8 +66,8 @@ impl Sizeable for CachedSearchResult {
                     .iter()
                     .map(arrow::array::RecordBatch::get_array_memory_size)
                     .sum::<usize>()
-                    + (result.primary_keys.len() * std::mem::size_of::<Arc<str>>())
-                    + (result.data_columns.len() * std::mem::size_of::<Arc<str>>())
+                    + (result.primary_keys.len() * std::mem::size_of::<String>())
+                    + (result.data_columns.len() * std::mem::size_of::<String>())
                     + result
                         .matches
                         .iter()

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -27,6 +27,7 @@ pub struct SimpleCache<
 > {
     cache: Cache<u64, V, T>,
     hasher: T,
+    max_size: u64,
 }
 
 impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
@@ -50,7 +51,11 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
             .support_invalidation_closures()
             .build_with_hasher(hasher.clone());
 
-        SimpleCache { cache, hasher }
+        SimpleCache {
+            cache,
+            hasher,
+            max_size: cache_max_size,
+        }
     }
 }
 
@@ -84,6 +89,10 @@ impl<V: Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 's
 
     fn item_count(&self) -> u64 {
         self.cache.entry_count()
+    }
+
+    fn max_size(&self) -> usize {
+        usize::try_from(self.max_size).unwrap_or_default()
     }
 
     async fn checkpoint(&self) {

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -211,8 +211,7 @@ impl Query {
                 .results_cache_hit(true)
         });
 
-        let record_batch_stream =
-            CachedStream::try_new(cached_result.records, cached_result.schema);
+        let record_batch_stream = CachedStream::new(cached_result.records, cached_result.schema);
 
         Ok((
             CacheResult::Hit(QueryResult::new(

--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -146,8 +146,9 @@ pub(crate) async fn post(
         }
     };
 
-    match vs.search(&search_request).await {
-        Ok(resp) => match to_matches_sorted(resp, search_request.limit).await {
+    let cache_provider = vs.df.search_cache_provider();
+    match vs.search_with_cache(&search_request, cache_provider).await {
+        Ok((resp, _)) => match to_matches_sorted(resp, search_request.limit).await {
             Ok(m) => (
                 StatusCode::OK,
                 Json(SearchResponse {

--- a/crates/runtime/src/search/request.rs
+++ b/crates/runtime/src/search/request.rs
@@ -108,6 +108,7 @@ impl TryFrom<SearchRequestAIJson> for SearchRequest {
     }
 }
 
+#[derive(Debug, Clone)]
 #[allow(clippy::doc_markdown)]
 pub struct SearchRequest {
     /// The text to search documents for similarity

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -134,13 +134,13 @@ impl VectorSearch {
         cache_provider: Option<Arc<dyn CacheProvider<CachedSearchResult> + Send + Sync>>,
     ) -> Result<(VectorSearchResult, CacheStatus)> {
         Ok(if let Some(cache_provider) = cache_provider {
-            tracing::debug!("Search cache is enabled");
+            tracing::trace!("Search cache is enabled");
             let search_key = SearchKey::from(req.clone());
             let cache_key = CacheKey::Search(&search_key);
             let raw_cache_key = cache_key.as_raw_key(cache_provider.hasher());
 
             if let Some(cached_result) = cache_provider.get_raw_key(&raw_cache_key.as_u64()).await {
-                tracing::debug!("Search cache hit");
+                tracing::trace!("Search cache hit");
                 // each CachedAggregationResult needs to be re-mapped to an AggregationResult
                 let mut results = HashMap::new();
                 for (table_ref, cached_aggregation_result) in cached_result.results.iter() {
@@ -158,7 +158,7 @@ impl VectorSearch {
 
                 (results, CacheStatus::CacheHit)
             } else {
-                tracing::debug!("Search cache miss");
+                tracing::trace!("Search cache miss");
                 let results = self.search(req).await?;
                 (
                     wrap_cache_to_result(raw_cache_key, results, Arc::clone(&cache_provider)),
@@ -166,7 +166,7 @@ impl VectorSearch {
                 )
             }
         } else {
-            tracing::debug!("Search cache is disabled");
+            tracing::trace!("Search cache is disabled");
             (self.search(req).await?, CacheStatus::CacheDisabled)
         })
     }
@@ -336,7 +336,7 @@ fn wrap_cache_to_result(
         }
 
         if results.is_empty() {
-            tracing::debug!("No results to cache for tables: {expected_keys:?}");
+            tracing::trace!("No results to cache for tables: {expected_keys:?}");
             return;
         } else if !expected_keys
             .iter()
@@ -344,20 +344,20 @@ fn wrap_cache_to_result(
             .collect::<Vec<_>>()
             .is_empty()
         {
-            tracing::debug!(
+            tracing::trace!(
                 "Not all expected keys were found in the cached results: {expected_keys:?}"
             );
             return;
         }
 
-        tracing::debug!("Caching search results for key: {}", key.as_u64());
+        tracing::trace!("Caching search results for key: {}", key.as_u64());
 
         let result = CachedSearchResult {
             results: Arc::new(results),
         };
 
         if result.get_memory_size() > cache_provider.max_size() {
-            tracing::debug!("Search results exceed cache size, not caching");
+            tracing::trace!("Search results exceed cache size, not caching");
             return;
         }
 

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -25,10 +25,19 @@ use crate::search::{
     util::{embedding_columns_from_table, get_primary_keys_with_overrides},
 };
 use crate::{datafusion::DataFusion, model::EmbeddingModelStore};
+use arrow::array::RecordBatch;
+use async_stream::stream;
+use cache::key::{CacheKey, RawCacheKey, SearchKey};
+use cache::result::CacheStatus;
+use cache::result::query::CachedStream;
+use cache::result::search::{CachedAggregationResult, CachedSearchResult};
+use cache::{CacheProvider, Sizeable};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::sql::{
     TableReference,
     sqlparser::ast::{Expr, Ident},
 };
+use futures::StreamExt;
 use itertools::Itertools;
 use search::{
     aggregation::{AggregationResult, reciprocal_rank::ReciprocalRankFusion},
@@ -119,6 +128,49 @@ impl VectorSearch {
         ))
     }
 
+    pub async fn search_with_cache(
+        &self,
+        req: &SearchRequest,
+        cache_provider: Option<Arc<dyn CacheProvider<CachedSearchResult> + Send + Sync>>,
+    ) -> Result<(VectorSearchResult, CacheStatus)> {
+        Ok(if let Some(cache_provider) = cache_provider {
+            tracing::debug!("Search cache is enabled");
+            let search_key = SearchKey::from(req.clone());
+            let cache_key = CacheKey::Search(&search_key);
+            let raw_cache_key = cache_key.as_raw_key(cache_provider.hasher());
+
+            if let Some(cached_result) = cache_provider.get_raw_key(&raw_cache_key.as_u64()).await {
+                tracing::debug!("Search cache hit");
+                // each CachedAggregationResult needs to be re-mapped to an AggregationResult
+                let mut results = HashMap::new();
+                for (table_ref, cached_aggregation_result) in cached_result.results.iter() {
+                    let result = AggregationResult {
+                        data: Box::pin(CachedStream::new(
+                            Arc::clone(&cached_aggregation_result.records),
+                            Arc::clone(&cached_aggregation_result.schema),
+                        )),
+                        primary_key: cached_aggregation_result.primary_keys.clone(),
+                        data_columns: cached_aggregation_result.data_columns.clone(),
+                        matches: cached_aggregation_result.matches.clone(),
+                    };
+                    results.insert(table_ref.clone(), result);
+                }
+
+                (results, CacheStatus::CacheHit)
+            } else {
+                tracing::debug!("Search cache miss");
+                let results = self.search(req).await?;
+                (
+                    wrap_cache_to_result(raw_cache_key, results, Arc::clone(&cache_provider)),
+                    CacheStatus::CacheMiss,
+                )
+            }
+        } else {
+            tracing::debug!("Search cache is disabled");
+            (self.search(req).await?, CacheStatus::CacheDisabled)
+        })
+    }
+
     pub async fn search(&self, req: &SearchRequest) -> Result<VectorSearchResult> {
         let SearchRequest {
             text: query,
@@ -198,4 +250,119 @@ impl VectorSearch {
             }
         }
     }
+}
+
+fn wrap_cache_to_result(
+    key: RawCacheKey,
+    aggregation_result: HashMap<TableReference, AggregationResult>,
+    cache_provider: Arc<dyn CacheProvider<CachedSearchResult> + Send + Sync>,
+) -> HashMap<TableReference, AggregationResult> {
+    // each hashmap entry is an aggregation result which contains a sendable record batch stream
+    // for each table reference, we need to wrap the batch stream in another stream to pull out the record batches
+    // because these occur on different streams though, we need a channel to centralise the results
+    // once the results are collated, we can cache the result
+    let mut wrapped_results = HashMap::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<(TableReference, CachedAggregationResult)>(100);
+    let tx = Arc::new(tx);
+    let expected_keys = aggregation_result.keys().cloned().collect::<Vec<_>>();
+
+    for (table_ref, aggregation_result) in aggregation_result {
+        let tx = Arc::clone(&tx);
+        let primary_key = aggregation_result.primary_key.clone();
+        let data_columns = aggregation_result.data_columns.clone();
+        let matches = aggregation_result.matches.clone();
+        let mut stream = aggregation_result.data;
+        let schema = stream.schema();
+
+        let cloned_table_ref = table_ref.clone();
+        let cloned_primary_key = primary_key.clone();
+        let cloned_data_columns = data_columns.clone();
+        let cloned_matches = matches.clone();
+        let cloned_schema = Arc::clone(&schema);
+        let cloned_cache_provider = Arc::clone(&cache_provider);
+
+        let cached_stream = stream! {
+            let mut records: Vec<RecordBatch> = Vec::new();
+            let mut records_size: usize = 0;
+            let cache_max_size = cloned_cache_provider.max_size();
+
+            while let Some(batch_result) = stream.next().await {
+                if records_size < cache_max_size {
+                    if let Ok(batch) = &batch_result {
+                        records.push(batch.clone());
+                        records_size += batch.get_array_memory_size();
+                    }
+                }
+
+                yield batch_result;
+            }
+
+            if records_size < cache_max_size {
+                let cached_result = CachedAggregationResult::new(
+                    Arc::new(records),
+                    cloned_primary_key,
+                    cloned_data_columns,
+                    cloned_matches,
+                    cloned_schema,
+                );
+                if tx.send((cloned_table_ref.clone(), cached_result)).await.is_err() {
+                    tracing::error!("Failed to send cached search result for {cloned_table_ref}");
+                }
+            }
+        };
+
+        wrapped_results.insert(
+            table_ref,
+            AggregationResult {
+                primary_key,
+                data_columns,
+                matches,
+                data: Box::pin(RecordBatchStreamAdapter::new(
+                    schema,
+                    Box::pin(cached_stream),
+                )),
+            },
+        );
+    }
+
+    // start a background task to collect the results and cache them
+    // if we try to do this in this function before returning, we never return results so the stream never gets polled
+    // if the stream never gets polled, we never get results on the channel
+    // deadlock!
+    tokio::spawn(async move {
+        let mut results = HashMap::new();
+        while let Some((table_ref, cached_result)) = rx.recv().await {
+            results.insert(table_ref, cached_result);
+        }
+
+        if results.is_empty() {
+            tracing::debug!("No results to cache for tables: {expected_keys:?}");
+            return;
+        } else if !expected_keys
+            .iter()
+            .filter(|key| !results.contains_key(key))
+            .collect::<Vec<_>>()
+            .is_empty()
+        {
+            tracing::debug!(
+                "Not all expected keys were found in the cached results: {expected_keys:?}"
+            );
+            return;
+        }
+
+        tracing::debug!("Caching search results for key: {}", key.as_u64());
+
+        let result = CachedSearchResult {
+            results: Arc::new(results),
+        };
+
+        if result.get_memory_size() > cache_provider.max_size() {
+            tracing::debug!("Search results exceed cache size, not caching");
+            return;
+        }
+
+        cache_provider.put_raw_key(&key.as_u64(), result).await;
+    });
+
+    wrapped_results
 }

--- a/crates/runtime/src/tools/builtin/document_similarity.rs
+++ b/crates/runtime/src/tools/builtin/document_similarity.rs
@@ -76,8 +76,13 @@ impl SpiceModelTool for DocumentSimilarityTool {
             );
 
             let search_request = SearchRequest::try_from(req)?;
-
-            let result = vs.search(&search_request).await.boxed()?;
+            let (result, _) = vs
+                .search_with_cache(
+                    &search_request,
+                    self.rt.datafusion().search_cache_provider(),
+                )
+                .await
+                .boxed()?;
 
             let mut formatted = serde_json::Map::with_capacity(result.len());
             for (tbl, result) in result {

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -23,12 +23,14 @@ use runtime::auth::EndpointAuth;
 use runtime::config::Config;
 use serde_json::{Value, json};
 use spicepod::acceleration::Acceleration;
+use spicepod::component::caching::CacheConfig;
 use spicepod::component::dataset::Dataset;
 use spicepod::component::embeddings::{ColumnEmbeddingConfig, EmbeddingChunkConfig};
 use spicepod::param::Params;
 use spicepod::semantic::{Column, ColumnLevelEmbeddingConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use crate::models::hf::get_huggingface_embeddings;
 use crate::models::openai::get_openai_embeddings;
@@ -429,4 +431,63 @@ async fn test_multi_column_w_existing_embedding() -> Result<(), anyhow::Error> {
         ],
     )
     .await
+}
+
+#[tokio::test]
+async fn test_search_with_cache() -> Result<(), anyhow::Error> {
+    let chunked = catalog_page_tpch_dataset_w_embeddings(
+        "cached_search",
+        "hf_minilm",
+        Some(vec!["cp_catalog_page_sk".to_string()]),
+        Some(EmbeddingChunkConfig {
+            enabled: true,
+            target_chunk_size: 512,
+            overlap_size: 128,
+            trim_whitespace: false,
+        }),
+    );
+
+    let cache_config = CacheConfig {
+        enabled: true,
+        item_ttl: Some("10s".to_string()),
+        ..Default::default()
+    };
+
+    let app = AppBuilder::new("cached_search")
+        .with_dataset(chunked)
+        .with_embedding(get_huggingface_embeddings(
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "hf_minilm",
+        ))
+        .with_search_cache(cache_config)
+        .build();
+
+    let _tracing = init_tracing(None);
+
+    test_request_context()
+        .scope(async {
+            let api_config = start_app(app).await?;
+            let http_base_url = format!("http://{}", api_config.http_bind_address);
+            let start = Instant::now();
+            run_search_test(http_base_url.as_str(), &SearchTestCase {
+                name: "pre_cache",
+                body: json!({
+                    "text": "new patient",
+                    "limit": 2,
+                }),
+            }).await?;
+            let duration = start.elapsed();
+            let start = Instant::now();
+            run_search_test(http_base_url.as_str(), &SearchTestCase {
+                name: "post_cache",
+                body: json!({
+                    "text": "new patient",
+                    "limit": 2,
+                }),
+            }).await?;
+            let duration_cached = start.elapsed();
+            assert!(duration_cached * 10 < duration, "Cache did not improve performance by an order of magnitude. First: {duration:?}, Second: {duration_cached:?}");
+            Ok(())
+        })
+        .await
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__post_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__post_cache_response.snap
@@ -1,0 +1,29 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: normalize_search_response(response)
+---
+{
+  "duration_ms": "duration_ms_val",
+  "results": [
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "In general basic characters welcome. Clearly lively friends con"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
+      },
+      "score": 0.94
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Close customers might struggle away different mem"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 15
+      },
+      "score": 0.939
+    }
+  ]
+}

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__pre_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__pre_cache_response.snap
@@ -1,0 +1,29 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: normalize_search_response(response)
+---
+{
+  "duration_ms": "duration_ms_val",
+  "results": [
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "In general basic characters welcome. Clearly lively friends con"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
+      },
+      "score": 0.94
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Close customers might struggle away different mem"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 15
+      },
+      "score": 0.939
+    }
+  ]
+}


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Integrates the search cache to retrieve and store search results into the search cache
* Prepares to add cache status headers to HTTP responses from search cache. Headers will be addressed in https://github.com/spiceai/spiceai/issues/6028
* Adds an integration test for the effectiveness of the search cache

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6019
* Part of #3018

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

* Docs updates are tracked in: https://github.com/spiceai/docs/issues/1018
