### PR TITLE
Fix the case sensitivity of the key in env secrets store

### DIFF
--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -112,6 +112,17 @@ impl Parameters {
                 );
                 // Insert without the prefix into the params
                 params.push((secret_key.name.to_string(), secret));
+            } else {
+                // Try to load the secret using an uppercased key, because env secret store is case sensitive
+                let secret_key_with_prefix_upper = secret_key_with_prefix.to_uppercase();
+                let secret = secret_guard.get_secret(&secret_key_with_prefix_upper).await;
+                if let Ok(Some(secret)) = secret {
+                    tracing::debug!(
+                        "Autoloading secret for {component_name}: {secret_key_with_prefix_upper}",
+                    );
+                    // Insert without the prefix into the params
+                    params.push((secret_key.name.to_string(), secret));
+                }
             }
         }
 

--- a/crates/runtime/src/parameters.rs
+++ b/crates/runtime/src/parameters.rs
@@ -112,17 +112,6 @@ impl Parameters {
                 );
                 // Insert without the prefix into the params
                 params.push((secret_key.name.to_string(), secret));
-            } else {
-                // Try to load the secret using an uppercased key, because env secret store is case sensitive
-                let secret_key_with_prefix_upper = secret_key_with_prefix.to_uppercase();
-                let secret = secret_guard.get_secret(&secret_key_with_prefix_upper).await;
-                if let Ok(Some(secret)) = secret {
-                    tracing::debug!(
-                        "Autoloading secret for {component_name}: {secret_key_with_prefix_upper}",
-                    );
-                    // Insert without the prefix into the params
-                    params.push((secret_key.name.to_string(), secret));
-                }
             }
         }
 

--- a/crates/runtime/src/secrets/mod.rs
+++ b/crates/runtime/src/secrets/mod.rs
@@ -389,12 +389,12 @@ mod tests {
 
         unsafe {
             std::env::set_var(&upper_key, "UPPER_SECRET");
-            std::env::set_var(&lower_key, "lower_secret");
+            std::env::set_var(lower_key, "lower_secret");
         }
 
         let result_upper = secrets
             .inject_secrets(
-                &upper_key,
+                upper_key,
                 super::ParamStr(&format!("Upper: ${{ env:{upper_key} }}")),
             )
             .await;
@@ -402,7 +402,7 @@ mod tests {
 
         let result_lower = secrets
             .inject_secrets(
-                &lower_key,
+                lower_key,
                 super::ParamStr(&format!("Lower: ${{ env:{lower_key} }}")),
             )
             .await;
@@ -410,7 +410,7 @@ mod tests {
 
         unsafe {
             std::env::remove_var(&upper_key);
-            std::env::remove_var(&lower_key);
+            std::env::remove_var(lower_key);
         }
     }
 
@@ -424,7 +424,7 @@ mod tests {
 
         unsafe {
             std::env::set_var(&upper_key, "UPPER_SECRET");
-            std::env::set_var(&lower_key, "original_secret");
+            std::env::set_var(lower_key, "original_secret");
         }
 
         let result_upper = secrets
@@ -437,7 +437,7 @@ mod tests {
 
         let result_lower = secrets
             .inject_secrets(
-                &lower_key,
+                lower_key,
                 super::ParamStr(&format!("Lower: ${{ env:{lower_key} }}")),
             )
             .await;
@@ -445,7 +445,7 @@ mod tests {
 
         unsafe {
             std::env::remove_var(&upper_key);
-            std::env::remove_var(&lower_key);
+            std::env::remove_var(lower_key);
         }
     }
 

--- a/crates/runtime/src/secrets/mod.rs
+++ b/crates/runtime/src/secrets/mod.rs
@@ -380,6 +380,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_inject_secrets_case_sensitive() {
+        let mut secrets = super::Secrets::new();
+        secrets.load_from(&[]).await.expect("to load successfully"); // Will automatically load `env` as the default
+
+        let base_key = &format!("MY_SECRET_KEY_{}", rand::random::<u64>());
+        let upper_key = base_key.to_uppercase();
+        let lower_key = base_key.to_lowercase();
+
+        unsafe {
+            std::env::set_var(&upper_key, "UPPER_SECRET");
+            std::env::set_var(&lower_key, "lower_secret");
+        }
+
+        let result_upper = secrets
+            .inject_secrets(
+                &upper_key,
+                super::ParamStr(&format!("Upper: ${{ env:{upper_key} }}")),
+            )
+            .await;
+        assert_eq!("Upper: UPPER_SECRET", result_upper.expose_secret());
+
+        let result_lower = secrets
+            .inject_secrets(
+                &lower_key,
+                super::ParamStr(&format!("Lower: ${{ env:{lower_key} }}")),
+            )
+            .await;
+        assert_eq!("Lower: lower_secret", result_lower.expose_secret());
+
+        unsafe {
+            std::env::remove_var(&upper_key);
+            std::env::remove_var(&lower_key);
+        }
+    }
+
+    #[tokio::test]
     async fn test_inject_secrets_no_env() {
         let mut secrets = super::Secrets::new();
         secrets.load_from(&[]).await.expect("to load successfully"); // Will automatically load `env` as the default

--- a/crates/runtime/src/secrets/mod.rs
+++ b/crates/runtime/src/secrets/mod.rs
@@ -384,9 +384,8 @@ mod tests {
         let mut secrets = super::Secrets::new();
         secrets.load_from(&[]).await.expect("to load successfully"); // Will automatically load `env` as the default
 
-        let base_key = &format!("MY_SECRET_KEY_{}", rand::random::<u64>());
-        let upper_key = base_key.to_uppercase();
-        let lower_key = base_key.to_lowercase();
+        let upper_key = &format!("MY_UPPERCASE_SECRET_KEY_{}", rand::random::<u64>());
+        let lower_key = &format!("MY_LOWERCASE_SECRET_KEY_{}", rand::random::<u64>());
 
         unsafe {
             std::env::set_var(&upper_key, "UPPER_SECRET");
@@ -408,6 +407,41 @@ mod tests {
             )
             .await;
         assert_eq!("Lower: lower_secret", result_lower.expose_secret());
+
+        unsafe {
+            std::env::remove_var(&upper_key);
+            std::env::remove_var(&lower_key);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_inject_secrets_original_key_takes_precedence() {
+        let mut secrets = super::Secrets::new();
+        secrets.load_from(&[]).await.expect("to load successfully"); // Will automatically load `env` as the default
+
+        let lower_key = &format!("my_secret_key_{}", rand::random::<u64>());
+        let upper_key = lower_key.to_uppercase();
+
+        unsafe {
+            std::env::set_var(&upper_key, "UPPER_SECRET");
+            std::env::set_var(&lower_key, "original_secret");
+        }
+
+        let result_upper = secrets
+            .inject_secrets(
+                &upper_key,
+                super::ParamStr(&format!("Upper: ${{ env:{upper_key} }}")),
+            )
+            .await;
+        assert_eq!("Upper: UPPER_SECRET", result_upper.expose_secret());
+
+        let result_lower = secrets
+            .inject_secrets(
+                &lower_key,
+                super::ParamStr(&format!("Lower: ${{ env:{lower_key} }}")),
+            )
+            .await;
+        assert_eq!("Lower: original_secret", result_lower.expose_secret());
 
         unsafe {
             std::env::remove_var(&upper_key);

--- a/crates/runtime/src/secrets/mod.rs
+++ b/crates/runtime/src/secrets/mod.rs
@@ -388,7 +388,7 @@ mod tests {
         let lower_key = &format!("MY_LOWERCASE_SECRET_KEY_{}", rand::random::<u64>());
 
         unsafe {
-            std::env::set_var(&upper_key, "UPPER_SECRET");
+            std::env::set_var(upper_key, "UPPER_SECRET");
             std::env::set_var(lower_key, "lower_secret");
         }
 
@@ -409,7 +409,7 @@ mod tests {
         assert_eq!("Lower: lower_secret", result_lower.expose_secret());
 
         unsafe {
-            std::env::remove_var(&upper_key);
+            std::env::remove_var(upper_key);
             std::env::remove_var(lower_key);
         }
     }
@@ -444,7 +444,7 @@ mod tests {
         assert_eq!("Lower: original_secret", result_lower.expose_secret());
 
         unsafe {
-            std::env::remove_var(&upper_key);
+            std::env::remove_var(upper_key);
             std::env::remove_var(lower_key);
         }
     }

--- a/crates/runtime/src/secrets/stores/env.rs
+++ b/crates/runtime/src/secrets/stores/env.rs
@@ -94,7 +94,7 @@ impl SecretStore for EnvSecretStore {
     async fn get_secret(&self, key: &str) -> crate::secrets::AnyErrorResult<Option<SecretString>> {
         let uppercase_key = key.to_uppercase();
 
-        let result = [
+        [
             // First try looking for original prefixed `SPICE_my_key`
             format!("{ENV_SECRET_PREFIX}{key}"),
             // Then try looking for original `my_key`
@@ -112,8 +112,6 @@ impl SecretStore for EnvSecretStore {
                 Box::new(err) as Box<dyn std::error::Error + Send + Sync>
             )),
         })
-        .transpose();
-
-        result
+        .transpose()
     }
 }

--- a/crates/runtime/src/secrets/stores/env.rs
+++ b/crates/runtime/src/secrets/stores/env.rs
@@ -86,19 +86,34 @@ impl EnvSecretStore {
 
 #[async_trait]
 impl SecretStore for EnvSecretStore {
+    /// The key for std::env::var is case-sensitive. Calling `std::env::var("my_key")` is distinct from `std::env::var("MY_KEY")`.
+    ///
+    /// However, the convention is to use uppercase for environment variables - so to make the experience
+    /// consistent across secret stores that don't have this convention we will search for both original and uppercased keys.
     #[must_use]
     async fn get_secret(&self, key: &str) -> crate::secrets::AnyErrorResult<Option<SecretString>> {
-        // First try looking for `SPICE_MY_KEY` and then `MY_KEY`
-        let prefixed_key = format!("{ENV_SECRET_PREFIX}{key}");
-        match std::env::var(prefixed_key) {
-            Ok(value) => Ok(Some(SecretString::from(value))),
-            // If the prefixed key is not found, try the original key
-            Err(std::env::VarError::NotPresent) => match std::env::var(key) {
-                Ok(value) => Ok(Some(SecretString::from(value))),
-                Err(std::env::VarError::NotPresent) => Ok(None),
-                Err(err) => Err(Box::new(err)),
-            },
-            Err(err) => Err(Box::new(err)),
-        }
+        let uppercase_key = key.to_uppercase();
+
+        let result = [
+            // First try looking for original prefixed `SPICE_my_key`
+            format!("{ENV_SECRET_PREFIX}{key}"),
+            // Then try looking for original `my_key`
+            key.to_string(),
+            // Then try looking for prefixed `SPICE_MY_KEY` in uppercase
+            format!("{ENV_SECRET_PREFIX}{uppercase_key}"),
+            // Then try looking for `MY_KEY` in uppercase
+            uppercase_key,
+        ]
+        .iter()
+        .find_map(|variant| match std::env::var(variant) {
+            Ok(value) => Some(Ok(SecretString::from(value))),
+            Err(std::env::VarError::NotPresent) => None,
+            Err(err) => Some(Err(
+                Box::new(err) as Box<dyn std::error::Error + Send + Sync>
+            )),
+        })
+        .transpose();
+
+        result
     }
 }

--- a/crates/runtime/src/secrets/stores/env.rs
+++ b/crates/runtime/src/secrets/stores/env.rs
@@ -86,21 +86,14 @@ impl EnvSecretStore {
 
 #[async_trait]
 impl SecretStore for EnvSecretStore {
-    /// The key for std::env::var is case-sensitive. Calling `std::env::var("my_key")` is distinct from `std::env::var("MY_KEY")`.
-    ///
-    /// However, the convention is to use uppercase for environment variables - so to make the experience
-    /// consistent across secret stores that don't have this convention we will uppercase the key before
-    /// looking up the environment variable.
     #[must_use]
     async fn get_secret(&self, key: &str) -> crate::secrets::AnyErrorResult<Option<SecretString>> {
-        let upper_key = key.to_uppercase();
-
         // First try looking for `SPICE_MY_KEY` and then `MY_KEY`
-        let prefixed_key = format!("{ENV_SECRET_PREFIX}{upper_key}");
+        let prefixed_key = format!("{ENV_SECRET_PREFIX}{key}");
         match std::env::var(prefixed_key) {
             Ok(value) => Ok(Some(SecretString::from(value))),
             // If the prefixed key is not found, try the original key
-            Err(std::env::VarError::NotPresent) => match std::env::var(upper_key) {
+            Err(std::env::VarError::NotPresent) => match std::env::var(key) {
                 Ok(value) => Ok(Some(SecretString::from(value))),
                 Err(std::env::VarError::NotPresent) => Ok(None),
                 Err(err) => Err(Box::new(err)),


### PR DESCRIPTION
## 📝 Summary

Removed unexpected behavior with automatic env secret key uppercasing. `${env:my_key}` and `${env:MY_KEY}` are now distinct.
Uperrcased key is still used as a fallback, if original key is not found in the env store.

## 🔗 Related

closes #6283 
