### PR TITLE
Add CSV support to Glue data connector

### DIFF
--- a/crates/runtime/src/catalogconnector/glue.rs
+++ b/crates/runtime/src/catalogconnector/glue.rs
@@ -30,7 +30,6 @@ use async_trait::async_trait;
 use aws_sdk_glue::{
     error::SdkError,
     operation::{get_databases::GetDatabasesError, get_tables::GetTablesError},
-    types::Table,
 };
 use snafu::prelude::*;
 use std::any::Any;
@@ -109,6 +108,8 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+type DatabaseName = String;
+
 /// A catalog connector for AWS Glue, providing access to database and table metadata.
 #[derive(Clone)]
 pub struct GlueCatalog {
@@ -142,40 +143,5 @@ impl CatalogConnector for GlueCatalog {
                     source: Box::new(e),
                 })?,
         ))
-    }
-}
-
-type DatabaseName = String;
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-enum TableType {
-    HiveParquet,
-    Iceberg,
-    Unsupported,
-}
-
-impl TableType {
-    fn from(table: &Table) -> TableType {
-        if table
-            .parameters
-            .as_ref()
-            .and_then(|params| params.get("table_type"))
-            .is_some_and(|value| value.to_lowercase() == "iceberg")
-        {
-            return Self::Iceberg;
-        }
-
-        if table
-            .storage_descriptor
-            .as_ref()
-            .and_then(|sd| sd.input_format.as_ref())
-            .is_some_and(|input_format| {
-                input_format == "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
-            })
-        {
-            return Self::HiveParquet;
-        }
-
-        Self::Unsupported
     }
 }

--- a/crates/runtime/src/catalogconnector/glue/state.rs
+++ b/crates/runtime/src/catalogconnector/glue/state.rs
@@ -73,44 +73,50 @@ impl GlueCatalogState {
     }
 
     pub async fn refresh(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let get_databases_output = self
-            .client
-            .get_databases()
-            .send()
-            .await
-            .context(super::GetDatabasesSnafu)?;
+        let mut paginator = self.client.get_databases().into_paginator().send();
 
         let mut databases = HashMap::new();
-        for db in get_databases_output.database_list {
-            if !database_might_match(&db.name, &self.orig_include) {
-                tracing::debug!("skipping database {}", &db.name);
-                continue;
+
+        while let Some(maybe_get_databases_output) = paginator.next().await {
+            let get_databases_output =
+                maybe_get_databases_output.context(super::GetDatabasesSnafu)?;
+            for db in get_databases_output.database_list {
+                if !database_might_match(&db.name, &self.orig_include) {
+                    tracing::debug!("skipping database {}", &db.name);
+                    continue;
+                }
+
+                let mut paginator = self
+                    .client
+                    .get_tables()
+                    .database_name(&db.name)
+                    .into_paginator()
+                    .send();
+
+                let mut tables = Vec::new();
+
+                while let Some(maybe_get_tables_output) = paginator.next().await {
+                    let get_tables_output =
+                        maybe_get_tables_output.map_err(|source| super::Error::GetTables {
+                            database: db.name.to_string(),
+                            source,
+                        })?;
+                    let some_tables = get_tables_output
+                        .table_list
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|t| {
+                            InputFormat::try_from(t).is_ok()
+                                && is_included(self.include.as_ref(), &db.name, t.name())
+                        })
+                        .collect::<Vec<_>>();
+
+                    tables.extend(some_tables);
+                }
+
+                databases.insert(db.name, tables);
             }
-
-            let get_tables_output = self
-                .client
-                .get_tables()
-                .database_name(&db.name)
-                .send()
-                .await
-                .map_err(|source| super::Error::GetTables {
-                    database: db.name.to_string(),
-                    source,
-                })?;
-
-            let table_names = get_tables_output
-                .table_list
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|t| {
-                    InputFormat::try_from(t).is_ok()
-                        && is_included(self.include.as_ref(), &db.name, t.name())
-                })
-                .collect::<Vec<_>>();
-
-            databases.insert(db.name, table_names);
         }
-
         let mut dbs = match self.databases.write() {
             Ok(dbs) => dbs,
             Err(poisoned) => poisoned.into_inner(),

--- a/crates/runtime/src/catalogconnector/glue/state.rs
+++ b/crates/runtime/src/catalogconnector/glue/state.rs
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::{ConfigurationLoadingFailedSnafu, DatabaseName, TableType};
+use super::{ConfigurationLoadingFailedSnafu, DatabaseName};
+use crate::dataconnector::glue::InputFormat;
 use crate::dataconnector::parameters::aws::load_config;
 use crate::{Runtime, dataconnector::parameters::ConnectorParams};
 use aws_sdk_glue::Client;
@@ -102,7 +103,7 @@ impl GlueCatalogState {
                 .unwrap_or_default()
                 .into_iter()
                 .filter(|t| {
-                    !matches!(TableType::from(t), TableType::Unsupported)
+                    InputFormat::try_from(t).is_ok()
                         && is_included(self.include.as_ref(), &db.name, t.name())
                 })
                 .collect::<Vec<_>>();

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -309,16 +309,30 @@ async fn create_s3_provider(
         });
     };
 
+    match input_format {
+        InputFormat::Csv => {
+            // If the table specifies a delimiter, pass it down to the data connector
+            // as a parameter
+            if let Some(delimiter) = table
+                .parameters()
+                .and_then(|params| params.get("delimiter"))
+            {
+                params.insert("csv_delimiter".to_string(), delimiter.as_str().into());
+            }
+        }
+        InputFormat::Parquet => {
+            dataset
+                .params
+                .insert("hive_partitioning_enabled".to_string(), "true".to_string());
+        }
+        InputFormat::Iceberg => {}
+    }
+
     // Add required file_format parameter for S3
     params.insert("file_format".into(), input_format.file_format().into());
     let s3 = S3 { params };
 
     dataset.from = from;
-    if matches!(input_format, InputFormat::Parquet) {
-        dataset
-            .params
-            .insert("hive_partitioning_enabled".to_string(), "true".to_string());
-    }
 
     s3.read_provider(&dataset).await
 }

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -164,8 +164,8 @@ impl DataConnector for GlueDataConnector {
                 message,
             }
         })? {
-            InputFormat::Parquet => {
-                create_parquet_provider(dataset.clone(), self.params.clone(), &table).await
+            input_format @ (InputFormat::Parquet | InputFormat::Csv) => {
+                create_s3_provider(input_format, dataset.clone(), self.params.clone(), &table).await
             }
             InputFormat::Iceberg => {
                 let region = self.params.get("region").expose().ok().ok_or_else(|| {
@@ -182,14 +182,28 @@ impl DataConnector for GlueDataConnector {
     }
 }
 
-enum InputFormat {
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum InputFormat {
     // Avro,
-    // Csv,
+    Csv,
     // Json,
     // Xml,
     Parquet,
     // Orc,
     Iceberg,
+}
+
+impl InputFormat {
+    /// Return the file format of the [`InputFormat`]. For
+    /// [`InputFormat::Iceberg`], it's not a file format but we return a value
+    /// rather than have to use an `Option` return type for convenience.
+    fn file_format(self) -> &'static str {
+        match self {
+            InputFormat::Csv => "csv",
+            InputFormat::Parquet => "parquet",
+            InputFormat::Iceberg => "iceberg",
+        }
+    }
 }
 
 impl TryFrom<&Table> for InputFormat {
@@ -217,6 +231,7 @@ impl TryFrom<&Table> for InputFormat {
 
         Ok(match input_format {
             "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat" => Self::Parquet,
+            "org.apache.hadoop.mapred.TextInputFormat" => Self::Csv,
             input_format => return Err(format!("input format `{input_format} is not supported`")),
         })
     }
@@ -268,7 +283,8 @@ async fn create_iceberg_provider(
     Ok(Arc::new(table_provider))
 }
 
-async fn create_parquet_provider(
+async fn create_s3_provider(
+    input_format: InputFormat,
     mut dataset: Dataset,
     mut params: Parameters,
     table: &Table,
@@ -281,7 +297,7 @@ async fn create_parquet_provider(
         });
     };
 
-    let Some(mut from) = storage_descriptor.location().map(String::from) else {
+    let Some(from) = storage_descriptor.location().map(String::from) else {
         return Err(super::DataConnectorError::InternalWithSource {
             dataconnector: PREFIX.to_string(),
             connector_component: (&dataset).into(),
@@ -293,19 +309,16 @@ async fn create_parquet_provider(
         });
     };
 
-    if !from.ends_with('/') {
-        from.push('/');
-    }
-
     // Add required file_format parameter for S3
-    params.insert("file_format".into(), "parquet".into());
+    params.insert("file_format".into(), input_format.file_format().into());
     let s3 = S3 { params };
 
-    // Modify the dataset for S3 parquet
     dataset.from = from;
-    dataset
-        .params
-        .insert("hive_partitioning_enabled".to_string(), "true".to_string());
+    if matches!(input_format, InputFormat::Parquet) {
+        dataset
+            .params
+            .insert("hive_partitioning_enabled".to_string(), "true".to_string());
+    }
 
     s3.read_provider(&dataset).await
 }

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -232,7 +232,7 @@ impl TryFrom<&Table> for InputFormat {
         Ok(match input_format {
             "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat" => Self::Parquet,
             "org.apache.hadoop.mapred.TextInputFormat" => Self::Csv,
-            input_format => return Err(format!("input format `{input_format} is not supported`")),
+            input_format => return Err(format!("input format `{input_format}` is not supported")),
         })
     }
 }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -279,13 +279,20 @@ pub trait ListingTableConnector: DataConnector {
             .ok()
             .unwrap_or_default();
 
+        let delimiter = params
+            .get(&format!("{delimiter}_delimiter"))
+            .expose()
+            .ok()
+            .and_then(|d| d.chars().next().map(|c| c as u8))
+            .unwrap_or(delimiter.separator());
+
         Ok(Arc::new(
             CsvFormat::default()
                 .with_has_header(has_header)
                 .with_quote(quote)
                 .with_escape(escape)
                 .with_schema_infer_max_rec(schema_infer_max_rec)
-                .with_delimiter(delimiter.separator())
+                .with_delimiter(delimiter)
                 .with_file_compression_type(
                     FileCompressionType::from_str(compression_type)
                         .boxed()

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -279,12 +279,15 @@ pub trait ListingTableConnector: DataConnector {
             .ok()
             .unwrap_or_default();
 
-        let delimiter = params
-            .get(&format!("{delimiter}_delimiter"))
-            .expose()
-            .ok()
-            .and_then(|d| d.chars().next().map(|c| c as u8))
-            .unwrap_or(delimiter.separator());
+        let delimiter = match delimiter {
+            DelimitedFormat::Tsv => delimiter.separator(),
+            DelimitedFormat::Csv => params
+                .get("csv_delimiter")
+                .expose()
+                .ok()
+                .and_then(|d| d.chars().next().map(|c| c as u8))
+                .unwrap_or(delimiter.separator()),
+        };
 
         Ok(Arc::new(
             CsvFormat::default()


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

- Adds support for CSV files to the Glue data connector.
- Adds pagination to the Glue catalog connector for databases and tables. Limit was 90.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->
Closes:
- #6116

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
