### PR TITLE
Upgrade delta_kernel to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,9 +3933,9 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
 name = "delta_kernel"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547318d6ee083b99d0e1daef01c3873b8c9e2f832bbbf1c5fa2f248051046cbf"
+checksum = "de0b553d03fce69da6bedd91ec7e2348d52af2783a95d2dc91970df0cb614783"
 dependencies = [
  "arrow",
  "bytes",
@@ -3962,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "delta_kernel_derive"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acac3d1b207020f0754cbc827c1d71fb342b78bcf8ab0a8e3cf79d264f22d54"
+checksum = "deacb882456b0a3e7a5bf22a708190758cc8f572e02cd34954931e24286a4509"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ datafusion-expr = "47"
 datafusion-federation = { version = "0.4.2", features = ["sql"] }
 datafusion-functions-json = "0.47"
 datafusion-table-providers = "0.1"
-delta_kernel = { version = "0.11", features = ["default-engine", "arrow-55"] }
+delta_kernel = { version = "0.12", features = ["default-engine", "arrow-55"] }
 dotenvy = "0.15"
 duckdb = "1.1.3"
 fundu = "2.0.1"

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -44,7 +44,7 @@ use delta_kernel::engine::default::DefaultEngine;
 use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::expressions::{BinaryExpressionOp, DecimalData, Expression, Scalar};
 use delta_kernel::scan::ScanBuilder;
-use delta_kernel::scan::state::{DvInfo, GlobalScanState, Stats};
+use delta_kernel::scan::state::{DvInfo, Stats};
 use delta_kernel::schema::{DecimalType, PrimitiveType};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::{ExpressionRef, Predicate};
@@ -374,9 +374,9 @@ impl TableProvider for DeltaTable {
                 let scan = scan_builder
                     .build()
                     .map_err(map_delta_error_to_datafusion_err)?;
-                let scan_state = scan.global_scan_state();
 
-                let mut scan_context = ScanContext::new(scan_state, Arc::clone(&engine));
+                let table_root = scan.table_root();
+                let mut scan_context = ScanContext::new(Arc::clone(&engine), table_root.clone());
 
                 let scan_iter = scan
                     .scan_metadata(engine.as_ref())
@@ -523,20 +523,17 @@ impl TableProvider for DeltaTable {
 struct ScanContext {
     pub errs: Vec<datafusion::error::DataFusionError>,
     engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
-    scan_state: GlobalScanState,
     pub files: Vec<PartitionFileContext>,
+    table_root: Url,
 }
 
 impl ScanContext {
-    fn new(
-        scan_state: GlobalScanState,
-        engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
-    ) -> Self {
+    fn new(engine: Arc<DefaultEngine<TokioBackgroundExecutor>>, table_root: Url) -> Self {
         Self {
-            scan_state,
             engine,
             errs: Vec::new(),
             files: Vec::new(),
+            table_root,
         }
     }
 }
@@ -586,17 +583,7 @@ fn handle_scan_file(
     transform: Option<ExpressionRef>,
     partition_values: HashMap<String, String>,
 ) {
-    let root_url = match Url::parse(&scan_context.scan_state.table_root) {
-        Ok(url) => url,
-        Err(e) => {
-            scan_context
-                .errs
-                .push(datafusion::error::DataFusionError::Execution(format!(
-                    "Error parsing table root URL: {e}",
-                )));
-            return;
-        }
-    };
+    let root_url = &scan_context.table_root;
 
     let path = if root_url.path().ends_with('/') {
         format!("{}{}", root_url.path(), path)
@@ -630,7 +617,7 @@ fn handle_scan_file(
 
     // Get the selection vector (i.e. inverse deletion vector)
     let selection_vector =
-        match dv_info.get_selection_vector(scan_context.engine.as_ref(), &root_url) {
+        match dv_info.get_selection_vector(scan_context.engine.as_ref(), root_url) {
             Ok(selection_vector) => selection_vector,
             Err(e) => {
                 scan_context


### PR DESCRIPTION
## 📝 Summary

Upgrades `delta_kernel` to `0.12.1`.

See https://github.com/delta-io/delta-kernel-rs/blob/main/CHANGELOG.md for changes.

> ## [v0.12.1](https://github.com/delta-io/delta-kernel-rs/tree/v0.12.1/) (2025-06-05)
> 
> [Full Changelog](https://github.com/delta-io/delta-kernel-rs/compare/v0.12.0...v0.12.1)
> 
> 
> ### 🐛 Bug Fixes
> 
> 1. Remove azure suffix range request ([#1006])
> 
> 
> [#1006]: https://github.com/delta-io/delta-kernel-rs/pull/1006
> 
> 
> ## [v0.12.0](https://github.com/delta-io/delta-kernel-rs/tree/v0.12.0/) (2025-06-04)
> 
> [Full Changelog](https://github.com/delta-io/delta-kernel-rs/compare/v0.11.0...v0.12.0)
> 
> ### 🏗️ Breaking changes
> 1. Remove `GlobalScanState`: instead use new `Scan` APIs directly (`logical_schema`, `physical_schema`, etc.) ([#947])
> 2. table feature enums are now `internal_api` (not public, unless `internal-api` flag is set) ([#998])
> 
> ### 🚀 Features / new APIs
> 
> 1. Use compacted log files in log-replay ([#950])
> 2. New `#[derive(IntoEngineData)]` proc macro ([#830])
> 3. Add support for kernel default expression evaluation ([#979])
> 4. **New: panic in debug builds if ListedLogFiles breaks invariants** ([#986])
> 5. Create visitor for getting In-commit Timestamp ([#897])
> 6. Binary searching utility function for timestamp to version conversion ([#896])
> 7. Enable "TimestampWithoutTimezone" table feature and add protocol validation for it ([#988])
> 8. add missing reader/writer features (variantType/clustered) ([#998])
> 
> ### 🐛 Bug Fixes
> 
> 1. Disable timestamp column's `maxValues` for data skipping ([#1003])
> 
> ### 🚜 Refactor
> 
> 1. Make KernelPredicateEvaluator trait dyn-compatible ([#994])
> 
> 
> [#950]: https://github.com/delta-io/delta-kernel-rs/pull/950
> [#830]: https://github.com/delta-io/delta-kernel-rs/pull/830
> [#979]: https://github.com/delta-io/delta-kernel-rs/pull/979
> [#994]: https://github.com/delta-io/delta-kernel-rs/pull/994
> [#986]: https://github.com/delta-io/delta-kernel-rs/pull/986
> [#897]: https://github.com/delta-io/delta-kernel-rs/pull/897
> [#896]: https://github.com/delta-io/delta-kernel-rs/pull/896
> [#988]: https://github.com/delta-io/delta-kernel-rs/pull/988
> [#947]: https://github.com/delta-io/delta-kernel-rs/pull/947
> [#1003]: https://github.com/delta-io/delta-kernel-rs/pull/1003
> [#998]: https://github.com/delta-io/delta-kernel-rs/pull/998
