### PR TITLE
fix: Glue catalog dispatch runner type

### DIFF
--- a/tools/testoperator/dispatch/tpch/sf1/federated/glue[catalog].yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/federated/glue[catalog].yaml
@@ -3,5 +3,5 @@ tests:
     spicepod_path: ./test/spicepods/tpch/sf1/federated/glue[catalog].yaml
     query_set: tpch
     query_overrides: glue-catalog
-    runner_type: spiceai-runners
+    runner_type: spiceai-dev-runners
     validate_results: true


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates the glue catalog dispatch file to run on `spiceai-dev-runners`, as `spiceai-runners` is not permitted.