### PR TITLE
Default xAI to 'grok-3'

### DIFF
--- a/crates/llms/src/xai.rs
+++ b/crates/llms/src/xai.rs
@@ -31,7 +31,7 @@ use serde_json::json;
 use crate::chat::{Chat, Error, nsql::SqlGeneration};
 
 static DEFAULT_ENDPOINT: &str = "https://api.x.ai/v1";
-static DEFAULT_MODEL: &str = "grok-beta";
+static DEFAULT_MODEL: &str = "grok-3";
 
 /// [`Xai`] is a chat model for xAI models. xAI is nearly `OpenAI` compatible.
 pub struct Xai {

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -68,9 +68,7 @@ static TEST_MODELS: LazyLock<Vec<ModelDef>> = LazyLock::new(|| {
         ("openai", Box::new(|| create::create_openai("gpt-4o-mini"))),
         (
             "xai",
-            Box::new(|| {
-                create::create_xai("grok-beta").expect("failed to create 'grok-beta' from xAI")
-            }),
+            Box::new(|| create::create_xai("grok-3").expect("failed to create 'grok-3' from xAI")),
         ),
         (
             "hf_phi3",


### PR DESCRIPTION
## 📝 Summary
`grok-beta` is deprecating. Default to new `grok-3` model. 

> You are receiving this email because you have used grok-beta or grok-vision-beta recently. Reminder to upgrade to grok-3 or grok-2-vision as those older models will be removed from our API on June 30.
