### PR TITLE
chore: Update testoperator release target to 1.4

### DIFF
--- a/.github/workflows/testoperator_dispatch.yml
+++ b/.github/workflows/testoperator_dispatch.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         branch:
           - 'trunk'
-          - 'release/1.3'
+          - 'release/1.4'
     concurrency:
       group: testoperator-dispatch-scheduled
       cancel-in-progress: false


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates the testoperator dispatch target to run on `release/1.4`, instead of `release/1.3`, with the new release.