### PR TITLE
Fix perplexity model parameters in llm integration tests

### DIFF
--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -81,10 +81,7 @@ pub(crate) fn create_hf(model_id: &str) -> Result<Arc<dyn Chat>, ChatError> {
 pub(crate) fn create_perplexity() -> Result<Arc<dyn Chat>, ChatError> {
     let mut params: HashMap<String, SecretString> = HashMap::new();
     if let Ok(api_key) = std::env::var("SPICE_PERPLEXITY_AUTH_TOKEN") {
-        params.insert(
-            "perplexity_auth_token".to_string(),
-            SecretString::from(api_key),
-        );
+        params.insert("auth_token".to_string(), SecretString::from(api_key));
     }
     let sonar = PerplexitySonar::from_params(None, &params)
         .map_err(|e| ChatError::FailedToLoadModel { source: e })?;


### PR DESCRIPTION
## 📝 Summary

Fix perplexity model parameters in llm integration tests, the `PerplexitySonar::from_params` takes un-prefixed parameters after the model param refactor work.

https://github.com/spiceai/spiceai/actions/workflows/integration_llms.yml

Note that the llm integration tests will still fail, I've done some initial investigation and the llm tests will need to be refactored to not rely on model output. Since the tests has always been failing in the past few months, scoped out as separate issue: https://github.com/spiceai/spiceai/issues/6399

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
