### PR TITLE
Ensure views load even if they're the only components defined

### DIFF
--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -74,6 +74,10 @@ impl Runtime {
         let valid_datasets = Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
 
         if valid_datasets.is_empty() {
+            // If views are provided, make sure to load them.
+            if !valid_views.is_empty() {
+                Arc::clone(&self).load_views(app);
+            }
             return;
         }
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -66,16 +66,16 @@ impl Runtime {
             Arc::new(Semaphore::new(Semaphore::MAX_PERMITS))
         };
 
+        // Before loading datasets, we must initialize views accelerators (if any).
+        // This is required for acceleration federation for some engines (e.g. `DuckDB`).
+        let valid_views = Arc::clone(&self).get_valid_views(app, LogErrors(true));
+        self.initialize_views_accelerators(&valid_views).await;
+
         let valid_datasets = Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
 
         if valid_datasets.is_empty() {
             return;
         }
-
-        // Before loading datasets, we must initialize views accelerators (if any).
-        // This is required for acceleration federation for some engines (e.g. `DuckDB`).
-        let valid_views = Arc::clone(&self).get_valid_views(app, LogErrors(true));
-        self.initialize_views_accelerators(&valid_views).await;
 
         let initialized_datasets = self.initialize_datasets_accelerators(&valid_datasets).await;
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -73,14 +73,6 @@ impl Runtime {
 
         let valid_datasets = Arc::clone(&self).get_valid_datasets(app, LogErrors(true));
 
-        if valid_datasets.is_empty() {
-            // If views are provided, make sure to load them.
-            if !valid_views.is_empty() {
-                Arc::clone(&self).load_views(app);
-            }
-            return;
-        }
-
         let initialized_datasets = self.initialize_datasets_accelerators(&valid_datasets).await;
 
         // Create a map of dataset names to their futures


### PR DESCRIPTION
## 📝 Summary

- This PR ensures that views load even if no datasets and/or catalogs are defined. Previously, if just a view was defined, the runtime wouldn't load it.

## 🔗 Related

- Closes #5744 

## Output
`spicepod.yaml`:
```yaml
version: v1
kind: Spicepod
name: example

views:
    - name: test
      sql: |
          WITH employees AS (
          -- Create inline dataset of employees
          SELECT *
          FROM (VALUES
            (1, 'Alice', 'Engineering', 85000),
            (2, 'Bob', 'Engineering', 90000),
            (3, 'Charlie', 'HR', 60000),
            (4, 'Diana', 'Marketing', 70000),
            (5, 'Eve', 'Engineering', 95000),
            (6, 'Frank', 'HR', 62000)
          ) AS t(id, name, department, salary)
          )

          SELECT department, 
                COUNT(*) AS employee_count
          FROM employees
          GROUP BY department
          ORDER BY department;
```

**Before**:
![image](https://github.com/user-attachments/assets/cd48fff1-5f66-4463-9da2-015514141691)

**After**:
![image](https://github.com/user-attachments/assets/74e09532-f313-49a5-ba69-a8f91c9856e0)

Queries against the view work as expected as well:
![image](https://github.com/user-attachments/assets/c6446abe-fb04-4257-bcba-7362645d0f9c)

