### PR TITLE
Improve parsing of full text search query 

### DIFF
--- a/crates/search/src/generation/snapshots/search__generation__text_search__tests__and_conjunction.snap
+++ b/crates/search/src/generation/snapshots/search__generation__text_search__tests__and_conjunction.snap
@@ -1,0 +1,43 @@
+---
+source: crates/search/src/generation/text_search.rs
+expression: "parse_query_literal(\"foo and bar\")"
+snapshot_kind: text
+---
+{
+  "type": "bool",
+  "clauses": [
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "foo",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "and",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "bar",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ]
+  ]
+}

--- a/crates/search/src/generation/snapshots/search__generation__text_search__tests__operators.snap
+++ b/crates/search/src/generation/snapshots/search__generation__text_search__tests__operators.snap
@@ -1,0 +1,98 @@
+---
+source: crates/search/src/generation/text_search.rs
+expression: "parse_query_literal(\"How much (in USD) don't I get?\")"
+snapshot_kind: text
+---
+{
+  "type": "bool",
+  "clauses": [
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "how",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "much",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "in",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "usd",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "don",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "t",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "i",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "get",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ]
+  ]
+}

--- a/crates/search/src/generation/snapshots/search__generation__text_search__tests__quotes_conjunction.snap
+++ b/crates/search/src/generation/snapshots/search__generation__text_search__tests__quotes_conjunction.snap
@@ -1,0 +1,43 @@
+---
+source: crates/search/src/generation/text_search.rs
+expression: "parse_query_literal(\"'foo and' bar\")"
+snapshot_kind: text
+---
+{
+  "type": "bool",
+  "clauses": [
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "foo",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "and",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "bar",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ]
+  ]
+}

--- a/crates/search/src/generation/snapshots/search__generation__text_search__tests__special_characters.snap
+++ b/crates/search/src/generation/snapshots/search__generation__text_search__tests__special_characters.snap
@@ -1,0 +1,76 @@
+---
+source: crates/search/src/generation/text_search.rs
+expression: "parse_query_literal(\"title:sea^20 body:whale^70\")"
+snapshot_kind: text
+---
+{
+  "type": "bool",
+  "clauses": [
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "title",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "sea",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "20",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "body",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "whale",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ],
+    [
+      "should",
+      {
+        "type": "literal",
+        "field_name": null,
+        "phrase": "70",
+        "delimiter": "none",
+        "slop": 0,
+        "prefix": false
+      }
+    ]
+  ]
+}

--- a/crates/search/src/generation/text_search.rs
+++ b/crates/search/src/generation/text_search.rs
@@ -26,9 +26,10 @@ use snafu::{ResultExt, Snafu};
 use tantivy::{
     Index, ReloadPolicy, Searcher, TantivyError,
     collector::TopDocs,
-    query::{QueryParser, QueryParserError},
+    query::{Occur, QueryParser, QueryParserError},
     query_grammar::{Delimiter, UserInputAst, UserInputLeaf, UserInputLiteral},
     schema::{Field, OwnedValue},
+    tokenizer::{LowerCaser, SimpleTokenizer, TextAnalyzer},
 };
 
 use super::{
@@ -146,16 +147,14 @@ impl FullTextSearch {
 
     fn search_query_literal(&self, literal: &str, limit: usize) -> Result<Vec<Value>> {
         // Explicitly create AST to avoid user queries being considered a query language (e.g. `"title:sea^20 body:whale^70"`).
-        let q = QueryParser::for_index(&self.idx, vec![])
-            .build_query_from_user_input_ast(UserInputAst::Leaf(Box::new(UserInputLeaf::Literal(
-                UserInputLiteral {
-                    field_name: Some(self.field.clone()),
-                    phrase: literal.to_string(),
-                    delimiter: Delimiter::None,
-                    slop: 0,
-                    prefix: false,
-                },
-            ))))
+        let default_field = self
+            .idx
+            .schema()
+            .find_field(self.field.as_str())
+            .map(|(f, _)| vec![f])
+            .unwrap_or_default();
+        let q = QueryParser::for_index(&self.idx, default_field)
+            .build_query_from_user_input_ast(parse_query_literal(literal))
             .context(InvalidTextSearchQuerySnafu {
                 query: literal.to_string(),
             })?;
@@ -193,6 +192,39 @@ impl FullTextSearch {
 
         Ok(top_docs)
     }
+}
+
+// Parse a user-provided query to interpret it without terms (e.g. `IN ['foo', 'bar']`) or clauses (foo AND bar).
+//
+// A query, q, is interpreted as a space-delimited, OR-conjuncted set of string literals.
+//
+// Examples:
+//   - q="'foo and' bar" -> Returns any document containing at least one of ["foo", "and", "bar"].
+fn parse_query_literal(q: &str) -> UserInputAst {
+    let mut literal = vec![];
+    let mut tok = TextAnalyzer::builder(SimpleTokenizer::default())
+        .filter(LowerCaser)
+        .build();
+    let mut s = tok.token_stream(q);
+    while s.advance() {
+        let t = s.token();
+        literal.push(UserInputAst::Leaf(Box::new(UserInputLeaf::Literal(
+            UserInputLiteral {
+                field_name: None,
+                phrase: t.text.clone(),
+                delimiter: Delimiter::None,
+                slop: 0,
+                prefix: false,
+            },
+        ))));
+    }
+
+    UserInputAst::Clause(
+        literal
+            .into_iter()
+            .map(|l| (Some(Occur::Should), l))
+            .collect(),
+    )
 }
 
 #[async_trait]
@@ -296,7 +328,8 @@ pub(crate) mod tests {
     use crate::{
         aggregation::write_to_json_string,
         generation::{
-            CandidateGeneration, Result as GenerationResult, text_search::FullTextSearch,
+            CandidateGeneration, Result as GenerationResult,
+            text_search::{FullTextSearch, parse_query_literal},
         },
     };
 
@@ -360,6 +393,16 @@ pub(crate) mod tests {
         index_writer.commit().expect("failed to commit documents");
 
         index
+    }
+
+    #[test]
+    fn test_parse_query_literal() {
+        insta::assert_json_snapshot!("and_conjunction", parse_query_literal("foo and bar"));
+        insta::assert_json_snapshot!("quotes_conjunction", parse_query_literal("'foo and' bar"));
+        insta::assert_json_snapshot!(
+            "special_characters",
+            parse_query_literal("title:sea^20 body:whale^70")
+        );
     }
 
     #[tokio::test]

--- a/crates/search/src/generation/text_search.rs
+++ b/crates/search/src/generation/text_search.rs
@@ -199,30 +199,35 @@ impl FullTextSearch {
 // A query, q, is interpreted as a space-delimited, OR-conjuncted set of string literals.
 //
 // Examples:
-//   - q="'foo and' bar" -> Returns any document containing at least one of ["foo", "and", "bar"].
+//  - q="'foo and' bar" -> ["foo", "and", "bar"]
+//  - q="title:sea^20 body:whale^70" -> ["title", "sea", "20", "body", "whale", "70"]
+//  - q="How much (in USD) don't I get?" -> ["how", "much", "in", "usd", "don", "t", "i", "get"]
 fn parse_query_literal(q: &str) -> UserInputAst {
     let mut literal = vec![];
     let mut tok = TextAnalyzer::builder(SimpleTokenizer::default())
         .filter(LowerCaser)
         .build();
+
     let mut s = tok.token_stream(q);
     while s.advance() {
-        let t = s.token();
-        literal.push(UserInputAst::Leaf(Box::new(UserInputLeaf::Literal(
-            UserInputLiteral {
-                field_name: None,
-                phrase: t.text.clone(),
-                delimiter: Delimiter::None,
-                slop: 0,
-                prefix: false,
-            },
-        ))));
+        literal.push(s.token().text.clone());
     }
 
     UserInputAst::Clause(
         literal
             .into_iter()
-            .map(|l| (Some(Occur::Should), l))
+            .map(|phrase| {
+                (
+                    Some(Occur::Should),
+                    UserInputAst::Leaf(Box::new(UserInputLeaf::Literal(UserInputLiteral {
+                        field_name: None,
+                        phrase,
+                        delimiter: Delimiter::None,
+                        slop: 0,
+                        prefix: false,
+                    }))),
+                )
+            })
             .collect(),
     )
 }
@@ -402,6 +407,10 @@ pub(crate) mod tests {
         insta::assert_json_snapshot!(
             "special_characters",
             parse_query_literal("title:sea^20 body:whale^70")
+        );
+        insta::assert_json_snapshot!(
+            "operators",
+            parse_query_literal("How much (in USD) don't I get?")
         );
     }
 


### PR DESCRIPTION
## 📝 Summary
 - Currently, full text search will match against documents the contain the full query string. 
 - This PR updates it so that it score against documents that contain any of the terms in the query string. Scoring will still be relative to term frequency etc. 
- Example
  - Before: "foo and bar" -> Match documents that contain the string "foo and bar".
  - After: "foo and bar" -> Match documents that contain at least one of "foo", "and", "bar".