### PR TITLE
fix: Warn about no configured datasets if no datasets and catalogs are present

### DIFF
--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -67,12 +67,8 @@ impl Runtime {
         };
 
         let valid_datasets = Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
-        let valid_catalogs = Arc::clone(&self).get_valid_catalogs(app, LogErrors(true));
 
-        if valid_datasets.is_empty() && valid_catalogs.is_empty() {
-            tracing::info!(
-                "No datasets were configured. If this is unexpected, check the Spicepod configuration."
-            );
+        if valid_datasets.is_empty() {
             return;
         }
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -67,8 +67,9 @@ impl Runtime {
         };
 
         let valid_datasets = Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
+        let valid_catalogs = Arc::clone(&self).get_valid_catalogs(app, LogErrors(true));
 
-        if valid_datasets.is_empty() {
+        if valid_datasets.is_empty() && valid_catalogs.is_empty() {
             tracing::info!(
                 "No datasets were configured. If this is unexpected, check the Spicepod configuration."
             );

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -868,7 +868,7 @@ impl Runtime {
                                     Arc::clone(&self).get_valid_catalogs(app, LogErrors(false));
                                 if valid_datasets.is_empty() && valid_catalogs.is_empty() {
                                     tracing::info!(
-                                        "No datasets or catalogs were configured. If this is unexpected, please check the configuration of your Spicepod."
+                                        "No datasets or catalogs were configured. If this is unexpected, check the Spicepod configuration."
                                     );
                                 }
                             }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -863,9 +863,9 @@ impl Runtime {
                         if status.is_ready() {
                             if let Some(app) = self.app.read().await.as_ref() {
                                 let valid_datasets =
-                                    Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
+                                    Arc::clone(&self).get_valid_datasets(app, LogErrors(false));
                                 let valid_catalogs =
-                                    Arc::clone(&self).get_valid_catalogs(app, LogErrors(true));
+                                    Arc::clone(&self).get_valid_catalogs(app, LogErrors(false));
                                 if valid_datasets.is_empty() && valid_catalogs.is_empty() {
                                     tracing::info!(
                                         "No datasets or catalogs were configured. If this is unexpected, please check the configuration of your Spicepod."

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -813,6 +813,16 @@ impl Runtime {
             }
         }
 
+        if let Some(app) = self.app.read().await.as_ref() {
+            let valid_datasets = Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
+            let valid_catalogs = Arc::clone(&self).get_valid_catalogs(app, LogErrors(true));
+            if valid_datasets.is_empty() && valid_catalogs.is_empty() {
+                tracing::info!(
+                    "No datasets or catalogs were configured. If this is unexpected, please check the configuration of your Spicepod."
+                );
+            }
+        }
+
         let components = vec![task_history, datasets, catalogs, models_and_evals];
 
         // Signal that the load must be canceled if the runtime is shut down before the components are loaded

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -813,16 +813,6 @@ impl Runtime {
             }
         }
 
-        if let Some(app) = self.app.read().await.as_ref() {
-            let valid_datasets = Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
-            let valid_catalogs = Arc::clone(&self).get_valid_catalogs(app, LogErrors(true));
-            if valid_datasets.is_empty() && valid_catalogs.is_empty() {
-                tracing::info!(
-                    "No datasets or catalogs were configured. If this is unexpected, please check the configuration of your Spicepod."
-                );
-            }
-        }
-
         let components = vec![task_history, datasets, catalogs, models_and_evals];
 
         // Signal that the load must be canceled if the runtime is shut down before the components are loaded
@@ -871,6 +861,17 @@ impl Runtime {
                             break;
                         }
                         if status.is_ready() {
+                            if let Some(app) = self.app.read().await.as_ref() {
+                                let valid_datasets =
+                                    Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
+                                let valid_catalogs =
+                                    Arc::clone(&self).get_valid_catalogs(app, LogErrors(true));
+                                if valid_datasets.is_empty() && valid_catalogs.is_empty() {
+                                    tracing::info!(
+                                        "No datasets or catalogs were configured. If this is unexpected, please check the configuration of your Spicepod."
+                                    );
+                                }
+                            }
                             tracing::info!("All components are loaded. Spice runtime is ready!");
                             break;
                         }


### PR DESCRIPTION
## 📝 Summary

- Warn about no configured datasets only when no datasets *and* no catalogs are present

## 🔗 Related

- Closes #5982 

## Output

`spicepod.yaml`:
```yaml
version: v1
kind: Spicepod
name: spice-catalog-demo
catalogs:
    - from: spice.ai/spiceai/tpch
      name: scp
      include:
          - tpch.part*
          - tpch.supplier
    - from: spice.ai/spiceai/quickstart
      name: quickstart
```

Before:
![image](https://github.com/user-attachments/assets/e73d593b-0d26-4751-a1aa-3e6d5e0e7cc2)

After:
![image](https://github.com/user-attachments/assets/faefdc93-7d26-4fd5-8bc5-a705945dad58)
