### PR TITLE
Emit retry error on flight transient connection failure

### DIFF
--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -558,9 +558,9 @@ fn map_connection_reset_error(error: FlightError) -> Error {
                     }),
                 };
             }
-            return Error::ArrowFlight {
+            Error::ArrowFlight {
                 source: Box::new(error),
-            };
+            }
         }
         _ => Error::ArrowFlight {
             source: Box::new(error),

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -39,7 +39,9 @@ use datafusion::{
 };
 use datafusion_federation::sql::MultiPartTableReference;
 use datafusion_table_providers::sql::sql_provider_datafusion::expr;
-use flight_client::FlightClient;
+use flight_client::{
+    Error as FlightClientError, FlightClient, TonicStatusError, is_connection_reset_error,
+};
 use futures::{Stream, StreamExt};
 use snafu::prelude::*;
 use std::{any::Any, fmt, sync::Arc};
@@ -68,7 +70,9 @@ pub enum Error {
     },
 
     #[snafu(display("Query execution failed.\n{source}\nVerify the configuration and try again."))]
-    ArrowFlight { source: FlightError },
+    ArrowFlight {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -520,7 +524,7 @@ fn query_to_stream(
                     match batch {
                         Ok(batch) => yield Ok(batch),
                         Err(error) => {
-                            yield Err(to_execution_error(Error::ArrowFlight { source: error }));
+                            yield Err(to_execution_error(map_connection_reset_error(error)));
                         }
                     }
                 }
@@ -540,5 +544,26 @@ fn to_execution_error(e: Error) -> DataFusionError {
             _ => DataFusionError::Execution(format!("{source}")),
         },
         _ => DataFusionError::Execution(format!("{e}")),
+    }
+}
+
+fn map_connection_reset_error(error: FlightError) -> Error {
+    match error {
+        FlightError::Tonic(ref source) => {
+            let source_owned = *source.clone();
+            if is_connection_reset_error(&source_owned) {
+                return Error::ArrowFlight {
+                    source: Box::new(FlightClientError::ConnectionReset {
+                        source: TonicStatusError::from(source_owned),
+                    }),
+                };
+            }
+            return Error::ArrowFlight {
+                source: Box::new(error),
+            };
+        }
+        _ => Error::ArrowFlight {
+            source: Box::new(error),
+        },
     }
 }

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -172,6 +172,9 @@ pub enum Error {
         "No endpoints found. Ensure the endpoint is configured and the server is running."
     ))]
     NoEndpointsFound,
+
+    #[snafu(display("Connection is reset by the server. Please retry the request.\n{source}"))]
+    ConnectionReset { source: TonicStatusError },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -599,8 +602,17 @@ impl FlightClient {
             .clone()
             .handshake(req)
             .await
-            .map_err(TonicStatusError::from)
-            .context(UnableToPerformHandshakeSnafu)?;
+            .map_err(|e| {
+                if is_connection_reset_error(&e) {
+                    Error::ConnectionReset {
+                        source: TonicStatusError::from(e),
+                    }
+                } else {
+                    Error::UnableToPerformHandshake {
+                        source: TonicStatusError::from(e),
+                    }
+                }
+            })?;
         let mut token: Option<Token> = None;
         if let Some(auth) = resp.metadata().get("authorization") {
             let auth = auth
@@ -629,7 +641,25 @@ impl FlightClient {
 
 #[allow(clippy::needless_pass_by_value)]
 fn map_tonic_error_to_message(e: tonic::Status) -> Error {
+    if is_connection_reset_error(&e) {
+        return Error::ConnectionReset {
+            source: TonicStatusError::from(e),
+        };
+    }
     Error::UnableToQuery {
         source: e.message().into(),
     }
+}
+
+pub fn is_connection_reset_error(error: &tonic::Status) -> bool {
+    if error.code() == tonic::Code::Internal {
+        let error_message = error.message().to_lowercase();
+        if error_message.contains("operation was canceled")
+            || error_message.contains("http2 error")
+            || error_message.contains("grpc-status header missing")
+        {
+            return true;
+        }
+    }
+    false
 }


### PR DESCRIPTION
## 📝 Summary

Define a new error variant `ConnectionReset` in spice_client error indicating retryable connection reset. Emit this  retry error on all transient connection failure for flight requests.

## 🔗 Related

- Close: https://github.com/spiceai/spiceai/issues/6120
- Part of: https://github.com/spiceai/spiceai/issues/4035

Client retry will be implemented in incremental change as part of https://github.com/spiceai/spiceai/issues/6121 and https://github.com/spiceai/spiceai/issues/6122

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
