### PR TITLE
Fix issue in limit clause for the Github Data connector

### DIFF
--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -703,8 +703,6 @@ impl GraphQLQuery {
 
 pub(crate) struct GraphQLQueryResult {
     pub(crate) records: Vec<RecordBatch>,
-    #[allow(dead_code)]
-    record_count: usize,
     limit_reached: bool,
     pub(crate) schema: SchemaRef,
     cursor: Option<String>,
@@ -834,13 +832,10 @@ impl GraphQLClient {
             res.extend(batch);
         }
 
-        let record_count = res.len();
-
-        let limit_reached = query.limit_reached(limit, record_count);
+        let limit_reached = query.limit_reached(limit, res.len());
 
         Ok(GraphQLQueryResult {
             records: res,
-            record_count,
             limit_reached,
             schema: Arc::clone(&schema),
             cursor: next_cursor,

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -905,6 +905,10 @@ impl GraphQLClient {
                         DataFusionError::Execution("Failed to send record batch".to_string())
                     })?;
                 }
+
+                if result.limit_reached {
+                    break;
+                }
             }
             Ok(())
         });

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -884,8 +884,8 @@ impl GraphQLClient {
 
             while let Some(next_cursor_val) = result.cursor {
                 if let Some(p) = query.pagination_parameters.as_ref() {
-                    if limit.is_some() {
-                        limit = Some(p.reduce_limit(result.record_count));
+                    if let Some(value) = limit {
+                        limit = Some(p.reduce_limit(value));
                     }
                 }
 
@@ -904,10 +904,6 @@ impl GraphQLClient {
                     tx.send(Ok(batch)).await.map_err(|_| {
                         DataFusionError::Execution("Failed to send record batch".to_string())
                     })?;
-                }
-
-                if result.limit_reached {
-                    break;
                 }
             }
             Ok(())

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -703,6 +703,7 @@ impl GraphQLQuery {
 
 pub(crate) struct GraphQLQueryResult {
     pub(crate) records: Vec<RecordBatch>,
+    #[allow(dead_code)]
     record_count: usize,
     limit_reached: bool,
     pub(crate) schema: SchemaRef,

--- a/crates/runtime/tests/graphql/mod.rs
+++ b/crates/runtime/tests/graphql/mod.rs
@@ -182,7 +182,7 @@ impl QueryRoot {
 
     async fn single_paginated_users(&self, first: usize, after: Option<String>) -> UsersPaginated {
         let users_service = UserService::new();
-        let users = users_service.paginated_users(std::cmp::max(first, 1), after);
+        let users = users_service.paginated_users(std::cmp::min(first, 1), after);
         let all_users = users_service.users();
         let last_id = unsafe { all_users.last().unwrap_unchecked().id.clone() };
 

--- a/crates/runtime/tests/graphql/mod.rs
+++ b/crates/runtime/tests/graphql/mod.rs
@@ -205,6 +205,8 @@ async fn graphql_handler(schema: Extension<ServiceSchema>, req: GraphQLRequest) 
 
     // Append query to log for snapshot testing
     if let Ok(mut log) = QUERY_LOG.lock() {
+        // Push_str works because MutexGuard<String> implements DerefMut
+        // and allows us to modify the underlying String.
         log.push_str(query);
         log.push_str("\n---\n");
     }
@@ -467,7 +469,9 @@ async fn test_graphql_pagination_with_limit() -> Result<(), String> {
             assert_eq!(total, 3);
 
             if let Ok(log) = QUERY_LOG.lock() {
-                // No need to get the whole query, just snapshot the pagination since that's what's relevant
+                // We want to snapshot the `first` and `after` parameters to ensure pagination is working correctly with a `LIMIT`
+                // We don't need the body of the query to do so, so we can split on all lines and only take the ones containing `singlePaginatedUsers`
+                // This way, we know the lines we take have the `first` and `after` parameters and no other irrelevant details.
                 let filtered_log = log.lines()
                     .filter(|line| line.contains("singlePaginatedUsers"))
                     .collect::<Vec<_>>()

--- a/crates/runtime/tests/graphql/mod.rs
+++ b/crates/runtime/tests/graphql/mod.rs
@@ -17,9 +17,11 @@ limitations under the License.
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use app::AppBuilder;
 
+use arrow::array::RecordBatch;
 use async_graphql::{EmptyMutation, EmptySubscription, SimpleObject};
 use async_graphql::{Object, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
@@ -33,6 +35,10 @@ use crate::utils::test_request_context;
 use crate::{ValidateFn, configure_test_datafusion, init_tracing, run_query_and_check_results};
 
 type ServiceSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
+
+// Static string buffer to collect GraphQL queries
+static QUERY_LOG: std::sync::LazyLock<Mutex<String>> =
+    std::sync::LazyLock::new(|| Mutex::new(String::new()));
 
 #[derive(SimpleObject, Clone, Debug)]
 struct Post {
@@ -173,11 +179,37 @@ impl QueryRoot {
         };
         UsersPaginated { users, page_info }
     }
+
+    async fn single_paginated_users(&self, first: usize, after: Option<String>) -> UsersPaginated {
+        let users_service = UserService::new();
+        let users = users_service.paginated_users(std::cmp::max(first, 1), after);
+        let all_users = users_service.users();
+        let last_id = unsafe { all_users.last().unwrap_unchecked().id.clone() };
+
+        let (has_next_page, end_cursor) = if let Some(last_fetched) = users.last() {
+            (last_fetched.id < last_id, last_fetched.id.clone())
+        } else {
+            (false, String::new())
+        };
+
+        let page_info = PageInfo {
+            has_next_page,
+            end_cursor,
+        };
+        UsersPaginated { users, page_info }
+    }
 }
 
 async fn graphql_handler(schema: Extension<ServiceSchema>, req: GraphQLRequest) -> GraphQLResponse {
-    let response = schema.execute(req.into_inner()).await;
+    let query = &req.0.query.clone();
 
+    // Append query to log for snapshot testing
+    if let Ok(mut log) = QUERY_LOG.lock() {
+        log.push_str(query);
+        log.push_str("\n---\n");
+    }
+
+    let response = schema.execute(req.into_inner()).await;
     response.into()
 }
 
@@ -390,4 +422,73 @@ async fn test_graphql_pagination() -> Result<(), String> {
         Ok(())
     })
     .await
+}
+
+#[tokio::test]
+async fn test_graphql_pagination_with_limit() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context().scope(async {
+        let (tx, addr) = start_server().await?;
+        tracing::debug!("Server started at {}", addr);
+        let app = AppBuilder::new("graphql_integration_test")
+            .with_dataset(make_graphql_dataset(
+                &format!("http://{addr}/graphql"),
+                "test_graphql",
+                "query { singlePaginatedUsers(first: 1) { users { id name posts { id title content } } pageInfo { hasNextPage endCursor } } }",
+                "/data/singlePaginatedUsers/users",
+                None
+            ))
+            .build();
+
+        let mut rt =
+            Runtime::builder()
+                .with_app(app)
+                .with_datafusion_configuration_fn(configure_test_datafusion)
+                .build()
+                .await;
+
+        let cloned_rt = Arc::new(rt.clone());
+
+        tokio::select! {
+            () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                return Err("Timed out waiting for datasets to load".to_string());
+            }
+            () = cloned_rt.load_components() => {}
+        }
+
+        run_query_and_check_results(&mut rt, "test_graphql_pagination_with_limit", "select * from test_graphql limit 3;", false, Some(Box::new(|result_batches| {
+            let mut total = 0;
+            for batch in result_batches {
+                let batch: RecordBatch = batch;
+                assert_eq!(batch.num_columns(), 3, "num_cols: {}", batch.num_columns());
+                total += batch.num_rows();
+            }
+            assert_eq!(total, 3);
+
+            if let Ok(log) = QUERY_LOG.lock() {
+                // No need to get the whole query, just snapshot the pagination since that's what's relevant
+                let filtered_log = log.lines()
+                    .filter(|line| line.contains("singlePaginatedUsers"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                insta::with_settings!({
+                        description => format!("GraphQL Pagination With Limit Results"),
+                        omit_expression => true,
+                        snapshot_path => "../snapshots"
+                    }, {
+                        insta::assert_snapshot!("graphql_pagination_with_limit", filtered_log);
+                });
+            }
+        }))).await?;
+
+
+        tx.send(()).map_err(|()| {
+            tracing::error!("Failed to send shutdown signal");
+            "Failed to send shutdown signal".to_string()
+        })?;
+
+        Ok(())
+
+    }).await
 }

--- a/crates/runtime/tests/snapshots/integration__graphql__graphql_pagination_with_limit.snap
+++ b/crates/runtime/tests/snapshots/integration__graphql__graphql_pagination_with_limit.snap
@@ -1,0 +1,8 @@
+---
+source: crates/runtime/tests/graphql/mod.rs
+description: GraphQL Pagination With Limit Results
+---
+  singlePaginatedUsers (first: 1) {
+  singlePaginatedUsers (first: 1) {
+  singlePaginatedUsers (first: 1, after: "1") {
+  singlePaginatedUsers (first: 1, after: "2") {


### PR DESCRIPTION
## 📝 Summary
- Fixes an issue where any `LIMIT` over the maximum Github pagination size is effectively ignored and reduced to that max pagination size. 

## 🔗 Related

- Closes #6017

## Output
`spicepod.yaml`:
```yaml
datasets:
  - from: github:github.com/spiceai/spiceai/pulls
    name: spiceai.issues
    params:
      github_token: ${secrets:GITHUB_TOKEN}
    acceleration:
      enabled: true
      refresh_sql: SELECT * FROM spiceai.issues limit 202
```

Before:
```
2025-05-28T01:51:11.396805Z  INFO runtime::accelerated_table::refresh_task: Loaded 100 rows (491.41 kiB) for dataset spiceai.issues in 2s 841ms.
```

After:
```
2025-07-14T19:03:20.751068Z  INFO runtime::accelerated_table::refresh_task: Loaded 202 rows (973.83 kiB) for dataset spiceai.issues in 13s 304ms.
```
