### PR TITLE
Add support for Oracle Autonomous Database connections (Oracle Cloud)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -196,6 +196,10 @@ jobs:
           AWS_GLUE_SECRET: ${{ secrets.AWS_ICEBERG_SECRET_ACCESS_KEY }}
           AWS_DYNAMODB_KEY: ${{ secrets.AWS_DYNAMODB_ACCESS_KEY_ID }}
           AWS_DYNAMODB_SECRET: ${{ secrets.AWS_DYNAMODB_SECRET_ACCESS_KEY }}
+          ORACLE_CLOUD_CONNECTION_STRING: ${{ secrets.ORACLE_CLOUD_CONNECTION_STRING }}
+          ORACLE_CLOUD_USERNAME: ${{ secrets.ORACLE_CLOUD_USERNAME }}
+          ORACLE_CLOUD_PASSWORD: ${{ secrets.ORACLE_CLOUD_PASSWORD }}
+          ORACLE_CLOUD_WALLET_SSO_CERT: ${{ secrets.ORACLE_CLOUD_WALLET_SSO_CERT }}
         run: |
           if [ -n "$SPICE_SECRET_SPICEAI_KEY" ]; then
             INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./integration_test/integration.tar.zst

--- a/crates/data_components/src/oracle/connection.rs
+++ b/crates/data_components/src/oracle/connection.rs
@@ -20,7 +20,7 @@ use oracle::{Connection, Connector};
 use snafu::ResultExt;
 use std::sync::Arc;
 
-use crate::oracle::ConnectionSnafu;
+use crate::oracle::{ConnectionSnafu, OracleInitSnafu};
 
 #[derive(Debug)]
 pub struct OracleConnectionPool {
@@ -59,14 +59,23 @@ impl CustomizeConnection<Arc<Connection>, bb8_oracle::Error> for SetTimezoneCust
 
 #[derive(Debug)]
 pub struct OracleConnectionParams {
-    pub host: String,
-    pub port: u16,
     pub username: String,
     pub password: String,
-    pub service_name: String,
+    pub connect_string: String,
 }
 
-pub struct OracleConnectionParamsBuilder {
+impl OracleConnectionParams {
+    #[must_use]
+    pub fn new(username: &str, password: &str, connect_string: &str) -> Self {
+        Self {
+            username: username.to_string(),
+            password: password.to_string(),
+            connect_string: connect_string.to_string(),
+        }
+    }
+}
+
+pub struct OracleOnPremConnectionParamsBuilder {
     host: String,
     username: String,
     password: String,
@@ -74,7 +83,7 @@ pub struct OracleConnectionParamsBuilder {
     service_name: Option<String>,
 }
 
-impl OracleConnectionParamsBuilder {
+impl OracleOnPremConnectionParamsBuilder {
     pub fn new(
         host: impl Into<String>,
         username: impl Into<String>,
@@ -101,22 +110,39 @@ impl OracleConnectionParamsBuilder {
 
     #[must_use]
     pub fn build(self) -> OracleConnectionParams {
+        let connect_string = format!(
+            "//{}:{}/{}",
+            self.port.unwrap_or(1521),
+            self.host,
+            self.service_name.unwrap_or_else(|| "XEPDB1".to_string())
+        );
+
         OracleConnectionParams {
-            host: self.host,
             username: self.username,
             password: self.password,
-            port: self.port.unwrap_or(1521),
-            service_name: self.service_name.unwrap_or_else(|| "XEPDB1".to_string()),
+            connect_string,
         }
     }
 }
 
-pub async fn connect(params: &OracleConnectionParams) -> super::Result<OracleConnectionPool> {
-    let connect_string = format!("//{}:{}/{}", params.host, params.port, params.service_name);
+pub async fn connect(
+    params: &OracleConnectionParams,
+    tns_admin: Option<&str>,
+) -> super::Result<OracleConnectionPool> {
+    if let Some(tns_admin) = tns_admin {
+        // Initializes Oracle client library with the specified TNS_ADMIN directory
+        // Note: this is applied for the first connection only, if library is already initialized, dyanmically changing TNS_ADMIN  has no affect
+        let _ = oracle::InitParams::new()
+            .oracle_client_config_dir(tns_admin)
+            .context(OracleInitSnafu)?
+            .init()
+            .context(OracleInitSnafu)?;
+    }
+
     let connector = Connector::new(
         params.username.clone(),
         params.password.clone(),
-        connect_string,
+        params.connect_string.clone(),
     );
 
     // verify connection to an Oracle server

--- a/crates/data_components/src/oracle/connection.rs
+++ b/crates/data_components/src/oracle/connection.rs
@@ -131,7 +131,7 @@ pub async fn connect(
 ) -> super::Result<OracleConnectionPool> {
     if let Some(tns_admin) = tns_admin {
         // Initializes Oracle client library with the specified TNS_ADMIN directory
-        // Note: this is applied for the first connection only, if library is already initialized, dyanmically changing TNS_ADMIN  has no affect
+        // Note: this is applied for the first connection only, if library is already initialized, dynamically changing TNS_ADMIN has no effect
         let _ = oracle::InitParams::new()
             .oracle_client_config_dir(tns_admin)
             .context(OracleInitSnafu)?

--- a/crates/data_components/src/oracle/connection.rs
+++ b/crates/data_components/src/oracle/connection.rs
@@ -75,7 +75,14 @@ impl OracleConnectionParams {
     }
 }
 
-pub struct OracleOnPremConnectionParamsBuilder {
+/// Default TCP port for Oracle Database (commonly used in on-prem/self-managed installations).
+const DEFAULT_PORT: u16 = 1521;
+
+/// `XEPDB1` is the default pluggable database (PDB) name in Oracle Database XE 18c/21c and later versions.
+static DEFAULT_SERVICE_NAME: &str = "XEPDB1";
+
+/// Builds Oracle connection parameters for direct TCP connections using host, port, and service name.
+pub struct OracleDirectConnectionParamsBuilder {
     host: String,
     username: String,
     password: String,
@@ -83,7 +90,7 @@ pub struct OracleOnPremConnectionParamsBuilder {
     service_name: Option<String>,
 }
 
-impl OracleOnPremConnectionParamsBuilder {
+impl OracleDirectConnectionParamsBuilder {
     pub fn new(
         host: impl Into<String>,
         username: impl Into<String>,
@@ -112,9 +119,10 @@ impl OracleOnPremConnectionParamsBuilder {
     pub fn build(self) -> OracleConnectionParams {
         let connect_string = format!(
             "//{}:{}/{}",
-            self.port.unwrap_or(1521),
             self.host,
-            self.service_name.unwrap_or_else(|| "XEPDB1".to_string())
+            self.port.unwrap_or(DEFAULT_PORT),
+            self.service_name
+                .unwrap_or_else(|| DEFAULT_SERVICE_NAME.to_string())
         );
 
         OracleConnectionParams {
@@ -127,16 +135,24 @@ impl OracleOnPremConnectionParamsBuilder {
 
 pub async fn connect(
     params: &OracleConnectionParams,
-    tns_admin: Option<&str>,
+    wallet_path: Option<&str>,
 ) -> super::Result<OracleConnectionPool> {
-    if let Some(tns_admin) = tns_admin {
-        // Initializes Oracle client library with the specified TNS_ADMIN directory
-        // Note: this is applied for the first connection only, if library is already initialized, dynamically changing TNS_ADMIN has no effect
-        let _ = oracle::InitParams::new()
-            .oracle_client_config_dir(tns_admin)
+    if let Some(wallet_path) = wallet_path {
+        // Initializes Oracle client library with the specified wallet directory
+        // Note: this is applied for the first connection only, if library is already initialized, dynamically changing wallet directory has no effect
+        let initialized_here = oracle::InitParams::new()
+            .oracle_client_config_dir(wallet_path)
             .context(OracleInitSnafu)?
             .init()
             .context(OracleInitSnafu)?;
+
+        if initialized_here {
+            tracing::info!("Using wallet directory for Oracle data connector: {wallet_path}");
+        } else {
+            tracing::debug!(
+                "Oracle client library was already initialized, using existing configuration"
+            );
+        }
     }
 
     let connector = Connector::new(

--- a/crates/data_components/src/oracle/mod.rs
+++ b/crates/data_components/src/oracle/mod.rs
@@ -52,6 +52,9 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    #[snafu(display("Failed to initialize Oracle client: {source}"))]
+    OracleInitError { source: oracle::Error },
+
     #[snafu(display("Error executing query: {source}"))]
     QueryError { source: oracle::Error },
 

--- a/crates/runtime/src/dataconnector/oracle.rs
+++ b/crates/runtime/src/dataconnector/oracle.rs
@@ -16,12 +16,17 @@ limitations under the License.
 
 use crate::component::dataset::Dataset;
 use async_trait::async_trait;
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use data_components::oracle::OracleTableProvider;
 use data_components::oracle::connection::{
-    OracleConnectionParams, OracleConnectionPool, OracleOnPremConnectionParamsBuilder,
+    OracleConnectionParams, OracleConnectionPool, OracleDirectConnectionParamsBuilder,
 };
 use datafusion::datasource::TableProvider;
+use once_cell::sync::OnceCell;
 use snafu::{ResultExt, Snafu};
+use std::fs;
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::{any::Any, future::Future};
@@ -30,6 +35,13 @@ use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, DataConnectorResult,
     ParameterSpec, Parameters, UnableToGetReadProviderSnafu,
 };
+
+const DEFAULT_WALLET_PATH: &str = ".oracle";
+
+// Ensures that the wallet certificate is only saved once, even if multiple datasets
+// attempt to initialize concurrently. This avoids race conditions when writing the
+// cwallet.sso file and ensures the Oracle OCI client is initialized with a valid wallet.
+static WALLET_INIT: OnceCell<()> = OnceCell::new();
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -49,6 +61,21 @@ pub enum Error {
         "Invalid value provided for the 'port' parameter: {port}.\nSpecify a valid port, and try again.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/oracle"
     ))]
     FailedToParsePort { port: String },
+
+    #[snafu(display("Failed to create wallet directory: {path}.\n{source}"))]
+    FailedToCreateWalletDirectory {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to decode wallet certificate from base64.\n{source}"))]
+    FailedToDecodeWalletCert { source: base64::DecodeError },
+
+    #[snafu(display("Failed to write wallet certificate file: {path}.\n{source}"))]
+    FailedToWriteWalletFile {
+        path: String,
+        source: std::io::Error,
+    },
 }
 
 const PARAMETERS: &[ParameterSpec] = &[
@@ -58,7 +85,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("port"),
     ParameterSpec::component("service_name"),
     ParameterSpec::component("connection_string").secret(),
-    ParameterSpec::component("tns_admin"),
+    ParameterSpec::component("wallet_sso_cert").secret(),
+    ParameterSpec::component("wallet"),
 ];
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -95,7 +123,7 @@ impl Oracle {
 
             OracleConnectionParams::new(username, password, connect_string)
         } else {
-            let mut conn_params = OracleOnPremConnectionParamsBuilder::new(
+            let mut conn_params = OracleDirectConnectionParamsBuilder::new(
                 params
                     .get("host")
                     .expose()
@@ -122,15 +150,64 @@ impl Oracle {
         };
 
         // Optional parameter to specify mTLS Wallet directory
-        let tns_admin = params.get("tns_admin").expose().ok();
+        let mut wallet_path_opt = params.get("wallet").expose().ok();
 
-        let conn = data_components::oracle::connection::connect(&connect_params, tns_admin)
+        // If wallet certificate is provided, decode it and save it to the specified or default wallet path
+        if let Some(wallet_sso_cert) = params.get("wallet_sso_cert").expose().ok() {
+            let wallet_path = wallet_path_opt.unwrap_or(DEFAULT_WALLET_PATH);
+            Self::save_wallet_cert_once(wallet_sso_cert, wallet_path)?;
+            // Set the wallet path to the one provided or default
+            wallet_path_opt = Some(wallet_path);
+        }
+
+        let conn = data_components::oracle::connection::connect(&connect_params, wallet_path_opt)
             .await
             .context(UnableToCreateConnectionPoolSnafu)?;
 
         Ok(Self {
             conn: Arc::new(conn),
         })
+    }
+
+    /// Writes the decoded `cwallet.sso` certificate to the specified wallet path.
+    /// Ensures safe, single initialization across concurrent dataset connections by guarding
+    /// against race conditions using `WALLET_INIT`. If multiple datasets attempt to initialize
+    /// the wallet concurrently, only the first call will perform the write and initialization;
+    /// subsequent calls will no-op.
+    pub fn save_wallet_cert_once(cert_base64_str: &str, wallet_path: &str) -> Result<()> {
+        WALLET_INIT.get_or_try_init(|| {
+            Self::save_wallet_cert(cert_base64_str, wallet_path)?;
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    /// Save base64-encoded wallet certificate as cwallet.sso file
+    fn save_wallet_cert(cert_base64_str: &str, wallet_path: &str) -> Result<()> {
+        let wallet_dir = Path::new(wallet_path);
+
+        // Create wallet directory if it doesn't exist
+        if !wallet_dir.exists() {
+            fs::create_dir_all(wallet_dir).context(FailedToCreateWalletDirectorySnafu {
+                path: wallet_path.to_string(),
+            })?;
+        }
+
+        let cert_data = BASE64_STANDARD
+            .decode(cert_base64_str)
+            .context(FailedToDecodeWalletCertSnafu)?;
+
+        let wallet_file_path = wallet_dir.join("cwallet.sso");
+        fs::write(&wallet_file_path, cert_data).context(FailedToWriteWalletFileSnafu {
+            path: wallet_file_path.to_string_lossy().to_string(),
+        })?;
+
+        tracing::debug!(
+            "Wallet certificate saved at: {}",
+            wallet_file_path.to_string_lossy()
+        );
+
+        Ok(())
     }
 }
 

--- a/crates/runtime/src/dataconnector/oracle.rs
+++ b/crates/runtime/src/dataconnector/oracle.rs
@@ -17,7 +17,9 @@ limitations under the License.
 use crate::component::dataset::Dataset;
 use async_trait::async_trait;
 use data_components::oracle::OracleTableProvider;
-use data_components::oracle::connection::{OracleConnectionParamsBuilder, OracleConnectionPool};
+use data_components::oracle::connection::{
+    OracleConnectionParams, OracleConnectionPool, OracleOnPremConnectionParamsBuilder,
+};
 use datafusion::datasource::TableProvider;
 use snafu::{ResultExt, Snafu};
 use std::pin::Pin;
@@ -55,6 +57,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("host"),
     ParameterSpec::component("port"),
     ParameterSpec::component("service_name"),
+    ParameterSpec::component("connection_string").secret(),
+    ParameterSpec::component("tns_admin"),
 ];
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -66,36 +70,61 @@ pub struct Oracle {
 
 impl Oracle {
     async fn new(params: &Parameters) -> Result<Self> {
-        let mut conn_params = OracleConnectionParamsBuilder::new(
-            params
-                .get("host")
-                .expose()
-                .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?,
-            params
-                .get("username")
-                .expose()
-                .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?,
-            params
-                .get("password")
-                .expose()
-                .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?,
-        );
+        let username = params
+            .get("username")
+            .expose()
+            .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?;
 
-        if let Some(port_str) = params.get("port").expose().ok() {
-            let port = port_str.parse::<u16>().map_err(|_| {
-                FailedToParsePortSnafu {
-                    port: port_str.to_string(),
+        let password = params
+            .get("password")
+            .expose()
+            .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?;
+
+        let connect_params: OracleConnectionParams = if let Some(connect_string) =
+            params.get("connection_string").expose().ok()
+        {
+            // verify that no conflicting parameters are used
+            for param in ["host", "port", "service_name"] {
+                if params.get(param).expose().ok().is_some() {
+                    tracing::warn!(
+                        "'oracle_{}' parameter is not supported together with 'oracle_connection_string' and will be ignored.",
+                        param
+                    );
                 }
-                .build()
-            })?;
-            conn_params.port(port);
-        }
+            }
 
-        if let Some(service_name) = params.get("service_name").expose().ok() {
-            conn_params.service_name(service_name);
-        }
+            OracleConnectionParams::new(username, password, connect_string)
+        } else {
+            let mut conn_params = OracleOnPremConnectionParamsBuilder::new(
+                params
+                    .get("host")
+                    .expose()
+                    .ok_or_else(|p| MissingParameterSnafu { parameter: p.0 }.build())?,
+                username,
+                password,
+            );
 
-        let conn = data_components::oracle::connection::connect(&conn_params.build())
+            if let Some(port_str) = params.get("port").expose().ok() {
+                let port = port_str.parse::<u16>().map_err(|_| {
+                    FailedToParsePortSnafu {
+                        port: port_str.to_string(),
+                    }
+                    .build()
+                })?;
+                conn_params.port(port);
+            }
+
+            if let Some(service_name) = params.get("service_name").expose().ok() {
+                conn_params.service_name(service_name);
+            }
+
+            conn_params.build()
+        };
+
+        // Optional parameter to specify mTLS Wallet directory
+        let tns_admin = params.get("tns_admin").expose().ok();
+
+        let conn = data_components::oracle::connection::connect(&connect_params, tns_admin)
             .await
             .context(UnableToCreateConnectionPoolSnafu)?;
 

--- a/crates/runtime/tests/oracle/common.rs
+++ b/crates/runtime/tests/oracle/common.rs
@@ -41,6 +41,30 @@ pub fn make_oracle_dataset(path: &str, name: &str, port: u16) -> Dataset {
     dataset
 }
 
+pub fn make_oracle_cloud_dataset(path: &str, name: &str) -> Dataset {
+    let mut dataset = Dataset::new(format!("oracle:{path}"), name.to_string());
+    let params = HashMap::from([
+        (
+            "oracle_connection_string".to_string(),
+            "${ env:ORACLE_CLOUD_CONNECTION_STRING }".to_string(),
+        ),
+        (
+            "oracle_username".to_string(),
+            "${ env:ORACLE_CLOUD_USERNAME }".to_string(),
+        ),
+        (
+            "oracle_password".to_string(),
+            "${ env:ORACLE_CLOUD_PASSWORD }".to_string(),
+        ),
+        (
+            "oracle_wallet_sso_cert".to_string(),
+            "${ env:ORACLE_CLOUD_WALLET_SSO_CERT }".to_string(),
+        ),
+    ]);
+    dataset.params = Some(DatasetParams::from_string_map(params));
+    dataset
+}
+
 #[instrument]
 pub async fn start_oracle_docker_container(
     container_name: &'static str,

--- a/crates/runtime/tests/oracle/mod.rs
+++ b/crates/runtime/tests/oracle/mod.rs
@@ -20,8 +20,10 @@ use data_components::oracle::oracle_connector;
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
 
 use crate::init_tracing;
-use crate::oracle::common::{make_oracle_dataset, start_oracle_docker_container};
-use crate::utils::{runtime_ready_check, test_request_context};
+use crate::oracle::common::{
+    make_oracle_cloud_dataset, make_oracle_dataset, start_oracle_docker_container,
+};
+use crate::utils::{runtime_ready_check, test_request_context, verify_env_secret_exists};
 
 pub mod common;
 
@@ -162,7 +164,7 @@ async fn init_oracle_db(port: u16) -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-async fn oracle_integration_test() -> Result<(), anyhow::Error> {
+async fn oracle_test_direct_connection() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
     test_request_context()
@@ -270,6 +272,59 @@ async fn oracle_integration_test() -> Result<(), anyhow::Error> {
                 tracing::error!("running_container.remove: {e}");
                  e
             })?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn oracle_test_cloud_mtls() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    for env_var in [
+        "ORACLE_CLOUD_CONNECTION_STRING",
+        "ORACLE_CLOUD_USERNAME",
+        "ORACLE_CLOUD_PASSWORD",
+        "ORACLE_CLOUD_WALLET_SSO_CERT",
+    ] {
+        verify_env_secret_exists(env_var)
+            .await
+            .map_err(anyhow::Error::msg)?;
+    }
+
+    test_request_context()
+        .scope(async {
+            let ds = make_oracle_cloud_dataset("\"NATION\"", "nation");
+
+            let app = AppBuilder::new("oracle_cloud_test")
+                .with_dataset(ds)
+                .build();
+
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_datafusion_configuration_fn(configure_test_datafusion)
+                .build()
+                .await;
+
+            let cloned_rt = Arc::new(rt.clone());
+
+            // Set a timeout for the test
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            run_and_snapshot_query(
+                &rt,
+                "select N_NAME, N_COMMENT from nation order by N_NAME limit 5",
+                "oracle_cloud_query_result",
+            )
+            .await?;
 
             Ok(())
         })

--- a/crates/runtime/tests/oracle/snapshots/integration__oracle__oracle_cloud_query_result.snap
+++ b/crates/runtime/tests/oracle/snapshots/integration__oracle__oracle_cloud_query_result.snap
@@ -1,0 +1,13 @@
+---
+source: crates/runtime/tests/oracle/mod.rs
+expression: formatted
+---
++-----------+------------------------------------------------------------------------------------------------------------+
+| N_NAME    | N_COMMENT                                                                                                  |
++-----------+------------------------------------------------------------------------------------------------------------+
+| ALGERIA   | haggle. carefully final deposits detect slyly agai                                                         |
+| ARGENTINA | al foxes promise slyly according to the regular accounts. bold requests alon                               |
+| BRAZIL    | y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special |
+| CANADA    | eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold      |
+| CHINA     | c dependencies. furiously express notornis sleep slyly regular accounts. ideas sleep. depos                |
++-----------+------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
## 📝 Summary

This PR adds support for mTLS/Wallet and TLS/Easy Connect connection options for Oracle Autonomous Databases via the following parameters:

- `oracle_connection_string`: The raw connection string (use either a TNS alias or an Easy Connect descriptor string)
- `oracle_wallet_sso_cert`: The base64-encoded `cwallet.sso` (wallet auto-login certificate) to use for mTLS authentication.
- `oracle_wallet`: Specifies the Oracle wallet location used to save the provided mTLS certificate or retrieve an existing/pre-downloaded certificate. See [TNS_ADMIN documentation](https://docs.oracle.com/en/database/oracle/oracle-database/19/ntqrf/about-tns-admin-parameter.html) for details.

**mTLS (Wallet-based)**

```yaml
  - from: oracle:"SALES"
    name: my.sales
    params:
      oracle_username: admin
      oracle_password: ${SPICE_ORACLE_PASSWORD}
      # TNS alias;
      oracle_connection_string: 'fgp1tqxys1e_low'
      # this can also be specified via env::TNS_ADMIN
      oracle_wallet: 'path/to/existing/wallet'


  - from: oracle:"SALES"
    name: my.sales
    params:
      oracle_username: admin
      oracle_password: ${SPICE_ORACLE_PASSWORD}
      # base64 encoded cwallet.sso
      oracle_wallet_sso_cert:  ${SPICE_ORACLE_WALLET_SSO_CERT}
      oracle_connection_string: '(description=(retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1522)(host=adb.us-sanjose-1.oraclecloud.com))(connect_data=(service_name=g81f1d801d5c853_fgp1t_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
```
**Easy Connect string (no wallet required / TLS-only)**

```yaml
- from: oracle:"SALES"
    name: my.sales
    params:
      oracle_username: admin
      oracle_password: ${SPICE_ORACLE_PASSWORD}
      # Easy Connect string (no wallet required for TLS-only)
      oracle_connection_string: 'tcps://adb.us-sanjose-1.oraclecloud.com:1522/g81f1d801d5c853_fgp1tqxyc1e_low.adb.oraclecloud.com?ssl_server_dn_match=yes'
```

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/6314

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Cloud Connection will be tested/used as part of automated benchmarks
