### PR TITLE
Add truncate UDF

### DIFF
--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -22,11 +22,13 @@ use crate::embeddings::cosine_distance::CosineDistance;
 
 pub mod alias;
 pub mod bucket;
+pub mod truncate;
 
 pub fn register_udfs(ctx: &SessionContext) {
     ctx.register_udf(CosineDistance::new().into());
     ctx.register_udf(alias::ScalarUDFAlias::new(Arc::new(RandomFunc::default()), "rand").into());
     ctx.register_udf(bucket::Bucket::new().into());
+    ctx.register_udf(truncate::Truncate::new().into());
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -17,7 +17,8 @@ limitations under the License.
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, Decimal128Array, Decimal256Array, Int32Array, Int64Array, StringArray,
+    ArrayRef, Decimal128Array, Decimal256Array, Int8Array, Int16Array, Int32Array, Int64Array,
+    StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::compute::binary;
 use arrow::compute::kernels::substring::{substring, substring_by_char};
@@ -46,7 +47,7 @@ pub enum TruncateError {
     InvalidArgumentCount { count: usize },
 
     #[snafu(display(
-        "Second argument must be Int32, Int64, Decimal128, Utf8, or Binary, got {value}"
+        "Second argument must be Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Decimal128, Decimal256, Utf8, or Binary, got {value}"
     ))]
     InvalidSecondArgType { value: ColumnarValue },
 }
@@ -72,11 +73,6 @@ impl Truncate {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            // We cannot match all the exact combinations because we want to
-            // support DataType::Decimal128(precision, scale) and
-            // DataType::Decimal256(precision, scale) which has (obviously)
-            // many combinations of precision and scale. We will have to
-            // validate argument datatypes at runtime.
             signature: Signature::any(2, Volatility::Immutable),
         }
     }
@@ -138,7 +134,9 @@ impl ScalarUDFImpl for Truncate {
             | DataType::UInt32
             | DataType::UInt64
             | DataType::Decimal128(_, _)
-            | DataType::Decimal256(_, _) => Ok(arg_types[1].clone()),
+            | DataType::Decimal256(_, _)
+            | DataType::Utf8
+            | DataType::Binary => Ok(arg_types[1].clone()),
             _ => Err(TruncateError::InvalidSecondArgType {
                 value: ColumnarValue::Scalar(ScalarValue::try_from(&arg_types[1])?),
             }
@@ -173,6 +171,16 @@ fn compute_truncate_scalar(
     }
 
     match scalar {
+        ScalarValue::Int8(Some(v)) => {
+            let width = width as i8;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int8(Some(result)))
+        }
+        ScalarValue::Int16(Some(v)) => {
+            let width = width as i16;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int16(Some(result)))
+        }
         ScalarValue::Int32(Some(v)) => {
             let width = width as i32;
             let result = v - (((v % width) + width) % width);
@@ -181,6 +189,26 @@ fn compute_truncate_scalar(
         ScalarValue::Int64(Some(v)) => {
             let result = v - (((v % width) + width) % width);
             Ok(ScalarValue::Int64(Some(result)))
+        }
+        ScalarValue::UInt8(Some(v)) => {
+            let width = width as u8;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::UInt8(Some(result)))
+        }
+        ScalarValue::UInt16(Some(v)) => {
+            let width = width as u16;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::UInt16(Some(result)))
+        }
+        ScalarValue::UInt32(Some(v)) => {
+            let width = width as u32;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::UInt32(Some(result)))
+        }
+        ScalarValue::UInt64(Some(v)) => {
+            let width = width as u64;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::UInt64(Some(result)))
         }
         ScalarValue::Decimal128(Some(v), p, s) => {
             let width = width as i128;
@@ -211,6 +239,30 @@ fn compute_truncate_scalar(
 
 fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
     match array.data_type() {
+        DataType::Int8 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .expect("cast success");
+            let width = width as i8;
+            let width_array = Int8Array::from_value(width, array.len());
+            let result: Int8Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
+        DataType::Int16 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .expect("cast success");
+            let width = width as i16;
+            let width_array = Int16Array::from_value(width, array.len());
+            let result: Int16Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
         DataType::Int32 => {
             let casted_array = array
                 .as_any()
@@ -230,6 +282,54 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
                 .expect("cast success");
             let width_array = Int64Array::from_value(width, array.len());
             let result: Int64Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
+        DataType::UInt8 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .expect("cast success");
+            let width = width as u8;
+            let width_array = UInt8Array::from_value(width, array.len());
+            let result: UInt8Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
+        DataType::UInt16 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .expect("cast success");
+            let width = width as u16;
+            let width_array = UInt16Array::from_value(width, array.len());
+            let result: UInt16Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
+        DataType::UInt32 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .expect("cast success");
+            let width = width as u32;
+            let width_array = UInt32Array::from_value(width, array.len());
+            let result: UInt32Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
+        DataType::UInt64 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("cast success");
+            let width = width as u64;
+            let width_array = UInt64Array::from_value(width, array.len());
+            let result: UInt64Array =
                 binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
                     .map_err(|e| DataFusionError::ArrowError(e, None))?;
             Ok(Arc::new(result))
@@ -282,9 +382,70 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
 mod tests {
     use super::*;
     use arrow::array::{
-        Array as _, BinaryArray, Decimal128Array, Int32Array, Int64Array, StringArray,
+        Array as _, BinaryArray, Decimal128Array, Int8Array, Int16Array, Int32Array, Int64Array,
+        StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
     };
     use datafusion::arrow::datatypes::DataType;
+
+    #[test]
+    fn test_truncate_int8_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
+                ColumnarValue::Array(Arc::new(Int8Array::from(vec![101, -1, 0]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Int8,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .expect("downcast to Int8Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(int_array.value(0), 100, "Expected truncate(10, 101) = 100");
+            assert_eq!(int_array.value(1), -10, "Expected truncate(10, -1) = -10");
+            assert_eq!(int_array.value(2), 0, "Expected truncate(10, 0) = 0");
+        } else {
+            panic!("Expected Int8 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_int16_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ColumnarValue::Array(Arc::new(Int16Array::from(vec![1234, -567, 99]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Int16,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .expect("downcast to Int16Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1200,
+                "Expected truncate(100, 1234) = 1200"
+            );
+            assert_eq!(
+                int_array.value(1),
+                -600,
+                "Expected truncate(100, -567) = -600"
+            );
+            assert_eq!(int_array.value(2), 0, "Expected truncate(100, 99) = 0");
+        } else {
+            panic!("Expected Int16 array");
+        }
+    }
 
     #[test]
     fn test_truncate_int32_array() {
@@ -302,13 +463,13 @@ mod tests {
             let int_array = array
                 .as_any()
                 .downcast_ref::<Int32Array>()
-                .expect("downcast to Int64Array");
+                .expect("downcast to Int32Array");
             assert_eq!(int_array.len(), 3);
             assert_eq!(int_array.value(0), 100, "Expected truncate(10, 101) = 100");
             assert_eq!(int_array.value(1), -10, "Expected truncate(10, -1) = -10");
             assert_eq!(int_array.value(2), 0, "Expected truncate(10, 0) = 0");
         } else {
-            panic!("Expected Int64 array");
+            panic!("Expected Int32 array");
         }
     }
 
@@ -343,6 +504,130 @@ mod tests {
             assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
         } else {
             panic!("Expected Int64 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_uint8_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
+                ColumnarValue::Array(Arc::new(UInt8Array::from(vec![101, 1, 0]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::UInt8,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .expect("downcast to UInt8Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(int_array.value(0), 100, "Expected truncate(10, 101) = 100");
+            assert_eq!(int_array.value(1), 0, "Expected truncate(10, 1) = 0");
+            assert_eq!(int_array.value(2), 0, "Expected truncate(10, 0) = 0");
+        } else {
+            panic!("Expected UInt8 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_uint16_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ColumnarValue::Array(Arc::new(UInt16Array::from(vec![1234, 567, 99]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::UInt16,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .expect("downcast to UInt16Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1200,
+                "Expected truncate(100, 1234) = 1200"
+            );
+            assert_eq!(int_array.value(1), 500, "Expected truncate(100, 567) = 500");
+            assert_eq!(int_array.value(2), 0, "Expected truncate(100, 99) = 0");
+        } else {
+            panic!("Expected UInt16 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_uint32_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
+                ColumnarValue::Array(Arc::new(UInt32Array::from(vec![1234, 5678, 999]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::UInt32,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .expect("downcast to UInt32Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1000,
+                "Expected truncate(1000, 1234) = 1000"
+            );
+            assert_eq!(
+                int_array.value(1),
+                5000,
+                "Expected truncate(1000, 5678) = 5000"
+            );
+            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
+        } else {
+            panic!("Expected UInt32 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_uint64_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
+                ColumnarValue::Array(Arc::new(UInt64Array::from(vec![1234, 5678, 999]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::UInt64,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("downcast to UInt64Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1000,
+                "Expected truncate(1000, 1234) = 1000"
+            );
+            assert_eq!(
+                int_array.value(1),
+                5000,
+                "Expected truncate(1000, 5678) = 5000"
+            );
+            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
+        } else {
+            panic!("Expected UInt64 array");
         }
     }
 

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -29,6 +29,7 @@ use datafusion::logical_expr::{
 };
 use datafusion::scalar::ScalarValue;
 use snafu::{Snafu, ensure};
+use tract_core::num_traits::Num;
 
 /// Maximum truncation width or length, chosen to prevent overflow or excessive memory usage.
 const MAX_TRUNCATE_WIDTH: i64 = i64::MAX / 2;
@@ -171,47 +172,47 @@ fn compute_truncate_scalar(
 
     match scalar {
         ScalarValue::Int8(Some(v)) => {
-            let width = width as i8;
-            let result = v - (((v % width) + width) % width);
+            let w = width as i8;
+            let result = truncate_numeric(v, w);
             Ok(ScalarValue::Int8(Some(result)))
         }
         ScalarValue::Int16(Some(v)) => {
-            let width = width as i16;
-            let result = v - (((v % width) + width) % width);
+            let w = width as i16;
+            let result = truncate_numeric(v, w);
             Ok(ScalarValue::Int16(Some(result)))
         }
         ScalarValue::Int32(Some(v)) => {
-            let width = width as i32;
-            let result = v - (((v % width) + width) % width);
+            let w = width as i32;
+            let result = truncate_numeric(v, w);
             Ok(ScalarValue::Int32(Some(result)))
         }
         ScalarValue::Int64(Some(v)) => {
-            let result = v - (((v % width) + width) % width);
+            let result = truncate_numeric(v, width);
             Ok(ScalarValue::Int64(Some(result)))
         }
         ScalarValue::UInt8(Some(v)) => {
-            let width = width as u8;
-            let result = v - (((v % width) + width) % width);
+            let w = width as u8;
+            let result = truncate_numeric(v, w);
             Ok(ScalarValue::UInt8(Some(result)))
         }
         ScalarValue::UInt16(Some(v)) => {
-            let width = width as u16;
-            let result = v - (((v % width) + width) % width);
+            let w = width as u16;
+            let result = truncate_numeric(v, w);
             Ok(ScalarValue::UInt16(Some(result)))
         }
         ScalarValue::UInt32(Some(v)) => {
-            let width = width as u32;
-            let result = v - (((v % width) + width) % width);
+            let w = width as u32;
+            let result = truncate_numeric(v, w);
             Ok(ScalarValue::UInt32(Some(result)))
         }
         ScalarValue::UInt64(Some(v)) => {
-            let width = width as u64;
-            let result = v - (((v % width) + width) % width);
+            let w = width as u64;
+            let result = truncate_numeric(v, w);
             Ok(ScalarValue::UInt64(Some(result)))
         }
         ScalarValue::Decimal128(Some(v), p, s) => {
-            let width = width as i128;
-            let result = v - (((v % width) + width) % width);
+            let w = width as i128;
+            let result = truncate_numeric(v, w);
             Ok(ScalarValue::Decimal128(Some(result), p, s))
         }
         ScalarValue::Decimal256(Some(v), p, s) => {
@@ -236,13 +237,16 @@ fn compute_truncate_scalar(
     }
 }
 
+fn truncate_numeric<T: Num + Copy>(v: T, w: T) -> T {
+    v - (((v % w) + w) % w)
+}
+
 fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
     match array.data_type() {
         DataType::Int8 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<Int8Array>()
-                .expect("cast success");
+            let casted_array = array.as_any().downcast_ref::<Int8Array>().ok_or_else(|| {
+                DataFusionError::Internal("Failed to downcast to Int8Array".into())
+            })?;
             let width = width as i8;
             let width_array = Int8Array::from_value(width, array.len());
             let result: Int8Array =
@@ -251,10 +255,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             Ok(Arc::new(result))
         }
         DataType::Int16 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<Int16Array>()
-                .expect("cast success");
+            let casted_array = array.as_any().downcast_ref::<Int16Array>().ok_or_else(|| {
+                DataFusionError::Internal("Failed to downcast to Int16Array".into())
+            })?;
             let width = width as i16;
             let width_array = Int16Array::from_value(width, array.len());
             let result: Int16Array =
@@ -263,10 +266,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             Ok(Arc::new(result))
         }
         DataType::Int32 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .expect("cast success");
+            let casted_array = array.as_any().downcast_ref::<Int32Array>().ok_or_else(|| {
+                DataFusionError::Internal("Failed to downcast to Int32Array".into())
+            })?;
             let width = width as i32;
             let width_array = Int32Array::from_value(width, array.len());
             let result: Int32Array =
@@ -275,10 +277,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             Ok(Arc::new(result))
         }
         DataType::Int64 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .expect("cast success");
+            let casted_array = array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
+                DataFusionError::Internal("Failed to downcast to Int64Array".into())
+            })?;
             let width_array = Int64Array::from_value(width, array.len());
             let result: Int64Array =
                 binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
@@ -286,10 +287,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             Ok(Arc::new(result))
         }
         DataType::UInt8 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<UInt8Array>()
-                .expect("cast success");
+            let casted_array = array.as_any().downcast_ref::<UInt8Array>().ok_or_else(|| {
+                DataFusionError::Internal("Failed to downcast to UInt8Array".into())
+            })?;
             let width = width as u8;
             let width_array = UInt8Array::from_value(width, array.len());
             let result: UInt8Array =
@@ -301,7 +301,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             let casted_array = array
                 .as_any()
                 .downcast_ref::<UInt16Array>()
-                .expect("cast success");
+                .ok_or_else(|| {
+                    DataFusionError::Internal("Failed to downcast to UInt16Array".into())
+                })?;
             let width = width as u16;
             let width_array = UInt16Array::from_value(width, array.len());
             let result: UInt16Array =
@@ -313,7 +315,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             let casted_array = array
                 .as_any()
                 .downcast_ref::<UInt32Array>()
-                .expect("cast success");
+                .ok_or_else(|| {
+                    DataFusionError::Internal("Failed to downcast to UInt32Array".into())
+                })?;
             let width = width as u32;
             let width_array = UInt32Array::from_value(width, array.len());
             let result: UInt32Array =
@@ -325,7 +329,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             let casted_array = array
                 .as_any()
                 .downcast_ref::<UInt64Array>()
-                .expect("cast success");
+                .ok_or_else(|| {
+                    DataFusionError::Internal("Failed to downcast to UInt64Array".into())
+                })?;
             let width = width as u64;
             let width_array = UInt64Array::from_value(width, array.len());
             let result: UInt64Array =
@@ -337,7 +343,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             let casted_array = array
                 .as_any()
                 .downcast_ref::<Decimal128Array>()
-                .expect("cast success");
+                .ok_or_else(|| {
+                    DataFusionError::Internal("Failed to downcast to Decimal128Array".into())
+                })?;
             let width = width as i128;
             let width_array = Decimal128Array::from_value(width, array.len());
             let result: Decimal128Array =
@@ -349,7 +357,9 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             let casted_array = array
                 .as_any()
                 .downcast_ref::<Decimal256Array>()
-                .expect("cast success");
+                .ok_or_else(|| {
+                    DataFusionError::Internal("Failed to downcast to Decimal256Array".into())
+                })?;
             let width = i256::from_i128(width as i128);
             let width_array = Decimal256Array::from_value(width, array.len());
             let result: Decimal256Array =
@@ -364,7 +374,12 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             Ok(result)
         }
         DataType::Utf8 => {
-            let casted_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| {
+                    DataFusionError::Internal("Failed to downcast to StringArray".into())
+                })?;
             let width = width as u64;
             let result = substring_by_char(casted_array, 0, Some(width))
                 .map_err(|e| DataFusionError::ArrowError(e, None))?;

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -31,7 +31,7 @@ use datafusion::scalar::ScalarValue;
 use snafu::{Snafu, ensure};
 use tract_core::num_traits::Num;
 
-/// Maximum truncation width or length, chosen to prevent overflow or excessive memory usage.
+// Maximum truncation width or length, chosen to prevent overflow or excessive memory usage.
 const MAX_TRUNCATE_WIDTH: i64 = i64::MAX / 2;
 
 #[derive(Debug, Snafu)]
@@ -166,6 +166,42 @@ impl ScalarUDFImpl for Truncate {
     }
 }
 
+macro_rules! truncate_numeric_scalar {
+    ($SCALAR:expr, $WIDTH:expr, $TYPE:ty, $SCALAR_TYPE:ident) => {
+        match $SCALAR {
+            ScalarValue::$SCALAR_TYPE(Some(v)) => {
+                let w = $WIDTH as $TYPE;
+                let result = truncate_numeric(v, w);
+                Ok(ScalarValue::$SCALAR_TYPE(Some(result)))
+            }
+            _ => Err(TruncateError::InvalidSecondArgType {
+                data_type: $SCALAR.data_type(),
+            }
+            .into()),
+        }
+    };
+}
+
+macro_rules! truncate_numeric_array {
+    ($ARRAY:expr, $WIDTH:expr, $ARRAY_TYPE:ty, $SCALAR_TYPE:ty) => {{
+        let casted_array = $ARRAY
+            .as_any()
+            .downcast_ref::<$ARRAY_TYPE>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "Failed to downcast to {}",
+                    stringify!($ARRAY_TYPE)
+                ))
+            })?;
+        let width = $WIDTH as $SCALAR_TYPE;
+        let width_array = <$ARRAY_TYPE>::from_value(width, $ARRAY.len());
+        let result: $ARRAY_TYPE =
+            binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                .map_err(|e| DataFusionError::ArrowError(e, None))?;
+        Ok(Arc::new(result) as ArrayRef)
+    }};
+}
+
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn compute_truncate_scalar(
     scalar: ScalarValue,
@@ -176,45 +212,14 @@ fn compute_truncate_scalar(
     }
 
     match scalar {
-        ScalarValue::Int8(Some(v)) => {
-            let w = width as i8;
-            let result = truncate_numeric(v, w);
-            Ok(ScalarValue::Int8(Some(result)))
-        }
-        ScalarValue::Int16(Some(v)) => {
-            let w = width as i16;
-            let result = truncate_numeric(v, w);
-            Ok(ScalarValue::Int16(Some(result)))
-        }
-        ScalarValue::Int32(Some(v)) => {
-            let w = width as i32;
-            let result = truncate_numeric(v, w);
-            Ok(ScalarValue::Int32(Some(result)))
-        }
-        ScalarValue::Int64(Some(v)) => {
-            let result = truncate_numeric(v, width);
-            Ok(ScalarValue::Int64(Some(result)))
-        }
-        ScalarValue::UInt8(Some(v)) => {
-            let w = width as u8;
-            let result = truncate_numeric(v, w);
-            Ok(ScalarValue::UInt8(Some(result)))
-        }
-        ScalarValue::UInt16(Some(v)) => {
-            let w = width as u16;
-            let result = truncate_numeric(v, w);
-            Ok(ScalarValue::UInt16(Some(result)))
-        }
-        ScalarValue::UInt32(Some(v)) => {
-            let w = width as u32;
-            let result = truncate_numeric(v, w);
-            Ok(ScalarValue::UInt32(Some(result)))
-        }
-        ScalarValue::UInt64(Some(v)) => {
-            let w = width as u64;
-            let result = truncate_numeric(v, w);
-            Ok(ScalarValue::UInt64(Some(result)))
-        }
+        ScalarValue::Int8(_) => truncate_numeric_scalar!(scalar, width, i8, Int8),
+        ScalarValue::Int16(_) => truncate_numeric_scalar!(scalar, width, i16, Int16),
+        ScalarValue::Int32(_) => truncate_numeric_scalar!(scalar, width, i32, Int32),
+        ScalarValue::Int64(_) => truncate_numeric_scalar!(scalar, width, i64, Int64),
+        ScalarValue::UInt8(_) => truncate_numeric_scalar!(scalar, width, u8, UInt8),
+        ScalarValue::UInt16(_) => truncate_numeric_scalar!(scalar, width, u16, UInt16),
+        ScalarValue::UInt32(_) => truncate_numeric_scalar!(scalar, width, u32, UInt32),
+        ScalarValue::UInt64(_) => truncate_numeric_scalar!(scalar, width, u64, UInt64),
         ScalarValue::Decimal128(Some(v), p, s) => {
             let w = i128::from(width);
             let result = truncate_numeric(v, w);
@@ -252,102 +257,14 @@ fn truncate_numeric<T: Num + Copy>(v: T, w: T) -> T {
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
     match array.data_type() {
-        DataType::Int8 => {
-            let casted_array = array.as_any().downcast_ref::<Int8Array>().ok_or_else(|| {
-                DataFusionError::Internal("Failed to downcast to Int8Array".into())
-            })?;
-            let width = width as i8;
-            let width_array = Int8Array::from_value(width, array.len());
-            let result: Int8Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
-        DataType::Int16 => {
-            let casted_array = array.as_any().downcast_ref::<Int16Array>().ok_or_else(|| {
-                DataFusionError::Internal("Failed to downcast to Int16Array".into())
-            })?;
-            let width = width as i16;
-            let width_array = Int16Array::from_value(width, array.len());
-            let result: Int16Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
-        DataType::Int32 => {
-            let casted_array = array.as_any().downcast_ref::<Int32Array>().ok_or_else(|| {
-                DataFusionError::Internal("Failed to downcast to Int32Array".into())
-            })?;
-            let width = width as i32;
-            let width_array = Int32Array::from_value(width, array.len());
-            let result: Int32Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
-        DataType::Int64 => {
-            let casted_array = array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
-                DataFusionError::Internal("Failed to downcast to Int64Array".into())
-            })?;
-            let width_array = Int64Array::from_value(width, array.len());
-            let result: Int64Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
-        DataType::UInt8 => {
-            let casted_array = array.as_any().downcast_ref::<UInt8Array>().ok_or_else(|| {
-                DataFusionError::Internal("Failed to downcast to UInt8Array".into())
-            })?;
-            let width = width as u8;
-            let width_array = UInt8Array::from_value(width, array.len());
-            let result: UInt8Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
-        DataType::UInt16 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<UInt16Array>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal("Failed to downcast to UInt16Array".into())
-                })?;
-            let width = width as u16;
-            let width_array = UInt16Array::from_value(width, array.len());
-            let result: UInt16Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
-        DataType::UInt32 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<UInt32Array>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal("Failed to downcast to UInt32Array".into())
-                })?;
-            let width = width as u32;
-            let width_array = UInt32Array::from_value(width, array.len());
-            let result: UInt32Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
-        DataType::UInt64 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .ok_or_else(|| {
-                    DataFusionError::Internal("Failed to downcast to UInt64Array".into())
-                })?;
-            let width = width as u64;
-            let width_array = UInt64Array::from_value(width, array.len());
-            let result: UInt64Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
+        DataType::Int8 => truncate_numeric_array!(array, width, Int8Array, i8),
+        DataType::Int16 => truncate_numeric_array!(array, width, Int16Array, i16),
+        DataType::Int32 => truncate_numeric_array!(array, width, Int32Array, i32),
+        DataType::Int64 => truncate_numeric_array!(array, width, Int64Array, i64),
+        DataType::UInt8 => truncate_numeric_array!(array, width, UInt8Array, u8),
+        DataType::UInt16 => truncate_numeric_array!(array, width, UInt16Array, u16),
+        DataType::UInt32 => truncate_numeric_array!(array, width, UInt32Array, u32),
+        DataType::UInt64 => truncate_numeric_array!(array, width, UInt64Array, u64),
         DataType::Decimal128(_, _) => {
             let casted_array = array
                 .as_any()

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -181,7 +181,7 @@ macro_rules! truncate_numeric_array {
                     stringify!($ARRAY_TYPE)
                 ))
             })?;
-        let width = $WIDTH as $SCALAR_TYPE;
+        let width: $SCALAR_TYPE = $WIDTH.try_into().context(WidthCastingFailedSnafu)?;
         let width_array = <$ARRAY_TYPE>::from_value(width, $ARRAY.len());
         let result: $ARRAY_TYPE =
             binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
@@ -221,13 +221,13 @@ fn compute_truncate_scalar(
             Ok(ScalarValue::Decimal256(Some(result), p, s))
         }
         ScalarValue::Utf8(Some(mut v)) => {
-            let width = width as usize;
-            v.truncate(width);
+            let new_len = usize::try_from(width).context(WidthCastingFailedSnafu)?;
+            v.truncate(new_len);
             Ok(ScalarValue::Utf8(Some(v)))
         }
         ScalarValue::Binary(Some(v)) => {
-            let width = width as usize;
-            let truncated = v.iter().take(width).copied().collect::<Vec<u8>>();
+            let n = usize::try_from(width).context(WidthCastingFailedSnafu)?;
+            let truncated = v.iter().take(n).copied().collect::<Vec<u8>>();
             Ok(ScalarValue::Binary(Some(truncated)))
         }
         _ => Err(TruncateError::InvalidSecondArgType {
@@ -250,7 +250,16 @@ fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, Data
         DataType::Int8 => truncate_numeric_array!(array, width, Int8Array, i8),
         DataType::Int16 => truncate_numeric_array!(array, width, Int16Array, i16),
         DataType::Int32 => truncate_numeric_array!(array, width, Int32Array, i32),
-        DataType::Int64 => truncate_numeric_array!(array, width, Int64Array, i64),
+        DataType::Int64 => {
+            let casted_array = array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
+                DataFusionError::Internal("Failed to downcast to Int64Array".into())
+            })?;
+            let width_array = Int64Array::from_value(width, array.len());
+            let result: Int64Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result) as ArrayRef)
+        }
         DataType::UInt8 => truncate_numeric_array!(array, width, UInt8Array, u8),
         DataType::UInt16 => truncate_numeric_array!(array, width, UInt16Array, u16),
         DataType::UInt32 => truncate_numeric_array!(array, width, UInt32Array, u32),
@@ -284,8 +293,8 @@ fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, Data
             Ok(Arc::new(result))
         }
         DataType::Binary => {
-            let width = width as u64;
-            let result = substring(&array, 0, Some(width))
+            let length = u64::try_from(width).context(WidthCastingFailedSnafu)?;
+            let result = substring(&array, 0, Some(length))
                 .map_err(|e| DataFusionError::ArrowError(e, None))?;
             Ok(result)
         }
@@ -296,8 +305,8 @@ fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, Data
                 .ok_or_else(|| {
                     DataFusionError::Internal("Failed to downcast to StringArray".into())
                 })?;
-            let width = width as u64;
-            let result = substring_by_char(casted_array, 0, Some(width))
+            let length = u64::try_from(width).context(WidthCastingFailedSnafu)?;
+            let result = substring_by_char(casted_array, 0, Some(length))
                 .map_err(|e| DataFusionError::ArrowError(e, None))?;
             Ok(Arc::new(result))
         }

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -179,98 +179,33 @@ fn compute_truncate_scalar(
     width: i64,
 ) -> Result<ScalarValue, DataFusionError> {
     if scalar.is_null() {
-        return match scalar {
-            ScalarValue::Int8(_) => Ok(ScalarValue::Int8(None)),
-            ScalarValue::Int16(_) => Ok(ScalarValue::Int16(None)),
-            ScalarValue::Int32(_) => Ok(ScalarValue::Int32(None)),
-            ScalarValue::Int64(_) => Ok(ScalarValue::Int64(None)),
-            ScalarValue::UInt8(_) => Ok(ScalarValue::UInt8(None)),
-            ScalarValue::UInt16(_) => Ok(ScalarValue::UInt16(None)),
-            ScalarValue::UInt32(_) => Ok(ScalarValue::UInt32(None)),
-            ScalarValue::UInt64(_) => Ok(ScalarValue::UInt64(None)),
-            ScalarValue::Float32(_) => Ok(ScalarValue::Float32(None)),
-            ScalarValue::Float64(_) => Ok(ScalarValue::Float64(None)),
-            ScalarValue::Utf8(_) => Ok(ScalarValue::Utf8(None)),
-            ScalarValue::Binary(_) => Ok(ScalarValue::Binary(None)),
-            _ => Err(TruncateError::InvalidSecondArgType {
-                value: ColumnarValue::Scalar(scalar.clone()),
-            }
-            .into()),
-        };
+        return Ok(scalar.clone());
     }
 
     match scalar {
-        ScalarValue::Int8(Some(v)) => {
-            let v = i64::from(*v);
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::Int8(Some(result.try_into().map_err(
-                |_| DataFusionError::Execution(format!("Value out of range for Int8: {}", result)),
-            )?)))
-        }
-        ScalarValue::Int16(Some(v)) => {
-            let v = i64::from(*v);
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::Int16(Some(result.try_into().map_err(
-                |_| DataFusionError::Execution(format!("Value out of range for Int16: {}", result)),
-            )?)))
-        }
-        ScalarValue::Int32(Some(v)) => {
-            let v = i64::from(*v);
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::Int32(Some(result.try_into().map_err(
-                |_| DataFusionError::Execution(format!("Value out of range for Int32: {}", result)),
-            )?)))
-        }
-        ScalarValue::Int64(Some(v)) => {
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::Int64(Some(result)))
-        }
-        ScalarValue::UInt8(Some(v)) => {
-            let v = i64::from(*v);
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::UInt8(Some(result.try_into().map_err(
-                |_| DataFusionError::Execution(format!("Value out of range for UInt8: {}", result)),
-            )?)))
-        }
-        ScalarValue::UInt16(Some(v)) => {
-            let v = i64::from(*v);
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::UInt16(Some(result.try_into().map_err(
-                |_| {
-                    DataFusionError::Execution(format!("Value out of range for UInt16: {}", result))
-                },
-            )?)))
-        }
-        ScalarValue::UInt32(Some(v)) => {
-            let v = i64::from(*v);
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::UInt32(Some(result.try_into().map_err(
-                |_| {
-                    DataFusionError::Execution(format!("Value out of range for UInt32: {}", result))
-                },
-            )?)))
-        }
+        ScalarValue::Int8(Some(v)) => Ok(ScalarValue::Int8(Some(truncate_numeric(*v, width)?))),
+        ScalarValue::Int16(Some(v)) => Ok(ScalarValue::Int16(Some(truncate_numeric(*v, width)?))),
+        ScalarValue::Int32(Some(v)) => Ok(ScalarValue::Int32(Some(truncate_numeric(*v, width)?))),
+        ScalarValue::Int64(Some(v)) => Ok(ScalarValue::Int64(Some(truncate_numeric(*v, width)?))),
+        ScalarValue::UInt8(Some(v)) => Ok(ScalarValue::UInt8(Some(truncate_numeric(*v, width)?))),
+        ScalarValue::UInt16(Some(v)) => Ok(ScalarValue::UInt16(Some(truncate_numeric(*v, width)?))),
+        ScalarValue::UInt32(Some(v)) => Ok(ScalarValue::UInt32(Some(truncate_numeric(*v, width)?))),
         ScalarValue::UInt64(Some(v)) => {
             let v = i64::try_from(*v).map_err(|_| {
-                DataFusionError::Execution(format!("Value too large for Int64: {}", v))
+                DataFusionError::Execution(format!("Value too large for Int64: {v}"))
             })?;
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::UInt64(Some(result.try_into().map_err(
-                |_| {
-                    DataFusionError::Execution(format!("Value out of range for UInt64: {}", result))
-                },
-            )?)))
+            Ok(ScalarValue::UInt64(
+                Some(truncate_numeric(v, width)? as u64),
+            ))
         }
-        ScalarValue::Float32(Some(v)) => {
-            let v = v.floor() as i64;
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::Float32(Some(result as f32)))
-        }
-        ScalarValue::Float64(Some(v)) => {
-            let v = v.floor() as i64;
-            let result = v - (((v % width) + width) % width);
-            Ok(ScalarValue::Float64(Some(result as f64)))
-        }
+        ScalarValue::Float32(Some(v)) => Ok(ScalarValue::Float32(Some(truncate_numeric(
+            v.floor() as i64,
+            width,
+        )? as f32))),
+        ScalarValue::Float64(Some(v)) => Ok(ScalarValue::Float64(Some(truncate_numeric(
+            v.floor() as i64,
+            width,
+        )? as f64))),
         ScalarValue::Utf8(Some(v)) => Ok(ScalarValue::Utf8(Some(
             v.chars().take(width as usize).collect::<String>(),
         ))),
@@ -283,6 +218,14 @@ fn compute_truncate_scalar(
         }
         .into()),
     }
+}
+
+fn truncate_numeric<T: Into<i64> + TryFrom<i64>>(v: T, width: i64) -> Result<T, DataFusionError> {
+    let v = v.into();
+    let result = v - (((v % width) + width) % width);
+    result
+        .try_into()
+        .map_err(|_| DataFusionError::Execution(format!("Value out of range: {result}")))
 }
 
 fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -84,18 +84,22 @@ impl Truncate {
         if args.len() != 2 {
             return Err(TruncateError::InvalidArgumentCount { count: args.len() });
         }
-        if let (ColumnarValue::Scalar(ScalarValue::Int64(Some(width))), arg) =
-            (args[0].clone(), args[1].clone())
-        {
-            ensure!(
-                width > 0 && width <= MAX_TRUNCATE_WIDTH,
-                InvalidWidthValueSnafu { width }
-            );
-            Ok((width, arg))
-        } else {
-            Err(TruncateError::InvalidWidthDataType {
-                width_datatype: args[0].data_type(),
-            })
+
+        let count = args.len();
+        let mut args = args.into_iter();
+        match (args.next(), args.next()) {
+            (Some(ColumnarValue::Scalar(ScalarValue::Int64(Some(width)))), Some(arg)) => {
+                ensure!(
+                    width > 0 && width <= MAX_TRUNCATE_WIDTH,
+                    InvalidWidthValueSnafu { width }
+                );
+                Ok((width, arg))
+            }
+            (Some(width), Some(_)) => {
+                let width_datatype = width.data_type();
+                Err(TruncateError::InvalidWidthDataType { width_datatype })
+            }
+            _ => Err(TruncateError::InvalidArgumentCount { count }),
         }
     }
 }
@@ -155,13 +159,14 @@ impl ScalarUDFImpl for Truncate {
                 Ok(ColumnarValue::Scalar(result))
             }
             ColumnarValue::Array(array) => {
-                let result = compute_truncate_array(array, width)?;
+                let result = compute_truncate_array(&array, width)?;
                 Ok(ColumnarValue::Array(result))
             }
         }
     }
 }
 
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn compute_truncate_scalar(
     scalar: ScalarValue,
     width: i64,
@@ -211,12 +216,12 @@ fn compute_truncate_scalar(
             Ok(ScalarValue::UInt64(Some(result)))
         }
         ScalarValue::Decimal128(Some(v), p, s) => {
-            let w = width as i128;
+            let w = i128::from(width);
             let result = truncate_numeric(v, w);
             Ok(ScalarValue::Decimal128(Some(result), p, s))
         }
         ScalarValue::Decimal256(Some(v), p, s) => {
-            let width = i256::from_i128(width as i128);
+            let width = i256::from_i128(i128::from(width));
             let result = v - (((v % width) + width) % width);
             Ok(ScalarValue::Decimal256(Some(result), p, s))
         }
@@ -238,10 +243,14 @@ fn compute_truncate_scalar(
 }
 
 fn truncate_numeric<T: Num + Copy>(v: T, w: T) -> T {
+    if w == T::zero() {
+        return v;
+    }
     v - (((v % w) + w) % w)
 }
 
-fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
     match array.data_type() {
         DataType::Int8 => {
             let casted_array = array.as_any().downcast_ref::<Int8Array>().ok_or_else(|| {
@@ -346,7 +355,7 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
                 .ok_or_else(|| {
                     DataFusionError::Internal("Failed to downcast to Decimal128Array".into())
                 })?;
-            let width = width as i128;
+            let width = i128::from(width);
             let width_array = Decimal128Array::from_value(width, array.len());
             let result: Decimal128Array =
                 binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
@@ -360,7 +369,7 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
                 .ok_or_else(|| {
                     DataFusionError::Internal("Failed to downcast to Decimal256Array".into())
                 })?;
-            let width = i256::from_i128(width as i128);
+            let width = i256::from_i128(i128::from(width));
             let width_array = Decimal256Array::from_value(width, array.len());
             let result: Decimal256Array =
                 binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -751,4 +751,42 @@ mod tests {
             "Expected error for invalid second argument type"
         );
     }
+
+    #[test]
+    fn test_truncate_scalar_int64() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1234))),
+            ],
+            number_rows: 1,
+            return_type: &DataType::Int64,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Scalar(ScalarValue::Int64(Some(value))) = result {
+            assert_eq!(value, 1000, "Expected truncate(1000, 1234) = 1000");
+        } else {
+            panic!("Expected Int64 scalar");
+        }
+    }
+
+    #[test]
+    fn test_truncate_scalar_utf8() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(3))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("iceberg".to_string()))),
+            ],
+            number_rows: 1,
+            return_type: &DataType::Utf8,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(value))) = result {
+            assert_eq!(value, "ice", "Expected truncate(3, 'iceberg') = 'ice'");
+        } else {
+            panic!("Expected Utf8 scalar");
+        }
+    }
 }

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -47,9 +47,9 @@ pub enum TruncateError {
     InvalidArgumentCount { count: usize },
 
     #[snafu(display(
-        "Second argument must be Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Decimal128, Decimal256, Utf8, or Binary, got {value}"
+        "Second argument must be Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Decimal128, Decimal256, Utf8, or Binary, got {data_type}"
     ))]
-    InvalidSecondArgType { value: ColumnarValue },
+    InvalidSecondArgType { data_type: DataType },
 }
 
 impl From<TruncateError> for DataFusionError {
@@ -138,7 +138,7 @@ impl ScalarUDFImpl for Truncate {
             | DataType::Utf8
             | DataType::Binary => Ok(arg_types[1].clone()),
             _ => Err(TruncateError::InvalidSecondArgType {
-                value: ColumnarValue::Scalar(ScalarValue::try_from(&arg_types[1])?),
+                data_type: arg_types[1].clone(),
             }
             .into()),
         }
@@ -231,7 +231,7 @@ fn compute_truncate_scalar(
             Ok(ScalarValue::Binary(Some(truncated)))
         }
         _ => Err(TruncateError::InvalidSecondArgType {
-            value: ColumnarValue::Scalar(scalar.clone()),
+            data_type: scalar.data_type(),
         }
         .into()),
     }
@@ -372,7 +372,7 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
             Ok(Arc::new(result))
         }
         _ => Err(TruncateError::InvalidSecondArgType {
-            value: ColumnarValue::Array(array),
+            data_type: array.data_type().clone(),
         }
         .into()),
     }

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -142,26 +142,33 @@ impl ScalarUDFImpl for Truncate {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {
         let args = args.args;
-        if args.len() != 2 {
-            tracing::debug!("Invalid argument count: {}", args.len());
-            return Err(TruncateError::InvalidArgumentCount { count: args.len() }.into());
-        }
+        let count = args.len();
+        let mut args_iter = args.into_iter();
+        let (first, second) = match (args_iter.next(), args_iter.next(), args_iter.next()) {
+            (Some(first), Some(second), None) => (first, second),
+            _ => {
+                tracing::error!("Invalid argument count: expected 2, got {count}");
+                return Err(TruncateError::InvalidArgumentCount { count }.into());
+            }
+        };
 
-        let width = match &args[0] {
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(w))) => {
-                if *w <= 0 || *w > MAX_TRUNCATE_WIDTH {
-                    return Err(TruncateError::InvalidWidth { width: *w }.into());
-                }
-                *w
+        let width = if let ColumnarValue::Scalar(ScalarValue::Int64(Some(w))) = &first {
+            if *w <= 0 || *w > MAX_TRUNCATE_WIDTH {
+                tracing::error!("Invalid width: {}", w);
+                return Err(TruncateError::InvalidWidth { width: *w }.into());
             }
-            arg => {
-                return Err(TruncateError::InvalidFirstArgType { value: arg.clone() }.into());
+            *w
+        } else {
+            tracing::error!("Invalid first argument type: {:?}", first);
+            return Err(TruncateError::InvalidFirstArgType {
+                value: first.clone(),
             }
+            .into());
         };
 
         tracing::trace!("Computing truncate with width: {}", width);
 
-        match &args[1] {
+        match second {
             ColumnarValue::Scalar(scalar) => {
                 let result = compute_truncate_scalar(scalar, width)?;
                 Ok(ColumnarValue::Scalar(result))
@@ -175,7 +182,7 @@ impl ScalarUDFImpl for Truncate {
 }
 
 fn compute_truncate_scalar(
-    scalar: &ScalarValue,
+    scalar: ScalarValue,
     width: i64,
 ) -> Result<ScalarValue, DataFusionError> {
     if scalar.is_null() {
@@ -183,15 +190,15 @@ fn compute_truncate_scalar(
     }
 
     match scalar {
-        ScalarValue::Int8(Some(v)) => Ok(ScalarValue::Int8(Some(truncate_numeric(*v, width)?))),
-        ScalarValue::Int16(Some(v)) => Ok(ScalarValue::Int16(Some(truncate_numeric(*v, width)?))),
-        ScalarValue::Int32(Some(v)) => Ok(ScalarValue::Int32(Some(truncate_numeric(*v, width)?))),
-        ScalarValue::Int64(Some(v)) => Ok(ScalarValue::Int64(Some(truncate_numeric(*v, width)?))),
-        ScalarValue::UInt8(Some(v)) => Ok(ScalarValue::UInt8(Some(truncate_numeric(*v, width)?))),
-        ScalarValue::UInt16(Some(v)) => Ok(ScalarValue::UInt16(Some(truncate_numeric(*v, width)?))),
-        ScalarValue::UInt32(Some(v)) => Ok(ScalarValue::UInt32(Some(truncate_numeric(*v, width)?))),
+        ScalarValue::Int8(Some(v)) => Ok(ScalarValue::Int8(Some(truncate_numeric(v, width)?))),
+        ScalarValue::Int16(Some(v)) => Ok(ScalarValue::Int16(Some(truncate_numeric(v, width)?))),
+        ScalarValue::Int32(Some(v)) => Ok(ScalarValue::Int32(Some(truncate_numeric(v, width)?))),
+        ScalarValue::Int64(Some(v)) => Ok(ScalarValue::Int64(Some(truncate_numeric(v, width)?))),
+        ScalarValue::UInt8(Some(v)) => Ok(ScalarValue::UInt8(Some(truncate_numeric(v, width)?))),
+        ScalarValue::UInt16(Some(v)) => Ok(ScalarValue::UInt16(Some(truncate_numeric(v, width)?))),
+        ScalarValue::UInt32(Some(v)) => Ok(ScalarValue::UInt32(Some(truncate_numeric(v, width)?))),
         ScalarValue::UInt64(Some(v)) => {
-            let v = i64::try_from(*v).map_err(|_| {
+            let v = i64::try_from(v).map_err(|_| {
                 DataFusionError::Execution(format!("Value too large for Int64: {v}"))
             })?;
             Ok(ScalarValue::UInt64(
@@ -228,7 +235,7 @@ fn truncate_numeric<T: Into<i64> + TryFrom<i64>>(v: T, width: i64) -> Result<T, 
         .map_err(|_| DataFusionError::Execution(format!("Value out of range: {result}")))
 }
 
-fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
+fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
     match array.data_type() {
         DataType::Int8 => truncate_numeric_array!(array, width, Int8Array, i8, i8),
         DataType::Int16 => truncate_numeric_array!(array, width, Int16Array, i16, i16),
@@ -289,12 +296,12 @@ fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, Data
             )))
         }
         DataType::Utf8 | DataType::Binary => {
-            let result = substring(array, 0, Some(width as u64))
+            let result = substring(&array, 0, Some(width as u64))
                 .map_err(|e| DataFusionError::ArrowError(e, None))?;
             Ok(Arc::new(result))
         }
         _ => Err(TruncateError::InvalidSecondArgType {
-            value: ColumnarValue::Array(Arc::clone(array)),
+            value: ColumnarValue::Array(Arc::clone(&array)),
         }
         .into()),
     }

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -1,0 +1,915 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
+    UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::compute::binary;
+use arrow::compute::kernels::substring::substring;
+use arrow::datatypes::DataType;
+use datafusion::common::DataFusionError;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion::scalar::ScalarValue;
+use snafu::{OptionExt, Snafu};
+
+/// Maximum truncation width or length, chosen to prevent overflow or excessive memory usage.
+const MAX_TRUNCATE_WIDTH: i64 = i64::MAX / 2;
+
+#[derive(Debug, Snafu)]
+pub enum TruncateError {
+    #[snafu(display(
+        "Invalid width: {width}. Must be a positive integer less than or equal to {MAX_TRUNCATE_WIDTH}"
+    ))]
+    InvalidWidth { width: i64 },
+
+    #[snafu(display("Expected exactly two arguments, got {count}"))]
+    InvalidArgumentCount { count: usize },
+
+    #[snafu(display("First argument must be a positive Int64, got {value:?}"))]
+    InvalidFirstArgType { value: ColumnarValue },
+
+    #[snafu(display(
+        "Second argument must be Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64, Utf8, or Binary, got {value:?}"
+    ))]
+    InvalidSecondArgType { value: ColumnarValue },
+
+    #[snafu(display("Failed to downcast array"))]
+    DowncastFailed,
+
+    #[snafu(display("DataFusion error: {source}"))]
+    DataFusion { source: DataFusionError },
+}
+
+impl From<TruncateError> for DataFusionError {
+    fn from(val: TruncateError) -> Self {
+        DataFusionError::External(val.to_string().into())
+    }
+}
+
+#[derive(Debug)]
+pub struct Truncate {
+    signature: Signature,
+}
+
+impl Default for Truncate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Truncate {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for Truncate {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "truncate"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType, DataFusionError> {
+        if arg_types.len() != 2 {
+            return Err(TruncateError::InvalidArgumentCount {
+                count: arg_types.len(),
+            }
+            .into());
+        }
+        if !matches!(arg_types[0], DataType::Int64) {
+            return Err(TruncateError::InvalidFirstArgType {
+                value: ColumnarValue::Scalar(ScalarValue::try_from(&arg_types[0])?),
+            }
+            .into());
+        }
+        match &arg_types[1] {
+            DataType::Int8 => Ok(DataType::Int8),
+            DataType::Int16 => Ok(DataType::Int16),
+            DataType::Int32 => Ok(DataType::Int32),
+            DataType::Int64 => Ok(DataType::Int64),
+            DataType::UInt8 => Ok(DataType::UInt8),
+            DataType::UInt16 => Ok(DataType::UInt16),
+            DataType::UInt32 => Ok(DataType::UInt32),
+            DataType::UInt64 => Ok(DataType::UInt64),
+            DataType::Float32 => Ok(DataType::Float32),
+            DataType::Float64 => Ok(DataType::Float64),
+            DataType::Utf8 => Ok(DataType::Utf8),
+            DataType::Binary => Ok(DataType::Binary),
+            _ => Err(TruncateError::InvalidSecondArgType {
+                value: ColumnarValue::Scalar(ScalarValue::try_from(&arg_types[1])?),
+            }
+            .into()),
+        }
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {
+        let args = args.args;
+        if args.len() != 2 {
+            tracing::debug!("Invalid argument count: {}", args.len());
+            return Err(TruncateError::InvalidArgumentCount { count: args.len() }.into());
+        }
+
+        let width = match &args[0] {
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(w))) => {
+                if *w <= 0 || *w > MAX_TRUNCATE_WIDTH {
+                    return Err(TruncateError::InvalidWidth { width: *w }.into());
+                }
+                *w
+            }
+            arg => {
+                return Err(TruncateError::InvalidFirstArgType { value: arg.clone() }.into());
+            }
+        };
+
+        tracing::trace!("Computing truncate with width: {}", width);
+
+        match &args[1] {
+            ColumnarValue::Scalar(scalar) => {
+                let result = compute_truncate_scalar(scalar, width)?;
+                Ok(ColumnarValue::Scalar(result))
+            }
+            ColumnarValue::Array(array) => {
+                let result = compute_truncate_array(array, width)?;
+                Ok(ColumnarValue::Array(result))
+            }
+        }
+    }
+}
+
+fn compute_truncate_scalar(
+    scalar: &ScalarValue,
+    width: i64,
+) -> Result<ScalarValue, DataFusionError> {
+    if scalar.is_null() {
+        return match scalar {
+            ScalarValue::Int8(_) => Ok(ScalarValue::Int8(None)),
+            ScalarValue::Int16(_) => Ok(ScalarValue::Int16(None)),
+            ScalarValue::Int32(_) => Ok(ScalarValue::Int32(None)),
+            ScalarValue::Int64(_) => Ok(ScalarValue::Int64(None)),
+            ScalarValue::UInt8(_) => Ok(ScalarValue::UInt8(None)),
+            ScalarValue::UInt16(_) => Ok(ScalarValue::UInt16(None)),
+            ScalarValue::UInt32(_) => Ok(ScalarValue::UInt32(None)),
+            ScalarValue::UInt64(_) => Ok(ScalarValue::UInt64(None)),
+            ScalarValue::Float32(_) => Ok(ScalarValue::Float32(None)),
+            ScalarValue::Float64(_) => Ok(ScalarValue::Float64(None)),
+            ScalarValue::Utf8(_) => Ok(ScalarValue::Utf8(None)),
+            ScalarValue::Binary(_) => Ok(ScalarValue::Binary(None)),
+            _ => Err(TruncateError::InvalidSecondArgType {
+                value: ColumnarValue::Scalar(scalar.clone()),
+            }
+            .into()),
+        };
+    }
+
+    match scalar {
+        ScalarValue::Int8(Some(v)) => {
+            let v = i64::from(*v);
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int8(Some(result.try_into().map_err(
+                |_| DataFusionError::Execution(format!("Value out of range for Int8: {}", result)),
+            )?)))
+        }
+        ScalarValue::Int16(Some(v)) => {
+            let v = i64::from(*v);
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int16(Some(result.try_into().map_err(
+                |_| DataFusionError::Execution(format!("Value out of range for Int16: {}", result)),
+            )?)))
+        }
+        ScalarValue::Int32(Some(v)) => {
+            let v = i64::from(*v);
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int32(Some(result.try_into().map_err(
+                |_| DataFusionError::Execution(format!("Value out of range for Int32: {}", result)),
+            )?)))
+        }
+        ScalarValue::Int64(Some(v)) => {
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int64(Some(result)))
+        }
+        ScalarValue::UInt8(Some(v)) => {
+            let v = i64::from(*v);
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::UInt8(Some(result.try_into().map_err(
+                |_| DataFusionError::Execution(format!("Value out of range for UInt8: {}", result)),
+            )?)))
+        }
+        ScalarValue::UInt16(Some(v)) => {
+            let v = i64::from(*v);
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::UInt16(Some(result.try_into().map_err(
+                |_| {
+                    DataFusionError::Execution(format!("Value out of range for UInt16: {}", result))
+                },
+            )?)))
+        }
+        ScalarValue::UInt32(Some(v)) => {
+            let v = i64::from(*v);
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::UInt32(Some(result.try_into().map_err(
+                |_| {
+                    DataFusionError::Execution(format!("Value out of range for UInt32: {}", result))
+                },
+            )?)))
+        }
+        ScalarValue::UInt64(Some(v)) => {
+            let v = i64::try_from(*v).map_err(|_| {
+                DataFusionError::Execution(format!("Value too large for Int64: {}", v))
+            })?;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::UInt64(Some(result.try_into().map_err(
+                |_| {
+                    DataFusionError::Execution(format!("Value out of range for UInt64: {}", result))
+                },
+            )?)))
+        }
+        ScalarValue::Float32(Some(v)) => {
+            let v = v.floor() as i64;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Float32(Some(result as f32)))
+        }
+        ScalarValue::Float64(Some(v)) => {
+            let v = v.floor() as i64;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Float64(Some(result as f64)))
+        }
+        ScalarValue::Utf8(Some(v)) => Ok(ScalarValue::Utf8(Some(
+            v.chars().take(width as usize).collect::<String>(),
+        ))),
+        ScalarValue::Binary(Some(v)) => {
+            let truncated = v.iter().take(width as usize).copied().collect::<Vec<u8>>();
+            Ok(ScalarValue::Binary(Some(truncated)))
+        }
+        _ => Err(TruncateError::InvalidSecondArgType {
+            value: ColumnarValue::Scalar(scalar.clone()),
+        }
+        .into()),
+    }
+}
+
+fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
+    match array.data_type() {
+        DataType::Int8 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = Int8Array::from_value(width as i8, array.len());
+            let result: Int8Array = binary(casted_array, &width_array, |v, w| {
+                let v = i64::from(v);
+                let w = i64::from(w);
+                (v - (((v % w) + w) % w)) as i8
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(Int8Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::Int16 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = Int16Array::from_value(width as i16, array.len());
+            let result: Int16Array = binary(casted_array, &width_array, |v, w| {
+                let v = i64::from(v);
+                let w = i64::from(w);
+                (v - (((v % w) + w) % w)) as i16
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(Int16Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::Int32 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = Int32Array::from_value(width as i32, array.len());
+            let result: Int32Array = binary(casted_array, &width_array, |v, w| {
+                let v = i64::from(v);
+                let w = i64::from(w);
+                (v - (((v % w) + w) % w)) as i32
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(Int32Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::Int64 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = Int64Array::from_value(width, array.len());
+            let result: Int64Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(Int64Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::UInt8 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = UInt8Array::from_value(width as u8, array.len());
+            let result: UInt8Array = binary(casted_array, &width_array, |v, w| {
+                let v = i64::from(v);
+                let w = i64::from(w);
+                (v - (((v % w) + w) % w)) as u8
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(UInt8Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::UInt16 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = UInt16Array::from_value(width as u16, array.len());
+            let result: UInt16Array = binary(casted_array, &width_array, |v, w| {
+                let v = i64::from(v);
+                let w = i64::from(w);
+                (v - (((v % w) + w) % w)) as u16
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(UInt16Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::UInt32 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = UInt32Array::from_value(width as u32, array.len());
+            let result: UInt32Array = binary(casted_array, &width_array, |v, w| {
+                let v = i64::from(v);
+                let w = i64::from(w);
+                (v - (((v % w) + w) % w)) as u32
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(UInt32Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::UInt64 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = UInt64Array::from_value(width as u64, array.len());
+            let result: UInt64Array = binary(casted_array, &width_array, |v, w| {
+                let v = i64::try_from(v).unwrap_or(i64::MAX);
+                let w = i64::try_from(w).unwrap_or(i64::MAX);
+                (v - (((v % w) + w) % w)) as u64
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(UInt64Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::Float32 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = Float32Array::from_value(width as f32, array.len());
+            let result: Float32Array = binary(casted_array, &width_array, |v, w| {
+                let v = v.floor() as i64;
+                let w = w as i64;
+                (v - (((v % w) + w) % w)) as f32
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(Float32Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::Float64 => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .context(DowncastFailedSnafu)?;
+            let width_array = Float64Array::from_value(width as f64, array.len());
+            let result: Float64Array = binary(casted_array, &width_array, |v, w| {
+                let v = v.floor() as i64;
+                let w = w as i64;
+                (v - (((v % w) + w) % w)) as f64
+            })
+            .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(Float64Array::new(
+                result.values().clone(),
+                array.nulls().cloned(),
+            )))
+        }
+        DataType::Utf8 => {
+            let result = substring(array, 0, Some(width as u64))
+                .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
+        DataType::Binary => {
+            let result = substring(array, 0, Some(width as u64))
+                .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
+        _ => Err(TruncateError::InvalidSecondArgType {
+            value: ColumnarValue::Array(Arc::clone(array)),
+        }
+        .into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{
+        Array as _, BinaryArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array,
+        Int64Array, StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+    };
+    use datafusion::arrow::datatypes::DataType;
+
+    #[test]
+    fn test_truncate_int8_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
+                ColumnarValue::Array(Arc::new(Int8Array::from(vec![101, -1, 0]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Int8,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .expect("downcast to Int8Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(int_array.value(0), 100, "Expected truncate(10, 101) = 100");
+            assert_eq!(int_array.value(1), -10, "Expected truncate(10, -1) = -10");
+            assert_eq!(int_array.value(2), 0, "Expected truncate(10, 0) = 0");
+        } else {
+            panic!("Expected Int8 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_int16_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ColumnarValue::Array(Arc::new(Int16Array::from(vec![1234, -567, 99]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Int16,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<Int16Array>()
+                .expect("downcast to Int16Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1200,
+                "Expected truncate(100, 1234) = 1200"
+            );
+            assert_eq!(
+                int_array.value(1),
+                -600,
+                "Expected truncate(100, -567) = -600"
+            );
+            assert_eq!(int_array.value(2), 0, "Expected truncate(100, 99) = 0");
+        } else {
+            panic!("Expected Int16 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_int32_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
+                ColumnarValue::Array(Arc::new(Int32Array::from(vec![1234, -5678, 999]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Int32,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("downcast to Int32Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1000,
+                "Expected truncate(1000, 1234) = 1000"
+            );
+            assert_eq!(
+                int_array.value(1),
+                -6000,
+                "Expected truncate(1000, -5678) = -6000"
+            );
+            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
+        } else {
+            panic!("Expected Int32 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_int64_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
+                ColumnarValue::Array(Arc::new(Int64Array::from(vec![1234, -5678, 999]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Int64,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("downcast to Int64Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1000,
+                "Expected truncate(1000, 1234) = 1000"
+            );
+            assert_eq!(
+                int_array.value(1),
+                -6000,
+                "Expected truncate(1000, -5678) = -6000"
+            );
+            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
+        } else {
+            panic!("Expected Int64 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_uint8_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
+                ColumnarValue::Array(Arc::new(UInt8Array::from(vec![101, 1, 0]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::UInt8,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .expect("downcast to UInt8Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(int_array.value(0), 100, "Expected truncate(10, 101) = 100");
+            assert_eq!(int_array.value(1), 0, "Expected truncate(10, 1) = 0");
+            assert_eq!(int_array.value(2), 0, "Expected truncate(10, 0) = 0");
+        } else {
+            panic!("Expected UInt8 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_uint16_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ColumnarValue::Array(Arc::new(UInt16Array::from(vec![1234, 567, 99]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::UInt16,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .expect("downcast to UInt16Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1200,
+                "Expected truncate(100, 1234) = 1200"
+            );
+            assert_eq!(int_array.value(1), 500, "Expected truncate(100, 567) = 500");
+            assert_eq!(int_array.value(2), 0, "Expected truncate(100, 99) = 0");
+        } else {
+            panic!("Expected UInt16 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_uint32_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
+                ColumnarValue::Array(Arc::new(UInt32Array::from(vec![1234, 5678, 999]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::UInt32,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .expect("downcast to UInt32Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1000,
+                "Expected truncate(1000, 1234) = 1000"
+            );
+            assert_eq!(
+                int_array.value(1),
+                5000,
+                "Expected truncate(1000, 5678) = 5000"
+            );
+            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
+        } else {
+            panic!("Expected UInt32 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_uint64_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
+                ColumnarValue::Array(Arc::new(UInt64Array::from(vec![1234, 5678, 999]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::UInt64,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("downcast to UInt64Array");
+            assert_eq!(int_array.len(), 3);
+            assert_eq!(
+                int_array.value(0),
+                1000,
+                "Expected truncate(1000, 1234) = 1000"
+            );
+            assert_eq!(
+                int_array.value(1),
+                5000,
+                "Expected truncate(1000, 5678) = 5000"
+            );
+            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
+        } else {
+            panic!("Expected UInt64 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_float32_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
+                ColumnarValue::Array(Arc::new(Float32Array::from(vec![101.7, -1.2, 0.0]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Float32,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let float_array = array
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .expect("downcast to Float32Array");
+            assert_eq!(float_array.len(), 3);
+            assert_eq!(
+                float_array.value(0),
+                100.0,
+                "Expected truncate(10, 101.7) = 100.0"
+            );
+            assert_eq!(
+                float_array.value(1),
+                -10.0,
+                "Expected truncate(10, -1.2) = -10.0"
+            );
+            assert_eq!(
+                float_array.value(2),
+                0.0,
+                "Expected truncate(10, 0.0) = 0.0"
+            );
+        } else {
+            panic!("Expected Float32 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_float64_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
+                ColumnarValue::Array(Arc::new(Float64Array::from(vec![123.4, -56.78, 9.9]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Float64,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let float_array = array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("downcast to Float64Array");
+            assert_eq!(float_array.len(), 3);
+            assert_eq!(
+                float_array.value(0),
+                100.0,
+                "Expected truncate(100, 123.4) = 100.0"
+            );
+            assert_eq!(
+                float_array.value(1),
+                -100.0,
+                "Expected truncate(100, -56.78) = -100.0"
+            );
+            assert_eq!(
+                float_array.value(2),
+                0.0,
+                "Expected truncate(100, 9.9) = 0.0"
+            );
+        } else {
+            panic!("Expected Float64 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_utf8_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(3))),
+                ColumnarValue::Array(Arc::new(StringArray::from(vec!["iceberg", "spark"]))),
+            ],
+            number_rows: 2,
+            return_type: &DataType::Utf8,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let str_array = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("downcast to StringArray");
+            assert_eq!(str_array.len(), 2);
+            assert_eq!(
+                str_array.value(0),
+                "ice",
+                "Expected truncate(3, 'iceberg') = 'ice'"
+            );
+            assert_eq!(
+                str_array.value(1),
+                "spa",
+                "Expected truncate(3, 'spark') = 'spa'"
+            );
+        } else {
+            panic!("Expected Utf8 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_binary_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(3))),
+                ColumnarValue::Array(Arc::new(BinaryArray::from_vec(vec![
+                    &[1, 2, 3, 4, 5],
+                    &[6, 7, 8],
+                ]))),
+            ],
+            number_rows: 2,
+            return_type: &DataType::Binary,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let bin_array = array
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .expect("downcast to BinaryArray");
+            assert_eq!(bin_array.len(), 2);
+            assert_eq!(
+                bin_array.value(0),
+                vec![1, 2, 3],
+                "Expected truncate(3, [1,2,3,4,5]) = [1,2,3]"
+            );
+            assert_eq!(
+                bin_array.value(1),
+                vec![6, 7, 8],
+                "Expected truncate(3, [6,7,8]) = [6,7,8]"
+            );
+        } else {
+            panic!("Expected Binary array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_null_array() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
+                ColumnarValue::Array(Arc::new(Int64Array::from(vec![None, Some(101), None]))),
+            ],
+            number_rows: 3,
+            return_type: &DataType::Int64,
+        };
+        let result = udf.invoke_with_args(args).expect("invoke UDF");
+        if let ColumnarValue::Array(array) = result {
+            let int_array = array
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("downcast to Int64Array");
+            assert_eq!(int_array.len(), 3);
+            assert!(int_array.is_null(0), "Expected NULL at index 0");
+            assert_eq!(int_array.value(1), 100, "Expected truncate(10, 101) = 100");
+            assert!(int_array.is_null(2), "Expected NULL at index 2");
+        } else {
+            panic!("Expected Int64 array");
+        }
+    }
+
+    #[test]
+    fn test_truncate_invalid_type() {
+        let udf = Truncate::new();
+        let args = ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
+                ColumnarValue::Array(Arc::new(arrow::array::BooleanArray::from(vec![
+                    true, false,
+                ]))),
+            ],
+            number_rows: 2,
+            return_type: &DataType::Boolean,
+        };
+        let result = udf.invoke_with_args(args);
+        assert!(
+            result.is_err(),
+            "Expected error for invalid second argument type"
+        );
+    }
+}

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -25,7 +25,7 @@ use arrow::compute::kernels::substring::substring;
 use arrow::datatypes::DataType;
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::{
-    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
 };
 use datafusion::scalar::ScalarValue;
 use snafu::{OptionExt, Snafu};
@@ -96,7 +96,23 @@ impl Truncate {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            signature: Signature::any(2, Volatility::Immutable),
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::Int8]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::Int16]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::Int32]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::Int64]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::UInt8]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::UInt16]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::UInt32]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::UInt64]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::Float32]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::Float64]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::Int64, DataType::Binary]),
+                ],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -121,30 +137,7 @@ impl ScalarUDFImpl for Truncate {
             }
             .into());
         }
-        if !matches!(arg_types[0], DataType::Int64) {
-            return Err(TruncateError::InvalidFirstArgType {
-                value: ColumnarValue::Scalar(ScalarValue::try_from(&arg_types[0])?),
-            }
-            .into());
-        }
-        match &arg_types[1] {
-            DataType::Int8 => Ok(DataType::Int8),
-            DataType::Int16 => Ok(DataType::Int16),
-            DataType::Int32 => Ok(DataType::Int32),
-            DataType::Int64 => Ok(DataType::Int64),
-            DataType::UInt8 => Ok(DataType::UInt8),
-            DataType::UInt16 => Ok(DataType::UInt16),
-            DataType::UInt32 => Ok(DataType::UInt32),
-            DataType::UInt64 => Ok(DataType::UInt64),
-            DataType::Float32 => Ok(DataType::Float32),
-            DataType::Float64 => Ok(DataType::Float64),
-            DataType::Utf8 => Ok(DataType::Utf8),
-            DataType::Binary => Ok(DataType::Binary),
-            _ => Err(TruncateError::InvalidSecondArgType {
-                value: ColumnarValue::Scalar(ScalarValue::try_from(&arg_types[1])?),
-            }
-            .into()),
-        }
+        Ok(arg_types[1].clone())
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -147,26 +147,23 @@ impl ScalarUDFImpl for Truncate {
         let (first, second) = match (args_iter.next(), args_iter.next(), args_iter.next()) {
             (Some(first), Some(second), None) => (first, second),
             _ => {
-                tracing::error!("Invalid argument count: expected 2, got {count}");
                 return Err(TruncateError::InvalidArgumentCount { count }.into());
             }
         };
 
         let width = if let ColumnarValue::Scalar(ScalarValue::Int64(Some(w))) = &first {
             if *w <= 0 || *w > MAX_TRUNCATE_WIDTH {
-                tracing::error!("Invalid width: {}", w);
                 return Err(TruncateError::InvalidWidth { width: *w }.into());
             }
             *w
         } else {
-            tracing::error!("Invalid first argument type: {:?}", first);
             return Err(TruncateError::InvalidFirstArgType {
                 value: first.clone(),
             }
             .into());
         };
 
-        tracing::trace!("Computing truncate with width: {}", width);
+        tracing::trace!("Computing truncate with width: {width}");
 
         match second {
             ColumnarValue::Scalar(scalar) => {
@@ -213,9 +210,10 @@ fn compute_truncate_scalar(
             v.floor() as i64,
             width,
         )? as f64))),
-        ScalarValue::Utf8(Some(v)) => Ok(ScalarValue::Utf8(Some(
-            v.chars().take(width as usize).collect::<String>(),
-        ))),
+        ScalarValue::Utf8(Some(mut v)) => {
+            v.truncate(width as usize);
+            Ok(ScalarValue::Utf8(Some(v)))
+        }
         ScalarValue::Binary(Some(v)) => {
             let truncated = v.iter().take(width as usize).copied().collect::<Vec<u8>>();
             Ok(ScalarValue::Binary(Some(truncated)))

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::num::TryFromIntError;
 use std::sync::Arc;
 
 use arrow::array::{
@@ -28,7 +29,7 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion::scalar::ScalarValue;
-use snafu::{Snafu, ensure};
+use snafu::{ResultExt, Snafu, ensure};
 use tract_core::num_traits::Num;
 
 // Maximum truncation width or length, chosen to prevent overflow or excessive memory usage.
@@ -51,6 +52,9 @@ pub enum TruncateError {
         "Second argument must be Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Decimal128, Decimal256, Utf8, or Binary, got {data_type}"
     ))]
     InvalidSecondArgType { data_type: DataType },
+
+    #[snafu(display("Failed to cast the width argument: {source}"))]
+    WidthCastingFailed { source: TryFromIntError },
 }
 
 impl From<TruncateError> for DataFusionError {
@@ -166,22 +170,6 @@ impl ScalarUDFImpl for Truncate {
     }
 }
 
-macro_rules! truncate_numeric_scalar {
-    ($SCALAR:expr, $WIDTH:expr, $TYPE:ty, $SCALAR_TYPE:ident) => {
-        match $SCALAR {
-            ScalarValue::$SCALAR_TYPE(Some(v)) => {
-                let w = $WIDTH as $TYPE;
-                let result = truncate_numeric(v, w);
-                Ok(ScalarValue::$SCALAR_TYPE(Some(result)))
-            }
-            _ => Err(TruncateError::InvalidSecondArgType {
-                data_type: $SCALAR.data_type(),
-            }
-            .into()),
-        }
-    };
-}
-
 macro_rules! truncate_numeric_array {
     ($ARRAY:expr, $WIDTH:expr, $ARRAY_TYPE:ty, $SCALAR_TYPE:ty) => {{
         let casted_array = $ARRAY
@@ -202,7 +190,6 @@ macro_rules! truncate_numeric_array {
     }};
 }
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn compute_truncate_scalar(
     scalar: ScalarValue,
     width: i64,
@@ -212,17 +199,20 @@ fn compute_truncate_scalar(
     }
 
     match scalar {
-        ScalarValue::Int8(_) => truncate_numeric_scalar!(scalar, width, i8, Int8),
-        ScalarValue::Int16(_) => truncate_numeric_scalar!(scalar, width, i16, Int16),
-        ScalarValue::Int32(_) => truncate_numeric_scalar!(scalar, width, i32, Int32),
-        ScalarValue::Int64(_) => truncate_numeric_scalar!(scalar, width, i64, Int64),
-        ScalarValue::UInt8(_) => truncate_numeric_scalar!(scalar, width, u8, UInt8),
-        ScalarValue::UInt16(_) => truncate_numeric_scalar!(scalar, width, u16, UInt16),
-        ScalarValue::UInt32(_) => truncate_numeric_scalar!(scalar, width, u32, UInt32),
-        ScalarValue::UInt64(_) => truncate_numeric_scalar!(scalar, width, u64, UInt64),
+        ScalarValue::Int8(Some(v)) => Ok(ScalarValue::Int8(Some(truncate_numeric(v, width)?))),
+        ScalarValue::Int16(Some(v)) => Ok(ScalarValue::Int16(Some(truncate_numeric(v, width)?))),
+        ScalarValue::Int32(Some(v)) => Ok(ScalarValue::Int32(Some(truncate_numeric(v, width)?))),
+        ScalarValue::Int64(Some(v)) => {
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int64(Some(result)))
+        }
+        ScalarValue::UInt8(Some(v)) => Ok(ScalarValue::UInt8(Some(truncate_numeric(v, width)?))),
+        ScalarValue::UInt16(Some(v)) => Ok(ScalarValue::UInt16(Some(truncate_numeric(v, width)?))),
+        ScalarValue::UInt32(Some(v)) => Ok(ScalarValue::UInt32(Some(truncate_numeric(v, width)?))),
+        ScalarValue::UInt64(Some(v)) => Ok(ScalarValue::UInt64(Some(truncate_numeric(v, width)?))),
         ScalarValue::Decimal128(Some(v), p, s) => {
-            let w = i128::from(width);
-            let result = truncate_numeric(v, w);
+            let width = i128::from(width);
+            let result = v - (((v % width) + width) % width);
             Ok(ScalarValue::Decimal128(Some(result), p, s))
         }
         ScalarValue::Decimal256(Some(v), p, s) => {
@@ -247,14 +237,14 @@ fn compute_truncate_scalar(
     }
 }
 
-fn truncate_numeric<T: Num + Copy>(v: T, w: T) -> T {
-    if w == T::zero() {
-        return v;
-    }
-    v - (((v % w) + w) % w)
+fn truncate_numeric<V, W>(v: V, w: W) -> Result<V, TruncateError>
+where
+    V: Num + Copy + TryFrom<W, Error = TryFromIntError>,
+{
+    let w = V::try_from(w).context(WidthCastingFailedSnafu)?;
+    Ok(v - (((v % w) + w) % w))
 }
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
     match array.data_type() {
         DataType::Int8 => truncate_numeric_array!(array, width, Int8Array, i8),

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -53,9 +53,6 @@ pub enum TruncateError {
 
     #[snafu(display("Failed to downcast array"))]
     DowncastFailed,
-
-    #[snafu(display("DataFusion error: {source}"))]
-    DataFusion { source: DataFusionError },
 }
 
 impl From<TruncateError> for DataFusionError {

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -17,38 +17,17 @@ limitations under the License.
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
-    UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+    ArrayRef, Decimal128Array, Decimal256Array, Int32Array, Int64Array, StringArray,
 };
 use arrow::compute::binary;
-use arrow::compute::kernels::substring::substring;
-use arrow::datatypes::DataType;
+use arrow::compute::kernels::substring::{substring, substring_by_char};
+use arrow::datatypes::{DataType, i256};
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::{
-    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion::scalar::ScalarValue;
-use snafu::{OptionExt, Snafu};
-
-macro_rules! truncate_numeric_array {
-    ($array:expr, $width:expr, $array_type:ty, $cast_type:ty, $output_type:ty) => {{
-        let casted_array = $array
-            .as_any()
-            .downcast_ref::<$array_type>()
-            .context(DowncastFailedSnafu)?;
-        let width_array = <$array_type>::from_value($width as $cast_type, $array.len());
-        let result: $array_type = binary(casted_array, &width_array, |v, w| {
-            let v = i64::from(v);
-            let w = i64::from(w);
-            (v - (((v % w) + w) % w)) as $output_type
-        })
-        .map_err(|e| DataFusionError::ArrowError(e, None))?;
-        Ok(Arc::new(<$array_type>::new(
-            result.values().clone(),
-            $array.nulls().cloned(),
-        )))
-    }};
-}
+use snafu::{Snafu, ensure};
 
 /// Maximum truncation width or length, chosen to prevent overflow or excessive memory usage.
 const MAX_TRUNCATE_WIDTH: i64 = i64::MAX / 2;
@@ -56,23 +35,20 @@ const MAX_TRUNCATE_WIDTH: i64 = i64::MAX / 2;
 #[derive(Debug, Snafu)]
 pub enum TruncateError {
     #[snafu(display(
-        "Invalid width: {width}. Must be a positive integer less than or equal to {MAX_TRUNCATE_WIDTH}"
+        "Invalid width value: '{width}'. Must be a positive integer less than or equal to {MAX_TRUNCATE_WIDTH}"
     ))]
-    InvalidWidth { width: i64 },
+    InvalidWidthValue { width: i64 },
+
+    #[snafu(display("Truncation width must be a positive Int64, got {width_datatype}"))]
+    InvalidWidthDataType { width_datatype: DataType },
 
     #[snafu(display("Expected exactly two arguments, got {count}"))]
     InvalidArgumentCount { count: usize },
 
-    #[snafu(display("First argument must be a positive Int64, got {value:?}"))]
-    InvalidFirstArgType { value: ColumnarValue },
-
     #[snafu(display(
-        "Second argument must be Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, Float32, Float64, Utf8, or Binary, got {value:?}"
+        "Second argument must be Int32, Int64, Decimal128, Utf8, or Binary, got {value}"
     ))]
     InvalidSecondArgType { value: ColumnarValue },
-
-    #[snafu(display("Failed to downcast array"))]
-    DowncastFailed,
 }
 
 impl From<TruncateError> for DataFusionError {
@@ -96,23 +72,34 @@ impl Truncate {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            signature: Signature::one_of(
-                vec![
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::Int8]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::Int16]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::Int32]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::Int64]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::UInt8]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::UInt16]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::UInt32]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::UInt64]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::Float32]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::Float64]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::Utf8]),
-                    TypeSignature::Exact(vec![DataType::Int64, DataType::Binary]),
-                ],
-                Volatility::Immutable,
-            ),
+            // We cannot match all the exact combinations because we want to
+            // support DataType::Decimal128(precision, scale) and
+            // DataType::Decimal256(precision, scale) which has (obviously)
+            // many combinations of precision and scale. We will have to
+            // validate argument datatypes at runtime.
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
+
+impl Truncate {
+    fn validate_args(args: Vec<ColumnarValue>) -> Result<(i64, ColumnarValue), TruncateError> {
+        let num_args = args.len();
+
+        let mut args = args.into_iter();
+        match (args.next(), args.next()) {
+            (Some(ColumnarValue::Scalar(ScalarValue::Int64(Some(width)))), Some(arg)) => {
+                ensure!(
+                    width > 0 && width <= MAX_TRUNCATE_WIDTH,
+                    InvalidWidthValueSnafu { width }
+                );
+                Ok((width, arg))
+            }
+            (Some(width), Some(_)) => {
+                let width_datatype = width.data_type();
+                Err(TruncateError::InvalidWidthDataType { width_datatype })
+            }
+            _ => Err(TruncateError::InvalidArgumentCount { count: num_args }),
         }
     }
 }
@@ -131,41 +118,40 @@ impl ScalarUDFImpl for Truncate {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType, DataFusionError> {
-        if arg_types.len() != 2 {
-            return Err(TruncateError::InvalidArgumentCount {
-                count: arg_types.len(),
+        let count = arg_types.len();
+        ensure!(count == 2, InvalidArgumentCountSnafu { count });
+
+        let width_datatype = arg_types[0].clone();
+
+        ensure!(
+            matches!(width_datatype, DataType::Int64),
+            InvalidWidthDataTypeSnafu { width_datatype }
+        );
+
+        match &arg_types[1] {
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Decimal128(_, _)
+            | DataType::Decimal256(_, _) => Ok(arg_types[1].clone()),
+            _ => Err(TruncateError::InvalidSecondArgType {
+                value: ColumnarValue::Scalar(ScalarValue::try_from(&arg_types[1])?),
             }
-            .into());
+            .into()),
         }
-        Ok(arg_types[1].clone())
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {
-        let args = args.args;
-        let count = args.len();
-        let mut args_iter = args.into_iter();
-        let (first, second) = match (args_iter.next(), args_iter.next(), args_iter.next()) {
-            (Some(first), Some(second), None) => (first, second),
-            _ => {
-                return Err(TruncateError::InvalidArgumentCount { count }.into());
-            }
-        };
-
-        let width = if let ColumnarValue::Scalar(ScalarValue::Int64(Some(w))) = &first {
-            if *w <= 0 || *w > MAX_TRUNCATE_WIDTH {
-                return Err(TruncateError::InvalidWidth { width: *w }.into());
-            }
-            *w
-        } else {
-            return Err(TruncateError::InvalidFirstArgType {
-                value: first.clone(),
-            }
-            .into());
-        };
+        let (width, arg) = Self::validate_args(args.args)?;
 
         tracing::trace!("Computing truncate with width: {width}");
 
-        match second {
+        match arg {
             ColumnarValue::Scalar(scalar) => {
                 let result = compute_truncate_scalar(scalar, width)?;
                 Ok(ColumnarValue::Scalar(result))
@@ -183,39 +169,37 @@ fn compute_truncate_scalar(
     width: i64,
 ) -> Result<ScalarValue, DataFusionError> {
     if scalar.is_null() {
-        return Ok(scalar.clone());
+        return Ok(scalar);
     }
 
     match scalar {
-        ScalarValue::Int8(Some(v)) => Ok(ScalarValue::Int8(Some(truncate_numeric(v, width)?))),
-        ScalarValue::Int16(Some(v)) => Ok(ScalarValue::Int16(Some(truncate_numeric(v, width)?))),
-        ScalarValue::Int32(Some(v)) => Ok(ScalarValue::Int32(Some(truncate_numeric(v, width)?))),
-        ScalarValue::Int64(Some(v)) => Ok(ScalarValue::Int64(Some(truncate_numeric(v, width)?))),
-        ScalarValue::UInt8(Some(v)) => Ok(ScalarValue::UInt8(Some(truncate_numeric(v, width)?))),
-        ScalarValue::UInt16(Some(v)) => Ok(ScalarValue::UInt16(Some(truncate_numeric(v, width)?))),
-        ScalarValue::UInt32(Some(v)) => Ok(ScalarValue::UInt32(Some(truncate_numeric(v, width)?))),
-        ScalarValue::UInt64(Some(v)) => {
-            let v = i64::try_from(v).map_err(|_| {
-                DataFusionError::Execution(format!("Value too large for Int64: {v}"))
-            })?;
-            Ok(ScalarValue::UInt64(
-                Some(truncate_numeric(v, width)? as u64),
-            ))
+        ScalarValue::Int32(Some(v)) => {
+            let width = width as i32;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int32(Some(result)))
         }
-        ScalarValue::Float32(Some(v)) => Ok(ScalarValue::Float32(Some(truncate_numeric(
-            v.floor() as i64,
-            width,
-        )? as f32))),
-        ScalarValue::Float64(Some(v)) => Ok(ScalarValue::Float64(Some(truncate_numeric(
-            v.floor() as i64,
-            width,
-        )? as f64))),
+        ScalarValue::Int64(Some(v)) => {
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Int64(Some(result)))
+        }
+        ScalarValue::Decimal128(Some(v), p, s) => {
+            let width = width as i128;
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Decimal128(Some(result), p, s))
+        }
+        ScalarValue::Decimal256(Some(v), p, s) => {
+            let width = i256::from_i128(width as i128);
+            let result = v - (((v % width) + width) % width);
+            Ok(ScalarValue::Decimal256(Some(result), p, s))
+        }
         ScalarValue::Utf8(Some(mut v)) => {
-            v.truncate(width as usize);
+            let width = width as usize;
+            v.truncate(width);
             Ok(ScalarValue::Utf8(Some(v)))
         }
         ScalarValue::Binary(Some(v)) => {
-            let truncated = v.iter().take(width as usize).copied().collect::<Vec<u8>>();
+            let width = width as usize;
+            let truncated = v.iter().take(width).copied().collect::<Vec<u8>>();
             Ok(ScalarValue::Binary(Some(truncated)))
         }
         _ => Err(TruncateError::InvalidSecondArgType {
@@ -225,81 +209,70 @@ fn compute_truncate_scalar(
     }
 }
 
-fn truncate_numeric<T: Into<i64> + TryFrom<i64>>(v: T, width: i64) -> Result<T, DataFusionError> {
-    let v = v.into();
-    let result = v - (((v % width) + width) % width);
-    result
-        .try_into()
-        .map_err(|_| DataFusionError::Execution(format!("Value out of range: {result}")))
-}
-
 fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
     match array.data_type() {
-        DataType::Int8 => truncate_numeric_array!(array, width, Int8Array, i8, i8),
-        DataType::Int16 => truncate_numeric_array!(array, width, Int16Array, i16, i16),
-        DataType::Int32 => truncate_numeric_array!(array, width, Int32Array, i32, i32),
-        DataType::Int64 => truncate_numeric_array!(array, width, Int64Array, i64, i64),
-        DataType::UInt8 => truncate_numeric_array!(array, width, UInt8Array, u8, u8),
-        DataType::UInt16 => truncate_numeric_array!(array, width, UInt16Array, u16, u16),
-        DataType::UInt32 => truncate_numeric_array!(array, width, UInt32Array, u32, u32),
-        DataType::UInt64 => {
+        DataType::Int32 => {
             let casted_array = array
                 .as_any()
-                .downcast_ref::<UInt64Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = UInt64Array::from_value(width as u64, array.len());
-            let result: UInt64Array = binary(casted_array, &width_array, |v, w| {
-                let v = i64::try_from(v).unwrap_or(i64::MAX);
-                let w = i64::try_from(w).unwrap_or(i64::MAX);
-                (v - (((v % w) + w) % w)) as u64
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(UInt64Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
+                .downcast_ref::<Int32Array>()
+                .expect("cast success");
+            let width = width as i32;
+            let width_array = Int32Array::from_value(width, array.len());
+            let result: Int32Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
         }
-        DataType::Float32 => {
+        DataType::Int64 => {
             let casted_array = array
                 .as_any()
-                .downcast_ref::<Float32Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = Float32Array::from_value(width as f32, array.len());
-            let result: Float32Array = binary(casted_array, &width_array, |v, w| {
-                let v = v.floor() as i64;
-                let w = w as i64;
-                (v - (((v % w) + w) % w)) as f32
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(Float32Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
+                .downcast_ref::<Int64Array>()
+                .expect("cast success");
+            let width_array = Int64Array::from_value(width, array.len());
+            let result: Int64Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
         }
-        DataType::Float64 => {
+        DataType::Decimal128(_, _) => {
             let casted_array = array
                 .as_any()
-                .downcast_ref::<Float64Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = Float64Array::from_value(width as f64, array.len());
-            let result: Float64Array = binary(casted_array, &width_array, |v, w| {
-                let v = v.floor() as i64;
-                let w = w as i64;
-                (v - (((v % w) + w) % w)) as f64
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(Float64Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
+                .downcast_ref::<Decimal128Array>()
+                .expect("cast success");
+            let width = width as i128;
+            let width_array = Decimal128Array::from_value(width, array.len());
+            let result: Decimal128Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
         }
-        DataType::Utf8 | DataType::Binary => {
-            let result = substring(&array, 0, Some(width as u64))
+        DataType::Decimal256(_, _) => {
+            let casted_array = array
+                .as_any()
+                .downcast_ref::<Decimal256Array>()
+                .expect("cast success");
+            let width = i256::from_i128(width as i128);
+            let width_array = Decimal256Array::from_value(width, array.len());
+            let result: Decimal256Array =
+                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
+                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(Arc::new(result))
+        }
+        DataType::Binary => {
+            let width = width as u64;
+            let result = substring(&array, 0, Some(width))
+                .map_err(|e| DataFusionError::ArrowError(e, None))?;
+            Ok(result)
+        }
+        DataType::Utf8 => {
+            let casted_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+            let width = width as u64;
+            let result = substring_by_char(casted_array, 0, Some(width))
                 .map_err(|e| DataFusionError::ArrowError(e, None))?;
             Ok(Arc::new(result))
         }
         _ => Err(TruncateError::InvalidSecondArgType {
-            value: ColumnarValue::Array(Arc::clone(&array)),
+            value: ColumnarValue::Array(array),
         }
         .into()),
     }
@@ -309,78 +282,17 @@ fn compute_truncate_array(array: ArrayRef, width: i64) -> Result<ArrayRef, DataF
 mod tests {
     use super::*;
     use arrow::array::{
-        Array as _, BinaryArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array,
-        Int64Array, StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+        Array as _, BinaryArray, Decimal128Array, Int32Array, Int64Array, StringArray,
     };
     use datafusion::arrow::datatypes::DataType;
-
-    #[test]
-    fn test_truncate_int8_array() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
-                ColumnarValue::Array(Arc::new(Int8Array::from(vec![101, -1, 0]))),
-            ],
-            number_rows: 3,
-            return_type: &DataType::Int8,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Array(array) = result {
-            let int_array = array
-                .as_any()
-                .downcast_ref::<Int8Array>()
-                .expect("downcast to Int8Array");
-            assert_eq!(int_array.len(), 3);
-            assert_eq!(int_array.value(0), 100, "Expected truncate(10, 101) = 100");
-            assert_eq!(int_array.value(1), -10, "Expected truncate(10, -1) = -10");
-            assert_eq!(int_array.value(2), 0, "Expected truncate(10, 0) = 0");
-        } else {
-            panic!("Expected Int8 array");
-        }
-    }
-
-    #[test]
-    fn test_truncate_int16_array() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
-                ColumnarValue::Array(Arc::new(Int16Array::from(vec![1234, -567, 99]))),
-            ],
-            number_rows: 3,
-            return_type: &DataType::Int16,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Array(array) = result {
-            let int_array = array
-                .as_any()
-                .downcast_ref::<Int16Array>()
-                .expect("downcast to Int16Array");
-            assert_eq!(int_array.len(), 3);
-            assert_eq!(
-                int_array.value(0),
-                1200,
-                "Expected truncate(100, 1234) = 1200"
-            );
-            assert_eq!(
-                int_array.value(1),
-                -600,
-                "Expected truncate(100, -567) = -600"
-            );
-            assert_eq!(int_array.value(2), 0, "Expected truncate(100, 99) = 0");
-        } else {
-            panic!("Expected Int16 array");
-        }
-    }
 
     #[test]
     fn test_truncate_int32_array() {
         let udf = Truncate::new();
         let args = ScalarFunctionArgs {
             args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
-                ColumnarValue::Array(Arc::new(Int32Array::from(vec![1234, -5678, 999]))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
+                ColumnarValue::Array(Arc::new(Int32Array::from(vec![101, -1, 0]))),
             ],
             number_rows: 3,
             return_type: &DataType::Int32,
@@ -390,21 +302,13 @@ mod tests {
             let int_array = array
                 .as_any()
                 .downcast_ref::<Int32Array>()
-                .expect("downcast to Int32Array");
+                .expect("downcast to Int64Array");
             assert_eq!(int_array.len(), 3);
-            assert_eq!(
-                int_array.value(0),
-                1000,
-                "Expected truncate(1000, 1234) = 1000"
-            );
-            assert_eq!(
-                int_array.value(1),
-                -6000,
-                "Expected truncate(1000, -5678) = -6000"
-            );
-            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
+            assert_eq!(int_array.value(0), 100, "Expected truncate(10, 101) = 100");
+            assert_eq!(int_array.value(1), -10, "Expected truncate(10, -1) = -10");
+            assert_eq!(int_array.value(2), 0, "Expected truncate(10, 0) = 0");
         } else {
-            panic!("Expected Int32 array");
+            panic!("Expected Int64 array");
         }
     }
 
@@ -443,202 +347,37 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_uint8_array() {
+    fn test_truncate_decimal_array() {
         let udf = Truncate::new();
         let args = ScalarFunctionArgs {
             args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
-                ColumnarValue::Array(Arc::new(UInt8Array::from(vec![101, 1, 0]))),
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(50))),
+                ColumnarValue::Array(Arc::new(Decimal128Array::from_iter_values(vec![
+                    1065i128, 1234i128,
+                ]))),
             ],
-            number_rows: 3,
-            return_type: &DataType::UInt8,
+            number_rows: 2,
+            return_type: &DataType::Decimal128(10, 2),
         };
         let result = udf.invoke_with_args(args).expect("invoke UDF");
         if let ColumnarValue::Array(array) = result {
-            let int_array = array
+            let dec_array = array
                 .as_any()
-                .downcast_ref::<UInt8Array>()
-                .expect("downcast to UInt8Array");
-            assert_eq!(int_array.len(), 3);
-            assert_eq!(int_array.value(0), 100, "Expected truncate(10, 101) = 100");
-            assert_eq!(int_array.value(1), 0, "Expected truncate(10, 1) = 0");
-            assert_eq!(int_array.value(2), 0, "Expected truncate(10, 0) = 0");
-        } else {
-            panic!("Expected UInt8 array");
-        }
-    }
-
-    #[test]
-    fn test_truncate_uint16_array() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
-                ColumnarValue::Array(Arc::new(UInt16Array::from(vec![1234, 567, 99]))),
-            ],
-            number_rows: 3,
-            return_type: &DataType::UInt16,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Array(array) = result {
-            let int_array = array
-                .as_any()
-                .downcast_ref::<UInt16Array>()
-                .expect("downcast to UInt16Array");
-            assert_eq!(int_array.len(), 3);
+                .downcast_ref::<Decimal128Array>()
+                .expect("downcast to Decimal128Array");
+            assert_eq!(dec_array.len(), 2);
             assert_eq!(
-                int_array.value(0),
+                dec_array.value(0),
+                1050,
+                "Expected truncate(50, 10.65) = 10.50"
+            );
+            assert_eq!(
+                dec_array.value(1),
                 1200,
-                "Expected truncate(100, 1234) = 1200"
-            );
-            assert_eq!(int_array.value(1), 500, "Expected truncate(100, 567) = 500");
-            assert_eq!(int_array.value(2), 0, "Expected truncate(100, 99) = 0");
-        } else {
-            panic!("Expected UInt16 array");
-        }
-    }
-
-    #[test]
-    fn test_truncate_uint32_array() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
-                ColumnarValue::Array(Arc::new(UInt32Array::from(vec![1234, 5678, 999]))),
-            ],
-            number_rows: 3,
-            return_type: &DataType::UInt32,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Array(array) = result {
-            let int_array = array
-                .as_any()
-                .downcast_ref::<UInt32Array>()
-                .expect("downcast to UInt32Array");
-            assert_eq!(int_array.len(), 3);
-            assert_eq!(
-                int_array.value(0),
-                1000,
-                "Expected truncate(1000, 1234) = 1000"
-            );
-            assert_eq!(
-                int_array.value(1),
-                5000,
-                "Expected truncate(1000, 5678) = 5000"
-            );
-            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
-        } else {
-            panic!("Expected UInt32 array");
-        }
-    }
-
-    #[test]
-    fn test_truncate_uint64_array() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
-                ColumnarValue::Array(Arc::new(UInt64Array::from(vec![1234, 5678, 999]))),
-            ],
-            number_rows: 3,
-            return_type: &DataType::UInt64,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Array(array) = result {
-            let int_array = array
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .expect("downcast to UInt64Array");
-            assert_eq!(int_array.len(), 3);
-            assert_eq!(
-                int_array.value(0),
-                1000,
-                "Expected truncate(1000, 1234) = 1000"
-            );
-            assert_eq!(
-                int_array.value(1),
-                5000,
-                "Expected truncate(1000, 5678) = 5000"
-            );
-            assert_eq!(int_array.value(2), 0, "Expected truncate(1000, 999) = 0");
-        } else {
-            panic!("Expected UInt64 array");
-        }
-    }
-
-    #[test]
-    fn test_truncate_float32_array() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(10))),
-                ColumnarValue::Array(Arc::new(Float32Array::from(vec![101.7, -1.2, 0.0]))),
-            ],
-            number_rows: 3,
-            return_type: &DataType::Float32,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Array(array) = result {
-            let float_array = array
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .expect("downcast to Float32Array");
-            assert_eq!(float_array.len(), 3);
-            assert_eq!(
-                float_array.value(0),
-                100.0,
-                "Expected truncate(10, 101.7) = 100.0"
-            );
-            assert_eq!(
-                float_array.value(1),
-                -10.0,
-                "Expected truncate(10, -1.2) = -10.0"
-            );
-            assert_eq!(
-                float_array.value(2),
-                0.0,
-                "Expected truncate(10, 0.0) = 0.0"
+                "Expected truncate(50, 12.34) = 12.00"
             );
         } else {
-            panic!("Expected Float32 array");
-        }
-    }
-
-    #[test]
-    fn test_truncate_float64_array() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(100))),
-                ColumnarValue::Array(Arc::new(Float64Array::from(vec![123.4, -56.78, 9.9]))),
-            ],
-            number_rows: 3,
-            return_type: &DataType::Float64,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Array(array) = result {
-            let float_array = array
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .expect("downcast to Float64Array");
-            assert_eq!(float_array.len(), 3);
-            assert_eq!(
-                float_array.value(0),
-                100.0,
-                "Expected truncate(100, 123.4) = 100.0"
-            );
-            assert_eq!(
-                float_array.value(1),
-                -100.0,
-                "Expected truncate(100, -56.78) = -100.0"
-            );
-            assert_eq!(
-                float_array.value(2),
-                0.0,
-                "Expected truncate(100, 9.9) = 0.0"
-            );
-        } else {
-            panic!("Expected Float64 array");
+            panic!("Expected Decimal128 array");
         }
     }
 
@@ -748,50 +487,12 @@ mod tests {
                 ]))),
             ],
             number_rows: 2,
-            return_type: &DataType::Boolean,
+            return_type: &DataType::Int64,
         };
         let result = udf.invoke_with_args(args);
         assert!(
             result.is_err(),
             "Expected error for invalid second argument type"
         );
-    }
-
-    #[test]
-    fn test_truncate_scalar_int64() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(1000))),
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(1234))),
-            ],
-            number_rows: 1,
-            return_type: &DataType::Int64,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Scalar(ScalarValue::Int64(Some(value))) = result {
-            assert_eq!(value, 1000, "Expected truncate(1000, 1234) = 1000");
-        } else {
-            panic!("Expected Int64 scalar");
-        }
-    }
-
-    #[test]
-    fn test_truncate_scalar_utf8() {
-        let udf = Truncate::new();
-        let args = ScalarFunctionArgs {
-            args: vec![
-                ColumnarValue::Scalar(ScalarValue::Int64(Some(3))),
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some("iceberg".to_string()))),
-            ],
-            number_rows: 1,
-            return_type: &DataType::Utf8,
-        };
-        let result = udf.invoke_with_args(args).expect("invoke UDF");
-        if let ColumnarValue::Scalar(ScalarValue::Utf8(Some(value))) = result {
-            assert_eq!(value, "ice", "Expected truncate(3, 'iceberg') = 'ice'");
-        } else {
-            panic!("Expected Utf8 scalar");
-        }
     }
 }

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -30,6 +30,26 @@ use datafusion::logical_expr::{
 use datafusion::scalar::ScalarValue;
 use snafu::{OptionExt, Snafu};
 
+macro_rules! truncate_numeric_array {
+    ($array:expr, $width:expr, $array_type:ty, $cast_type:ty, $output_type:ty) => {{
+        let casted_array = $array
+            .as_any()
+            .downcast_ref::<$array_type>()
+            .context(DowncastFailedSnafu)?;
+        let width_array = <$array_type>::from_value($width as $cast_type, $array.len());
+        let result: $array_type = binary(casted_array, &width_array, |v, w| {
+            let v = i64::from(v);
+            let w = i64::from(w);
+            (v - (((v % w) + w) % w)) as $output_type
+        })
+        .map_err(|e| DataFusionError::ArrowError(e, None))?;
+        Ok(Arc::new(<$array_type>::new(
+            result.values().clone(),
+            $array.nulls().cloned(),
+        )))
+    }};
+}
+
 /// Maximum truncation width or length, chosen to prevent overflow or excessive memory usage.
 const MAX_TRUNCATE_WIDTH: i64 = i64::MAX / 2;
 
@@ -274,122 +294,13 @@ fn compute_truncate_scalar(
 
 fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, DataFusionError> {
     match array.data_type() {
-        DataType::Int8 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<Int8Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = Int8Array::from_value(width as i8, array.len());
-            let result: Int8Array = binary(casted_array, &width_array, |v, w| {
-                let v = i64::from(v);
-                let w = i64::from(w);
-                (v - (((v % w) + w) % w)) as i8
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(Int8Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
-        }
-        DataType::Int16 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<Int16Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = Int16Array::from_value(width as i16, array.len());
-            let result: Int16Array = binary(casted_array, &width_array, |v, w| {
-                let v = i64::from(v);
-                let w = i64::from(w);
-                (v - (((v % w) + w) % w)) as i16
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(Int16Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
-        }
-        DataType::Int32 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = Int32Array::from_value(width as i32, array.len());
-            let result: Int32Array = binary(casted_array, &width_array, |v, w| {
-                let v = i64::from(v);
-                let w = i64::from(w);
-                (v - (((v % w) + w) % w)) as i32
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(Int32Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
-        }
-        DataType::Int64 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = Int64Array::from_value(width, array.len());
-            let result: Int64Array =
-                binary(casted_array, &width_array, |v, w| v - (((v % w) + w) % w))
-                    .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(Int64Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
-        }
-        DataType::UInt8 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<UInt8Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = UInt8Array::from_value(width as u8, array.len());
-            let result: UInt8Array = binary(casted_array, &width_array, |v, w| {
-                let v = i64::from(v);
-                let w = i64::from(w);
-                (v - (((v % w) + w) % w)) as u8
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(UInt8Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
-        }
-        DataType::UInt16 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<UInt16Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = UInt16Array::from_value(width as u16, array.len());
-            let result: UInt16Array = binary(casted_array, &width_array, |v, w| {
-                let v = i64::from(v);
-                let w = i64::from(w);
-                (v - (((v % w) + w) % w)) as u16
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(UInt16Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
-        }
-        DataType::UInt32 => {
-            let casted_array = array
-                .as_any()
-                .downcast_ref::<UInt32Array>()
-                .context(DowncastFailedSnafu)?;
-            let width_array = UInt32Array::from_value(width as u32, array.len());
-            let result: UInt32Array = binary(casted_array, &width_array, |v, w| {
-                let v = i64::from(v);
-                let w = i64::from(w);
-                (v - (((v % w) + w) % w)) as u32
-            })
-            .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(UInt32Array::new(
-                result.values().clone(),
-                array.nulls().cloned(),
-            )))
-        }
+        DataType::Int8 => truncate_numeric_array!(array, width, Int8Array, i8, i8),
+        DataType::Int16 => truncate_numeric_array!(array, width, Int16Array, i16, i16),
+        DataType::Int32 => truncate_numeric_array!(array, width, Int32Array, i32, i32),
+        DataType::Int64 => truncate_numeric_array!(array, width, Int64Array, i64, i64),
+        DataType::UInt8 => truncate_numeric_array!(array, width, UInt8Array, u8, u8),
+        DataType::UInt16 => truncate_numeric_array!(array, width, UInt16Array, u16, u16),
+        DataType::UInt32 => truncate_numeric_array!(array, width, UInt32Array, u32, u32),
         DataType::UInt64 => {
             let casted_array = array
                 .as_any()
@@ -441,12 +352,7 @@ fn compute_truncate_array(array: &ArrayRef, width: i64) -> Result<ArrayRef, Data
                 array.nulls().cloned(),
             )))
         }
-        DataType::Utf8 => {
-            let result = substring(array, 0, Some(width as u64))
-                .map_err(|e| DataFusionError::ArrowError(e, None))?;
-            Ok(Arc::new(result))
-        }
-        DataType::Binary => {
+        DataType::Utf8 | DataType::Binary => {
             let result = substring(array, 0, Some(width as u64))
                 .map_err(|e| DataFusionError::ArrowError(e, None))?;
             Ok(Arc::new(result))

--- a/crates/runtime/src/datafusion/udf/truncate.rs
+++ b/crates/runtime/src/datafusion/udf/truncate.rs
@@ -80,22 +80,21 @@ impl Truncate {
 
 impl Truncate {
     fn validate_args(args: Vec<ColumnarValue>) -> Result<(i64, ColumnarValue), TruncateError> {
-        let num_args = args.len();
-
-        let mut args = args.into_iter();
-        match (args.next(), args.next()) {
-            (Some(ColumnarValue::Scalar(ScalarValue::Int64(Some(width)))), Some(arg)) => {
-                ensure!(
-                    width > 0 && width <= MAX_TRUNCATE_WIDTH,
-                    InvalidWidthValueSnafu { width }
-                );
-                Ok((width, arg))
-            }
-            (Some(width), Some(_)) => {
-                let width_datatype = width.data_type();
-                Err(TruncateError::InvalidWidthDataType { width_datatype })
-            }
-            _ => Err(TruncateError::InvalidArgumentCount { count: num_args }),
+        if args.len() != 2 {
+            return Err(TruncateError::InvalidArgumentCount { count: args.len() });
+        }
+        if let (ColumnarValue::Scalar(ScalarValue::Int64(Some(width))), arg) =
+            (args[0].clone(), args[1].clone())
+        {
+            ensure!(
+                width > 0 && width <= MAX_TRUNCATE_WIDTH,
+                InvalidWidthValueSnafu { width }
+            );
+            Ok((width, arg))
+        } else {
+            Err(TruncateError::InvalidWidthDataType {
+                width_datatype: args[0].data_type(),
+            })
         }
     }
 }


### PR DESCRIPTION
Adds a new `truncate` scalar UDF.

### Key Features
- **Functionality**: The `truncate(value, width)` function truncates numeric types (`Int8`, `Int16`, `Int32`, `Int64`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Decimal128`, `Decimal256`) to the nearest multiple of width and truncates `Utf8` and `Binary` data to the specified `width` length.
- **Signature**: Accepts two arguments: an `Int64` width and a supported value type.
- **Performance**: Uses Arrow's binary kernel for efficient array operations.
- **Safety**: Enforces a `MAX_TRUNCATE_WIDTH` constant to prevent overflow or excessive memory usage.

### Usage Example
```sql
SELECT truncate(50, CAST(10.65 AS DECIMAL(10, 2))) AS truncated; -- Returns 10.50
SELECT truncate(3, 'iceberg') AS truncated; -- Returns 'ice'
```
