### PR TITLE
Create a table provider from full text search index + query

### DIFF
--- a/crates/runtime/src/search/full_text/table.rs
+++ b/crates/runtime/src/search/full_text/table.rs
@@ -27,7 +27,7 @@ use datafusion::prelude::{Expr, SessionConfig, SessionContext};
 use logos::Source;
 use search::generation::CandidateGeneration;
 use search::generation::post_apply::PostApplyCandidateGeneration;
-use search::generation::text_search::FullTextSearch;
+use search::generation::text_search::FullTextSearchIndex;
 use snafu::{ResultExt, Snafu};
 use std::any::Any;
 use std::sync::Arc;
@@ -235,7 +235,7 @@ impl TableWithFullText {
     ) -> Result<Vec<Arc<dyn CandidateGeneration>>, search::generation::Error> {
         let mut generators = vec![];
         for search_field in self.search_fields.as_slice() {
-            let base = FullTextSearch::try_new(
+            let base = FullTextSearchIndex::try_new(
                 Arc::clone(&self.index),
                 search_field.clone(),
                 self.primary_key.clone(),

--- a/crates/search/src/generation/post_apply.rs
+++ b/crates/search/src/generation/post_apply.rs
@@ -313,7 +313,7 @@ mod tests {
     use crate::generation::CandidateGeneration;
     use crate::generation::text_search::tests::{create_basic_index, validate_result};
     use crate::generation::{
-        post_apply::PostApplyCandidateGeneration, text_search::FullTextSearch,
+        post_apply::PostApplyCandidateGeneration, text_search::FullTextSearchIndex,
     };
     use arrow::{
         array::{RecordBatch, StringArray, UInt64Array},
@@ -396,7 +396,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_filter() {
-        let fts = FullTextSearch::try_new(
+        let fts = FullTextSearchIndex::try_new(
             Arc::new(create_basic_index()),
             "body".to_string(),
             vec!["title".to_string()],
@@ -422,7 +422,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_projection() {
-        let fts = FullTextSearch::try_new(
+        let fts = FullTextSearchIndex::try_new(
             Arc::new(create_basic_index()),
             "body".to_string(),
             vec![],

--- a/crates/search/src/generation/text_search/exec.rs
+++ b/crates/search/src/generation/text_search/exec.rs
@@ -32,14 +32,15 @@ use futures::StreamExt;
 
 use super::CandidateGeneration;
 
-pub struct FullTextSearchTableExec {
+/// Executes a  [`FullTextSearchTable`]
+pub struct FullTextSearchExec {
     pub(super) tbl: FullTextSearchTable,
     filters: Vec<LogicalExpr>,
     limit: usize,
     plan_properties: PlanProperties,
 }
 
-impl FullTextSearchTableExec {
+impl FullTextSearchExec {
     pub fn try_new(
         tbl: FullTextSearchTable,
         projection: Option<&Vec<usize>>,
@@ -65,7 +66,7 @@ impl FullTextSearchTableExec {
     }
 }
 
-impl std::fmt::Debug for FullTextSearchTableExec {
+impl std::fmt::Debug for FullTextSearchExec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FullTextSearchTableExec")
             .field("tbl", &self.tbl)
@@ -74,13 +75,13 @@ impl std::fmt::Debug for FullTextSearchTableExec {
             .finish_non_exhaustive()
     }
 }
-impl DisplayAs for FullTextSearchTableExec {
+impl DisplayAs for FullTextSearchExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "FullTextSearchTableExec q={}", self.tbl.query)
     }
 }
 
-impl ExecutionPlan for FullTextSearchTableExec {
+impl ExecutionPlan for FullTextSearchExec {
     fn name(&self) -> &'static str {
         "FullTextSearchTableExec"
     }

--- a/crates/search/src/generation/text_search/exec.rs
+++ b/crates/search/src/generation/text_search/exec.rs
@@ -1,0 +1,148 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use std::{any::Any, fmt::Formatter, sync::Arc};
+
+use crate::generation::text_search::table::FullTextSearchTable;
+use arrow::error::ArrowError;
+use async_stream::stream;
+use datafusion::{
+    catalog::TableProvider,
+    error::{DataFusionError, Result as DataFusionResult},
+    execution::SendableRecordBatchStream,
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+        execution_plan::{Boundedness, EmissionType},
+        stream::RecordBatchStreamAdapter,
+    },
+    prelude::Expr as LogicalExpr,
+};
+
+use futures::StreamExt;
+
+use super::CandidateGeneration;
+
+pub struct FullTextSearchTableExec {
+    pub(super) tbl: FullTextSearchTable,
+    filters: Vec<LogicalExpr>,
+    limit: usize,
+    plan_properties: PlanProperties,
+}
+
+impl FullTextSearchTableExec {
+    pub fn try_new(
+        tbl: FullTextSearchTable,
+        projection: Option<&Vec<usize>>,
+        filters: Vec<LogicalExpr>,
+        limit: usize,
+    ) -> Result<Self, ArrowError> {
+        let schema = match projection {
+            Some(proj) => Arc::new(tbl.schema().project(proj.as_slice())?),
+            None => Arc::clone(&tbl.schema()),
+        };
+
+        Ok(Self {
+            tbl,
+            filters,
+            limit,
+            plan_properties: PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            ),
+        })
+    }
+}
+
+impl std::fmt::Debug for FullTextSearchTableExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FullTextSearchTableExec")
+            .field("tbl", &self.tbl)
+            .field("filters", &self.filters)
+            .field("limit", &self.limit)
+            .finish_non_exhaustive()
+    }
+}
+impl DisplayAs for FullTextSearchTableExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "FullTextSearchTableExec q={}", self.tbl.query)
+    }
+}
+
+impl ExecutionPlan for FullTextSearchTableExec {
+    fn name(&self) -> &'static str {
+        "FullTextSearchTableExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.plan_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::clone(&self) as Arc<dyn ExecutionPlan>)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<datafusion::execution::TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let idx = self.tbl.index.clone();
+        let schema = self.schema();
+        let limit = self.limit;
+        let query = self.tbl.query.clone();
+        let s = stream! {
+        // TODO: Support filters.
+            match idx
+                .search(query, &[], &[], limit)
+                .await
+                .map_err(|e| DataFusionError::Plan(format!("Failed to prepare full text search: {e}"))) {
+                Ok(mut stream) => {
+                    while let Some(item) = stream.next().await {
+                        match item {
+                            Err(e) => yield Err(e),
+                            Ok(rb) => {
+                                // Apply projection, as per `self.schema()`, to record batch from FTS.
+                                let proj = rb.schema().fields().iter().enumerate().filter_map(|(i, f)| {
+                                    if schema.column_with_name(f.name()).is_some() {
+                                        Some(i)
+                                    } else {
+                                        None
+                                    }
+                                }).collect::<Vec<_>>();
+                                yield rb.project(proj.as_slice()).map_err(DataFusionError::from)
+                            }
+                        }
+                    }
+                },
+                Err(e) => {
+                    yield Err(e);
+                    return;
+                }
+            }
+        };
+        Ok(Box::pin(RecordBatchStreamAdapter::new(self.schema(), s)))
+    }
+}

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -13,7 +13,11 @@ limitations under the License.
 use std::{cmp::min, collections::HashMap, sync::Arc};
 
 use crate::{SEARCH_SCORE_COLUMN_NAME, SEARCH_VALUE_COLUMN_NAME};
-use arrow::{array::RecordBatch, datatypes::Schema, error::ArrowError};
+use arrow::{
+    array::RecordBatch,
+    datatypes::{Field, Schema},
+    error::ArrowError,
+};
 use arrow_json::reader::Decoder;
 use async_stream::stream;
 use async_trait::async_trait;
@@ -31,7 +35,7 @@ use tantivy::{
     collector::TopDocs,
     query::{Occur, QueryParser, QueryParserError},
     query_grammar::{Delimiter, UserInputAst, UserInputLeaf, UserInputLiteral},
-    schema::{Field, OwnedValue},
+    schema::{FieldType, OwnedValue},
     tokenizer::{LowerCaser, SimpleTokenizer, TextAnalyzer},
 };
 
@@ -41,6 +45,9 @@ use super::{
 };
 
 static DEFAULT_BATCH_SIZE: usize = 100;
+
+pub mod exec;
+pub mod table;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -88,7 +95,7 @@ impl Error {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FullTextSearch {
     idx: Arc<Index>,
     field: String,
@@ -211,7 +218,7 @@ impl FullTextSearch {
             .context(TextSearchSnafu)?
             .into_iter()
             .map(|(score, addr)| {
-                let doc: HashMap<Field, OwnedValue> =
+                let doc: HashMap<tantivy::schema::Field, OwnedValue> =
                     searcher.doc(addr).context(TextSearchSnafu)?;
 
                 let mut doc_w_col_names = doc
@@ -378,7 +385,7 @@ fn make_stream(
             remaining_limit -= limit;
 
             let mut decoder = match tantivy_json_to_arrow_decoder(hits.as_slice())
-                .map_err(|e| DataFusionError::ArrowError(e, None)) {
+                .map_err(DataFusionError::from) {
                     Ok(h) => h,
                     Err(e) => {
                         yield Err(e);
@@ -389,7 +396,7 @@ fn make_stream(
             match decoder.flush() {
                 Ok(Some(rb)) => yield Ok(rb),
                 Ok(None) => {},
-                Err(e) => yield Err(DataFusionError::ArrowError(e, None))
+                Err(e) => yield Err(DataFusionError::from(e))
             }
         }
     }
@@ -399,11 +406,44 @@ fn tantivy_json_to_arrow_decoder(hits: &[Value]) -> std::result::Result<Decoder,
     let schema = Arc::new(arrow_json::reader::infer_json_schema_from_iterator(
         hits.iter().map(Ok),
     )?);
+
+    // Ensure `SEARCH_SCORE_COLUMN_NAME` is f64 not f32 or other numeric.
+    let schema = Arc::new(Schema::new(
+        schema
+            .fields()
+            .into_iter()
+            .map(|f| {
+                if f.name() == SEARCH_SCORE_COLUMN_NAME {
+                    Arc::new(Field::new(
+                        f.name(),
+                        arrow::datatypes::DataType::Float64,
+                        f.is_nullable(),
+                    ))
+                } else {
+                    Arc::clone(f)
+                }
+            })
+            .collect::<Vec<_>>(),
+    ));
+
     let mut decoder = arrow_json::ReaderBuilder::new(Arc::clone(&schema)).build_decoder()?;
 
     decoder.serialize(hits)?;
 
     Ok(decoder)
+}
+
+fn tantivy_to_arrow_type(t: &FieldType) -> Option<arrow::datatypes::DataType> {
+    match t {
+        FieldType::Str(_) => Some(arrow::datatypes::DataType::Utf8),
+        FieldType::I64(_) => Some(arrow::datatypes::DataType::Int64),
+        FieldType::U64(_) => Some(arrow::datatypes::DataType::UInt64),
+        FieldType::F64(_) => Some(arrow::datatypes::DataType::Float64),
+        FieldType::Date(_) => Some(arrow::datatypes::DataType::Date32),
+        FieldType::Bool(_) => Some(arrow::datatypes::DataType::Boolean),
+        FieldType::Bytes(_) => Some(arrow::datatypes::DataType::Binary),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -96,7 +96,7 @@ impl Error {
 }
 
 #[derive(Clone, Debug)]
-pub struct FullTextSearch {
+pub struct FullTextSearchIndex {
     idx: Arc<Index>,
     field: String,
     primary_key: Vec<String>,
@@ -106,7 +106,7 @@ pub struct FullTextSearch {
     additional_columns: Option<Vec<String>>,
 }
 
-impl FullTextSearch {
+impl FullTextSearchIndex {
     pub fn try_new(
         index: Arc<Index>,
         field: String,
@@ -292,7 +292,7 @@ fn parse_query_literal(q: &str) -> UserInputAst {
 }
 
 #[async_trait]
-impl CandidateGeneration for FullTextSearch {
+impl CandidateGeneration for FullTextSearchIndex {
     async fn search(
         &self,
         query: String,
@@ -366,7 +366,7 @@ impl CandidateGeneration for FullTextSearch {
 }
 
 fn make_stream(
-    fts: FullTextSearch,
+    fts: FullTextSearchIndex,
     query: String,
     keep_search_field: bool,
     limit: usize,
@@ -462,7 +462,7 @@ pub(crate) mod tests {
         aggregation::write_to_json_string,
         generation::{
             CandidateGeneration, Result as GenerationResult,
-            text_search::{FullTextSearch, parse_query_literal},
+            text_search::{FullTextSearchIndex, parse_query_literal},
         },
     };
 
@@ -544,7 +544,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_basic_index() {
-        let fts = FullTextSearch::try_new(
+        let fts = FullTextSearchIndex::try_new(
             Arc::new(create_basic_index()),
             "body".to_string(),
             vec![],

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -187,6 +187,16 @@ impl FullTextSearch {
             .searcher())
     }
 
+    fn query_parser(&self) -> QueryParser {
+        let default_field = self
+            .idx
+            .schema()
+            .find_field(self.field.as_str())
+            .map(|(f, _)| vec![f])
+            .unwrap_or_default();
+        QueryParser::for_index(&self.idx, default_field)
+    }
+
     /// If `keep_search_field`, `self.field` will be kept in result (as well as [`SEARCH_VALUE_COLUMN_NAME`]).
     fn search_query_literal(
         &self,
@@ -195,14 +205,8 @@ impl FullTextSearch {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<Value>> {
-        // Explicitly create AST to avoid user queries being considered a query language (e.g. `"title:sea^20 body:whale^70"`).
-        let default_field = self
-            .idx
-            .schema()
-            .find_field(self.field.as_str())
-            .map(|(f, _)| vec![f])
-            .unwrap_or_default();
-        let q = QueryParser::for_index(&self.idx, default_field)
+        let q = self
+            .query_parser()
             .build_query_from_user_input_ast(parse_query_literal(literal))
             .context(InvalidTextSearchQuerySnafu {
                 query: literal.to_string(),
@@ -330,10 +334,7 @@ impl CandidateGeneration for FullTextSearch {
                 ));
             }
         };
-        let strm =
-            Box::pin(RecordBatchStreamAdapter::new(schema, strm)) as SendableRecordBatchStream;
-
-        Ok(strm)
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, strm)) as SendableRecordBatchStream)
     }
 
     fn supports_filters_pushdown(&self, filters: &[&Expr]) -> GenerationResult<Vec<bool>> {

--- a/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__and_conjunction.snap
+++ b/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__and_conjunction.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/search/src/generation/text_search.rs
-expression: "parse_query_literal(\"'foo and' bar\")"
+source: crates/search/src/generation/text_search/mod.rs
+expression: "parse_query_literal(\"foo and bar\")"
 snapshot_kind: text
 ---
 {

--- a/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__basic_index.snap
+++ b/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__basic_index.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/search/src/generation/text_search.rs
+source: crates/search/src/generation/text_search/mod.rs
 expression: rb_as_value
 snapshot_kind: text
 ---

--- a/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__operators.snap
+++ b/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__operators.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/search/src/generation/text_search.rs
+source: crates/search/src/generation/text_search/mod.rs
 expression: "parse_query_literal(\"How much (in USD) don't I get?\")"
 snapshot_kind: text
 ---

--- a/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__quotes_conjunction.snap
+++ b/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__quotes_conjunction.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/search/src/generation/text_search.rs
-expression: "parse_query_literal(\"foo and bar\")"
+source: crates/search/src/generation/text_search/mod.rs
+expression: "parse_query_literal(\"'foo and' bar\")"
 snapshot_kind: text
 ---
 {

--- a/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__special_characters.snap
+++ b/crates/search/src/generation/text_search/snapshots/search__generation__text_search__tests__special_characters.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/search/src/generation/text_search.rs
+source: crates/search/src/generation/text_search/mod.rs
 expression: "parse_query_literal(\"title:sea^20 body:whale^70\")"
 snapshot_kind: text
 ---

--- a/crates/search/src/generation/text_search/table.rs
+++ b/crates/search/src/generation/text_search/table.rs
@@ -1,0 +1,119 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use std::{any::Any, sync::Arc};
+
+use crate::{
+    SEARCH_SCORE_COLUMN_NAME,
+    generation::text_search::{
+        DEFAULT_BATCH_SIZE, FullTextSearch, exec::FullTextSearchTableExec, tantivy_to_arrow_type,
+    },
+};
+use arrow::datatypes::{Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::{
+    catalog::{Session, TableProvider},
+    common::Constraints,
+    datasource::TableType,
+    error::{DataFusionError, Result as DataFusionResult},
+    logical_expr::TableProviderFilterPushDown,
+    physical_plan::ExecutionPlan,
+    prelude::Expr as LogicalExpr,
+};
+
+/// An implementation of [`TableProvider`] based on a known query on a [`FullTextSearch`] index.
+#[derive(Clone, Debug)]
+pub struct FullTextSearchTable {
+    pub index: FullTextSearch,
+    pub query: String,
+    pub default_limit: usize,
+}
+
+impl FullTextSearchTable {
+    #[must_use]
+    pub fn new(index: FullTextSearch, query: String) -> Self {
+        Self {
+            index,
+            query,
+            default_limit: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    #[must_use]
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.default_limit = limit;
+        self
+    }
+}
+#[async_trait]
+impl TableProvider for FullTextSearchTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        let tantivy_schema = self.index.idx.schema();
+
+        let fields = self
+            .index
+            .all_columns()
+            .iter()
+            .filter_map(|field_name| {
+                let f = tantivy_schema.get_field(field_name).ok()?;
+                let entry = tantivy_schema.get_field_entry(f);
+                let data_type = tantivy_to_arrow_type(entry.field_type())?;
+                Some(Field::new(field_name, data_type, false))
+            })
+            .chain([Field::new(
+                SEARCH_SCORE_COLUMN_NAME,
+                arrow::datatypes::DataType::Float64,
+                false,
+            )])
+            .collect::<Vec<_>>();
+
+        Arc::new(Schema::new(fields))
+    }
+
+    fn constraints(&self) -> Option<&Constraints> {
+        // TODO primary keys
+        None
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[LogicalExpr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(
+            FullTextSearchTableExec::try_new(
+                self.clone(),
+                projection,
+                filters.to_vec(),
+                limit.unwrap_or(self.default_limit),
+            )
+            .map_err(DataFusionError::from)?,
+        ))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        _filters: &[&LogicalExpr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![])
+    }
+}

--- a/crates/search/src/generation/text_search/table.rs
+++ b/crates/search/src/generation/text_search/table.rs
@@ -30,7 +30,9 @@ use datafusion::{
     prelude::Expr as LogicalExpr,
 };
 
-/// An implementation of [`TableProvider`] based on a known query on a [`FullTextSearch`] index.
+/// An implementation of [`TableProvider`] based on a given query on a [`FullTextSearch`] index.
+///
+/// Currently, filter pushdown support is unavailable.
 #[derive(Clone, Debug)]
 pub struct FullTextSearchTable {
     pub index: FullTextSearch,

--- a/crates/search/src/generation/text_search/table.rs
+++ b/crates/search/src/generation/text_search/table.rs
@@ -15,7 +15,7 @@ use std::{any::Any, sync::Arc};
 use crate::{
     SEARCH_SCORE_COLUMN_NAME,
     generation::text_search::{
-        DEFAULT_BATCH_SIZE, FullTextSearch, exec::FullTextSearchTableExec, tantivy_to_arrow_type,
+        DEFAULT_BATCH_SIZE, FullTextSearchIndex, exec::FullTextSearchExec, tantivy_to_arrow_type,
     },
 };
 use arrow::datatypes::{Field, Schema, SchemaRef};
@@ -35,14 +35,14 @@ use datafusion::{
 /// Currently, filter pushdown support is unavailable.
 #[derive(Clone, Debug)]
 pub struct FullTextSearchTable {
-    pub index: FullTextSearch,
+    pub index: FullTextSearchIndex,
     pub query: String,
     pub default_limit: usize,
 }
 
 impl FullTextSearchTable {
     #[must_use]
-    pub fn new(index: FullTextSearch, query: String) -> Self {
+    pub fn new(index: FullTextSearchIndex, query: String) -> Self {
         Self {
             index,
             query,
@@ -102,7 +102,7 @@ impl TableProvider for FullTextSearchTable {
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(
-            FullTextSearchTableExec::try_new(
+            FullTextSearchExec::try_new(
                 self.clone(),
                 projection,
                 filters.to_vec(),


### PR DESCRIPTION
## 📝 Summary
 - A given full text search index and a query is enough to define a [`TableProvider`]. 
 - This PR introduces this ability, for use in future work where an index needs to be used further within datafusion.

Structs are renamed to make the distinction clearer:
 - `FullTextSearch` -> `FullTextSearchIndex`: A search index that can be used in search.
 - `FullTextSearchTable`: A table that can be used in the database, for a given search index and query.
 - `FullTextSearchExec`: The physical execution of a `FullTextSearchTable` (i.e. has given projection/filters/limit). 

## 🔗 Related
Preparation for #6240 
