### PR TITLE
Use spice-rs in test operator and retry on connection reset error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12297,7 +12297,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "2.0.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=5272a8f43002993a30144cac7175dfc95400d287#5272a8f43002993a30144cac7175dfc95400d287"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=3d0e679a98ca51d8df3fa593f3db8f3f7f2b2eae#3d0e679a98ca51d8df3fa593f3db8f3f7f2b2eae"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12297,7 +12297,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "2.0.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=df953882dbb54e4c0d713fd87ed6ddf077406250#df953882dbb54e4c0d713fd87ed6ddf077406250"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=1579a895fa467a8d9f8eafd48219f9768e48524d#1579a895fa467a8d9f8eafd48219f9768e48524d"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12297,6 +12297,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "2.0.0"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=6fd5d663151949836eb510326854bbf7c67efbf1#6fd5d663151949836eb510326854bbf7c67efbf1"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12297,7 +12297,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "2.0.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=3d0e679a98ca51d8df3fa593f3db8f3f7f2b2eae#3d0e679a98ca51d8df3fa593f3db8f3f7f2b2eae"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=df953882dbb54e4c0d713fd87ed6ddf077406250#df953882dbb54e4c0d713fd87ed6ddf077406250"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13129,6 +13129,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
+ "util",
  "uuid 1.17.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,6 +4258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "git+https://github.com/spiceai/dotenvy.git?rev=e5cef1871b08003198949dfe2da988633eaad78f#e5cef1871b08003198949dfe2da988633eaad78f"
@@ -12289,6 +12295,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "spiceai"
+version = "2.0.0"
+dependencies = [
+ "arrow",
+ "arrow-flight",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "dotenv",
+ "futures",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
+ "reqwest 0.12.15",
+ "rustls 0.23.27",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "winver",
+]
+
+[[package]]
 name = "spiced"
 version = "1.4.0-unstable"
 dependencies = [
@@ -13091,6 +13121,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "spiceai",
  "spicepod",
  "sysinfo 0.33.1",
  "telemetry",
@@ -13111,6 +13142,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "spiceai",
  "test-framework",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12297,7 +12297,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "2.0.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=6fd5d663151949836eb510326854bbf7c67efbf1#6fd5d663151949836eb510326854bbf7c67efbf1"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=1ab50ce213e090b9dff13f50499294c371618d61#1ab50ce213e090b9dff13f50499294c371618d61"
 dependencies = [
  "arrow",
  "arrow-flight",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,7 +3276,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "util",
+ "util 1.4.0-unstable",
  "uuid 1.17.0",
 ]
 
@@ -3947,7 +3947,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "util",
+ "util 1.4.0-unstable",
 ]
 
 [[package]]
@@ -11166,7 +11166,7 @@ dependencies = [
  "tracing-subscriber",
  "tract-core",
  "url",
- "util",
+ "util 1.4.0-unstable",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid 1.17.0",
@@ -12297,7 +12297,7 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "2.0.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=1ab50ce213e090b9dff13f50499294c371618d61#1ab50ce213e090b9dff13f50499294c371618d61"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=5272a8f43002993a30144cac7175dfc95400d287#5272a8f43002993a30144cac7175dfc95400d287"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -12316,6 +12316,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
+ "tracing",
+ "util 1.4.0-unstable (git+https://github.com/spiceai/spiceai)",
  "winver",
 ]
 
@@ -13130,7 +13132,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
- "util",
+ "util 1.4.0-unstable",
  "uuid 1.17.0",
 ]
 
@@ -14564,6 +14566,19 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "1.4.0-unstable"
+dependencies = [
+ "backoff",
+ "ctrlc",
+ "humantime",
+ "rand 0.9.1",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "util"
+version = "1.4.0-unstable"
+source = "git+https://github.com/spiceai/spiceai#76e2b0555c4b0e0036f951078a8f091be1cf5197"
 dependencies = [
  "backoff",
  "ctrlc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,7 +3276,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "util 1.4.0-unstable",
+ "util",
  "uuid 1.17.0",
 ]
 
@@ -3947,7 +3947,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "util 1.4.0-unstable",
+ "util",
 ]
 
 [[package]]
@@ -11166,7 +11166,7 @@ dependencies = [
  "tracing-subscriber",
  "tract-core",
  "url",
- "util 1.4.0-unstable",
+ "util",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid 1.17.0",
@@ -12297,10 +12297,11 @@ dependencies = [
 [[package]]
 name = "spiceai"
 version = "2.0.0"
-source = "git+https://github.com/spiceai/spice-rs.git?rev=1579a895fa467a8d9f8eafd48219f9768e48524d#1579a895fa467a8d9f8eafd48219f9768e48524d"
+source = "git+https://github.com/spiceai/spice-rs.git?rev=4e1b0394aeba7b03d61edfcad27562045c450b02#4e1b0394aeba7b03d61edfcad27562045c450b02"
 dependencies = [
  "arrow",
  "arrow-flight",
+ "backoff",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -12308,16 +12309,16 @@ dependencies = [
  "futures",
  "prost 0.12.6",
  "prost-types 0.12.6",
+ "rand 0.9.1",
  "reqwest 0.12.15",
  "rustls 0.23.27",
- "rustls-native-certs 0.6.3",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "tokio",
  "tonic",
  "tracing",
- "util 1.4.0-unstable (git+https://github.com/spiceai/spiceai)",
  "winver",
 ]
 
@@ -13132,7 +13133,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
- "util 1.4.0-unstable",
+ "util",
  "uuid 1.17.0",
 ]
 
@@ -14566,19 +14567,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "1.4.0-unstable"
-dependencies = [
- "backoff",
- "ctrlc",
- "humantime",
- "rand 0.9.1",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "util"
-version = "1.4.0-unstable"
-source = "git+https://github.com/spiceai/spiceai#76e2b0555c4b0e0036f951078a8f091be1cf5197"
 dependencies = [
  "backoff",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "1ab50ce213e090b9dff13f50499294c371618d61" }
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "5272a8f43002993a30144cac7175dfc95400d287" }
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "1579a895fa467a8d9f8eafd48219f9768e48524d" }
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "4e1b0394aeba7b03d61edfcad27562045c450b02" }
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
+spiceai = { path = "../spice-rs" }
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
+# TODO: Switch to official crate once spice-rs is released
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "4e1b0394aeba7b03d61edfcad27562045c450b02" }
 
 [profile.release-lto]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "3d0e679a98ca51d8df3fa593f3db8f3f7f2b2eae" }
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "df953882dbb54e4c0d713fd87ed6ddf077406250" }
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "5272a8f43002993a30144cac7175dfc95400d287" }
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "3d0e679a98ca51d8df3fa593f3db8f3f7f2b2eae" }
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "df953882dbb54e4c0d713fd87ed6ddf077406250" }
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "1579a895fa467a8d9f8eafd48219f9768e48524d" }
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
-spiceai = { path = "../spice-rs" }
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "6fd5d663151949836eb510326854bbf7c67efbf1" }
 
 [profile.release-lto]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = "1"
 x509-certificate = "0.23.1"
-spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "6fd5d663151949836eb510326854bbf7c67efbf1" }
+spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "1ab50ce213e090b9dff13f50499294c371618d61" }
 
 [profile.release-lto]
 inherits = "release"

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -524,7 +524,7 @@ fn query_to_stream(
                     match batch {
                         Ok(batch) => yield Ok(batch),
                         Err(error) => {
-                            yield Err(to_execution_error(map_connection_reset_error(error)));
+                            yield Err(map_query_stream_error(error));
                         }
                     }
                 }
@@ -538,8 +538,11 @@ fn query_to_stream(
 fn to_execution_error(e: Error) -> DataFusionError {
     match e {
         Error::Flight { source } => match source {
-            flight_client::Error::UnableToQuery { source } => {
-                DataFusionError::Execution(format!("{source}"))
+            flight_client::Error::UnableToQuery {
+                source: source_error,
+            } => DataFusionError::Execution(format!("{source_error}")),
+            flight_client::Error::ConnectionReset { source: _ } => {
+                DataFusionError::External(Box::new(source))
             }
             _ => DataFusionError::Execution(format!("{source}")),
         },
@@ -547,23 +550,27 @@ fn to_execution_error(e: Error) -> DataFusionError {
     }
 }
 
-fn map_connection_reset_error(error: FlightError) -> Error {
+fn map_query_stream_error(error: FlightError) -> DataFusionError {
     match error {
         FlightError::Tonic(ref source) => {
             let source_owned = *source.clone();
             if is_connection_reset_error(&source_owned) {
-                return Error::ArrowFlight {
-                    source: Box::new(FlightClientError::ConnectionReset {
-                        source: TonicStatusError::from(source_owned),
-                    }),
-                };
+                return DataFusionError::External(Box::new(FlightClientError::ConnectionReset {
+                    source: TonicStatusError::from(source_owned),
+                }));
             }
+            DataFusionError::Execution(format!(
+                "{}",
+                Error::ArrowFlight {
+                    source: Box::new(error),
+                }
+            ))
+        }
+        _ => DataFusionError::Execution(format!(
+            "{}",
             Error::ArrowFlight {
                 source: Box::new(error),
             }
-        }
-        _ => Error::ArrowFlight {
-            source: Box::new(error),
-        },
+        )),
     }
 }

--- a/crates/data_components/src/flight.rs
+++ b/crates/data_components/src/flight.rs
@@ -538,10 +538,10 @@ fn query_to_stream(
 fn to_execution_error(e: Error) -> DataFusionError {
     match e {
         Error::Flight { source } => match source {
-            flight_client::Error::UnableToQuery {
-                source: source_error,
-            } => DataFusionError::Execution(format!("{source_error}")),
-            flight_client::Error::ConnectionReset { source: _ } => {
+            flight_client::Error::UnableToQuery { source } => {
+                DataFusionError::Execution(format!("{source}"))
+            }
+            flight_client::Error::ConnectionReset { .. } => {
                 DataFusionError::External(Box::new(source))
             }
             _ => DataFusionError::Execution(format!("{source}")),
@@ -559,18 +559,18 @@ fn map_query_stream_error(error: FlightError) -> DataFusionError {
                     source: TonicStatusError::from(source_owned),
                 }));
             }
-            DataFusionError::Execution(format!(
-                "{}",
+            DataFusionError::Execution(
                 Error::ArrowFlight {
                     source: Box::new(error),
                 }
-            ))
+                .to_string(),
+            )
         }
-        _ => DataFusionError::Execution(format!(
-            "{}",
+        _ => DataFusionError::Execution(
             Error::ArrowFlight {
                 source: Box::new(error),
             }
-        )),
+            .to_string(),
+        ),
     }
 }

--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -652,14 +652,19 @@ fn map_tonic_error_to_message(e: tonic::Status) -> Error {
 }
 
 pub fn is_connection_reset_error(error: &tonic::Status) -> bool {
-    if error.code() == tonic::Code::Internal {
-        let error_message = error.message().to_lowercase();
-        if error_message.contains("operation was canceled")
-            || error_message.contains("http2 error")
-            || error_message.contains("grpc-status header missing")
-        {
-            return true;
+    match error.code() {
+        tonic::Code::Internal | tonic::Code::Cancelled => {
+            let error_message = error.message().to_lowercase();
+            if error_message.contains("operation was canceled")
+                || error_message.contains("http2 error")
+                || error_message.contains("grpc-status header missing")
+                || error_message.contains("received message with invalid compression flag")
+                || error_message.contains("error reading a body from connection")
+            {
+                return true;
+            }
+            false
         }
+        _ => false,
     }
-    false
 }

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -40,6 +40,7 @@ use datafusion::common::ParamValues;
 use datafusion::error::DataFusionError;
 use datafusion::sql::TableReference;
 use datafusion::sql::sqlparser::parser::ParserError;
+use flight_client::Error as FlightClientError;
 use futures::stream::{self, BoxStream, StreamExt};
 use futures::{Stream, TryStreamExt};
 use governor::{Quota, RateLimiter};
@@ -301,6 +302,15 @@ fn handle_datafusion_error(e: DataFusionError) -> Status {
                             "Acceleration not ready; loading initial data for {dataset_name}"
                         ))
                     }
+                }
+            } else if let Some(err) = e.downcast_ref::<FlightClientError>() {
+                match err {
+                    FlightClientError::ConnectionReset { source } => {
+                        let mut error = Status::invalid_argument(format!("{source}"));
+                        error.metadata_mut().insert("spiceai-retryable", 1.into());
+                        error
+                    }
+                    _ => to_tonic_err(e),
                 }
             } else {
                 to_tonic_err(e)

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -47,6 +47,7 @@ tempfile.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 tokio-util.workspace = true
+util = { path = "../util" }
 uuid = { workspace = true, features = ["v4"] }
 spiceai = { workspace = true }
 

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -48,6 +48,7 @@ tokio.workspace = true
 tonic.workspace = true
 tokio-util.workspace = true
 uuid = { workspace = true, features = ["v4"] }
+spiceai = { workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]
 nix = { version = "0.29", features = ["signal"] }

--- a/crates/test-framework/src/flight/mod.rs
+++ b/crates/test-framework/src/flight/mod.rs
@@ -17,19 +17,16 @@ limitations under the License.
 use std::sync::Arc;
 
 use crate::spicetest::datasets::{MAX_RETRIES, QueryError, is_transient_error};
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use arrow::{
     array::ArrayRef,
     datatypes::{Field, FieldRef, Schema},
     record_batch::RecordBatch,
 };
-use arrow_flight::{
-    decode::FlightRecordBatchStream, error::FlightError, sql::client::FlightSqlServiceClient,
-};
+use arrow_flight::error::FlightError;
 use flight_client::FlightClient;
 use futures::StreamExt;
 use spiceai::Client as SpiceClient;
-use tonic::{async_trait, transport::Channel};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{RetryError, retry};
 
@@ -96,36 +93,6 @@ pub async fn put_batches(
     Ok(client.publish(dataset_path, batches).await?)
 }
 
-/// Query a prepared statement against a ``FlightSQL`` compatible server.
-///
-/// To construct `parameters` as a [`RecordBatch`], see [`create_param_batch`].
-pub async fn execute_prepared_statement(
-    client: &mut FlightSqlServiceClient<Channel>,
-    query: &str,
-    parameters: RecordBatch,
-) -> anyhow::Result<FlightRecordBatchStream> {
-    let mut prepared_stmt = client.prepare(query.to_string(), None).await?;
-
-    prepared_stmt.set_parameters(parameters)?;
-
-    let flight_info = prepared_stmt.execute().await?;
-
-    let endpoint = flight_info
-        .endpoint
-        .first()
-        .context("No endpoint in flight info")?;
-
-    let stream = client
-        .do_get(
-            endpoint
-                .ticket
-                .clone()
-                .context("No flight ticket in response")?,
-        )
-        .await?;
-    Ok(stream)
-}
-
 pub struct PreparedStatementParamColumn {
     name: String,
     dtype: arrow::datatypes::DataType,
@@ -184,29 +151,4 @@ pub fn create_param_batch(
         .unzip();
 
     RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).map_err(Into::into)
-}
-
-#[async_trait]
-pub trait ExtendedTestFlightClient {
-    async fn query_with_params(
-        &self,
-        query: &str,
-        params: Option<RecordBatch>,
-    ) -> anyhow::Result<FlightRecordBatchStream>;
-}
-
-#[async_trait]
-impl ExtendedTestFlightClient for FlightClient {
-    async fn query_with_params(
-        &self,
-        query: &str,
-        params: Option<RecordBatch>,
-    ) -> anyhow::Result<FlightRecordBatchStream> {
-        if let Some(params) = params {
-            let mut client = FlightSqlServiceClient::new_from_inner(self.client().clone());
-            Ok(execute_prepared_statement(&mut client, query, params).await?)
-        } else {
-            Ok(self.query(query).await?)
-        }
-    }
 }

--- a/crates/test-framework/src/flight/mod.rs
+++ b/crates/test-framework/src/flight/mod.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use crate::spicetest::datasets::{MAX_RETRIES, is_transient_error};
 use anyhow::{Context, Result};
 use arrow::{
     array::ArrayRef,
@@ -28,6 +29,8 @@ use futures::StreamExt;
 use spiceai::Client as SpiceClient;
 use tokio::sync::Mutex;
 use tonic::{async_trait, transport::Channel};
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use util::{RetryError, retry};
 
 /// Query a flight client and return the result as a vector of record batches
 ///
@@ -35,6 +38,30 @@ use tonic::{async_trait, transport::Channel};
 ///
 /// - If the flight client fails to query
 pub async fn query_to_batches(
+    spice_client: Arc<Mutex<SpiceClient>>,
+    sql: &str,
+    params: Option<RecordBatch>,
+) -> Result<Vec<RecordBatch>> {
+    let retry_strategy = FibonacciBackoffBuilder::new()
+        .max_retries(Some(MAX_RETRIES))
+        .build();
+
+    retry(retry_strategy, || async {
+        match query_to_batches_internal(Arc::clone(&spice_client), sql, params.clone()).await {
+            Ok(batches) => Ok(batches),
+            Err(e) => {
+                if is_transient_error(&e) {
+                    Err(RetryError::transient(e))
+                } else {
+                    Err(RetryError::permanent(e))
+                }
+            }
+        }
+    })
+    .await
+}
+
+pub async fn query_to_batches_internal(
     spice_client: Arc<Mutex<SpiceClient>>,
     sql: &str,
     params: Option<RecordBatch>,

--- a/crates/test-framework/src/flight/mod.rs
+++ b/crates/test-framework/src/flight/mod.rs
@@ -25,6 +25,8 @@ use arrow::{
 use arrow_flight::{decode::FlightRecordBatchStream, sql::client::FlightSqlServiceClient};
 use flight_client::FlightClient;
 use futures::StreamExt;
+use spiceai::Client as SpiceClient;
+use tokio::sync::Mutex;
 use tonic::{async_trait, transport::Channel};
 
 /// Query a flight client and return the result as a vector of record batches
@@ -33,11 +35,15 @@ use tonic::{async_trait, transport::Channel};
 ///
 /// - If the flight client fails to query
 pub async fn query_to_batches(
-    client: &FlightClient,
+    spice_client: Arc<Mutex<SpiceClient>>,
     sql: &str,
     params: Option<RecordBatch>,
 ) -> Result<Vec<RecordBatch>> {
-    let mut stream = client.query_with_params(sql, params).await?;
+    let mut spice_client = spice_client.lock().await;
+    let mut stream = spice_client
+        .query_with_params(sql, params)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     let mut batches = Vec::new();
     while let Some(batch) = stream.next().await {
         batches.push(batch?);

--- a/crates/test-framework/src/flight/mod.rs
+++ b/crates/test-framework/src/flight/mod.rs
@@ -16,14 +16,16 @@ limitations under the License.
 
 use std::sync::Arc;
 
-use crate::spicetest::datasets::{MAX_RETRIES, is_transient_error};
-use anyhow::{Context, Result};
+use crate::spicetest::datasets::{MAX_RETRIES, QueryError, is_transient_error};
+use anyhow::{Context, Result, anyhow};
 use arrow::{
     array::ArrayRef,
     datatypes::{Field, FieldRef, Schema},
     record_batch::RecordBatch,
 };
-use arrow_flight::{decode::FlightRecordBatchStream, sql::client::FlightSqlServiceClient};
+use arrow_flight::{
+    decode::FlightRecordBatchStream, error::FlightError, sql::client::FlightSqlServiceClient,
+};
 use flight_client::FlightClient;
 use futures::StreamExt;
 use spiceai::Client as SpiceClient;
@@ -48,30 +50,40 @@ pub async fn query_to_batches(
     retry(retry_strategy, || async {
         match query_to_batches_internal(Arc::clone(&spice_client), sql, params.clone()).await {
             Ok(batches) => Ok(batches),
-            Err(e) => {
-                if is_transient_error(&e) {
-                    Err(RetryError::transient(e))
-                } else {
-                    Err(RetryError::permanent(e))
-                }
-            }
+            Err(e) => match e {
+                QueryError::Retryable { source } => Err(RetryError::transient(source)),
+                QueryError::NonRetryable { source } => Err(RetryError::permanent(source)),
+            },
         }
     })
     .await
+    .map_err(|e| anyhow!(format!("{e}")))
 }
 
 pub async fn query_to_batches_internal(
     spice_client: Arc<SpiceClient>,
     sql: &str,
     params: Option<RecordBatch>,
-) -> Result<Vec<RecordBatch>> {
+) -> std::result::Result<Vec<RecordBatch>, QueryError> {
     let mut stream = spice_client
         .query_with_params(sql, params)
         .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        .map_err(|e| QueryError::NonRetryable { source: anyhow!(e) })?;
+
     let mut batches = Vec::new();
     while let Some(batch) = stream.next().await {
-        batches.push(batch?);
+        match batch {
+            Ok(batch) => batches.push(batch),
+            Err(e) => match e {
+                FlightError::Tonic(ref status) => {
+                    if is_transient_error(status) {
+                        return Err(QueryError::Retryable { source: e.into() });
+                    }
+                    return Err(QueryError::NonRetryable { source: e.into() });
+                }
+                _ => return Err(QueryError::NonRetryable { source: e.into() }),
+            },
+        }
     }
     Ok(batches)
 }

--- a/crates/test-framework/src/flight/mod.rs
+++ b/crates/test-framework/src/flight/mod.rs
@@ -27,7 +27,6 @@ use arrow_flight::{decode::FlightRecordBatchStream, sql::client::FlightSqlServic
 use flight_client::FlightClient;
 use futures::StreamExt;
 use spiceai::Client as SpiceClient;
-use tokio::sync::Mutex;
 use tonic::{async_trait, transport::Channel};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{RetryError, retry};
@@ -38,7 +37,7 @@ use util::{RetryError, retry};
 ///
 /// - If the flight client fails to query
 pub async fn query_to_batches(
-    spice_client: Arc<Mutex<SpiceClient>>,
+    spice_client: Arc<SpiceClient>,
     sql: &str,
     params: Option<RecordBatch>,
 ) -> Result<Vec<RecordBatch>> {
@@ -62,11 +61,10 @@ pub async fn query_to_batches(
 }
 
 pub async fn query_to_batches_internal(
-    spice_client: Arc<Mutex<SpiceClient>>,
+    spice_client: Arc<SpiceClient>,
     sql: &str,
     params: Option<RecordBatch>,
 ) -> Result<Vec<RecordBatch>> {
-    let mut spice_client = spice_client.lock().await;
     let mut stream = spice_client
         .query_with_params(sql, params)
         .await

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 use std::{panic, sync::Arc};
-use tokio::sync::Mutex;
 
 use crate::{flight::query_to_batches, queries::Query};
 use spiceai::Client as SpiceClient;
@@ -25,7 +24,7 @@ fn make_tmpdir_regex_pattern(tempdir: &str) -> String {
 }
 
 pub async fn record_explain_plan(
-    spice_client: Arc<Mutex<SpiceClient>>,
+    spice_client: Arc<SpiceClient>,
     name: &str,
     query: &Query,
     scale_factor: f64,

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -15,17 +15,17 @@ limitations under the License.
 */
 
 use std::{panic, sync::Arc};
-
-use flight_client::FlightClient;
+use tokio::sync::Mutex;
 
 use crate::{flight::query_to_batches, queries::Query};
+use spiceai::Client as SpiceClient;
 
 fn make_tmpdir_regex_pattern(tempdir: &str) -> String {
     format!(r"(?:{tempdir}|private/{tempdir})/[^/]*/(\.spice/)?data")
 }
 
 pub async fn record_explain_plan(
-    client: &FlightClient,
+    spice_client: Arc<Mutex<SpiceClient>>,
     name: &str,
     query: &Query,
     scale_factor: f64,
@@ -34,7 +34,7 @@ pub async fn record_explain_plan(
     let sql = Arc::clone(&query.sql);
     let query_name = Arc::clone(&query.name);
     let parameters = query.get_parameters_batch().transpose()?;
-    let plan_results = query_to_batches(client, &format!("EXPLAIN {sql}"), parameters)
+    let plan_results = query_to_batches(spice_client, &format!("EXPLAIN {sql}"), parameters)
         .await
         .map_err(|e| anyhow::anyhow!("query `{query_name}` to plan: {e}"))?;
 

--- a/crates/test-framework/src/spiced/mod.rs
+++ b/crates/test-framework/src/spiced/mod.rs
@@ -21,8 +21,9 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use flight_client::{Credentials, FlightClient};
+use spiceai::{Client as SpiceClient, ClientBuilder};
 use spicepod::spec::SpicepodDefinition;
 use sysinfo::Pid;
 use tempfile::TempDir;
@@ -199,6 +200,36 @@ impl SpicedInstance {
             FlightClient::try_new("http://localhost:50051".into(), credentials, Some(metadata))
                 .await?,
         )
+    }
+
+    /// Get a spice client for the spiced instance
+    ///
+    /// # Errors
+    ///
+    /// - If the spice client fails to be created
+    pub async fn spice_client(
+        &self,
+        api_key: Option<String>,
+        disable_caching: bool,
+    ) -> Result<SpiceClient> {
+        let mut spice_client = ClientBuilder::new();
+
+        if let Some(key) = api_key {
+            spice_client = spice_client.api_key(key.as_str());
+        }
+
+        if disable_caching {
+            spice_client = spice_client.cache_control("no-cache");
+        }
+
+        let spice_client = spice_client
+            .flight_url("http://localhost:50051")
+            .user_agent("spice-test-framework/1.0")
+            .build()
+            .await
+            .map_err(|e| anyhow!("{e}"))?;
+
+        Ok(spice_client)
     }
 
     /// Get an http client for the spiced instance

--- a/crates/test-framework/src/spiced/mod.rs
+++ b/crates/test-framework/src/spiced/mod.rs
@@ -22,7 +22,6 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
-use flight_client::{Credentials, FlightClient};
 use spiceai::{Client as SpiceClient, ClientBuilder};
 use spicepod::spec::SpicepodDefinition;
 use sysinfo::Pid;
@@ -172,34 +171,6 @@ impl SpicedInstance {
     #[must_use]
     pub fn get_tempdir_path(&self) -> PathBuf {
         self.tempdir.path().to_path_buf()
-    }
-
-    /// Get a flight client for the spiced instance
-    ///
-    /// # Errors
-    ///
-    /// - If the flight client fails to be created
-    pub async fn flight_client(
-        &self,
-        api_key: Option<String>,
-        disable_caching: bool,
-    ) -> Result<FlightClient> {
-        let mut metadata = tonic::metadata::MetadataMap::new();
-        metadata.insert("user-agent", "spice-test-framework/1.0".parse()?);
-        if disable_caching {
-            metadata.insert("cache-control", "no-cache".parse()?);
-        }
-
-        let credentials = if let Some(api_key) = api_key {
-            Credentials::new("", api_key.into())
-        } else {
-            Credentials::new("", "".into())
-        };
-
-        Ok(
-            FlightClient::try_new("http://localhost:50051".into(), credentials, Some(metadata))
-                .await?,
-        )
     }
 
     /// Get a spice client for the spiced instance

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -34,7 +34,9 @@ use tokio::task::JoinHandle;
 
 use super::{SpiceTest, TestCompleted, TestNotStarted, TestState};
 mod worker;
-pub(crate) use worker::{SpiceTestQueryWorker, SpiceTestQueryWorkerResult};
+pub(crate) use worker::{
+    MAX_RETRIES, SpiceTestQueryWorker, SpiceTestQueryWorkerResult, is_transient_error,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub enum EndCondition {

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -177,33 +177,33 @@ impl SpiceTest<NotStarted> {
             None
         };
 
-        let mut query_workers = Vec::with_capacity(self.state.parallel_count);
-        for id in 0..self.state.parallel_count {
-            let spice_client = self
-                .get_spiced()?
-                .spice_client(self.api_key.clone(), self.state.disable_caching)
-                .await?;
+        let spice_client = self
+            .get_spiced()?
+            .spice_client(self.api_key.clone(), self.state.disable_caching)
+            .await?;
 
-            let worker = SpiceTestQueryWorker::new(
-                id,
-                self.state.query_set.clone(),
-                self.state.end_condition,
-                spice_client,
-                self.name.clone(),
-            )
-            .with_explain_plan_snapshot(self.explain_plan_snapshot)
-            .with_results_snapshot(self.results_snapshot_predicate)
-            .with_validate(self.state.validate)
-            .with_scale_factor(self.state.scale_factor);
+        let query_workers = (0..self.state.parallel_count)
+            .map(|id| {
+                let worker = SpiceTestQueryWorker::new(
+                    id,
+                    self.state.query_set.clone(),
+                    self.state.end_condition,
+                    spice_client.clone(),
+                    self.name.clone(),
+                )
+                .with_explain_plan_snapshot(self.explain_plan_snapshot)
+                .with_results_snapshot(self.results_snapshot_predicate)
+                .with_validate(self.state.validate)
+                .with_scale_factor(self.state.scale_factor);
 
-            let worker = if let Some(multi) = &multi {
-                worker.with_progress_bar(multi.add(self.get_new_progress_bar()))
-            } else {
-                worker
-            };
-
-            query_workers.push(SpiceTestQueryWorker::start(worker));
-        }
+                if let Some(multi) = &multi {
+                    worker.with_progress_bar(multi.add(self.get_new_progress_bar()))
+                } else {
+                    worker
+                }
+            })
+            .map(SpiceTestQueryWorker::start)
+            .collect();
 
         Ok(SpiceTest {
             name: self.name,

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -175,32 +175,33 @@ impl SpiceTest<NotStarted> {
             None
         };
 
-        let flight_client = self
-            .get_spiced()?
-            .flight_client(self.api_key.clone(), self.state.disable_caching)
-            .await?;
-        let query_workers = (0..self.state.parallel_count)
-            .map(|id| {
-                let worker = SpiceTestQueryWorker::new(
-                    id,
-                    self.state.query_set.clone(),
-                    self.state.end_condition,
-                    flight_client.clone(),
-                    self.name.clone(),
-                )
-                .with_explain_plan_snapshot(self.explain_plan_snapshot)
-                .with_results_snapshot(self.results_snapshot_predicate)
-                .with_validate(self.state.validate)
-                .with_scale_factor(self.state.scale_factor);
+        let mut query_workers = Vec::with_capacity(self.state.parallel_count);
+        for id in 0..self.state.parallel_count {
+            let spice_client = self
+                .get_spiced()?
+                .spice_client(self.api_key.clone(), self.state.disable_caching)
+                .await?;
 
-                if let Some(multi) = &multi {
-                    worker.with_progress_bar(multi.add(self.get_new_progress_bar()))
-                } else {
-                    worker
-                }
-            })
-            .map(SpiceTestQueryWorker::start)
-            .collect();
+            let worker = SpiceTestQueryWorker::new(
+                id,
+                self.state.query_set.clone(),
+                self.state.end_condition,
+                spice_client,
+                self.name.clone(),
+            )
+            .with_explain_plan_snapshot(self.explain_plan_snapshot)
+            .with_results_snapshot(self.results_snapshot_predicate)
+            .with_validate(self.state.validate)
+            .with_scale_factor(self.state.scale_factor);
+
+            let worker = if let Some(multi) = &multi {
+                worker.with_progress_bar(multi.add(self.get_new_progress_bar()))
+            } else {
+                worker
+            };
+
+            query_workers.push(SpiceTestQueryWorker::start(worker));
+        }
 
         Ok(SpiceTest {
             name: self.name,

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -35,7 +35,7 @@ use tokio::task::JoinHandle;
 use super::{SpiceTest, TestCompleted, TestNotStarted, TestState};
 mod worker;
 pub(crate) use worker::{
-    MAX_RETRIES, SpiceTestQueryWorker, SpiceTestQueryWorkerResult, is_transient_error,
+    MAX_RETRIES, QueryError, SpiceTestQueryWorker, SpiceTestQueryWorkerResult, is_transient_error,
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
+use arrow_flight::error::FlightError;
 use futures::TryStreamExt;
 use indicatif::ProgressBar;
 use spiceai::Client as SpiceClient;
@@ -41,6 +42,32 @@ use crate::{
 use super::EndCondition;
 
 pub(crate) const MAX_RETRIES: usize = 5;
+
+#[derive(Debug)]
+pub enum QueryError {
+    Retryable { source: anyhow::Error },
+    NonRetryable { source: anyhow::Error },
+}
+
+impl QueryError {
+    pub fn retryable<E>(error: E) -> Self
+    where
+        E: Into<anyhow::Error>,
+    {
+        Self::Retryable {
+            source: error.into(),
+        }
+    }
+
+    pub fn nonretryable<E>(error: E) -> Self
+    where
+        E: Into<anyhow::Error>,
+    {
+        Self::NonRetryable {
+            source: error.into(),
+        }
+    }
+}
 
 pub(crate) struct SpiceTestQueryWorker {
     id: usize,
@@ -414,13 +441,10 @@ impl SpiceTestQueryWorker {
                 .await
             {
                 Ok((duration, row_count)) => Ok((duration, row_count)),
-                Err(e) => {
-                    if is_transient_error(&e) {
-                        Err(RetryError::transient(e))
-                    } else {
-                        Err(RetryError::permanent(e))
-                    }
-                }
+                Err(e) => match e {
+                    QueryError::Retryable { source } => Err(RetryError::transient(source)),
+                    QueryError::NonRetryable { source } => Err(RetryError::permanent(source)),
+                },
             }
         })
         .await
@@ -458,13 +482,19 @@ impl SpiceTestQueryWorker {
         query: &Query,
         results_snapshot: bool,
         validate: bool,
-    ) -> Result<(Duration, usize)> {
+    ) -> std::result::Result<(Duration, usize), QueryError> {
         let query_start = Instant::now();
         let mut result_stream = self
             .spice_client
-            .query_with_params(&query.sql, query.get_parameters_batch().transpose()?)
+            .query_with_params(
+                &query.sql,
+                query
+                    .get_parameters_batch()
+                    .transpose()
+                    .map_err(QueryError::nonretryable)?,
+            )
             .await
-            .map_err(|e| anyhow!("{e}"))?;
+            .map_err(|e| QueryError::nonretryable(anyhow!(e)))?;
 
         let mut row_count: usize = 0;
         let mut limited_records = vec![];
@@ -473,9 +503,16 @@ impl SpiceTestQueryWorker {
             let batch = result_stream.try_next().await;
             match batch {
                 Ok(None) => break,
-                Err(e) => {
-                    return Err(e.into());
-                }
+                Err(e) => match e {
+                    FlightError::Tonic(e) => {
+                        if is_transient_error(&e) {
+                            return Err(QueryError::retryable(anyhow!("{e}")));
+                        }
+                    }
+                    _ => {
+                        return Err(QueryError::nonretryable(anyhow!("{e}")));
+                    }
+                },
                 Ok(Some(batch)) => {
                     if validate {
                         validation_records.push(batch.clone());
@@ -508,15 +545,16 @@ impl SpiceTestQueryWorker {
 
         if validate {
             // Validate the query results
-            let validation_result = validation::validate_tpch_query(query, &validation_records)?;
+            let validation_result = validation::validate_tpch_query(query, &validation_records)
+                .map_err(QueryError::nonretryable)?;
             if let QueryValidationResult::Fail(validation_reason) = validation_result {
                 eprintln!(
                     "FAIL - Worker {} - Query '{}' validation failed: {validation_reason:?}",
                     self.id, query.name
                 );
-                return Err(anyhow::anyhow!(
+                return Err(QueryError::nonretryable(anyhow!(
                     "Query validation failed: {validation_reason:?}"
-                ));
+                )));
             }
         }
 
@@ -530,7 +568,9 @@ impl SpiceTestQueryWorker {
                 format!("{name}_{query_name}_sf{}", self.scale_factor)
             };
 
-            let records_pretty = arrow::util::pretty::pretty_format_batches(&limited_records)?;
+            let records_pretty = arrow::util::pretty::pretty_format_batches(&limited_records)
+                .map_err(QueryError::nonretryable)?
+                .to_string();
             let result = panic::catch_unwind(|| {
                 insta::with_settings!({
                     description => format!("Query: {query_name}"),
@@ -544,7 +584,7 @@ impl SpiceTestQueryWorker {
             if result.is_err() {
                 let error_str = format!("Query `{name}` `{query_name}` snapshot assertion failed",);
                 eprintln!("{error_str}");
-                return Err(anyhow::anyhow!(error_str));
+                return Err(QueryError::nonretryable(anyhow!(error_str)));
             }
         }
 
@@ -553,8 +593,9 @@ impl SpiceTestQueryWorker {
     }
 }
 
-pub(crate) fn is_transient_error(e: &anyhow::Error) -> bool {
-    e.to_string()
-        .to_lowercase()
-        .contains("connection is reset by the server. please retry the request.")
+pub(crate) fn is_transient_error(e: &tonic::Status) -> bool {
+    if e.metadata().get("spiceai-retryable").is_some() {
+        return true;
+    }
+    false
 }

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -25,7 +25,6 @@ use anyhow::{Result, anyhow};
 use futures::TryStreamExt;
 use indicatif::ProgressBar;
 use spiceai::Client as SpiceClient;
-use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{RetryError, retry};
@@ -53,7 +52,7 @@ pub(crate) struct SpiceTestQueryWorker {
     pub progress_bar: Option<ProgressBar>,
     validate: bool,
     scale_factor: f64,
-    spice_client: Arc<Mutex<SpiceClient>>,
+    spice_client: Arc<SpiceClient>,
 }
 
 pub struct SpiceTestQueryWorkerResult {
@@ -99,7 +98,7 @@ impl SpiceTestQueryWorker {
             id,
             query_set,
             end_condition,
-            spice_client: Arc::new(Mutex::new(spice_client)),
+            spice_client: Arc::new(spice_client),
             explain_plan_snapshot: false,
             results_snapshot_predicate: None,
             name,
@@ -461,8 +460,8 @@ impl SpiceTestQueryWorker {
         validate: bool,
     ) -> Result<(Duration, usize)> {
         let query_start = Instant::now();
-        let mut spice_client = self.spice_client.lock().await;
-        let mut result_stream = spice_client
+        let mut result_stream = self
+            .spice_client
             .query_with_params(&query.sql, query.get_parameters_batch().transpose()?)
             .await
             .map_err(|e| anyhow!("{e}"))?;

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -21,14 +21,14 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 
-use anyhow::Result;
-use flight_client::FlightClient;
+use anyhow::{Result, anyhow};
 use futures::TryStreamExt;
 use indicatif::ProgressBar;
+use spiceai::Client as SpiceClient;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
 use crate::{
-    flight::ExtendedTestFlightClient,
     metrics::QueryStatus,
     queries::{
         Query,
@@ -43,13 +43,13 @@ pub(crate) struct SpiceTestQueryWorker {
     id: usize,
     query_set: Vec<Query>,
     end_condition: EndCondition,
-    flight_client: FlightClient,
     explain_plan_snapshot: bool,
     results_snapshot_predicate: Option<fn(&str) -> bool>,
     name: String,
     pub progress_bar: Option<ProgressBar>,
     validate: bool,
     scale_factor: f64,
+    spice_client: Arc<Mutex<SpiceClient>>,
 }
 
 pub struct SpiceTestQueryWorkerResult {
@@ -88,14 +88,14 @@ impl SpiceTestQueryWorker {
         id: usize,
         query_set: Vec<Query>,
         end_condition: EndCondition,
-        flight_client: FlightClient,
+        spice_client: SpiceClient,
         name: String,
     ) -> Self {
         Self {
             id,
             query_set,
             end_condition,
-            flight_client,
+            spice_client: Arc::new(Mutex::new(spice_client)),
             explain_plan_snapshot: false,
             results_snapshot_predicate: None,
             name,
@@ -223,7 +223,7 @@ impl SpiceTestQueryWorker {
                         if self.explain_plan_snapshot && self.id == 0 {
                             println!("Worker {} - Query '{}' - Explain plan", self.id, query.name);
                             if let Err(e) = record_explain_plan(
-                                &self.flight_client,
+                                Arc::clone(&self.spice_client),
                                 self.name.as_str(),
                                 query,
                                 self.scale_factor,
@@ -402,10 +402,11 @@ impl SpiceTestQueryWorker {
         validate: bool,
     ) -> Result<()> {
         let query_start = Instant::now();
-        let mut result_stream = self
-            .flight_client
+        let mut spice_client = self.spice_client.lock().await;
+        let mut result_stream = spice_client
             .query_with_params(&query.sql, query.get_parameters_batch().transpose()?)
-            .await?;
+            .await
+            .map_err(|e| anyhow!("{e}"))?;
 
         let mut row_count: usize = 0;
         let mut limited_records = vec![];

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -569,8 +569,7 @@ impl SpiceTestQueryWorker {
             };
 
             let records_pretty = arrow::util::pretty::pretty_format_batches(&limited_records)
-                .map_err(QueryError::nonretryable)?
-                .to_string();
+                .map_err(QueryError::nonretryable)?;
             let result = panic::catch_unwind(|| {
                 insta::with_settings!({
                     description => format!("Query: {query_name}"),

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -27,6 +27,8 @@ use indicatif::ProgressBar;
 use spiceai::Client as SpiceClient;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use util::{RetryError, retry};
 
 use crate::{
     metrics::QueryStatus,
@@ -38,6 +40,8 @@ use crate::{
 };
 
 use super::EndCondition;
+
+pub(crate) const MAX_RETRIES: usize = 5;
 
 pub(crate) struct SpiceTestQueryWorker {
     id: usize,
@@ -401,6 +405,61 @@ impl SpiceTestQueryWorker {
         results_snapshot: bool,
         validate: bool,
     ) -> Result<()> {
+        let retry_strategy = FibonacciBackoffBuilder::new()
+            .max_retries(Some(MAX_RETRIES))
+            .build();
+
+        let (duration, row_count) = match retry(retry_strategy, || async {
+            match self
+                .execute_query_internal(query, results_snapshot, validate)
+                .await
+            {
+                Ok((duration, row_count)) => Ok((duration, row_count)),
+                Err(e) => {
+                    if is_transient_error(&e) {
+                        Err(RetryError::transient(e))
+                    } else {
+                        Err(RetryError::permanent(e))
+                    }
+                }
+            }
+        })
+        .await
+        {
+            Ok((duration, row_count)) => (duration, row_count),
+            Err(e) => {
+                eprintln!(
+                    "FAIL - Worker {} - Query '{}' failed: {}",
+                    self.id, query.name, e
+                );
+                query_durations.entry(Arc::clone(&query.name)).or_default();
+                return Err(e);
+            }
+        };
+
+        query_durations
+            .entry(Arc::clone(&query.name))
+            .or_default()
+            .push(duration);
+
+        row_counts
+            .entry(Arc::clone(&query.name))
+            .or_default()
+            .push(row_count);
+
+        if let Some(pb) = self.progress_bar.as_ref() {
+            pb.inc(1);
+        }
+
+        Ok(())
+    }
+
+    async fn execute_query_internal(
+        &self,
+        query: &Query,
+        results_snapshot: bool,
+        validate: bool,
+    ) -> Result<(Duration, usize)> {
         let query_start = Instant::now();
         let mut spice_client = self.spice_client.lock().await;
         let mut result_stream = spice_client
@@ -416,11 +475,6 @@ impl SpiceTestQueryWorker {
             match batch {
                 Ok(None) => break,
                 Err(e) => {
-                    eprintln!(
-                        "FAIL - Worker {} - Query '{}' failed: {}",
-                        self.id, query.name, e
-                    );
-                    query_durations.entry(Arc::clone(&query.name)).or_default();
                     return Err(e.into());
                 }
                 Ok(Some(batch)) => {
@@ -496,20 +550,12 @@ impl SpiceTestQueryWorker {
         }
 
         let duration = query_start.elapsed();
-        query_durations
-            .entry(Arc::clone(&query.name))
-            .or_default()
-            .push(duration);
-
-        row_counts
-            .entry(Arc::clone(&query.name))
-            .or_default()
-            .push(row_count);
-
-        if let Some(pb) = self.progress_bar.as_ref() {
-            pb.inc(1);
-        }
-
-        Ok(())
+        Ok((duration, row_count))
     }
+}
+
+pub(crate) fn is_transient_error(e: &anyhow::Error) -> bool {
+    e.to_string()
+        .to_lowercase()
+        .contains("connection is reset by the server. please retry the request.")
 }

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_yaml.workspace = true
 serde_json.workspace = true
 arrow-json.workspace = true
+spiceai.workspace = true
 
 [features]
 anonymous_telemetry = []

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -18,6 +18,7 @@ use crate::args::EvalsTestArgs;
 
 use super::get_app_and_start_request;
 use serde_json::json;
+use spiceai::Client as SpiceClient;
 use std::time::{Duration, SystemTime};
 use test_framework::{
     anyhow,
@@ -25,7 +26,6 @@ use test_framework::{
         array::{Float64Array, RecordBatch, StringArray},
         util::pretty::pretty_format_batches,
     },
-    flight_client::FlightClient,
     futures::TryStreamExt,
     git,
     opentelemetry::KeyValue,
@@ -140,26 +140,26 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
 
     println!("Retrieving results...");
 
-    let mut flight_client = spiced_instance.flight_client(None, false).await?;
+    let mut spice_client = spiced_instance.spice_client(None, false).await?;
 
-    let eval_result = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_MAIN_METRICS).await?;
+    let eval_result = execute_sql(&mut spice_client, QUERY_EVAL_BENCHMARK_MAIN_METRICS).await?;
     println!("Result:\n{}\n", pretty_format_batches(&eval_result)?);
 
     // Extract metrics from the evaluation result. If the evaluation run was not successful (EvalStatus::Failed),
     // we will return an error at the end after printing statistics and cleaning up.
     let metrics = EvalMetrics::from_record_batch(&eval_result)?;
 
-    let tasks_calls = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_TASKS).await?;
+    let tasks_calls = execute_sql(&mut spice_client, QUERY_EVAL_BENCHMARK_TASKS).await?;
     println!(
         "Executed tasks:\n{}\n",
         pretty_format_batches(&tasks_calls)?
     );
 
-    let failed_tests = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_FAILED_TESTS).await?;
+    let failed_tests = execute_sql(&mut spice_client, QUERY_EVAL_BENCHMARK_FAILED_TESTS).await?;
     // json format is easier to read as table could be too wide
     println!("Failed tests:\n{}\n", arrow_to_json(&failed_tests)?);
 
-    let top_errors = execute_sql(&mut flight_client, QUERY_EVAL_BENCHMARK_TOP_ERRORS).await?;
+    let top_errors = execute_sql(&mut spice_client, QUERY_EVAL_BENCHMARK_TOP_ERRORS).await?;
     // json format is easier to read as table could be too wide
     println!("Top errors:\n{}\n", arrow_to_json(&top_errors)?);
 
@@ -201,12 +201,13 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
 }
 
 async fn execute_sql(
-    flight_client: &mut FlightClient,
+    spice_client: &mut SpiceClient,
     sql: &str,
 ) -> Result<Vec<RecordBatch>, anyhow::Error> {
-    let res = flight_client
+    let res = spice_client
         .query(sql)
-        .await?
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?
         .try_collect::<Vec<RecordBatch>>()
         .await?;
     Ok(res)
@@ -216,14 +217,14 @@ async fn execute_sql(
  * Fetches key metrics for the latest evaluation run, including duration, evaluation score, task call counts, and errors.
  *
  * Output:
- * - `run_id`: Evaluation run ID  
- * - `model`: Model name  
- * - `status`: Run status  
+ * - `run_id`: Evaluation run ID
+ * - `model`: Model name
+ * - `status`: Run status
  * - `tests`: Number of tests performed
- * - `duration_seconds`: Eval duration (seconds)  
+ * - `duration_seconds`: Eval duration (seconds)
  * - `score`: Rounded average score
- * - `task_calls`: Total task invocations  
- * - `task_errors`: Task task errors  
+ * - `task_calls`: Total task invocations
+ * - `task_errors`: Task task errors
  *
  * Example:
  * +----------------------------------+-------------+-----------+-------+------------------+--------+------------+-------------+
@@ -245,11 +246,11 @@ score AS (
     GROUP BY run_id
 ),
 tool_stats AS (
-    SELECT 
+    SELECT
         COUNT(*) AS task_calls,
         COUNT(CASE WHEN error_message IS NOT NULL THEN 1 END) AS task_errors
     FROM runtime.task_history
-    WHERE 
+    WHERE
         task != 'test_connectivity'
         AND start_time BETWEEN (SELECT created_at FROM latest_run)
         AND COALESCE(end_time, NOW())
@@ -265,10 +266,10 @@ LEFT JOIN tool_stats ts ON 1 = 1;
  * Retrieves statistis on executed tasks/tools during the latest evaluation run.
  *
  * Output:
- * - `task`: Task name  
- * - `calls`: Total number of task calls  
- * - `failures`: Total number of task failures  
- * - `duration_ms`: Aggregated task duration in milliseconds  
+ * - `task`: Task name
+ * - `calls`: Total number of task calls
+ * - `failures`: Total number of task failures
+ * - `duration_ms`: Aggregated task duration in milliseconds
  *
  * Example:
  * +-------------------------+-------+----------+--------------------+
@@ -282,20 +283,20 @@ LEFT JOIN tool_stats ts ON 1 = 1;
  */
 static QUERY_EVAL_BENCHMARK_TASKS: &str = "
 WITH latest_run AS (
-  SELECT id 
-  FROM spice.eval.runs 
-  ORDER BY created_at DESC 
+  SELECT id
+  FROM spice.eval.runs
+  ORDER BY created_at DESC
   LIMIT 1
 )
-SELECT 
-  task, 
+SELECT
+  task,
   COUNT(*) AS calls,
   COUNT(CASE WHEN error_message IS NOT NULL THEN 1 END) AS failures,
   SUM(CAST((end_time - start_time) AS Float) /  1000000) AS duration_ms
 FROM runtime.task_history
-WHERE 
+WHERE
   task != 'test_connectivity'
-  AND start_time BETWEEN (SELECT created_at FROM spice.eval.runs WHERE id = (SELECT id FROM latest_run)) AND 
+  AND start_time BETWEEN (SELECT created_at FROM spice.eval.runs WHERE id = (SELECT id FROM latest_run)) AND
   COALESCE(end_time, NOW())
 GROUP BY task
 ORDER BY duration_ms DESC;
@@ -305,10 +306,10 @@ ORDER BY duration_ms DESC;
  * Fetches the top task errors for the latest evaluation run aggregated by associated task name, error message, and input
  *
  * Output:
- * - `task`: Task name  
- * - `count`: Number of error occurrences  
- * - `message`: Error message  
- * - `input`: Input causing the error  
+ * - `task`: Task name
+ * - `count`: Number of error occurrences
+ * - `message`: Error message
+ * - `input`: Input causing the error
  *
  * Example:
  * +---------------+-------+---------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------+
@@ -319,25 +320,25 @@ ORDER BY duration_ms DESC;
  */
 static QUERY_EVAL_BENCHMARK_TOP_ERRORS: &str = "
 WITH latest_run AS (
-  SELECT id 
-  FROM spice.eval.runs 
-  ORDER BY created_at DESC 
+  SELECT id
+  FROM spice.eval.runs
+  ORDER BY created_at DESC
   LIMIT 1
 )
-SELECT 
+SELECT
     task,
     COUNT(*) AS count,
     error_message as message,
     input
-FROM 
+FROM
     runtime.task_history
-WHERE 
+WHERE
     error_message IS NOT NULL
-    AND start_time BETWEEN (SELECT created_at FROM spice.eval.runs WHERE id = (SELECT id FROM latest_run)) AND 
+    AND start_time BETWEEN (SELECT created_at FROM spice.eval.runs WHERE id = (SELECT id FROM latest_run)) AND
   	COALESCE(end_time, NOW())
-GROUP BY 
+GROUP BY
     task, input, message
-ORDER BY 
+ORDER BY
     count DESC
 LIMIT 20;
 ";
@@ -346,11 +347,11 @@ LIMIT 20;
  * Fetches the failed tests for the latest evaluation run.
  *
  * Output:
- * - `run_id`: Evaluation run ID  
- * - `input`: Test input query  
- * - `output`: Model response  
- * - `expected`: Expected response  
- * - `score`: Test score  
+ * - `run_id`: Evaluation run ID
+ * - `input`: Test input query
+ * - `output`: Model response
+ * - `expected`: Expected response
+ * - `score`: Test score
  *
  * Example:
  * +----------------------------------+----------------------------------+----------------------------------+----------------------------------+-------+


### PR DESCRIPTION
## 📝 Summary

This PR includes changes to use spice-rs sdk inside the test framework, and changes to retry on connection reset error emitted by spice cloud connector
- Replace flight client with spice-rs client for query in test framework & test operator. Each `SpiceTestQueryWorker` contains a `spice_client: Arc<SpiceClient>`.
- In test-framework / test operator, retry the query stream consumption in `execute_query` and `query_to_batches` when the connection reset error is encountered. `is_transient_error` function is used to determine the connection reset error
- For retryable spice error, add `spiceai-retryable` metadata in tonic error status for easy matching & handling of retryable error from client side.

TPCDS Load test run at designated concurrency without issue after this change: https://github.com/spiceai/spiceai/actions/runs/15497392622/job/43637240095

Changes have been validated on a full benchmark dispatch:
https://github.com/spiceai/spiceai/actions/runs/15501496471 and a throughput run: https://github.com/spiceai/spiceai/actions/runs/15570591024

## 🔗 Related

- spice-rs change: https://github.com/spiceai/spice-rs/pull/51
- Close: https://github.com/spiceai/spiceai/issues/6121

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
