### PR TITLE
New tool `parsley`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9183,6 +9183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "parsley"
+version = "1.4.0-unstable"
+dependencies = [
+ "bytes",
+ "clap",
+ "document_parse",
+ "llms",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9192,6 +9192,10 @@ dependencies = [
  "llms",
  "serde",
  "serde_json",
+ "spicepod",
+ "text-splitter",
+ "tiktoken-rs",
+ "tokenizers",
 ]
 
 [[package]]
@@ -13354,6 +13358,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.2.16",
+ "hf-hub 0.4.2",
  "indicatif",
  "itertools 0.13.0",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
     "tools/otelpublisher/",
     "tools/spicepodschema/",
     "tools/spiceschema",
-    "tools/testoperator",
+    "tools/testoperator", "tools/parsley",
 ]
 
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021

--- a/crates/document_parse/src/docx.rs
+++ b/crates/document_parse/src/docx.rs
@@ -43,6 +43,7 @@ impl DocumentParserFactory for DocxParserFactory {
 #[derive(Default)]
 pub struct DocxParser {}
 impl DocxParser {
+    #[must_use]
     pub fn new(_parser_options: &HashMap<String, String>) -> Self {
         DocxParser::default()
     }

--- a/crates/document_parse/src/lib.rs
+++ b/crates/document_parse/src/lib.rs
@@ -28,6 +28,8 @@ use tokio::sync::Mutex;
 
 mod docx;
 mod pdf;
+pub use docx::DocxParser;
+pub use pdf::PdfParser;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/document_parse/src/pdf.rs
+++ b/crates/document_parse/src/pdf.rs
@@ -41,6 +41,7 @@ impl DocumentParserFactory for PdfParserFactory {
 #[derive(Default)]
 pub struct PdfParser {}
 impl PdfParser {
+    #[must_use]
     pub fn new(_parser_options: &HashMap<String, String>) -> Self {
         PdfParser::default()
     }

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -41,15 +41,15 @@ text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "5
 pulldown-cmark = "0.13.0"
 tiktoken-rs = "0.6.0"
 
-mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "027c8da1a8fbd3a65bcf8e60d6e30264f41bc194" }
-mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "027c8da1a8fbd3a65bcf8e60d6e30264f41bc194", package = "mistralrs-core" }
+mistralrs = { git = "https://github.com/spiceai/mistral.rs", rev = "027c8da1a8fbd3a65bcf8e60d6e30264f41bc194" , optional = true}
+mistralrs-core = { git = "https://github.com/spiceai/mistral.rs", rev = "027c8da1a8fbd3a65bcf8e60d6e30264f41bc194", package = "mistralrs-core" , optional = true}
 rand = "0.9.1"
-tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
+tei_backend = { package = "text-embeddings-backend", git = "https://github.com/spiceai/text-embeddings-inference.git", optional = true, rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", features = [
     "candle",
 ] }
-tei_backend_core = { package = "text-embeddings-backend-core", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4" }
-tei_candle = { package = "text-embeddings-backend-candle", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4" }
-tei_core = { package = "text-embeddings-core", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4" }
+tei_backend_core = { package = "text-embeddings-backend-core", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", optional = true }
+tei_candle = { package = "text-embeddings-backend-candle", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", optional = true }
+tei_core = { package = "text-embeddings-core", git = "https://github.com/spiceai/text-embeddings-inference.git", rev = "a23f1aec8d53008a642cb632199d58d26fe88ae4", optional = true}
 
 cudarc = { version = "0.12.2", optional = true, features = [
     "cuda-version-from-build-system",
@@ -85,3 +85,14 @@ metal = [
     "mistralrs-core/metal",
     "mistralrs/metal",
 ]
+local_llm = [
+"dep:mistralrs", "dep:mistralrs-core"
+]
+local_embed = [
+"dep:tei_backend",
+"dep:tei_backend_core",
+"dep:tei_candle",
+"dep:tei_core",
+]
+
+default = ["local_llm", "local_embed"]

--- a/crates/llms/src/chunking/mod.rs
+++ b/crates/llms/src/chunking/mod.rs
@@ -104,7 +104,7 @@ impl From<Arc<dyn ChunkSizer + Send + Sync>> for ArcSizer {
 }
 
 /// Basic wrapper around a [`Arc<Tokenizer>`], so as to be able to `impl ChunkSizer for TokenizerWrapper`.
-pub(crate) struct TokenizerWrapper(Arc<Tokenizer>);
+pub struct TokenizerWrapper(Arc<Tokenizer>);
 
 impl ChunkSizer for TokenizerWrapper {
     fn size(&self, chunk: &str) -> usize {

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -92,6 +92,29 @@ pub enum ModelSource {
     Databricks,
 }
 
+impl ModelSource {
+    pub fn parse_from(&self, from: &str) -> Option<String> {
+        match self {
+            ModelSource::HuggingFace => HUGGINGFACE_PATH_REGEX.captures(from).map(|caps| {
+                let model = format!("{}/{}", &caps["org"], &caps["model"]);
+                if let Some(revision) = caps.name("revision") {
+                    format!("{}:{}", model, revision.as_str())
+                } else {
+                    model
+                }
+            }),
+            p => {
+                if let Some(stripped) = from.strip_prefix(&format!("{p}:")) {
+                    Some(stripped.to_string())
+                } else {
+                    from.strip_prefix(&format!("{p}/"))
+                        .map(std::string::ToString::to_string)
+                }
+            }
+        }
+    }
+}
+
 // Matches model paths in these formats:
 // - organization/model-name
 // - organization/model-name:revision
@@ -299,28 +322,7 @@ impl Model {
     ///    - Source: `gpt-4o`
     #[must_use]
     pub fn get_model_id(&self) -> Option<String> {
-        match self.get_source() {
-            Some(ModelSource::HuggingFace) => {
-                HUGGINGFACE_PATH_REGEX.captures(&self.from).map(|caps| {
-                    let model = format!("{}/{}", &caps["org"], &caps["model"]);
-                    if let Some(revision) = caps.name("revision") {
-                        format!("{}:{}", model, revision.as_str())
-                    } else {
-                        model
-                    }
-                })
-            }
-            Some(p) => {
-                let from = &self.from;
-                if let Some(stripped) = from.strip_prefix(&format!("{p}:")) {
-                    Some(stripped.to_string())
-                } else {
-                    from.strip_prefix(&format!("{p}/"))
-                        .map(std::string::ToString::to_string)
-                }
-            }
-            None => None,
-        }
+        self.get_source()?.parse_from(self.from.as_str())
     }
 
     /// Attempts to determine the model's type based on its `from` field and, `files` and `params`.

--- a/tools/parsley/Cargo.toml
+++ b/tools/parsley/Cargo.toml
@@ -15,3 +15,12 @@ document_parse = { path = "../../crates/document_parse" }
 llms = { path = "../../crates/llms", features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+spicepod = { path = "../../crates/spicepod" }
+text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "58f9c21006e01e5e968c5de80a0398b3f5ec439a", features = [
+    "markdown",
+    "tokenizers",
+    "tiktoken-rs",
+] }
+tiktoken-rs = "0.6.0"
+tokenizers = { version = "0.21.0", features = ["http"] }

--- a/tools/parsley/Cargo.toml
+++ b/tools/parsley/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "parsley"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+bytes.workspace = true
+clap = { version = "4.5", features = ["derive"] }
+document_parse = { path = "../../crates/document_parse" }
+llms = { path = "../../crates/llms", features = [] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/tools/parsley/src/main.rs
+++ b/tools/parsley/src/main.rs
@@ -15,10 +15,13 @@ limitations under the License.
 */
 use bytes::Bytes;
 use clap::Parser;
+use spicepod::component::model::ModelSource;
 use std::{path::PathBuf, str::from_utf8, sync::Arc};
+use tiktoken_rs::{get_bpe_from_tokenizer, tokenizer::get_tokenizer};
+use tokenizers::Tokenizer;
 
 use document_parse::{DocumentParser, DocxParser, PdfParser};
-use llms::chunking::{Chunker, ChunkingConfig, RecursiveSplittingChunker};
+use llms::chunking::{Chunker, ChunkingConfig, RecursiveSplittingChunker, TokenizerWrapper};
 
 use crate::output::StructuredOutput;
 
@@ -48,6 +51,10 @@ pub struct Args {
     /// If set, return the parsed document within a JSON structure.
     #[arg(long, help = "Output in JSON format")]
     json: bool,
+
+    /// The name of the embedding model to use when sizing tokens during chunking.
+    #[arg(long)]
+    pub model: Option<String>,
 }
 
 impl Args {
@@ -59,20 +66,56 @@ impl Args {
         }
     }
 
-    fn chunker(&self) -> Option<Arc<dyn Chunker>> {
+    fn chunker(&self) -> Result<Option<Arc<dyn Chunker>>, String> {
         if self.target_chunk_size == 0 && self.overlap_size == 0 && !self.trim_whitespace {
-            return None;
+            return Ok(None);
         };
-        // TODO use openai or tokenizer sizer.
-        let chunker = RecursiveSplittingChunker::with_character_sizer(&ChunkingConfig {
+        let cfg = ChunkingConfig {
             target_chunk_size: self.target_chunk_size,
             trim_whitespace: self.trim_whitespace,
             overlap_size: self.overlap_size,
             file_format: self.file.extension().and_then(|s| s.to_str()),
-        })
-        .unwrap();
+        };
 
-        Some(Arc::new(chunker))
+        // From user-provided `model`, ensure it's in valid `from: ` spicepod format and get chunker for OpenAI or HF models.
+        let source_and_model_id: Option<(Result<ModelSource, &str>, Option<String>)> = self
+            .model
+            .as_ref()
+            .map(|from| match ModelSource::try_from(from.as_str()) {
+                Ok(source) => (Ok(source.clone()), source.parse_from(from.as_str())),
+                Err(e) => (Err(e), None),
+            });
+
+        let chunker: Arc<dyn Chunker> = match source_and_model_id {
+            Some((Ok(ModelSource::HuggingFace), Some(model_id))) => {
+                let sizer = TokenizerWrapper::from(Arc::new(
+                    Tokenizer::from_pretrained(model_id, None).map_err(|e| e.to_string())?,
+                ));
+                Arc::new(
+                    RecursiveSplittingChunker::try_new(&cfg, sizer).map_err(|e| e.to_string())?,
+                )
+            }
+            Some((Ok(ModelSource::OpenAi), Some(model_id))) => {
+                let Some(tok) = get_tokenizer(model_id.as_str()) else {
+                    return Err(format!(
+                        "Could not get tokenizer for OpenAI model: '{model_id}'"
+                    ));
+                };
+                let bpe = get_bpe_from_tokenizer(tok)
+                    .map_err(|e| format!("Could not create BPE tokenizer: {e:?}"))?;
+                Arc::new(RecursiveSplittingChunker::try_new(&cfg, bpe).map_err(|e| e.to_string())?)
+            }
+            None => Arc::new(
+                RecursiveSplittingChunker::with_character_sizer(&cfg).map_err(|e| e.to_string())?,
+            ),
+            Some((Ok(model_source), _)) => {
+                return Err(format!(
+                    "Cannot specify model from '{model_source}' as source of tokenizer"
+                ));
+            }
+            Some((Err(e), _)) => return Err(e.to_string()),
+        };
+        Ok(Some(chunker))
     }
 }
 
@@ -118,13 +161,19 @@ fn main() {
         }
     };
 
-    let result = if let Some(chunker) = args.chunker() {
-        StructuredOutput::from_chunks(
+    let result = match args.chunker() {
+        Ok(Some(chunker)) => StructuredOutput::from_chunks(
             args.file.to_string_lossy(),
             chunker.chunks(content.as_str()).collect(),
-        )
-    } else {
-        StructuredOutput::from_content(args.file.to_string_lossy(), content.as_str())
+        ),
+        Ok(None) => StructuredOutput::from_content(args.file.to_string_lossy(), content.as_str()),
+        Err(e) => {
+            eprintln!(
+                "Error preparing tokenizer model '{}' for use in chunking. Error: {e}",
+                args.model.unwrap_or_default()
+            );
+            return;
+        }
     };
 
     // Output dependent on return type.

--- a/tools/parsley/src/main.rs
+++ b/tools/parsley/src/main.rs
@@ -69,7 +69,7 @@ impl Args {
     fn chunker(&self) -> Result<Option<Arc<dyn Chunker>>, String> {
         if self.target_chunk_size == 0 && self.overlap_size == 0 && !self.trim_whitespace {
             return Ok(None);
-        };
+        }
         let cfg = ChunkingConfig {
             target_chunk_size: self.target_chunk_size,
             trim_whitespace: self.trim_whitespace,
@@ -182,10 +182,9 @@ fn main() {
             Ok(s) => println!("{s}"),
             Err(e) => {
                 eprintln!("Cannot parse output to JSON: {e}");
-                return;
             }
         }
     } else {
-        println!("{result}")
+        println!("{result}");
     }
 }

--- a/tools/parsley/src/main.rs
+++ b/tools/parsley/src/main.rs
@@ -1,0 +1,142 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use bytes::Bytes;
+use clap::Parser;
+use std::{path::PathBuf, str::from_utf8, sync::Arc};
+
+use document_parse::{DocumentParser, DocxParser, PdfParser};
+use llms::chunking::{Chunker, ChunkingConfig, RecursiveSplittingChunker};
+
+use crate::output::StructuredOutput;
+
+mod output;
+
+/// Parses and chunks documents in the same manner used internally to Spice.
+///
+/// Helpful for debugging `spiced`, or optimising various configurations for your spicepod dataset.
+#[derive(Parser)]
+pub struct Args {
+    /// Filepath of the document to consider.
+    #[arg(long)]
+    pub file: PathBuf,
+
+    /// The desired size of each chunk, in tokens.
+    #[arg(long, default_value_t = 0)]
+    pub target_chunk_size: usize,
+
+    /// The amount of overlap between chunks, in tokens.
+    #[arg(long, default_value_t = 0)]
+    pub overlap_size: usize,
+
+    /// Whether to trim the chunks to remove leading and trailing whitespace.
+    #[arg(long, default_value_t = false)]
+    pub trim_whitespace: bool,
+
+    /// If set, return the parsed document within a JSON structure.
+    #[arg(long, help = "Output in JSON format")]
+    json: bool,
+}
+
+impl Args {
+    fn parser(&self) -> Option<Arc<dyn DocumentParser>> {
+        match self.file.extension().and_then(|s| s.to_str())? {
+            "pdf" => Some(Arc::new(PdfParser::default())),
+            "docx" => Some(Arc::new(DocxParser::default())),
+            _ => None,
+        }
+    }
+
+    fn chunker(&self) -> Option<Arc<dyn Chunker>> {
+        if self.target_chunk_size == 0 && self.overlap_size == 0 && !self.trim_whitespace {
+            return None;
+        };
+        // TODO use openai or tokenizer sizer.
+        let chunker = RecursiveSplittingChunker::with_character_sizer(&ChunkingConfig {
+            target_chunk_size: self.target_chunk_size,
+            trim_whitespace: self.trim_whitespace,
+            overlap_size: self.overlap_size,
+            file_format: self.file.extension().and_then(|s| s.to_str()),
+        })
+        .unwrap();
+
+        Some(Arc::new(chunker))
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+
+    // Get raw content.
+    let bytz: Bytes = match std::fs::read(&args.file) {
+        Ok(b) => b.into(),
+        Err(e) => {
+            eprintln!(
+                "Could not load file '{}'. Error: {}",
+                args.file.display(),
+                e
+            );
+            return;
+        }
+    };
+
+    // Convert to Utf8 string content. Either use parser, or interpret as raw UTF8.
+    let content = if let Some(parser) = args.parser() {
+        match parser.parse(&bytz) {
+            Ok(doc) => match doc.as_flat_utf8() {
+                Ok(content) => content,
+                Err(e) => {
+                    eprintln!("File could not be parsed into UTF8 correctly: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                eprintln!("File could not be parsed correctly: {e}");
+                return;
+            }
+        }
+    } else {
+        let z: Vec<_> = bytz.into();
+        match from_utf8(z.as_slice()) {
+            Ok(s) => s.to_string(),
+            Err(e) => {
+                eprintln!("File could not be parsed into UTF8 correctly: {e}");
+                return;
+            }
+        }
+    };
+
+    let result = if let Some(chunker) = args.chunker() {
+        StructuredOutput::from_chunks(
+            args.file.to_string_lossy(),
+            chunker.chunks(content.as_str()).collect(),
+        )
+    } else {
+        StructuredOutput::from_content(args.file.to_string_lossy(), content.as_str())
+    };
+
+    // Output dependent on return type.
+    if args.json {
+        match serde_json::to_string(&result) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("Cannot parse output to JSON: {e}");
+                return;
+            }
+        }
+    } else {
+        println!("{result}")
+    }
+}

--- a/tools/parsley/src/output.rs
+++ b/tools/parsley/src/output.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for StructuredOutput<'_> {
                 }
             }
             OutputContent::Full(content) => f.write_fmt(format_args!("{content}---\n"))?,
-        };
+        }
         Ok(())
     }
 }

--- a/tools/parsley/src/output.rs
+++ b/tools/parsley/src/output.rs
@@ -1,0 +1,60 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+pub struct StructuredOutput<'a> {
+    path: String,
+    content: OutputContent<'a>,
+}
+
+impl<'a> StructuredOutput<'a> {
+    pub fn from_chunks(path: impl Into<String>, chunks: Vec<&'a str>) -> Self {
+        StructuredOutput {
+            path: path.into(),
+            content: OutputContent::Chunks(chunks),
+        }
+    }
+
+    pub fn from_content(path: impl Into<String>, content: &'a str) -> Self {
+        StructuredOutput {
+            path: path.into(),
+            content: OutputContent::Full(content),
+        }
+    }
+}
+
+impl std::fmt::Display for StructuredOutput<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("---\nfile: {}\n---\n", self.path))?;
+        match &self.content {
+            OutputContent::Chunks(chnks) => {
+                for c in chnks {
+                    f.write_fmt(format_args!("{c}---\n"))?;
+                }
+            }
+            OutputContent::Full(content) => f.write_fmt(format_args!("{content}---\n"))?,
+        };
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum OutputContent<'a> {
+    Full(&'a str),
+    Chunks(Vec<&'a str>),
+}


### PR DESCRIPTION
## 📝 Summary
```bash
>> ./parsely --help

Parses and chunks documents in the same manner used internally to Spice

Usage: parsley [OPTIONS] --file <FILE>

Options:
      --file <FILE>                            Filepath of the document to consider
      --target-chunk-size <TARGET_CHUNK_SIZE>  The desired size of each chunk, in tokens [default: 0]
      --overlap-size <OVERLAP_SIZE>            The amount of overlap between chunks, in tokens [default: 0]
      --trim-whitespace                        Whether to trim the chunks to remove leading and trailing whitespace
      --json                                   Output in JSON format
  -h, --help                                   Print help (see more with '--help')
```

Easy to read
```bash
>>> ./parsely ./tools/parsley/Cargo.toml --target-chunk-size 128
---
file: /Users/jeadie/Github/spiceai/tools/parsley/Cargo.toml
---
[package]
edition.workspace = true
exclude.workspace = true
homepage.workspace = true
license.workspace = true
name = "parsley"
---
repository.workspace = true
rust-version.workspace = true
version.workspace = true

---
[dependencies]
bytes.workspace = true
clap = { version = "4.5", features = ["derive"] }
---
document_parse = { path = "../../crates/document_parse" }
llms = { path = "../../crates/llms", features = [] }
---
serde = { version = "1.0", features = ["derive"] }
serde_json = "1.0"
---
```

Or JSON structured results
```bash
>>> ./parsely ./tools/parsley/Cargo.toml --target-chunk-size 128 --json 
```
```json
{
  "path": "/Users/jeadie/Github/spiceai/tools/parsley/Cargo.toml",
  "content": [
    "[package]\nedition.workspace = true\nexclude.workspace = true\nhomepage.workspace = true\nlicense.workspace = true\nname = \"parsley\"\n",
    "repository.workspace = true\nrust-version.workspace = true\nversion.workspace = true\n\n",
    "[dependencies]\nbytes.workspace = true\nclap = { version = \"4.5\", features = [\"derive\"] }\n",
    "document_parse = { path = \"../../crates/document_parse\" }\nllms = { path = \"../../crates/llms\", features = [] }\n",
    "serde = { version = \"1.0\", features = [\"derive\"] }\nserde_json = \"1.0\"\n"
  ]
}
```

And supports for the tokenizer used in embedding models 
```bash
>>> ./parsely ./tools/parsley/Cargo.toml \
    --target-chunk-size 128 \
    --model huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
```
## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
