### PR TITLE
Fix GetDbSchemas and GetTables schemas to fully adhere to the FlightSQL protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,8 +325,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bb018b6960c87fd9d025009820406f74e83281185a8bdcb44880d2aa5c9a87"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -346,8 +345,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44de76b51473aa888ecd6ad93ceb262fb8d40d1f1154a4df2f069b3590aa7575"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -360,8 +358,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ed77e22744475a9a53d00026cf8e166fe73cf42d89c4c4ae63607ee1cfcc3f"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -377,8 +374,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0391c96eb58bf7389171d1e103112d3fc3e5625ca6b372d606f2688f1ea4cce"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "bytes",
  "half",
@@ -388,8 +384,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39e1d774ece9292697fcbe06b5584401b26bd34be1bec25c33edae65c2420ff"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -409,8 +404,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9055c972a07bf12c2a827debfd34f88d3b93da1941d36e1d9fee85eebe38a12a"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -425,8 +419,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf75ac27a08c7f48b88e5c923f267e980f27070147ab74615ad85b5c5f90473d"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -437,8 +430,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91efc67a4f5a438833dd76ef674745c80f6f6b9a428a3b440cbfbf74e32867e6"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -464,8 +456,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a222f0d93772bd058d1268f4c28ea421a603d66f7979479048c429292fac7b2e"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -478,8 +469,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9085342bbca0f75e8cb70513c0807cc7351f1fbf5cb98192a67d5e3044acb033"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -513,8 +503,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2f1065a5cad7b9efa9e22ce5747ce826aa3855766755d4904535123ef431e7"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -526,8 +515,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3703a0e3e92d23c3f756df73d2dc9476873f873a76ae63ef9d3de17fda83b2d8"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -539,8 +527,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a47aa0c771b5381de2b7f16998d351a6f4eb839f1e13d48353e17e873d969b"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "bitflags 2.9.1",
  "serde",
@@ -549,8 +536,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b7b85575702b23b85272b01bc1c25a01c9b9852305e5d0078c79ba25d995d4"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -563,8 +549,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9260fddf1cdf2799ace2b4c2fc0356a9789fa7551e0953e35435536fecefebbd"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,3 +211,20 @@ cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40
 # Override candle-core v0.8.x to use matching cudarc version 0.12.2 to satisfy candle-cublaslt requirement
 candle-core = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d63f86cf819ad3dffe0fa796155a0" }  # spiceai-0.8.4-cudarc-0.12
 candle-metal-kernels = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d63f86cf819ad3dffe0fa796155a0" }  # spiceai-0.8.4-cudarc-0.12
+
+# Use patched arrow-rs 55.1 untill next release
+arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }        # spiceai-55.1
+arrow-flight = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
+arrow-arith = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }  # spiceai-55.1
+arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }  # spiceai-55.1
+arrow-buffer = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
+arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }   # spiceai-55.1
+arrow-csv = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }    # spiceai-55.1
+arrow-data = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }   # spiceai-55.1
+arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }    # spiceai-55.1
+arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }   # spiceai-55.1
+arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }    # spiceai-55.1
+arrow-row = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }    # spiceai-55.1
+arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
+arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
+arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1


### PR DESCRIPTION
## 📝 Summary

Switch to the patched `arrow-rs` version `55.1`, which includes the fix needed to fully adhere to the FlightSQL protocol and improve compatibility with clients and drivers such as [arrow-adbc](https://github.com/apache/arrow-adbc).

 - https://github.com/apache/arrow-rs/pull/7638

Patched version: https://github.com/spiceai/arrow-rs/tree/spiceai-55.1

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Alternative approach considered was manually modifying/patching returned by arrow-rs schema (FlightSQL implementation), selected current approach to avoid adding/removing unnecessary code and complexity
