### PR TITLE
Enforce max_tokens_per_request limit in OpenAI embedding logic

### DIFF
--- a/crates/llms/src/openai/embed.rs
+++ b/crates/llms/src/openai/embed.rs
@@ -98,19 +98,8 @@ impl<C: Config + Sync + Send + Debug> Embed for OpenaiEmbed<C> {
     }
 
     async fn embed(&self, input: EmbeddingInput) -> EmbedResult<Vec<Vec<f32>>> {
-        // Batch requests to OpenAI endpoint because "any array must be 2048 dimensions or less".
-        // https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-input
-        let embed_batches = match input {
-            EmbeddingInput::StringArray(ref batch) => batch
-                .chunks(2048)
-                .map(|chunk| EmbeddingInput::StringArray(chunk.to_vec()))
-                .collect(),
-            EmbeddingInput::ArrayOfIntegerArray(ref batch) => batch
-                .chunks(2048)
-                .map(|chunk| EmbeddingInput::ArrayOfIntegerArray(chunk.to_vec()))
-                .collect(),
-            _ => vec![input],
-        };
+        // Batch requests to match OpenAI API limits: max_tokens_per_request and max array size.
+        let embed_batches: Vec<EmbeddingInput> = chunk_embedding_input(&input);
 
         let request_batches_result: EmbedResult<Vec<CreateEmbeddingRequest>> = embed_batches
             .into_iter()
@@ -173,5 +162,185 @@ impl<C: Config + Sync + Send + Debug> Embed for OpenaiEmbed<C> {
                     .map_err(|e| EmbedError::FailedToCreateChunker { source: e })?,
             )),
         }
+    }
+}
+
+// `OpenAPI` estimator counts utf-8 bytes as 0.25 tokens so allowed string size is 1,200,000 bytes.
+const MAX_BATCH_STR_BYTES: usize = 300_000 * 4;
+const MAX_BATCH_SIZE: usize = 2048;
+
+/// Chunks embedding input to batches to be `OpenAI` API compliant: `<https://platform.openai.com/docs/api-reference/embeddings/create>`
+///  - "any array must be 2048 dimensions or less"
+///  - "maximum of 300,000 tokens summed across all inputs in a single request"
+fn chunk_embedding_input(input: &EmbeddingInput) -> Vec<EmbeddingInput> {
+    match input {
+        EmbeddingInput::StringArray(items) => {
+            let mut batches = Vec::new();
+            let mut curr_batch = Vec::new();
+            let mut curr_str_bytes = 0;
+
+            for str in items {
+                let str_bytes = str.len(); // `len` returns the length in bytes
+                if (!curr_batch.is_empty())
+                    && (curr_batch.len() >= MAX_BATCH_SIZE
+                        || curr_str_bytes + str_bytes > MAX_BATCH_STR_BYTES)
+                {
+                    batches.push(EmbeddingInput::StringArray(curr_batch));
+                    curr_batch = Vec::new();
+                    curr_str_bytes = 0;
+                }
+                curr_batch.push(str.clone());
+                curr_str_bytes += str_bytes;
+            }
+
+            if !curr_batch.is_empty() {
+                batches.push(EmbeddingInput::StringArray(curr_batch));
+            }
+
+            batches
+        }
+        EmbeddingInput::ArrayOfIntegerArray(arr) => arr
+            .chunks(MAX_BATCH_SIZE)
+            .map(|chunk| EmbeddingInput::ArrayOfIntegerArray(chunk.to_vec()))
+            .collect(),
+        _ => vec![input.clone()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chunk_embedding_input_single_batch() {
+        let input = EmbeddingInput::StringArray(vec!["short".to_string(); 10]);
+        let batches = chunk_embedding_input(&input);
+
+        assert_eq!(batches.len(), 1);
+        if let EmbeddingInput::StringArray(strings) = &batches[0] {
+            assert_eq!(strings.len(), 10);
+        } else {
+            panic!("Expected StringArray");
+        }
+    }
+
+    #[test]
+    fn test_chunk_embedding_input_breaks_max_batch_size() {
+        let input = EmbeddingInput::StringArray(vec!["test".to_string(); 3000]);
+        let batches = chunk_embedding_input(&input);
+
+        // Should break into multiple batches due to MAX_BATCH_SIZE (2048)
+        assert_eq!(batches.len(), 2);
+
+        let total_items: usize = batches
+            .iter()
+            .map(|batch| {
+                if let EmbeddingInput::StringArray(strings) = batch {
+                    strings.len()
+                } else {
+                    0
+                }
+            })
+            .sum();
+
+        assert_eq!(total_items, 3000);
+    }
+
+    #[test]
+    fn test_chunk_embedding_input_breaks_300k_tokens_fits_estimator() {
+        // 1001 chunks each 300 characters = 300300 characters
+        // OpenAI estimator counts utf-8 bytes as 0.25 tokens
+        // ASCII characters are 1 byte each, so 300300 bytes = 75075 tokens (under 300k)
+        let input = EmbeddingInput::StringArray(vec!["a".repeat(300); 1001]);
+        let batches = chunk_embedding_input(&input);
+
+        // Should fit in one batch since estimated tokens < 300k
+        assert_eq!(batches.len(), 1);
+        if let EmbeddingInput::StringArray(strings) = &batches[0] {
+            assert_eq!(strings.len(), 1001);
+        } else {
+            panic!("Expected StringArray");
+        }
+    }
+
+    #[test]
+    fn test_chunk_embedding_input_breaks_300k_tokens() {
+        // 500 chunks each 3000 ASCII characters = 1,500,000 bytes
+        // 1500,000 bytes / 4 = 375000 tokens (over 300k, should split)
+        let input = EmbeddingInput::StringArray(vec!["a".repeat(3000); 500]);
+        let batches = chunk_embedding_input(&input);
+
+        // Should break into 2 batches due to exceeding MAX_BATCH_STR_BYTES
+        assert_eq!(batches.len(), 2);
+
+        let total_items: usize = batches
+            .iter()
+            .map(|batch| {
+                if let EmbeddingInput::StringArray(strings) = batch {
+                    strings.len()
+                } else {
+                    0
+                }
+            })
+            .sum();
+
+        assert_eq!(total_items, 500);
+    }
+
+    #[test]
+    fn test_chunk_embedding_input_breaks_300k_tokens_unicode() {
+        // 500 chunks each 1000 characters using multi-byte UTF-8 character (中)
+        // 中 is 3 bytes = 0.75 tokens * 1000 * 500 = 375000 tokens (over 300k, should split)
+        let input = EmbeddingInput::StringArray(vec!["中".repeat(1000); 500]);
+        let batches = chunk_embedding_input(&input);
+
+        // Should break into 2 batches due to exceeding MAX_BATCH_STR_BYTES
+        assert_eq!(batches.len(), 2);
+
+        let total_items: usize = batches
+            .iter()
+            .map(|batch| {
+                if let EmbeddingInput::StringArray(strings) = batch {
+                    strings.len()
+                } else {
+                    0
+                }
+            })
+            .sum();
+
+        assert_eq!(total_items, 500);
+    }
+
+    #[test]
+    fn test_chunk_embedding_input_integer_array() {
+        let large_array = vec![vec![1, 2, 3]; 3000];
+        let input = EmbeddingInput::ArrayOfIntegerArray(large_array);
+        let batches = chunk_embedding_input(&input);
+
+        // Should break into chunks of MAX_BATCH_SIZE (2048)
+        assert!(batches.len() > 1);
+
+        let total_items: usize = batches
+            .iter()
+            .map(|batch| {
+                if let EmbeddingInput::ArrayOfIntegerArray(arrays) = batch {
+                    arrays.len()
+                } else {
+                    0
+                }
+            })
+            .sum();
+
+        assert_eq!(total_items, 3000);
+    }
+
+    #[test]
+    fn test_chunk_embedding_input_single_string() {
+        let input = EmbeddingInput::String("test".to_string());
+        let batches = chunk_embedding_input(&input);
+
+        // Single string should remain as-is
+        assert_eq!(batches.len(), 1);
+        assert!(matches!(batches[0], EmbeddingInput::String(_)));
     }
 }


### PR DESCRIPTION
## 📝 Summary

OpenAI embeddings API enforces a limit of 300,000 tokens summed across all inputs in a single request. PR improves existing batching mechanism to respect this limit.

https://platform.openai.com/docs/api-reference/embeddings/create

>input
Required
Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for all embedding models), cannot be an empty string, and any array must be 2048 dimensions or less. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens. In addition to the per-input token limit, **all embedding models enforce a maximum of 300,000 tokens summed across all inputs in a single request.**

## 🔗 Related

Fixes
 - https://github.com/spiceai/spiceai/issues/6142

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
