### PR TITLE
HuggingFace cache directory in Sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,10 @@ RUN mkdir -p /spice_sandbox/bin && \
     mkdir -p /spice_sandbox/etc && \
     mkdir -p /spice_sandbox/etc/ssl && \
     mkdir -p /spice_sandbox/dev && \
-    mkdir -p /spice_sandbox/app
+    mkdir -p /spice_sandbox/app && \
+    mkdir -p /spice_sandbox/.cache && \
+    mkdir -p /spice_sandbox/.cache/huggingface
+
 
 # Copy the binary
 COPY --from=build /root/spiced /spice_sandbox/usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN chmod 755 /spice_sandbox/.duckdb
 
 # Give the nobody user ownership of app dir
 RUN chown -R 65534:65534 /spice_sandbox/app
+RUN chown -R 65534:65534 /spice_sandbox/.cache
 
 FROM scratch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,7 @@ RUN mkdir -p /spice_sandbox/bin && \
     mkdir -p /spice_sandbox/etc && \
     mkdir -p /spice_sandbox/etc/ssl && \
     mkdir -p /spice_sandbox/dev && \
-    mkdir -p /spice_sandbox/app && \
-    mkdir -p /spice_sandbox/.cache && \
-    mkdir -p /spice_sandbox/.cache/huggingface
+    mkdir -p /spice_sandbox/app
 
 
 # Copy the binary
@@ -77,7 +75,12 @@ RUN chmod 755 /spice_sandbox/.duckdb
 
 # Give the nobody user ownership of app dir
 RUN chown -R 65534:65534 /spice_sandbox/app
+
+# Create HuggingFace cache directory in sandbox
+RUN mkdir -p /spice_sandbox/.cache/huggingface/hub
 RUN chown -R 65534:65534 /spice_sandbox/.cache
+RUN chmod 755 /spice_sandbox/.cache
+ENV HF_HOME=/spice_sandbox/.cache/huggingface
 
 FROM scratch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,9 @@ RUN chown -R 65534:65534 /spice_sandbox/app
 # Create HuggingFace cache directory in sandbox
 RUN mkdir -p /spice_sandbox/.cache/huggingface/hub
 RUN chown -R 65534:65534 /spice_sandbox/.cache
-RUN chmod 755 /spice_sandbox/.cache
+RUN chmod -R 755 /spice_sandbox/.cache
 ENV HF_HOME=/spice_sandbox/.cache/huggingface
+ENV HF_HUB_CACHE=/spice_sandbox/.cache/huggingface/hub
 
 FROM scratch
 


### PR DESCRIPTION
## 📝 Summary
- For sandbox docker image, ensure `~/.cache/huggingface` exists and useable by `spiced`.
- This is needed for HF models (both embedding and LLMs). 