### PR TITLE
Make DynamoDB connectivity errors more specific and actionable

### DIFF
--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -23,10 +23,7 @@ use arrow::{
 use async_trait::async_trait;
 use aws_sdk_dynamodb::{
     Client,
-    operation::{
-        describe_table::DescribeTableError,
-        scan::{ScanError, builders::ScanFluentBuilder},
-    },
+    operation::scan::{ScanError, builders::ScanFluentBuilder},
     types::{AttributeValue, TableStatus},
 };
 use datafusion::{
@@ -49,9 +46,11 @@ use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("{source}"))]
+    #[snafu(display(
+        "Failed to fetch table information.\nError: {source}\nVerify configuration and try again.\nFor details, visit https://spiceai.org/docs/components/data-connectors/dynamodb"
+    ))]
     DescribeTableError {
-        source: aws_sdk_dynamodb::error::SdkError<DescribeTableError>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     #[snafu(display("{source}"))]
@@ -99,6 +98,31 @@ impl DynamoDBTableProvider {
             .table_name(table_name.to_string())
             .send()
             .await
+            .map_err(|err| {
+                // Convert the SdkError to a more user-friendly error
+                let source = match err.into_source() {
+                    Ok(source) => source,
+                    Err(err) => {
+                        // If there is no error source, then original instance of SdkError is returned
+                        return err.into();
+                    }
+                };
+
+                if let Some(err) = source.downcast_ref::<aws_sdk_dynamodb::operation::describe_table::DescribeTableError>() {
+                    // Error metadata message (if present) contains a specific error message
+                    if let Some(err_msg) = err.meta().message() {
+                        return err_msg.into();
+                    }
+                }
+
+                // If a connection error occurs, provide detailed information available via Debug format.
+                // This happens when the request failed during dispatch. An HTTP response was not received, thus no error code or message is available.
+                if let Some(conn_error) = source.downcast_ref::<aws_sdk_dynamodb::error::ConnectorError>() {
+                    return format!("The request failed during dispatch (response was not received). This might indicate an invalid region setting or another connectivity problem.\n{conn_error:?}").into();
+                }
+
+                source
+            })
             .context(DescribeTableSnafu)?;
 
         let Some(table) = response.table() else {

--- a/crates/data_components/src/dynamodb/provider.rs
+++ b/crates/data_components/src/dynamodb/provider.rs
@@ -118,7 +118,9 @@ impl DynamoDBTableProvider {
                 // If a connection error occurs, provide detailed information available via Debug format.
                 // This happens when the request failed during dispatch. An HTTP response was not received, thus no error code or message is available.
                 if let Some(conn_error) = source.downcast_ref::<aws_sdk_dynamodb::error::ConnectorError>() {
-                    return format!("The request failed during dispatch (response was not received). This might indicate an invalid region setting or another connectivity problem.\n{conn_error:?}").into();
+                    return format!(
+                        "Connection error. This may indicate an invalid region setting, connectivity, or access issue.\nDetails: {conn_error:?}"
+                    ).into();
                 }
 
                 source


### PR DESCRIPTION
## 📝 Summary

**Before**

>2025-06-21T01:23:39.320832Z  WARN runtime::init::dataset: Failed to load the dataset sales_transactions (dynamodb).
service error

>2025-06-21T01:24:20.953444Z  WARN runtime::init::dataset: Failed to load the dataset sales_transactions (dynamodb).
dispatch failure

**After**

>2025-06-21T01:20:10.869384Z  WARN runtime::init::dataset: Failed to load the dataset sales_transactions (dynamodb).
Failed to fetch table information.
Error: The security token included in the request is invalid.
Verify configuration and try again.
For details, visit https://spiceai.org/docs/components/data-connectors/dynamodb


>2025-06-21T01:50:41.444866Z  WARN runtime::init::dataset: Failed to load the dataset sales_transactions (dynamodb).
Failed to fetch table information.
Error: Connection error. This may indicate an invalid region setting, connectivity, or access issue.
Details: ConnectorError { kind: Other(None), source: hyper_util::client::legacy::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: nodename nor servname provided, or not known" })), connection: Unknown }
Verify configuration and try again.
For details, visit https://spiceai.org/docs/components/data-connectors/dynamodb

Error: Requested resource not found: Table: sales_transactions2 not found
Error: The security token included in the request is invalid.
Error: The security token included in the request is expired

## 🔗 Related

Closes  https://github.com/spiceai/spiceai/issues/6290

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
