### PR TITLE
Fix regression in Parquet pushdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3384,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3407,7 +3407,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "futures",
  "log",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3452,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3476,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3530,12 +3530,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 
 [[package]]
 name = "datafusion-execution"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "dashmap",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "chrono",
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3645,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3669,7 +3669,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -3689,7 +3689,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3704,7 +3704,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "chrono",
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3791,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3861,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5c62f29d2c70c5331ff50015b67b5e1cafcd578#b5c62f29d2c70c5331ff50015b67b5e1cafcd578"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ea3a2aba98fb65443a52956db718aaae38f086cc#ea3a2aba98fb65443a52956db718aaae38f086cc"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,11 +186,11 @@ lto = "off"
 
 [patch.crates-io]
 
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b5c62f29d2c70c5331ff50015b67b5e1cafcd578" }            # spiceai-47
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5c62f29d2c70c5331ff50015b67b5e1cafcd578" }     # spiceai-47
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b5c62f29d2c70c5331ff50015b67b5e1cafcd578" } # spiceai-47
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b5c62f29d2c70c5331ff50015b67b5e1cafcd578" }  # spiceai-47
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b5c62f29d2c70c5331ff50015b67b5e1cafcd578" }       # spiceai-47
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ea3a2aba98fb65443a52956db718aaae38f086cc" }            # spiceai-47
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ea3a2aba98fb65443a52956db718aaae38f086cc" }     # spiceai-47
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "ea3a2aba98fb65443a52956db718aaae38f086cc" } # spiceai-47
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "ea3a2aba98fb65443a52956db718aaae38f086cc" }  # spiceai-47
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ea3a2aba98fb65443a52956db718aaae38f086cc" }       # spiceai-47
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9db74a4b360df6be1bb554c59a474a2fd4bfb7e9" }                      # spiceai-47
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "d2cfe4644286df7cad006c090174e475716cb8d8" } # spiceai


### PR DESCRIPTION
## 📝 Summary

Fixes a regression in Parquet filter pushdown that was introduced in DF 47 and subsequently fixed with this PR: https://github.com/apache/datafusion/pull/16086

I've cherry-picked the commit from that upstream PR into our fork.