### PR TITLE
Surface table not found errors immediately

### DIFF
--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -545,10 +545,48 @@ fn lines_need_truncation(lines: &[&str]) -> bool {
     lines.iter().any(|line| line.len() > 120)
 }
 
+fn is_table_not_found_error(err: &Status) -> (bool, Option<String>) {
+    let message = err.message();
+    if message.contains("table '") && message.contains("' not found") {
+        // Find the start of the table name after "table '"
+        if let Some(start) = message.find("table '") {
+            let start_pos = start + "table '".len();
+            // Find the end of the table name at the next single quote
+            if let Some(end_pos) = message[start_pos..].find('\'') {
+                let table_name = &message[start_pos..start_pos + end_pos];
+                return (true, Some(table_name.to_string()));
+            }
+        }
+        // Found the pattern but couldn't extract the table name
+        (true, None)
+    } else {
+        (false, None)
+    }
+}
+
 fn display_grpc_error(err: &Status) {
     let (error_type, user_err_msg) = match err.code() {
         Code::Ok => return,
-        Code::Unknown | Code::Internal | Code::DataLoss | Code::FailedPrecondition => (
+        Code::Internal => {
+            let (is_table_not_found, table_name) = is_table_not_found_error(err);
+            if is_table_not_found {
+                let message = if let Some(name) = table_name {
+                    format!(
+                        "The table '{name}' does not exist. Check that the table name was entered correctly or verify the configuration in the Spicepod."
+                    )
+                } else {
+                    "The specified table does not exist. Check that the table name was entered correctly or verify the configuration in the Spicepod.".to_string()
+                };
+                ("Table Not Found", message)
+            } else {
+                (
+                    "Internal Error",
+                    "An unexpected internal error occurred. Execute '.error' for details."
+                        .to_string(),
+                )
+            }
+        }
+        Code::Unknown | Code::DataLoss | Code::FailedPrecondition => (
             "Internal Error",
             "An unexpected internal error occurred. Execute '.error' for details.".to_string(),
         ),

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -567,25 +567,10 @@ fn is_table_not_found_error(err: &Status) -> (bool, Option<String>) {
 fn display_grpc_error(err: &Status) {
     let (error_type, user_err_msg) = match err.code() {
         Code::Ok => return,
-        Code::Internal => {
-            let (is_table_not_found, table_name) = is_table_not_found_error(err);
-            if is_table_not_found {
-                let message = if let Some(name) = table_name {
-                    format!(
-                        "The table '{name}' does not exist. Check that the table name was entered correctly or verify the configuration in the Spicepod."
-                    )
-                } else {
-                    "The specified table does not exist. Check that the table name was entered correctly or verify the configuration in the Spicepod.".to_string()
-                };
-                ("Table Not Found", message)
-            } else {
-                (
-                    "Internal Error",
-                    "An unexpected internal error occurred. Execute '.error' for details."
-                        .to_string(),
-                )
-            }
-        }
+        Code::Internal => (
+            "Internal Error",
+            "An unexpected internal error occurred. Execute '.error' for details.".to_string(),
+        ),
         Code::Unknown | Code::DataLoss | Code::FailedPrecondition => (
             "Internal Error",
             "An unexpected internal error occurred. Execute '.error' for details.".to_string(),

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -548,11 +548,7 @@ fn lines_need_truncation(lines: &[&str]) -> bool {
 fn display_grpc_error(err: &Status) {
     let (error_type, user_err_msg) = match err.code() {
         Code::Ok => return,
-        Code::Internal => (
-            "Internal Error",
-            "An unexpected internal error occurred. Execute '.error' for details.".to_string(),
-        ),
-        Code::Unknown | Code::DataLoss | Code::FailedPrecondition => (
+        Code::Unknown | Code::Internal | Code::DataLoss | Code::FailedPrecondition => (
             "Internal Error",
             "An unexpected internal error occurred. Execute '.error' for details.".to_string(),
         ),

--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -545,25 +545,6 @@ fn lines_need_truncation(lines: &[&str]) -> bool {
     lines.iter().any(|line| line.len() > 120)
 }
 
-fn is_table_not_found_error(err: &Status) -> (bool, Option<String>) {
-    let message = err.message();
-    if message.contains("table '") && message.contains("' not found") {
-        // Find the start of the table name after "table '"
-        if let Some(start) = message.find("table '") {
-            let start_pos = start + "table '".len();
-            // Find the end of the table name at the next single quote
-            if let Some(end_pos) = message[start_pos..].find('\'') {
-                let table_name = &message[start_pos..start_pos + end_pos];
-                return (true, Some(table_name.to_string()));
-            }
-        }
-        // Found the pattern but couldn't extract the table name
-        (true, None)
-    } else {
-        (false, None)
-    }
-}
-
 fn display_grpc_error(err: &Status) {
     let (error_type, user_err_msg) = match err.code() {
         Code::Ok => return,

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -317,19 +317,20 @@ fn handle_datafusion_error(e: DataFusionError) -> Status {
             }
         }
         DataFusionError::ResourcesExhausted(source) => Status::resource_exhausted(source),
-        DataFusionError::Diagnostic(_, source) => handle_datafusion_error(*source),
-        DataFusionError::Context(_, source) => handle_datafusion_error(*source),
+        DataFusionError::Diagnostic(_, source) | DataFusionError::Context(_, source) => {
+            handle_datafusion_error(*source)
+        }
         DataFusionError::Shared(source) => {
             // Since DataFusionError doesn't implement Clone, we can't extract it from Arc
             // Just treat it as a generic error
-            Status::internal(format!("Shared DataFusion error: {}", source))
+            Status::internal(format!("Shared DataFusion error: {source}"))
         }
         DataFusionError::Collection(sources) => {
-            if sources.is_empty() {
-                unreachable!("DataFusionError::Collection is never empty");
-            } else {
-                let first_error = sources.into_iter().next().unwrap();
+            let first_error = sources.into_iter().next();
+            if let Some(first_error) = first_error {
                 handle_datafusion_error(first_error)
+            } else {
+                unreachable!("DataFusionError::Collection should always contain at least one error")
             }
         }
         DataFusionError::Internal(_)

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -330,7 +330,7 @@ fn handle_datafusion_error(e: DataFusionError) -> Status {
             if let Some(first_error) = first_error {
                 handle_datafusion_error(first_error)
             } else {
-                unreachable!("DataFusionError::Collection should always contain at least one error")
+                Status::internal("Several DataFusion errors occurred, but no details available")
             }
         }
         DataFusionError::Internal(_)

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -316,8 +316,31 @@ fn handle_datafusion_error(e: DataFusionError) -> Status {
                 to_tonic_err(e)
             }
         }
+        DataFusionError::ResourcesExhausted(source) => Status::resource_exhausted(source),
         DataFusionError::Diagnostic(_, source) => handle_datafusion_error(*source),
-        _ => to_tonic_err(e),
+        DataFusionError::Context(_, source) => handle_datafusion_error(*source),
+        DataFusionError::Shared(source) => {
+            // Since DataFusionError doesn't implement Clone, we can't extract it from Arc
+            // Just treat it as a generic error
+            Status::internal(format!("Shared DataFusion error: {}", source))
+        }
+        DataFusionError::Collection(sources) => {
+            if sources.is_empty() {
+                unreachable!("DataFusionError::Collection is never empty");
+            } else {
+                let first_error = sources.into_iter().next().unwrap();
+                handle_datafusion_error(first_error)
+            }
+        }
+        DataFusionError::Internal(_)
+        | DataFusionError::NotImplemented(_)
+        | DataFusionError::ArrowError(..)
+        | DataFusionError::IoError(_)
+        | DataFusionError::ObjectStore(_)
+        | DataFusionError::ParquetError(_)
+        | DataFusionError::Substrait(_)
+        | DataFusionError::Configuration(_)
+        | DataFusionError::ExecutionJoin(_) => to_tonic_err(e),
     }
 }
 

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -316,13 +316,7 @@ fn handle_datafusion_error(e: DataFusionError) -> Status {
                 to_tonic_err(e)
             }
         }
-        DataFusionError::Diagnostic(_, ref source) => {
-            if let DataFusionError::Plan(err_msg) = source.as_ref() {
-                Status::invalid_argument(err_msg.clone())
-            } else {
-                to_tonic_err(e)
-            }
-        }
+        DataFusionError::Diagnostic(_, source) => handle_datafusion_error(*source),
         _ => to_tonic_err(e),
     }
 }

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -316,6 +316,13 @@ fn handle_datafusion_error(e: DataFusionError) -> Status {
                 to_tonic_err(e)
             }
         }
+        DataFusionError::Diagnostic(_, ref source) => {
+            if let DataFusionError::Plan(err_msg) = source.as_ref() {
+                Status::invalid_argument(err_msg.clone())
+            } else {
+                to_tonic_err(e)
+            }
+        }
         _ => to_tonic_err(e),
     }
 }


### PR DESCRIPTION
## 📝 Summary

- In `spice sql`, if a user entered a table name that does not exist, the error was misclassified as an internal error.
- This PR surfaces the table not found error immediately

## 🔗 Related
- Closes #6315 

## 👀 Notes for Reviewers
- Based on what I saw, I believe the root cause of the misclassification is within Arrow Flight (not in this repo)
- I found a workaround, but I'm unsure if there's a better way of checking whether or not the error is a table not found error
- Any suggestions here are appreciated

## Output

Before:
![image](https://github.com/user-attachments/assets/4a501089-763b-4ddd-ad34-307ef5255d8d)

After:
![image](https://github.com/user-attachments/assets/ca0f14ef-4006-493b-94e0-41a6ac704000)

