### PR TITLE
fix glue iceberg catalog integration test

### DIFF
--- a/crates/runtime/tests/iceberg/catalog/mod.rs
+++ b/crates/runtime/tests/iceberg/catalog/mod.rs
@@ -64,7 +64,7 @@ async fn glue_iceberg_integration_test_catalog() -> Result<(), anyhow::Error> {
 
             tokio::select! {
                 // `params.include` not supported and full catalog is loaded: https://github.com/spiceai/spiceai/issues/5314
-                () = tokio::time::sleep(std::time::Duration::from_secs(600)) => {
+                () = tokio::time::sleep(std::time::Duration::from_secs(1200)) => {
                     panic!("Timeout waiting for components to load");
                 }
                 () = cloned_rt.load_components() => {}


### PR DESCRIPTION
## 📝 Summary

Further bump the `glue_iceberg_integration_test_catalog` timeout, catalog loading is slow as test tables are in the Seoul AWS region and include param is not supported.

Successful run: https://github.com/spiceai/spiceai/actions/runs/15689015320

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

The test could potentially use internal iceberg tables if we don't want to test glue iceberg specifically.
