### PR TITLE
Fix CSV delimiter not being respected

### DIFF
--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -279,13 +279,20 @@ pub trait ListingTableConnector: DataConnector {
             .ok()
             .unwrap_or_default();
 
+        let delimiter = params
+            .get(&format!("{delimiter}_delimiter"))
+            .expose()
+            .ok()
+            .and_then(|d| d.chars().next().map(|c| c as u8))
+            .unwrap_or(delimiter.separator());
+
         Ok(Arc::new(
             CsvFormat::default()
                 .with_has_header(has_header)
                 .with_quote(quote)
                 .with_escape(escape)
                 .with_schema_infer_max_rec(schema_infer_max_rec)
-                .with_delimiter(delimiter.separator())
+                .with_delimiter(delimiter)
                 .with_file_compression_type(
                     FileCompressionType::from_str(compression_type)
                         .boxed()


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

Use the specified `csv_delimiter` parameter when reading CSV files. Fallback to the previous default, if not provided.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
