### PR TITLE
fix: consume response stream before reading `authorization` metadata

### DIFF
--- a/crates/flight_client/src/lib.rs
+++ b/crates/flight_client/src/lib.rs
@@ -597,7 +597,7 @@ impl FlightClient {
             .parse()
             .context(InvalidMetadataSnafu)?;
         req.metadata_mut().insert("authorization", val);
-        let resp = self
+        let mut resp = self
             .flight_client
             .clone()
             .handshake(req)
@@ -613,13 +613,34 @@ impl FlightClient {
                     }
                 }
             })?;
+
         let mut token: Option<Token> = None;
+
+        // Consume the response stream before reading the metadata
+        let stream = resp.get_mut();
+        while let Some(data) = stream.next().await {
+            match data {
+                Ok(_) => {}
+                Err(e) => {
+                    if is_connection_reset_error(&e) {
+                        return Err(Error::ConnectionReset {
+                            source: TonicStatusError::from(e),
+                        });
+                    }
+                    return Err(Error::UnableToPerformHandshake {
+                        source: TonicStatusError::from(e),
+                    });
+                }
+            }
+        }
+
         if let Some(auth) = resp.metadata().get("authorization") {
             let auth = auth
                 .to_str()
                 .context(UnableToConvertMetadataToStringSnafu)?;
             token = Some(Token::new(&auth["Bearer ".len()..], true));
         }
+
         Ok(token)
     }
 


### PR DESCRIPTION
## 📝 Summary

Consume the response stream before before reading `authorization` metadata in the flight `authenticate_basic_token`. `authorization` header could be missing from a failed request, and such failure is only detected when consuming the stream, not necessarily when obtaining the response.

This also corresponds to the official arrow flight [AuthenticateBasicToken](https://github.com/apache/arrow/blob/c5d192b05e604f7f9bd32e59ade8dd550440c2e8/cpp/src/arrow/flight/transport/grpc/grpc_client.cc#L873) C++ implementation, where the token is only ready after the stream is fully consumed. 

## 🔗 Related

- https://github.com/spiceai/spiceai/issues/6291

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
