### PR TITLE
Add per-dataset availability monitor configuration

### DIFF
--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -17,8 +17,8 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use super::{
-    Dataset, Error, Mode, ReadyState, Result, TimeFormat, UnsupportedTypeAction, acceleration,
-    replication, validate_identifier,
+    AvailabilityMonitor, Dataset, Error, Mode, ReadyState, Result, TimeFormat,
+    UnsupportedTypeAction, acceleration, replication, validate_identifier,
 };
 use crate::{Runtime, component::dataset::acceleration::Engine};
 use app::App;
@@ -26,7 +26,10 @@ use datafusion::sql::TableReference;
 use serde_json::Value;
 use snafu::prelude::*;
 use spicepod::{
-    component::{dataset as spicepod_dataset, embeddings::ColumnEmbeddingConfig},
+    component::{
+        dataset::{self as spicepod_dataset},
+        embeddings::ColumnEmbeddingConfig,
+    },
     metric::Metrics,
     param::Params,
     semantic::Column,
@@ -54,7 +57,7 @@ pub struct DatasetBuilder {
     pub metrics: Metrics,
     pub runtime: Option<Arc<Runtime>>,
     pub vectors: Option<VectorStore>,
-    pub availability_monitor_enabled: bool,
+    pub availability_monitor: AvailabilityMonitor,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
@@ -131,7 +134,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             metrics: dataset.metrics.unwrap_or_default(),
             runtime: None,
             vectors: dataset.vectors,
-            availability_monitor_enabled: dataset.availability_monitor_enabled,
+            availability_monitor: AvailabilityMonitor::from(dataset.availability_monitor),
         })
     }
 }
@@ -159,7 +162,7 @@ impl DatasetBuilder {
             metrics: Metrics::default(),
             runtime: None,
             vectors: None,
-            availability_monitor_enabled: true,
+            availability_monitor: AvailabilityMonitor::default(),
         })
     }
 
@@ -246,7 +249,7 @@ impl DatasetBuilder {
             metrics: self.metrics,
             runtime,
             vectors: self.vectors,
-            availability_monitor_enabled: self.availability_monitor_enabled,
+            availability_monitor: self.availability_monitor,
         };
 
         Ok(dataset)

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -54,6 +54,7 @@ pub struct DatasetBuilder {
     pub metrics: Metrics,
     pub runtime: Option<Arc<Runtime>>,
     pub vectors: Option<VectorStore>,
+    pub availability_monitor_enabled: bool,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
@@ -130,6 +131,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             metrics: dataset.metrics.unwrap_or_default(),
             runtime: None,
             vectors: dataset.vectors,
+            availability_monitor_enabled: dataset.availability_monitor_enabled,
         })
     }
 }
@@ -157,6 +159,7 @@ impl DatasetBuilder {
             metrics: Metrics::default(),
             runtime: None,
             vectors: None,
+            availability_monitor_enabled: true,
         })
     }
 
@@ -243,6 +246,7 @@ impl DatasetBuilder {
             metrics: self.metrics,
             runtime,
             vectors: self.vectors,
+            availability_monitor_enabled: self.availability_monitor_enabled,
         };
 
         Ok(dataset)

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -17,8 +17,8 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use super::{
-    AvailabilityMonitor, Dataset, Error, Mode, ReadyState, Result, TimeFormat,
-    UnsupportedTypeAction, acceleration, replication, validate_identifier,
+    CheckAvailability, Dataset, Error, Mode, ReadyState, Result, TimeFormat, UnsupportedTypeAction,
+    acceleration, replication, validate_identifier,
 };
 use crate::{Runtime, component::dataset::acceleration::Engine};
 use app::App;
@@ -57,7 +57,7 @@ pub struct DatasetBuilder {
     pub metrics: Metrics,
     pub runtime: Option<Arc<Runtime>>,
     pub vectors: Option<VectorStore>,
-    pub availability_monitor: AvailabilityMonitor,
+    pub check_availability: CheckAvailability,
 }
 
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
@@ -134,7 +134,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             metrics: dataset.metrics.unwrap_or_default(),
             runtime: None,
             vectors: dataset.vectors,
-            availability_monitor: AvailabilityMonitor::from(dataset.availability_monitor),
+            check_availability: CheckAvailability::from(dataset.check_availability),
         })
     }
 }
@@ -162,7 +162,7 @@ impl DatasetBuilder {
             metrics: Metrics::default(),
             runtime: None,
             vectors: None,
-            availability_monitor: AvailabilityMonitor::default(),
+            check_availability: CheckAvailability::default(),
         })
     }
 
@@ -249,7 +249,7 @@ impl DatasetBuilder {
             metrics: self.metrics,
             runtime,
             vectors: self.vectors,
-            availability_monitor: self.availability_monitor,
+            check_availability: self.check_availability,
         };
 
         Ok(dataset)

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -217,7 +217,7 @@ impl Display for ReadyState {
 
 /// Controls whether the federated table periodically has its availability checked.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub enum AvailabilityMonitor {
+pub enum CheckAvailability {
     /// The dataset is checked for availability if it isn't accelerated.
     #[default]
     Default,
@@ -225,20 +225,20 @@ pub enum AvailabilityMonitor {
     Disabled,
 }
 
-impl From<spicepod_dataset::AvailabilityMonitor> for AvailabilityMonitor {
-    fn from(monitor: spicepod_dataset::AvailabilityMonitor) -> Self {
+impl From<spicepod_dataset::CheckAvailability> for CheckAvailability {
+    fn from(monitor: spicepod_dataset::CheckAvailability) -> Self {
         match monitor {
-            spicepod_dataset::AvailabilityMonitor::Default => AvailabilityMonitor::Default,
-            spicepod_dataset::AvailabilityMonitor::Disabled => AvailabilityMonitor::Disabled,
+            spicepod_dataset::CheckAvailability::Default => CheckAvailability::Default,
+            spicepod_dataset::CheckAvailability::Disabled => CheckAvailability::Disabled,
         }
     }
 }
 
-impl Display for AvailabilityMonitor {
+impl Display for CheckAvailability {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AvailabilityMonitor::Default => write!(f, "default"),
-            AvailabilityMonitor::Disabled => write!(f, "disabled"),
+            CheckAvailability::Default => write!(f, "default"),
+            CheckAvailability::Disabled => write!(f, "disabled"),
         }
     }
 }
@@ -266,7 +266,7 @@ pub struct Dataset {
     pub metrics: Metrics,
     pub runtime: Arc<Runtime>,
     pub vectors: Option<VectorStore>,
-    pub availability_monitor: AvailabilityMonitor,
+    pub check_availability: CheckAvailability,
 }
 
 impl std::fmt::Debug for Dataset {
@@ -292,7 +292,7 @@ impl std::fmt::Debug for Dataset {
             .field("ready_state", &self.ready_state)
             .field("metrics", &self.metrics)
             .field("vectors", &self.vectors)
-            .field("availability_monitor", &self.availability_monitor)
+            .field("check_availability", &self.check_availability)
             .finish_non_exhaustive()
     }
 }
@@ -318,7 +318,7 @@ impl PartialEq for Dataset {
             && self.columns == other.columns
             && self.metrics == other.metrics
             && self.vectors == other.vectors
-            && self.availability_monitor == other.availability_monitor
+            && self.check_availability == other.check_availability
     }
 }
 

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -215,6 +215,34 @@ impl Display for ReadyState {
     }
 }
 
+/// Controls whether the federated table periodically has its availability checked.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum AvailabilityMonitor {
+    /// The dataset is checked for availability if it isn't accelerated.
+    #[default]
+    Default,
+    /// The dataset is not checked for availability.
+    Disabled,
+}
+
+impl From<spicepod_dataset::AvailabilityMonitor> for AvailabilityMonitor {
+    fn from(monitor: spicepod_dataset::AvailabilityMonitor) -> Self {
+        match monitor {
+            spicepod_dataset::AvailabilityMonitor::Default => AvailabilityMonitor::Default,
+            spicepod_dataset::AvailabilityMonitor::Disabled => AvailabilityMonitor::Disabled,
+        }
+    }
+}
+
+impl Display for AvailabilityMonitor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AvailabilityMonitor::Default => write!(f, "default"),
+            AvailabilityMonitor::Disabled => write!(f, "disabled"),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Dataset {
     pub from: String,
@@ -238,7 +266,7 @@ pub struct Dataset {
     pub metrics: Metrics,
     pub runtime: Arc<Runtime>,
     pub vectors: Option<VectorStore>,
-    pub availability_monitor_enabled: bool,
+    pub availability_monitor: AvailabilityMonitor,
 }
 
 impl std::fmt::Debug for Dataset {
@@ -264,10 +292,7 @@ impl std::fmt::Debug for Dataset {
             .field("ready_state", &self.ready_state)
             .field("metrics", &self.metrics)
             .field("vectors", &self.vectors)
-            .field(
-                "availability_monitor_enabled",
-                &self.availability_monitor_enabled,
-            )
+            .field("availability_monitor", &self.availability_monitor)
             .finish_non_exhaustive()
     }
 }
@@ -293,7 +318,7 @@ impl PartialEq for Dataset {
             && self.columns == other.columns
             && self.metrics == other.metrics
             && self.vectors == other.vectors
-            && self.availability_monitor_enabled == other.availability_monitor_enabled
+            && self.availability_monitor == other.availability_monitor
     }
 }
 

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -238,6 +238,7 @@ pub struct Dataset {
     pub metrics: Metrics,
     pub runtime: Arc<Runtime>,
     pub vectors: Option<VectorStore>,
+    pub availability_monitor_enabled: bool,
 }
 
 impl std::fmt::Debug for Dataset {
@@ -263,6 +264,10 @@ impl std::fmt::Debug for Dataset {
             .field("ready_state", &self.ready_state)
             .field("metrics", &self.metrics)
             .field("vectors", &self.vectors)
+            .field(
+                "availability_monitor_enabled",
+                &self.availability_monitor_enabled,
+            )
             .finish_non_exhaustive()
     }
 }
@@ -288,6 +293,7 @@ impl PartialEq for Dataset {
             && self.columns == other.columns
             && self.metrics == other.metrics
             && self.vectors == other.vectors
+            && self.availability_monitor_enabled == other.availability_monitor_enabled
     }
 }
 

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -30,7 +30,7 @@ use tokio::sync::Mutex;
 use tracing_futures::Instrument;
 
 use crate::{
-    component::dataset::{AvailabilityMonitor, Dataset},
+    component::dataset::{CheckAvailability, Dataset},
     datafusion::{DataFusion, error::find_datafusion_root},
     metrics,
 };
@@ -120,7 +120,7 @@ impl DatasetsHealthMonitor {
             return Ok(());
         }
 
-        if matches!(dataset.availability_monitor, AvailabilityMonitor::Disabled) {
+        if matches!(dataset.check_availability, CheckAvailability::Disabled) {
             tracing::debug!(
                 "Skipping dataset {} for availability monitoring (disabled in config)",
                 dataset.name

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -120,6 +120,11 @@ impl DatasetsHealthMonitor {
             return Ok(());
         }
 
+        if !dataset.availability_monitor_enabled {
+            tracing::debug!("Skipping dataset {} for availability monitoring (disabled in config)", dataset.name);
+            return Ok(());
+        }
+
         let dataset_name = &dataset.name.to_string();
 
         tracing::debug!("Registering dataset {dataset_name} for periodic availability check");

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -95,7 +95,7 @@ enum AvailabilityVerificationResult {
 
 pub struct DatasetsHealthMonitor {
     df: Arc<DataFusion>,
-    monitored_datasets: Arc<Mutex<HashMap<String, Arc<DatasetAvailabilityInfo>>>>,
+    pub monitored_datasets: Arc<Mutex<HashMap<String, Arc<DatasetAvailabilityInfo>>>>,
     is_task_history_enabled: bool,
 }
 

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -63,7 +63,7 @@ pub enum Error {
 }
 
 #[derive(Clone)]
-struct DatasetAvailabilityInfo {
+pub struct DatasetAvailabilityInfo {
     name: String,
     table_provider: Arc<dyn TableProvider>,
     last_available_time: SystemTime,

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -30,7 +30,7 @@ use tokio::sync::Mutex;
 use tracing_futures::Instrument;
 
 use crate::{
-    component::dataset::Dataset,
+    component::dataset::{AvailabilityMonitor, Dataset},
     datafusion::{DataFusion, error::find_datafusion_root},
     metrics,
 };
@@ -120,7 +120,7 @@ impl DatasetsHealthMonitor {
             return Ok(());
         }
 
-        if !dataset.availability_monitor_enabled {
+        if matches!(dataset.availability_monitor, AvailabilityMonitor::Disabled) {
             tracing::debug!(
                 "Skipping dataset {} for availability monitoring (disabled in config)",
                 dataset.name
@@ -239,7 +239,7 @@ AND labels.error_code IS NULL"
                 // Only datasets without recent activity/availability
                 let datasets_to_check = datasets_for_availability_check(&monitored_datasets).await;
 
-                // check `task_history` first to exlude anything that had a successful query in the last 10 minutes
+                // check `task_history` first to exclude anything that had a successful query in the last 10 minutes
                 let recently_accessed_datasets = if is_task_history_enabled {
                     match Self::get_recently_accessed_datasets(Arc::clone(&df)).await {
                         Ok(datasets) => datasets,

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -121,7 +121,10 @@ impl DatasetsHealthMonitor {
         }
 
         if !dataset.availability_monitor_enabled {
-            tracing::debug!("Skipping dataset {} for availability monitoring (disabled in config)", dataset.name);
+            tracing::debug!(
+                "Skipping dataset {} for availability monitoring (disabled in config)",
+                dataset.name
+            );
             return Ok(());
         }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -493,6 +493,11 @@ impl Runtime {
         Arc::clone(&self.schedulers)
     }
 
+    #[must_use]
+    pub fn datasets_health_monitor(&self) -> Option<Arc<DatasetsHealthMonitor>> {
+        self.datasets_health_monitor.clone()
+    }
+
     /// Requests a loaded extension, or will attempt to load it if part of the autoloaded extensions.
     pub async fn extension(self: Arc<Self>, name: &str) -> Option<Arc<dyn Extension>> {
         let extensions = self.extensions.read().await;

--- a/crates/runtime/tests/dataset_availability/mod.rs
+++ b/crates/runtime/tests/dataset_availability/mod.rs
@@ -20,10 +20,10 @@ use runtime::{
     component::dataset::{Dataset, builder::DatasetBuilder},
     datasets_health_monitor::DatasetsHealthMonitor,
 };
-use spicepod::component::dataset::AvailabilityMonitor;
+use spicepod::component::dataset::CheckAvailability;
 use std::sync::Arc;
 
-async fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyhow::Error> {
+async fn get_test_dataset_with_check_availability_disabled() -> Result<Dataset, anyhow::Error> {
     let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
         "./tests/file/datatypes.parquet"
     } else if std::fs::exists("./crates/runtime/tests/file/datatypes.parquet")? {
@@ -34,7 +34,7 @@ async fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset
 
     let mut spicepod_dataset =
         spicepod::component::dataset::Dataset::new(format!("file:{file_path}"), "datatypes");
-    spicepod_dataset.availability_monitor = AvailabilityMonitor::Disabled;
+    spicepod_dataset.check_availability = CheckAvailability::Disabled;
 
     let app = AppBuilder::new("test")
         .with_dataset(spicepod_dataset.clone())
@@ -78,17 +78,16 @@ async fn get_test_dataset_with_acceleration() -> Result<Dataset, anyhow::Error> 
 }
 
 #[tokio::test]
-async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result<(), anyhow::Error>
-{
+async fn dataset_check_availability_register_skipped_when_disabled() -> Result<(), anyhow::Error> {
     // Create a test runtime to get DataFusion instance
-    let app = AppBuilder::new("dataset_availability_monitor_test").build();
+    let app = AppBuilder::new("dataset_check_availability_test").build();
     let rt = Runtime::builder().with_app(app).build().await;
 
     // Create DatasetsHealthMonitor directly
     let monitor = DatasetsHealthMonitor::new(rt.datafusion());
 
     // Create dataset with availability monitor disabled
-    let dataset = get_test_dataset_with_availability_monitor_disabled().await?;
+    let dataset = get_test_dataset_with_check_availability_disabled().await?;
 
     // Try to register the dataset - should be skipped
     let result = monitor.register_dataset(&dataset).await;
@@ -102,10 +101,10 @@ async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result
 }
 
 #[tokio::test]
-async fn dataset_availability_monitor_register_skipped_when_accelerated()
--> Result<(), anyhow::Error> {
+async fn dataset_check_availability_register_skipped_when_accelerated() -> Result<(), anyhow::Error>
+{
     // Create a test runtime to get DataFusion instance
-    let app = AppBuilder::new("dataset_availability_monitor_test").build();
+    let app = AppBuilder::new("dataset_check_availability_test").build();
     let rt = Runtime::builder().with_app(app).build().await;
 
     // Create DatasetsHealthMonitor directly

--- a/crates/runtime/tests/dataset_availability/mod.rs
+++ b/crates/runtime/tests/dataset_availability/mod.rs
@@ -20,32 +20,8 @@ use runtime::{
     component::dataset::{Dataset, builder::DatasetBuilder},
     datasets_health_monitor::DatasetsHealthMonitor,
 };
+use spicepod::component::dataset::AvailabilityMonitor;
 use std::sync::Arc;
-
-async fn get_test_dataset() -> Result<Dataset, anyhow::Error> {
-    let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
-        "./tests/file/datatypes.parquet"
-    } else if std::fs::exists("./crates/runtime/tests/file/datatypes.parquet")? {
-        "./crates/runtime/tests/file/datatypes.parquet"
-    } else {
-        return Err(anyhow::anyhow!("Could not find datatypes.parquet file"));
-    };
-
-    let spicepod_dataset =
-        spicepod::component::dataset::Dataset::new(format!("file:{file_path}"), "datatypes");
-    let app = AppBuilder::new("test")
-        .with_dataset(spicepod_dataset.clone())
-        .build();
-    let rt = Runtime::builder().with_app(app).build().await;
-
-    let dataset = DatasetBuilder::try_from(spicepod_dataset)?
-        .with_app(Arc::new(AppBuilder::new("test").build()))
-        .with_runtime(Arc::new(rt))
-        .build()
-        .map_err(|e| anyhow::anyhow!("Failed to build dataset: {}", e))?;
-
-    Ok(dataset)
-}
 
 async fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyhow::Error> {
     let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
@@ -58,7 +34,7 @@ async fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset
 
     let mut spicepod_dataset =
         spicepod::component::dataset::Dataset::new(format!("file:{file_path}"), "datatypes");
-    spicepod_dataset.availability_monitor_enabled = false;
+    spicepod_dataset.availability_monitor = AvailabilityMonitor::Disabled;
 
     let app = AppBuilder::new("test")
         .with_dataset(spicepod_dataset.clone())

--- a/crates/runtime/tests/dataset_availability_monitor.rs
+++ b/crates/runtime/tests/dataset_availability_monitor.rs
@@ -15,11 +15,14 @@ limitations under the License.
 */
 
 use app::AppBuilder;
-use runtime::{Runtime, datasets_health_monitor::DatasetsHealthMonitor};
-use spicepod::component::dataset::Dataset;
+use runtime::{
+    Runtime,
+    component::dataset::{Dataset, builder::DatasetBuilder},
+    datasets_health_monitor::DatasetsHealthMonitor,
+};
 use std::sync::Arc;
 
-fn get_test_dataset() -> Result<Dataset, anyhow::Error> {
+async fn get_test_dataset() -> Result<Dataset, anyhow::Error> {
     let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
         "./tests/file/datatypes.parquet"
     } else if std::fs::exists("./crates/runtime/tests/file/datatypes.parquet")? {
@@ -28,10 +31,23 @@ fn get_test_dataset() -> Result<Dataset, anyhow::Error> {
         return Err(anyhow::anyhow!("Could not find datatypes.parquet file"));
     };
 
-    Ok(Dataset::new(format!("file:{file_path}"), "datatypes"))
+    let spicepod_dataset =
+        spicepod::component::dataset::Dataset::new(format!("file:{file_path}"), "datatypes");
+    let app = AppBuilder::new("test")
+        .with_dataset(spicepod_dataset.clone())
+        .build();
+    let rt = Runtime::builder().with_app(app).build().await;
+
+    let dataset = DatasetBuilder::try_from(spicepod_dataset)?
+        .with_app(Arc::new(AppBuilder::new("test").build()))
+        .with_runtime(Arc::new(rt))
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build dataset: {}", e))?;
+
+    Ok(dataset)
 }
 
-fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyhow::Error> {
+async fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyhow::Error> {
     let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
         "./tests/file/datatypes.parquet"
     } else if std::fs::exists("./crates/runtime/tests/file/datatypes.parquet")? {
@@ -40,8 +56,48 @@ fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyh
         return Err(anyhow::anyhow!("Could not find datatypes.parquet file"));
     };
 
-    let mut dataset = Dataset::new(format!("file:{file_path}"), "datatypes");
-    dataset.availability_monitor_enabled = false;
+    let mut spicepod_dataset =
+        spicepod::component::dataset::Dataset::new(format!("file:{file_path}"), "datatypes");
+    spicepod_dataset.availability_monitor_enabled = false;
+
+    let app = AppBuilder::new("test")
+        .with_dataset(spicepod_dataset.clone())
+        .build();
+    let rt = Runtime::builder().with_app(app).build().await;
+
+    let dataset = DatasetBuilder::try_from(spicepod_dataset)?
+        .with_app(Arc::new(AppBuilder::new("test").build()))
+        .with_runtime(Arc::new(rt))
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build dataset: {}", e))?;
+
+    Ok(dataset)
+}
+
+async fn get_test_dataset_with_acceleration() -> Result<Dataset, anyhow::Error> {
+    let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
+        "./tests/file/datatypes.parquet"
+    } else if std::fs::exists("./crates/runtime/tests/file/datatypes.parquet")? {
+        "./crates/runtime/tests/file/datatypes.parquet"
+    } else {
+        return Err(anyhow::anyhow!("Could not find datatypes.parquet file"));
+    };
+
+    let mut spicepod_dataset =
+        spicepod::component::dataset::Dataset::new(format!("file:{file_path}"), "datatypes");
+    spicepod_dataset.acceleration = Some(spicepod::acceleration::Acceleration::default());
+
+    let app = AppBuilder::new("test")
+        .with_dataset(spicepod_dataset.clone())
+        .build();
+    let rt = Runtime::builder().with_app(app).build().await;
+
+    let dataset = DatasetBuilder::try_from(spicepod_dataset)?
+        .with_app(Arc::new(AppBuilder::new("test").build()))
+        .with_runtime(Arc::new(rt))
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to build dataset: {}", e))?;
+
     Ok(dataset)
 }
 
@@ -49,17 +105,14 @@ fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyh
 async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result<(), anyhow::Error>
 {
     // Create a test runtime to get DataFusion instance
-    let app = AppBuilder::new("dataset_availability_monitor_test")
-        .with_dataset(get_test_dataset()?)
-        .build();
-
+    let app = AppBuilder::new("dataset_availability_monitor_test").build();
     let rt = Runtime::builder().with_app(app).build().await;
 
     // Create DatasetsHealthMonitor directly
-    let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
+    let monitor = DatasetsHealthMonitor::new(rt.datafusion());
 
     // Create dataset with availability monitor disabled
-    let dataset = get_test_dataset_with_availability_monitor_disabled()?;
+    let dataset = get_test_dataset_with_availability_monitor_disabled().await?;
 
     // Try to register the dataset - should be skipped
     let result = monitor.register_dataset(&dataset).await;
@@ -76,17 +129,14 @@ async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result
 async fn dataset_availability_monitor_register_succeeds_when_enabled() -> Result<(), anyhow::Error>
 {
     // Create a test runtime to get DataFusion instance
-    let app = AppBuilder::new("dataset_availability_monitor_test")
-        .with_dataset(get_test_dataset()?)
-        .build();
-
+    let app = AppBuilder::new("dataset_availability_monitor_test").build();
     let rt = Runtime::builder().with_app(app).build().await;
 
     // Create DatasetsHealthMonitor directly
-    let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
+    let monitor = DatasetsHealthMonitor::new(rt.datafusion());
 
     // Create dataset with availability monitor enabled (default)
-    let dataset = get_test_dataset()?;
+    let dataset = get_test_dataset().await?;
 
     // Try to register the dataset - should succeed
     let result = monitor.register_dataset(&dataset).await;
@@ -104,18 +154,14 @@ async fn dataset_availability_monitor_register_succeeds_when_enabled() -> Result
 async fn dataset_availability_monitor_register_skipped_when_accelerated()
 -> Result<(), anyhow::Error> {
     // Create a test runtime to get DataFusion instance
-    let app = AppBuilder::new("dataset_availability_monitor_test")
-        .with_dataset(get_test_dataset()?)
-        .build();
-
+    let app = AppBuilder::new("dataset_availability_monitor_test").build();
     let rt = Runtime::builder().with_app(app).build().await;
 
     // Create DatasetsHealthMonitor directly
-    let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
+    let monitor = DatasetsHealthMonitor::new(rt.datafusion());
 
     // Create dataset with acceleration enabled (which should skip monitoring)
-    let mut dataset = get_test_dataset()?;
-    dataset.acceleration = Some(spicepod::acceleration::Acceleration::default());
+    let dataset = get_test_dataset_with_acceleration().await?;
 
     // Try to register the dataset - should be skipped due to acceleration
     let result = monitor.register_dataset(&dataset).await;
@@ -131,14 +177,12 @@ async fn dataset_availability_monitor_register_skipped_when_accelerated()
 #[tokio::test]
 async fn dataset_availability_monitor_disabled_when_builder_not_called() -> Result<(), anyhow::Error>
 {
-    let app = AppBuilder::new("dataset_availability_monitor_test")
-        .with_dataset(get_test_dataset()?)
-        .build();
+    let app = AppBuilder::new("dataset_availability_monitor_test").build();
 
     // Build runtime WITHOUT calling with_datasets_health_monitor
     let rt = Runtime::builder().with_app(app).build().await;
 
     // Monitor should be disabled since with_datasets_health_monitor wasn't called
-    assert!(rt.datasets_health_monitor.is_none());
+    assert!(rt.datasets_health_monitor().is_none());
     Ok(())
 }

--- a/crates/runtime/tests/dataset_availability_monitor.rs
+++ b/crates/runtime/tests/dataset_availability_monitor.rs
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::Arc;
 use app::AppBuilder;
 use runtime::{Runtime, datasets_health_monitor::DatasetsHealthMonitor};
 use spicepod::component::dataset::Dataset;
+use std::sync::Arc;
 
 fn get_test_dataset() -> Result<Dataset, anyhow::Error> {
     let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
@@ -45,120 +45,99 @@ fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyh
     Ok(dataset)
 }
 
-#[tokio::test]
-async fn dataset_availability_monitor_enabled_by_default() -> Result<(), anyhow::Error> {
-    let dataset = get_test_dataset()?;
-    assert!(dataset.availability_monitor_enabled);
-    Ok(())
-}
 
 #[tokio::test]
-async fn dataset_availability_monitor_disabled_via_config() -> Result<(), anyhow::Error> {
-    let dataset = get_test_dataset_with_availability_monitor_disabled()?;
-    assert!(!dataset.availability_monitor_enabled);
-    Ok(())
-}
-
-#[tokio::test]
-async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result<(), anyhow::Error> {
+async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result<(), anyhow::Error>
+{
     // Create a test runtime to get DataFusion instance
     let app = AppBuilder::new("dataset_availability_monitor_test")
         .with_dataset(get_test_dataset()?)
         .build();
 
-    let rt = Runtime::builder()
-        .with_app(app)
-        .build()
-        .await;
+    let rt = Runtime::builder().with_app(app).build().await;
 
     // Create DatasetsHealthMonitor directly
     let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
-    
+
     // Create dataset with availability monitor disabled
     let dataset = get_test_dataset_with_availability_monitor_disabled()?;
-    
+
     // Try to register the dataset - should be skipped
     let result = monitor.register_dataset(&dataset).await;
     assert!(result.is_ok());
-    
+
     // Check that monitored_datasets is empty
     let monitored_datasets = monitor.monitored_datasets.lock().await;
     assert!(monitored_datasets.is_empty());
-    
+
     Ok(())
 }
 
 #[tokio::test]
-async fn dataset_availability_monitor_register_succeeds_when_enabled() -> Result<(), anyhow::Error> {
+async fn dataset_availability_monitor_register_succeeds_when_enabled() -> Result<(), anyhow::Error>
+{
     // Create a test runtime to get DataFusion instance
     let app = AppBuilder::new("dataset_availability_monitor_test")
         .with_dataset(get_test_dataset()?)
         .build();
 
-    let rt = Runtime::builder()
-        .with_app(app)
-        .build()
-        .await;
+    let rt = Runtime::builder().with_app(app).build().await;
 
     // Create DatasetsHealthMonitor directly
     let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
-    
+
     // Create dataset with availability monitor enabled (default)
     let dataset = get_test_dataset()?;
-    
+
     // Try to register the dataset - should succeed
     let result = monitor.register_dataset(&dataset).await;
     assert!(result.is_ok());
-    
+
     // Check that monitored_datasets contains the dataset
     let monitored_datasets = monitor.monitored_datasets.lock().await;
     assert_eq!(monitored_datasets.len(), 1);
     assert!(monitored_datasets.contains_key("datatypes"));
-    
+
     Ok(())
 }
 
 #[tokio::test]
-async fn dataset_availability_monitor_register_skipped_when_accelerated() -> Result<(), anyhow::Error> {
+async fn dataset_availability_monitor_register_skipped_when_accelerated()
+-> Result<(), anyhow::Error> {
     // Create a test runtime to get DataFusion instance
     let app = AppBuilder::new("dataset_availability_monitor_test")
         .with_dataset(get_test_dataset()?)
         .build();
 
-    let rt = Runtime::builder()
-        .with_app(app)
-        .build()
-        .await;
+    let rt = Runtime::builder().with_app(app).build().await;
 
     // Create DatasetsHealthMonitor directly
     let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
-    
+
     // Create dataset with acceleration enabled (which should skip monitoring)
     let mut dataset = get_test_dataset()?;
     dataset.acceleration = Some(spicepod::acceleration::Acceleration::default());
-    
+
     // Try to register the dataset - should be skipped due to acceleration
     let result = monitor.register_dataset(&dataset).await;
     assert!(result.is_ok());
-    
+
     // Check that monitored_datasets is empty
     let monitored_datasets = monitor.monitored_datasets.lock().await;
     assert!(monitored_datasets.is_empty());
-    
+
     Ok(())
 }
 
 #[tokio::test]
-async fn dataset_availability_monitor_disabled_when_builder_not_called() -> Result<(), anyhow::Error> {
+async fn dataset_availability_monitor_disabled_when_builder_not_called() -> Result<(), anyhow::Error>
+{
     let app = AppBuilder::new("dataset_availability_monitor_test")
         .with_dataset(get_test_dataset()?)
         .build();
 
     // Build runtime WITHOUT calling with_datasets_health_monitor
-    let rt = Runtime::builder()
-        .with_app(app)
-        .build()
-        .await;
+    let rt = Runtime::builder().with_app(app).build().await;
 
     // Monitor should be disabled since with_datasets_health_monitor wasn't called
     assert!(rt.datasets_health_monitor.is_none());

--- a/crates/runtime/tests/dataset_availability_monitor.rs
+++ b/crates/runtime/tests/dataset_availability_monitor.rs
@@ -45,7 +45,6 @@ fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyh
     Ok(dataset)
 }
 
-
 #[tokio::test]
 async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result<(), anyhow::Error>
 {

--- a/crates/runtime/tests/dataset_availability_monitor.rs
+++ b/crates/runtime/tests/dataset_availability_monitor.rs
@@ -126,31 +126,6 @@ async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result
 }
 
 #[tokio::test]
-async fn dataset_availability_monitor_register_succeeds_when_enabled() -> Result<(), anyhow::Error>
-{
-    // Create a test runtime to get DataFusion instance
-    let app = AppBuilder::new("dataset_availability_monitor_test").build();
-    let rt = Runtime::builder().with_app(app).build().await;
-
-    // Create DatasetsHealthMonitor directly
-    let monitor = DatasetsHealthMonitor::new(rt.datafusion());
-
-    // Create dataset with availability monitor enabled (default)
-    let dataset = get_test_dataset().await?;
-
-    // Try to register the dataset - should succeed
-    let result = monitor.register_dataset(&dataset).await;
-    assert!(result.is_ok());
-
-    // Check that monitored_datasets contains the dataset
-    let monitored_datasets = monitor.monitored_datasets.lock().await;
-    assert_eq!(monitored_datasets.len(), 1);
-    assert!(monitored_datasets.contains_key("datatypes"));
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn dataset_availability_monitor_register_skipped_when_accelerated()
 -> Result<(), anyhow::Error> {
     // Create a test runtime to get DataFusion instance
@@ -171,18 +146,5 @@ async fn dataset_availability_monitor_register_skipped_when_accelerated()
     let monitored_datasets = monitor.monitored_datasets.lock().await;
     assert!(monitored_datasets.is_empty());
 
-    Ok(())
-}
-
-#[tokio::test]
-async fn dataset_availability_monitor_disabled_when_builder_not_called() -> Result<(), anyhow::Error>
-{
-    let app = AppBuilder::new("dataset_availability_monitor_test").build();
-
-    // Build runtime WITHOUT calling with_datasets_health_monitor
-    let rt = Runtime::builder().with_app(app).build().await;
-
-    // Monitor should be disabled since with_datasets_health_monitor wasn't called
-    assert!(rt.datasets_health_monitor().is_none());
     Ok(())
 }

--- a/crates/runtime/tests/dataset_availability_monitor.rs
+++ b/crates/runtime/tests/dataset_availability_monitor.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::sync::Arc;
 use app::AppBuilder;
-use runtime::Runtime;
+use runtime::{Runtime, datasets_health_monitor::DatasetsHealthMonitor};
 use spicepod::component::dataset::Dataset;
 
 fn get_test_dataset() -> Result<Dataset, anyhow::Error> {
@@ -61,61 +61,90 @@ async fn dataset_availability_monitor_disabled_via_config() -> Result<(), anyhow
 
 #[tokio::test]
 async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result<(), anyhow::Error> {
-    let dataset = get_test_dataset_with_availability_monitor_disabled()?;
-    
+    // Create a test runtime to get DataFusion instance
     let app = AppBuilder::new("dataset_availability_monitor_test")
-        .with_dataset(dataset)
+        .with_dataset(get_test_dataset()?)
         .build();
 
     let rt = Runtime::builder()
         .with_app(app)
-        .with_datasets_health_monitor()
         .build()
         .await;
 
-    // The monitor should exist but the dataset should not be registered
-    assert!(rt.datasets_health_monitor.is_some());
+    // Create DatasetsHealthMonitor directly
+    let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
     
-    // Load the dataset to trigger registration
-    let cloned_rt = Arc::new(rt.clone());
-    tokio::select! {
-        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {},
-        () = cloned_rt.load_components() => {}
-    }
+    // Create dataset with availability monitor disabled
+    let dataset = get_test_dataset_with_availability_monitor_disabled()?;
     
-    // Check that the dataset was not registered for monitoring
-    // (this would be more complex to test - we'd need to check internal state)
-    // For now, we just verify the monitor exists and can handle disabled datasets
-    assert!(rt.datasets_health_monitor.is_some());
+    // Try to register the dataset - should be skipped
+    let result = monitor.register_dataset(&dataset).await;
+    assert!(result.is_ok());
+    
+    // Check that monitored_datasets is empty
+    let monitored_datasets = monitor.monitored_datasets.lock().await;
+    assert!(monitored_datasets.is_empty());
+    
     Ok(())
 }
 
 #[tokio::test]
 async fn dataset_availability_monitor_register_succeeds_when_enabled() -> Result<(), anyhow::Error> {
-    let dataset = get_test_dataset()?;
-    
+    // Create a test runtime to get DataFusion instance
     let app = AppBuilder::new("dataset_availability_monitor_test")
-        .with_dataset(dataset)
+        .with_dataset(get_test_dataset()?)
         .build();
 
     let rt = Runtime::builder()
         .with_app(app)
-        .with_datasets_health_monitor()
         .build()
         .await;
 
-    // The monitor should exist and the dataset should be registered
-    assert!(rt.datasets_health_monitor.is_some());
+    // Create DatasetsHealthMonitor directly
+    let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
     
-    // Load the dataset to trigger registration
-    let cloned_rt = Arc::new(rt.clone());
-    tokio::select! {
-        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {},
-        () = cloned_rt.load_components() => {}
-    }
+    // Create dataset with availability monitor enabled (default)
+    let dataset = get_test_dataset()?;
     
-    // Check that the monitor exists and handled the enabled dataset
-    assert!(rt.datasets_health_monitor.is_some());
+    // Try to register the dataset - should succeed
+    let result = monitor.register_dataset(&dataset).await;
+    assert!(result.is_ok());
+    
+    // Check that monitored_datasets contains the dataset
+    let monitored_datasets = monitor.monitored_datasets.lock().await;
+    assert_eq!(monitored_datasets.len(), 1);
+    assert!(monitored_datasets.contains_key("datatypes"));
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn dataset_availability_monitor_register_skipped_when_accelerated() -> Result<(), anyhow::Error> {
+    // Create a test runtime to get DataFusion instance
+    let app = AppBuilder::new("dataset_availability_monitor_test")
+        .with_dataset(get_test_dataset()?)
+        .build();
+
+    let rt = Runtime::builder()
+        .with_app(app)
+        .build()
+        .await;
+
+    // Create DatasetsHealthMonitor directly
+    let monitor = DatasetsHealthMonitor::new(Arc::clone(&rt.df));
+    
+    // Create dataset with acceleration enabled (which should skip monitoring)
+    let mut dataset = get_test_dataset()?;
+    dataset.acceleration = Some(spicepod::acceleration::Acceleration::default());
+    
+    // Try to register the dataset - should be skipped due to acceleration
+    let result = monitor.register_dataset(&dataset).await;
+    assert!(result.is_ok());
+    
+    // Check that monitored_datasets is empty
+    let monitored_datasets = monitor.monitored_datasets.lock().await;
+    assert!(monitored_datasets.is_empty());
+    
     Ok(())
 }
 

--- a/crates/runtime/tests/dataset_availability_monitor.rs
+++ b/crates/runtime/tests/dataset_availability_monitor.rs
@@ -1,0 +1,137 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+use app::AppBuilder;
+use runtime::Runtime;
+use spicepod::component::dataset::Dataset;
+
+fn get_test_dataset() -> Result<Dataset, anyhow::Error> {
+    let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
+        "./tests/file/datatypes.parquet"
+    } else if std::fs::exists("./crates/runtime/tests/file/datatypes.parquet")? {
+        "./crates/runtime/tests/file/datatypes.parquet"
+    } else {
+        return Err(anyhow::anyhow!("Could not find datatypes.parquet file"));
+    };
+
+    Ok(Dataset::new(format!("file:{file_path}"), "datatypes"))
+}
+
+fn get_test_dataset_with_availability_monitor_disabled() -> Result<Dataset, anyhow::Error> {
+    let file_path = if std::fs::exists("./tests/file/datatypes.parquet")? {
+        "./tests/file/datatypes.parquet"
+    } else if std::fs::exists("./crates/runtime/tests/file/datatypes.parquet")? {
+        "./crates/runtime/tests/file/datatypes.parquet"
+    } else {
+        return Err(anyhow::anyhow!("Could not find datatypes.parquet file"));
+    };
+
+    let mut dataset = Dataset::new(format!("file:{file_path}"), "datatypes");
+    dataset.availability_monitor_enabled = false;
+    Ok(dataset)
+}
+
+#[tokio::test]
+async fn dataset_availability_monitor_enabled_by_default() -> Result<(), anyhow::Error> {
+    let dataset = get_test_dataset()?;
+    assert!(dataset.availability_monitor_enabled);
+    Ok(())
+}
+
+#[tokio::test]
+async fn dataset_availability_monitor_disabled_via_config() -> Result<(), anyhow::Error> {
+    let dataset = get_test_dataset_with_availability_monitor_disabled()?;
+    assert!(!dataset.availability_monitor_enabled);
+    Ok(())
+}
+
+#[tokio::test]
+async fn dataset_availability_monitor_register_skipped_when_disabled() -> Result<(), anyhow::Error> {
+    let dataset = get_test_dataset_with_availability_monitor_disabled()?;
+    
+    let app = AppBuilder::new("dataset_availability_monitor_test")
+        .with_dataset(dataset)
+        .build();
+
+    let rt = Runtime::builder()
+        .with_app(app)
+        .with_datasets_health_monitor()
+        .build()
+        .await;
+
+    // The monitor should exist but the dataset should not be registered
+    assert!(rt.datasets_health_monitor.is_some());
+    
+    // Load the dataset to trigger registration
+    let cloned_rt = Arc::new(rt.clone());
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {},
+        () = cloned_rt.load_components() => {}
+    }
+    
+    // Check that the dataset was not registered for monitoring
+    // (this would be more complex to test - we'd need to check internal state)
+    // For now, we just verify the monitor exists and can handle disabled datasets
+    assert!(rt.datasets_health_monitor.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn dataset_availability_monitor_register_succeeds_when_enabled() -> Result<(), anyhow::Error> {
+    let dataset = get_test_dataset()?;
+    
+    let app = AppBuilder::new("dataset_availability_monitor_test")
+        .with_dataset(dataset)
+        .build();
+
+    let rt = Runtime::builder()
+        .with_app(app)
+        .with_datasets_health_monitor()
+        .build()
+        .await;
+
+    // The monitor should exist and the dataset should be registered
+    assert!(rt.datasets_health_monitor.is_some());
+    
+    // Load the dataset to trigger registration
+    let cloned_rt = Arc::new(rt.clone());
+    tokio::select! {
+        () = tokio::time::sleep(std::time::Duration::from_secs(5)) => {},
+        () = cloned_rt.load_components() => {}
+    }
+    
+    // Check that the monitor exists and handled the enabled dataset
+    assert!(rt.datasets_health_monitor.is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn dataset_availability_monitor_disabled_when_builder_not_called() -> Result<(), anyhow::Error> {
+    let app = AppBuilder::new("dataset_availability_monitor_test")
+        .with_dataset(get_test_dataset()?)
+        .build();
+
+    // Build runtime WITHOUT calling with_datasets_health_monitor
+    let rt = Runtime::builder()
+        .with_app(app)
+        .build()
+        .await;
+
+    // Monitor should be disabled since with_datasets_health_monitor wasn't called
+    assert!(rt.datasets_health_monitor.is_none());
+    Ok(())
+}

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -47,7 +47,7 @@ mod databricks_spark_catalog;
 mod databricks_spark_catalog_m2m;
 #[cfg(all(feature = "spark", feature = "databricks"))]
 mod databricks_spark_m2m;
-mod dataset_availability_monitor;
+mod dataset_availability;
 #[cfg(feature = "delta_lake")]
 mod delta_lake;
 mod docker;

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -31,7 +31,6 @@ mod catalog;
 #[cfg(feature = "duckdb")]
 mod clickbench;
 mod cors;
-mod dataset_availability_monitor;
 #[cfg(all(feature = "delta_lake", feature = "databricks"))]
 mod databricks_delta;
 #[cfg(all(feature = "delta_lake", feature = "databricks"))]
@@ -48,6 +47,7 @@ mod databricks_spark_catalog;
 mod databricks_spark_catalog_m2m;
 #[cfg(all(feature = "spark", feature = "databricks"))]
 mod databricks_spark_m2m;
+mod dataset_availability_monitor;
 #[cfg(feature = "delta_lake")]
 mod delta_lake;
 mod docker;

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -31,6 +31,7 @@ mod catalog;
 #[cfg(feature = "duckdb")]
 mod clickbench;
 mod cors;
+mod dataset_availability_monitor;
 #[cfg(all(feature = "delta_lake", feature = "databricks"))]
 mod databricks_delta;
 #[cfg(all(feature = "delta_lake", feature = "databricks"))]

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -21,7 +21,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{Nameable, WithDependsOn, embeddings::ColumnEmbeddingConfig, is_default};
+use super::{Nameable, WithDependsOn, embeddings::ColumnEmbeddingConfig, is_default, default_true};
 use crate::acceleration::Acceleration;
 use crate::metric::Metrics;
 use crate::param::Params;
@@ -143,6 +143,13 @@ pub struct Dataset {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vectors: Option<VectorStore>,
+
+    /// Configures whether the dataset availability monitor is enabled for this dataset.
+    /// When enabled, the runtime will periodically check dataset availability
+    /// and report metrics. Disabling this can prevent unnecessary remote calls
+    /// that might wake up warehouses like Databricks or Snowflake.
+    #[serde(default = "default_true", skip_serializing_if = "is_default")]
+    pub availability_monitor_enabled: bool,
 }
 
 impl Nameable for Dataset {
@@ -175,6 +182,7 @@ impl Dataset {
             ready_state: ReadyState::default(),
             metrics: None,
             vectors: None,
+            availability_monitor_enabled: true,
         }
     }
 
@@ -242,6 +250,7 @@ impl WithDependsOn<Dataset> for Dataset {
             ready_state: self.ready_state,
             metrics: self.metrics.clone(),
             vectors: self.vectors.clone(),
+            availability_monitor_enabled: self.availability_monitor_enabled,
         }
     }
 }
@@ -316,6 +325,8 @@ struct DatasetDeserializer {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     vectors: Option<VectorStore>,
+    #[serde(default = "default_true", skip_serializing_if = "is_default")]
+    availability_monitor_enabled: bool,
 }
 
 #[allow(deprecated)]
@@ -366,7 +377,46 @@ impl TryFrom<DatasetDeserializer> for Dataset {
             ready_state: deserializer.ready_state,
             metrics: deserializer.metrics,
             vectors: deserializer.vectors,
+            availability_monitor_enabled: deserializer.availability_monitor_enabled,
         })
+    }
+}
+
+#[cfg(test)]
+mod availability_monitor_tests {
+    use super::*;
+    use serde_yaml;
+
+    #[test]
+    fn test_availability_monitor_enabled_by_default() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+        ";
+        let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert!(dataset.availability_monitor_enabled);
+    }
+
+    #[test]
+    fn test_availability_monitor_disabled_via_config() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+            availability_monitor_enabled: false
+        ";
+        let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert!(!dataset.availability_monitor_enabled);
+    }
+
+    #[test]
+    fn test_availability_monitor_enabled_via_config() {
+        let yaml = r"
+            name: test
+            from: file://test.csv
+            availability_monitor_enabled: true
+        ";
+        let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert!(dataset.availability_monitor_enabled);
     }
 }
 

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -84,7 +84,7 @@ pub enum ReadyState {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
-pub enum AvailabilityMonitor {
+pub enum CheckAvailability {
     /// The dataset is checked for availability if it isn't accelerated.
     #[default]
     Default,
@@ -160,7 +160,7 @@ pub struct Dataset {
     /// When enabled, the runtime will periodically check dataset availability
     /// and report metrics. Dataset availability is only checked if the dataset is not accelerated.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub availability_monitor: AvailabilityMonitor,
+    pub check_availability: CheckAvailability,
 }
 
 impl Nameable for Dataset {
@@ -193,7 +193,7 @@ impl Dataset {
             ready_state: ReadyState::default(),
             metrics: None,
             vectors: None,
-            availability_monitor: AvailabilityMonitor::default(),
+            check_availability: CheckAvailability::default(),
         }
     }
 
@@ -261,7 +261,7 @@ impl WithDependsOn<Dataset> for Dataset {
             ready_state: self.ready_state,
             metrics: self.metrics.clone(),
             vectors: self.vectors.clone(),
-            availability_monitor: self.availability_monitor,
+            check_availability: self.check_availability,
         }
     }
 }
@@ -337,7 +337,7 @@ struct DatasetDeserializer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     vectors: Option<VectorStore>,
     #[serde(default, skip_serializing_if = "is_default")]
-    availability_monitor: AvailabilityMonitor,
+    check_availability: CheckAvailability,
 }
 
 #[allow(deprecated)]
@@ -388,46 +388,46 @@ impl TryFrom<DatasetDeserializer> for Dataset {
             ready_state: deserializer.ready_state,
             metrics: deserializer.metrics,
             vectors: deserializer.vectors,
-            availability_monitor: deserializer.availability_monitor,
+            check_availability: deserializer.check_availability,
         })
     }
 }
 
 #[cfg(test)]
-mod availability_monitor_tests {
+mod check_availability_tests {
     use super::*;
     use serde_yaml;
 
     #[test]
-    fn test_availability_monitor_enabled_by_default() {
+    fn test_check_availability_enabled_by_default() {
         let yaml = r"
             name: test
             from: file://test.csv
         ";
         let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
-        assert_eq!(dataset.availability_monitor, AvailabilityMonitor::Default);
+        assert_eq!(dataset.check_availability, CheckAvailability::Default);
     }
 
     #[test]
-    fn test_availability_monitor_disabled_via_config() {
+    fn test_check_availability_disabled_via_config() {
         let yaml = r"
             name: test
             from: file://test.csv
-            availability_monitor: disabled
+            check_availability: disabled
         ";
         let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
-        assert_eq!(dataset.availability_monitor, AvailabilityMonitor::Disabled);
+        assert_eq!(dataset.check_availability, CheckAvailability::Disabled);
     }
 
     #[test]
-    fn test_availability_monitor_enabled_via_config() {
+    fn test_check_availability_enabled_via_config() {
         let yaml = r"
             name: test
             from: file://test.csv
-            availability_monitor: default
+            check_availability: default
         ";
         let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
-        assert_eq!(dataset.availability_monitor, AvailabilityMonitor::Default);
+        assert_eq!(dataset.check_availability, CheckAvailability::Default);
     }
 }
 

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -21,7 +21,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{Nameable, WithDependsOn, embeddings::ColumnEmbeddingConfig, is_default, default_true};
+use super::{Nameable, WithDependsOn, default_true, embeddings::ColumnEmbeddingConfig, is_default};
 use crate::acceleration::Acceleration;
 use crate::metric::Metrics;
 use crate::param::Params;

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -21,7 +21,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{Nameable, WithDependsOn, default_true, embeddings::ColumnEmbeddingConfig, is_default};
+use super::{Nameable, WithDependsOn, embeddings::ColumnEmbeddingConfig, is_default};
 use crate::acceleration::Acceleration;
 use crate::metric::Metrics;
 use crate::param::Params;
@@ -78,6 +78,18 @@ pub enum ReadyState {
     OnLoad,
     /// The table is ready immediately on registration, with fallback to federated table for queries until the initial load completes.
     OnRegistration,
+}
+
+/// Controls whether the federated table periodically has its availability checked.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum AvailabilityMonitor {
+    /// The dataset is checked for availability if it isn't accelerated.
+    #[default]
+    Default,
+    /// The dataset is not checked for availability.
+    Disabled,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -146,10 +158,9 @@ pub struct Dataset {
 
     /// Configures whether the dataset availability monitor is enabled for this dataset.
     /// When enabled, the runtime will periodically check dataset availability
-    /// and report metrics. Disabling this can prevent unnecessary remote calls
-    /// that might wake up warehouses like Databricks or Snowflake.
-    #[serde(default = "default_true", skip_serializing_if = "is_default")]
-    pub availability_monitor_enabled: bool,
+    /// and report metrics. Dataset availability is only checked if the dataset is not accelerated.
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub availability_monitor: AvailabilityMonitor,
 }
 
 impl Nameable for Dataset {
@@ -182,7 +193,7 @@ impl Dataset {
             ready_state: ReadyState::default(),
             metrics: None,
             vectors: None,
-            availability_monitor_enabled: true,
+            availability_monitor: AvailabilityMonitor::default(),
         }
     }
 
@@ -250,7 +261,7 @@ impl WithDependsOn<Dataset> for Dataset {
             ready_state: self.ready_state,
             metrics: self.metrics.clone(),
             vectors: self.vectors.clone(),
-            availability_monitor_enabled: self.availability_monitor_enabled,
+            availability_monitor: self.availability_monitor,
         }
     }
 }
@@ -325,8 +336,8 @@ struct DatasetDeserializer {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     vectors: Option<VectorStore>,
-    #[serde(default = "default_true", skip_serializing_if = "is_default")]
-    availability_monitor_enabled: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    availability_monitor: AvailabilityMonitor,
 }
 
 #[allow(deprecated)]
@@ -377,7 +388,7 @@ impl TryFrom<DatasetDeserializer> for Dataset {
             ready_state: deserializer.ready_state,
             metrics: deserializer.metrics,
             vectors: deserializer.vectors,
-            availability_monitor_enabled: deserializer.availability_monitor_enabled,
+            availability_monitor: deserializer.availability_monitor,
         })
     }
 }
@@ -394,7 +405,7 @@ mod availability_monitor_tests {
             from: file://test.csv
         ";
         let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
-        assert!(dataset.availability_monitor_enabled);
+        assert_eq!(dataset.availability_monitor, AvailabilityMonitor::Default);
     }
 
     #[test]
@@ -402,10 +413,10 @@ mod availability_monitor_tests {
         let yaml = r"
             name: test
             from: file://test.csv
-            availability_monitor_enabled: false
+            availability_monitor: disabled
         ";
         let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
-        assert!(!dataset.availability_monitor_enabled);
+        assert_eq!(dataset.availability_monitor, AvailabilityMonitor::Disabled);
     }
 
     #[test]
@@ -413,10 +424,10 @@ mod availability_monitor_tests {
         let yaml = r"
             name: test
             from: file://test.csv
-            availability_monitor_enabled: true
+            availability_monitor: default
         ";
         let dataset: Dataset = serde_yaml::from_str(yaml).expect("Failed to parse Dataset");
-        assert!(dataset.availability_monitor_enabled);
+        assert_eq!(dataset.availability_monitor, AvailabilityMonitor::Default);
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a new `check_availability` configuration option to individual datasets to control whether the dataset availability monitor checks that specific dataset. This provides granular control over which datasets are monitored, preventing unnecessary remote calls that could wake up expensive warehouses.

- Closes #5676

## Usage
Users can now disable availability monitoring for specific datasets that might cause expensive warehouse wake-ups:

```yaml
datasets:
  - from: snowflake
    name: expensive_table
    check_availability: disabled
  
  - from: file://local_data.csv
    name: local_data
    check_availability: default
```
