### PR TITLE
Partitioning TableProvider::scan and streaming ExecutionPlan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11202,6 +11202,7 @@ dependencies = [
  "async-trait",
  "datafusion",
  "futures",
+ "parking_lot 0.12.3",
  "serde",
  "serde_qs 1.0.0-rc.3",
  "snafu",

--- a/crates/runtime-table-partition/Cargo.toml
+++ b/crates/runtime-table-partition/Cargo.toml
@@ -13,6 +13,7 @@ arrow-schema.workspace = true
 async-trait.workspace = true
 datafusion.workspace = true
 futures.workspace = true
+parking_lot = "0.12"
 serde.workspace = true
 serde_qs = { git = "https://github.com/samscott89/serde_qs.git", rev = "f24f916a6420cf500c97fb85dc5e64015fdb6b40" }
 snafu.workspace = true

--- a/crates/runtime-table-partition/src/creator.rs
+++ b/crates/runtime-table-partition/src/creator.rs
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use async_trait::async_trait;
-use datafusion::{catalog::TableProvider, scalar::ScalarValue};
+use datafusion::scalar::ScalarValue;
 use snafu::prelude::*;
 
 use crate::Partition;
@@ -36,6 +36,9 @@ pub enum Error {
 
 #[async_trait]
 pub trait PartitionCreator: Debug + Send + Sync {
+    /// Connection pool to the partitioned data source
+    type ConnectionPool;
+
     /// Create a new [`Partition`] using the `partition_value`.
     ///
     /// # Errors
@@ -43,11 +46,13 @@ pub trait PartitionCreator: Debug + Send + Sync {
     async fn create_partition(
         &self,
         partition_value: ScalarValue,
-    ) -> Result<Arc<dyn TableProvider>, Error>;
+    ) -> Result<Partition<Self::ConnectionPool>, Error>;
 
     /// Find and load previously created [`Parition`]s.
     ///
     /// # Errors
     /// Returns an error when [`Partition`]s cannot be inferred.
-    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, Error>;
+    async fn infer_existing_partitions(
+        &self,
+    ) -> Result<Vec<Partition<Self::ConnectionPool>>, Error>;
 }

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -1,0 +1,318 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow_schema::SchemaRef;
+use datafusion::arrow::array::{Array, UInt64Array};
+use datafusion::arrow::compute;
+use datafusion::common::DFSchema;
+use datafusion::execution::context::ExecutionProps;
+use datafusion::logical_expr::ColumnarValue;
+use datafusion::logical_expr::dml::InsertOp;
+use datafusion::physical_expr::{EquivalenceProperties, create_physical_expr};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::memory::LazyBatchGenerator;
+use datafusion::physical_plan::{
+    DisplayAs, EmptyRecordBatchStream, Partitioning, PlanProperties, execute_stream,
+};
+use datafusion::prelude::SessionContext;
+use datafusion::scalar::ScalarValue;
+use datafusion::{
+    arrow::record_batch::RecordBatch,
+    error::DataFusionError,
+    execution::context::TaskContext,
+    physical_plan::{ExecutionPlan, SendableRecordBatchStream, memory::LazyMemoryExec},
+    prelude::Expr,
+};
+use futures::stream::StreamExt;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio::task::block_in_place;
+
+use crate::Partition;
+use crate::creator::PartitionCreator;
+
+#[derive(Debug)]
+pub struct PartitionInsertExec<ConnectionPool> {
+    input: Arc<dyn ExecutionPlan>,
+    creator: Arc<dyn PartitionCreator<ConnectionPool = ConnectionPool>>,
+    partitions: Arc<RwLock<HashMap<String, Partition<ConnectionPool>>>>,
+    partition_by: Expr,
+    insert_op: InsertOp,
+    schema: SchemaRef,
+    properties: PlanProperties,
+}
+
+impl<ConnectionPool> PartitionInsertExec<ConnectionPool>
+where
+    ConnectionPool: std::fmt::Debug + Send + Sync + 'static,
+{
+    pub(crate) fn new(
+        input: Arc<dyn ExecutionPlan>,
+        partition_by: Expr,
+        creator: Arc<dyn PartitionCreator<ConnectionPool = ConnectionPool>>,
+        partitions: Arc<RwLock<HashMap<String, Partition<ConnectionPool>>>>,
+        insert_op: InsertOp,
+        schema: SchemaRef,
+    ) -> Self {
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        Self {
+            input,
+            partition_by,
+            creator,
+            partitions,
+            insert_op,
+            schema,
+            properties,
+        }
+    }
+}
+
+impl<ConnectionPool> DisplayAs for PartitionInsertExec<ConnectionPool> {
+    fn fmt_as(
+        &self,
+        _t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "PartitionInsertExec")
+    }
+}
+
+impl<ConnectionPool> ExecutionPlan for PartitionInsertExec<ConnectionPool>
+where
+    ConnectionPool: std::fmt::Debug + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Plan(
+                "PartitionInsertExec requires exactly one child".to_string(),
+            ));
+        }
+        Ok(Arc::new(Self::new(
+            children[0].clone(),
+            self.partition_by.clone(),
+            Arc::clone(&self.creator),
+            Arc::clone(&self.partitions),
+            self.insert_op,
+            Arc::clone(&self.schema),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        // We want to stream the input RecordBatches, partition them into
+        // RecordBatches destined for a particular partitioned file, stream
+        // them into that partitioned file without buffering all of the data,
+        // and call `insert_into` on the DuckDB Table Providers only once
+        // because data are rewritten every call to `insert_into`.
+        //
+        // We also have an interesting mix of async/sync contexts here in
+        // `execute` which we deal with by using `block_in_place` and
+        // `Handle::block_on`.
+        //
+        // In one task, we stream the input RecordBatches and partition them
+        // according to the partition_by expression. If the partition has not
+        // yet been created, we create it. We also create a channel for sending
+        // RecordBatches. We make a LazyMemExec ExecutionPlan which we pass to
+        // that partition's `insert_into` one time. The LazyMemExec is passed
+        // a generator that we create which generates record batches out of the
+        // receiving end of the partition's RecordBatch channel. Each partition
+        // `insert_into` invokation is ran in a separate task. So we have one
+        // partitioning task and N insertion tasks where N is the number of
+        // partitions.
+
+        let session_config = context.session_config();
+        let ctx = SessionContext::new_with_config(session_config.clone());
+
+        if partition != 0 {
+            return Err(DataFusionError::Execution(
+                "PartitionInsertExec only supports single partition".to_string(),
+            ));
+        }
+
+        let insert_op = self.insert_op;
+        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
+        let props = ExecutionProps::new();
+        let physical_expr = create_physical_expr(&self.partition_by, &df_schema, &props)?;
+        let schema = Arc::clone(&self.schema);
+        let creator = Arc::clone(&self.creator);
+        let partition_providers = Arc::clone(&self.partitions);
+        let input = Arc::clone(&self.input);
+        let task_ctx = Arc::clone(&context);
+
+        let mut partition_senders: HashMap<String, Sender<RecordBatch>> = HashMap::new();
+
+        let mut stream = execute_stream(input, task_ctx)?;
+
+        block_in_place(move || {
+            Handle::current().block_on(async move {
+                while let Some(batch) = stream.next().await {
+                    let batch = batch?;
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+
+                    let column = physical_expr.evaluate(&batch)?;
+                    let array = match column {
+                        ColumnarValue::Array(array) => array,
+                        ColumnarValue::Scalar(_) => {
+                            return Err(DataFusionError::Execution(
+                                "Invalid partition expression".to_string(),
+                            ));
+                        }
+                    };
+
+                    let partitions = compute::partition(&[Arc::clone(&array)])?;
+                    for indices in partitions.ranges() {
+                        if indices.is_empty() {
+                            continue;
+                        }
+                        let indices = indices.collect::<Vec<_>>();
+                        let partition_value = ScalarValue::try_from_array(&array, indices[0])?;
+                        let partition_key = partition_value.to_string();
+                        let new_batch = filter_batch_by_indices(&batch, &indices)?;
+
+                        let tx = if let Some(tx) = partition_senders.get(&partition_key) {
+                            tx.clone()
+                        } else {
+                            // Create a new partition
+                            let partition = creator
+                                .create_partition(partition_value.clone())
+                                .await
+                                .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                            let new_provider = Arc::clone(&partition.table_provider);
+                            let mut partitions = partition_providers.write().await;
+                            partitions.insert(partition_key.clone(), partition);
+
+                            // Create a new channel
+                            let (tx, rx) = channel(100);
+                            partition_senders.insert(partition_key.clone(), tx.clone());
+
+                            // Create the generator
+                            let generator = BatchGenerator {
+                                partition_value,
+                                rx,
+                            };
+
+                            // Create the Lazy execution plan for the table provider
+                            let exec = LazyMemoryExec::try_new(
+                                Arc::clone(&schema),
+                                vec![Arc::new(parking_lot::RwLock::new(generator))],
+                            )?;
+
+                            let state = ctx.state();
+                            let context = Arc::clone(&context);
+
+                            // spawn the insertion task for this partition
+                            tokio::spawn(async move {
+                                let plan = new_provider
+                                    .insert_into(&state, Arc::new(exec), insert_op)
+                                    .await?;
+
+                                let mut stream = execute_stream(plan, context)?;
+                                while let Some(batch) = stream.next().await {
+                                    batch?;
+                                }
+
+                                Result::<(), DataFusionError>::Ok(())
+                            });
+
+                            tx
+                        };
+
+                        // Send the partitioned RecordBatch to the partition's
+                        // channel
+                        let _ = tx.send(new_batch).await;
+                    }
+                }
+
+                Ok(())
+            })
+        })?;
+
+        Ok(Box::pin(EmptyRecordBatchStream::new(Arc::clone(
+            &self.schema,
+        ))))
+    }
+
+    fn name(&self) -> &str {
+        "PartitionInsertExec"
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+}
+
+#[derive(Debug)]
+struct BatchGenerator {
+    partition_value: ScalarValue,
+    rx: Receiver<RecordBatch>,
+}
+
+impl fmt::Display for BatchGenerator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BatchGenerator")
+            .field("partition_value", &self.partition_value)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LazyBatchGenerator for BatchGenerator {
+    fn generate_next_batch(&mut self) -> Result<Option<RecordBatch>, DataFusionError> {
+        block_in_place(|| Handle::current().block_on(async { Ok(self.rx.recv().await) }))
+    }
+}
+
+fn filter_batch_by_indices(
+    batch: &RecordBatch,
+    indices: &[usize],
+) -> Result<RecordBatch, DataFusionError> {
+    let indices_array = UInt64Array::from_iter_values(indices.iter().map(|&i| i as u64));
+    let indices_array = Arc::new(indices_array) as Arc<dyn Array>;
+    let columns = batch
+        .columns()
+        .iter()
+        .map(|col| compute::take(col, &indices_array, None))
+        .collect::<Result<Vec<_>, _>>()?;
+    RecordBatch::try_new(batch.schema(), columns).map_err(|e| DataFusionError::ArrowError(e, None))
+}

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -79,9 +79,9 @@ where
         );
         Self {
             input,
-            partition_by,
             creator,
             partitions,
+            partition_by,
             insert_op,
             schema,
             properties,
@@ -125,7 +125,7 @@ where
             ));
         }
         Ok(Arc::new(Self::new(
-            children[0].clone(),
+            Arc::clone(&children[0]),
             self.partition_by.clone(),
             Arc::clone(&self.creator),
             Arc::clone(&self.partitions),
@@ -274,7 +274,7 @@ where
         ))))
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "PartitionInsertExec"
     }
 

--- a/crates/runtime-table-partition/src/lib.rs
+++ b/crates/runtime-table-partition/src/lib.rs
@@ -20,6 +20,7 @@ use datafusion::{catalog::TableProvider, scalar::ScalarValue};
 
 pub mod creator;
 pub mod expression;
+pub mod insert;
 pub mod provider;
 
 #[derive(Debug)]

--- a/crates/runtime-table-partition/src/lib.rs
+++ b/crates/runtime-table-partition/src/lib.rs
@@ -23,7 +23,8 @@ pub mod expression;
 pub mod provider;
 
 #[derive(Debug)]
-pub struct Partition {
+pub struct Partition<Pool> {
     pub partition_value: ScalarValue,
+    pub pool: Arc<Pool>,
     pub table_provider: Arc<dyn TableProvider>,
 }

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -57,7 +57,7 @@ type ScalarValueString = String;
 #[derive(Debug)]
 pub struct PartitionTableProvider<ConnectionPool> {
     creator: Arc<dyn PartitionCreator<ConnectionPool = ConnectionPool>>,
-    partition_by: Vec<Expr>,
+    partition_by: Expr,
     partitions: Arc<RwLock<HashMap<ScalarValueString, Partition<ConnectionPool>>>>,
     schema: SchemaRef,
 }
@@ -71,12 +71,16 @@ impl<ConnectionPool> PartitionTableProvider<ConnectionPool> {
     /// validation fails.
     pub async fn new(
         creator: Arc<dyn PartitionCreator<ConnectionPool = ConnectionPool>>,
-        partition_by: Vec<Expr>,
+        mut partition_by: Vec<Expr>,
         schema: SchemaRef,
     ) -> Result<Self, Error> {
         let num_partition_by = partition_by.len();
-        let expr = partition_by
-            .first()
+        ensure!(
+            num_partition_by == 1,
+            PartitionByViolationSnafu { num_partition_by }
+        );
+        let partition_by = partition_by
+            .pop()
             .context(PartitionByViolationSnafu { num_partition_by })?;
 
         let df_schema = DFSchema::try_from(Arc::clone(&schema)).context(SchemaConversionSnafu)?;
@@ -87,7 +91,7 @@ impl<ConnectionPool> PartitionTableProvider<ConnectionPool> {
             .context(CreatingPartitionSnafu)?
             .into_iter()
             .map(|p| {
-                validate_scalar_compatibility(expr, &p.partition_value, &df_schema)?;
+                validate_scalar_compatibility(&partition_by, &p.partition_value, &df_schema)?;
                 Ok((p.partition_value.to_string(), p))
             })
             .collect::<Result<HashMap<_, _>, _>>()
@@ -151,15 +155,10 @@ where
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let Some(partition_by) = self.partition_by.first() else {
-            return Err(DataFusionError::Execution(
-                "No 'partition_by' expression provided in the spicepod.yaml".to_string(),
-            ));
-        };
         let partitions = self.partitions.read().await;
         let mut plans = Vec::with_capacity(partitions.len());
         for partition in partitions.values() {
-            if prune_partition(filters, partition_by, &partition.partition_value) {
+            if prune_partition(filters, &self.partition_by, &partition.partition_value) {
                 continue;
             }
             let plan = partition
@@ -173,11 +172,9 @@ where
             plans if plans.is_empty() => {
                 return Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema))));
             }
-            mut plans if plans.len() == 1 => {
-                #[allow(clippy::unwrap_used)]
-                // NOTE: Unwrap is okay because we ensure the length is 1
-                plans.pop().unwrap()
-            }
+            mut plans if plans.len() == 1 => plans.pop().ok_or_else(|| {
+                DataFusionError::Execution("expected an ExecutionPlan".to_string())
+            })?,
             plans => Arc::new(UnionExec::new(plans)),
         };
 
@@ -194,14 +191,9 @@ where
         input: Arc<dyn ExecutionPlan>,
         insert_op: InsertOp,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let Some(partition_by) = self.partition_by.first() else {
-            return Err(DataFusionError::Execution(
-                "No 'partition_by' expression provided in the spicepod.yaml".to_string(),
-            ));
-        };
         Ok(Arc::new(PartitionInsertExec::new(
             input,
-            partition_by.clone(),
+            self.partition_by.clone(),
             Arc::clone(&self.creator),
             Arc::clone(&self.partitions),
             insert_op,

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -33,7 +33,9 @@ use datafusion::{
     execution::{TaskContext, context::ExecutionProps},
     logical_expr::{ColumnarValue, dml::InsertOp},
     physical_expr::create_physical_expr,
-    physical_plan::{ExecutionPlan, execute_stream, union::UnionExec},
+    physical_plan::{
+        ExecutionPlan, empty::EmptyExec, execute_stream, limit::GlobalLimitExec, union::UnionExec,
+    },
     prelude::Expr,
     scalar::ScalarValue,
 };
@@ -131,14 +133,37 @@ impl TableProvider for PartitionTableProvider {
 
     async fn scan(
         &self,
-        _state: &dyn Session,
-        _projection: Option<&Vec<usize>>,
-        _filters: &[Expr],
-        _limit: Option<usize>,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        Err(DataFusionError::Execution(
-            "PartitionedTableProvider::scan not implemented yet".to_string(),
-        ))
+        let partitions = self.partitions.read().await;
+        let mut plans = Vec::with_capacity(partitions.len());
+        for table_provider in partitions.values() {
+            let plan = table_provider
+                .scan(state, projection, filters, limit)
+                .await?;
+            plans.push(plan);
+        }
+
+        if plans.is_empty() {
+            let empty = EmptyExec::new(Arc::clone(&self.schema));
+            return Ok(Arc::new(empty));
+        }
+
+        let plan = if plans.len() > 1 {
+            Arc::new(UnionExec::new(plans))
+        } else {
+            #[allow(clippy::unwrap_used)]
+            plans.into_iter().next().unwrap()
+        };
+
+        if let Some(limit) = limit {
+            return Ok(Arc::new(GlobalLimitExec::new(plan, limit, None)));
+        }
+
+        Ok(plan)
     }
 
     async fn insert_into(

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -43,7 +43,10 @@ use futures::StreamExt as _;
 use snafu::prelude::*;
 use tokio::sync::RwLock;
 
-use crate::{Partition, creator::PartitionCreator, expression::validate_scalar_compatibility};
+use crate::{
+    Partition, creator::PartitionCreator, expression::validate_scalar_compatibility,
+    insert::PartitionInsertExec,
+};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -67,7 +70,7 @@ type ScalarValueString = String;
 pub struct PartitionTableProvider<ConnectionPool> {
     creator: Arc<dyn PartitionCreator<ConnectionPool = ConnectionPool>>,
     partition_by: Vec<Expr>,
-    partitions: RwLock<HashMap<ScalarValueString, Partition<ConnectionPool>>>,
+    partitions: Arc<RwLock<HashMap<ScalarValueString, Partition<ConnectionPool>>>>,
     schema: SchemaRef,
 }
 
@@ -102,7 +105,7 @@ impl<ConnectionPool> PartitionTableProvider<ConnectionPool> {
             .collect::<Result<HashMap<_, _>, _>>()
             .context(ValidatingExpressionsSnafu)?;
 
-        let partitions = RwLock::new(partitions);
+        let partitions = Arc::new(RwLock::new(partitions));
 
         Ok(Self {
             creator,
@@ -188,122 +191,14 @@ where
         input: Arc<dyn ExecutionPlan>,
         insert_op: InsertOp,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let expr = self.partition_by.first().ok_or_else(|| {
-            DataFusionError::Execution("Failed to get first partition expression".to_string())
-        })?;
-        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
-
-        let task_ctx = Arc::new(TaskContext::from(state));
-        let mut stream = execute_stream(Arc::clone(&input), task_ctx)?;
-        let mut execution_plans = Vec::new();
-
-        while let Some(batch) = stream.next().await {
-            let batch = batch?;
-            if batch.num_rows() == 0 {
-                continue;
-            }
-
-            let partition_groups = group_by_partition(expr, &[batch], &df_schema)?;
-
-            for (partition_value, batch) in partition_groups {
-                let partition_key = partition_value.to_string();
-                let table_provider = {
-                    let partitions = self.partitions.read().await;
-                    if let Some(partition) = partitions.get(&partition_key) {
-                        Arc::clone(&partition.table_provider)
-                    } else {
-                        drop(partitions);
-                        let partition = self
-                            .creator
-                            .create_partition(partition_value.clone())
-                            .await
-                            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
-                        let table_provider = Arc::clone(&partition.table_provider);
-                        let mut partitions = self.partitions.write().await;
-                        partitions.insert(partition_key.clone(), partition);
-                        table_provider
-                    }
-                };
-
-                let mem_exec = DataSourceExec::new(Arc::new(MemorySourceConfig::try_new(
-                    &[vec![batch]],
-                    Arc::clone(&self.schema),
-                    None,
-                )?));
-
-                let plan = table_provider
-                    .insert_into(state, Arc::new(mem_exec), insert_op)
-                    .await?;
-                execution_plans.push(plan);
-            }
-        }
-
-        if execution_plans.is_empty() {
-            let empty = EmptyExec::new(Arc::clone(&self.schema));
-            Ok(Arc::new(empty))
-        } else if execution_plans.len() == 1 {
-            #[allow(clippy::unwrap_used)]
-            Ok(execution_plans.into_iter().next().unwrap())
-        } else {
-            Ok(Arc::new(UnionExec::new(execution_plans)))
-        }
+        let partition_by = self.partition_by.first().unwrap().clone();
+        Ok(Arc::new(PartitionInsertExec::new(
+            input,
+            partition_by,
+            Arc::clone(&self.creator),
+            Arc::clone(&self.partitions),
+            insert_op,
+            Arc::clone(&self.schema),
+        )))
     }
-}
-
-fn group_by_partition(
-    expr: &Expr,
-    batches: &[RecordBatch],
-    df_schema: &DFSchema,
-) -> Result<HashMap<ScalarValue, RecordBatch>, DataFusionError> {
-    let props = ExecutionProps::new();
-    let physical_expr = create_physical_expr(expr, df_schema, &props)?;
-    let mut partition_map = HashMap::new();
-
-    for batch in batches.iter().filter(|b| b.num_rows() > 0) {
-        let column = physical_expr.evaluate(batch)?;
-        let array = match column {
-            ColumnarValue::Array(array) => array,
-            ColumnarValue::Scalar(_) => return Err(Error::InvalidPartitionExpression).boxed()?,
-        };
-
-        let partitions = partition(&[Arc::clone(&array)])?;
-
-        for indices in partitions.ranges() {
-            if indices.is_empty() {
-                continue;
-            }
-            // Extract scalar value from the first row of the partition
-            let indices = indices.collect::<Vec<_>>();
-            let scalar = ScalarValue::try_from_array(&array, indices[0])?;
-            let partition_batches = partition_map.entry(scalar).or_insert_with(Vec::new);
-            // Create a single batch for the partition using indices
-            let new_batch = filter_batch_by_indices(batch, &indices)?;
-            partition_batches.push(new_batch);
-        }
-    }
-
-    let mut result = HashMap::with_capacity(partition_map.len());
-    for (scalar, batches) in partition_map {
-        if batches.is_empty() {
-            continue;
-        }
-        let concat_batch = concat_batches(&batches[0].schema(), &batches)?;
-        result.insert(scalar, concat_batch);
-    }
-
-    Ok(result)
-}
-
-fn filter_batch_by_indices(
-    batch: &RecordBatch,
-    indices: &[usize],
-) -> Result<RecordBatch, DataFusionError> {
-    let indices_array = UInt64Array::from_iter_values(indices.iter().map(|&i| i as u64));
-    let indices_array = Arc::new(indices_array) as Arc<dyn Array>;
-    let columns = batch
-        .columns()
-        .iter()
-        .map(|col| take(col, &indices_array, None))
-        .collect::<Result<Vec<_>, _>>()?;
-    RecordBatch::try_new(batch.schema(), columns).map_err(|e| DataFusionError::ArrowError(e, None))
 }

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -43,7 +43,7 @@ use futures::StreamExt as _;
 use snafu::prelude::*;
 use tokio::sync::RwLock;
 
-use crate::{creator::PartitionCreator, expression::validate_scalar_compatibility};
+use crate::{Partition, creator::PartitionCreator, expression::validate_scalar_compatibility};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -64,14 +64,14 @@ pub enum Error {
 type ScalarValueString = String;
 
 #[derive(Debug)]
-pub struct PartitionTableProvider {
-    creator: Arc<dyn PartitionCreator>,
+pub struct PartitionTableProvider<ConnectionPool> {
+    creator: Arc<dyn PartitionCreator<ConnectionPool = ConnectionPool>>,
     partition_by: Vec<Expr>,
-    partitions: RwLock<HashMap<ScalarValueString, Arc<dyn TableProvider>>>,
+    partitions: RwLock<HashMap<ScalarValueString, Partition<ConnectionPool>>>,
     schema: SchemaRef,
 }
 
-impl PartitionTableProvider {
+impl<ConnectionPool> PartitionTableProvider<ConnectionPool> {
     /// Creates a new [`PartitionTableProvider`] that partitions the data using
     /// the first expression in `partition_by`.
     ///
@@ -79,7 +79,7 @@ impl PartitionTableProvider {
     /// This function will return an Error when the `partition_by` expression
     /// validation fails.
     pub async fn new(
-        creator: Arc<dyn PartitionCreator>,
+        creator: Arc<dyn PartitionCreator<ConnectionPool = ConnectionPool>>,
         partition_by: Vec<Expr>,
         schema: SchemaRef,
     ) -> Result<Self, Error> {
@@ -97,7 +97,7 @@ impl PartitionTableProvider {
             .into_iter()
             .map(|p| {
                 validate_scalar_compatibility(expr, &p.partition_value, &df_schema)?;
-                Ok((p.partition_value.to_string(), p.table_provider))
+                Ok((p.partition_value.to_string(), p))
             })
             .collect::<Result<HashMap<_, _>, _>>()
             .context(ValidatingExpressionsSnafu)?;
@@ -111,10 +111,25 @@ impl PartitionTableProvider {
             schema,
         })
     }
+
+    /// Get ConnectionPools for each partition.
+    ///
+    /// # Errors
+    pub async fn get_shared_pools(&self) -> Vec<Arc<ConnectionPool>> {
+        self.partitions
+            .read()
+            .await
+            .values()
+            .map(|p| p.pool.clone())
+            .collect()
+    }
 }
 
 #[async_trait]
-impl TableProvider for PartitionTableProvider {
+impl<ConnectionPool> TableProvider for PartitionTableProvider<ConnectionPool>
+where
+    ConnectionPool: std::fmt::Debug + Send + Sync + 'static,
+{
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -140,8 +155,9 @@ impl TableProvider for PartitionTableProvider {
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
         let partitions = self.partitions.read().await;
         let mut plans = Vec::with_capacity(partitions.len());
-        for table_provider in partitions.values() {
-            let plan = table_provider
+        for partition in partitions.values() {
+            let plan = partition
+                .table_provider
                 .scan(state, projection, filters, limit)
                 .await?;
             plans.push(plan);
@@ -189,22 +205,23 @@ impl TableProvider for PartitionTableProvider {
 
             let partition_groups = group_by_partition(expr, &[batch], &df_schema)?;
 
-            for (scalar_value, batch) in partition_groups {
-                let partition_key = scalar_value.to_string();
+            for (partition_value, batch) in partition_groups {
+                let partition_key = partition_value.to_string();
                 let table_provider = {
                     let partitions = self.partitions.read().await;
-                    if let Some(existing_provider) = partitions.get(&partition_key) {
-                        Arc::clone(existing_provider)
+                    if let Some(partition) = partitions.get(&partition_key) {
+                        Arc::clone(&partition.table_provider)
                     } else {
                         drop(partitions);
-                        let new_provider = self
+                        let partition = self
                             .creator
-                            .create_partition(scalar_value.clone())
+                            .create_partition(partition_value.clone())
                             .await
                             .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                        let table_provider = Arc::clone(&partition.table_provider);
                         let mut partitions = self.partitions.write().await;
-                        partitions.insert(partition_key.clone(), Arc::clone(&new_provider));
-                        new_provider
+                        partitions.insert(partition_key.clone(), partition);
+                        table_provider
                     }
                 };
 

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -185,10 +185,14 @@ where
         input: Arc<dyn ExecutionPlan>,
         insert_op: InsertOp,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        let partition_by = self.partition_by.first().unwrap().clone();
+        let Some(partition_by) = self.partition_by.first() else {
+            return Err(DataFusionError::Execution(
+                "No 'partition_by' expression provided in the spicepod.yaml".to_string(),
+            ));
+        };
         Ok(Arc::new(PartitionInsertExec::new(
             input,
-            partition_by,
+            partition_by.clone(),
             Arc::clone(&self.creator),
             Arc::clone(&self.partitions),
             insert_op,

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -102,7 +102,7 @@ impl<ConnectionPool> PartitionTableProvider<ConnectionPool> {
         })
     }
 
-    /// Get ConnectionPools for each partition.
+    /// Get `ConnectionPool`s for each partition.
     ///
     /// # Errors
     pub async fn get_shared_pools(&self) -> Vec<Arc<ConnectionPool>> {
@@ -110,7 +110,7 @@ impl<ConnectionPool> PartitionTableProvider<ConnectionPool> {
             .read()
             .await
             .values()
-            .map(|p| p.pool.clone())
+            .map(|p| Arc::clone(&p.pool))
             .collect()
     }
 }

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -160,16 +160,16 @@ where
             plans.push(plan);
         }
 
-        if plans.is_empty() {
-            let empty = EmptyExec::new(Arc::clone(&self.schema));
-            return Ok(Arc::new(empty));
-        }
-
-        let plan = if plans.len() > 1 {
-            Arc::new(UnionExec::new(plans))
-        } else {
-            #[allow(clippy::unwrap_used)]
-            plans.into_iter().next().unwrap()
+        let plan = match plans {
+            plans if plans.is_empty() => {
+                return Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema))));
+            }
+            mut plans if plans.len() == 1 => {
+                #[allow(clippy::unwrap_used)]
+                // NOTE: Unwrap is okay because we ensure the length is 1
+                plans.pop().unwrap()
+            }
+            plans => Arc::new(UnionExec::new(plans)),
         };
 
         if let Some(limit) = limit {

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -23,9 +23,10 @@ use datafusion::{
     common::{Constraints, DFSchema},
     datasource::TableType,
     error::DataFusionError,
-    logical_expr::{TableProviderFilterPushDown, dml::InsertOp},
+    logical_expr::{BinaryExpr, Operator, TableProviderFilterPushDown, dml::InsertOp},
     physical_plan::{ExecutionPlan, empty::EmptyExec, limit::GlobalLimitExec, union::UnionExec},
     prelude::Expr,
+    scalar::ScalarValue,
 };
 use snafu::prelude::*;
 use tokio::sync::RwLock;
@@ -150,9 +151,17 @@ where
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let Some(partition_by) = self.partition_by.first() else {
+            return Err(DataFusionError::Execution(
+                "No 'partition_by' expression provided in the spicepod.yaml".to_string(),
+            ));
+        };
         let partitions = self.partitions.read().await;
         let mut plans = Vec::with_capacity(partitions.len());
         for partition in partitions.values() {
+            if prune_partition(filters, partition_by, &partition.partition_value) {
+                continue;
+            }
             let plan = partition
                 .table_provider
                 .scan(state, projection, filters, limit)
@@ -198,5 +207,90 @@ where
             insert_op,
             Arc::clone(&self.schema),
         )))
+    }
+}
+
+/// Determine whether a partition should be pruned from the scan plan based on
+/// the query `filters`, the expression that the partition was created from,
+/// `partition_by`, and the `partition_value` produced by the `partition_by`
+/// `Expr` for this particular partition.
+fn prune_partition(filters: &[Expr], partition_by: &Expr, partition_value: &ScalarValue) -> bool {
+    for filter in filters {
+        if let Expr::BinaryExpr(BinaryExpr {
+            left,
+            right,
+            op: Operator::Eq,
+        }) = filter
+        {
+            if left.as_ref() == partition_by {
+                if let Expr::Literal(lit) = right.as_ref() {
+                    return lit != partition_value;
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::common::Column;
+
+    use super::*;
+
+    #[test]
+    fn test_prune_partition_exact_match() {
+        let region_expr = Expr::Column(Column::from_name("region"));
+        let partition_value = ScalarValue::Utf8(Some("us-east-1".to_string()));
+        let filters = &[region_expr
+            .clone()
+            .eq(Expr::Literal(partition_value.clone()))];
+
+        let partition_by = region_expr;
+        assert!(!prune_partition(filters, &partition_by, &partition_value));
+
+        let partition_value = ScalarValue::Utf8(Some("ap-northeast-2".to_string()));
+        assert!(prune_partition(filters, &partition_by, &partition_value));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_prune_partition_range() {
+        let column = Expr::Column(Column::from_name("fare_amount"));
+        let partition_by = column
+            .clone()
+            .gt(Expr::Literal(ScalarValue::Float64(Some(10.0))));
+
+        let filters = &[column
+            .clone()
+            .gt(Expr::Literal(ScalarValue::Float64(Some(10.0))))];
+        let partition_value = ScalarValue::Boolean(Some(true));
+        assert!(!prune_partition(filters, &partition_by, &partition_value));
+        let partition_value = ScalarValue::Boolean(Some(false));
+        assert!(prune_partition(filters, &partition_by, &partition_value));
+
+        let filters = &[column
+            .clone()
+            .gt(Expr::Literal(ScalarValue::Float64(Some(9.0))))];
+        let partition_value = ScalarValue::Boolean(Some(true));
+        assert!(!prune_partition(filters, &partition_by, &partition_value));
+        let partition_value = ScalarValue::Boolean(Some(false));
+        assert!(prune_partition(filters, &partition_by, &partition_value));
+
+        let filters = &[column
+            .clone()
+            .gt(Expr::Literal(ScalarValue::Float64(Some(11.0))))];
+        let partition_value = ScalarValue::Boolean(Some(true));
+        assert!(!prune_partition(filters, &partition_by, &partition_value));
+        let partition_value = ScalarValue::Boolean(Some(false));
+        assert!(prune_partition(filters, &partition_by, &partition_value));
+
+        let filters = &[column
+            .clone()
+            .lt(Expr::Literal(ScalarValue::Float64(Some(9.0))))];
+        let partition_value = ScalarValue::Boolean(Some(true));
+        assert!(prune_partition(filters, &partition_by, &partition_value));
+        let partition_value = ScalarValue::Boolean(Some(false));
+        assert!(!prune_partition(filters, &partition_by, &partition_value));
     }
 }

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -19,27 +19,14 @@ use std::{any::Any, collections::HashMap, sync::Arc};
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{
-    arrow::{
-        array::{Array, RecordBatch, UInt64Array},
-        compute::{concat_batches, partition, take},
-    },
-    catalog::{
-        Session, TableProvider,
-        memory::{DataSourceExec, MemorySourceConfig},
-    },
+    catalog::{Session, TableProvider},
     common::{Constraints, DFSchema},
     datasource::TableType,
     error::DataFusionError,
-    execution::{TaskContext, context::ExecutionProps},
-    logical_expr::{ColumnarValue, dml::InsertOp},
-    physical_expr::create_physical_expr,
-    physical_plan::{
-        ExecutionPlan, empty::EmptyExec, execute_stream, limit::GlobalLimitExec, union::UnionExec,
-    },
+    logical_expr::{TableProviderFilterPushDown, dml::InsertOp},
+    physical_plan::{ExecutionPlan, empty::EmptyExec, limit::GlobalLimitExec, union::UnionExec},
     prelude::Expr,
-    scalar::ScalarValue,
 };
-use futures::StreamExt as _;
 use snafu::prelude::*;
 use tokio::sync::RwLock;
 
@@ -149,6 +136,13 @@ where
         TableType::Base
     }
 
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
+    }
+
     async fn scan(
         &self,
         state: &dyn Session,
@@ -187,7 +181,7 @@ where
 
     async fn insert_into(
         &self,
-        state: &dyn Session,
+        _state: &dyn Session,
         input: Arc<dyn ExecutionPlan>,
         insert_op: InsertOp,
     ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -222,12 +222,8 @@ impl TableProvider for PartitionTableProvider {
         }
 
         if execution_plans.is_empty() {
-            let mem_exec = DataSourceExec::new(Arc::new(MemorySourceConfig::try_new(
-                &[vec![]],
-                Arc::clone(&self.schema),
-                None,
-            )?));
-            Ok(Arc::new(mem_exec))
+            let empty = EmptyExec::new(Arc::clone(&self.schema));
+            Ok(Arc::new(empty))
         } else if execution_plans.len() == 1 {
             #[allow(clippy::unwrap_used)]
             Ok(execution_plans.into_iter().next().unwrap())

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -346,7 +346,7 @@ async fn get_pool(
     duckdb_factory: &DuckDBTableProviderFactory,
     duckdb_path: &str,
 ) -> Result<Arc<DuckDbConnectionPool>, datafusion_table_providers::duckdb::Error> {
-    let pool_builder = DuckDbConnectionPoolBuilder::file(&duckdb_path)
+    let pool_builder = DuckDbConnectionPoolBuilder::file(duckdb_path)
         .with_max_size(Some(10))
         .with_min_idle(Some(10));
     Ok(Arc::new(

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -17,7 +17,10 @@ limitations under the License.
 use std::{
     any::Any,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use async_trait::async_trait;
@@ -107,6 +110,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 pub(crate) struct PartitionedDuckDBAccelerator {
     base_accelerator: DuckDBAccelerator,
     table_provider: Mutex<Option<Arc<PartitionTableProvider<DuckDbConnectionPool>>>>,
+    is_initialized: AtomicBool,
 }
 
 impl PartitionedDuckDBAccelerator {
@@ -115,6 +119,7 @@ impl PartitionedDuckDBAccelerator {
         Self {
             base_accelerator: DuckDBAccelerator::new(),
             table_provider: Mutex::new(None),
+            is_initialized: AtomicBool::new(false),
         }
     }
 
@@ -143,11 +148,19 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
         "partitioned_duckdb"
     }
 
+    fn is_initialized(&self, _source: &dyn AccelerationSource) -> bool {
+        self.is_initialized.load(Ordering::Acquire)
+    }
+
     fn valid_file_extensions(&self) -> Vec<&'static str> {
         self.base_accelerator.valid_file_extensions()
     }
 
     fn file_path(&self, _source: &dyn AccelerationSource) -> Result<String, DataAcceleratorError> {
+        // There is no one file path but one for each partition
+        // This function is only internally used (within this trait) in the
+        // DuckDBAccelerator, for example, but is never used in this
+        // implementation.
         Ok(String::new())
     }
 
@@ -186,6 +199,7 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
             Arc::new(PartitionTableProvider::new(creator, partition_by, schema).await?);
 
         *table_provider_guard = Some(Arc::clone(&table_provider));
+        self.is_initialized.store(true, Ordering::Release);
 
         Ok(table_provider)
     }

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{any::Any, path::Path, sync::Arc};
+use std::{
+    any::Any,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use datafusion::{
@@ -30,12 +34,12 @@ use runtime_table_partition::{
     Partition,
     creator::{
         self, PartitionCreator,
-        filename::{decode_scalar_value, encode_scalar_value},
+        filename::{self, decode_scalar_value, encode_scalar_value},
     },
     provider::PartitionTableProvider,
 };
 use snafu::prelude::*;
-use tokio::{fs::create_dir, sync::Mutex};
+use tokio::{fs::create_dir_all, sync::Mutex};
 
 use super::{
     AccelerationSource, DataAccelerator, Error as DataAcceleratorError,
@@ -191,10 +195,15 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
 pub(crate) struct DuckDBPartitionCreator {
     cmd: CreateExternalTable,
     duckdb_factory: DuckDBTableProviderFactory,
+    partition_dir: PathBuf,
 }
 
 impl DuckDBPartitionCreator {
     pub(crate) fn new(cmd: CreateExternalTable) -> Self {
+        let data_path = spice_data_base_path();
+        let table = cmd.name.table();
+        let partition_dir = Path::new(&data_path).join(table);
+
         Self {
             cmd,
             duckdb_factory: DuckDBTableProviderFactory::new(AccessMode::ReadWrite)
@@ -202,6 +211,7 @@ impl DuckDBPartitionCreator {
                 .with_settings_registry(
                     DuckDBSettingsRegistry::new().with_setting(Box::new(OrderByNonIntegerLiteral)),
                 ),
+            partition_dir,
         }
     }
 }
@@ -213,14 +223,10 @@ impl PartitionCreator for DuckDBPartitionCreator {
         partition_value: ScalarValue,
     ) -> Result<Arc<dyn TableProvider>, creator::Error> {
         let mut cmd = self.cmd.clone();
-        let partition_value_str = encode_scalar_value(&partition_value)
+        let duckdb_path = add_open(&self.partition_dir, &mut cmd, &partition_value)
             .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
-        let table = cmd.name.table();
-        let data_path = spice_data_base_path();
-
-        let duckdb_file = format!("{data_path}/{table}/{partition_value_str}.db");
-        let pool_builder = DuckDbConnectionPoolBuilder::file(&duckdb_file)
+        let pool_builder = DuckDbConnectionPoolBuilder::file(&duckdb_path)
             .with_max_size(Some(10))
             .with_min_idle(Some(10));
         self.duckdb_factory
@@ -228,9 +234,7 @@ impl PartitionCreator for DuckDBPartitionCreator {
             .await
             .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
-        cmd.options.insert("open".to_string(), duckdb_file);
-
-        tracing::debug!("creating partition at {}", &cmd.location);
+        tracing::debug!("creating partition at {duckdb_path}");
 
         let table_provider = create_table_provider(&self.duckdb_factory, &cmd)
             .await
@@ -240,18 +244,14 @@ impl PartitionCreator for DuckDBPartitionCreator {
     }
 
     async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, creator::Error> {
-        let data_path = spice_data_base_path();
-        let table = self.cmd.name.table();
-        let data_path = Path::new(&data_path).join(table);
-
-        if !data_path.is_dir() {
-            create_dir(data_path)
+        if !self.partition_dir.is_dir() {
+            create_dir_all(&self.partition_dir)
                 .await
                 .map_err(|e| creator::Error::InferringPartitions { source: e.into() })?;
             return Ok(vec![]);
         }
 
-        let mut dir_entries = tokio::fs::read_dir(&data_path)
+        let mut dir_entries = tokio::fs::read_dir(&self.partition_dir)
             .await
             .map_err(|e| creator::Error::InferringPartitions { source: e.into() })?;
 
@@ -283,7 +283,11 @@ impl PartitionCreator for DuckDBPartitionCreator {
                     }
                 };
 
-                let table_provider = create_table_provider(&self.duckdb_factory, &self.cmd)
+                let mut cmd = self.cmd.clone();
+                add_open(&self.partition_dir, &mut cmd, &partition_value)
+                    .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
+
+                let table_provider = create_table_provider(&self.duckdb_factory, &cmd)
                     .await
                     .map_err(|e| creator::Error::InferringPartitions { source: e })?;
 
@@ -294,11 +298,26 @@ impl PartitionCreator for DuckDBPartitionCreator {
             }
         }
 
-        tracing::info!(
+        tracing::debug!(
             "inferred {} existing partitions from '{}'",
             partitions.len(),
-            data_path.display()
+            self.partition_dir.display().to_string(),
         );
         Ok(partitions)
     }
+}
+
+fn add_open(
+    partition_dir: &Path,
+    cmd: &mut CreateExternalTable,
+    partition_value: &ScalarValue,
+) -> Result<String, filename::Error> {
+    let partition_value_str = encode_scalar_value(partition_value)?;
+
+    let duckdb_file = format!("{partition_value_str}.db");
+    let duckdb_path = partition_dir.join(&duckdb_file);
+    let duckdb_path = duckdb_path.display().to_string();
+    cmd.options.insert("open".to_string(), duckdb_path.clone());
+
+    Ok(duckdb_path)
 }

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -27,7 +27,7 @@ use datafusion::{
 };
 use datafusion_table_providers::{
     duckdb::{DuckDBSettingsRegistry, DuckDBTableProviderFactory},
-    sql::db_connection_pool::duckdbpool::DuckDbConnectionPoolBuilder,
+    sql::db_connection_pool::duckdbpool::{DuckDbConnectionPool, DuckDbConnectionPoolBuilder},
 };
 use duckdb::AccessMode;
 use runtime_table_partition::{
@@ -104,17 +104,25 @@ pub enum Error {
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub struct PartitionedDuckDBAccelerator {
+pub(crate) struct PartitionedDuckDBAccelerator {
     base_accelerator: DuckDBAccelerator,
-    table_provider: Mutex<Option<Arc<PartitionTableProvider>>>,
+    table_provider: Mutex<Option<Arc<PartitionTableProvider<DuckDbConnectionPool>>>>,
 }
 
 impl PartitionedDuckDBAccelerator {
     #[must_use]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             base_accelerator: DuckDBAccelerator::new(),
             table_provider: Mutex::new(None),
+        }
+    }
+
+    pub(crate) async fn get_shared_pools(&self) -> Vec<Arc<DuckDbConnectionPool>> {
+        if let Some(provider) = self.table_provider.lock().await.as_ref() {
+            provider.get_shared_pools().await
+        } else {
+            vec![]
         }
     }
 }
@@ -218,19 +226,17 @@ impl DuckDBPartitionCreator {
 
 #[async_trait]
 impl PartitionCreator for DuckDBPartitionCreator {
+    type ConnectionPool = DuckDbConnectionPool;
+
     async fn create_partition(
         &self,
         partition_value: ScalarValue,
-    ) -> Result<Arc<dyn TableProvider>, creator::Error> {
+    ) -> Result<Partition<Self::ConnectionPool>, creator::Error> {
         let mut cmd = self.cmd.clone();
         let duckdb_path = add_open(&self.partition_dir, &mut cmd, &partition_value)
             .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
-        let pool_builder = DuckDbConnectionPoolBuilder::file(&duckdb_path)
-            .with_max_size(Some(10))
-            .with_min_idle(Some(10));
-        self.duckdb_factory
-            .get_or_init_instance_with_builder(pool_builder)
+        let pool = get_pool(&self.duckdb_factory, &duckdb_path)
             .await
             .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
@@ -240,10 +246,18 @@ impl PartitionCreator for DuckDBPartitionCreator {
             .await
             .map_err(|e| creator::Error::CreatePartition { source: e })?;
 
-        Ok(table_provider)
+        let partition = Partition {
+            partition_value,
+            pool,
+            table_provider,
+        };
+
+        Ok(partition)
     }
 
-    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, creator::Error> {
+    async fn infer_existing_partitions(
+        &self,
+    ) -> Result<Vec<Partition<Self::ConnectionPool>>, creator::Error> {
         if !self.partition_dir.is_dir() {
             create_dir_all(&self.partition_dir)
                 .await
@@ -287,12 +301,18 @@ impl PartitionCreator for DuckDBPartitionCreator {
                 add_open(&self.partition_dir, &mut cmd, &partition_value)
                     .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
+                let duckdb_path = path.display().to_string();
+                let pool = get_pool(&self.duckdb_factory, &duckdb_path)
+                    .await
+                    .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
+
                 let table_provider = create_table_provider(&self.duckdb_factory, &cmd)
                     .await
                     .map_err(|e| creator::Error::InferringPartitions { source: e })?;
 
                 partitions.push(Partition {
                     partition_value,
+                    pool,
                     table_provider,
                 });
             }
@@ -320,4 +340,18 @@ fn add_open(
     cmd.options.insert("open".to_string(), duckdb_path.clone());
 
     Ok(duckdb_path)
+}
+
+async fn get_pool(
+    duckdb_factory: &DuckDBTableProviderFactory,
+    duckdb_path: &str,
+) -> Result<Arc<DuckDbConnectionPool>, datafusion_table_providers::duckdb::Error> {
+    let pool_builder = DuckDbConnectionPoolBuilder::file(&duckdb_path)
+        .with_max_size(Some(10))
+        .with_min_idle(Some(10));
+    Ok(Arc::new(
+        duckdb_factory
+            .get_or_init_instance_with_builder(pool_builder)
+            .await?,
+    ))
 }

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -188,13 +188,13 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
 }
 
 #[derive(Debug)]
-struct DuckDBPartitionCreator {
+pub(crate) struct DuckDBPartitionCreator {
     cmd: CreateExternalTable,
     duckdb_factory: DuckDBTableProviderFactory,
 }
 
 impl DuckDBPartitionCreator {
-    fn new(cmd: CreateExternalTable) -> Self {
+    pub(crate) fn new(cmd: CreateExternalTable) -> Self {
         Self {
             cmd,
             duckdb_factory: DuckDBTableProviderFactory::new(AccessMode::ReadWrite)
@@ -282,10 +282,6 @@ impl PartitionCreator for DuckDBPartitionCreator {
                         continue;
                     }
                 };
-
-                let mut cmd = self.cmd.clone();
-                cmd.options
-                    .insert("location".to_string(), path.to_string_lossy().into_owned());
 
                 let table_provider = create_table_provider(&self.duckdb_factory, &self.cmd)
                     .await

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -18,7 +18,7 @@ limitations under the License.
 
 use std::{path::Path, sync::Arc};
 
-use super::AccelerationSource;
+use super::{AccelerationSource, partitioned_duckdb::PartitionedDuckDBAccelerator};
 
 #[cfg(feature = "postgres")]
 use {
@@ -46,6 +46,8 @@ pub mod debezium_kafka;
 enum AccelerationConnection {
     #[cfg(feature = "duckdb")]
     DuckDB(Arc<DuckDbConnectionPool>),
+    #[cfg(feature = "duckdb")]
+    PartitionedDuckDB(Vec<Arc<DuckDbConnectionPool>>),
     #[cfg(feature = "postgres")]
     Postgres(PostgresConnectionPool),
     #[cfg(feature = "sqlite")]
@@ -69,22 +71,34 @@ async fn acceleration_connection(
                 .get_accelerator_engine(acceleration_settings)
                 .await
                 .ok_or("DuckDB accelerator engine not available")?;
-            let duckdb_accelerator = accelerator
-                .as_any()
-                .downcast_ref::<DuckDBAccelerator>()
-                .ok_or("Accelerator is not a DuckDBAccelerator")?;
 
-            let duckdb_file = duckdb_accelerator.duckdb_file_path(source)?;
-            if !create_table_if_not_exists && !Path::new(&duckdb_file).exists() {
-                return Err("DuckDB file does not exist.".into());
+            if acceleration_settings.partition_by.is_empty() {
+                let duckdb_accelerator = accelerator
+                    .as_any()
+                    .downcast_ref::<DuckDBAccelerator>()
+                    .ok_or("Accelerator is not a DuckDBAccelerator")?;
+
+                let duckdb_file = duckdb_accelerator.duckdb_file_path(source)?;
+                if !create_table_if_not_exists && !Path::new(&duckdb_file).exists() {
+                    return Err("DuckDB file does not exist.".into());
+                }
+
+                let pool = duckdb_accelerator
+                    .get_shared_pool(source)
+                    .await
+                    .map_err(|e| e.to_string())?;
+
+                Ok(AccelerationConnection::DuckDB(Arc::new(pool)))
+            } else {
+                let duckdb_accelerator = accelerator
+                    .as_any()
+                    .downcast_ref::<PartitionedDuckDBAccelerator>()
+                    .ok_or("Accelerator is not a PartitionedDuckDBAccelerator")?;
+
+                let pools = duckdb_accelerator.get_shared_pools().await;
+
+                Ok(AccelerationConnection::PartitionedDuckDB(pools))
             }
-
-            let pool = duckdb_accelerator
-                .get_shared_pool(source)
-                .await
-                .map_err(|e| e.to_string())?;
-
-            Ok(AccelerationConnection::DuckDB(Arc::new(pool)))
         }
         #[cfg(not(feature = "duckdb"))]
         Engine::DuckDB => Err("Spice wasn't built with DuckDB support enabled".into()),

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -18,7 +18,7 @@ limitations under the License.
 
 use std::{path::Path, sync::Arc};
 
-use super::{AccelerationSource, partitioned_duckdb::PartitionedDuckDBAccelerator};
+use super::AccelerationSource;
 
 #[cfg(feature = "postgres")]
 use {
@@ -28,7 +28,7 @@ use {
 
 #[cfg(feature = "duckdb")]
 use {
-    super::duckdb::DuckDBAccelerator,
+    super::duckdb::DuckDBAccelerator, super::partitioned_duckdb::PartitionedDuckDBAccelerator,
     datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool,
 };
 #[cfg(feature = "sqlite")]

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
@@ -87,6 +87,10 @@ impl DatasetCheckpoint {
         match connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => Self::init_duckdb(pool)?,
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::PartitionedDuckDB(pools) => {
+                pools.iter().try_for_each(|pool| Self::init_duckdb(pool))?
+            }
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => Self::init_postgres(pool).await?,
             #[cfg(feature = "sqlite")]
@@ -99,6 +103,10 @@ impl DatasetCheckpoint {
         match connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => Self::migrate_duckdb(pool)?,
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::PartitionedDuckDB(pools) => pools
+                .iter()
+                .try_for_each(|pool| Self::migrate_duckdb(pool))?,
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => Self::migrate_postgres(pool).await?,
             #[cfg(feature = "sqlite")]
@@ -123,6 +131,10 @@ impl DatasetCheckpoint {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => self.exists_duckdb(pool).ok().unwrap_or(false),
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::PartitionedDuckDB(pools) => pools
+                .iter()
+                .all(|pool| self.exists_duckdb(pool).ok().unwrap_or(false)),
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => {
                 self.exists_postgres(pool).await.ok().unwrap_or(false)
@@ -140,6 +152,11 @@ impl DatasetCheckpoint {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => self.last_checkpoint_time_duckdb(pool),
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::PartitionedDuckDB(pools) => Ok(pools
+                .iter()
+                .filter_map(|pool| self.last_checkpoint_time_duckdb(pool).ok().flatten())
+                .min()),
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => {
                 self.last_checkpoint_time_postgres(pool).await
@@ -155,6 +172,10 @@ impl DatasetCheckpoint {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => self.checkpoint_duckdb(pool, schema),
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::PartitionedDuckDB(pools) => pools
+                .iter()
+                .try_for_each(|pool| self.checkpoint_duckdb(pool, schema)),
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => self.checkpoint_postgres(pool, schema).await,
             #[cfg(feature = "sqlite")]
@@ -168,6 +189,13 @@ impl DatasetCheckpoint {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => self.get_schema_duckdb(pool),
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::PartitionedDuckDB(pools) => {
+                if let Some(pool) = pools.first() {
+                    return self.get_schema_duckdb(pool);
+                }
+                Ok(None)
+            }
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => self.get_schema_postgres(pool).await,
             #[cfg(feature = "sqlite")]

--- a/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/dataset_checkpoint/mod.rs
@@ -89,7 +89,7 @@ impl DatasetCheckpoint {
             AccelerationConnection::DuckDB(pool) => Self::init_duckdb(pool)?,
             #[cfg(feature = "duckdb")]
             AccelerationConnection::PartitionedDuckDB(pools) => {
-                pools.iter().try_for_each(|pool| Self::init_duckdb(pool))?
+                pools.iter().try_for_each(|pool| Self::init_duckdb(pool))?;
             }
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => Self::init_postgres(pool).await?,

--- a/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/debezium_kafka/mod.rs
@@ -60,6 +60,8 @@ impl DebeziumKafkaSys {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => self.get_duckdb(pool),
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::PartitionedDuckDB(_) => None,
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => self.get_postgres(pool).await,
             #[cfg(feature = "sqlite")]
@@ -73,6 +75,10 @@ impl DebeziumKafkaSys {
         match &self.acceleration_connection {
             #[cfg(feature = "duckdb")]
             AccelerationConnection::DuckDB(pool) => self.upsert_duckdb(pool, metadata),
+            #[cfg(feature = "duckdb")]
+            AccelerationConnection::PartitionedDuckDB(_) => {
+                Err("Not yet supported for partitioned DuckDB".into())
+            }
             #[cfg(feature = "postgres")]
             AccelerationConnection::Postgres(pool) => self.upsert_postgres(pool, metadata).await,
             #[cfg(feature = "sqlite")]


### PR DESCRIPTION
## 📝 Summary

- Implemented `PartitionInsertExec` execution plan for streaming, non-blocking partitioned data insertion.
- Added a generic `ConnectionPool` to the `Partition`, `PartitionTableProvider`, and `PartitionCreator` so that pools can be retrieved for checkpointing purposes.
- Added checkpointing for PartitionedDuckDb which checkpoints each partition eliminating the need for a full refresh.
- Implement `TableProvider::scan` for `PartitionTableProvider` with filter push down.
## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->
Closes:
- #6186 
## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

- Checkpoints are stored in each partitioned database. May be better approach to make a table at the root which is used only for checkpointing the entire dataset.
- A separate pool is created for each duckdb file and insert_into involves separate transactions to each.
- Filters are pushed down to the partitions, but partition pruning only works for column equality.
