### PR TITLE
Update Spice Cloud Platform management UX

### DIFF
--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -21,7 +21,8 @@ use std::{
 };
 
 use crate::{
-    dataaccelerator::AcceleratorEngineRegistry, object_store_registry::SpiceObjectStoreRegistry,
+    dataaccelerator::AcceleratorEngineRegistry, datafusion::SPICE_SCP_SCHEMA,
+    object_store_registry::SpiceObjectStoreRegistry,
 };
 use cache::Caching;
 use datafusion::{
@@ -213,7 +214,14 @@ impl DataFusionBuilder {
         match catalog.register_schema(SPICE_METADATA_SCHEMA, Arc::new(metadata_schema)) {
             Ok(_) => {}
             Err(e) => {
-                panic!("Unable to register spice runtime schema: {e}");
+                panic!("Unable to register spice metadata schema: {e}");
+            }
+        }
+
+        match catalog.register_schema(SPICE_SCP_SCHEMA, Arc::new(SpiceSchemaProvider::new())) {
+            Ok(_) => {}
+            Err(e) => {
+                panic!("Unable to register spice cloud platform schema: {e}");
             }
         }
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -90,6 +90,7 @@ pub const SPICE_RUNTIME_SCHEMA: &str = "runtime";
 pub const SPICE_EVAL_SCHEMA: &str = "eval";
 pub const SPICE_DEFAULT_SCHEMA: &str = "public";
 pub const SPICE_METADATA_SCHEMA: &str = "metadata";
+pub const SPICE_SCP_SCHEMA: &str = "scp";
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -1519,6 +1520,7 @@ impl DataFusion {
                             .filter(|schema| {
                                 !(ctlg == SPICE_DEFAULT_CATALOG && *schema == SPICE_RUNTIME_SCHEMA
                                     || *schema == SPICE_METADATA_SCHEMA
+                                    || *schema == SPICE_SCP_SCHEMA
                                     || *schema == SPICE_EVAL_SCHEMA)
                             })
                             .flat_map(|schema| {
@@ -1628,6 +1630,7 @@ pub fn is_spice_internal_schema(catalog: &str, schema: &str) -> bool {
     catalog == SPICE_DEFAULT_CATALOG
         && (schema == SPICE_RUNTIME_SCHEMA
             || schema == SPICE_METADATA_SCHEMA
+            || schema == SPICE_SCP_SCHEMA
             || schema == SPICE_EVAL_SCHEMA)
 }
 

--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 const TASK_HISTORY_SINK_REMOTE_TABLE: &str = "runtime.task_history";
-const TASK_HISTORY_SINK_TABLE: &str = "runtime.task_history_cloud";
+const TASK_HISTORY_SINK_TABLE: &str = "scp.task_history";
 const DEFAULT_EXPORT_INTERVAL_SECS: u64 = 5;
 
 use std::{
@@ -36,8 +36,9 @@ use datafusion::{
     sql::TableReference,
 };
 use secrecy::{ExposeSecret, SecretString};
-use snafu::{OptionExt, ResultExt, Snafu};
+use snafu::{ResultExt, Snafu};
 use spicepod::component::management::Management as SpicepodManagement;
+use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -49,6 +50,7 @@ use crate::{
     },
     dataupdate::{DataUpdate, UpdateType},
     get_params_with_secrets,
+    secrets::Secrets,
     task_history::DEFAULT_TASK_HISTORY_TABLE,
 };
 
@@ -106,15 +108,21 @@ impl Management {
         config: &SpicepodManagement,
         runtime: Arc<Runtime>,
     ) -> Result<Self, Error> {
-        let params = get_params_with_secrets(runtime.secrets(), &config.params).await;
+        let secrets = runtime.secrets();
 
-        let api_key = params
-            .get("api_key")
-            .context(MissingRequiredSecretSnafu { name: "api_key" })?;
+        let api_key: SecretString = if config.api_key.is_empty() {
+            return Err(Error::MissingRequiredSecret {
+                name: "api_key".to_string(),
+            });
+        } else {
+            resolve_secret(&secrets, &config.api_key).await
+        };
+
+        let params = get_params_with_secrets(secrets, &config.params).await;
 
         Ok(Self {
-            api_key: api_key.clone(),
             runtime,
+            api_key,
             params,
         })
     }
@@ -184,7 +192,7 @@ impl Management {
             self.api_key.expose_secret().to_string(),
         );
 
-        if let Some(flight_endpoint) = self.params.get("flight_endpoint") {
+        if let Some(flight_endpoint) = self.params.get("data_endpoint") {
             params.insert(
                 "spiceai_endpoint".to_string(),
                 flight_endpoint.expose_secret().to_string(),
@@ -371,4 +379,14 @@ fn is_table_not_ready_error(e: &DataFusionError) -> bool {
         }
     }
     false
+}
+
+// Resolve a secret by key, returning the secret string if found, or the original key if not.
+async fn resolve_secret(secrets: &Arc<RwLock<Secrets>>, key: &str) -> SecretString {
+    let secrets = secrets.read().await;
+    if let Ok(Some(secret)) = secrets.get_secret(key).await {
+        secret
+    } else {
+        SecretString::new(key.to_string().into())
+    }
 }

--- a/crates/spicepod/src/component/management.rs
+++ b/crates/spicepod/src/component/management.rs
@@ -26,15 +26,7 @@ use serde::{Deserialize, Serialize};
 pub struct Management {
     #[serde(default = "default_true")]
     pub enabled: bool,
+    pub api_key: String,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub params: HashMap<String, String>,
-}
-
-impl Default for Management {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            params: HashMap::new(),
-        }
-    }
 }


### PR DESCRIPTION
## 📝 Summary

Update Spice Cloud Platform management UX:

1. Internal sink dataset is now under dedicated `scp` schema: `runtime.task_history_cloud` -> `scp.task_history`
2. `api_key` has been moved from `params` directly to `management`
3. Target flight endpoint override param renamed to `data_endpoint`
```yaml
management:
  enabled: true
  api_key: ${ secrets:SPICEAI_API_KEY}
  params:
    data_endpoint: https://dev-flight.spiceai.io
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
