### PR TITLE
Improve error message for incorrect/missing Glue table or database

### DIFF
--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -51,7 +51,7 @@ static PREFIX: &str = "glue";
 #[derive(Debug, Snafu)]
 enum Error {
     #[snafu(display(
-        "Unable to get the table `{table}` from database `{database}`. Do the database and table exist?"
+        "Could not retrieve table '{table}' from database '{database}'. Verify that both the database and table exist and are accessible."
     ))]
     GetTable { database: String, table: String },
     #[snafu(display("Unable to load the AWS configuration.\n{source}"))]

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -30,6 +30,7 @@ use iceberg_catalog_glue::{
     GlueCatalogConfig,
 };
 use iceberg_datafusion::IcebergTableProvider;
+use snafu::prelude::*;
 
 use crate::{
     component::dataset::Dataset,
@@ -46,6 +47,16 @@ use super::{
 };
 
 static PREFIX: &str = "glue";
+
+#[derive(Debug, Snafu)]
+enum Error {
+    #[snafu(display(
+        "Unable to get the table `{table}` from database `{database}`. Do the database and table exist?"
+    ))]
+    GetTable { database: String, table: String },
+    #[snafu(display("Unable to load the AWS configuration.\n{source}"))]
+    AWSConfig { source: aws::Error },
+}
 
 #[derive(Clone, Debug)]
 pub struct GlueDataConnector {
@@ -140,7 +151,7 @@ impl DataConnector for GlueDataConnector {
             super::DataConnectorError::UnableToConnectInternal {
                 dataconnector: PREFIX.to_string(),
                 connector_component: dataset.into(),
-                source: e.into(),
+                source: Box::new(Error::AWSConfig { source: e }),
             }
         })?;
 
@@ -152,10 +163,13 @@ impl DataConnector for GlueDataConnector {
             .name(table)
             .send()
             .await
-            .map_err(|e| super::DataConnectorError::UnableToConnectInternal {
+            .map_err(|_| super::DataConnectorError::UnableToConnectInternal {
                 dataconnector: PREFIX.to_string(),
                 connector_component: dataset.into(),
-                source: e.into(),
+                source: Box::new(Error::GetTable {
+                    database: database.to_string(),
+                    table: table.to_string(),
+                }),
             })?;
 
         let table =
@@ -251,7 +265,7 @@ async fn create_iceberg_provider(
             .ok_or_else(|| super::DataConnectorError::InvalidConfigurationNoSource {
                 dataconnector: PREFIX.to_string(),
                 connector_component: dataset.into(),
-                message: "no region specified".to_string(),
+                message: "No AWS region specified. Add `glue_region` to the spicepod.".to_string(),
             })?;
 
     let credentials = config


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->
Fixed poor error message when Glue dataset specifies an incorrect or missing table or database.

```shell
2025-06-17T17:12:13.306206Z  WARN runtime::init::dataset: Cannot connect to the dataset does_not_exist (glue).
Unable to get the table `bad_table` from database `bad_db`. Do the database and table exist?
```
## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->
Closes:
- #6251 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
