### PR TITLE
feat: Add metrics for search results cache

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -212,8 +212,6 @@ impl QueryResultsCacheProvider {
             ignore_schemas,
         };
 
-        metrics::MAX_SIZE_BYTES.record(cache_max_size, &[]);
-
         Ok(cache_provider)
     }
 
@@ -229,10 +227,10 @@ impl QueryResultsCacheProvider {
     ///
     /// Will return `Err` if method fails to access the cache
     pub async fn get_raw_key(&self, raw_key: &RawCacheKey) -> Result<Option<CachedQueryResult>> {
-        metrics::REQUESTS.add(1, &[]);
+        metrics::sql_results::REQUESTS.add(1, &[]);
         match self.cache.get_raw_key(&raw_key.as_u64()).await {
             Some(cached_result) => {
-                metrics::HITS.add(1, &[]);
+                metrics::sql_results::HITS.add(1, &[]);
                 Ok(Some(cached_result))
             }
             None => Ok(None),
@@ -266,8 +264,8 @@ impl QueryResultsCacheProvider {
         if now_seconds - self.metrics_reported_last_time.load(Ordering::Relaxed) >= 5 {
             self.metrics_reported_last_time
                 .store(now_seconds, Ordering::Relaxed);
-            metrics::SIZE_BYTES.record(self.size(), &[]);
-            metrics::ITEMS.record(self.item_count(), &[]);
+            metrics::sql_results::SIZE_BYTES.record(self.size(), &[]);
+            metrics::sql_results::ITEMS.record(self.item_count(), &[]);
         }
     }
 
@@ -340,7 +338,7 @@ impl Display for QueryResultsCacheProvider {
     }
 }
 
-fn current_time_secs() -> u64 {
+pub(crate) fn current_time_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -19,7 +19,6 @@ use std::fmt::Formatter;
 use std::hash::BuildHasher;
 use std::hash::Hasher;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -154,7 +153,6 @@ pub struct QueryResultsCacheProvider {
     cache: Arc<dyn QueryResultCache + Send + Sync>,
     cache_max_size: u64,
     ttl: std::time::Duration,
-    metrics_reported_last_time: AtomicU64,
 
     ignore_schemas: Box<[Box<str>]>,
 }
@@ -165,10 +163,6 @@ impl std::fmt::Debug for QueryResultsCacheProvider {
             .field("cache_max_size", &self.cache_max_size)
             .field("ttl", &self.ttl)
             .field("ignore_schemas", &self.ignore_schemas)
-            .field(
-                "metrics_reported_last_time",
-                &self.metrics_reported_last_time,
-            )
             .finish_non_exhaustive()
     }
 }
@@ -208,7 +202,6 @@ impl QueryResultsCacheProvider {
             },
             cache_max_size,
             ttl,
-            metrics_reported_last_time: AtomicU64::new(0),
             ignore_schemas,
         };
 
@@ -227,12 +220,8 @@ impl QueryResultsCacheProvider {
     ///
     /// Will return `Err` if method fails to access the cache
     pub async fn get_raw_key(&self, raw_key: &RawCacheKey) -> Result<Option<CachedQueryResult>> {
-        metrics::sql_results::REQUESTS.add(1, &[]);
         match self.cache.get_raw_key(&raw_key.as_u64()).await {
-            Some(cached_result) => {
-                metrics::sql_results::HITS.add(1, &[]);
-                Ok(Some(cached_result))
-            }
+            Some(cached_result) => Ok(Some(cached_result)),
             None => Ok(None),
         }
     }
@@ -254,19 +243,7 @@ impl QueryResultsCacheProvider {
         result: CachedQueryResult,
     ) -> Result<()> {
         let res = self.cache.put_raw_key(&raw_key.as_u64(), result).await;
-        self.report_size_metrics();
         Ok(res)
-    }
-
-    fn report_size_metrics(&self) {
-        let now_seconds = current_time_secs();
-
-        if now_seconds - self.metrics_reported_last_time.load(Ordering::Relaxed) >= 5 {
-            self.metrics_reported_last_time
-                .store(now_seconds, Ordering::Relaxed);
-            metrics::sql_results::SIZE_BYTES.record(self.size(), &[]);
-            metrics::sql_results::ITEMS.record(self.item_count(), &[]);
-        }
     }
 
     /// # Errors

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -21,6 +21,8 @@ use crate::HashProvider;
 use crate::Result;
 use crate::Sizeable;
 use crate::TableInvalidator;
+use crate::current_time_secs;
+use crate::metrics::CacheMetrics;
 use async_trait::async_trait;
 use byte_unit::Byte;
 use datafusion::sql::TableReference;
@@ -31,20 +33,25 @@ use spicepod::component::caching::HashingAlgorithm;
 use std::hash::BuildHasher;
 use std::hash::Hasher;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 // 'static is required by a bound from moka::Cache
 pub struct LruCache<
-    V: Sizeable + Clone + Send + Sync + 'static,
+    V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
     T: BuildHasher + Clone + Send + Sync + 'static,
 > {
     cache: Cache<u64, V, T>,
     hasher: T,
     max_size: u64,
+    metrics_last_reported_time: AtomicU64,
 }
 
-impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    std::fmt::Debug for LruCache<V, T>
+impl<
+    V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
+    T: BuildHasher + Clone + Send + Sync + 'static,
+> std::fmt::Debug for LruCache<V, T>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LruCache")
@@ -60,7 +67,7 @@ impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send 
 ///
 /// - If the specified `max_size` cannot be parsed as a valid byte size.
 /// - If the specified `item_ttl` cannot be parsed as a valid duration.
-pub fn build_from_config<V: Sizeable + Clone + Send + Sync + 'static>(
+pub fn build_from_config<V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static>(
     cache_config: &CacheConfig,
 ) -> Result<Arc<dyn CacheProvider<V> + Send + Sync>> {
     let cache_max_size: u64 = match &cache_config.max_size {
@@ -91,8 +98,10 @@ pub fn build_from_config<V: Sizeable + Clone + Send + Sync + 'static>(
     })
 }
 
-impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    LruCache<V, T>
+impl<
+    V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
+    T: BuildHasher + Clone + Send + Sync + 'static,
+> LruCache<V, T>
 {
     pub fn new(cache_max_size: u64, ttl: Duration, hasher: T) -> Self {
         let cache: Cache<u64, V, T> = Cache::builder()
@@ -122,12 +131,15 @@ impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send 
             cache,
             hasher,
             max_size: cache_max_size,
+            metrics_last_reported_time: AtomicU64::new(0),
         }
     }
 }
 
-impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    HashProvider for LruCache<V, T>
+impl<
+    V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
+    T: BuildHasher + Clone + Send + Sync + 'static,
+> HashProvider for LruCache<V, T>
 {
     fn hasher(&self) -> Box<dyn Hasher> {
         Box::new(self.hasher.build_hasher())
@@ -153,19 +165,47 @@ impl<T: BuildHasher + Clone + Send + Sync + 'static> TableInvalidator
 }
 
 #[async_trait]
-impl<V: Sizeable + Clone + Send + Sync + 'static, T: BuildHasher + Clone + Send + Sync + 'static>
-    CacheProvider<V> for LruCache<V, T>
+impl<
+    V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
+    T: BuildHasher + Clone + Send + Sync + 'static,
+> CacheProvider<V> for LruCache<V, T>
 {
     async fn get_raw_key(&self, key: &u64) -> Option<V> {
-        self.cache.get(key).await
+        V::record_request();
+        match self.cache.get(key).await {
+            Some(v) => {
+                V::record_hit();
+                Some(v)
+            }
+            None => None,
+        }
     }
 
     async fn put_raw_key(&self, key: &u64, value: V) {
         self.cache.insert(*key, value).await;
+
+        let now_seconds = current_time_secs();
+        if now_seconds - self.metrics_last_reported_time.load(Ordering::Relaxed) >= 5 {
+            self.metrics_last_reported_time
+                .store(now_seconds, Ordering::Relaxed);
+
+            V::record_item_count(self.item_count());
+            V::record_size(self.size_bytes());
+            V::record_max_size(self.max_size() as u64);
+        }
     }
 
     fn invalidate_all(&self) {
         self.cache.invalidate_all();
+
+        let now_seconds = current_time_secs();
+        if now_seconds - self.metrics_last_reported_time.load(Ordering::Relaxed) >= 5 {
+            self.metrics_last_reported_time
+                .store(now_seconds, Ordering::Relaxed);
+
+            V::record_item_count(self.item_count());
+            V::record_size(self.size_bytes());
+        }
     }
 
     fn size_bytes(&self) -> u64 {

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -57,6 +57,10 @@ impl<
         f.debug_struct("LruCache")
             .field("cache_size", &self.cache.weighted_size())
             .field("item_count", &self.cache.entry_count())
+            .field(
+                "metrics_reported_last_time",
+                &self.metrics_last_reported_time,
+            )
             .finish_non_exhaustive()
     }
 }

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -21,41 +21,117 @@ use opentelemetry::{
     metrics::{Counter, Gauge, Meter},
 };
 
-static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("results_cache"));
+use crate::result::{query::CachedQueryResult, search::CachedSearchResult};
 
-pub(crate) static SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
-    METER
-        .u64_gauge("results_cache_size_bytes")
-        .with_description("Size of the cache in bytes.")
-        .with_unit("By")
-        .build()
-});
+macro_rules! generate_cache_metrics {
+    ($prefix:literal, $name:ident) => {
+        pub mod $name {
+            use super::*;
 
-pub(crate) static MAX_SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
-    METER
-        .u64_gauge("results_cache_max_size_bytes")
-        .with_description("Maximum allowed size of the cache in bytes.")
-        .with_unit("By")
-        .build()
-});
+            static METER: LazyLock<Meter> =
+                LazyLock::new(|| global::meter(concat!($prefix, "_cache")));
 
-pub(crate) static REQUESTS: LazyLock<Counter<u64>> = LazyLock::new(|| {
-    METER
-        .u64_counter("results_cache_requests")
-        .with_description("Number of requests to get a key from the cache.")
-        .build()
-});
+            pub static SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+                METER
+                    .u64_gauge(concat!($prefix, "_cache_size_bytes"))
+                    .with_description("Size of the cache in bytes.")
+                    .with_unit("By")
+                    .build()
+            });
 
-pub(crate) static HITS: LazyLock<Counter<u64>> = LazyLock::new(|| {
-    METER
-        .u64_counter("results_cache_hits")
-        .with_description("Cache hit count.")
-        .build()
-});
+            pub static MAX_SIZE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+                METER
+                    .u64_gauge(concat!($prefix, "_cache_max_size_bytes"))
+                    .with_description("Maximum allowed size of the cache in bytes.")
+                    .with_unit("By")
+                    .build()
+            });
 
-pub(crate) static ITEMS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
-    METER
-        .u64_gauge("results_cache_items_count")
-        .with_description("Number of items currently in the cache.")
-        .build()
-});
+            pub static REQUESTS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+                METER
+                    .u64_counter(concat!($prefix, "_cache_requests"))
+                    .with_description("Number of requests to get a key from the cache.")
+                    .build()
+            });
+
+            pub static HITS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+                METER
+                    .u64_counter(concat!($prefix, "_cache_hits"))
+                    .with_description("Cache hit count.")
+                    .build()
+            });
+
+            pub static ITEMS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+                METER
+                    .u64_gauge(concat!($prefix, "_cache_items_count"))
+                    .with_description("Number of items currently in the cache.")
+                    .build()
+            });
+        }
+    };
+}
+
+generate_cache_metrics!("results", sql_results); // TODO: update the prefix to `sql_results` in v2.0 - https://github.com/spiceai/spiceai/issues/6128
+generate_cache_metrics!("search_results", search_results);
+
+pub trait CacheMetrics: Send + Sync {
+    fn record_hit()
+    where
+        Self: Sized;
+    fn record_request()
+    where
+        Self: Sized;
+    fn record_item_count(count: u64)
+    where
+        Self: Sized;
+    fn record_size(size: u64)
+    where
+        Self: Sized;
+    fn record_max_size(size: u64)
+    where
+        Self: Sized;
+}
+
+impl CacheMetrics for CachedSearchResult {
+    fn record_hit() {
+        search_results::HITS.add(1, &[]);
+    }
+
+    fn record_request() {
+        search_results::REQUESTS.add(1, &[]);
+    }
+
+    fn record_item_count(count: u64) {
+        search_results::ITEMS.record(count, &[]);
+    }
+
+    fn record_size(size: u64) {
+        search_results::SIZE_BYTES.record(size, &[]);
+    }
+
+    fn record_max_size(size: u64) {
+        search_results::MAX_SIZE_BYTES.record(size, &[]);
+    }
+}
+
+impl CacheMetrics for CachedQueryResult {
+    fn record_hit() {
+        sql_results::HITS.add(1, &[]);
+    }
+
+    fn record_request() {
+        sql_results::REQUESTS.add(1, &[]);
+    }
+
+    fn record_item_count(count: u64) {
+        sql_results::ITEMS.record(count, &[]);
+    }
+
+    fn record_size(size: u64) {
+        sql_results::SIZE_BYTES.record(size, &[]);
+    }
+
+    fn record_max_size(size: u64) {
+        sql_results::MAX_SIZE_BYTES.record(size, &[]);
+    }
+}


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds metrics for the search cache, replicating the same metric properties that are reported for the SQL results cache
  * Updated the bound for `V` on an `LruCache`, requiring that `V: CacheMetrics`. This means that any value used in an `LruCache` must be able to report on metrics, which it obtains by performing `V::record_*`
  * Deletes the metric reporting from the `QueryResultsCacheProvider` as they are now handled by the underlying `LruCache`

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #6109
* Part of #3018

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

* Observability docs will need updating for the new search results metric names, tracked in https://github.com/spiceai/docs/issues/1018
