### PR TITLE
fix: Deny extra caching parameters

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -204,20 +204,20 @@ impl QueryResultsCacheProvider {
         config: &SQLResultsCacheConfig,
         ignore_schemas: Box<[Box<str>]>,
     ) -> Result<Self> {
-        let cache_max_size: u64 = match &config.inner.max_size {
+        let cache_max_size: u64 = match &config.max_size {
             Some(cache_max_size) => Byte::parse_str(cache_max_size, true)
                 .context(FailedToParseCacheMaxSizeSnafu)?
                 .as_u64(),
             None => 128 * 1024 * 1024, // 128 MiB
         };
 
-        let ttl = match &config.inner.item_ttl {
+        let ttl = match &config.item_ttl {
             Some(item_ttl) => fundu::parse_duration(item_ttl).context(FailedToParseItemTtlSnafu)?,
             None => std::time::Duration::from_secs(1),
         };
 
         let cache_provider = QueryResultsCacheProvider {
-            cache: match config.inner.hashing_algorithm {
+            cache: match config.hashing_algorithm {
                 HashingAlgorithm::Ahash => Arc::new(LruCache::new(
                     cache_max_size,
                     ttl,

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -263,7 +263,7 @@ mod tests {
     use cache::{
         Caching, QueryResultsCacheProvider, SimpleCache, key::CacheKey, result::CacheStatus,
     };
-    use spicepod::component::caching::{CacheConfig, SQLResultsCacheConfig};
+    use spicepod::component::caching::SQLResultsCacheConfig;
 
     use crate::{
         builder::RuntimeBuilder,
@@ -295,11 +295,9 @@ mod tests {
     #[allow(clippy::too_many_lines)]
     async fn test_get_plan_or_cached_cache_miss_and_hit() {
         let results_cache_config = SQLResultsCacheConfig {
-            inner: CacheConfig {
-                item_ttl: Some("10m".to_string()),
-                ..Default::default()
-            },
+            item_ttl: Some("10m".to_string()),
             cache_key_type: spicepod::component::caching::CacheKeyType::Sql,
+            ..Default::default()
         };
         let cache_provider =
             QueryResultsCacheProvider::try_new(&results_cache_config, Box::new([]))
@@ -408,11 +406,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_plan_or_cached_sql_cached_prepared_statements() {
         let results_cache_config = SQLResultsCacheConfig {
-            inner: CacheConfig {
-                item_ttl: Some("10m".to_string()),
-                ..Default::default()
-            },
+            item_ttl: Some("10m".to_string()),
             cache_key_type: spicepod::component::caching::CacheKeyType::Sql,
+            ..Default::default()
         };
         let cache_provider =
             QueryResultsCacheProvider::try_new(&results_cache_config, Box::new([]))
@@ -472,11 +468,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_plan_or_cached_plan_cached_prepared_statements() {
         let results_cache_config = SQLResultsCacheConfig {
-            inner: CacheConfig {
-                item_ttl: Some("10m".to_string()),
-                ..Default::default()
-            },
+            item_ttl: Some("10m".to_string()),
             cache_key_type: spicepod::component::caching::CacheKeyType::Plan,
+            ..Default::default()
         };
         let cache_provider =
             QueryResultsCacheProvider::try_new(&results_cache_config, Box::new([]))

--- a/crates/runtime/src/init/caching.rs
+++ b/crates/runtime/src/init/caching.rs
@@ -44,7 +44,7 @@ impl Runtime {
             .clone()
             .unwrap_or(CacheConfig::default());
 
-        if sql_results_config.inner.enabled {
+        if sql_results_config.enabled {
             match QueryResultsCacheProvider::try_new(
                 &sql_results_config,
                 Box::new([SPICE_RUNTIME_SCHEMA.into(), "information_schema".into()]),
@@ -65,7 +65,7 @@ impl Runtime {
 
         // TODO: logical plan cache needs its own configuration?
         let plan_cache_provider: Arc<dyn CacheProvider<LogicalPlan> + Send + Sync> =
-            match sql_results_config.inner.hashing_algorithm {
+            match sql_results_config.hashing_algorithm {
                 HashingAlgorithm::Siphash => Arc::new(SimpleCache::new(
                     DEFAULT_CACHED_PLANS_MAX_CAPACITY,
                     Duration::from_secs(3600),

--- a/crates/spicepod/src/component/caching.rs
+++ b/crates/spicepod/src/component/caching.rs
@@ -72,12 +72,20 @@ impl Default for CacheConfig {
     }
 }
 
+// https://serde.rs/attr-flatten.html
+// > Note: flatten is not supported in combination with structs that use deny_unknown_fields. Neither the outer nor inner flattened struct should use that attribute.
+// As a result, we cannot use flatten to get a nice unknown field experience
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct SQLResultsCacheConfig {
-    #[serde(flatten)]
-    pub inner: CacheConfig,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub max_size: Option<String>,
+    pub item_ttl: Option<String>,
+    pub eviction_policy: Option<String>,
+    #[serde(default)]
+    pub hashing_algorithm: HashingAlgorithm,
     #[serde(default)]
     pub cache_key_type: CacheKeyType,
 }
@@ -113,13 +121,11 @@ impl Default for ResultsCache {
 impl From<ResultsCache> for SQLResultsCacheConfig {
     fn from(val: ResultsCache) -> Self {
         SQLResultsCacheConfig {
-            inner: CacheConfig {
-                enabled: val.enabled,
-                max_size: val.cache_max_size,
-                item_ttl: val.item_ttl,
-                eviction_policy: val.eviction_policy,
-                hashing_algorithm: val.hashing_algorithm,
-            },
+            enabled: val.enabled,
+            max_size: val.cache_max_size,
+            item_ttl: val.item_ttl,
+            eviction_policy: val.eviction_policy,
+            hashing_algorithm: val.hashing_algorithm,
             cache_key_type: val.cache_key_type,
         }
     }

--- a/crates/spicepod/src/component/caching.rs
+++ b/crates/spicepod/src/component/caching.rs
@@ -38,6 +38,7 @@ pub enum HashingAlgorithm {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Caching {
     #[serde(skip_serializing_if = "is_default_or_none")]
@@ -47,6 +48,7 @@ pub struct Caching {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct CacheConfig {
     #[serde(default = "default_true")]
@@ -71,6 +73,7 @@ impl Default for CacheConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct SQLResultsCacheConfig {
     #[serde(flatten)]
@@ -80,6 +83,7 @@ pub struct SQLResultsCacheConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct ResultsCache {
     #[serde(default = "default_true")]


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds `serde(deny_unknown_fields)` for Runtime caching parameters
* Replaces `serde(flatten)` with the actual fields for the SQL Results Cache struct, as serde does not support `deny_unknown_fields` with `flatten`.

**Before:**
```console
2025-06-20T07:34:16.436522Z  INFO spiced: Starting runtime v1.4.0+models.cuda
2025-06-20T07:34:16.452011Z  INFO runtime::init::caching: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
2025-06-20T07:34:16.453741Z  INFO runtime::init::caching: Initialized search results cache;
```

**After:**
```console
2025-06-20T07:05:51.910431Z  INFO spiced: Starting runtime v1.5.0-unstable-build.9e9b5095d
2025-06-20T07:05:51.910861Z  WARN spiced: Unable to load spicepod /home/owner/spiceai: Unable to parse spicepod.yaml: runtime.caching: unknown field `somerandomkey`, expected `sql_results` or `search_results` at line 6 column 5
```

or:

```console
2025-06-20T07:25:44.502456Z  INFO spiced: Starting runtime v1.5.0-unstable-build.9e9b5095d
2025-06-20T07:25:44.502910Z  WARN spiced: Unable to load spicepod /home/owner/spiceai: Unable to parse spicepod.yaml: runtime.caching.sql_results: unknown field `somerandomkey`, expected one of `enabled`, `max_size`, `item_ttl`, `eviction_policy`, `hashing_algorithm`, `cache_key_type` at line 7 column 7
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6287 