### PR TITLE
runtime-datafusion-index: Stop infinite recursion for IndexTableScanOptimizerRule

### DIFF
--- a/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
+++ b/crates/runtime-datafusion-index/src/analyzer/index_table_scan.rs
@@ -122,9 +122,12 @@ impl OptimizerRule for IndexTableScanOptimizerRule {
                 let new_node =
                     IndexTableScanNode::new(LogicalPlan::TableScan(table_scan), available_indexes);
 
-                Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+                let plan = LogicalPlan::Extension(Extension {
                     node: Arc::new(new_node),
-                })))
+                });
+
+                // We don't need to process the TableScan we just processed, so we jump to the next node.
+                Ok(Transformed::new(plan, true, TreeNodeRecursion::Jump))
             }
             _ => Ok(Transformed::no(plan)),
         })


### PR DESCRIPTION
Fixes a bug with the `IndexTableScanOptimizerRule` that would cause infinite recursion because it didn't tell the TreeNode API to stop the recusion after replacing the TableScan with the extension node.

- Closes #6350