### PR TITLE
Provide error message when partition by expression changes

### DIFF
--- a/crates/runtime-table-partition/src/creator.rs
+++ b/crates/runtime-table-partition/src/creator.rs
@@ -35,6 +35,10 @@ pub enum Error {
     CreatePartition { source: StdError },
     #[snafu(display("Failed to infer accelerated partitions: {source}"))]
     InferringPartitions { source: StdError },
+    #[snafu(display(
+        "The 'partition_by' expressions are different from the expressions used to create the existing partition files. Revert the 'partition_by' expressions, delete the partition files, or change the location the partition files are stored to create new partitions."
+    ))]
+    PartitionByExpressionsChanged,
 }
 
 #[async_trait]
@@ -45,15 +49,11 @@ pub trait PartitionCreator: Debug + Send + Sync {
     /// Returns an error when creating a [`Partition`] is unsuccessful.
     async fn create_partition(&self, partition_value: ScalarValue) -> Result<Partition, Error>;
 
-    /// Find and load previously created [`Partition`]s based on the
-    /// `partition_by` expressions.
+    /// Find and load previously created [`Partition`]s
     ///
     /// # Errors
     /// Returns an error when [`Partition`]s cannot be inferred.
-    async fn infer_existing_partitions(
-        &self,
-        partition_by: &[Expr],
-    ) -> Result<Vec<Partition>, Error>;
+    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, Error>;
 
     /// See [`TableProvider::supports_filters_pushdown`].
     ///

--- a/crates/runtime-table-partition/src/creator.rs
+++ b/crates/runtime-table-partition/src/creator.rs
@@ -45,11 +45,15 @@ pub trait PartitionCreator: Debug + Send + Sync {
     /// Returns an error when creating a [`Partition`] is unsuccessful.
     async fn create_partition(&self, partition_value: ScalarValue) -> Result<Partition, Error>;
 
-    /// Find and load previously created [`Parition`]s.
+    /// Find and load previously created [`Partition`]s based on the
+    /// `partition_by` expressions.
     ///
     /// # Errors
     /// Returns an error when [`Partition`]s cannot be inferred.
-    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, Error>;
+    async fn infer_existing_partitions(
+        &self,
+        partition_by: &[Expr],
+    ) -> Result<Vec<Partition>, Error>;
 
     /// See [`TableProvider::supports_filters_pushdown`].
     ///

--- a/crates/runtime-table-partition/src/creator/filename.rs
+++ b/crates/runtime-table-partition/src/creator/filename.rs
@@ -33,34 +33,47 @@ use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to serialize scalar value: {source}"))]
+    #[snafu(display("Failed to serialize: {source}"))]
     Serialize { source: serde_qs::Error },
 
-    #[snafu(display("Failed to deserialize scalar value: {source}"))]
+    #[snafu(display("Failed to deserialize: {source}"))]
     Deserialize { source: serde_qs::Error },
 
     #[snafu(display("Unsupported scalar value type: {data_type}"))]
     UnsupportedType { data_type: DataType },
 }
 
-/// Converts a [`ScalarValue`] to its [`String`] representation.
+#[derive(Serialize, Deserialize)]
+struct SerializablePair {
+    scalar: SupportedScalarValue,
+    exprs_hash: u64,
+}
+
+/// Encodes a [`ScalarValue`] and a hash of the partition_by expressions
 ///
 /// # Errors
-/// Returns an error if the [`ScalarValue`] is not supported.
-pub fn encode_scalar_value(value: &ScalarValue) -> Result<String, Error> {
-    let supported_value = SupportedScalarValue::try_from(value.clone())?;
-    let encoded = serde_qs::to_string(&supported_value).context(SerializeSnafu)?;
+/// Returns an error if the [`ScalarValue`] is not supported or cannot be
+/// serialized.
+pub fn encode_pair(scalar: &ScalarValue, exprs_hash: u64) -> Result<String, Error> {
+    let supported_scalar = SupportedScalarValue::try_from(scalar.clone())?;
+    let pair = SerializablePair {
+        scalar: supported_scalar,
+        exprs_hash,
+    };
+    let encoded = serde_qs::to_string(&pair).context(SerializeSnafu)?;
     Ok(encoded)
 }
 
-/// Converts a [`String`] back to a [`ScalarValue`].
+/// Decodes a [`String`] back into a [`ScalarValue`] and the hash of the
+/// partition_by expressions.
 ///
 /// # Errors
-/// Returns an error if a [`ScalarValue`] cannot be created.
-pub fn decode_scalar_value(value: &str) -> Result<ScalarValue, Error> {
-    let decoded: SupportedScalarValue = serde_qs::from_str(value).context(DeserializeSnafu)?;
-    let value = ScalarValue::try_from(decoded)?;
-    Ok(value)
+/// Returns an error if the str cannot be deserialized or converted to a
+/// [`ScalarValue`]
+pub fn decode_pair(value: &str) -> Result<(ScalarValue, u64), Error> {
+    let pair: SerializablePair = serde_qs::from_str(value).context(DeserializeSnafu)?;
+    let scalar = ScalarValue::try_from(pair.scalar)?;
+    Ok((scalar, pair.exprs_hash))
 }
 
 #[derive(Serialize, Deserialize)]
@@ -188,18 +201,23 @@ impl TryFrom<SupportedScalarValue> for ScalarValue {
 mod tests {
     use super::*;
 
+    const EXPRS_HASH: u64 = 7;
+
     #[test]
     fn test_encode_decode_boolean() {
         let values = vec![Some(true), Some(false), None];
         for value in values {
             let scalar = ScalarValue::Boolean(value);
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode boolean scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode boolean scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode boolean pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode boolean pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "Boolean value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for boolean {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -209,12 +227,16 @@ mod tests {
         let values = vec![Some(42_i8), Some(-42_i8), None];
         for value in values {
             let scalar = ScalarValue::Int8(value);
-            let encoded = encode_scalar_value(&scalar).expect("Failed to encode int8 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode int8 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode int8 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode int8 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "Int8 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for int8 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -224,13 +246,16 @@ mod tests {
         let values = vec![Some(1000_i16), Some(-1000_i16), None];
         for value in values {
             let scalar = ScalarValue::Int16(value);
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode int16 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode int16 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode int16 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode int16 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "Int16 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for int16 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -240,13 +265,16 @@ mod tests {
         let values = vec![Some(100_000_i32), Some(-100_000_i32), None];
         for value in values {
             let scalar = ScalarValue::Int32(value);
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode int32 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode int32 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode int32 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode int32 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "Int32 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for int32 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -256,13 +284,16 @@ mod tests {
         let values = vec![Some(1_000_000_000_i64), Some(-1_000_000_000_i64), None];
         for value in values {
             let scalar = ScalarValue::Int64(value);
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode int64 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode int64 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode int64 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode int64 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "Int64 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for int64 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -272,13 +303,16 @@ mod tests {
         let values = vec![Some(255_u8), Some(0_u8), None];
         for value in values {
             let scalar = ScalarValue::UInt8(value);
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode uint8 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode uint8 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode uint8 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode uint8 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "UInt8 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for uint8 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -288,13 +322,16 @@ mod tests {
         let values = vec![Some(65_535_u16), Some(0_u16), None];
         for value in values {
             let scalar = ScalarValue::UInt16(value);
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode uint16 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode uint16 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode uint16 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode uint16 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "UInt16 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for uint16 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -304,13 +341,16 @@ mod tests {
         let values = vec![Some(4_294_967_295_u32), Some(0_u32), None];
         for value in values {
             let scalar = ScalarValue::UInt32(value);
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode uint32 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode uint32 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode uint32 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode uint32 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "UInt32 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for uint32 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -320,13 +360,16 @@ mod tests {
         let values = vec![Some(18_446_744_073_709_551_615_u64), Some(0_u64), None];
         for value in values {
             let scalar = ScalarValue::UInt64(value);
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode uint64 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode uint64 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode uint64 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode uint64 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "UInt64 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for uint64 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -336,12 +379,16 @@ mod tests {
         let values = vec![Some("hello".to_string()), Some(String::new()), None];
         for value in values {
             let scalar = ScalarValue::Utf8(value.clone());
-            let encoded = encode_scalar_value(&scalar).expect("Failed to encode utf8 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode utf8 scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode utf8 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode utf8 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "Utf8 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for utf8 {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -351,13 +398,16 @@ mod tests {
         let values = vec![Some("world".to_string()), Some(String::new()), None];
         for value in values {
             let scalar = ScalarValue::Utf8View(value.clone());
-            let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode utf8view scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode utf8view scalar value");
+            let encoded = encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode utf8view pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode utf8view pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "Utf8View value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for utf8view {value:?} failed to encode/decode correctly"
             );
         }
     }
@@ -368,12 +418,16 @@ mod tests {
         for value in values {
             let scalar = ScalarValue::LargeUtf8(value.clone());
             let encoded =
-                encode_scalar_value(&scalar).expect("Failed to encode large utf8 scalar value");
-            let decoded =
-                decode_scalar_value(&encoded).expect("Failed to decode large utf8 scalar value");
+                encode_pair(&scalar, EXPRS_HASH).expect("Failed to encode large utf8 pair");
+            let (decoded_scalar, decoded_exprs_hash) =
+                decode_pair(&encoded).expect("Failed to decode large utf8 pair");
             assert_eq!(
-                decoded, scalar,
+                decoded_scalar, scalar,
                 "LargeUtf8 value {value:?} failed to encode/decode correctly"
+            );
+            assert_eq!(
+                decoded_exprs_hash, EXPRS_HASH,
+                "Exprs hash for large utf8 {value:?} failed to encode/decode correctly"
             );
         }
     }

--- a/crates/runtime-table-partition/src/creator/filename.rs
+++ b/crates/runtime-table-partition/src/creator/filename.rs
@@ -49,7 +49,7 @@ struct SerializablePair {
     exprs_hash: u64,
 }
 
-/// Encodes a [`ScalarValue`] and a hash of the partition_by expressions
+/// Encodes a [`ScalarValue`] and a hash of the `partition_by` expressions
 ///
 /// # Errors
 /// Returns an error if the [`ScalarValue`] is not supported or cannot be
@@ -65,7 +65,7 @@ pub fn encode_pair(scalar: &ScalarValue, exprs_hash: u64) -> Result<String, Erro
 }
 
 /// Decodes a [`String`] back into a [`ScalarValue`] and the hash of the
-/// partition_by expressions.
+/// `partition_by` expressions.
 ///
 /// # Errors
 /// Returns an error if the str cannot be deserialized or converted to a

--- a/crates/runtime-table-partition/src/expression.rs
+++ b/crates/runtime-table-partition/src/expression.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::fmt::Write as _;
+use std::{
+    fmt::Write as _,
+    hash::{DefaultHasher, Hash as _, Hasher},
+};
 
 use arrow_schema::DataType;
 use datafusion::{
@@ -50,6 +53,12 @@ pub enum Error {
 
 pub type ValidationResult = Result<(), Error>;
 
+#[derive(Debug)]
+pub struct PartitionBy {
+    pub expressions_hash: u64,
+    pub expressions: Vec<Expr>,
+}
+
 /// Converts the spicepod `partition_by` list of [`String`]s into [`Expr`]s,
 /// validating that they meet the expression criteria.
 ///
@@ -60,8 +69,12 @@ pub fn partition_by_expressions(
     partition_by: &[String],
     ctx: &SessionContext,
     df_schema: &DFSchema,
-) -> Result<Vec<Expr>, Error> {
-    partition_by
+) -> Result<PartitionBy, Error> {
+    let mut hasher = DefaultHasher::new();
+    partition_by.hash(&mut hasher);
+    let expressions_hash = hasher.finish();
+
+    let expressions = partition_by
         .iter()
         .map(|sql| {
             let expr = ctx
@@ -70,7 +83,12 @@ pub fn partition_by_expressions(
             PartitionCriteria.validate(&expr, df_schema)?;
             Ok(expr)
         })
-        .collect::<Result<Vec<_>, _>>()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(PartitionBy {
+        expressions_hash,
+        expressions,
+    })
 }
 
 /// Validates whether a [`ScalarValue`] can be produced by the given [`Expr`].

--- a/crates/runtime-table-partition/src/insert.rs
+++ b/crates/runtime-table-partition/src/insert.rs
@@ -248,7 +248,9 @@ impl ExecutionPlan for PartitionerExec {
 
                 for handle in handles {
                     if let Ok(output) = handle.await {
-                        output?;
+                        output.map_err(|e| DataFusionError::Execution(
+                            format!("An error occurred while writing to one or more partition files. Some partitions may contain outdated or corrupted data. It is recommended to delete and recreate the accelerated files: {e}")
+                        ))?;
                     }
                 }
 

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -84,7 +84,7 @@ impl PartitionTableProvider {
         let df_schema = DFSchema::try_from(Arc::clone(&schema)).context(SchemaConversionSnafu)?;
 
         let partitions = creator
-            .infer_existing_partitions(&partition_by)
+            .infer_existing_partitions()
             .await
             .context(CreatingPartitionSnafu)?;
 

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -81,16 +81,18 @@ impl PartitionTableProvider {
             num_partition_by == 1,
             PartitionByViolationSnafu { num_partition_by }
         );
+        let df_schema = DFSchema::try_from(Arc::clone(&schema)).context(SchemaConversionSnafu)?;
+
+        let partitions = creator
+            .infer_existing_partitions(&partition_by)
+            .await
+            .context(CreatingPartitionSnafu)?;
+
         let partition_by = partition_by
             .pop()
             .context(PartitionByViolationSnafu { num_partition_by })?;
 
-        let df_schema = DFSchema::try_from(Arc::clone(&schema)).context(SchemaConversionSnafu)?;
-
-        let partitions = creator
-            .infer_existing_partitions()
-            .await
-            .context(CreatingPartitionSnafu)?
+        let partitions = partitions
             .into_iter()
             .map(|p| {
                 validate_scalar_compatibility(&partition_by, &p.partition_value, &df_schema)?;

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -69,9 +69,7 @@ impl DataAccelerator for ArrowAccelerator {
         ensure!(
             partition_by.is_none(),
             super::InvalidConfigurationSnafu {
-                msg: format!(
-                    "Arrow data accelerator does not support the `partition_by` parameter but it was provided"
-                )
+                msg: "Arrow data accelerator does not support the `partition_by` parameter but it was provided".to_string()
             }
         );
 

--- a/crates/runtime/src/dataaccelerator/arrow.rs
+++ b/crates/runtime/src/dataaccelerator/arrow.rs
@@ -18,8 +18,9 @@ use async_trait::async_trait;
 use data_components::arrow::ArrowFactory;
 use datafusion::{
     catalog::TableProviderFactory, datasource::TableProvider, execution::context::SessionContext,
-    logical_expr::CreateExternalTable, prelude::Expr,
+    logical_expr::CreateExternalTable,
 };
+use runtime_table_partition::expression::PartitionBy;
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
@@ -63,14 +64,13 @@ impl DataAccelerator for ArrowAccelerator {
         &self,
         cmd: CreateExternalTable,
         _source: Option<&dyn AccelerationSource>,
-        partition_by: Vec<Expr>,
+        partition_by: Option<PartitionBy>,
     ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
-        let num_partitions = partition_by.len();
         ensure!(
-            num_partitions == 0,
+            partition_by.is_none(),
             super::InvalidConfigurationSnafu {
                 msg: format!(
-                    "Arrow data accelerator does not support the `partition_by` setting but {num_partitions} expressions were provided"
+                    "Arrow data accelerator does not support the `partition_by` parameter but it was provided"
                 )
             }
         );

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -494,7 +494,7 @@ mod tests {
         let duckdb_accelerator = DuckDBAccelerator::new();
         let ctx = SessionContext::new();
         let (table, _) = duckdb_accelerator
-            .create_external_table(external_table, None, vec![])
+            .create_external_table(external_table, None, None)
             .await
             .expect("table should be created");
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -32,7 +32,7 @@ use async_trait::async_trait;
 use data_components::poly::PolyTableProvider;
 use datafusion::{
     catalog::TableProviderFactory, datasource::TableProvider, execution::context::SessionContext,
-    logical_expr::CreateExternalTable, prelude::Expr,
+    logical_expr::CreateExternalTable,
 };
 use datafusion_table_providers::{
     duckdb::{DuckDBSettingsRegistry, DuckDBTableProviderFactory, write::DuckDBTableWriter},
@@ -40,6 +40,7 @@ use datafusion_table_providers::{
 };
 use duckdb::AccessMode;
 use itertools::Itertools;
+use runtime_table_partition::expression::PartitionBy;
 use settings::OrderByNonIntegerLiteral;
 use snafu::prelude::*;
 use std::{
@@ -322,7 +323,7 @@ impl DataAccelerator for DuckDBAccelerator {
         &self,
         mut cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
-        _partition_by: Vec<Expr>,
+        _partition_by: Option<PartitionBy>,
     ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
         if let Some(duckdb_file) = cmd.options.remove("file") {
             cmd.options

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -23,7 +23,7 @@ use crate::{Runtime, spice_data_base_path};
 use ::arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::common::{Constraint, DFSchema};
-use datafusion::prelude::{Expr, SessionContext};
+use datafusion::prelude::SessionContext;
 use datafusion::{
     common::{Constraints, TableReference, ToDFSchema},
     datasource::TableProvider,
@@ -32,7 +32,7 @@ use datafusion::{
 use datafusion_table_providers::util::{
     column_reference::ColumnReference, on_conflict::OnConflict,
 };
-use runtime_table_partition::expression::partition_by_expressions;
+use runtime_table_partition::expression::{PartitionBy, partition_by_expressions};
 use secrecy::SecretString;
 use snafu::prelude::*;
 use std::{any::Any, collections::HashMap, sync::Arc};
@@ -251,9 +251,14 @@ impl AcceleratorEngineRegistry {
         let df_schema = DFSchema::try_from(schema)
             .map_err(|e| Error::AccelerationCreationFailed { source: e.into() })?;
 
-        let partition_by =
-            partition_by_expressions(&acceleration_settings.partition_by, &ctx, &df_schema)
-                .map_err(|e| Error::AccelerationCreationFailed { source: e.into() })?;
+        let partition_by = if acceleration_settings.partition_by.is_empty() {
+            None
+        } else {
+            Some(
+                partition_by_expressions(&acceleration_settings.partition_by, &ctx, &df_schema)
+                    .map_err(|e| Error::AccelerationCreationFailed { source: e.into() })?,
+            )
+        };
 
         let table_provider = accelerator
             .create_external_table(external_table, source, partition_by)
@@ -276,7 +281,7 @@ pub trait DataAccelerator: Send + Sync {
         &self,
         cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
-        partition_by: Vec<Expr>,
+        partition_by: Option<PartitionBy>,
     ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>>;
 
     /// The name of the accelerator

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -316,7 +316,10 @@ impl PartitionCreator for DuckDBPartitionCreator {
         Ok(partition)
     }
 
-    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, creator::Error> {
+    async fn infer_existing_partitions(
+        &self,
+        partition_by: &[Expr],
+    ) -> Result<Vec<Partition>, creator::Error> {
         if !self.partition_dir.is_dir() {
             create_dir_all(&self.partition_dir)
                 .await

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -41,8 +41,9 @@ use runtime_table_partition::{
     Partition,
     creator::{
         self, PartitionCreator,
-        filename::{self, decode_scalar_value, encode_scalar_value},
+        filename::{self, decode_pair, encode_pair},
     },
+    expression::PartitionBy,
     provider::PartitionTableProvider,
 };
 use snafu::{OptionExt, prelude::*};
@@ -111,6 +112,9 @@ pub enum Error {
 
     #[snafu(display("Partitioned DuckDB expected an AccelerationSource"))]
     ExpectedAccelerationSource,
+
+    #[snafu(display("Partition by expressions are required for Partitioned DuckDB acceleration"))]
+    PartitionByRequired,
 
     #[snafu(display("Unable to create partition: {source}"))]
     UnableToCreatePartition {
@@ -237,8 +241,10 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
         &self,
         cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
-        partition_by: Vec<Expr>,
+        partition_by: Option<PartitionBy>,
     ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
+        let partition_by = partition_by.context(PartitionByRequiredSnafu)?;
+
         let source = source.context(ExpectedAccelerationSourceSnafu)?;
 
         parameter_validation(source);
@@ -246,8 +252,17 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
         let mut table_provider_guard = self.table_provider.lock().await;
         ensure!(table_provider_guard.is_none(), SingleTableSnafu);
 
+        let PartitionBy {
+            expressions_hash,
+            expressions: partition_by,
+        } = partition_by;
+
         let schema = Arc::new(cmd.schema.as_arrow().clone());
-        let creator = Arc::new(DuckDBPartitionCreator::new(partition_dir(source), cmd));
+        let creator = Arc::new(DuckDBPartitionCreator::new(
+            partition_dir(source),
+            cmd,
+            expressions_hash,
+        ));
         let table_provider =
             Arc::new(PartitionTableProvider::new(creator, partition_by, schema).await?);
 
@@ -274,21 +289,42 @@ pub(crate) struct DuckDBPartitionCreator {
     cmd: CreateExternalTable,
     duckdb_factory: DuckDBTableProviderFactory,
     partition_dir: PathBuf,
+    expressions_hash: u64,
 }
 
 impl DuckDBPartitionCreator {
-    pub(crate) fn new(partition_dir: PathBuf, cmd: CreateExternalTable) -> Self {
+    pub(crate) fn new(
+        partition_dir: PathBuf,
+        cmd: CreateExternalTable,
+        expressions_hash: u64,
+    ) -> Self {
         let duckdb_factory = create_factory();
 
         Self {
             cmd,
             duckdb_factory,
             partition_dir,
+            expressions_hash,
         }
     }
 
     fn valid_file_extensions() -> Vec<&'static str> {
         vec!["db", "ddb", "duckdb"]
+    }
+
+    fn add_open(
+        &self,
+        cmd: &mut CreateExternalTable,
+        partition_value: &ScalarValue,
+    ) -> Result<String, filename::Error> {
+        let partition_value_str = encode_pair(partition_value, self.expressions_hash)?;
+
+        let duckdb_file = format!("{partition_value_str}.db");
+        let duckdb_path = self.partition_dir.join(&duckdb_file);
+        let duckdb_path = duckdb_path.display().to_string();
+        cmd.options.insert("open".to_string(), duckdb_path.clone());
+
+        Ok(duckdb_path)
     }
 }
 
@@ -299,7 +335,8 @@ impl PartitionCreator for DuckDBPartitionCreator {
         partition_value: ScalarValue,
     ) -> Result<Partition, creator::Error> {
         let mut cmd = self.cmd.clone();
-        let duckdb_path = add_open(&self.partition_dir, &mut cmd, &partition_value)
+        let duckdb_path = self
+            .add_open(&mut cmd, &partition_value)
             .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
         tracing::debug!("creating partition at {duckdb_path}");
@@ -316,10 +353,7 @@ impl PartitionCreator for DuckDBPartitionCreator {
         Ok(partition)
     }
 
-    async fn infer_existing_partitions(
-        &self,
-        partition_by: &[Expr],
-    ) -> Result<Vec<Partition>, creator::Error> {
+    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, creator::Error> {
         if !self.partition_dir.is_dir() {
             create_dir_all(&self.partition_dir)
                 .await
@@ -349,8 +383,13 @@ impl PartitionCreator for DuckDBPartitionCreator {
                     continue;
                 };
 
-                let partition_value = match decode_scalar_value(file_name) {
-                    Ok(value) => value,
+                let partition_value = match decode_pair(file_name) {
+                    Ok((value, partition_by_hash)) => {
+                        if self.expressions_hash != partition_by_hash {
+                            return Err(creator::Error::PartitionByExpressionsChanged);
+                        }
+                        value
+                    }
                     Err(e) => {
                         tracing::trace!("Unable to decode ScalarValue: {e}");
                         continue;
@@ -358,7 +397,7 @@ impl PartitionCreator for DuckDBPartitionCreator {
                 };
 
                 let mut cmd = self.cmd.clone();
-                add_open(&self.partition_dir, &mut cmd, &partition_value)
+                self.add_open(&mut cmd, &partition_value)
                     .map_err(|e| creator::Error::CreatePartition { source: e.into() })?;
 
                 let duckdb_path = path.display().to_string();
@@ -400,21 +439,6 @@ impl PartitionCreator for DuckDBPartitionCreator {
             })
             .collect())
     }
-}
-
-fn add_open(
-    partition_dir: &Path,
-    cmd: &mut CreateExternalTable,
-    partition_value: &ScalarValue,
-) -> Result<String, filename::Error> {
-    let partition_value_str = encode_scalar_value(partition_value)?;
-
-    let duckdb_file = format!("{partition_value_str}.db");
-    let duckdb_path = partition_dir.join(&duckdb_file);
-    let duckdb_path = duckdb_path.display().to_string();
-    cmd.options.insert("open".to_string(), duckdb_path.clone());
-
-    Ok(duckdb_path)
 }
 
 fn create_factory() -> DuckDBTableProviderFactory {

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -94,9 +94,7 @@ impl DataAccelerator for PostgresAccelerator {
         ensure!(
             partition_by.is_none(),
             super::InvalidConfigurationSnafu {
-                msg: format!(
-                    "Postgres data accelerator does not support the `partition_by` parameter but it was provided"
-                )
+                msg: "Postgres data accelerator does not support the `partition_by` parameter but it was provided".to_string()
             }
         );
 

--- a/crates/runtime/src/dataaccelerator/postgres.rs
+++ b/crates/runtime/src/dataaccelerator/postgres.rs
@@ -18,11 +18,12 @@ use async_trait::async_trait;
 use data_components::poly::PolyTableProvider;
 use datafusion::{
     catalog::TableProviderFactory, datasource::TableProvider, execution::context::SessionContext,
-    logical_expr::CreateExternalTable, prelude::Expr,
+    logical_expr::CreateExternalTable,
 };
 use datafusion_table_providers::postgres::{
     PostgresTableProviderFactory, write::PostgresTableWriter,
 };
+use runtime_table_partition::expression::PartitionBy;
 use snafu::prelude::*;
 use std::{any::Any, sync::Arc};
 
@@ -88,14 +89,13 @@ impl DataAccelerator for PostgresAccelerator {
         &self,
         mut cmd: CreateExternalTable,
         _source: Option<&dyn AccelerationSource>,
-        partition_by: Vec<Expr>,
+        partition_by: Option<PartitionBy>,
     ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
-        let num_partitions = partition_by.len();
         ensure!(
-            num_partitions == 0,
+            partition_by.is_none(),
             super::InvalidConfigurationSnafu {
                 msg: format!(
-                    "Postgres data accelerator does not support the `partition_by` setting but {num_partitions} expressions were provided"
+                    "Postgres data accelerator does not support the `partition_by` parameter but it was provided"
                 )
             }
         );

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -253,9 +253,7 @@ impl DataAccelerator for SqliteAccelerator {
         ensure!(
             partition_by.is_none(),
             super::InvalidConfigurationSnafu {
-                msg: format!(
-                    "Sqlite data accelerator does not support the `partition_by` parameter but it was provided"
-                )
+                msg: "Sqlite data accelerator does not support the `partition_by` parameter but it was provided".to_string()
             }
         );
 
@@ -382,7 +380,7 @@ mod tests {
         };
         let ctx = SessionContext::new();
         let (table, _) = SqliteAccelerator::new()
-            .create_external_table(external_table, None, vec![])
+            .create_external_table(external_table, None, None)
             .await
             .expect("table should be created");
 

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -18,12 +18,13 @@ use async_trait::async_trait;
 use data_components::poly::PolyTableProvider;
 use datafusion::{
     catalog::TableProviderFactory, datasource::TableProvider, execution::context::SessionContext,
-    logical_expr::CreateExternalTable, prelude::Expr,
+    logical_expr::CreateExternalTable,
 };
 use datafusion_table_providers::{
     sql::db_connection_pool::sqlitepool::SqliteConnectionPool,
     sqlite::{SqliteTableProviderFactory, write::SqliteTableWriter},
 };
+use runtime_table_partition::expression::PartitionBy;
 use rusqlite::ffi::{sqlite3_auto_extension, sqlite3_decimal_init};
 use snafu::prelude::*;
 use std::{any::Any, ffi::OsStr, sync::Arc, time::Duration};
@@ -247,14 +248,13 @@ impl DataAccelerator for SqliteAccelerator {
         &self,
         mut cmd: CreateExternalTable,
         source: Option<&dyn AccelerationSource>,
-        partition_by: Vec<Expr>,
+        partition_by: Option<PartitionBy>,
     ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
-        let num_partitions = partition_by.len();
         ensure!(
-            num_partitions == 0,
+            partition_by.is_none(),
             super::InvalidConfigurationSnafu {
                 msg: format!(
-                    "Sqlite data accelerator does not support the `partition_by` setting but {num_partitions} expressions were provided"
+                    "Sqlite data accelerator does not support the `partition_by` parameter but it was provided"
                 )
             }
         );

--- a/crates/runtime/src/dataaccelerator/void.rs
+++ b/crates/runtime/src/dataaccelerator/void.rs
@@ -41,6 +41,7 @@ use datafusion::{
 };
 use datafusion_datasource::sink::{DataSink, DataSinkExec};
 use futures::StreamExt;
+use runtime_table_partition::expression::PartitionBy;
 
 use super::{
     AccelerationSource, Behaviors, DataAccelerator,
@@ -77,7 +78,7 @@ impl DataAccelerator for VoidAccelerator {
         &self,
         cmd: CreateExternalTable,
         _source: Option<&dyn AccelerationSource>,
-        _partition_by: Vec<Expr>,
+        _partition_by: Option<PartitionBy>,
     ) -> Result<(Arc<dyn TableProvider>, Behaviors), Box<dyn std::error::Error + Send + Sync>> {
         let (table_provider, underlying_provider_cb) =
             VoidTable::new(Arc::clone(cmd.schema.inner()));


### PR DESCRIPTION
## 📝 Summary

- Provided error context when partition writing fails for one or more partitions
- Detect when partition_by expressions are modified and fail with a descriptive error
  - Added partition_by argument to the trait methods in `PartitionCreator` for creating and inferring partitions
  - Encoded a hash of the partition_by expressions into the partition filenames


## 🔗 Related

Closes:
- #6414
<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

There is an opporunity to store this (and other) metadata in the checkpointing database file but I thought this would suffice for now.