### PR TITLE
fix: Fix specifying individual caching blocks in spicepod

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -218,7 +218,7 @@ impl AppBuilder {
 
     #[must_use]
     pub fn with_search_cache(mut self, search_cache: CacheConfig) -> AppBuilder {
-        self.runtime.caching.search_results = search_cache;
+        self.runtime.caching.search_results = Some(search_cache);
         self
     }
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -179,7 +179,7 @@ impl RuntimeBuilder {
                     "The `results_cache` Runtime parameter is deprecated and will be removed in a future release.\nUse `caching.sql_results` instead.\nFor more information, visit: https://spiceai.org/docs/features/caching"
                 );
             });
-            caching_config.sql_results = results_cache.into();
+            caching_config.sql_results = Some(results_cache.into());
         }
 
         let caching = Runtime::init_caching(self.app.as_ref().map(|app| &app.runtime.caching));

--- a/crates/runtime/src/init/caching.rs
+++ b/crates/runtime/src/init/caching.rs
@@ -18,7 +18,9 @@ use std::{sync::Arc, time::Duration};
 
 use cache::{CacheProvider, Caching, QueryResultsCacheProvider, SimpleCache, lru_cache};
 use datafusion::logical_expr::LogicalPlan;
-use spicepod::component::caching::{Caching as CachingConfig, HashingAlgorithm};
+use spicepod::component::caching::{
+    CacheConfig, Caching as CachingConfig, HashingAlgorithm, SQLResultsCacheConfig,
+};
 
 use crate::{Runtime, datafusion::SPICE_RUNTIME_SCHEMA};
 
@@ -33,9 +35,18 @@ impl Runtime {
 
         let mut caching = Caching::new();
 
-        if cache_config.sql_results.inner.enabled {
+        let sql_results_config = cache_config
+            .sql_results
+            .clone()
+            .unwrap_or(SQLResultsCacheConfig::default());
+        let search_results_config = cache_config
+            .search_results
+            .clone()
+            .unwrap_or(CacheConfig::default());
+
+        if sql_results_config.inner.enabled {
             match QueryResultsCacheProvider::try_new(
-                &cache_config.sql_results,
+                &sql_results_config,
                 Box::new([SPICE_RUNTIME_SCHEMA.into(), "information_schema".into()]),
             ) {
                 Ok(cache_provider) => {
@@ -54,7 +65,7 @@ impl Runtime {
 
         // TODO: logical plan cache needs its own configuration?
         let plan_cache_provider: Arc<dyn CacheProvider<LogicalPlan> + Send + Sync> =
-            match cache_config.sql_results.inner.hashing_algorithm {
+            match sql_results_config.inner.hashing_algorithm {
                 HashingAlgorithm::Siphash => Arc::new(SimpleCache::new(
                     DEFAULT_CACHED_PLANS_MAX_CAPACITY,
                     Duration::from_secs(3600),
@@ -69,9 +80,8 @@ impl Runtime {
 
         caching = caching.with_plans_cache(plan_cache_provider);
 
-        if cache_config.search_results.enabled {
-            let config = &cache_config.search_results;
-            match lru_cache::build_from_config(config) {
+        if search_results_config.enabled {
+            match lru_cache::build_from_config(&search_results_config) {
                 Ok(cache_provider) => {
                     crate::in_tracing_context(|| {
                         tracing::info!("Initialized search results cache;"); // TODO: update to include max size and ttl. https://github.com/spiceai/spiceai/issues/6019

--- a/crates/runtime/src/request/cache_control.rs
+++ b/crates/runtime/src/request/cache_control.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use app::App;
 use http::{HeaderMap, header::CACHE_CONTROL};
+use spicepod::component::caching::SQLResultsCacheConfig;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub enum CacheKeyType {
@@ -35,11 +36,20 @@ impl CacheKeyType {
             return Self::Default;
         };
 
+        let sql_results_config = app
+            .runtime
+            .caching
+            .sql_results
+            .clone()
+            .unwrap_or(SQLResultsCacheConfig::default());
+
+        let cache_key_type = app.runtime.results_cache.as_ref().map_or_else(
+            || sql_results_config.cache_key_type,
+            |c| c.cache_key_type, // while results_cache is being deprecated, it has higher priority than sql_results
+        );
+
         // Mapping from the user-facing `CacheKeyType` to the internal `CacheKeyType`.
-        match app.runtime.results_cache.as_ref().map_or_else(
-            || app.runtime.caching.sql_results.cache_key_type,
-            |c| c.cache_key_type,
-        ) {
+        match cache_key_type {
             spicepod::component::caching::CacheKeyType::Plan => Self::Default,
             spicepod::component::caching::CacheKeyType::Sql => Self::Raw,
         }

--- a/crates/spicepod/src/component/caching.rs
+++ b/crates/spicepod/src/component/caching.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::{default_true, is_default};
+use super::{default_true, is_default_or_none};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -40,10 +40,10 @@ pub enum HashingAlgorithm {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Caching {
-    #[serde(skip_serializing_if = "is_default")]
-    pub sql_results: SQLResultsCacheConfig,
-    #[serde(skip_serializing_if = "is_default")]
-    pub search_results: CacheConfig,
+    #[serde(skip_serializing_if = "is_default_or_none")]
+    pub sql_results: Option<SQLResultsCacheConfig>,
+    #[serde(skip_serializing_if = "is_default_or_none")]
+    pub search_results: Option<CacheConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -272,3 +272,24 @@ fn from_definition(
         management: spicepod_definition.management,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_spicepods() {
+        const SPICEPOD_FILES: [&str; 5] = [
+            "./tests/basic_spicepod.yaml",
+            "./tests/spicepod_with_caching.yaml",
+            "./tests/spicepod_with_only_sql_results.yaml",
+            "./tests/spicepod_with_only_search_results.yaml",
+            "./tests/spicepod_with_results_cache.yaml",
+        ];
+
+        for file in SPICEPOD_FILES {
+            let path = PathBuf::from(file);
+            Spicepod::load_exact(&path).expect("Should load spicepod");
+        }
+    }
+}

--- a/crates/spicepod/tests/basic_spicepod.yaml
+++ b/crates/spicepod/tests/basic_spicepod.yaml
@@ -1,0 +1,3 @@
+version: v1
+kind: Spicepod
+name: basic_spicepod

--- a/crates/spicepod/tests/spicepod_with_caching.yaml
+++ b/crates/spicepod/tests/spicepod_with_caching.yaml
@@ -1,0 +1,11 @@
+version: v1
+kind: Spicepod
+name: spicepod_with_only_sql_results
+runtime:
+  caching:
+    sql_results:
+      enabled: true
+      item_ttl: 1s
+    search_results:
+      enabled: true
+      item_ttl: 1s

--- a/crates/spicepod/tests/spicepod_with_only_search_results.yaml
+++ b/crates/spicepod/tests/spicepod_with_only_search_results.yaml
@@ -1,0 +1,8 @@
+version: v1
+kind: Spicepod
+name: spicepod_with_only_search_results
+runtime:
+  caching:
+    search_results:
+      enabled: true
+      item_ttl: 1s

--- a/crates/spicepod/tests/spicepod_with_only_sql_results.yaml
+++ b/crates/spicepod/tests/spicepod_with_only_sql_results.yaml
@@ -1,0 +1,8 @@
+version: v1
+kind: Spicepod
+name: spicepod_with_only_sql_results
+runtime:
+  caching:
+    sql_results:
+      enabled: true
+      item_ttl: 1s

--- a/crates/spicepod/tests/spicepod_with_results_cache.yaml
+++ b/crates/spicepod/tests/spicepod_with_results_cache.yaml
@@ -1,0 +1,7 @@
+version: v1
+kind: Spicepod
+name: spicepod_with_only_search_results
+runtime:
+  results_cache:
+    enabled: true
+    item_ttl: 1s


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

Previously, the following spicepod would fail to load:

```yaml
runtime:
  caching:
    sql_results:
      enabled: true
```

This is because, while `caching:` is optional, the blocks inside `caching:` were not - so if any `caching:` was specified, it must specify every cache type (`sql_results`, `search_results`, etc).

This PR updates the caching blocks to be optional, so the above example now passes.

* Also includes a new directory for `spicepod/tests/` which contains some sample spicepods, and a rudimentary test to ensure these spicepods load successfully.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6106 
