### PR TITLE
Fix load status metric description

### DIFF
--- a/crates/runtime/src/metrics/catalogs/mod.rs
+++ b/crates/runtime/src/metrics/catalogs/mod.rs
@@ -28,6 +28,6 @@ pub(crate) static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
 pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     CATALOGS_METER
             .u64_gauge("catalog_load_state")
-            .with_description("Status of the catalog provider. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.")
+            .with_description("Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.")
             .build()
 });

--- a/crates/runtime/src/metrics/datasets/mod.rs
+++ b/crates/runtime/src/metrics/datasets/mod.rs
@@ -44,7 +44,7 @@ pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     DATASETS_METER
         .u64_gauge("dataset_load_state")
         .with_description(
-            "Status of the dataset. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            "Status of the dataset. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.",
         )
         .build()
 });

--- a/crates/runtime/src/metrics/embeddings/mod.rs
+++ b/crates/runtime/src/metrics/embeddings/mod.rs
@@ -36,7 +36,7 @@ pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     EMBEDDINGS_METER
         .u64_gauge("embeddings_load_state")
         .with_description(
-            "Status of the embedding. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            "Status of the embedding. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.",
         )
         .build()
 });

--- a/crates/runtime/src/metrics/llms/mod.rs
+++ b/crates/runtime/src/metrics/llms/mod.rs
@@ -22,7 +22,7 @@ pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     LLMS_METER
         .u64_gauge("llm_load_state")
         .with_description(
-            "Status of the LLM model. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            "Status of the LLM model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.",
         )
         .build()
 });

--- a/crates/runtime/src/metrics/models/mod.rs
+++ b/crates/runtime/src/metrics/models/mod.rs
@@ -44,7 +44,7 @@ pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     MODELS_METER
         .u64_gauge("model_load_state")
         .with_description(
-            "Status of the model. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            "Status of the model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.",
         )
         .build()
 });

--- a/crates/runtime/src/metrics/tools/mod.rs
+++ b/crates/runtime/src/metrics/tools/mod.rs
@@ -29,7 +29,7 @@ pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     TOOLS_METER
         .u64_gauge("tool_load_state")
         .with_description(
-            "Status of the LLM tools. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            "Status of the LLM tools. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.",
         )
         .build()
 });

--- a/crates/runtime/src/metrics/views/mod.rs
+++ b/crates/runtime/src/metrics/views/mod.rs
@@ -29,7 +29,7 @@ pub(crate) static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     VIEWS_METER
         .u64_gauge("view_load_state")
         .with_description(
-            "Status of the views. 1=Initializing, 2=Ready, 3=Disabled, 4=Error, 5=Refreshing.",
+            "Status of the views. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.",
         )
         .build()
 });

--- a/crates/runtime/src/status.rs
+++ b/crates/runtime/src/status.rs
@@ -34,22 +34,22 @@ use crate::metrics;
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum ComponentStatus {
     /// The component is initializing and not yet ready
-    Initializing,
+    Initializing = 0,
 
     /// The component is ready to accept connections
-    Ready,
+    Ready = 1,
 
     /// The component is disabled and not running
-    Disabled,
+    Disabled = 2,
 
     /// An error occurred in the component
-    Error,
+    Error = 3,
 
     /// The component is in the process of refreshing its state
-    Refreshing,
+    Refreshing = 4,
 
     /// The component is in the process of shutting down
-    ShuttingDown,
+    ShuttingDown = 5,
 }
 
 impl Display for ComponentStatus {


### PR DESCRIPTION
## 📝 Summary

Fixes the metric description for the various `load_status` metrics to be accurate. Previously they were off by one from the true values. I've also explicitly set the integer values on the `ComponentStatus` enum to make it obvious what the values are.
