### PR TITLE
Fix projection pushdown issues for document based file connector

### DIFF
--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -81,24 +81,19 @@ impl ObjectStoreTextTable {
         ])
     }
 
-    fn to_record_batch(
-        meta_list: &[ObjectMeta],
-        raw: &[Bytes],
-        formatter: Option<&Arc<dyn DocumentParser>>,
-    ) -> Result<RecordBatch, ArrowError> {
-        if meta_list.len() != raw.len() {
-            return Err(ArrowError::ParseError("Length mismatch".to_string()));
-        }
-
-        let schema = Self::table_schema();
-
-        let location_array: ArrayRef = Arc::new(StringArray::from(
+    fn get_location_value(meta_list: &[ObjectMeta]) -> ArrayRef {
+        Arc::new(StringArray::from(
             meta_list
                 .iter()
                 .map(|meta| meta.location.to_string())
                 .collect::<Vec<_>>(),
-        ));
+        ))
+    }
 
+    fn get_content_value(
+        raw: &[Bytes],
+        formatter: Option<&Arc<dyn DocumentParser>>,
+    ) -> Result<ArrayRef, ArrowError> {
         let utf8_strings: Result<Vec<_>, ArrowError> = raw
             .iter()
             .enumerate()
@@ -108,24 +103,56 @@ impl ObjectStoreTextTable {
                         .parse(bytes)
                         .and_then(|doc| doc.as_flat_utf8())
                         .boxed()
-                        .map_err(|e| {
-                            if let Some(meta) = meta_list.get(idx) {
-                                format!("Error parsing document {}: {e}", meta.location).into()
-                            } else {
-                                e
-                            }
-                        }),
+                        .map_err(|e| format!("Error parsing document {}: {e}", idx).into()),
                     None => std::str::from_utf8(bytes).boxed().map(ToString::to_string),
                 };
                 utf8.map_err(ArrowError::from_external_error)
             })
             .collect();
 
-        let content_array: ArrayRef = Arc::new(StringArray::from(
+        Ok(Arc::new(StringArray::from(
             utf8_strings?.into_iter().collect::<Vec<_>>(),
-        ));
+        )))
+    }
 
-        RecordBatch::try_new(Arc::new(schema), vec![location_array, content_array])
+    fn get_field_value(
+        meta_list: &[ObjectMeta],
+        raw: &[Bytes],
+        field_name: &str,
+        formatter: Option<&Arc<dyn DocumentParser>>,
+    ) -> Result<ArrayRef, ArrowError> {
+        match field_name {
+            "location" => Ok(Self::get_location_value(meta_list)),
+            "content" => Self::get_content_value(raw, formatter),
+            _ => Err(ArrowError::SchemaError(format!(
+                "Unsupported field name: {}",
+                field_name
+            ))),
+        }
+    }
+
+    fn to_record_batch(
+        meta_list: &[ObjectMeta],
+        raw: &[Bytes],
+        formatter: Option<&Arc<dyn DocumentParser>>,
+        schema: SchemaRef,
+    ) -> Result<RecordBatch, ArrowError> {
+        if meta_list.len() != raw.len() {
+            return Err(ArrowError::ParseError("Length mismatch".to_string()));
+        }
+
+        let columns = schema
+            .fields()
+            .iter()
+            .map(|field| {
+                let field_name = field.name();
+                Self::get_field_value(meta_list, raw, field_name, formatter).map_err(|e| {
+                    ArrowError::SchemaError(format!("Error getting field {}: {}", field_name, e))
+                })
+            })
+            .collect::<Result<Vec<_>, ArrowError>>()?;
+
+        RecordBatch::try_new(schema, columns)
     }
 }
 
@@ -237,7 +264,12 @@ impl ExecutionPlan for ObjectStoreTextExec {
     ) -> DataFusionResult<SendableRecordBatchStream> {
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
-            to_sendable_stream(self.ctx.clone(), self.formatter.clone(), self.limit), // TODO get prefix from filters
+            to_sendable_stream(
+                self.ctx.clone(),
+                self.formatter.clone(),
+                self.limit,
+                self.schema(),
+            ), // TODO get prefix from filter
         )))
     }
 }
@@ -270,6 +302,7 @@ pub(crate) fn to_sendable_stream(
     ctx: ObjectStoreContext,
     formatter: Option<Arc<dyn DocumentParser>>,
     limit: Option<usize>,
+    schema: SchemaRef,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> + 'static {
     stream! {
         let mut object_stream = ctx.store.list(ctx.prefix.clone().map(Path::from).as_ref());
@@ -286,7 +319,7 @@ pub(crate) fn to_sendable_stream(
                     let result: GetResult = ctx.store.get(&object_meta.location).await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
                     let bytz = result.bytes().await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
 
-                    match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz], formatter.as_ref()) {
+                    match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz], formatter.as_ref(), schema.clone()) {
                         Ok(batch) => {
                             let n = batch.num_rows();
                             yield Ok(batch);

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -103,7 +103,7 @@ impl ObjectStoreTextTable {
                         .parse(bytes)
                         .and_then(|doc| doc.as_flat_utf8())
                         .boxed()
-                        .map_err(|e| format!("Error parsing document {}: {e}", idx).into()),
+                        .map_err(|e| format!("Error parsing document {idx}: {e}").into()),
                     None => std::str::from_utf8(bytes).boxed().map(ToString::to_string),
                 };
                 utf8.map_err(ArrowError::from_external_error)
@@ -125,8 +125,7 @@ impl ObjectStoreTextTable {
             "location" => Ok(Self::get_location_value(meta_list)),
             "content" => Self::get_content_value(raw, formatter),
             _ => Err(ArrowError::SchemaError(format!(
-                "Unsupported field name: {}",
-                field_name
+                "Unsupported field name: {field_name}",
             ))),
         }
     }
@@ -147,7 +146,7 @@ impl ObjectStoreTextTable {
             .map(|field| {
                 let field_name = field.name();
                 Self::get_field_value(meta_list, raw, field_name, formatter).map_err(|e| {
-                    ArrowError::SchemaError(format!("Error getting field {}: {}", field_name, e))
+                    ArrowError::SchemaError(format!("Error getting field {field_name}: {e}"))
                 })
             })
             .collect::<Result<Vec<_>, ArrowError>>()?;
@@ -319,7 +318,7 @@ pub(crate) fn to_sendable_stream(
                     let result: GetResult = ctx.store.get(&object_meta.location).await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
                     let bytz = result.bytes().await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
 
-                    match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz], formatter.as_ref(), schema.clone()) {
+                    match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz], formatter.as_ref(), Arc::clone(&schema)) {
                         Ok(batch) => {
                             let n = batch.num_rows();
                             yield Ok(batch);

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -275,7 +275,7 @@ impl ExecutionPlan for ObjectStoreTextExec {
                 self.formatter.clone(),
                 self.limit,
                 self.schema(),
-            ), // TODO get prefix from filter
+            ),
         )))
     }
 }

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -93,6 +93,7 @@ impl ObjectStoreTextTable {
     fn get_content_value(
         raw: &[Bytes],
         formatter: Option<&Arc<dyn DocumentParser>>,
+        meta_list: &[ObjectMeta],
     ) -> Result<ArrayRef, ArrowError> {
         let utf8_strings: Result<Vec<_>, ArrowError> = raw
             .iter()
@@ -103,7 +104,13 @@ impl ObjectStoreTextTable {
                         .parse(bytes)
                         .and_then(|doc| doc.as_flat_utf8())
                         .boxed()
-                        .map_err(|e| format!("Error parsing document {idx}: {e}").into()),
+                        .map_err(|e| {
+                            if let Some(meta) = meta_list.get(idx) {
+                                format!("Error parsing document {}: {e}", meta.location).into()
+                            } else {
+                                e
+                            }
+                        }),
                     None => std::str::from_utf8(bytes).boxed().map(ToString::to_string),
                 };
                 utf8.map_err(ArrowError::from_external_error)
@@ -123,7 +130,7 @@ impl ObjectStoreTextTable {
     ) -> Result<ArrayRef, ArrowError> {
         match field_name {
             "location" => Ok(Self::get_location_value(meta_list)),
-            "content" => Self::get_content_value(raw, formatter),
+            "content" => Self::get_content_value(raw, formatter, meta_list),
             _ => Err(ArrowError::SchemaError(format!(
                 "Unsupported field name: {field_name}",
             ))),

--- a/crates/runtime/tests/file/mod.rs
+++ b/crates/runtime/tests/file/mod.rs
@@ -14,16 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use app::AppBuilder;
 
 use runtime::Runtime;
-use spicepod::component::dataset::Dataset;
+use spicepod::{
+    component::dataset::Dataset,
+    param::{ParamValue, Params},
+};
 
 use crate::{
     ValidateFn, configure_test_datafusion, init_tracing, run_query_and_check_results,
-    utils::test_request_context,
+    run_query_and_check_results_with_plan_checks, utils::test_request_context,
 };
 
 pub fn get_dataset() -> Result<Dataset, anyhow::Error> {
@@ -39,6 +42,30 @@ pub fn get_dataset() -> Result<Dataset, anyhow::Error> {
     };
 
     Ok(Dataset::new(format!("file:{file_path}"), "datatypes"))
+}
+
+pub fn get_raw_file_dataset() -> Result<Dataset, anyhow::Error> {
+    // if tests are running with `cargo test --package runtime`, this path is relative to the `runtime` crate
+    // if tests are running as a built binary, this path is relative to the binary.
+    // in binary mode, we expect to be running in the root of the project
+    let file_path = if std::fs::exists("./tests/file/test_docs")? {
+        "./tests/file/test_docs"
+    } else if std::fs::exists("./crates/runtime/tests/file/test_docs")? {
+        "./crates/runtime/tests/file/test_docs"
+    } else {
+        return Err(anyhow::anyhow!("Could not find test_docs directory"));
+    };
+
+    let mut dataset = Dataset::new(format!("file:{file_path}"), "docs");
+
+    dataset.params = Some(Params {
+        data: HashMap::from([(
+            "file_format".to_string(),
+            ParamValue::String("md".to_string()),
+        )]),
+    });
+
+    Ok(dataset)
 }
 
 #[tokio::test]
@@ -100,6 +127,68 @@ async fn file_connector_datatypes() -> Result<(), anyhow::Error> {
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
+            }
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn file_connector_projection_pushdown() -> Result<(), anyhow::Error> {
+    type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("file_connector")
+                .with_dataset(get_raw_file_dataset()?)
+                .build();
+
+            let mut rt = Runtime::builder()
+                .with_app(app)
+                .with_datafusion_configuration_fn(configure_test_datafusion)
+                .build()
+                .await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::anyhow!("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            let queries: QueryTests = vec![(
+                "SELECT content FROM docs",
+                "projection_pushdown",
+                Some(Box::new(|result_batches| {
+                    for batch in &result_batches {
+                        assert_eq!(batch.num_columns(), 1, "num_cols: {}", batch.num_columns());
+                        assert_eq!(batch.num_rows(), 1, "num_rows: {}", batch.num_rows());
+                    }
+
+                    let results = arrow::util::pretty::pretty_format_batches(&result_batches)
+                        .expect("should pretty print result batch");
+                    insta::with_settings!({
+                        description => format!("File Integration Test Results"),
+                        omit_expression => true,
+                        snapshot_path => "../snapshots"
+                    }, {
+                        insta::assert_snapshot!("file_integration_test_projection_pushdown", results);
+                    });
+                })),
+            )];
+
+
+            for (query, _, validate_result) in queries {
+                let plan_checks = vec![
+                    ("TableScan", Box::new(|plan: &str| {
+                        plan.contains("docs") && plan.contains("projection=[content]")
+                    }) as Box<dyn Fn(&str) -> bool + 'static>),
+                ];
+                run_query_and_check_results_with_plan_checks(&mut rt, query, plan_checks, validate_result).await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
 
             Ok(())

--- a/crates/runtime/tests/file/mod.rs
+++ b/crates/runtime/tests/file/mod.rs
@@ -182,12 +182,11 @@ async fn file_connector_projection_pushdown() -> Result<(), anyhow::Error> {
 
 
             for (query, _, validate_result) in queries {
-                let plan_checks = vec![
-                    ("TableScan", Box::new(|plan: &str| {
-                        plan.contains("docs") && plan.contains("projection=[content]")
-                    }) as Box<dyn Fn(&str) -> bool + 'static>),
-                ];
-                run_query_and_check_results_with_plan_checks(&mut rt, query, plan_checks, validate_result).await
+                let plan_check =
+                        ("TableScan", Box::new(|plan: &str| {
+                            plan.contains("docs") && plan.contains("projection=[content]")
+                        }) as Box<dyn Fn(&str) -> bool + 'static>);
+                run_query_and_check_results_with_plan_checks(&mut rt, query, vec![plan_check], validate_result).await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
             }
 

--- a/crates/runtime/tests/file/test_docs/test.md
+++ b/crates/runtime/tests/file/test_docs/test.md
@@ -1,0 +1,3 @@
+Testing 1
+Testing 2
+Testing 3

--- a/crates/runtime/tests/snapshots/integration__file__file_integration_test_projection_pushdown.snap
+++ b/crates/runtime/tests/snapshots/integration__file__file_integration_test_projection_pushdown.snap
@@ -1,0 +1,12 @@
+---
+source: crates/runtime/tests/file/mod.rs
+description: File Integration Test Results
+---
++-----------+
+| content   |
++-----------+
+| Testing 1 |
+| Testing 2 |
+| Testing 3 |
+|           |
++-----------+


### PR DESCRIPTION
## 📝 Summary

- Fixes projection pushdown issues in the document-based file connector
- For local file connectors, when a user asks for a projection with a single column (e.g., `content`), the `location` column is incorrectly always returned. This PR fixes the issue by ensuring the record batch returned from a scan always matches the requested schema.

## 🔗 Related

- Closes #4882 

