### PR TITLE
Fixes and reenable FTS tests

### DIFF
--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -137,7 +137,7 @@ impl VectorSearchTableFunc {
         ];
 
         if let Some(col) = args.column.as_ref() {
-            expr.push(Expr::Literal(ScalarValue::Utf8(Some(col.clone()))));
+            expr.push(Expr::Column(Column::new_unqualified(col)));
         }
         if let Some(limit) = args.limit {
             expr.push(Expr::Literal(ScalarValue::UInt64(Some(limit as u64))));

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -175,7 +175,7 @@ impl VectorSearchTableFunc {
             (None, None, None) => (None, None, Some(true)),
 
             // Single argument cases
-            (Some(Expr::Literal(ScalarValue::Utf8(Some(col)))), None, None) => {
+            (Some(Expr::Column(Column { name: col, .. })), None, None) => {
                 (Some(col.clone()), None, Some(true))
             }
             (Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))), None, None) => {
@@ -187,12 +187,12 @@ impl VectorSearchTableFunc {
 
             // 2 of 3 arguments. When user provides two of three arguments, they must still be in correct order (i.e. no limit before column)
             (
-                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Column(Column { name: col, .. })),
                 Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))),
                 None,
             ) => (Some(col.clone()), Some(*limit), Some(true)),
             (
-                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Column(Column { name: col, .. })),
                 Some(Expr::Literal(ScalarValue::Boolean(Some(include_score)))),
                 None,
             ) => (Some(col.clone()), None, Some(*include_score)),
@@ -204,7 +204,7 @@ impl VectorSearchTableFunc {
 
             // All three arguments provided
             (
-                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Column(Column { name: col, .. })),
                 Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))),
                 Some(Expr::Literal(ScalarValue::Boolean(Some(include_score)))),
             ) => (Some(col.clone()), Some(*limit), Some(*include_score)),

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -111,7 +111,7 @@ impl TextSearchTableFunc {
             (None, None, None) => (None, None, Some(true)),
 
             // Single argument cases
-            (Some(Expr::Literal(ScalarValue::Utf8(Some(col)))), None, None) => {
+            (Some(Expr::Column(Column { name: col, .. })), None, None) => {
                 (Some(col.clone()), None, Some(true))
             }
             (Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))), None, None) => {
@@ -123,12 +123,12 @@ impl TextSearchTableFunc {
 
             // 2 of 3 arguments. When user provides two of three arguments, they must still be in correct order (i.e. no limit before column)
             (
-                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Column(Column { name: col, .. })),
                 Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))),
                 None,
             ) => (Some(col.clone()), Some(*limit), Some(true)),
             (
-                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Column(Column { name: col, .. })),
                 Some(Expr::Literal(ScalarValue::Boolean(Some(include_score)))),
                 None,
             ) => (Some(col.clone()), None, Some(*include_score)),
@@ -140,7 +140,7 @@ impl TextSearchTableFunc {
 
             // All three arguments provided
             (
-                Some(Expr::Literal(ScalarValue::Utf8(Some(col)))),
+                Some(Expr::Column(Column { name: col, .. })),
                 Some(Expr::Literal(ScalarValue::UInt64(Some(limit)))),
                 Some(Expr::Literal(ScalarValue::Boolean(Some(include_score)))),
             ) => (Some(col.clone()), Some(*limit), Some(*include_score)),

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -303,10 +303,15 @@ impl TextSearchUDTFProvider {
             .all_columns()
             .iter()
             .filter_map(|field_name| {
-                let f = tantivy_schema.get_field(field_name).ok()?;
-                let entry = tantivy_schema.get_field_entry(f);
-                let data_type = tantivy_to_arrow_type(entry.field_type())?;
-                Some(Field::new(field_name, data_type, false))
+                let (data_type, nullable) = match field_index.get_type_hint(field_name) {
+                    Some(f) => (f.data_type().clone(), f.is_nullable()),
+                    None => {
+                        let f = tantivy_schema.get_field(field_name).ok()?;
+                        let entry = tantivy_schema.get_field_entry(f);
+                        (tantivy_to_arrow_type(entry.field_type())?, false)
+                    }
+                };
+                Some(Field::new(field_name, data_type, nullable))
             })
             .chain([Field::new(
                 SEARCH_SCORE_COLUMN_NAME,

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -303,13 +303,12 @@ impl TextSearchUDTFProvider {
             .all_columns()
             .iter()
             .filter_map(|field_name| {
-                let (data_type, nullable) = match field_index.get_type_hint(field_name) {
-                    Some(f) => (f.data_type().clone(), f.is_nullable()),
-                    None => {
-                        let f = tantivy_schema.get_field(field_name).ok()?;
-                        let entry = tantivy_schema.get_field_entry(f);
-                        (tantivy_to_arrow_type(entry.field_type())?, false)
-                    }
+                let (data_type, nullable) = if let Some(f) = field_index.get_type_hint(field_name) {
+                    (f.data_type().clone(), f.is_nullable())
+                } else {
+                    let f = tantivy_schema.get_field(field_name).ok()?;
+                    let entry = tantivy_schema.get_field_entry(f);
+                    (tantivy_to_arrow_type(entry.field_type())?, false)
                 };
                 Some(Field::new(field_name, data_type, nullable))
             })

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -528,7 +528,6 @@ async fn test_hybrid_search_multiple_column() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_text_search() -> Result<(), anyhow::Error> {
     let mut ds = get_tpcds_dataset("item", Some("item"), None);
     ds.columns = vec![Column {

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -463,7 +463,6 @@ async fn test_hybrid_search_single_column() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_hybrid_search_multiple_column() -> Result<(), anyhow::Error> {
     let mut ds = catalog_page_tpch_dataset_w_embeddings(
         "multi_column_hybrid_search",

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -580,7 +580,6 @@ async fn test_text_search() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_text_search_multiple_columns() -> Result<(), anyhow::Error> {
     let mut ds = get_tpcds_dataset(
             "catalog_page",
@@ -648,16 +647,16 @@ async fn test_text_search_multiple_columns() -> Result<(), anyhow::Error> {
         vec![
             (
                 "multi_text_column_sql_text_search_basic",
-                "SELECT cp_catalog_page_sk, score, cp_department FROM text_search(catalog_page, 'In general basic', cp_department) LIMIT 4"
+                "SELECT cp_catalog_page_sk, score, cp_department FROM text_search(catalog_page, 'DEPARTMENT', cp_department) LIMIT 4"
             ),
             // We expect an error if dataset has > 1 column and specific column isn't added in `text_search`.
             (
                 "multi_text_column_sql_text_search_error",
-                "SELECT cp_catalog_page_sk, score, cp_department FROM text_search(catalog_page, 'In general basic') LIMIT 4"
+                "SELECT cp_catalog_page_sk, score, cp_department FROM text_search(catalog_page, 'DEPARTMENT') LIMIT 4"
             ),
             (
                 "multi_text_column_sql_text_search_additional",
-                "SELECT cp_catalog_page_sk, score, cp_department, cp_description, cp_catalog_number FROM text_search(catalog_page, 'In general basic', cp_department) LIMIT 4"
+                "SELECT cp_catalog_page_sk, score, cp_department, cp_description, cp_catalog_number FROM text_search(catalog_page, 'DEPARTMENT', cp_department) LIMIT 4"
             ), (
                 "multi_text_column_sql_text_search_filters",
                 "SELECT cp_catalog_page_sk, score, cp_description FROM text_search(catalog_page, 'In general basic', cp_description) where cp_department='DEPARTMENT'LIMIT 4"

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -395,7 +395,6 @@ async fn test_multi_column_srch_no_pk() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_hybrid_search_single_column() -> Result<(), anyhow::Error> {
     let mut ds = catalog_page_tpch_dataset_w_embeddings(
         "hybrid_column_search",
@@ -449,15 +448,15 @@ async fn test_hybrid_search_single_column() -> Result<(), anyhow::Error> {
         vec![
             (
                 "hybrid_column_sql_text_search_basic",
-                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(hybrid_column_search, 'basic') LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
             ), (
                 "hybrid_column_sql_text_search_projection",
-                format!("SELECT cp_catalog_page_sk, score, {column_name}, cp_catalog_number FROM text_search(hybrid_column_search, 'basic') LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, score, {column_name}, cp_catalog_number FROM text_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
             ), (
                 "hybrid_column_sql_text_search_filters",
-                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(hybrid_column_search, 'basic') WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
             )
-        ]
+        ],
     )
     .await
 }

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -357,8 +357,8 @@ async fn test_multi_embedding_model_search() -> Result<(), anyhow::Error> {
     .await
 }
 
+// Ensure that if there is no primary key inferrable or available, that search results for multiple columns are not returned.
 #[tokio::test]
-#[ignore]
 async fn test_multi_column_srch_no_pk() -> Result<(), anyhow::Error> {
     let mut chunked =
         catalog_page_tpch_dataset_w_embeddings("mulit_column_no_pks", "hf_minilm", None, None);

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_search_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_search_additional_response.snap
@@ -12,23 +12,26 @@ snapshot_kind: text
       },
       "dataset": "hybrid_column_search",
       "matches": {
-        "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+        "cp_description": [
+          "In general basic characters welcome. Clearly lively friends conv",
+          "In general basic characters welcome. Clearly lively friends conv"
+        ]
       },
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "score": 0.016
+      "score": 0.032
     },
     {
       "data": {
-        "cp_catalog_number": 32
+        "cp_catalog_number": 1
       },
       "dataset": "hybrid_column_search",
       "matches": {
-        "cp_description": "Levels will attend ago general, basic ideas. Physical, "
+        "cp_description": "Close customers might struggle away different memb"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 3404
+        "cp_catalog_page_sk": 15
       },
       "score": 0.016
     }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_search_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_search_basic_response.snap
@@ -9,20 +9,23 @@ snapshot_kind: text
     {
       "dataset": "hybrid_column_search",
       "matches": {
-        "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+        "cp_description": [
+          "In general basic characters welcome. Clearly lively friends conv",
+          "In general basic characters welcome. Clearly lively friends conv"
+        ]
       },
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "score": 0.016
+      "score": 0.032
     },
     {
       "dataset": "hybrid_column_search",
       "matches": {
-        "cp_description": "Levels will attend ago general, basic ideas. Physical, "
+        "cp_description": "Close customers might struggle away different memb"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 3404
+        "cp_catalog_page_sk": 15
       },
       "score": 0.016
     }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_basic.snap
@@ -1,0 +1,12 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 1,
+    "score": 2.708303689956665,
+    "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_filters.snap
@@ -1,0 +1,12 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 1,
+    "score": 2.708303689956665,
+    "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_projection.snap
@@ -1,0 +1,13 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 1,
+    "score": 2.708303689956665,
+    "cp_description": "In general basic characters welcome. Clearly lively friends conv",
+    "cp_catalog_number": 1
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_additional_response.snap
@@ -12,12 +12,12 @@ snapshot_kind: text
       },
       "dataset": "multi_column_hybrid_search",
       "matches": {
-        "cp_description": "In general basic characters welcome. Clearly lively friends con"
+        "cp_description": "Close customers might struggle away different mem"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 1
+        "cp_catalog_page_sk": 15
       },
-      "score": 0.016
+      "score": 0.941
     },
     {
       "data": {
@@ -25,12 +25,12 @@ snapshot_kind: text
       },
       "dataset": "multi_column_hybrid_search",
       "matches": {
-        "cp_description": "Close customers might struggle away different mem"
+        "cp_description": "In general basic characters welcome. Clearly lively friends con"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 15
+        "cp_catalog_page_sk": 1
       },
-      "score": 0.016
+      "score": 0.941
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_hybrid_where_response.snap
@@ -14,7 +14,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "score": 0.016
+      "score": 0.942
     },
     {
       "dataset": "multi_column_hybrid_search",
@@ -24,7 +24,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 3
       },
-      "score": 0.016
+      "score": 0.938
     },
     {
       "dataset": "multi_column_hybrid_search",
@@ -34,7 +34,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 15
       },
-      "score": 0.015
+      "score": 0.936
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_additional_response.snap
@@ -17,20 +17,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "score": 12.843
-    },
-    {
-      "data": {
-        "cp_catalog_number": 1
-      },
-      "dataset": "catalog_page",
-      "matches": {
-        "cp_description": "Close times adopt only in a interests. Far strings might say slowly. Times go strictly cattle. Sign"
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 21
-      },
-      "score": 2.205
+      "score": 8.124
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_basic_response.snap
@@ -14,17 +14,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "score": 12.843
-    },
-    {
-      "dataset": "catalog_page",
-      "matches": {
-        "cp_description": "Levels will attend ago general, basic ideas. Physical, "
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 3404
-      },
-      "score": 10.345
+      "score": 8.124
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_additional.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_additional.snap
@@ -1,0 +1,35 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 7,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT",
+    "cp_description": "Years must understand. Well fat thousands take. Good police l",
+    "cp_catalog_number": 1
+  },
+  {
+    "cp_catalog_page_sk": 16,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT",
+    "cp_description": "Social pictures welcome almost british teams. Awful preparations leave ga",
+    "cp_catalog_number": 1
+  },
+  {
+    "cp_catalog_page_sk": 19,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT",
+    "cp_description": "Good questions borrow only base children. Remarkably present e",
+    "cp_catalog_number": 1
+  },
+  {
+    "cp_catalog_page_sk": 10,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT",
+    "cp_description": "Human, successive tears highlight also as radical produ",
+    "cp_catalog_number": 1
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_basic.snap
@@ -1,0 +1,27 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 7,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT"
+  },
+  {
+    "cp_catalog_page_sk": 16,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT"
+  },
+  {
+    "cp_catalog_page_sk": 19,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT"
+  },
+  {
+    "cp_catalog_page_sk": 10,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT"
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error.snap
@@ -1,0 +1,27 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 7,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT"
+  },
+  {
+    "cp_catalog_page_sk": 16,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT"
+  },
+  {
+    "cp_catalog_page_sk": 19,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT"
+  },
+  {
+    "cp_catalog_page_sk": 10,
+    "score": 0.02409752830862999,
+    "cp_department": "DEPARTMENT"
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_filters.snap
@@ -1,0 +1,12 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 1,
+    "score": 8.124911308288574,
+    "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_where_response.snap
@@ -14,27 +14,7 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 1
       },
-      "score": 12.843
-    },
-    {
-      "dataset": "catalog_page",
-      "matches": {
-        "cp_description": "Great, available rules find in addition groups; broad, local circumstances wa"
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 23
-      },
-      "score": 2.696
-    },
-    {
-      "dataset": "catalog_page",
-      "matches": {
-        "cp_description": "Close times adopt only in a interests. Far strings might say slowly. Times go strictly cattle. Sign"
-      },
-      "primary_key": {
-        "cp_catalog_page_sk": 21
-      },
-      "score": 2.205
+      "score": 8.124
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_basic_response.snap
@@ -18,21 +18,7 @@ snapshot_kind: text
       "primary_key": {
         "i_item_sk": 19
       },
-      "score": 10.071
-    },
-    {
-      "data": {
-        "i_color": "green",
-        "i_item_id": "AAAAAAAALNABAAAA"
-      },
-      "dataset": "item",
-      "matches": {
-        "i_item_desc": "Necessary patient"
-      },
-      "primary_key": {
-        "i_item_sk": 4315
-      },
-      "score": 9.641
+      "score": 4.284
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_basic.snap
@@ -1,0 +1,12 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "i_item_sk": 19,
+    "i_item_desc": "Patient",
+    "score": 4.284671306610107
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_filters.snap
@@ -1,0 +1,12 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "i_item_sk": 19,
+    "i_item_desc": "Patient",
+    "score": 4.284671306610107
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_projection.snap
@@ -1,0 +1,14 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "i_item_sk": 19,
+    "i_color": "smoke",
+    "i_item_id": "AAAAAAAADBAAAAAA",
+    "i_item_desc": "Patient",
+    "score": 4.284671306610107
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_with_extra_columns_and_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_with_extra_columns_and_where_response.snap
@@ -18,7 +18,7 @@ snapshot_kind: text
       "primary_key": {
         "i_item_sk": 19
       },
-      "score": 10.071
+      "score": 4.284
     }
   ]
 }

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -15,7 +15,7 @@ use std::{cmp::min, collections::HashMap, sync::Arc};
 use crate::{SEARCH_SCORE_COLUMN_NAME, SEARCH_VALUE_COLUMN_NAME};
 use arrow::{
     array::RecordBatch,
-    datatypes::{DataType, Field, FieldRef, Schema, SchemaRef},
+    datatypes::{Field, FieldRef, Schema, SchemaRef},
     error::ArrowError,
 };
 use arrow_json::reader::Decoder;
@@ -168,6 +168,7 @@ impl FullTextSearchFieldIndex {
         self.type_hints.insert(name.into(), field.into());
     }
 
+    #[must_use]
     pub fn get_type_hint(&self, name: &String) -> Option<&FieldRef> {
         self.type_hints.get(name)
     }

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -15,7 +15,7 @@ use std::{cmp::min, collections::HashMap, sync::Arc};
 use crate::{SEARCH_SCORE_COLUMN_NAME, SEARCH_VALUE_COLUMN_NAME};
 use arrow::{
     array::RecordBatch,
-    datatypes::{Field, Schema, SchemaRef},
+    datatypes::{DataType, Field, FieldRef, Schema, SchemaRef},
     error::ArrowError,
 };
 use arrow_json::reader::Decoder;
@@ -166,6 +166,10 @@ impl FullTextSearchFieldIndex {
 
     pub fn add_type_hint(&mut self, name: impl Into<String>, field: impl Into<Arc<Field>>) {
         self.type_hints.insert(name.into(), field.into());
+    }
+
+    pub fn get_type_hint(&self, name: &String) -> Option<&FieldRef> {
+        self.type_hints.get(name)
     }
 
     #[must_use]


### PR DESCRIPTION
## 📝 Summary
- This PR reenables several full text search tests. It also updates snapshots where needed and has several bug fixes. 

### Bug 1: Type Hints for FTS UDTF
 - Tantivy has more coarse types than Apache Arrow. As such, there can be schema mismatch problems when converting back into Arrow types (e.g. a table with primary key int32, would recevied int64 from its FTS index). To resolve this, the FTS index is created with type hints from the dataset associated to it.
 - The schema returned via the UDTF `TableProvider` did not propagate these type hints.

### Bug 2: Column type in UDTF
 - `text_search(catalog_page, 'In general basic', cp_description)` was incorrectly trying to parse the optional column argument as a string literal, instead of a column. 