### PR TITLE
Upgrade DuckDB to 1.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4044,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=0af0b11112dd12ef786ce5714789580066008e78#0af0b11112dd12ef786ce5714789580066008e78"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a5a92f39edf5224a2b90cc57ab2c2ca083d52aab#a5a92f39edf5224a2b90cc57ab2c2ca083d52aab"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -4511,22 +4511,21 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=69ae7518ee093a1b070e9e4e6f011ef353431086#69ae7518ee093a1b070e9e4e6f011ef353431086"
+version = "1.3.2"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b3547f0c1b37030b623b1e03fcaea0e4e2bb753e#b3547f0c1b37030b623b1e03fcaea0e4e2bb753e"
 dependencies = [
  "arrow",
  "cast",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.10.0",
  "libduckdb-sys",
- "memchr",
  "num",
  "num-integer",
  "r2d2",
  "rust_decimal",
  "smallvec",
- "strum 0.25.0",
+ "strum 0.27.1",
 ]
 
 [[package]]
@@ -5806,6 +5805,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -7148,10 +7156,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.1.3"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=69ae7518ee093a1b070e9e4e6f011ef353431086#69ae7518ee093a1b070e9e4e6f011ef353431086"
+version = "1.3.2"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=b3547f0c1b37030b623b1e03fcaea0e4e2bb753e#b3547f0c1b37030b623b1e03fcaea0e4e2bb753e"
 dependencies = [
- "autocfg",
  "cc",
  "flate2",
  "pkg-config",
@@ -11439,7 +11446,7 @@ dependencies = [
  "chrono",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4044,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=a5a92f39edf5224a2b90cc57ab2c2ca083d52aab#a5a92f39edf5224a2b90cc57ab2c2ca083d52aab"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=2f3389ab88150fe13950f300e59baf510d1edf5a#2f3389ab88150fe13950f300e59baf510d1edf5a"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ datafusion-functions-json = "0.47"
 datafusion-table-providers = "0.1"
 delta_kernel = { version = "0.12", features = ["default-engine", "arrow-55"] }
 dotenvy = "0.15"
-duckdb = "1.1.3"
+duckdb = "1.3.2"
 fundu = "2.0.1"
 futures = "0.3.30"
 globset = "0.4.16"
@@ -205,9 +205,9 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" }       # spiceai-47
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9db74a4b360df6be1bb554c59a474a2fd4bfb7e9" }                      # spiceai-47
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "0af0b11112dd12ef786ce5714789580066008e78" } # spiceai
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a5a92f39edf5224a2b90cc57ab2c2ca083d52aab" } # phillip/250714-upgrade-duckdb
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "69ae7518ee093a1b070e9e4e6f011ef353431086" } # spiceai-1.1.3-backported-arrow-55
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b3547f0c1b37030b623b1e03fcaea0e4e2bb753e" } # spiceai-1.3.2
 
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af725caf5d3e952e349746706e00d0ea5" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" }       # spiceai-47
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9db74a4b360df6be1bb554c59a474a2fd4bfb7e9" }                      # spiceai-47
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "a5a92f39edf5224a2b90cc57ab2c2ca083d52aab" } # phillip/250714-upgrade-duckdb
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "2f3389ab88150fe13950f300e59baf510d1edf5a" } # spiceai
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b3547f0c1b37030b623b1e03fcaea0e4e2bb753e" } # spiceai-1.3.2
 


### PR DESCRIPTION
## 📝 Summary

Upgrades DuckDB to 1.3.2
