### PR TITLE
fix: Apply results cache deprecation correctly

### DIFF
--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -182,7 +182,7 @@ impl RuntimeBuilder {
             caching_config.sql_results = Some(results_cache.into());
         }
 
-        let caching = Runtime::init_caching(self.app.as_ref().map(|app| &app.runtime.caching));
+        let caching = Runtime::init_caching(Some(&caching_config));
 
         let mut df_builder = DataFusion::builder(
             Arc::clone(&self.runtime_status),


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Ensures that the `caching_config` which has the results cache deprecation override applied to it, is correctly passed to the `Runtime::init_caching` during startup
