### PR TITLE
Don't run tests that require a Databricks cluster on every PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/end_game.md
+++ b/.github/ISSUE_TEMPLATE/end_game.md
@@ -49,6 +49,7 @@ assignees: ''
 1. **Unit/Integration Tests**
 
    - [ ] Confirm local and CI tests pass without major failures.
+     - [ ] Verify [integration](https://github.com/spiceai/spiceai/actions/workflows/integration.yml) tests (which include the `run_all_tests` flag) is green on the release branch.
 
 1. **E2E Tests**
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,13 +90,13 @@ jobs:
       # Build the test binary without running tests
       - name: Build integration test binary
         env:
-            RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
-            CARGO_INCREMENTAL: 0
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+          CARGO_INCREMENTAL: 0
         run: |
           FEATURES="postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,spark,dynamodb,oracle"
-          if [[ "${{ github.event.inputs.run_all_tests }}" == "true" ]] || [[ "${{ github.ref }}" == "refs/heads/release"* ]] || [[ "${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release') }}" == "true" ]]; then
+          if [[ "${{ github.event.inputs.run_all_tests }}" == "true" ]]; then
             FEATURES="${FEATURES},extended_tests"
             echo "Including extended_tests"
           else

--- a/crates/runtime/tests/databricks_delta_catalog_m2m/mod.rs
+++ b/crates/runtime/tests/databricks_delta_catalog_m2m/mod.rs
@@ -25,6 +25,10 @@ use spicepod::{component::catalog::Catalog, param::Params};
 use std::sync::Arc;
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_delta_lake_m2m_integration_test_catalog() -> Result<(), anyhow::Error> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _tracing = init_tracing(None);

--- a/crates/runtime/tests/databricks_delta_m2m/mod.rs
+++ b/crates/runtime/tests/databricks_delta_m2m/mod.rs
@@ -65,6 +65,10 @@ fn get_params() -> Params {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_delta_lake_m2m_integration_test() -> Result<(), anyhow::Error> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _tracing = init_tracing(Some("integration=debug,info"));

--- a/crates/runtime/tests/databricks_spark/mod.rs
+++ b/crates/runtime/tests/databricks_spark/mod.rs
@@ -62,6 +62,10 @@ fn get_params() -> Params {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_spark_integration_test() -> Result<(), anyhow::Error> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _ = rustls::crypto::CryptoProvider::install_default(

--- a/crates/runtime/tests/databricks_spark_catalog/mod.rs
+++ b/crates/runtime/tests/databricks_spark_catalog/mod.rs
@@ -25,6 +25,10 @@ use spicepod::{component::catalog::Catalog, param::Params};
 use std::sync::Arc;
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_spark_connect_integration_test_catalog() -> Result<(), anyhow::Error> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _tracing = init_tracing(None);

--- a/crates/runtime/tests/databricks_spark_catalog_m2m/mod.rs
+++ b/crates/runtime/tests/databricks_spark_catalog_m2m/mod.rs
@@ -25,6 +25,10 @@ use spicepod::{component::catalog::Catalog, param::Params};
 use std::sync::Arc;
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_spark_connect_m2m_integration_test_catalog() -> Result<(), anyhow::Error> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _tracing = init_tracing(None);

--- a/crates/runtime/tests/databricks_spark_m2m/mod.rs
+++ b/crates/runtime/tests/databricks_spark_m2m/mod.rs
@@ -70,6 +70,10 @@ fn get_params() -> Params {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_spark_m2m_integration_test() -> Result<(), anyhow::Error> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _ = rustls::crypto::CryptoProvider::install_default(

--- a/crates/runtime/tests/odbc/mod.rs
+++ b/crates/runtime/tests/odbc/mod.rs
@@ -64,6 +64,10 @@ fn make_databricks_odbc(path: &str, name: &str, acceleration: bool, engine: &str
 // Running this test in local requires ODBC setup in local, check https://github.com/spiceai/spiceai/pull/1204 to see the details
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_odbc() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
@@ -117,6 +121,10 @@ async fn databricks_odbc() -> Result<(), String> {
 
 #[tokio::test]
 #[instrument]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn databricks_odbc_with_acceleration() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/spark/mod.rs
+++ b/crates/runtime/tests/spark/mod.rs
@@ -47,6 +47,10 @@ fn make_spark_dataset(path: &str, name: &str) -> Dataset {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    not(feature = "extended_tests"),
+    ignore = "Extended test - run with --features extended_tests"
+)]
 async fn spark_integration_test() -> Result<(), anyhow::Error> {
     type QueryTests<'a> = Vec<(&'a str, &'a str, Option<Box<ValidateFn>>)>;
     let _ = rustls::crypto::CryptoProvider::install_default(


### PR DESCRIPTION
## 📝 Summary

Keeping a databricks warehouse up and running during the week is fairly expensive, so let's only run it as part of our release process.