### PR TITLE
S3 vector data cannot be null

### DIFF
--- a/crates/data_components/src/s3_vectors/list_provider.rs
+++ b/crates/data_components/src/s3_vectors/list_provider.rs
@@ -396,17 +396,16 @@ fn to_flat_value(output: ListOutputVector) -> serde_json::Value {
     } = output;
     let mut result = metadata.unwrap_or_default();
     if let Some(data) = data {
-        if let Some(vec) = data.float_32 {
-            result.insert(
-                S3_VECTOR_EMBEDDING_NAME.into(),
-                serde_json::Value::Array(
-                    vec.into_iter()
-                        .filter_map(|f| serde_json::Number::from_f64(f64::from(f)))
-                        .map(serde_json::Value::Number)
-                        .collect::<Vec<_>>(),
-                ),
-            );
-        }
+        result.insert(
+            S3_VECTOR_EMBEDDING_NAME.into(),
+            serde_json::Value::Array(
+                data.float_32
+                    .into_iter()
+                    .filter_map(|f| serde_json::Number::from_f64(f64::from(f)))
+                    .map(serde_json::Value::Number)
+                    .collect::<Vec<_>>(),
+            ),
+        );
     }
     result.insert(
         S3_VECTOR_PRIMARY_KEY_NAME.to_string(),

--- a/crates/data_components/src/s3_vectors/mod.rs
+++ b/crates/data_components/src/s3_vectors/mod.rs
@@ -145,7 +145,7 @@ pub mod tests {
                 vectors: vec![
                     PutInputVector {
                         data: VectorData {
-                            float_32: Some(vec![1.0, 2.0, 3.0]),
+                            float_32: vec![1.0, 2.0, 3.0],
                         },
                         key: "v1".into(),
                         metadata: Some(serde_json::Map::from_iter([
@@ -157,7 +157,7 @@ pub mod tests {
                     },
                     PutInputVector {
                         data: VectorData {
-                            float_32: Some(vec![4.0, 5.0, 6.0]),
+                            float_32: vec![4.0, 5.0, 6.0],
                         },
                         key: "v2".into(),
                         metadata: Some(serde_json::Map::from_iter([
@@ -169,7 +169,7 @@ pub mod tests {
                     },
                     PutInputVector {
                         data: VectorData {
-                            float_32: Some(vec![7.0, 8.0, 9.0]),
+                            float_32: vec![7.0, 8.0, 9.0],
                         },
                         key: "v3".into(),
                         metadata: Some(serde_json::Map::from_iter([
@@ -181,7 +181,7 @@ pub mod tests {
                     },
                     PutInputVector {
                         data: VectorData {
-                            float_32: Some(vec![2.0, 2.0, 2.0]),
+                            float_32: vec![2.0, 2.0, 2.0],
                         },
                         key: "v4".into(),
                         metadata: Some(serde_json::Map::from_iter([

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -290,9 +290,7 @@ async fn query_vector_stream(
 
     let QueryVectorsOutput { vectors } = client
         .query_vectors(QueryVectorsInput {
-            query_vector: VectorData {
-                float_32: Some(query),
-            },
+            query_vector: VectorData { float_32: query },
             return_distance: Some(true),
             top_k: limit,
             filter: s3_filter.map(Into::into),
@@ -349,17 +347,16 @@ fn to_flat_value(output: QueryOutputVector) -> serde_json::Value {
     } = output;
     let mut result = metadata.unwrap_or_default();
     if let Some(data) = data {
-        if let Some(vec) = data.float_32 {
-            result.insert(
-                S3_VECTOR_EMBEDDING_NAME.into(),
-                serde_json::Value::Array(
-                    vec.into_iter()
-                        .filter_map(|f| serde_json::Number::from_f64(f64::from(f)))
-                        .map(serde_json::Value::Number)
-                        .collect::<Vec<_>>(),
-                ),
-            );
-        }
+        result.insert(
+            S3_VECTOR_EMBEDDING_NAME.into(),
+            serde_json::Value::Array(
+                data.float_32
+                    .into_iter()
+                    .filter_map(|f| serde_json::Number::from_f64(f64::from(f)))
+                    .map(serde_json::Value::Number)
+                    .collect::<Vec<_>>(),
+            ),
+        );
     }
     result.insert(
         S3_VECTOR_PRIMARY_KEY_NAME.to_string(),

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -308,7 +308,7 @@ impl S3VectorsTable {
     /// Inputs are expected to have equal length.
     ///   `data.len() == key.len() == metadata[key].len()`, for all `key` in `metadata.keys()`.
     ///
-    /// For `None` values of `key`, the row will not be inserted.
+    /// For `None` values of either `key` or `data`, the row will not be inserted.
     pub async fn write_data(
         &self,
         data: Vec<Option<Vec<f32>>>,
@@ -323,6 +323,7 @@ impl S3VectorsTable {
             .enumerate()
             .filter_map(|(i, (data, key))| {
                 let key = key?.to_string();
+                let data = data?;
                 let meta: VectorMetadata = metadata
                     .iter()
                     .filter_map(|(k, v)| {

--- a/crates/s3_vectors/src/generated.rs
+++ b/crates/s3_vectors/src/generated.rs
@@ -17,8 +17,8 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
+use rusoto_core::{region, HttpClient};
 use rusoto_core::{Client, RusotoError};
-use rusoto_core::{HttpClient, region};
 
 use rusoto_core::proto;
 use rusoto_core::signature::SignedRequest;

--- a/crates/s3_vectors/src/generated.rs
+++ b/crates/s3_vectors/src/generated.rs
@@ -17,8 +17,8 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
-use rusoto_core::{region, HttpClient};
 use rusoto_core::{Client, RusotoError};
+use rusoto_core::{HttpClient, region};
 
 use rusoto_core::proto;
 use rusoto_core::signature::SignedRequest;
@@ -537,8 +537,7 @@ pub struct VectorBucketSummary {
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct VectorData {
     #[serde(rename = "float32")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub float_32: Option<Vec<f32>>,
+    pub float_32: Vec<f32>,
 }
 
 // #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/crates/s3_vectors/src/lib.rs
+++ b/crates/s3_vectors/src/lib.rs
@@ -96,9 +96,9 @@ impl ProvideAwsCredentials for S3VectorsCredentialProvider {
 #[cfg(test)]
 pub mod tests {
     use crate::{
-        generated, CreateIndexInput, CreateVectorBucketInput, DeleteIndexInput,
-        DeleteVectorBucketInput, ListVectorsInput, PutInputVector, PutVectorsInput,
-        QueryVectorsInput, S3Vectors, VectorData,
+        CreateIndexInput, CreateVectorBucketInput, DeleteIndexInput, DeleteVectorBucketInput,
+        ListVectorsInput, PutInputVector, PutVectorsInput, QueryVectorsInput, S3Vectors,
+        VectorData, generated,
     };
 
     #[tokio::test]
@@ -155,28 +155,28 @@ pub mod tests {
                 vectors: vec![
                     PutInputVector {
                         data: VectorData {
-                            float_32: Some(vec![1.0, 2.0, 3.0]),
+                            float_32: vec![1.0, 2.0, 3.0],
                         },
                         key: "v1".into(),
                         metadata: None,
                     },
                     PutInputVector {
                         data: VectorData {
-                            float_32: Some(vec![4.0, 5.0, 6.0]),
+                            float_32: vec![4.0, 5.0, 6.0],
                         },
                         key: "v2".into(),
                         metadata: None,
                     },
                     PutInputVector {
                         data: VectorData {
-                            float_32: Some(vec![7.0, 8.0, 9.0]),
+                            float_32: vec![7.0, 8.0, 9.0],
                         },
                         key: "v3".into(),
                         metadata: None,
                     },
                     PutInputVector {
                         data: VectorData {
-                            float_32: Some(vec![2.0, 2.0, 2.0]),
+                            float_32: vec![2.0, 2.0, 2.0],
                         },
                         key: "v4".into(),
                         metadata: None,
@@ -193,7 +193,7 @@ pub mod tests {
                 index_arn: None,
                 vector_bucket_name: Some("spice-s3-jeadie-vectors-2".into()),
                 query_vector: VectorData {
-                    float_32: Some(vec![4.0, 5.0, 3.0]),
+                    float_32: vec![4.0, 5.0, 3.0],
                 },
                 return_data: Some(true),
                 return_distance: Some(true),

--- a/crates/s3_vectors/src/lib.rs
+++ b/crates/s3_vectors/src/lib.rs
@@ -96,9 +96,9 @@ impl ProvideAwsCredentials for S3VectorsCredentialProvider {
 #[cfg(test)]
 pub mod tests {
     use crate::{
-        CreateIndexInput, CreateVectorBucketInput, DeleteIndexInput, DeleteVectorBucketInput,
-        ListVectorsInput, PutInputVector, PutVectorsInput, QueryVectorsInput, S3Vectors,
-        VectorData, generated,
+        generated, CreateIndexInput, CreateVectorBucketInput, DeleteIndexInput,
+        DeleteVectorBucketInput, ListVectorsInput, PutInputVector, PutVectorsInput,
+        QueryVectorsInput, S3Vectors, VectorData,
     };
 
     #[tokio::test]


### PR DESCRIPTION
## 📝 Summary
 - Embedded columns within spice can contain null values (e.g. if the underlying column is null). 
 - S3 vector cannot store empty/null data. 
 - When writing to S3 vector, ignore any data without vectors. 
