### PR TITLE
fix: Update the TPCDS postgres acceleration indexes

### DIFF
--- a/test/spicepods/tpcds/sf1/accelerated/file[parquet]-postgres.yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/file[parquet]-postgres.yaml
@@ -4,7 +4,7 @@ name: file[parquet]-postgres
 datasets:
   - from: file:data/catalog_returns.parquet
     name: catalog_returns
-    acceleration: &acceleration
+    acceleration:
       enabled: true
       engine: postgres
       refresh_on_startup: always
@@ -15,6 +15,9 @@ datasets:
         pg_pass: ${secrets:POSTGRES_PASSWORD}
         pg_db: tpcds_file_accelerated
         pg_sslmode: disable
+      primary_key: (cr_item_sk, cr_order_number)
+      indexes:
+        (cr_returned_date_sk, cr_catalog_page_sk): enabled
   - from: file:data/catalog_sales.parquet
     name: catalog_sales
     acceleration:
@@ -22,11 +25,23 @@ datasets:
       engine: postgres
       refresh_on_startup: always
       params: *pg_params
+      primary_key: (cs_item_sk, cs_order_number)
       indexes:
         cs_sold_date_sk: enabled
+        cs_item_sk: enabled
+        cs_ship_customer_sk: enabled
+        cs_bill_customer_sk: enabled
+        (cs_sold_date_sk, cs_item_sk): enabled
+        (cs_bill_customer_sk, cs_sold_date_sk): enabled
+        (cs_sold_date_sk, cs_catalog_page_sk): enabled
   - from: file:data/inventory.parquet
     name: inventory
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (inv_date_sk, inv_item_sk, inv_warehouse_sk)
   - from: file:data/store_sales.parquet
     name: store_sales
     acceleration:
@@ -34,22 +49,49 @@ datasets:
       engine: postgres
       refresh_on_startup: always
       params: *pg_params
+      primary_key: (ss_item_sk, ss_ticket_number)
       indexes:
         ss_item_sk: enabled
         ss_store_sk: enabled
         ss_customer_sk: enabled
         ss_ticket_number: enabled
         ss_hdemo_sk: enabled
+        ss_sold_date_sk: enabled
         (ss_customer_sk, ss_sold_date_sk): enabled
+        (ss_sold_date_sk, ss_item_sk, ss_customer_sk): enabled
+        (ss_item_sk, ss_customer_sk, ss_store_sk): enabled
+        (ss_sold_date_sk, ss_store_sk): enabled
   - from: file:data/store_returns.parquet
     name: store_returns
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (sr_item_sk, sr_ticket_number)
+      indexes:
+        (sr_returned_date_sk, sr_store_sk): enabled
   - from: file:data/web_sales.parquet
     name: web_sales
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (ws_item_sk, ws_order_number)
+      indexes:
+        ws_bill_customer_sk: enabled
+        ws_sold_date_sk: enabled
+        (ws_bill_customer_sk, ws_sold_date_sk): enabled
+        (ws_sold_date_sk, ws_web_site_sk): enabled
   - from: file:data/web_returns.parquet
     name: web_returns
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (wr_item_sk, wr_order_number)
   - from: file:data/customer.parquet
     name: customer
     acceleration:
@@ -57,13 +99,22 @@ datasets:
       engine: postgres
       refresh_on_startup: always
       params: *pg_params
+      primary_key: (c_customer_sk)
       indexes:
         c_current_addr_sk: enabled
         c_customer_sk: enabled
         c_current_hdemo_sk: enabled
+        (c_last_name, c_first_name): enabled
   - from: file:data/customer_address.parquet
     name: customer_address
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (ca_address_sk)
+      indexes:
+        ca_county: enabled
   - from: file:data/customer_demographics.parquet
     name: customer_demographics
     acceleration:
@@ -71,6 +122,7 @@ datasets:
       engine: postgres
       refresh_on_startup: always
       params: *pg_params
+      primary_key: (cd_demo_sk)
       indexes:
         cd_demo_sk: enabled
   - from: file:data/date_dim.parquet
@@ -80,12 +132,19 @@ datasets:
       engine: postgres
       refresh_on_startup: always
       params: *pg_params
+      primary_key: (d_date_sk)
       indexes:
         d_year: enabled
         d_date: enabled
+        d_date_sk: enabled
   - from: file:data/household_demographics.parquet
     name: household_demographics
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (hd_demo_sk)
   - from: file:data/item.parquet
     name: item
     acceleration:
@@ -93,15 +152,28 @@ datasets:
       engine: postgres
       refresh_on_startup: always
       params: *pg_params
+      primary_key: (i_item_sk)
       indexes:
         i_item_sk: enabled
         i_manufact_id: enabled
+        (i_item_sk, i_category_id): enabled
+        (i_category_id, i_brand_id): enabled
   - from: file:data/promotion.parquet
     name: promotion
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (p_promo_sk)
   - from: file:data/ship_mode.parquet
     name: ship_mode
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (sm_ship_mode_sk)
   - from: file:data/store.parquet
     name: store
     acceleration:
@@ -109,30 +181,76 @@ datasets:
       engine: postgres
       refresh_on_startup: always
       params: *pg_params
+      primary_key: (s_store_sk)
       indexes:
         s_store_name: enabled
         s_zip: enabled
+        s_store_sk: enabled
+        (s_store_sk, s_store_name): enabled
   - from: file:data/time_dim.parquet
     name: time_dim
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (t_time_sk)
+      indexes:
+        t_time_sk: enabled
+        t_time_id: enabled
   - from: file:data/warehouse.parquet
     name: warehouse
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (w_warehouse_sk)
   - from: file:data/web_page.parquet
     name: web_page
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (wp_web_page_sk)
   - from: file:data/web_site.parquet
     name: web_site
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (web_site_sk)
   - from: file:data/reason.parquet
     name: reason
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (r_reason_sk)
   - from: file:data/call_center.parquet
     name: call_center
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (cc_call_center_sk)
   - from: file:data/income_band.parquet
     name: income_band
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (ib_income_band_sk)
   - from: file:data/catalog_page.parquet
     name: catalog_page
-    acceleration: *acceleration
+    acceleration:
+      enabled: true
+      engine: postgres
+      refresh_on_startup: always
+      params: *pg_params
+      primary_key: (cp_catalog_page_sk)

--- a/test/spicepods/tpcds/sf1/accelerated/file[parquet]-postgres.yaml
+++ b/test/spicepods/tpcds/sf1/accelerated/file[parquet]-postgres.yaml
@@ -40,6 +40,7 @@ datasets:
         ss_customer_sk: enabled
         ss_ticket_number: enabled
         ss_hdemo_sk: enabled
+        (ss_customer_sk, ss_sold_date_sk): enabled
   - from: file:data/store_returns.parquet
     name: store_returns
     acceleration: *acceleration


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* An update to the physical plan has resulted in different indexes being hit, which we don't create on the acceleration. This updates the spicepod to replicate the indexes from [tpcds_index.sql](https://github.com/spiceai/spiceai/blob/trunk/test/tpc-bench/tpcds_index.sql)

