### PR TITLE
Oracle connector: support filter predicate pushdown

### DIFF
--- a/crates/data_components/src/oracle/execution_plan.rs
+++ b/crates/data_components/src/oracle/execution_plan.rs
@@ -28,7 +28,13 @@ use datafusion::{
         execution_plan::{Boundedness, EmissionType},
         stream::RecordBatchStreamAdapter,
     },
-    sql::TableReference,
+    sql::{
+        TableReference, sqlparser,
+        unparser::{
+            Unparser,
+            dialect::{CustomDialect, CustomDialectBuilder},
+        },
+    },
 };
 
 pub type Result<T, E = super::Error> = std::result::Result<T, E>;
@@ -44,8 +50,8 @@ pub struct OracleExecPlan {
     projected_schema: SchemaRef,
     table_reference: TableReference,
     pool: Arc<OracleConnectionPool>,
-    _filters: Vec<Expr>,
-    _limit: Option<usize>,
+    filters: Vec<Expr>,
+    limit: Option<usize>,
     properties: PlanProperties,
 }
 
@@ -64,8 +70,8 @@ impl OracleExecPlan {
             projected_schema: Arc::clone(&projected_schema),
             table_reference: table_reference.clone(),
             pool,
-            _filters: filters.to_vec(),
-            _limit: limit,
+            filters: filters.to_vec(),
+            limit,
             properties: PlanProperties::new(
                 EquivalenceProperties::new(projected_schema),
                 Partitioning::UnknownPartitioning(1),
@@ -75,19 +81,52 @@ impl OracleExecPlan {
         })
     }
 
+    fn dialect() -> CustomDialect {
+        CustomDialectBuilder::new()
+            .with_identifier_quote_style('"')
+            // There is no 'DOUBLE' SQL type in Oracle: it can use 'FLOAT' for both single and double precision float values
+            .with_float64_ast_dtype(sqlparser::ast::DataType::Float(None))
+            .build()
+    }
+
     #[allow(clippy::unnecessary_wraps)]
     pub fn sql(&self) -> DataFusionResult<String> {
         let columns = self
             .projected_schema
             .fields()
             .iter()
-            .map(|f| f.name().to_string())
+            // columns must be quoted to handle spaces and special characters
+            .map(|f| format!("\"{col}\"", col = f.name()))
             .collect::<Vec<_>>()
             .join(", ");
 
+        let dialect = OracleExecPlan::dialect();
+
+        let where_expr = if self.filters.is_empty() {
+            String::new()
+        } else {
+            let filter_expr = self
+                .filters
+                .iter()
+                .map(|f| {
+                    Unparser::new(&dialect)
+                        .expr_to_sql(f)
+                        .map(|e| e.to_string())
+                })
+                .collect::<DataFusionResult<Vec<String>>>()?
+                .join(" AND ");
+            format!("WHERE {filter_expr}")
+        };
+
+        let limit_expr = if let Some(limit) = self.limit {
+            format!("FETCH FIRST {limit} ROWS ONLY")
+        } else {
+            String::new()
+        };
+
         Ok(format!(
-            "SELECT {columns} FROM {table_reference}",
-            table_reference = self.table_reference
+            "SELECT {columns} FROM {table_reference} {where_expr} {limit_expr}",
+            table_reference = self.table_reference.to_quoted_string()
         ))
     }
 }

--- a/crates/data_components/src/oracle/mod.rs
+++ b/crates/data_components/src/oracle/mod.rs
@@ -18,10 +18,12 @@ use async_trait::async_trait;
 use bigdecimal::BigDecimal;
 use snafu::{ResultExt, Snafu};
 
-use arrow::datatypes::{Field, Schema, SchemaRef};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::{
     catalog::Session,
     datasource::{TableProvider, TableType},
+    error::DataFusionError,
+    logical_expr::{Operator, TableProviderFilterPushDown},
     physical_plan::ExecutionPlan,
     prelude::Expr,
     sql::TableReference,
@@ -202,6 +204,40 @@ impl TableProvider for OracleTableProvider {
         TableType::Base
     }
 
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> std::result::Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        let mut results = Vec::with_capacity(filters.len());
+
+        for filter in filters {
+            match filter {
+                Expr::BinaryExpr(binary_expr) => match binary_expr.op {
+                    Operator::Eq
+                    | Operator::Lt
+                    | Operator::LtEq
+                    | Operator::Gt
+                    | Operator::GtEq => {
+                        // Oracle requires a specific format for datetime literals to correctly cast them to timestamps.
+                        // Currently, the expression unparser cannot handle timestamps, resulting in
+                        // an `ORA-01843: not a valid month` error.
+                        // https://github.com/spiceai/spiceai/issues/6325
+                        if is_time_related_expr(&binary_expr.left)
+                            || is_time_related_expr(&binary_expr.right)
+                        {
+                            results.push(TableProviderFilterPushDown::Unsupported);
+                        } else {
+                            results.push(TableProviderFilterPushDown::Exact);
+                        }
+                    }
+                    _ => results.push(TableProviderFilterPushDown::Unsupported),
+                },
+                _ => results.push(TableProviderFilterPushDown::Unsupported),
+            }
+        }
+        Ok(results)
+    }
+
     async fn scan(
         &self,
         _state: &dyn Session,
@@ -217,5 +253,29 @@ impl TableProvider for OracleTableProvider {
             filters,
             limit,
         )?))
+    }
+}
+
+fn is_time_related_expr(expr: &Expr) -> bool {
+    match expr {
+        Expr::Cast(cast) => {
+            matches!(
+                cast.data_type,
+                DataType::Time32(_) | DataType::Time64(_) | DataType::Timestamp(_, _)
+            )
+        }
+        Expr::Literal(literal) => {
+            matches!(
+                literal.data_type(),
+                DataType::Time32(_) | DataType::Time64(_) | DataType::Timestamp(_, _)
+            )
+        }
+        Expr::ScalarVariable(dara_type, _) => {
+            matches!(
+                dara_type,
+                DataType::Time32(_) | DataType::Time64(_) | DataType::Timestamp(_, _)
+            )
+        }
+        _ => false,
     }
 }

--- a/crates/data_components/src/oracle/mod.rs
+++ b/crates/data_components/src/oracle/mod.rs
@@ -226,8 +226,8 @@ impl TableProvider for OracleTableProvider {
                         // Currently, the expression unparser cannot handle timestamps, resulting in
                         // an `ORA-01843: not a valid month` error.
                         // https://github.com/spiceai/spiceai/issues/6325
-                        if is_time_related_expr(&binary_expr.left)
-                            || is_time_related_expr(&binary_expr.right)
+                        if is_datetime_related_expr(&binary_expr.left)
+                            || is_datetime_related_expr(&binary_expr.right)
                         {
                             results.push(TableProviderFilterPushDown::Unsupported);
                         } else {
@@ -260,24 +260,36 @@ impl TableProvider for OracleTableProvider {
     }
 }
 
-fn is_time_related_expr(expr: &Expr) -> bool {
+fn is_datetime_related_expr(expr: &Expr) -> bool {
     match expr {
         Expr::Cast(cast) => {
             matches!(
                 cast.data_type,
-                DataType::Time32(_) | DataType::Time64(_) | DataType::Timestamp(_, _)
+                DataType::Time32(_)
+                    | DataType::Time64(_)
+                    | DataType::Date32
+                    | DataType::Date64
+                    | DataType::Timestamp(_, _)
             )
         }
         Expr::Literal(literal) => {
             matches!(
                 literal.data_type(),
-                DataType::Time32(_) | DataType::Time64(_) | DataType::Timestamp(_, _)
+                DataType::Time32(_)
+                    | DataType::Time64(_)
+                    | DataType::Date32
+                    | DataType::Date64
+                    | DataType::Timestamp(_, _)
             )
         }
-        Expr::ScalarVariable(dara_type, _) => {
+        Expr::ScalarVariable(data_type, _) => {
             matches!(
-                dara_type,
-                DataType::Time32(_) | DataType::Time64(_) | DataType::Timestamp(_, _)
+                data_type,
+                DataType::Time32(_)
+                    | DataType::Time64(_)
+                    | DataType::Date32
+                    | DataType::Date64
+                    | DataType::Timestamp(_, _)
             )
         }
         _ => false,


### PR DESCRIPTION
## 📝 Summary

Add support for `LIMIT` and filter predicates to `OracleTableProvider`. This enables more efficient federated queries and data loading when using acceleration with `refresh_sql` with predicates.

```
- from: oracle:"TEST_TABLE"
    name: table1
    params: 
      oracle_host: localhost
      oracle_username: ${secrets:SPICE_ORACLE_USER}
      oracle_password: ${secrets:SPICE_ORACLE_PASSWORD}
    acceleration:
      enabled: true
      refresh_sql: |
        SELECT * FROM table1
        WHERE "VAL_NUMBER" = 123.45
          AND "VAL_FLOAT" > 2.8
          AND "VAL_DECIMAL" < 10000
          AND "VAL_VARCHAR2" = 'ghi'
          AND "VAL_BOOL" = 'Y'
        limit 10;
```
This above is translated into single SQL query to fetch the data:

```sql
SELECT .. FROM "TEST_TABLE" WHERE ("VAL_NUMBER" = 123.45) AND ("VAL_FLOAT" > 2.8) AND ("VAL_DECIMAL" < 10000.0000) AND ("VAL_VARCHAR2" = 'ghi') AND ("VAL_BOOL" = 'Y') FETCH FIRST 10 ROWS ONLY
```

Note: Datetime filters are not currently supported (not pushed down) and tracked as the following work item.
- https://github.com/spiceai/spiceai/issues/6325

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/6314

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
