### PR TITLE
Parse fully qualified table names in UDTFs

### DIFF
--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -56,7 +56,7 @@ use crate::{
     embedding_col,
     embeddings::table::{EmbeddingColumnConfig, EmbeddingTable},
     model::EmbeddingModelStore,
-    search::util::find_concrete_table_provider,
+    search::util::{find_concrete_table_provider, table_ref_from_column_expr},
 };
 use tokio::sync::RwLock;
 
@@ -152,16 +152,12 @@ impl VectorSearchTableFunc {
         let mut args = args.iter();
 
         let tbl = args.next();
-        let Some(Expr::Column(Column {
-            relation: None,
-            name: table_name,
-            ..
-        })) = tbl
-        else {
+        let Some(Expr::Column(c)) = tbl else {
             return Err(DataFusionError::Plan(format!(
                 "First argument must be a table reference, but got a different expression: {tbl:?}."
             )));
         };
+        let tbl_ref = table_ref_from_column_expr(&c);
 
         let query = args.next();
         let Some(Expr::Literal(ScalarValue::Utf8(Some(q)))) = query else {
@@ -212,12 +208,12 @@ impl VectorSearchTableFunc {
             // Invalid argument combinations
             (a, b, c) => {
                 return Err(DataFusionError::Plan(format!(
-                    "Invalid arguments: ({table_name}, {q}, {a:?}, {b:?}, {c:?}. Expected (table, query, [column, limit, include_score])."
+                    "Invalid arguments: ({tbl_ref:?}, {q}, {a:?}, {b:?}, {c:?}. Expected (table, query, [column, limit, include_score])."
                 )));
             }
         };
         Ok(VectorSearchTableFuncArgs {
-            tbl: table_name.into(),
+            tbl: tbl_ref,
             query: q.to_string(),
             column,
             limit: limit.map(|l| usize::try_from(l).unwrap_or(usize::MAX)),

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -56,7 +56,7 @@ use crate::{
     embedding_col,
     embeddings::table::{EmbeddingColumnConfig, EmbeddingTable},
     model::EmbeddingModelStore,
-    search::util::{find_concrete_table_provider, table_ref_from_column_expr},
+    search::util::{find_concrete_table_provider, table_ref_from_column_expr, to_column_expr},
 };
 use tokio::sync::RwLock;
 
@@ -132,7 +132,7 @@ impl VectorSearchTableFunc {
     #[must_use]
     pub fn to_expr(args: &VectorSearchTableFuncArgs) -> Vec<Expr> {
         let mut expr = vec![
-            Expr::Column(Column::new_unqualified(args.tbl.to_string())),
+            Expr::Column(to_column_expr(&args.tbl)),
             Expr::Literal(ScalarValue::Utf8(Some(args.query.clone()))),
         ];
 
@@ -157,7 +157,7 @@ impl VectorSearchTableFunc {
                 "First argument must be a table reference, but got a different expression: {tbl:?}."
             )));
         };
-        let tbl_ref = table_ref_from_column_expr(&c);
+        let tbl_ref = table_ref_from_column_expr(c);
 
         let query = args.next();
         let Some(Expr::Literal(ScalarValue::Utf8(Some(q)))) = query else {

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -55,7 +55,10 @@ use search::{
 
 use crate::{
     datafusion::DataFusion,
-    search::{full_text::index::FullTextDatabaseIndex, util::find_concrete_table_provider},
+    search::{
+        full_text::index::FullTextDatabaseIndex,
+        util::{find_concrete_table_provider, table_ref_from_column_expr},
+    },
 };
 
 pub static TEXT_SEARCH_UDTF_NAME: &str = "text_search";
@@ -88,16 +91,12 @@ impl TextSearchTableFunc {
         let mut args = args.iter();
 
         let tbl = args.next();
-        let Some(Expr::Column(Column {
-            relation: None,
-            name: table_name,
-            ..
-        })) = tbl
-        else {
+        let Some(Expr::Column(c)) = tbl else {
             return Err(DataFusionError::Plan(format!(
                 "First argument must be a table reference, but got a different expression: {tbl:?}."
             )));
         };
+        let tbl_ref = table_ref_from_column_expr(&c);
 
         let query = args.next();
         let Some(Expr::Literal(ScalarValue::Utf8(Some(q)))) = query else {
@@ -148,12 +147,12 @@ impl TextSearchTableFunc {
             // Invalid argument combinations
             (a, b, c) => {
                 return Err(DataFusionError::Plan(format!(
-                    "Invalid arguments: ({table_name}, {q}, {a:?}, {b:?}, {c:?}. Expected (table, query, [column, limit, include_score])."
+                    "Invalid arguments: ({tbl_ref:?}, {q}, {a:?}, {b:?}, {c:?}. Expected (table, query, [column, limit, include_score])."
                 )));
             }
         };
         Ok(TextSearchTableFuncArgs {
-            tbl: table_name.into(),
+            tbl: tbl_ref,
             query: q.to_string(),
             column,
             limit: limit.map(|l| usize::try_from(l).unwrap_or(usize::MAX)),

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -96,7 +96,7 @@ impl TextSearchTableFunc {
                 "First argument must be a table reference, but got a different expression: {tbl:?}."
             )));
         };
-        let tbl_ref = table_ref_from_column_expr(&c);
+        let tbl_ref = table_ref_from_column_expr(c);
 
         let query = args.next();
         let Some(Expr::Literal(ScalarValue::Utf8(Some(q)))) = query else {

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -226,13 +226,14 @@ pub async fn full_text_search_candidates(
 /// There is no [`Expr`] that can parse a fully qualified table name. For UDTFs that require
 /// tables as an input [`Expr`], it will be parsed as a [`Column`]. This function converts a
 ///  [`Column`] to the [`TableReference`] intended.
+#[must_use]
 pub fn table_ref_from_column_expr(c: &Column) -> TableReference {
     let table: Arc<str> = c.name.clone().into();
-    let schema: Option<&str> = c.relation.as_ref().map(|r| r.table());
-    let catalog: Option<&str> = c.relation.as_ref().and_then(|r| r.schema().clone());
+    let schema: Option<&str> = c.relation.as_ref().map(TableReference::table);
+    let catalog: Option<&str> = c.relation.as_ref().and_then(TableReference::schema);
     match (catalog, schema) {
         // Catalog without schema is impossible.
-        (None, None) | (Some(_), None) => TableReference::Bare { table },
+        (None | Some(_), None) => TableReference::Bare { table },
         (None, Some(s)) => TableReference::Partial {
             schema: s.into(),
             table,
@@ -242,6 +243,30 @@ pub fn table_ref_from_column_expr(c: &Column) -> TableReference {
             schema: s.into(),
             table,
         },
+    }
+}
+
+// Constructs the associated [`Column`] derived from [`table_ref_from_column_expr`].
+pub fn to_column_expr(tbl: &TableReference) -> Column {
+    match tbl {
+        TableReference::Bare { table } => Column::new_unqualified(table.to_string()),
+        TableReference::Partial { schema, table } => Column::new(
+            Some(TableReference::Bare {
+                table: Arc::clone(schema),
+            }),
+            table.to_string(),
+        ),
+        TableReference::Full {
+            catalog,
+            schema,
+            table,
+        } => Column::new(
+            Some(TableReference::Partial {
+                schema: Arc::clone(catalog),
+                table: Arc::clone(schema),
+            }),
+            table.to_string(),
+        ),
     }
 }
 

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -18,6 +18,7 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use app::App;
+use datafusion::common::Column;
 use datafusion::{common::Constraint, datasource::TableProvider, sql::TableReference};
 use datafusion_federation::FederatedTableProviderAdaptor;
 use runtime_datafusion_index::IndexedTableProvider;
@@ -220,6 +221,28 @@ pub async fn full_text_search_candidates(
             .as_candidate_generations()
             .context(SearchGenerationSnafu),
     )
+}
+
+/// There is no [`Expr`] that can parse a fully qualified table name. For UDTFs that require
+/// tables as an input [`Expr`], it will be parsed as a [`Column`]. This function converts a
+///  [`Column`] to the [`TableReference`] intended.
+pub fn table_ref_from_column_expr(c: &Column) -> TableReference {
+    let table: Arc<str> = c.name.clone().into();
+    let schema: Option<&str> = c.relation.as_ref().map(|r| r.table());
+    let catalog: Option<&str> = c.relation.as_ref().and_then(|r| r.schema().clone());
+    match (catalog, schema) {
+        // Catalog without schema is impossible.
+        (None, None) | (Some(_), None) => TableReference::Bare { table },
+        (None, Some(s)) => TableReference::Partial {
+            schema: s.into(),
+            table,
+        },
+        (Some(c), Some(s)) => TableReference::Full {
+            catalog: c.into(),
+            schema: s.into(),
+            table,
+        },
+    }
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -247,6 +247,7 @@ pub fn table_ref_from_column_expr(c: &Column) -> TableReference {
 }
 
 // Constructs the associated [`Column`] derived from [`table_ref_from_column_expr`].
+#[must_use]
 pub fn to_column_expr(tbl: &TableReference) -> Column {
     match tbl {
         TableReference::Bare { table } => Column::new_unqualified(table.to_string()),

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -448,23 +448,23 @@ async fn test_hybrid_search_single_column() -> Result<(), anyhow::Error> {
         vec![
             (
                 "hybrid_column_sql_text_search_basic",
-                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, trunc(score, 3), {column_name} FROM text_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
             ), (
                 "hybrid_column_sql_text_search_projection",
-                format!("SELECT cp_catalog_page_sk, score, {column_name}, cp_catalog_number FROM text_search(public.hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, trunc(score, 3), {column_name}, cp_catalog_number FROM text_search(public.hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
             ), (
                 "hybrid_column_sql_text_search_filters",
-                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(spice.public.hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, trunc(score, 3), {column_name} FROM text_search(spice.public.hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
             ),
             (
                 "hybrid_column_sql_vector_search_basic",
-                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM vector_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, trunc(score, 3), {column_name} FROM vector_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
             ), (
                 "hybrid_column_sql_vector_search_projection",
-                format!("SELECT cp_catalog_page_sk, score, {column_name}, cp_catalog_number FROM vector_search(public.hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, trunc(score, 3), {column_name}, cp_catalog_number FROM vector_search(public.hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
             ), (
                 "hybrid_column_sql_vector_search_filters",
-                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM vector_search(spice.public.hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, trunc(score, 3), {column_name} FROM vector_search(spice.public.hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
             )
         ],
     )
@@ -574,13 +574,13 @@ async fn test_text_search() -> Result<(), anyhow::Error> {
         vec![
             (
                 "text_search_sql_text_search_basic",
-                "SELECT i_item_sk, i_item_desc, score FROM text_search(item, 'Patient') LIMIT 4"
+                "SELECT i_item_sk, i_item_desc, trunc(score, 3) FROM text_search(item, 'Patient') LIMIT 4"
             ), (
                 "text_search_sql_text_search_projection",
-                "SELECT i_item_sk, i_color, i_item_id, i_item_desc, score FROM text_search(item, 'Patient') LIMIT 4"
+                "SELECT i_item_sk, i_color, i_item_id, i_item_desc, trunc(score, 3) FROM text_search(item, 'Patient') LIMIT 4"
             ), (
                 "text_search_sql_text_search_filters",
-                "SELECT i_item_sk, i_item_desc, score FROM text_search(item, 'Patient') where i_color='smoke' LIMIT 4"
+                "SELECT i_item_sk, i_item_desc, trunc(score, 3) FROM text_search(item, 'Patient') where i_color='smoke' LIMIT 4"
             )
         ]
     )
@@ -655,19 +655,19 @@ async fn test_text_search_multiple_columns() -> Result<(), anyhow::Error> {
         vec![
             (
                 "multi_text_column_sql_text_search_basic",
-                "SELECT cp_catalog_page_sk, score, cp_department FROM text_search(catalog_page, 'DEPARTMENT', cp_department) LIMIT 4"
+                "SELECT cp_catalog_page_sk, trunc(score, 3), cp_department FROM text_search(catalog_page, 'DEPARTMENT', cp_department) LIMIT 4"
             ),
             // We expect an error if dataset has > 1 column and specific column isn't added in `text_search`.
             (
                 "multi_text_column_sql_text_search_error",
-                "SELECT cp_catalog_page_sk, score, cp_department FROM text_search(catalog_page, 'DEPARTMENT') LIMIT 4"
+                "SELECT cp_catalog_page_sk, trunc(score, 3), cp_department FROM text_search(catalog_page, 'DEPARTMENT') LIMIT 4"
             ),
             (
                 "multi_text_column_sql_text_search_additional",
-                "SELECT cp_catalog_page_sk, score, cp_department, cp_description, cp_catalog_number FROM text_search(catalog_page, 'DEPARTMENT', cp_department) LIMIT 4"
+                "SELECT cp_catalog_page_sk, trunc(score, 3), cp_department, cp_description, cp_catalog_number FROM text_search(catalog_page, 'DEPARTMENT', cp_department) LIMIT 4"
             ), (
                 "multi_text_column_sql_text_search_filters",
-                "SELECT cp_catalog_page_sk, score, cp_description FROM text_search(catalog_page, 'In general basic', cp_description) where cp_department='DEPARTMENT'LIMIT 4"
+                "SELECT cp_catalog_page_sk, trunc(score, 3), cp_description FROM text_search(catalog_page, 'In general basic', cp_description) where cp_department='DEPARTMENT'LIMIT 4"
             )
         ]
     )

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -455,6 +455,16 @@ async fn test_hybrid_search_single_column() -> Result<(), anyhow::Error> {
             ), (
                 "hybrid_column_sql_text_search_filters",
                 format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(spice.public.hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
+            ),
+            (
+                "hybrid_column_sql_vector_search_basic",
+                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM vector_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
+            ), (
+                "hybrid_column_sql_vector_search_projection",
+                format!("SELECT cp_catalog_page_sk, score, {column_name}, cp_catalog_number FROM vector_search(public.hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
+            ), (
+                "hybrid_column_sql_vector_search_filters",
+                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM vector_search(spice.public.hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
             )
         ],
     )

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -451,10 +451,10 @@ async fn test_hybrid_search_single_column() -> Result<(), anyhow::Error> {
                 format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
             ), (
                 "hybrid_column_sql_text_search_projection",
-                format!("SELECT cp_catalog_page_sk, score, {column_name}, cp_catalog_number FROM text_search(hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, score, {column_name}, cp_catalog_number FROM text_search(public.hybrid_column_search, 'basic', {column_name}) LIMIT 4").as_str()
             ), (
                 "hybrid_column_sql_text_search_filters",
-                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
+                format!("SELECT cp_catalog_page_sk, score, {column_name} FROM text_search(spice.public.hybrid_column_search, 'basic', {column_name}) WHERE cp_catalog_page_sk % 2 = 1 LIMIT 4").as_str()
             )
         ],
     )

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_basic.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 1,
-    "score": 2.708303689956665,
+    "trunc(text_search().score,Int64(3))": 2.708,
     "cp_description": "In general basic characters welcome. Clearly lively friends conv"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_filters.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 1,
-    "score": 2.708303689956665,
+    "trunc(text_search().score,Int64(3))": 2.708,
     "cp_description": "In general basic characters welcome. Clearly lively friends conv"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_text_search_projection.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 1,
-    "score": 2.708303689956665,
+    "trunc(text_search().score,Int64(3))": 2.708,
     "cp_description": "In general basic characters welcome. Clearly lively friends conv",
     "cp_catalog_number": 1
   }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_basic.snap
@@ -6,22 +6,22 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 1,
-    "score": 0.9474588746475064,
+    "trunc(vector_search().score,Int64(3))": 0.947,
     "cp_description": "In general basic characters welcome. Clearly lively friends conv"
   },
   {
     "cp_catalog_page_sk": 15,
-    "score": 0.940280433917256,
+    "trunc(vector_search().score,Int64(3))": 0.94,
     "cp_description": "Close customers might struggle away different memb"
   },
   {
     "cp_catalog_page_sk": 3,
-    "score": 0.937372876029606,
+    "trunc(vector_search().score,Int64(3))": 0.937,
     "cp_description": "Earlier different differences get just to a methods; masses includ"
   },
   {
     "cp_catalog_page_sk": 7,
-    "score": 0.9264550927529996,
+    "trunc(vector_search().score,Int64(3))": 0.926,
     "cp_description": "Years must understand. Well fat thousands take. Good police l"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_basic.snap
@@ -1,0 +1,27 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 1,
+    "score": 0.9474588746475064,
+    "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+  },
+  {
+    "cp_catalog_page_sk": 15,
+    "score": 0.940280433917256,
+    "cp_description": "Close customers might struggle away different memb"
+  },
+  {
+    "cp_catalog_page_sk": 3,
+    "score": 0.937372876029606,
+    "cp_description": "Earlier different differences get just to a methods; masses includ"
+  },
+  {
+    "cp_catalog_page_sk": 7,
+    "score": 0.9264550927529996,
+    "cp_description": "Years must understand. Well fat thousands take. Good police l"
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_filters.snap
@@ -1,0 +1,27 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 1,
+    "score": 0.9474588746475064,
+    "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+  },
+  {
+    "cp_catalog_page_sk": 3,
+    "score": 0.937372876029606,
+    "cp_description": "Earlier different differences get just to a methods; masses includ"
+  },
+  {
+    "cp_catalog_page_sk": 5,
+    "score": 0.8738318249864706,
+    "cp_description": "Narrowly great dogs carry only by the events. Successful, able legs would not"
+  },
+  {
+    "cp_catalog_page_sk": 7,
+    "score": 0.9264550927529996,
+    "cp_description": "Years must understand. Well fat thousands take. Good police l"
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_filters.snap
@@ -6,22 +6,22 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 1,
-    "score": 0.9474588746475064,
+    "trunc(vector_search().score,Int64(3))": 0.947,
     "cp_description": "In general basic characters welcome. Clearly lively friends conv"
   },
   {
     "cp_catalog_page_sk": 3,
-    "score": 0.937372876029606,
+    "trunc(vector_search().score,Int64(3))": 0.937,
     "cp_description": "Earlier different differences get just to a methods; masses includ"
   },
   {
     "cp_catalog_page_sk": 5,
-    "score": 0.8738318249864706,
+    "trunc(vector_search().score,Int64(3))": 0.874,
     "cp_description": "Narrowly great dogs carry only by the events. Successful, able legs would not"
   },
   {
     "cp_catalog_page_sk": 7,
-    "score": 0.9264550927529996,
+    "trunc(vector_search().score,Int64(3))": 0.926,
     "cp_description": "Years must understand. Well fat thousands take. Good police l"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_projection.snap
@@ -6,25 +6,25 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 1,
-    "score": 0.9474588746475064,
+    "trunc(vector_search().score,Int64(3))": 0.947,
     "cp_description": "In general basic characters welcome. Clearly lively friends conv",
     "cp_catalog_number": 1
   },
   {
     "cp_catalog_page_sk": 15,
-    "score": 0.940280433917256,
+    "trunc(vector_search().score,Int64(3))": 0.94,
     "cp_description": "Close customers might struggle away different memb",
     "cp_catalog_number": 1
   },
   {
     "cp_catalog_page_sk": 3,
-    "score": 0.937372876029606,
+    "trunc(vector_search().score,Int64(3))": 0.937,
     "cp_description": "Earlier different differences get just to a methods; masses includ",
     "cp_catalog_number": 1
   },
   {
     "cp_catalog_page_sk": 7,
-    "score": 0.9264550927529996,
+    "trunc(vector_search().score,Int64(3))": 0.926,
     "cp_description": "Years must understand. Well fat thousands take. Good police l",
     "cp_catalog_number": 1
   }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_column_sql_vector_search_projection.snap
@@ -1,0 +1,31 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp
+snapshot_kind: text
+---
+[
+  {
+    "cp_catalog_page_sk": 1,
+    "score": 0.9474588746475064,
+    "cp_description": "In general basic characters welcome. Clearly lively friends conv",
+    "cp_catalog_number": 1
+  },
+  {
+    "cp_catalog_page_sk": 15,
+    "score": 0.940280433917256,
+    "cp_description": "Close customers might struggle away different memb",
+    "cp_catalog_number": 1
+  },
+  {
+    "cp_catalog_page_sk": 3,
+    "score": 0.937372876029606,
+    "cp_description": "Earlier different differences get just to a methods; masses includ",
+    "cp_catalog_number": 1
+  },
+  {
+    "cp_catalog_page_sk": 7,
+    "score": 0.9264550927529996,
+    "cp_description": "Years must understand. Well fat thousands take. Good police l",
+    "cp_catalog_number": 1
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_additional.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_additional.snap
@@ -6,28 +6,28 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 7,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT",
     "cp_description": "Years must understand. Well fat thousands take. Good police l",
     "cp_catalog_number": 1
   },
   {
     "cp_catalog_page_sk": 16,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT",
     "cp_description": "Social pictures welcome almost british teams. Awful preparations leave ga",
     "cp_catalog_number": 1
   },
   {
     "cp_catalog_page_sk": 19,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT",
     "cp_description": "Good questions borrow only base children. Remarkably present e",
     "cp_catalog_number": 1
   },
   {
     "cp_catalog_page_sk": 10,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT",
     "cp_description": "Human, successive tears highlight also as radical produ",
     "cp_catalog_number": 1

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_basic.snap
@@ -6,22 +6,22 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 7,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT"
   },
   {
     "cp_catalog_page_sk": 16,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT"
   },
   {
     "cp_catalog_page_sk": 19,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT"
   },
   {
     "cp_catalog_page_sk": 10,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_error.snap
@@ -6,22 +6,22 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 7,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT"
   },
   {
     "cp_catalog_page_sk": 16,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT"
   },
   {
     "cp_catalog_page_sk": 19,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT"
   },
   {
     "cp_catalog_page_sk": 10,
-    "score": 0.02409752830862999,
+    "trunc(text_search().score,Int64(3))": 0.024,
     "cp_department": "DEPARTMENT"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_filters.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 [
   {
     "cp_catalog_page_sk": 1,
-    "score": 8.124911308288574,
+    "trunc(text_search().score,Int64(3))": 8.125,
     "cp_description": "In general basic characters welcome. Clearly lively friends conv"
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_basic.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_basic.snap
@@ -7,6 +7,6 @@ snapshot_kind: text
   {
     "i_item_sk": 19,
     "i_item_desc": "Patient",
-    "score": 4.284671306610107
+    "trunc(text_search().score,Int64(3))": 4.285
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_filters.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_filters.snap
@@ -7,6 +7,6 @@ snapshot_kind: text
   {
     "i_item_sk": 19,
     "i_item_desc": "Patient",
-    "score": 4.284671306610107
+    "trunc(text_search().score,Int64(3))": 4.285
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_projection.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_sql_text_search_projection.snap
@@ -9,6 +9,6 @@ snapshot_kind: text
     "i_color": "smoke",
     "i_item_id": "AAAAAAAADBAAAAAA",
     "i_item_desc": "Patient",
-    "score": 4.284671306610107
+    "trunc(text_search().score,Int64(3))": 4.285
   }
 ]


### PR DESCRIPTION
## 📝 Summary
User reported error

```shell
sql> SELECT cveId, score FROM vector_search(nginx.cve, 'test') limit 5;
Client specified an invalid argument.
First argument must be a table reference, but got a different expression:
    Some(Column(Column { relation: Some(Bare { table: "nginx" }), name: "cve" })).
```

This is because the UDTF `Expr` cannot parse tables. Instead, it parses into `Column`s. This PR:
- Does the conversion to a `TableReference` manually for both `vector_search` and `text_search` UDTFs.
- Expands search testing to use all of: `hybrid_column_search`, `public.hybrid_column_search` and `spice.public.hybrid_column_search`. 