### PR TITLE
Update Flight DoPut implementation to send single final PutResult

### DIFF
--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -223,7 +223,11 @@ fn create_response_stream(
                                 }
                             };
 
-                            yield handle_record_batch(new_batch, &batch_tx).await;
+                            // Only report errors; a success message is sent as the final step upon successful write completion
+                            if let Err(err) = handle_record_batch(new_batch, &batch_tx).await {
+                                yield Err(err);
+                                break;
+                            }
                         }
                         None => {
                             // End of the stream; signal that stream is completed and data write should be finalized
@@ -235,7 +239,8 @@ fn create_response_stream(
                                 tracing::error!("Write operation failed. Details included in the response.");
                                 yield Err(Status::internal(format!("Write operation failed: {e}")));
                             }
-                            tracing::trace!("Write operation completed successfully for path: {path}");
+                            tracing::debug!("Write operation completed successfully for dataset: {path}");
+                            yield Ok(PutResult::default())
                             break;
                         }
                         Some(Err(e)) => {

--- a/crates/runtime/tests/flight/snapshots/integration__flight__do_put__do_put_basic_reponse.snap
+++ b/crates/runtime/tests/flight/snapshots/integration__flight__do_put__do_put_basic_reponse.snap
@@ -2,4 +2,4 @@
 source: crates/runtime/tests/flight/do_put.rs
 expression: response_str
 ---
-[PutResult { app_metadata: b"" }, PutResult { app_metadata: b"" }]
+[PutResult { app_metadata: b"" }]


### PR DESCRIPTION
## 📝 Summary

The Flight DoPut specification does not explicitly define when the server must send a `PutResult` and allows sending multiple:

```proto
rpc DoPut(stream FlightData) returns (stream PutResult) {}
```

See the [Apache Arrow Flight Protocol documentation](https://arrow.apache.org/docs/format/Flight.html) for details.

However, most clients expect a single final response from the server (see [FlightSQLServer implementation](https://github.com/apache/arrow-rs/blob/6deefb7d6163dceb360236078d5d9f10d1021422/arrow-flight/src/sql/server.rs#L748) as an example), causing clients to treat the first response as the final message and to finalize or close the connection.

This PR improves the existing logic to align with this approach and sends a single final message at the end.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
