### PR TITLE
For Spice.ai connectors, do not default to dev SCP for dev builds

### DIFF
--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -117,7 +117,7 @@ impl SpiceCloudPlatformCatalog {
             .params
             .get("http_endpoint")
             .expose()
-            .unwrap_or_else(|_| "https://spiceai.io".into());
+            .unwrap_or_else(|_| "https://data.spiceai.io");
 
         let mut props = HashMap::new();
         if let ExposedParamLookup::Present(api_key) = self.params.get("api_key").expose() {

--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -117,7 +117,13 @@ impl SpiceCloudPlatformCatalog {
             .params
             .get("http_endpoint")
             .expose()
-            .unwrap_or_else(|_| "https://data.spiceai.io");
+            .unwrap_or_else(|_| {
+                if cfg!(feature = "dev") {
+                    "https://dev.spiceai.io".into()
+                } else {
+                    "https://spiceai.io".into()
+                }
+            });
 
         let mut props = HashMap::new();
         if let ExposedParamLookup::Present(api_key) = self.params.get("api_key").expose() {

--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -117,13 +117,7 @@ impl SpiceCloudPlatformCatalog {
             .params
             .get("http_endpoint")
             .expose()
-            .unwrap_or_else(|_| {
-                if cfg!(feature = "dev") {
-                    "https://dev.spiceai.io".into()
-                } else {
-                    "https://spiceai.io".into()
-                }
-            });
+            .unwrap_or_else(|_| "https://spiceai.io".into());
 
         let mut props = HashMap::new();
         if let ExposedParamLookup::Present(api_key) = self.params.get("api_key").expose() {

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -176,7 +176,8 @@ impl DataConnectorFactory for SpiceAIFactory {
                 .get("endpoint")
                 .expose()
                 .ok()
-                .map_or("https://flight.spiceai.io", Into::into);
+                .unwrap_or("https://flight.spiceai.io")
+                .into();
             tracing::trace!("Connecting to SpiceAI with flight url: {url}");
 
             verify_endpoint_connection(&url).await.with_context(|_| {

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -170,18 +170,13 @@ impl DataConnectorFactory for SpiceAIFactory {
         &self,
         params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
-        let default_flight_url: Arc<str> = if cfg!(feature = "dev") {
-            "https://dev-flight.spiceai.io".into()
-        } else {
-            "https://flight.spiceai.io".into()
-        };
         Box::pin(async move {
             let url: Arc<str> = params
                 .parameters
                 .get("endpoint")
                 .expose()
                 .ok()
-                .map_or(default_flight_url, Into::into);
+                .map_or("https://flight.spiceai.io", Into::into);
             tracing::trace!("Connecting to SpiceAI with flight url: {url}");
 
             verify_endpoint_connection(&url).await.with_context(|_| {


### PR DESCRIPTION
## 📝 Summary
For dev builds (`cfg!(feature="dev")`), Spice.AI connectors (catalog and dataconnector) currently point to dev by default. We no longer want this.