### PR TITLE
Add option to preinstall Oracle ODPI-C library in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim as sandbox-setup
 
 ARG CARGO_FEATURES
 
+ARG INSTALL_ORACLE_ODPIC=false
+
 # Install required packages
 RUN apt update \
     && apt install --yes ca-certificates libssl3 findutils --no-install-recommends \
@@ -64,6 +66,31 @@ RUN ldd /spice_sandbox/usr/local/bin/spiced | grep -o '/[^ ]*' | xargs -I '{}' s
 RUN find /lib /usr/lib -name 'libpthread.so.0' -exec sh -c 'mkdir -p /spice_sandbox/$(dirname "{}") && cp "{}" "/spice_sandbox{}"' \;
 RUN find /lib /usr/lib -name 'librt.so.1' -exec sh -c 'mkdir -p /spice_sandbox/$(dirname "{}") && cp "{}" "/spice_sandbox{}"' \;
 RUN find /lib /usr/lib -name 'libdl.so.2' -exec sh -c 'mkdir -p /spice_sandbox/$(dirname "{}") && cp "{}" "/spice_sandbox{}"' \;
+
+
+# Preinstall Oracle ODPI-C (if enabled)
+RUN if [ "$INSTALL_ORACLE_ODPIC" = "true" ]; then \
+    apt-get update && apt-get install -y --no-install-recommends libaio1 unzip curl; \
+    ARCH=$(dpkg --print-architecture); \
+    if [ "$ARCH" = "amd64" ]; then \
+    curl -sSL https://download.oracle.com/otn_software/linux/instantclient/2380000/instantclient-basiclite-linux.x64-23.8.0.25.04.zip -o basic.zip; \
+    elif [ "$ARCH" = "arm64" ]; then \
+    curl -sSL https://download.oracle.com/otn_software/linux/instantclient/2380000/instantclient-basiclite-linux.arm64-23.8.0.25.04.zip -o basic.zip; \
+    fi; \
+    unzip basic.zip && \
+    cp -v \
+    instantclient_*/libclntsh.so.23.1 \
+    instantclient_*/libclntshcore.so.23.1 \
+    instantclient_*/libnnz.so \
+    instantclient_*/libociicus.so \
+    instantclient_*/fips.so \
+    instantclient_*/legacy.so \
+    /spice_sandbox/usr/lib && \
+    ln -s libclntsh.so.23.1 /spice_sandbox/usr/lib/libclntsh.so && \
+    ln -s libclntshcore.so.23.1 /spice_sandbox/usr/lib/libclntshcore.so && \
+    cp "$(find /usr/lib /lib -name 'libaio.so.1' | head -n 1)" /spice_sandbox/usr/lib && \
+    cp "$(find /usr/lib /lib -name 'libresolv.so.2' | head -n 1)" /spice_sandbox/usr/lib; \
+    fi
 
 # Minimal passwd & group for the nobody user
 RUN echo 'nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin' > /spice_sandbox/etc/passwd && \


### PR DESCRIPTION
## 📝 Summary

This PR adds support for the optional `INSTALL_ORACLE_ODPIC` Docker build parameter, which enables pre-installing the Oracle ODPI-C library in the Docker image when set.

```yaml
services:
  spiceai:
    # platform: linux/amd64
    build:
      context: .
      dockerfile: Dockerfile
      args:
        RUST_VERSION: 1.86
        CARGO_FEATURES: release
        RUST_PROFILE: release
        INSTALL_ORACLE_ODPIC: "true"
    image: spiceai-enterprise:latest

    volumes:
      - ./spicepod.yaml:/app/spicepod.yaml:ro
      - ./.env:/app/.env:ro
      - ./spicepod.yaml:/spice_sandbox/app/spicepod.yaml:ro
      - ./.env:/spice_sandbox/app/.env:ro

    ports:
      - "8090:8090"
      - "50051:50051"
```
## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
