### PR TITLE
feat: Add support for cron-based view refresh

### DIFF
--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -70,6 +70,7 @@ use snafu::prelude::*;
 use tokio::spawn;
 use tokio::sync::Notify;
 use tokio::sync::{RwLock as TokioRwLock, Semaphore};
+use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{RetryError, retry};
@@ -780,7 +781,7 @@ impl DataFusion {
         self.ctx.catalog(catalog).is_some()
     }
 
-    pub fn remove_view(&self, view_name: &TableReference) -> Result<()> {
+    pub async fn remove_view(&self, view_name: &TableReference) -> Result<()> {
         if !self.ctx.table_exist(view_name.clone()).unwrap_or(false) {
             return Ok(());
         }
@@ -791,6 +792,11 @@ impl DataFusion {
             }
             .fail();
         }
+
+        if self.is_accelerated(view_name).await {
+            self.accelerated_tables.write().await.remove(view_name);
+        }
+
         Ok(())
     }
 
@@ -1282,7 +1288,7 @@ impl DataFusion {
         self: &Arc<Self>,
         view: Arc<View>,
         secrets: Arc<TokioRwLock<Secrets>>,
-    ) -> Result<()> {
+    ) -> Result<JoinHandle<Option<Arc<Notify>>>> {
         tracing::info!("Initializing view {}", &view.name);
 
         let table_exists = self.ctx.table_exist(view.name.clone()).unwrap_or(false);
@@ -1309,7 +1315,7 @@ impl DataFusion {
         let dependent_table_names = view::get_dependent_table_names(&statements[0]);
         let status = self.runtime_status();
 
-        spawn(async move {
+        let register_task: JoinHandle<Option<Arc<Notify>>> = spawn(async move {
             // Tables are currently lazily created (i.e. not created until first data is received) so that we know the table schema.
             // This means that we can't create a view on top of a table until the first data is received for all dependent tables and therefore
             // the tables are created. To handle this, wait until all tables are created.
@@ -1354,7 +1360,7 @@ impl DataFusion {
                     "Failed to create view {table}. Dependent table {missing_table} does not exist."
                 );
                 status.update_view(table, status::ComponentStatus::Error);
-                return;
+                return None;
             }
 
             let view_table = match create_view_table(&ctx, &statements[0], view.sql.as_ref()).await
@@ -1363,20 +1369,25 @@ impl DataFusion {
                 Err(e) => {
                     tracing::error!("Failed to create view: {e}");
                     status.update_view(table, status::ComponentStatus::Error);
-                    return;
+                    return None;
                 }
             };
 
             if let Some(acceleration) = &view.acceleration {
                 if acceleration.enabled {
-                    if let Err(e) = df_ref
+                    match df_ref
                         .create_accelerated_view(&view, view_table, &dependent_table_names, secrets)
                         .await
                     {
-                        tracing::error!("Failed to create view: {e}");
-                        status.update_view(table, status::ComponentStatus::Error);
+                        Ok(is_ready) => {
+                            return is_ready;
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to create view: {e}");
+                            status.update_view(table, status::ComponentStatus::Error);
+                            return None;
+                        }
                     }
-                    return;
                 }
             }
 
@@ -1384,13 +1395,15 @@ impl DataFusion {
             if let Err(e) = ctx.register_table(table.clone(), Arc::new(view_table)) {
                 tracing::error!("Failed to create view: {e}");
                 status.update_view(table, status::ComponentStatus::Error);
-                return;
+                return None;
             }
             tracing::info!("{}", view_registered_trace(table, None));
             status.update_view(table, status::ComponentStatus::Ready);
+
+            None
         });
 
-        Ok(())
+        Ok(register_task)
     }
 
     pub async fn create_accelerated_view(
@@ -1399,7 +1412,7 @@ impl DataFusion {
         view_table: ViewTable,
         dependent_tables: &[TableReference],
         secrets: Arc<TokioRwLock<Secrets>>,
-    ) -> Result<()> {
+    ) -> Result<Option<Arc<Notify>>> {
         let table = &view.name;
 
         tracing::debug!(
@@ -1488,6 +1501,8 @@ impl DataFusion {
                     dataset_name: table.to_string(),
                 })?;
 
+        let is_ready = accelerated_table.refresher().on_complete_notification();
+
         self.ctx
             .register_table(table.clone(), Arc::new(accelerated_table).table_provider())
             .map_err(|e| Error::UnableToCreateView {
@@ -1496,13 +1511,18 @@ impl DataFusion {
 
         tracing::info!("{}", view_registered_trace(table, Some(acceleration)));
 
+        self.accelerated_tables
+            .write()
+            .await
+            .insert(view.name.clone());
+
         // if initial load completed, mark view as ready; otherwise, ready status will be updated by acceleration
         if initial_load_complete || view.ready_state == ReadyState::OnRegistration {
             self.runtime_status
                 .update_view(&view.name, status::ComponentStatus::Ready);
         }
 
-        Ok(())
+        Ok(is_ready)
     }
 
     /// Returns all table names in user defined schemas (i.e. not system or runtime schemas).

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -448,7 +448,10 @@ impl Runtime {
         );
 
         if ds_acceleration.is_some() {
-            if let Err(e) = Arc::clone(&self).remove_dataset_schedule(&ds_name).await {
+            if let Err(e) = Arc::clone(&self)
+                .remove_dataset_or_view_schedule(&ds_name)
+                .await
+            {
                 tracing::warn!("Unable to remove dataset schedule for {}: {e}", &ds_name);
             }
         }
@@ -551,7 +554,9 @@ impl Runtime {
             FederatedTable::new(Arc::clone(&ds), read_table, Arc::clone(&connector)).await;
 
         // Remove the schedule if the dataset has one, to prevent scheduling while the dataset is being updated.
-        Arc::clone(&self).remove_dataset_schedule(&ds.name).await?;
+        Arc::clone(&self)
+            .remove_dataset_or_view_schedule(&ds.name)
+            .await?;
 
         // create new accelerated table for updated data connector
         let accelerated_table = self
@@ -571,7 +576,7 @@ impl Runtime {
 
         // recreate the scheduler, which also recreates with any updated parameters
         Arc::clone(&self)
-            .create_dataset_schedule(Arc::clone(&ds))
+            .create_dataset_or_view_schedule(Arc::clone(&ds))
             .await?;
 
         tracing::debug!("Accelerated table for dataset {} is ready", ds.name);
@@ -713,7 +718,7 @@ impl Runtime {
             let dataset_name = ds.name.to_string();
             tokio::task::spawn(async move {
                 notifier.notified().await;
-                if let Err(e) = runtime.create_dataset_schedule(ds).await {
+                if let Err(e) = runtime.create_dataset_or_view_schedule(ds).await {
                     tracing::error!("Failed to create dataset schedule for '{dataset_name}': {e}");
                 }
             });

--- a/crates/runtime/src/init/pods_watcher.rs
+++ b/crates/runtime/src/init/pods_watcher.rs
@@ -58,7 +58,9 @@ impl Runtime {
                 Arc::clone(&self)
                     .apply_dataset_diff(current_app, &new_app)
                     .await;
-                Arc::clone(&self).apply_view_diff(current_app, &new_app);
+                Arc::clone(&self)
+                    .apply_view_diff(current_app, &new_app)
+                    .await;
                 self.apply_model_diff(current_app, &new_app).await;
 
                 if !cfg!(feature = "models") {

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -241,7 +241,7 @@ impl Runtime {
         );
         let scheduler_lock = Arc::clone(&self.schedulers);
         let mut schedulers = scheduler_lock.write().await;
-        let view_name = component.name().to_string().into();
+        let component_name = component.name().to_string().into();
 
         let refresh_task: Arc<dyn ScheduledTask> = match component.clone() {
             ScheduleDataComponent::Dataset(dataset) => {
@@ -259,10 +259,10 @@ impl Runtime {
         ));
 
         let schedule = Arc::new(
-            Schedule::new(Arc::clone(&view_name), refresh_task).add_trigger(cron_request_channel),
+            Schedule::new(Arc::clone(&component_name), refresh_task).add_trigger(cron_request_channel),
         );
 
-        // a `refresh_scheduler` exists but does not contain this view's schedule
+        // a `refresh_scheduler` exists but does not contain this component's schedule
         if let Some(scheduler) = schedulers.get(REFRESH_SCHEDULER_NAME) {
             if scheduler
                 .schedules()
@@ -287,7 +287,7 @@ impl Runtime {
                 .add_schedule(schedule)
                 .await
                 .context(crate::FailedToAddScheduleSnafu {
-                    name: view_name.to_string(),
+                    name: component_name.to_string(),
                     scheduler: REFRESH_SCHEDULER_NAME.to_string(),
                 })?;
             return Ok(());

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -259,7 +259,8 @@ impl Runtime {
         ));
 
         let schedule = Arc::new(
-            Schedule::new(Arc::clone(&component_name), refresh_task).add_trigger(cron_request_channel),
+            Schedule::new(Arc::clone(&component_name), refresh_task)
+                .add_trigger(cron_request_channel),
         );
 
         // a `refresh_scheduler` exists but does not contain this component's schedule

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -227,7 +227,7 @@ impl Runtime {
 
         if matches!(acceleration.refresh_mode, Some(RefreshMode::Changes)) {
             tracing::warn!(
-                "Refresh schedule will not be set for the {} '{}'.\nSpecifying a `refresh_cron` with `refresh_mode` set to `changes` is not supported.\nRemove the `refresh_cron` from the dataset, or use a different `refresh_mode`.",
+                "Cannot set a refresh schedule for the {} '{}': `refresh_cron` is not supported when `refresh_mode` is set to `changes`. Either remove `refresh_cron` or use a different `refresh_mode`.",
                 component.component_type(),
                 component.name(),
             );

--- a/crates/runtime/src/init/scheduler.rs
+++ b/crates/runtime/src/init/scheduler.rs
@@ -28,10 +28,17 @@ use tokio::sync::RwLock;
 
 use crate::{
     Result, Runtime,
-    component::dataset::{Dataset, acceleration::RefreshMode},
+    component::{
+        dataset::{
+            Dataset,
+            acceleration::{Acceleration, RefreshMode},
+        },
+        view::View,
+    },
     dataaccelerator::AccelerationSource,
     scheduling::{
         dataset::DatasetRefreshTask,
+        view::ViewRefreshTask,
         worker::{WorkerPromptTask, WorkerSqlTask},
     },
     worker::{Worker, WorkerScheduleParameters},
@@ -43,100 +50,6 @@ const WORKER_SCHEDULER_NAME: &str = "worker_scheduler";
 pub(crate) type ScheduleRegistry = RwLock<HashMap<Arc<str>, Arc<Scheduler<Running>>>>;
 
 impl Runtime {
-    pub async fn create_dataset_schedule(self: Arc<Self>, dataset: Arc<Dataset>) -> Result<()> {
-        let Some(acceleration) = dataset.acceleration() else {
-            tracing::debug!(
-                "Dataset '{}' has no acceleration source, skipping schedule creation",
-                dataset.name
-            );
-            return Ok(());
-        };
-
-        let Some(refresh_cron) = acceleration.refresh_cron.clone() else {
-            tracing::debug!(
-                "Dataset '{}' has no refresh cron specified, skipping schedule creation",
-                dataset.name
-            );
-            return Ok(());
-        };
-
-        if matches!(acceleration.refresh_mode, Some(RefreshMode::Changes)) {
-            tracing::warn!(
-                "Refresh schedule will not be set for the dataset '{}'.\nSpecifying a `refresh_cron` with `refresh_mode` set to `changes` is not supported.\nRemove the `refresh_cron` from the dataset, or use a different `refresh_mode`.",
-                dataset.name
-            );
-            return Ok(());
-        }
-
-        tracing::debug!("Creating dataset scheduler for dataset: {}", dataset.name);
-        let scheduler_lock = Arc::clone(&self.schedulers);
-        let mut schedulers = scheduler_lock.write().await;
-        let dataset_name = dataset.name.to_string().into();
-
-        let refresh_task = Arc::new(DatasetRefreshTask::from(Arc::clone(&dataset)));
-
-        let cron_request_channel = Arc::new(RwLock::new(
-            CronRequestChannel::new(&refresh_cron).context(
-                crate::FailedToCreateCronChannelSnafu {
-                    cron: refresh_cron.to_string(),
-                },
-            )?,
-        ));
-
-        let schedule = Arc::new(
-            Schedule::new(Arc::clone(&dataset_name), refresh_task)
-                .add_trigger(cron_request_channel),
-        );
-
-        // a `refresh_scheduler` exists but does not contain this dataset's schedule
-        if let Some(scheduler) = schedulers.get(REFRESH_SCHEDULER_NAME) {
-            if scheduler
-                .schedules()
-                .await
-                .iter()
-                .any(|s| s.name() == schedule.name())
-            {
-                tracing::debug!(
-                    "Dataset schedule already exists in refresh scheduler for dataset: {}",
-                    dataset.name
-                );
-                return Ok(());
-            }
-
-            tracing::debug!(
-                "Adding dataset schedule to existing refresh scheduler for dataset: {}",
-                dataset.name
-            );
-            scheduler
-                .add_schedule(schedule)
-                .await
-                .context(crate::FailedToAddScheduleSnafu {
-                    name: dataset_name.to_string(),
-                    scheduler: REFRESH_SCHEDULER_NAME.to_string(),
-                })?;
-            return Ok(());
-        }
-
-        // no `refresh_scheduler` exists, create a new one
-        tracing::debug!(
-            "Creating new refresh scheduler for dataset schedule: {}",
-            dataset.name
-        );
-        let scheduler = Arc::new(
-            SchedulerBuilder::new(REFRESH_SCHEDULER_NAME.into())
-                .add_schedule(schedule)
-                .build()
-                .context(crate::FailedToBuildSchedulerSnafu)?
-                .start()
-                .await
-                .context(crate::FailedToStartSchedulerSnafu)?,
-        );
-
-        schedulers.insert(REFRESH_SCHEDULER_NAME.into(), Arc::clone(&scheduler));
-
-        Ok(())
-    }
-
     pub async fn create_worker_schedule(self: Arc<Self>, worker: Arc<dyn Worker>) -> Result<()> {
         let Some(worker_parameters) = worker.schedule_parameters() else {
             tracing::debug!(
@@ -253,7 +166,10 @@ impl Runtime {
         Ok(())
     }
 
-    pub async fn remove_dataset_schedule(self: Arc<Self>, ds_name: &TableReference) -> Result<()> {
+    pub async fn remove_dataset_or_view_schedule(
+        self: Arc<Self>,
+        ds_name: &TableReference,
+    ) -> Result<()> {
         let scheduler_lock = Arc::clone(&self.schedulers);
         let schedulers = scheduler_lock.read().await;
         let dataset_name = ds_name.to_string().into();
@@ -283,5 +199,159 @@ impl Runtime {
         }
 
         Ok(())
+    }
+
+    pub async fn create_dataset_or_view_schedule(
+        self: Arc<Self>,
+        component: impl Into<ScheduleDataComponent>,
+    ) -> Result<()> {
+        let component: ScheduleDataComponent = component.into();
+
+        let Some(acceleration) = component.acceleration() else {
+            tracing::debug!(
+                "{} '{}' has no acceleration source, skipping schedule creation",
+                component.component_type(),
+                component.name()
+            );
+            return Ok(());
+        };
+
+        let Some(refresh_cron) = acceleration.refresh_cron.clone() else {
+            tracing::debug!(
+                "{} '{}' has no refresh cron specified, skipping schedule creation",
+                component.component_type(),
+                component.name(),
+            );
+            return Ok(());
+        };
+
+        if matches!(acceleration.refresh_mode, Some(RefreshMode::Changes)) {
+            tracing::warn!(
+                "Refresh schedule will not be set for the {} '{}'.\nSpecifying a `refresh_cron` with `refresh_mode` set to `changes` is not supported.\nRemove the `refresh_cron` from the dataset, or use a different `refresh_mode`.",
+                component.component_type(),
+                component.name(),
+            );
+            return Ok(());
+        }
+
+        tracing::debug!(
+            "Creating {component_type} scheduler for {component_type}: {}",
+            component.name(),
+            component_type = component.component_type()
+        );
+        let scheduler_lock = Arc::clone(&self.schedulers);
+        let mut schedulers = scheduler_lock.write().await;
+        let view_name = component.name().to_string().into();
+
+        let refresh_task: Arc<dyn ScheduledTask> = match component.clone() {
+            ScheduleDataComponent::Dataset(dataset) => {
+                Arc::new(DatasetRefreshTask::from(Arc::clone(&dataset)))
+            }
+            ScheduleDataComponent::View(view) => Arc::new(ViewRefreshTask::from(Arc::clone(&view))),
+        };
+
+        let cron_request_channel = Arc::new(RwLock::new(
+            CronRequestChannel::new(&refresh_cron).context(
+                crate::FailedToCreateCronChannelSnafu {
+                    cron: refresh_cron.to_string(),
+                },
+            )?,
+        ));
+
+        let schedule = Arc::new(
+            Schedule::new(Arc::clone(&view_name), refresh_task).add_trigger(cron_request_channel),
+        );
+
+        // a `refresh_scheduler` exists but does not contain this view's schedule
+        if let Some(scheduler) = schedulers.get(REFRESH_SCHEDULER_NAME) {
+            if scheduler
+                .schedules()
+                .await
+                .iter()
+                .any(|s| s.name() == schedule.name())
+            {
+                tracing::debug!(
+                    "{component_type} schedule already exists in refresh scheduler for {component_type}: {}",
+                    component.name(),
+                    component_type = component.component_type()
+                );
+                return Ok(());
+            }
+
+            tracing::debug!(
+                "Adding {component_type} schedule to existing refresh scheduler for {component_type}: {}",
+                component.name(),
+                component_type = component.component_type()
+            );
+            scheduler
+                .add_schedule(schedule)
+                .await
+                .context(crate::FailedToAddScheduleSnafu {
+                    name: view_name.to_string(),
+                    scheduler: REFRESH_SCHEDULER_NAME.to_string(),
+                })?;
+            return Ok(());
+        }
+
+        // no `refresh_scheduler` exists, create a new one
+        tracing::debug!(
+            "Creating new refresh scheduler for {} schedule: {}",
+            component.component_type(),
+            component.name()
+        );
+        let scheduler = Arc::new(
+            SchedulerBuilder::new(REFRESH_SCHEDULER_NAME.into())
+                .add_schedule(schedule)
+                .build()
+                .context(crate::FailedToBuildSchedulerSnafu)?
+                .start()
+                .await
+                .context(crate::FailedToStartSchedulerSnafu)?,
+        );
+
+        schedulers.insert(REFRESH_SCHEDULER_NAME.into(), Arc::clone(&scheduler));
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ScheduleDataComponent {
+    Dataset(Arc<Dataset>),
+    View(Arc<View>),
+}
+
+impl ScheduleDataComponent {
+    pub fn acceleration(&self) -> Option<&Acceleration> {
+        match self {
+            ScheduleDataComponent::Dataset(dataset) => dataset.acceleration(),
+            ScheduleDataComponent::View(view) => view.acceleration(),
+        }
+    }
+
+    pub fn name(&self) -> &TableReference {
+        match self {
+            ScheduleDataComponent::Dataset(dataset) => dataset.name(),
+            ScheduleDataComponent::View(view) => view.name(),
+        }
+    }
+
+    pub fn component_type(&self) -> &'static str {
+        match self {
+            ScheduleDataComponent::Dataset(_) => "dataset",
+            ScheduleDataComponent::View(_) => "view",
+        }
+    }
+}
+
+impl From<Arc<Dataset>> for ScheduleDataComponent {
+    fn from(dataset: Arc<Dataset>) -> Self {
+        ScheduleDataComponent::Dataset(dataset)
+    }
+}
+
+impl From<Arc<View>> for ScheduleDataComponent {
+    fn from(view: Arc<View>) -> Self {
+        ScheduleDataComponent::View(view)
     }
 }

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -182,12 +182,12 @@ impl Runtime {
                 Ok(Some(notifier)) => {
                     notifier.notified().await;
                     if let Err(e) = runtime.create_dataset_or_view_schedule(view).await {
-                        tracing::error!("Failed to create view schedule for '{view_name}': {e}");
+                        tracing::error!("Failed to create refresh schedule for accelerated view '{view_name}': {e}.");
                     }
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    tracing::error!("Failed to create view schedule for '{view_name}': {e}");
+                    tracing::error!("Failed to create refresh schedule for accelerated view '{view_name}': {e}");
                 }
             }
         });
@@ -202,7 +202,7 @@ impl Runtime {
                     .remove_dataset_or_view_schedule(name)
                     .await
                 {
-                    tracing::warn!("Unable to remove view schedule for {}: {e}", &name);
+                    tracing::warn!("Failed to remove refresh schedule for accelerated view {}: {e}", &name);
                 }
             }
 

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -195,7 +195,7 @@ impl Runtime {
         Ok(())
     }
 
-    async fn remove_view(self: Arc<Runtime>, name: &TableReference) {
+    async fn remove_view(self: Arc<Self>, name: &TableReference) {
         if self.df.table_exists(name.clone()) {
             if self.df.is_accelerated(name).await {
                 if let Err(e) = Arc::clone(&self)

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -182,12 +182,16 @@ impl Runtime {
                 Ok(Some(notifier)) => {
                     notifier.notified().await;
                     if let Err(e) = runtime.create_dataset_or_view_schedule(view).await {
-                        tracing::error!("Failed to create refresh schedule for accelerated view '{view_name}': {e}.");
+                        tracing::error!(
+                            "Failed to create refresh schedule for accelerated view '{view_name}': {e}."
+                        );
                     }
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    tracing::error!("Failed to create refresh schedule for accelerated view '{view_name}': {e}");
+                    tracing::error!(
+                        "Failed to create refresh schedule for accelerated view '{view_name}': {e}"
+                    );
                 }
             }
         });
@@ -202,7 +206,10 @@ impl Runtime {
                     .remove_dataset_or_view_schedule(name)
                     .await
                 {
-                    tracing::warn!("Failed to remove refresh schedule for accelerated view {}: {e}", &name);
+                    tracing::warn!(
+                        "Failed to remove refresh schedule for accelerated view {}: {e}",
+                        &name
+                    );
                 }
             }
 

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -38,7 +38,9 @@ impl Runtime {
         let views = Arc::clone(&self).get_valid_views(app, LogErrors(true));
 
         for view in views {
-            if let Err(e) = self.load_view(&view, self.secrets()) {
+            let runtime = Arc::clone(&self);
+            let secrets = runtime.secrets();
+            if let Err(e) = runtime.load_view(&view, secrets) {
                 tracing::error!("Unable to load view: {e}");
             }
         }
@@ -160,20 +162,51 @@ impl Runtime {
             .await
     }
 
-    fn load_view(&self, view: &Arc<View>, secrets: Arc<RwLock<Secrets>>) -> Result<()> {
+    fn load_view(self: Arc<Self>, view: &Arc<View>, secrets: Arc<RwLock<Secrets>>) -> Result<()> {
         let df = Arc::clone(&self.df);
-        df.register_view(Arc::clone(view), secrets)
+        let register_task = df
+            .register_view(Arc::clone(view), secrets)
             .context(UnableToAttachViewSnafu)
             .inspect_err(|_| {
                 self.status
                     .update_view(&view.name, status::ComponentStatus::Error);
             })?;
+
+        let runtime = Arc::clone(&self);
+        let view = Arc::clone(view);
+
+        tokio::task::spawn(async move {
+            let view_name = view.name.clone();
+            let notifier = register_task.await;
+            match notifier {
+                Ok(Some(notifier)) => {
+                    notifier.notified().await;
+                    if let Err(e) = runtime.create_dataset_or_view_schedule(view).await {
+                        tracing::error!("Failed to create view schedule for '{view_name}': {e}");
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::error!("Failed to create view schedule for '{view_name}': {e}");
+                }
+            }
+        });
+
         Ok(())
     }
 
-    fn remove_view(&self, name: &TableReference) {
+    async fn remove_view(self: Arc<Runtime>, name: &TableReference) {
         if self.df.table_exists(name.clone()) {
-            if let Err(e) = self.df.remove_view(name) {
+            if self.df.is_accelerated(name).await {
+                if let Err(e) = Arc::clone(&self)
+                    .remove_dataset_or_view_schedule(name)
+                    .await
+                {
+                    tracing::warn!("Unable to remove view schedule for {}: {e}", &name);
+                }
+            }
+
+            if let Err(e) = self.df.remove_view(name).await {
                 tracing::warn!("Unable to unload view {}: {}", name, e);
                 return;
             }
@@ -181,17 +214,22 @@ impl Runtime {
         tracing::info!("Unloaded view {}", name);
     }
 
-    fn update_view(&self, view: &Arc<View>) {
+    async fn update_view(self: Arc<Self>, view: &Arc<View>) {
         self.status
             .update_view(&view.name, status::ComponentStatus::Refreshing);
-        self.remove_view(&view.name);
-        let _ = self.load_view(view, self.secrets());
+        Arc::clone(&self).remove_view(&view.name).await;
+        let secrets = self.secrets();
+        let _ = self.load_view(view, secrets);
     }
 
     /// Update views based on changed between the current and new app.
     /// This function will update views that have changed, and remove views that are no longer in the app.
     /// It will also update views that have dependencies that have changed.
-    pub(crate) fn apply_view_diff(self: Arc<Self>, current_app: &Arc<App>, new_app: &Arc<App>) {
+    pub(crate) async fn apply_view_diff(
+        self: Arc<Self>,
+        current_app: &Arc<App>,
+        new_app: &Arc<App>,
+    ) {
         let valid_views = Arc::clone(&self).get_valid_views(new_app, LogErrors(true));
         let existing_views = Arc::clone(&self).get_valid_views(current_app, LogErrors(false));
 
@@ -223,7 +261,7 @@ impl Runtime {
                 };
                 self.status
                     .update_view(&view_builder.name, status::ComponentStatus::Disabled);
-                self.remove_view(&view_builder.name);
+                Arc::clone(&self).remove_view(&view_builder.name).await;
             }
         }
 
@@ -252,13 +290,16 @@ impl Runtime {
 
         for view_name in affected_views_in_order_of_dependencies {
             if let Some(view) = valid_views.iter().find(|v| v.name == view_name) {
+                let runtime = Arc::clone(&self);
                 if existing_views.iter().any(|v| v.name == view.name) {
                     // Update view even if unchanged, as it may have dependencies that have changed
-                    self.update_view(view);
+                    runtime.update_view(view).await;
                 } else {
-                    self.status
+                    runtime
+                        .status
                         .update_view(&view.name, status::ComponentStatus::Initializing);
-                    let _ = self.load_view(view, self.secrets());
+                    let secrets = runtime.secrets();
+                    let _ = runtime.load_view(view, secrets);
                 }
             }
         }

--- a/crates/runtime/src/scheduling/mod.rs
+++ b/crates/runtime/src/scheduling/mod.rs
@@ -15,4 +15,5 @@ limitations under the License.
 */
 
 pub mod dataset;
+pub mod view;
 pub mod worker;

--- a/crates/runtime/src/scheduling/view/mod.rs
+++ b/crates/runtime/src/scheduling/view/mod.rs
@@ -1,0 +1,55 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use scheduler::Result;
+use scheduler::task::ScheduledTask;
+use tonic::async_trait;
+use tracing_futures::Instrument;
+
+use crate::component::view::View;
+
+pub struct ViewRefreshTask(Arc<View>);
+
+impl From<Arc<View>> for ViewRefreshTask {
+    fn from(view: Arc<View>) -> Self {
+        Self(view)
+    }
+}
+
+#[async_trait]
+impl ScheduledTask for ViewRefreshTask {
+    async fn execute(&self) -> Result<()> {
+        let view = Arc::clone(&self.0);
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "accelerated_refresh", input = %view.name.to_string());
+        async {
+            let runtime = Arc::clone(&view.runtime);
+
+            match runtime.datafusion().refresh_table(&view.name, None).await {
+                Ok(notifier) => {
+                    if let Some(notifier) = notifier {
+                        notifier.notified().await;
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(scheduler::Error::RefreshTaskFailure { source: e.into() }),
+            }
+        }
+        .instrument(span)
+        .await
+    }
+}

--- a/crates/runtime/tests/acceleration/cron.rs
+++ b/crates/runtime/tests/acceleration/cron.rs
@@ -546,3 +546,88 @@ async fn test_append_cron_schedule() -> Result<(), anyhow::Error> {
         })
         .await
 }
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_cron_view() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            std::fs::write("./test_cron_view.csv", NAMES_CSV).expect("write file");
+
+            let app = test_framework::app_utils::load_app_from_spicepod_str(include_str!(
+                "./spicepods/test_cron_view.yaml"
+            ))
+            .await
+            .expect("Should load app from spicepod string");
+
+            let rt = Arc::new(
+                Runtime::builder()
+                    .with_app(app)
+                    .with_datafusion_configuration_fn(configure_test_datafusion)
+                    .build()
+                    .await,
+            );
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&rt).load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            // validate that a scheduler exists in the runtime
+            let schedulers_lock = Arc::clone(&rt).schedulers();
+            let schedulers = schedulers_lock.read().await;
+
+            // there should only be one `refresh_scheduler` with one schedule for the configured dataset
+            assert!(
+                schedulers.len() == 1,
+                "Expected exactly one scheduler, found: {}",
+                schedulers.len()
+            );
+            let refresh_scheduler = schedulers
+                .get("refresh_scheduler")
+                .expect("Expected a refresh scheduler to be present");
+            let mut rt_schedules = refresh_scheduler.schedules().await;
+            assert!(
+                rt_schedules.len() == 1,
+                "Expected exactly one schedule, found: {}",
+                rt_schedules.len()
+            );
+            let schedule = rt_schedules
+                .pop()
+                .expect("Expected a schedule to be present");
+            assert_eq!(
+                schedule.name(),
+                "names_view".into(),
+                "Expected schedule name to match dataset name"
+            );
+
+            snapshot_names_from_runtime("test_cron_view", &rt, None).await;
+
+            // Append a new row to the CSV file
+            let new_row = "11,Spaceman,29,LEO,100\n".to_string();
+            std::fs::OpenOptions::new()
+                .append(true)
+                .open("./test_cron_view.csv")
+                .expect("open file")
+                .write_all(new_row.as_bytes())
+                .expect("append to file");
+
+            // wait for the next 15th second, and wait 5 seconds for the job to succeed
+            tokio::time::sleep(time_till_second(15, Some(5))).await;
+            snapshot_names_from_runtime("test_cron_view_after", &rt, None).await;
+
+            rt.shutdown().await;
+            drop(rt);
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            std::fs::remove_file("./test_cron_view.csv").expect("remove file");
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/acceleration/snapshots/integration__acceleration__cron__test_cron_view.snap
+++ b/crates/runtime/tests/acceleration/snapshots/integration__acceleration__cron__test_cron_view.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/acceleration/cron.rs
+expression: pretty
+---
++----+--------------+-----+--------------+-------+
+| id | name         | age | city         | score |
++----+--------------+-----+--------------+-------+
+| 1  | John Doe     | 28  | New York     | 85    |
+| 2  | Jane Smith   | 34  | Los Angeles  | 92    |
+| 3  | Mike Johnson | 45  | Chicago      | 78    |
+| 4  | Emily Brown  | 31  | Houston      | 89    |
+| 5  | David Lee    | 39  | Phoenix      | 76    |
+| 6  | Sarah Wilson | 26  | Philadelphia | 94    |
+| 7  | Tom Anderson | 52  | San Antonio  | 81    |
+| 8  | Lisa Taylor  | 29  | San Diego    | 88    |
+| 9  | Chris Martin | 37  | Dallas       | 79    |
+| 10 | Anna Garcia  | 41  | San Jose     | 90    |
++----+--------------+-----+--------------+-------+

--- a/crates/runtime/tests/acceleration/snapshots/integration__acceleration__cron__test_cron_view_after.snap
+++ b/crates/runtime/tests/acceleration/snapshots/integration__acceleration__cron__test_cron_view_after.snap
@@ -1,0 +1,19 @@
+---
+source: crates/runtime/tests/acceleration/cron.rs
+expression: pretty
+---
++----+--------------+-----+--------------+-------+
+| id | name         | age | city         | score |
++----+--------------+-----+--------------+-------+
+| 1  | John Doe     | 28  | New York     | 85    |
+| 2  | Jane Smith   | 34  | Los Angeles  | 92    |
+| 3  | Mike Johnson | 45  | Chicago      | 78    |
+| 4  | Emily Brown  | 31  | Houston      | 89    |
+| 5  | David Lee    | 39  | Phoenix      | 76    |
+| 6  | Sarah Wilson | 26  | Philadelphia | 94    |
+| 7  | Tom Anderson | 52  | San Antonio  | 81    |
+| 8  | Lisa Taylor  | 29  | San Diego    | 88    |
+| 9  | Chris Martin | 37  | Dallas       | 79    |
+| 10 | Anna Garcia  | 41  | San Jose     | 90    |
+| 11 | Spaceman     | 29  | LEO          | 100   |
++----+--------------+-----+--------------+-------+

--- a/crates/runtime/tests/acceleration/spicepods/test_cron_view.yaml
+++ b/crates/runtime/tests/acceleration/spicepods/test_cron_view.yaml
@@ -1,0 +1,12 @@
+version: v1
+kind: Spicepod
+name: test_cron_view
+views:
+  - name: names_view
+    sql: SELECT * FROM names
+    acceleration:
+      enabled: true
+      refresh_cron: "*/15 * * * * *" # every 15 seconds
+datasets:
+  - name: names
+    from: file:test_cron_view.csv

--- a/crates/scheduler/src/channel/cron.rs
+++ b/crates/scheduler/src/channel/cron.rs
@@ -213,6 +213,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_cron_cannot_go_faster_than_second() {
+        let cron_expression = "* * * * * * *".into(); // expression attempting to run every millisecond
+        let channel = CronRequestChannel::new(&cron_expression);
+        assert!(channel.is_err(), "Cron expression should be invalid");
+    }
+
+    #[tokio::test]
     async fn test_cron_resets_to_next() {
         // resetting while in-between a schedule should evaluate to the same next instance again
         let cron_expression = "*/5 * * * * *".into();


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds support for cron-based view refreshes
* Refactors the scheduler initialization to reduce code duplication for creating view and dataset schedules
* Adds support for notified completion of view refresh tasks (for notifying the schedule is ready to create)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #6266

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

* Views with cron refresh will require a minor update to docs to identify support for cron refresh schedules.
