### PR TITLE
`vector_search` UDTF and related changes

### DIFF
--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -22,6 +22,7 @@ use crate::{
     dataconnector,
     datafusion::DataFusion,
     datasets_health_monitor::DatasetsHealthMonitor,
+    embeddings::udtf::{VECTOR_SEARCH_UDTF_NAME, VectorSearchTableFunc},
     extension::{Extension, ExtensionFactory},
     flight::RateLimits,
     metrics, podswatcher,
@@ -210,6 +211,10 @@ impl RuntimeBuilder {
         df.ctx.register_udtf(
             "text_search",
             Arc::new(TextSearchTableFunc::new(Arc::downgrade(&df))),
+        );
+        df.ctx.register_udtf(
+            VECTOR_SEARCH_UDTF_NAME,
+            Arc::new(VectorSearchTableFunc::new(Arc::downgrade(&df))),
         );
 
         let datasets_health_monitor = if self.datasets_health_monitor_enabled {

--- a/crates/runtime/src/datafusion/dialect/mod.rs
+++ b/crates/runtime/src/datafusion/dialect/mod.rs
@@ -18,13 +18,15 @@ use std::sync::Arc;
 
 use datafusion::sql::unparser::dialect::{Dialect, DuckDBDialect, ScalarFnToSqlHandler};
 
+use crate::embeddings::cosine_distance::COSINE_DISTANCE_UDF_NAME;
+
 mod duckdb;
 
 /// Creates a new instance of the `DuckDB` dialect with support for Spice internal UDFs
 pub fn new_duckdb_dialect() -> Arc<dyn Dialect> {
     let dialect = DuckDBDialect::new().with_custom_scalar_overrides(vec![
         (
-            "cosine_distance",
+            COSINE_DISTANCE_UDF_NAME,
             Box::new(duckdb::cosine_distance_to_sql) as ScalarFnToSqlHandler,
         ),
         (

--- a/crates/runtime/src/embeddings/cosine_distance.rs
+++ b/crates/runtime/src/embeddings/cosine_distance.rs
@@ -31,9 +31,10 @@ use datafusion::{
     common::{DataFusionError, Result as DataFusionResult, exec_err},
     logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility},
 };
-
 use std::any::Any;
 use std::sync::Arc;
+
+pub static COSINE_DISTANCE_UDF_NAME: &str = "cosine_distance";
 
 macro_rules! downcast_arg {
     ($ARG:expr, $ARRAY_TYPE:ident) => {{
@@ -101,7 +102,7 @@ impl ScalarUDFImpl for CosineDistance {
     }
 
     fn name(&self) -> &'static str {
-        "cosine_distance"
+        COSINE_DISTANCE_UDF_NAME
     }
 
     fn signature(&self) -> &Signature {

--- a/crates/runtime/src/embeddings/mod.rs
+++ b/crates/runtime/src/embeddings/mod.rs
@@ -20,6 +20,7 @@ pub mod execution_plan;
 pub mod metrics;
 pub mod table;
 pub mod task;
+pub mod udtf;
 
 /// Converts string-like Arrow types into an iterator [`Option<Box<dyn Iterator<Item = Option<&str>>>>`]. If the downcast conversion
 /// fails, returns `None`.

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -60,9 +60,9 @@ pub enum Error {
 pub struct EmbeddingTable {
     base_table: Arc<dyn TableProvider>,
 
-    embedded_columns: HashMap<String, EmbeddingColumnConfig>,
+    pub embedded_columns: HashMap<String, EmbeddingColumnConfig>,
 
-    embedding_models: Arc<RwLock<EmbeddingModelStore>>,
+    pub embedding_models: Arc<RwLock<EmbeddingModelStore>>,
 }
 
 impl std::fmt::Debug for EmbeddingTable {

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -14,7 +14,7 @@ limitations under the License.
 //!
 //! `vector_search(tbl`: `TableReference`, query: &str, col: Option<str>, limit: Option<usize>, `include_score`: Option<bool>)
 //!
-//! - tbl: Table to perform full text search upon. If the table does not support it (i.e. no index), and empty table is returned.
+//! - tbl: Table to perform full text search upon. If the table does not support it (i.e. no index), an empty table is returned.
 //! - query: Query to perform full text search against.
 //! - col: If provided, use this column to compare vector search results against.
 //! - limit:

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -1,0 +1,421 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+//! A user-defined table function (UDTF) for performing vector search on a preexisting table that has an embedding configured on at least one of its columns.
+//!
+//! `vector_search(tbl`: `TableReference`, query: &str, col: Option<str>, limit: Option<usize>, `include_score`: Option<bool>)
+//!
+//! - tbl: Table to perform full text search upon. If the table does not support it (i.e. no index), and empty table is returned.
+//! - query: Query to perform full text search against.
+//! - col: If provided, use this column to compare vector search results against.
+//! - limit:
+//! - `include_score` (default true): If false, do not return `score` in the table projection.
+//!
+//! The schema of the resultant table will be: `schema(tbl) ∪ {score}`, where:
+//!  - `score` (f32): The similarity score of the row with the request `query`.
+//!  - `value` (UTF8): The subset of the column most relevant. For non-chunked embedding columns, `value` is the entire value.
+use std::{
+    any::Any,
+    collections::{HashMap, HashSet},
+    sync::{Arc, Weak},
+};
+
+use arrow::{array::FixedSizeListArray, datatypes::Float32Type};
+use arrow_schema::{Field, Schema, SchemaRef};
+use async_openai::types::EmbeddingInput;
+use datafusion::{
+    catalog::{Session, TableFunctionImpl, TableProvider},
+    common::Column,
+    datasource::{DefaultTableSource, TableType},
+    error::{DataFusionError, Result as DataFusionResult},
+    logical_expr::{
+        BinaryExpr, LogicalPlan, Operator, Projection, Sort, SortExpr, TableScan,
+        expr::{Alias, ScalarFunction},
+    },
+    physical_plan::ExecutionPlan,
+    prelude::{Expr, lit},
+    scalar::ScalarValue,
+    sql::TableReference,
+};
+use itertools::Itertools;
+use search::SEARCH_SCORE_COLUMN_NAME;
+use snafu::ResultExt;
+
+use crate::{
+    datafusion::DataFusion,
+    embedding_col,
+    embeddings::{
+        cosine_distance::COSINE_DISTANCE_UDF_NAME,
+        table::{EmbeddingColumnConfig, EmbeddingTable},
+    },
+    model::EmbeddingModelStore,
+    search::util::find_concrete_table_provider,
+};
+use tokio::sync::RwLock;
+
+pub static VECTOR_SEARCH_UDTF_NAME: &str = "vector_search";
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct VectorSearchTableFuncArgs {
+    pub tbl: TableReference,
+    pub query: String,
+
+    pub column: Option<String>,
+    pub limit: Option<usize>,
+    pub include_score: Option<bool>,
+}
+
+impl VectorSearchTableFuncArgs {
+    /// Check [`Self::column`] is valid, attempt to pick a default, and retrieve the associated [`EmbeddingColumnConfig`].
+    fn get_column_and_config(
+        &self,
+        embedded_columns: &HashMap<String, EmbeddingColumnConfig>,
+    ) -> DataFusionResult<(String, EmbeddingColumnConfig)> {
+        let cfg = self
+            .column
+            .as_ref()
+            .and_then(|c| embedded_columns.get(c))
+            .cloned();
+        match (self.column.as_deref(), cfg) {
+            (Some(col), Some(cfg)) => Ok((col.to_string(), cfg)),
+            (Some(col), None) => Err(DataFusionError::Internal(format!(
+                "User function 'vector_search' is called on table '{}' that does not have a embedding index on '{col}' column. Index is on column(s): {}.",
+                self.tbl,
+                embedded_columns
+                    .keys()
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .join(", ")
+            ))),
+            (None, _) => {
+                if embedded_columns.len() > 1 {
+                    return Err(DataFusionError::Internal(format!(
+                        "User function 'vector_search' is called on table '{}' that has {} vector search columns. Must call 'vector_search' with column parameter, e.g. `vector_search(\"my table\", 'my query', my_embedded_col)`.",
+                        self.tbl,
+                        embedded_columns.len()
+                    )));
+                }
+                if let Some((col, cfg)) = embedded_columns.iter().next() {
+                    Ok((col.clone(), cfg.clone()))
+                } else {
+                    Err(DataFusionError::Internal(format!(
+                        "User function 'vector_search' is called on table '{}' that has no associated full text search index.",
+                        self.tbl,
+                    )))
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VectorSearchTableFunc {
+    // This needs to be a weak reference because the DataFusion instance contains the SessionContext which contains this UDTF.
+    df: Weak<DataFusion>,
+}
+
+impl VectorSearchTableFunc {
+    #[must_use]
+    pub fn new(df: Weak<DataFusion>) -> Self {
+        Self { df }
+    }
+}
+
+impl VectorSearchTableFunc {
+    fn parse_args(args: &[Expr]) -> DataFusionResult<VectorSearchTableFuncArgs> {
+        let mut args = args.iter();
+
+        let tbl = args.next();
+        let Some(Expr::Column(Column {
+            relation: None,
+            name: table_name,
+            ..
+        })) = tbl
+        else {
+            return Err(DataFusionError::Plan(format!(
+                "First argument must be a table reference, but got a different expression: {tbl:?}."
+            )));
+        };
+
+        let query = args.next();
+        let Some(Expr::Literal(ScalarValue::Utf8(Some(q)))) = query else {
+            return Err(DataFusionError::Plan(format!(
+                "Second argument must be a query string, but got {query:?}."
+            )));
+        };
+
+        let (column, limit, include_score) = match (args.next(), args.next(), args.next()) {
+            // No arguments, provides defaults
+            (None, None, None) => (None, None, Some(true)),
+
+            // Single argument cases
+            (Some(Expr::Literal(ScalarValue::Utf8(Some(col)))), None, None) => {
+                (Some(col.clone()), None, Some(true))
+            }
+            (Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))), None, None) => {
+                (None, Some(*limit), Some(true))
+            }
+            (Some(Expr::Literal(ScalarValue::Boolean(Some(include_score)))), None, None) => {
+                (None, None, Some(*include_score))
+            }
+
+            // 2 of 3 arguments. When user provides two of three arguments, they must still be in correct order (i.e. no limit before column)
+            (
+                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))),
+                None,
+            ) => (Some(col.clone()), Some(*limit), Some(true)),
+            (
+                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Literal(ScalarValue::Boolean(Some(include_score)))),
+                None,
+            ) => (Some(col.clone()), None, Some(*include_score)),
+            (
+                Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))),
+                Some(Expr::Literal(ScalarValue::Boolean(Some(include_score)))),
+                None,
+            ) => (None, Some(*limit), Some(*include_score)),
+
+            // All three arguments provided
+            (
+                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))),
+                Some(Expr::Literal(ScalarValue::Boolean(Some(include_score)))),
+            ) => (Some(col.clone()), Some(*limit), Some(*include_score)),
+
+            // Invalid argument combinations
+            (a, b, c) => {
+                return Err(DataFusionError::Plan(format!(
+                    "Invalid arguments: ({table_name}, {q}, {a:?}, {b:?}, {c:?}. Expected (table, query, [column, limit, include_score])."
+                )));
+            }
+        };
+        Ok(VectorSearchTableFuncArgs {
+            tbl: table_name.into(),
+            query: q.to_string(),
+            column,
+            limit: limit.map(|l| usize::try_from(l).unwrap_or(usize::MAX)),
+            include_score,
+        })
+    }
+}
+
+impl TableFunctionImpl for VectorSearchTableFunc {
+    fn call(&self, args: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
+        let args = Self::parse_args(args)?;
+        let df = self.df.upgrade().ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "An unexpected error occurred when calling {VECTOR_SEARCH_UDTF_NAME}(). Report an issue on GitHub: https://github.com/spiceai/spiceai/issues.\nDetails: DataFusion instance has been dropped."
+            ))
+        })?;
+        let Some(table_provider) = df.get_table_sync(&args.tbl) else {
+            return Err(DataFusionError::Plan(format!(
+                "Table '{}' does not exist.",
+                args.tbl.clone()
+            )));
+        };
+
+        let embedding_table_provider =
+            find_concrete_table_provider::<EmbeddingTable>(&table_provider).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "Table '{}' does not have an embedding index.",
+                    args.tbl.clone()
+                ))
+            })?;
+
+        let (col, _) = args.get_column_and_config(&embedding_table_provider.embedded_columns)?;
+        if embedding_table_provider.is_chunked(col.as_str()) {
+            return Err(DataFusionError::Plan(format!(
+                "Chunked columns (i.e. '{col}' in '{}') are not yet supported by '{VECTOR_SEARCH_UDTF_NAME}()'",
+                args.tbl.clone()
+            )));
+        }
+        Ok(Arc::new(VectorSearchUDTFProvider {
+            args,
+            underlying: Arc::clone(&table_provider),
+            embedded_columns: embedding_table_provider.embedded_columns.clone(),
+            embedding_models: Arc::clone(&embedding_table_provider.embedding_models),
+        }))
+    }
+}
+
+/// The [`TableProvider`] produced from the [`VECTOR_SEARCH_UDTF_NAME`] UDTF.
+#[derive(Debug, Clone)]
+pub(super) struct VectorSearchUDTFProvider {
+    pub args: VectorSearchTableFuncArgs,
+    underlying: Arc<dyn TableProvider>,
+    embedded_columns: HashMap<String, EmbeddingColumnConfig>,
+    embedding_models: Arc<RwLock<EmbeddingModelStore>>,
+}
+
+impl VectorSearchUDTFProvider {
+    /// Embed the query argument and convert to [`Float32Array`].
+    async fn vector(
+        &self,
+        col: &str,
+        cfg: &EmbeddingColumnConfig,
+    ) -> Result<FixedSizeListArray, Box<dyn std::error::Error + Send + Sync>> {
+        let models = self.embedding_models.read().await;
+        let Some(embedding_model) = models.get(&cfg.model_name) else {
+            return Err(Box::from(format!(
+                "Column '{col}' in '{}' requires '{}' embedding model, but is not available.",
+                self.args.tbl, cfg.model_name
+            )));
+        };
+        let mut resp = embedding_model
+            .embed(EmbeddingInput::String(self.args.query.clone()))
+            .await
+            .boxed()?;
+        let Some(v) = resp.pop() else {
+            return Err(Box::from(format!(
+                "Embedding model '{}' produced no embedding for the query '{}'.",
+                cfg.model_name,
+                self.args.query.clone()
+            )));
+        };
+        let Ok(size) = i32::try_from(v.len()) else {
+            return Err(Box::from(format!(
+                "Embedding vector size '{}' is greater that 32-bit integer.",
+                v.len()
+            )));
+        };
+
+        Ok(
+            FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+                vec![Some(v.into_iter().map(Some).collect::<Vec<_>>())],
+                size,
+            ),
+        )
+    }
+}
+
+/// Create a new [`SchemaRef`] with the additional fields specified.
+///
+/// If a new field is already in [`SchemaRef`], it will be ignored.
+pub(super) fn append_fields(schema: &SchemaRef, new_fields: Vec<Arc<Field>>) -> SchemaRef {
+    let existing_names: HashSet<_> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+
+    let mut all_fields: Vec<Arc<Field>> = schema.fields().iter().cloned().collect();
+
+    for field in new_fields {
+        if !existing_names.contains(field.name().as_str()) {
+            all_fields.push(field);
+        }
+    }
+
+    Arc::new(Schema::new(all_fields))
+}
+
+#[async_trait::async_trait]
+impl TableProvider for VectorSearchUDTFProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        append_fields(
+            &self.underlying.schema(),
+            vec![Arc::new(Field::new(
+                SEARCH_SCORE_COLUMN_NAME.to_string(),
+                arrow_schema::DataType::Float64,
+                false,
+            ))],
+        )
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let (col, cfg) = self.args.get_column_and_config(&self.embedded_columns)?;
+
+        let query_vector = self
+            .vector(&col, &cfg)
+            .await
+            .map_err(DataFusionError::External)?;
+
+        let Some(cosine_distance_udf) = state
+            .scalar_functions()
+            .get(COSINE_DISTANCE_UDF_NAME)
+            .cloned()
+        else {
+            return Err(DataFusionError::Execution(format!(
+                "UDF '{COSINE_DISTANCE_UDF_NAME}' is required to perform {VECTOR_SEARCH_UDTF_NAME}, but it is not defined."
+            )));
+        };
+
+        // TODO: eventually this will need to be a join on underlying, and auxiliary table.
+        let scan = LogicalPlan::TableScan(TableScan::try_new(
+            self.args.tbl.clone(),
+            Arc::new(DefaultTableSource::new(Arc::clone(&self.underlying))),
+            None,
+            filters.to_vec(),
+            None,
+        )?);
+
+        let mut base_expr: Vec<Expr> = self
+            .schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| {
+                // `SEARCH_SCORE_COLUMN_NAME` not a simple projection, constructed below.
+                if f.name() == SEARCH_SCORE_COLUMN_NAME {
+                    return None;
+                }
+                // Check it is in projection
+                if projection.is_none() || projection.is_some_and(|proj| proj.contains(&i)) {
+                    Some(Expr::Column(Column::from_name(f.name())))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        base_expr.push(Expr::Alias(Alias {
+            expr: Box::from(Expr::BinaryExpr(BinaryExpr::new(
+                Box::new(lit(1.0)),
+                Operator::Minus,
+                Box::new(Expr::ScalarFunction(ScalarFunction {
+                    func: cosine_distance_udf,
+                    args: vec![
+                        Expr::Literal(ScalarValue::FixedSizeList(Arc::new(query_vector))),
+                        Expr::Column(Column::from_name(embedding_col!(col))),
+                    ],
+                })),
+            ))),
+            relation: None,
+            name: SEARCH_SCORE_COLUMN_NAME.to_string(),
+            metadata: None,
+        }));
+
+        let proj = LogicalPlan::Projection(Projection::try_new(base_expr, Arc::new(scan))?);
+        let sort = LogicalPlan::Sort(Sort {
+            expr: vec![SortExpr::new(
+                Expr::Column(Column::from_name(SEARCH_SCORE_COLUMN_NAME)),
+                false,
+                false,
+            )],
+            input: Arc::new(proj),
+            fetch: limit,
+        });
+
+        state.create_physical_plan(&sort).await
+    }
+}

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -53,7 +53,10 @@ use search::{
     },
 };
 
-use crate::{datafusion::DataFusion, search::full_text::index::FullTextDatabaseIndex};
+use crate::{
+    datafusion::DataFusion,
+    search::{full_text::index::FullTextDatabaseIndex, util::find_concrete_table_provider},
+};
 
 pub static TEXT_SEARCH_UDTF_NAME: &str = "text_search";
 
@@ -174,15 +177,15 @@ impl TableFunctionImpl for TextSearchTableFunc {
             )));
         };
 
-        let index_table_provider = table_provider
-            .as_any()
-            .downcast_ref::<IndexedTableProvider>()
-            .ok_or_else(|| {
-                DataFusionError::Plan(format!(
-                    "Table '{}' does not have a full text search index.",
-                    args.tbl.clone()
-                ))
-            })?;
+        let index_table_provider = find_concrete_table_provider::<IndexedTableProvider>(
+            &table_provider,
+        )
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "Table '{}' does not have a full text search index.",
+                args.tbl.clone()
+            ))
+        })?;
 
         let Some(fts_index) = index_table_provider.get_index::<FullTextDatabaseIndex>() else {
             return Err(DataFusionError::Plan(format!(

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -65,7 +65,7 @@ pub(crate) fn find_concrete_table_provider<T: TableProvider + Clone + 'static>(
         }
 
         if let Some(accelerated_table) = current_tbl.as_any().downcast_ref::<AcceleratedTable>() {
-            let current_tbl = accelerated_table
+            current_tbl = accelerated_table
                 .get_federated_table()
                 .try_table_provider_sync()?;
             continue;

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -35,7 +35,7 @@ use crate::search::full_text::index::FullTextDatabaseIndex;
 use super::{Error, Result};
 
 /// Attempt to return a concrete [`TableProvider`] type from a given [`impl TableProvider`]. This includes if the [`TableProvider`] is a base table for an [`AcceleratedTable`] or [`FederatedTableProviderAdaptor`] or other known [`TableProvider`] that wrap a table.
-pub(super) async fn find_concrete_table_provider<T: TableProvider + Clone + 'static>(
+pub(crate) fn find_concrete_table_provider<T: TableProvider + Clone + 'static>(
     tbl: &Arc<dyn TableProvider>,
 ) -> Option<Arc<T>> {
     let mut current_tbl = Arc::clone(tbl);
@@ -65,11 +65,9 @@ pub(super) async fn find_concrete_table_provider<T: TableProvider + Clone + 'sta
         }
 
         if let Some(accelerated_table) = current_tbl.as_any().downcast_ref::<AcceleratedTable>() {
-            let federated_table = accelerated_table
+            let current_tbl = accelerated_table
                 .get_federated_table()
-                .table_provider()
-                .await;
-            current_tbl = Arc::clone(&federated_table);
+                .try_table_provider_sync()?;
             continue;
         }
 
@@ -175,10 +173,7 @@ pub async fn user_tables_with_embeddings(df: &Arc<DataFusion>) -> Result<Vec<Tab
             .await
             // we should not fail here, as we are iterating over the tables that we know exist
             .ok_or_else(|| Error::DataSourceNotFound { table: t.clone() })?;
-        if find_concrete_table_provider::<EmbeddingTable>(&table_provider)
-            .await
-            .is_some()
-        {
+        if find_concrete_table_provider::<EmbeddingTable>(&table_provider).is_some() {
             tables_with_embeddings.push(t);
         }
     }
@@ -194,7 +189,7 @@ pub async fn embedding_columns_from_table(
 ) -> Option<Vec<String>> {
     let table_provider = df.get_table(tbl).await?;
 
-    let embedding_table = find_concrete_table_provider::<EmbeddingTable>(&table_provider).await?;
+    let embedding_table = find_concrete_table_provider::<EmbeddingTable>(&table_provider)?;
     Some(embedding_table.get_embedding_columns())
 }
 
@@ -211,8 +206,7 @@ pub async fn full_text_search_candidates(
     let table_provider = df.get_table(tbl).await?;
 
     // If the table exists, but does not have full text search support, return no candidates.
-    let Some(indexed_table) =
-        find_concrete_table_provider::<IndexedTableProvider>(&table_provider).await
+    let Some(indexed_table) = find_concrete_table_provider::<IndexedTableProvider>(&table_provider)
     else {
         return Some(Ok(vec![]));
     };
@@ -242,11 +236,7 @@ mod tests {
             MemTable::try_new(Arc::new(Schema::empty()), vec![]).expect("failed to make table"),
         );
 
-        assert!(
-            find_concrete_table_provider::<EmbeddingTable>(&base)
-                .await
-                .is_none()
-        );
+        assert!(find_concrete_table_provider::<EmbeddingTable>(&base).is_none());
     }
 
     #[tokio::test]
@@ -275,16 +265,8 @@ mod tests {
         let wrapped_table = Arc::new(IndexedTableProvider::new(base_table).add_index(index))
             as Arc<dyn TableProvider>;
 
-        assert!(
-            find_concrete_table_provider::<IndexedTableProvider>(&wrapped_table)
-                .await
-                .is_some()
-        );
+        assert!(find_concrete_table_provider::<IndexedTableProvider>(&wrapped_table).is_some());
 
-        assert!(
-            find_concrete_table_provider::<EmbeddingTable>(&wrapped_table)
-                .await
-                .is_none()
-        );
+        assert!(find_concrete_table_provider::<EmbeddingTable>(&wrapped_table).is_none());
     }
 }

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -95,8 +95,7 @@ impl VectorSearch {
                 data_source: vec![tbl.clone()],
             })?;
 
-        let Some(embedding_table) =
-            find_concrete_table_provider::<EmbeddingTable>(&table_provider).await
+        let Some(embedding_table) = find_concrete_table_provider::<EmbeddingTable>(&table_provider)
         else {
             return Err(Error::CannotVectorSearchDataset {
                 data_source: tbl.clone(),


### PR DESCRIPTION
## 📝 Summary
- New UDTF, similar to `text_search`, but for vector embedding based columns/datasets.
```sql
SELECT my_primary_key, score, something_else
FROM vector_search(my_dataset, 'search query')
WHERE any_normal_sql_filter IS NOT NULL
ORDER BY score
DESC LIMIT 1
```

 - Important points:
   - No support for chunked columns.
   - For datasets with >1 embedding column, no aggregation is done. Must be called with additional (optional) third param `vector_search(my_dataset, 'search query', chosen_column)`. 

## 📚 Docs
- [ ] SQL reference docs
- [ ] Docs in _"Search feature"_ describing new UX.
