### PR TITLE
Add optional behaviors to DataAccelerator tables + add WantsUnderlyingTableBehavior to VoidTable

### DIFF
--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -25,7 +25,7 @@ use std::{any::Any, sync::Arc};
 
 use crate::parameters::ParameterSpec;
 
-use super::{AccelerationSource, DataAccelerator};
+use super::{AccelerationSource, Behaviors, DataAccelerator};
 
 pub struct ArrowAccelerator {
     arrow_factory: ArrowFactory,
@@ -64,7 +64,7 @@ impl DataAccelerator for ArrowAccelerator {
         cmd: CreateExternalTable,
         _source: Option<&dyn AccelerationSource>,
         partition_by: Vec<Expr>,
-    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
         let num_partitions = partition_by.len();
         ensure!(
             num_partitions == 0,
@@ -76,9 +76,11 @@ impl DataAccelerator for ArrowAccelerator {
         );
 
         let ctx = SessionContext::new();
-        TableProviderFactory::create(&self.arrow_factory, &ctx.state(), &cmd)
+        let table_provider = TableProviderFactory::create(&self.arrow_factory, &ctx.state(), &cmd)
             .await
-            .boxed()
+            .boxed()?;
+
+        Ok((table_provider, Behaviors::default()))
     }
 
     fn prefix(&self) -> &'static str {

--- a/crates/runtime/src/dataaccelerator/behaviors/mod.rs
+++ b/crates/runtime/src/dataaccelerator/behaviors/mod.rs
@@ -1,0 +1,64 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+mod wants_underlying_provider;
+pub use wants_underlying_provider::WantsUnderlyingTableProvider;
+
+#[derive(Debug)]
+pub struct Behaviors(Vec<Behavior>);
+
+impl Behaviors {
+    #[must_use]
+    pub fn default() -> Self {
+        Self(vec![])
+    }
+
+    #[must_use]
+    pub fn add_behavior(mut self, behavior: Behavior) -> Self {
+        self.0.push(behavior);
+        self
+    }
+
+    #[must_use]
+    pub fn iter(&self) -> impl Iterator<Item = &Behavior> {
+        self.0.iter()
+    }
+
+    pub fn is_default(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl IntoIterator for Behaviors {
+    type Item = Behavior;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Behaviors {
+    type Item = &'a Behavior;
+    type IntoIter = std::slice::Iter<'a, Behavior>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+#[derive(Debug)]
+pub enum Behavior {
+    WantsUnderlyingTableProvider(WantsUnderlyingTableProvider),
+}

--- a/crates/runtime/src/dataaccelerator/behaviors/mod.rs
+++ b/crates/runtime/src/dataaccelerator/behaviors/mod.rs
@@ -17,12 +17,12 @@ limitations under the License.
 mod wants_underlying_provider;
 pub use wants_underlying_provider::WantsUnderlyingTableProvider;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Behaviors(Vec<Behavior>);
 
 impl Behaviors {
     #[must_use]
-    pub fn default() -> Self {
+    pub fn new() -> Self {
         Self(vec![])
     }
 
@@ -32,11 +32,11 @@ impl Behaviors {
         self
     }
 
-    #[must_use]
     pub fn iter(&self) -> impl Iterator<Item = &Behavior> {
         self.0.iter()
     }
 
+    #[must_use]
     pub fn is_default(&self) -> bool {
         self.0.is_empty()
     }

--- a/crates/runtime/src/dataaccelerator/behaviors/wants_underlying_provider.rs
+++ b/crates/runtime/src/dataaccelerator/behaviors/wants_underlying_provider.rs
@@ -1,0 +1,51 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    fmt::{self, Debug},
+    sync::Arc,
+};
+
+use datafusion::catalog::TableProvider;
+use datafusion::error::Result as DataFusionResult;
+
+pub struct WantsUnderlyingTableProvider {
+    callback_underlying_provider: Box<dyn FnOnce(Arc<dyn TableProvider>) -> DataFusionResult<()>>,
+}
+
+impl Debug for WantsUnderlyingTableProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WantsUnderlyingTableProvider")
+            .finish_non_exhaustive()
+    }
+}
+
+impl WantsUnderlyingTableProvider {
+    #[must_use]
+    pub fn new(
+        callback_underlying_provider: Box<
+            dyn FnOnce(Arc<dyn TableProvider>) -> DataFusionResult<()>,
+        >,
+    ) -> Self {
+        Self {
+            callback_underlying_provider,
+        }
+    }
+
+    pub fn set(self, underlying_provider: Arc<dyn TableProvider>) -> DataFusionResult<()> {
+        (self.callback_underlying_provider)(underlying_provider)
+    }
+}

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -472,7 +472,7 @@ mod tests {
         };
         let duckdb_accelerator = DuckDBAccelerator::new();
         let ctx = SessionContext::new();
-        let table = duckdb_accelerator
+        let (table, _) = duckdb_accelerator
             .create_external_table(external_table, None, vec![])
             .await
             .expect("table should be created");

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -44,7 +44,7 @@ use settings::OrderByNonIntegerLiteral;
 use snafu::prelude::*;
 use std::{any::Any, cmp::max, collections::HashSet, ffi::OsStr, sync::Arc};
 
-use super::{AccelerationSource, DataAccelerator, Error as DataAcceleratorError};
+use super::{AccelerationSource, Behaviors, DataAccelerator, Error as DataAcceleratorError};
 
 mod settings;
 
@@ -303,7 +303,7 @@ impl DataAccelerator for DuckDBAccelerator {
         mut cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
         partition_by: Vec<Expr>,
-    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
         let num_partitions = partition_by.len();
         ensure!(
             num_partitions == 0,
@@ -398,7 +398,7 @@ impl DataAccelerator for DuckDBAccelerator {
             read_provider,
         ));
 
-        Ok(table_provider)
+        Ok((table_provider, Behaviors::default()))
     }
 
     fn prefix(&self) -> &'static str {

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -48,6 +48,8 @@ use self::postgres::PostgresAccelerator;
 use self::sqlite::SqliteAccelerator;
 
 pub mod arrow;
+pub mod behaviors;
+use behaviors::Behaviors;
 #[cfg(feature = "duckdb")]
 pub mod duckdb;
 #[cfg(feature = "postgres")]
@@ -139,7 +141,7 @@ impl AcceleratorEngineRegistry {
         secrets: Arc<RwLock<Secrets>>,
         source: Option<&dyn AccelerationSource>,
         ctx: Arc<SessionContext>,
-    ) -> Result<Arc<dyn TableProvider>> {
+    ) -> Result<(Arc<dyn TableProvider>, Behaviors)> {
         let engine = acceleration_settings.engine;
 
         let accelerator = self.get_accelerator_engine(engine).await.ok_or_else(|| {
@@ -257,12 +259,14 @@ pub trait DataAccelerator: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
     /// Creates a new table in the accelerator engine, returning a `TableProvider` that supports reading and writing.
+    ///
+    /// Also returns the behaviors of the table provider created by the accelerator engine.
     async fn create_external_table(
         &self,
         cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
         partition_by: Vec<Expr>,
-    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>>;
+    ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>>;
 
     /// The name of the accelerator
     fn name(&self) -> &'static str;

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -28,7 +28,7 @@ use std::{any::Any, sync::Arc};
 
 use crate::parameters::ParameterSpec;
 
-use super::{AccelerationSource, DataAccelerator};
+use super::{AccelerationSource, Behaviors, DataAccelerator};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -89,7 +89,7 @@ impl DataAccelerator for PostgresAccelerator {
         mut cmd: CreateExternalTable,
         _source: Option<&dyn AccelerationSource>,
         partition_by: Vec<Expr>,
-    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
         let num_partitions = partition_by.len();
         ensure!(
             num_partitions == 0,
@@ -124,11 +124,13 @@ impl DataAccelerator for PostgresAccelerator {
         let postgres_writer = Arc::new(postgres_writer.clone());
         let cloned_writer = Arc::clone(&postgres_writer);
 
-        Ok(Arc::new(PolyTableProvider::new(
+        let table_provider = Arc::new(PolyTableProvider::new(
             cloned_writer,
             postgres_writer,
             read_provider,
-        )))
+        ));
+
+        Ok((table_provider, Behaviors::default()))
     }
 
     fn prefix(&self) -> &'static str {

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -381,7 +381,7 @@ mod tests {
             temporary: false,
         };
         let ctx = SessionContext::new();
-        let table = SqliteAccelerator::new()
+        let (table, _) = SqliteAccelerator::new()
             .create_external_table(external_table, None, vec![])
             .await
             .expect("table should be created");

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -35,7 +35,7 @@ use crate::{
     spice_data_base_path,
 };
 
-use super::{AccelerationSource, DataAccelerator, Error as DataAcceleratorError};
+use super::{AccelerationSource, Behaviors, DataAccelerator, Error as DataAcceleratorError};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -248,7 +248,7 @@ impl DataAccelerator for SqliteAccelerator {
         mut cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
         partition_by: Vec<Expr>,
-    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
         let num_partitions = partition_by.len();
         ensure!(
             num_partitions == 0,
@@ -315,11 +315,13 @@ impl DataAccelerator for SqliteAccelerator {
         let sqlite_writer = Arc::new(sqlite_writer.clone());
         let cloned_writer = Arc::clone(&sqlite_writer);
 
-        Ok(Arc::new(PolyTableProvider::new(
+        let table_provider = Arc::new(PolyTableProvider::new(
             cloned_writer,
             sqlite_writer,
             read_provider,
-        )))
+        ));
+
+        Ok((table_provider, Behaviors::default()))
     }
 
     fn prefix(&self) -> &'static str {

--- a/crates/runtime/src/dataaccelerator/void.rs
+++ b/crates/runtime/src/dataaccelerator/void.rs
@@ -19,7 +19,11 @@ limitations under the License.
 //! This is useful for indexes that are injected into the data acceleration read pipeline, but
 //! do not need to persist the data.
 
-use std::{any::Any, fmt, sync::Arc};
+use std::{
+    any::Any,
+    fmt,
+    sync::{Arc, OnceLock},
+};
 
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
@@ -38,7 +42,10 @@ use datafusion::{
 use datafusion_datasource::sink::{DataSink, DataSinkExec};
 use futures::StreamExt;
 
-use super::{AccelerationSource, DataAccelerator};
+use super::{
+    AccelerationSource, Behaviors, DataAccelerator,
+    behaviors::{Behavior, WantsUnderlyingTableProvider},
+};
 use crate::parameters::ParameterSpec;
 
 pub struct VoidAccelerator {}
@@ -71,8 +78,18 @@ impl DataAccelerator for VoidAccelerator {
         cmd: CreateExternalTable,
         _source: Option<&dyn AccelerationSource>,
         _partition_by: Vec<Expr>,
-    ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(Arc::new(VoidTable::new(Arc::clone(cmd.schema.inner()))))
+    ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
+        let (table_provider, underlying_provider_cb) =
+            VoidTable::new(Arc::clone(cmd.schema.inner()));
+        Ok((
+            Arc::new(table_provider) as Arc<dyn TableProvider>,
+            Behaviors::default().add_behavior(Behavior::WantsUnderlyingTableProvider(
+                WantsUnderlyingTableProvider::new(Box::new(move |underlying_provider| {
+                    let _ = underlying_provider_cb.set(underlying_provider);
+                    Ok(())
+                })),
+            )),
+        ))
     }
 
     fn prefix(&self) -> &'static str {
@@ -87,12 +104,21 @@ impl DataAccelerator for VoidAccelerator {
 #[derive(Debug)]
 pub struct VoidTable {
     schema: SchemaRef,
+    underlying_provider: Arc<OnceLock<Arc<dyn TableProvider>>>,
 }
 
 impl VoidTable {
+    /// Creates a new `VoidTable` and returns the placeholder for the underlying provider.
     #[must_use]
-    pub fn new(schema: SchemaRef) -> Self {
-        Self { schema }
+    pub fn new(schema: SchemaRef) -> (Self, Arc<OnceLock<Arc<dyn TableProvider>>>) {
+        let underlying_provider = Arc::new(OnceLock::new());
+        (
+            Self {
+                schema,
+                underlying_provider: Arc::clone(&underlying_provider),
+            },
+            underlying_provider,
+        )
     }
 }
 
@@ -112,13 +138,19 @@ impl TableProvider for VoidTable {
 
     async fn scan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        _filters: &[Expr],
-        _limit: Option<usize>,
+        filters: &[Expr],
+        limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        let projected_schema = project_schema(&self.schema, projection)?;
-        Ok(Arc::new(EmptyExec::new(projected_schema)))
+        let Some(underlying_provider) = self.underlying_provider.get() else {
+            let projected_schema = project_schema(&self.schema, projection)?;
+            return Ok(Arc::new(EmptyExec::new(projected_schema)));
+        };
+
+        underlying_provider
+            .scan(state, projection, filters, limit)
+            .await
     }
 
     async fn insert_into(

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1712,7 +1712,7 @@ pub fn handle_accelerated_table_behavior(
 ) -> Result<()> {
     for behavior in accelerated_table_behaviors {
         match behavior {
-            Behavior::WantsUnderlyingTableProvider(mut wants_underlying_table_provider) => {
+            Behavior::WantsUnderlyingTableProvider(wants_underlying_table_provider) => {
                 if let Some(underlying_provider) = federated_table.try_table_provider_sync() {
                     wants_underlying_table_provider
                         .set(underlying_provider)

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -27,7 +27,10 @@ use crate::component::dataset::{Dataset, Mode, ReadyState};
 use crate::component::view::View;
 use crate::dataaccelerator::AcceleratorEngineRegistry;
 use crate::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
-use crate::dataaccelerator::{self};
+use crate::dataaccelerator::{
+    self,
+    behaviors::{Behavior, Behaviors},
+};
 use crate::dataconnector::deferred::DeferredConnector;
 use crate::dataconnector::localpod::LOCALPOD_DATACONNECTOR;
 use crate::dataconnector::sink::SinkConnector;
@@ -247,6 +250,15 @@ pub enum Error {
         dataset_name: String,
         source: AcceleratedTableBuilderError,
     },
+
+    #[snafu(display(
+        "Failed to create an accelerated table for {component_name}.\nError setting the underlying table provider: {source}"
+    ))]
+    UnableToSetUnderlyingTableProvider {
+        component_name: String,
+        source: DataFusionError,
+    },
+
     #[snafu(display("Failed register a '{index_type}' index for the table '{dataset_name}'"))]
     UnableToRegisterTableIndex {
         dataset_name: String,
@@ -879,7 +891,7 @@ impl DataFusion {
             FederatedTable::Deferred(_) => None,
         };
 
-        let accelerated_table_provider = self
+        let (accelerated_table_provider, accelerated_table_behaviors) = self
             .accelerator_engine_registry
             .create_accelerator_table(
                 dataset.name.clone(),
@@ -892,6 +904,12 @@ impl DataFusion {
             )
             .await
             .context(UnableToCreateDataAcceleratorSnafu)?;
+
+        handle_accelerated_table_behavior(
+            accelerated_table_behaviors,
+            &source_table_provider,
+            &dataset.name.to_string(),
+        )?;
 
         // If we already have an existing dataset checkpoint table that has been checkpointed,
         // it means there is data from a previous acceleration and we don't need
@@ -1436,7 +1454,7 @@ impl DataFusion {
         let federated_table =
             FederatedTable::new_unchecked(Arc::new(view_table) as Arc<dyn TableProvider>);
 
-        let accelerated_table_provider = self
+        let (accelerated_table_provider, accelerated_table_behaviors) = self
             .accelerator_engine_registry()
             .create_accelerator_table(
                 table.clone(),
@@ -1451,6 +1469,12 @@ impl DataFusion {
             .map_err(|e| Error::UnableToCreateView {
                 reason: format!("Failed to create view acceleration: {e}"),
             })?;
+
+        handle_accelerated_table_behavior(
+            accelerated_table_behaviors,
+            &federated_table,
+            &view.name.to_string(),
+        )?;
 
         // Detect if data for view was already loaded so we don't need to wait for the first refresh to complete to mark it as ready.
         let mut initial_load_complete = false;
@@ -1679,6 +1703,29 @@ pub fn is_spice_internal_dataset(dataset: &TableReference) -> bool {
 // so it can be used for comparison.
 fn resolve_table_reference(table: TableReference) -> ResolvedTableReference {
     table.resolve(SPICE_DEFAULT_CATALOG, SPICE_DEFAULT_SCHEMA)
+}
+
+pub fn handle_accelerated_table_behavior(
+    accelerated_table_behaviors: Behaviors,
+    federated_table: &FederatedTable,
+    component_name: &str,
+) -> Result<()> {
+    for behavior in accelerated_table_behaviors {
+        match behavior {
+            Behavior::WantsUnderlyingTableProvider(mut wants_underlying_table_provider) => {
+                if let Some(underlying_provider) = federated_table.try_table_provider_sync() {
+                    wants_underlying_table_provider
+                        .set(underlying_provider)
+                        .map_err(find_datafusion_root)
+                        .context(UnableToSetUnderlyingTableProviderSnafu {
+                            component_name: component_name.to_string(),
+                        })?;
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[must_use]

--- a/crates/runtime/src/federated_table/mod.rs
+++ b/crates/runtime/src/federated_table/mod.rs
@@ -124,6 +124,22 @@ impl FederatedTable {
         )))
     }
 
+    /// Attempts to return the [`TableProvider`] without waiting for a deferred [`TableProvider`] that is not done (i.e. not in `DeferredState::Done`).
+    ///
+    /// Returns None if
+    ///   1. Active write on the [`DeferredTableProvider`]'s state.
+    ///   2. The [`DeferredTableProvider`] is not Ready.
+    pub fn try_table_provider_sync(&self) -> Option<Arc<dyn TableProvider>> {
+        let deferred_table_provider = match self {
+            Self::Immediate(table_provider) => return Some(Arc::clone(table_provider)),
+            Self::Deferred(deferred_table_provider) => deferred_table_provider,
+        };
+        match &*deferred_table_provider.state.try_read().ok()? {
+            DeferredState::Done(tbl) => Some(Arc::clone(tbl)),
+            _ => None,
+        }
+    }
+
     pub async fn table_provider(&self) -> Arc<dyn TableProvider> {
         let deferred_table_provider = match self {
             Self::Immediate(table_provider) => return Arc::clone(table_provider),

--- a/crates/runtime/src/federated_table/mod.rs
+++ b/crates/runtime/src/federated_table/mod.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use arrow::datatypes::SchemaRef;
 use arrow_tools::schema::schema_difference;
 use datafusion::catalog::TableProvider;
-use tokio::sync::{Mutex, oneshot};
+use tokio::sync::{RwLock, oneshot};
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
 
 use crate::{
@@ -62,7 +62,7 @@ enum DeferredState {
 
 #[derive(Debug)]
 pub struct DeferredTableProvider {
-    state: Mutex<DeferredState>,
+    state: RwLock<DeferredState>,
     schema: SchemaRef,
 }
 
@@ -147,7 +147,7 @@ impl FederatedTable {
         };
 
         // If the table provider is not available immediately, see if we already have it from the deferred task.
-        let mut deferred_state_guard = deferred_table_provider.state.lock().await;
+        let mut deferred_state_guard = deferred_table_provider.state.write().await;
 
         // If the table provider is available now, return it.
         if let DeferredState::Done(table_provider) = &*deferred_state_guard {
@@ -240,7 +240,7 @@ impl FederatedTable {
         });
 
         DeferredTableProvider {
-            state: Mutex::new(DeferredState::Waiting(rx)),
+            state: RwLock::new(DeferredState::Waiting(rx)),
             schema,
         }
     }

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -145,7 +145,7 @@ pub async fn create_internal_accelerated_table(
         .await
         .context(UnableToCreateAcceleratedTableProviderSnafu)?;
 
-    handle_accelerated_table_behavior(accelerated_table_behaviors, &federated_table, &name.table())
+    handle_accelerated_table_behavior(accelerated_table_behaviors, &federated_table, name.table())
         .boxed()
         .context(InternalSnafu {
             code: "IT-CIA-HATB".to_string(), // InternalTable - CreateInternalAcceleratedTable - HandleAcceleratedTableBehavior

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -32,6 +32,7 @@ use crate::{
     accelerated_table::{AcceleratedTable, refresh::Refresh},
     dataaccelerator::{self},
     dataconnector::{DataConnector, DataConnectorError, sink::SinkConnector},
+    datafusion::handle_accelerated_table_behavior,
 };
 
 #[derive(Debug, Snafu)]
@@ -130,7 +131,7 @@ pub async fn create_internal_accelerated_table(
     let federated_table = Arc::new(FederatedTable::new_unchecked(Arc::clone(
         &source_table_provider,
     )));
-    let accelerated_table_provider = runtime
+    let (accelerated_table_provider, accelerated_table_behaviors) = runtime
         .accelerator_engine_registry()
         .create_accelerator_table(
             name.clone(),
@@ -143,6 +144,12 @@ pub async fn create_internal_accelerated_table(
         )
         .await
         .context(UnableToCreateAcceleratedTableProviderSnafu)?;
+
+    handle_accelerated_table_behavior(accelerated_table_behaviors, &federated_table, &name.table())
+        .boxed()
+        .context(InternalSnafu {
+            code: "IT-CIA-HATB".to_string(), // InternalTable - CreateInternalAcceleratedTable - HandleAcceleratedTableBehavior
+        })?;
 
     let mut builder = AcceleratedTable::builder(
         runtime_status,

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -372,7 +372,7 @@ pub async fn create_synced_internal_accelerated_table(
     handle_accelerated_table_behavior(
         accelerated_table_behaviors,
         &federated_table,
-        &table_reference.table(),
+        table_reference.table(),
     )
     .boxed()
     .context(UnableToCreateDataAcceleratorTableSnafu)?;

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -35,6 +35,7 @@ use runtime::{
     },
     dataaccelerator::{self, AcceleratorEngineRegistry},
     dataconnector::{DataConnectorError, create_new_connector, parameters::ConnectorParamsBuilder},
+    datafusion::handle_accelerated_table_behavior,
     extension::{Error as ExtensionError, Extension, ExtensionFactory, ExtensionManifest, Result},
     federated_table::FederatedTable,
     secrets::{ExposeSecret, Secrets},
@@ -52,6 +53,13 @@ pub enum Error {
         "Unable to create data connector: {source}\nReport a bug to request support: https://github.com/spiceai/spiceai/issues"
     ))]
     UnableToCreateDataConnector {
+        source: Box<dyn std::error::Error + Sync + Send>,
+    },
+
+    #[snafu(display(
+        "Unable to create data accelerator: {source}\nReport a bug to request support: https://github.com/spiceai/spiceai/issues"
+    ))]
+    UnableToCreateDataAcceleratorTable {
         source: Box<dyn std::error::Error + Sync + Send>,
     },
 
@@ -348,7 +356,7 @@ pub async fn create_synced_internal_accelerated_table(
             .await?;
     let federated_table = Arc::new(FederatedTable::new_unchecked(source_table_provider));
 
-    let accelerated_table_provider = accelerator_engine_registry
+    let (accelerated_table_provider, accelerated_table_behaviors) = accelerator_engine_registry
         .create_accelerator_table(
             table_reference.clone(),
             federated_table.schema(),
@@ -360,6 +368,14 @@ pub async fn create_synced_internal_accelerated_table(
         )
         .await
         .context(UnableToCreateAcceleratedTableProviderSnafu)?;
+
+    handle_accelerated_table_behavior(
+        accelerated_table_behaviors,
+        &federated_table,
+        &table_reference.table(),
+    )
+    .boxed()
+    .context(UnableToCreateDataAcceleratorTableSnafu)?;
 
     let mut builder = AcceleratedTable::builder(
         runtime_status,


### PR DESCRIPTION
## 📝 Summary

Adds optional behaviors to DataAccelerator tables and adds `WantsUnderlyingTableBehavior` to `VoidTable`.

This allows tables created via the DataAccelerator::create_external_table trait to express that they have additional behaviors beyond the standard TableProvider trait in a way that doesn't require the consumer to know the exact type of the underlying table.

Adds the behavior `WantsUnderlyingTableProvider` which expresses that the accelerator table wants a reference to the underlying federated TableProvider. This is needed for the `void` TableProvider because by design it should always delegate scans to the underlying table, but the insert method should still be discarded.
