### PR TITLE
Adds a synchronous `get_table` function on the DataFusion context

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -32,6 +32,7 @@ use crate::dataconnector::deferred::DeferredConnector;
 use crate::dataconnector::localpod::LOCALPOD_DATACONNECTOR;
 use crate::dataconnector::sink::SinkConnector;
 use crate::dataconnector::{DataConnector, DataConnectorError};
+use crate::datafusion::schema::SpiceSchemaProvider;
 use crate::dataupdate::{
     DataUpdate, StreamingDataUpdate, StreamingDataUpdateExecutionPlan, UpdateType,
 };
@@ -327,25 +328,35 @@ impl DataFusion {
         &self,
         table_reference: &TableReference,
     ) -> Option<Arc<dyn TableProvider>> {
-        let catalog_provider = match table_reference {
-            TableReference::Bare { .. } | TableReference::Partial { .. } => {
-                self.ctx.catalog(SPICE_DEFAULT_CATALOG)
-            }
-            TableReference::Full { catalog, .. } => self.ctx.catalog(catalog),
-        }?;
+        let catalog_provider = self.resolve_catalog_provider(table_reference)?;
 
-        let schema_provider = match table_reference {
-            TableReference::Bare { .. } => catalog_provider.schema(SPICE_DEFAULT_SCHEMA),
-            TableReference::Partial { schema, .. } | TableReference::Full { schema, .. } => {
-                catalog_provider.schema(schema)
-            }
-        }?;
+        let schema_provider = Self::resolve_schema_provider(&catalog_provider, table_reference)?;
 
         schema_provider
             .table(table_reference.table())
             .await
             .ok()
             .flatten()
+    }
+
+    /// Returns the `TableProvider` for the given `TableReference` synchronously.
+    ///
+    /// This method may return `None` if the table is registered from a catalog provider that doesn't support synchronous table access.
+    /// All tables registered in the default catalog (i.e. `spice`) are available synchronously.
+    /// Catalog implementations that use `SpiceSchemaProvider` objects are also available synchronously.
+    pub fn get_table_sync(
+        &self,
+        table_reference: &TableReference,
+    ) -> Option<Arc<dyn TableProvider>> {
+        let catalog_provider = self.resolve_catalog_provider(table_reference)?;
+
+        let schema_provider = Self::resolve_schema_provider(&catalog_provider, table_reference)?;
+
+        let spice_schema_provider = schema_provider
+            .as_any()
+            .downcast_ref::<SpiceSchemaProvider>()?;
+
+        spice_schema_provider.table_sync(table_reference.table())
     }
 
     /// Register a table with its [`SchemaProvider`] if it exists and marks it as writable.
@@ -1591,6 +1602,30 @@ impl DataFusion {
         tracing::trace!("clearing cached logical plans");
         if let Some(cache_provider) = self.plans_cache_provider() {
             cache_provider.invalidate_all();
+        }
+    }
+
+    fn resolve_catalog_provider(
+        &self,
+        table_reference: &TableReference,
+    ) -> Option<Arc<dyn CatalogProvider>> {
+        match table_reference {
+            TableReference::Bare { .. } | TableReference::Partial { .. } => {
+                self.ctx.catalog(SPICE_DEFAULT_CATALOG)
+            }
+            TableReference::Full { catalog, .. } => self.ctx.catalog(catalog),
+        }
+    }
+
+    fn resolve_schema_provider(
+        catalog_provider: &Arc<dyn CatalogProvider>,
+        table_reference: &TableReference,
+    ) -> Option<Arc<dyn SchemaProvider>> {
+        match table_reference {
+            TableReference::Bare { .. } => catalog_provider.schema(SPICE_DEFAULT_SCHEMA),
+            TableReference::Partial { schema, .. } | TableReference::Full { schema, .. } => {
+                catalog_provider.schema(schema)
+            }
         }
     }
 }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -323,21 +323,6 @@ impl DataFusion {
         Arc::clone(&self.accelerator_engine_registry)
     }
 
-    pub async fn has_table(&self, table_reference: &TableReference) -> bool {
-        let table_name = table_reference.table();
-
-        if let Some(schema_name) = table_reference.schema() {
-            if let Some(schema) = self.schema(schema_name) {
-                return match schema.table(table_name).await {
-                    Ok(table) => table.is_some(),
-                    Err(_) => false,
-                };
-            }
-        }
-
-        self.ctx.table(table_name).await.is_ok()
-    }
-
     pub async fn get_table(
         &self,
         table_reference: &TableReference,

--- a/crates/runtime/src/datafusion/schema.rs
+++ b/crates/runtime/src/datafusion/schema.rs
@@ -44,6 +44,7 @@ impl SpiceSchemaProvider {
         }
     }
 
+    #[must_use]
     pub fn table_sync(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
         self.tables.get(name).map(|table| Arc::clone(table.value()))
     }

--- a/crates/runtime/src/datafusion/schema.rs
+++ b/crates/runtime/src/datafusion/schema.rs
@@ -43,6 +43,10 @@ impl SpiceSchemaProvider {
             tables: DashMap::new(),
         }
     }
+
+    pub fn table_sync(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        self.tables.get(name).map(|table| Arc::clone(table.value()))
+    }
 }
 
 impl Default for SpiceSchemaProvider {
@@ -65,7 +69,7 @@ impl SchemaProvider for SpiceSchemaProvider {
     }
 
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
-        Ok(self.tables.get(name).map(|table| Arc::clone(table.value())))
+        Ok(self.table_sync(name))
     }
 
     fn register_table(

--- a/crates/runtime/src/http/v1/eval.rs
+++ b/crates/runtime/src/http/v1/eval.rs
@@ -117,10 +117,7 @@ pub(crate) async fn post(
         return (StatusCode::NOT_FOUND, format!("model '{model}' not found")).into_response();
     }
 
-    if !df
-        .has_table(&TableReference::parse_str(eval.dataset.as_str()))
-        .await
-    {
+    if !df.table_exists(TableReference::parse_str(eval.dataset.as_str())) {
         return (
             StatusCode::NOT_FOUND,
             format!("dataset '{}' not found", eval.dataset),


### PR DESCRIPTION
## 📝 Summary

Adds a new function `get_table_sync` that allows resolving TableProviders without async. Basically all tables in Spice can be retrieved without async, but the trait definition itself only allows for async retrieval. By downcasting to `SpiceSchemaProvider` which all default tables are created in, we can get them synchronously.