### PR TITLE
feat: Add search cache status header, respect cache control

### DIFF
--- a/crates/cache/src/result/mod.rs
+++ b/crates/cache/src/result/mod.rs
@@ -28,3 +28,15 @@ pub enum CacheStatus {
     // The request was a cache miss.
     CacheMiss,
 }
+
+impl CacheStatus {
+    #[must_use]
+    pub fn to_header_string(&self) -> Option<String> {
+        match self {
+            CacheStatus::CacheDisabled => None,
+            CacheStatus::CacheBypass => Some("BYPASS".to_string()),
+            CacheStatus::CacheHit => Some("HIT".to_string()),
+            CacheStatus::CacheMiss => Some("MISS".to_string()),
+        }
+    }
+}

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -241,7 +241,10 @@ fn attach_cache_headers(headers: &mut HeaderMap, results_cache_status: CacheStat
         headers.insert("X-Cache", val);
     }
 
-    if let Some(val) = status_to_results_cache_value(results_cache_status) {
+    if let Some(val) = results_cache_status
+        .to_header_string()
+        .and_then(|v| v.parse().ok())
+    {
         headers.insert("Results-Cache-Status", val);
     }
 }
@@ -252,15 +255,6 @@ fn status_to_x_cache_value(results_cache_status: CacheStatus) -> Option<HeaderVa
         CacheStatus::CacheHit => "Hit from spiceai".parse().ok(),
         CacheStatus::CacheMiss => "Miss from spiceai".parse().ok(),
         CacheStatus::CacheDisabled | CacheStatus::CacheBypass => None,
-    }
-}
-
-fn status_to_results_cache_value(results_cache_status: CacheStatus) -> Option<HeaderValue> {
-    match results_cache_status {
-        CacheStatus::CacheHit => "HIT".parse().ok(),
-        CacheStatus::CacheMiss => "MISS".parse().ok(),
-        CacheStatus::CacheBypass => "BYPASS".parse().ok(),
-        CacheStatus::CacheDisabled => None,
     }
 }
 

--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -13,18 +13,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use crate::search::{
-    Error as VectorSearchError,
-    request::{SearchRequest, SearchRequestAIJson, SearchRequestHTTPJson},
-    types::Match,
-    types::to_matches_sorted,
-    vector_search::VectorSearch,
+use crate::{
+    request::{AsyncMarker, RequestContext},
+    search::{
+        Error as VectorSearchError,
+        request::{SearchRequest, SearchRequestAIJson, SearchRequestHTTPJson},
+        types::{Match, to_matches_sorted},
+        vector_search::VectorSearch,
+    },
 };
 use axum::{
     Extension, Json,
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use http::HeaderMap;
 use serde::{Deserialize, Serialize};
 use std::{sync::Arc, time::Instant};
 
@@ -146,17 +149,30 @@ pub(crate) async fn post(
         }
     };
 
+    let context = RequestContext::current(AsyncMarker::new().await);
     let cache_provider = vs.df.search_cache_provider();
-    match vs.search_with_cache(&search_request, cache_provider).await {
-        Ok((resp, _)) => match to_matches_sorted(resp, search_request.limit).await {
-            Ok(m) => (
-                StatusCode::OK,
-                Json(SearchResponse {
-                    results: m,
-                    duration_ms: start_time.elapsed().as_millis(),
-                }),
-            )
-                .into_response(),
+    match vs
+        .search_with_cache(&search_request, cache_provider, context.cache_control())
+        .await
+    {
+        Ok((resp, cache_status)) => match to_matches_sorted(resp, search_request.limit).await {
+            Ok(m) => {
+                let mut headers = HeaderMap::new();
+
+                if let Some(val) = cache_status.to_header_string().and_then(|v| v.parse().ok()) {
+                    headers.insert("Search-Results-Cache-Status", val);
+                }
+
+                (
+                    StatusCode::OK,
+                    headers,
+                    Json(SearchResponse {
+                        results: m,
+                        duration_ms: start_time.elapsed().as_millis(),
+                    }),
+                )
+                    .into_response()
+            }
             Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
         },
         Err(e) => {

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -19,6 +19,7 @@ use std::{collections::HashMap, sync::Arc};
 use super::request::SearchRequest;
 use super::util::{get_embedding_table, user_tables_with_embeddings};
 use super::{Error, Result};
+use crate::request::CacheControl;
 use crate::search::{
     SearchPipelineSnafu,
     candidate::vector::VectorGeneration,
@@ -132,9 +133,15 @@ impl VectorSearch {
         &self,
         req: &SearchRequest,
         cache_provider: Option<Arc<dyn CacheProvider<CachedSearchResult> + Send + Sync>>,
+        cache_control: CacheControl,
     ) -> Result<(VectorSearchResult, CacheStatus)> {
         Ok(if let Some(cache_provider) = cache_provider {
             tracing::trace!("Search cache is enabled");
+            if matches!(cache_control, CacheControl::NoCache) {
+                tracing::trace!("Search cache bypassed");
+                return Ok((self.search(req).await?, CacheStatus::CacheBypass));
+            }
+
             let search_key = SearchKey::from(req.clone());
             let cache_key = CacheKey::Search(&search_key);
             let raw_cache_key = cache_key.as_raw_key(cache_provider.hasher());

--- a/crates/runtime/src/tools/builtin/document_similarity.rs
+++ b/crates/runtime/src/tools/builtin/document_similarity.rs
@@ -21,6 +21,7 @@ use tracing_futures::Instrument;
 
 use crate::{
     Runtime,
+    request::{CacheControl, CacheKeyType},
     search::{
         request::{SearchRequest, SearchRequestAIJson},
         types::to_pretty,
@@ -80,6 +81,7 @@ impl SpiceModelTool for DocumentSimilarityTool {
                 .search_with_cache(
                     &search_request,
                     self.rt.datafusion().search_cache_provider(),
+                    CacheControl::Cache(CacheKeyType::Default),
                 )
                 .await
                 .boxed()?;

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -45,11 +45,17 @@ pub struct SearchTestCase {
     pub body: serde_json::Value,
 }
 
-pub async fn run_search_test(base_url: &str, ts: &SearchTestCase) -> Result<(), anyhow::Error> {
+pub async fn run_search_test(
+    base_url: &str,
+    ts: &SearchTestCase,
+    extra_headers: Option<HeaderMap>,
+) -> Result<(), anyhow::Error> {
     tracing::info!("Running test cases {}", ts.name);
 
     // Call /v1/search, check response
     let mut headers = HeaderMap::new();
+    headers.extend(extra_headers.unwrap_or_default());
+
     headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
     match http_post(
@@ -177,7 +183,7 @@ pub(crate) async fn run_search(
             let api_config = start_app(app).await?;
             let http_base_url = format!("http://{}", api_config.http_bind_address);
             for ts in test_cases {
-                run_search_test(http_base_url.as_str(), &ts).await?;
+                run_search_test(http_base_url.as_str(), &ts, None).await?;
             }
             Ok(())
         })
@@ -475,7 +481,7 @@ async fn test_search_with_cache() -> Result<(), anyhow::Error> {
                     "text": "new patient",
                     "limit": 2,
                 }),
-            }).await?;
+            }, None).await?;
             let duration = start.elapsed();
             let start = Instant::now();
             run_search_test(http_base_url.as_str(), &SearchTestCase {
@@ -484,9 +490,73 @@ async fn test_search_with_cache() -> Result<(), anyhow::Error> {
                     "text": "new patient",
                     "limit": 2,
                 }),
-            }).await?;
+            }, None).await?;
             let duration_cached = start.elapsed();
             assert!(duration_cached * 10 < duration, "Cache did not improve performance by an order of magnitude. First: {duration:?}, Second: {duration_cached:?}");
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_search_with_cache_bypass() -> Result<(), anyhow::Error> {
+    let chunked = catalog_page_tpch_dataset_w_embeddings(
+        "cached_search_bypass",
+        "hf_minilm",
+        Some(vec!["cp_catalog_page_sk".to_string()]),
+        Some(EmbeddingChunkConfig {
+            enabled: true,
+            target_chunk_size: 512,
+            overlap_size: 128,
+            trim_whitespace: false,
+        }),
+    );
+
+    let cache_config = CacheConfig {
+        enabled: true,
+        item_ttl: Some("10s".to_string()),
+        ..Default::default()
+    };
+
+    let app = AppBuilder::new("test_search_with_cache_bypass")
+        .with_dataset(chunked)
+        .with_embedding(get_huggingface_embeddings(
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "hf_minilm",
+        ))
+        .with_search_cache(cache_config)
+        .build();
+
+    let _tracing = init_tracing(None);
+
+    test_request_context()
+        .scope(async {
+            let api_config = start_app(app).await?;
+            let http_base_url = format!("http://{}", api_config.http_bind_address);
+            let start = Instant::now();
+
+            let mut bypass_headers = HeaderMap::new();
+            bypass_headers.insert("Cache-Control", "no-cache".parse().expect("valid header"));
+            run_search_test(http_base_url.as_str(), &SearchTestCase {
+                name: "pre_cache",
+                body: json!({
+                    "text": "new patient",
+                    "limit": 2,
+                }),
+            }, Some(bypass_headers.clone())).await?;
+            let duration = start.elapsed().as_secs_f64();
+            let start = Instant::now();
+            run_search_test(http_base_url.as_str(), &SearchTestCase {
+                name: "post_cache",
+                body: json!({
+                    "text": "new patient",
+                    "limit": 2,
+                }),
+            }, Some(bypass_headers)).await?;
+            let duration_cached = start.elapsed().as_secs_f64();
+
+            assert!(duration >= duration_cached*0.7 || duration <= duration_cached*1.3, 
+                "Cache bypass did not return similar performance. First: {duration:?}, Second: {duration_cached:?}");
             Ok(())
         })
         .await

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -555,7 +555,7 @@ async fn test_search_with_cache_bypass() -> Result<(), anyhow::Error> {
             }, Some(bypass_headers)).await?;
             let duration_cached = start.elapsed().as_secs_f64();
 
-            assert!(duration >= duration_cached*0.7 || duration <= duration_cached*1.3, 
+            assert!(duration >= duration_cached*0.7 || duration <= duration_cached*1.3,
                 "Cache bypass did not return similar performance. First: {duration:?}, Second: {duration_cached:?}");
             Ok(())
         })

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__post_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__post_cache_response.snap
@@ -6,7 +6,7 @@ expression: normalize_search_response(response)
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "dataset": "spice.public.cached_search",
+      "dataset": "spice.public.cached_search_bypass",
       "matches": {
         "cp_description": "In general basic characters welcome. Clearly lively friends con"
       },
@@ -16,7 +16,7 @@ expression: normalize_search_response(response)
       "score": 0.94
     },
     {
-      "dataset": "spice.public.cached_search",
+      "dataset": "spice.public.cached_search_bypass",
       "matches": {
         "cp_description": "Close customers might struggle away different mem"
       },

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__pre_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__pre_cache_response.snap
@@ -6,7 +6,7 @@ expression: normalize_search_response(response)
   "duration_ms": "duration_ms_val",
   "results": [
     {
-      "dataset": "spice.public.cached_search",
+      "dataset": "spice.public.cached_search_bypass",
       "matches": {
         "cp_description": "In general basic characters welcome. Clearly lively friends con"
       },
@@ -16,7 +16,7 @@ expression: normalize_search_response(response)
       "score": 0.94
     },
     {
-      "dataset": "spice.public.cached_search",
+      "dataset": "spice.public.cached_search_bypass",
       "matches": {
         "cp_description": "Close customers might struggle away different mem"
       },


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds the `Search-Results-Cache-Status` header on response of HTTP search requests
* Updates the Search HTTP route to respect the `Cache-Control` header to bypass the search results cache

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6028
