### PR TITLE
Add support for `retention_sql` acceleration param

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::time::SystemTime;
 use std::{any::Any, sync::Arc, time::Duration};
 
 use crate::component::dataset::acceleration::{RefreshMode, RefreshOnStartup, ZeroResultsAction};
@@ -24,23 +23,20 @@ use crate::datafusion::error::SpiceExternalError;
 use crate::datafusion::is_spice_internal_dataset;
 use crate::federated_table::FederatedTable;
 use crate::status;
-use arrow::array::UInt64Array;
 use arrow::datatypes::SchemaRef;
 use arrow::error::ArrowError;
 use async_trait::async_trait;
 use cache::Caching;
 use data_components::cdc::ChangesStream;
-use data_components::delete::get_deletion_provider;
 use datafusion::catalog::Session;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::logical_expr::dml::InsertOp;
-use datafusion::logical_expr::{Operator, TableProviderFilterPushDown};
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::union::UnionExec;
-use datafusion::physical_plan::{ExecutionPlan, collect};
 use datafusion::sql::TableReference;
 use datafusion::{
     datasource::{TableProvider, TableType},
-    execution::context::SessionContext,
     logical_expr::Expr,
 };
 use opentelemetry::KeyValue;
@@ -50,7 +46,6 @@ use synchronized_table::SynchronizedTable;
 use tokio::sync::{Notify, RwLock, Semaphore, mpsc};
 use tokio::task::JoinHandle;
 
-use crate::datafusion::filter_converter::TimestampFilterConvert;
 use crate::execution_plan::TableScanParams;
 use crate::execution_plan::fallback_on_zero_results::FallbackOnZeroResultsScanExec;
 use crate::execution_plan::schema_cast::SchemaCastScanExec;
@@ -62,6 +57,7 @@ mod metrics;
 pub mod refresh;
 pub mod refresh_task;
 mod refresh_task_runner;
+mod retention;
 mod sink;
 mod synchronized_table;
 
@@ -575,131 +571,6 @@ impl AcceleratedTable {
 
         Ok(())
     }
-
-    #[allow(clippy::cast_possible_wrap)]
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::too_many_lines)]
-    async fn start_retention_check(
-        dataset_name: TableReference,
-        accelerator: Arc<dyn TableProvider>,
-        retention: Retention,
-        caching: Option<Arc<Caching>>,
-    ) {
-        let time_column = retention.time_column;
-        let retention_period = retention.period;
-        let schema = accelerator.schema();
-        let field = schema
-            .column_with_name(time_column.as_str())
-            .map(|(_, f)| f);
-        let partition_field =
-            retention
-                .time_partition_column
-                .as_ref()
-                .and_then(|time_partition_column| {
-                    schema
-                        .column_with_name(time_partition_column.as_str())
-                        .map(|(_, f)| f)
-                });
-
-        let mut interval_timer = tokio::time::interval(retention.check_interval);
-
-        let Some(timestamp_filter_converter) = TimestampFilterConvert::create(
-            field.cloned(),
-            Some(time_column.clone()),
-            retention.time_format,
-            partition_field.cloned(),
-            retention.time_partition_column.clone(),
-            retention.time_partition_format,
-        ) else {
-            tracing::error!(
-                "[retention] Failed to get the expression time format for {time_column}, check schema and time format"
-            );
-            return;
-        };
-
-        loop {
-            interval_timer.tick().await;
-
-            if let Some(deleted_table_provider) = get_deletion_provider(Arc::clone(&accelerator)) {
-                let ctx = SessionContext::new();
-
-                let start = SystemTime::now() - retention_period;
-
-                let timestamp = refresh::get_timestamp(start);
-                let expr = timestamp_filter_converter.convert(timestamp, Operator::Lt);
-
-                let timestamp = if let Some(value) =
-                    chrono::DateTime::from_timestamp((timestamp / 1_000_000_000) as i64, 0)
-                {
-                    value.to_rfc3339()
-                } else {
-                    tracing::warn!("[retention] Unable to convert timestamp");
-                    continue;
-                };
-
-                if is_spice_internal_dataset(&dataset_name) {
-                    tracing::trace!(
-                        "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
-                        timestamp
-                    );
-                } else {
-                    tracing::info!(
-                        "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
-                        timestamp
-                    );
-                }
-
-                tracing::trace!("[retention] Expr {expr:?}");
-
-                let plan = deleted_table_provider
-                    .delete_from(&ctx.state(), &vec![expr])
-                    .await;
-                match plan {
-                    Ok(plan) => match collect(plan, ctx.task_ctx()).await {
-                        Err(e) => {
-                            tracing::error!("[retention] Error running retention check: {e}");
-                        }
-                        Ok(deleted) => {
-                            let num_records = deleted.first().map_or(0, |f| {
-                                f.column(0)
-                                    .as_any()
-                                    .downcast_ref::<UInt64Array>()
-                                    .map_or(0, |v| v.values().first().map_or(0, |f| *f))
-                            });
-
-                            if is_spice_internal_dataset(&dataset_name) {
-                                tracing::trace!(
-                                    "[retention] Evicted {num_records} records for {dataset_name}"
-                                );
-                            } else {
-                                tracing::info!(
-                                    "[retention] Evicted {num_records} records for {dataset_name}"
-                                );
-                            }
-
-                            if num_records > 0 {
-                                if let Some(cache_provider) = caching.as_ref() {
-                                    if let Err(e) =
-                                        cache_provider.invalidate_for_table(dataset_name.clone())
-                                    {
-                                        tracing::error!(
-                                            "Failed to invalidate cached results for dataset {}: {e}",
-                                            &dataset_name
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    Err(e) => {
-                        tracing::error!("[retention] Error running retention check: {e}");
-                    }
-                }
-            } else {
-                tracing::error!("[retention] Accelerated table does not support delete");
-            }
-        }
-    }
 }
 
 impl Drop for AcceleratedTable {
@@ -819,15 +690,17 @@ impl TableProvider for AcceleratedTable {
 }
 
 pub struct Retention {
-    pub(crate) time_column: String,
+    pub(crate) time_column: Option<String>,
     pub(crate) time_format: Option<TimeFormat>,
     pub(crate) time_partition_column: Option<String>,
     pub(crate) time_partition_format: Option<TimeFormat>,
-    pub(crate) period: Duration,
+    pub(crate) delete_expr: Option<Expr>,
+    pub(crate) period: Option<Duration>,
     pub(crate) check_interval: Duration,
 }
 
 impl Retention {
+    #[allow(clippy::too_many_arguments)]
     #[must_use]
     pub fn new(
         time_column: Option<String>,
@@ -837,23 +710,26 @@ impl Retention {
         retention_period: Option<Duration>,
         retention_check_interval: Option<Duration>,
         retention_check_enabled: bool,
+        delete_expr: Option<Expr>,
     ) -> Option<Self> {
         if !retention_check_enabled {
             return None;
         }
-        if let (Some(time_column), Some(period), Some(check_interval)) =
-            (time_column, retention_period, retention_check_interval)
-        {
-            Some(Self {
-                time_column,
-                time_format,
-                time_partition_column,
-                time_partition_format,
-                period,
-                check_interval,
-            })
-        } else {
-            None
+
+        let check_interval = retention_check_interval?;
+
+        if retention_period.is_none() && delete_expr.is_none() {
+            return None;
         }
+
+        Some(Self {
+            time_column,
+            time_format,
+            time_partition_column,
+            time_partition_format,
+            delete_expr,
+            period: retention_period,
+            check_interval,
+        })
     }
 }

--- a/crates/runtime/src/accelerated_table/retention.rs
+++ b/crates/runtime/src/accelerated_table/retention.rs
@@ -1,0 +1,223 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{sync::Arc, time::SystemTime};
+
+use arrow::array::UInt64Array;
+use cache::Caching;
+use data_components::delete::get_deletion_provider;
+use datafusion::{
+    catalog::TableProvider,
+    logical_expr::Operator,
+    physical_plan::collect,
+    prelude::{Expr, SessionContext},
+    sql::TableReference,
+};
+
+use crate::{
+    accelerated_table::{Retention, refresh},
+    datafusion::{
+        builder::get_df_default_config, filter_converter::TimestampFilterConvert,
+        is_spice_internal_dataset,
+    },
+    object_store_registry::default_runtime_env,
+};
+
+enum DataRetentionFilter {
+    DeleteExpr(Expr),
+    TimeColumn {
+        converter: TimestampFilterConvert,
+        time_column: String,
+        retention_period: std::time::Duration,
+    },
+}
+
+impl super::AcceleratedTable {
+    #[allow(clippy::cast_possible_wrap)]
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::too_many_lines)]
+    pub(crate) async fn start_retention_check(
+        dataset_name: TableReference,
+        accelerator: Arc<dyn TableProvider>,
+        retention: Retention,
+        caching: Option<Arc<Caching>>,
+    ) {
+        let retention_filter = if let Some(delete_expr) = retention.delete_expr {
+            DataRetentionFilter::DeleteExpr(delete_expr)
+        } else {
+            let Some(time_column) = &retention.time_column else {
+                tracing::error!(
+                    "[retention] The `time_column` parameter must be specified for retention"
+                );
+                return;
+            };
+
+            let Some(retention_period) = retention.period else {
+                tracing::error!(
+                    "[retention] The `retention_period` parameter must be specified for retention"
+                );
+                return;
+            };
+
+            let Some(converter) =
+                create_timestamp_filter_converter(&retention, &accelerator, time_column)
+            else {
+                return;
+            };
+            DataRetentionFilter::TimeColumn {
+                converter,
+                time_column: time_column.clone(),
+                retention_period,
+            }
+        };
+
+        let mut interval_timer = tokio::time::interval(retention.check_interval);
+
+        loop {
+            interval_timer.tick().await;
+
+            if let Some(deleted_table_provider) = get_deletion_provider(Arc::clone(&accelerator)) {
+                let expr = match &retention_filter {
+                    DataRetentionFilter::DeleteExpr(expr) => {
+                        if is_spice_internal_dataset(&dataset_name) {
+                            tracing::trace!(
+                                "[retention] Evicting data for {dataset_name} with using retention sql expression"
+                            );
+                        } else {
+                            tracing::info!(
+                                "[retention] Evicting data for {dataset_name} with using retention sql expression"
+                            );
+                        }
+                        expr.clone()
+                    }
+                    DataRetentionFilter::TimeColumn {
+                        converter,
+                        time_column,
+                        retention_period,
+                    } => {
+                        let start = SystemTime::now() - *retention_period;
+                        let timestamp = refresh::get_timestamp(start);
+                        let expr = converter.convert(timestamp, Operator::Lt);
+
+                        let timestamp = if let Some(value) =
+                            chrono::DateTime::from_timestamp((timestamp / 1_000_000_000) as i64, 0)
+                        {
+                            value.to_rfc3339()
+                        } else {
+                            tracing::warn!("[retention] Unable to convert timestamp");
+                            continue;
+                        };
+
+                        if is_spice_internal_dataset(&dataset_name) {
+                            tracing::trace!(
+                                "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
+                                timestamp
+                            );
+                        } else {
+                            tracing::info!(
+                                "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
+                                timestamp
+                            );
+                        }
+
+                        expr
+                    }
+                };
+
+                tracing::trace!("[retention] Expr {expr:?}");
+
+                let ctx = SessionContext::new_with_config_rt(
+                    get_df_default_config(),
+                    default_runtime_env(),
+                );
+
+                let plan = deleted_table_provider
+                    .delete_from(&ctx.state(), &vec![expr.clone()])
+                    .await;
+                match plan {
+                    Ok(plan) => match collect(plan, ctx.task_ctx()).await {
+                        Err(e) => {
+                            tracing::error!("[retention] Error running retention check: {e}");
+                        }
+                        Ok(deleted) => {
+                            let num_records = deleted.first().map_or(0, |f| {
+                                f.column(0)
+                                    .as_any()
+                                    .downcast_ref::<UInt64Array>()
+                                    .map_or(0, |v| v.values().first().map_or(0, |f| *f))
+                            });
+
+                            if is_spice_internal_dataset(&dataset_name) {
+                                tracing::trace!(
+                                    "[retention] Evicted {num_records} records for {dataset_name}"
+                                );
+                            } else {
+                                tracing::info!(
+                                    "[retention] Evicted {num_records} records for {dataset_name}"
+                                );
+                            }
+
+                            if num_records > 0 {
+                                if let Some(cache_provider) = caching.as_ref() {
+                                    if let Err(e) =
+                                        cache_provider.invalidate_for_table(dataset_name.clone())
+                                    {
+                                        tracing::error!(
+                                            "Failed to invalidate cached results for dataset {}: {e}",
+                                            &dataset_name
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    Err(e) => {
+                        tracing::error!("[retention] Error running retention check: {e}");
+                    }
+                }
+            } else {
+                tracing::error!("[retention] Accelerated table does not support delete");
+            }
+        }
+    }
+}
+
+fn create_timestamp_filter_converter(
+    retention: &Retention,
+    accelerator: &Arc<dyn TableProvider>,
+    time_column: &str,
+) -> Option<TimestampFilterConvert> {
+    let schema = accelerator.schema();
+    let field = schema.column_with_name(time_column).map(|(_, f)| f);
+    let partition_field =
+        retention
+            .time_partition_column
+            .as_ref()
+            .and_then(|time_partition_column| {
+                schema
+                    .column_with_name(time_partition_column.as_str())
+                    .map(|(_, f)| f)
+            });
+
+    TimestampFilterConvert::create(
+        field.cloned(),
+        Some(time_column.to_string()),
+        retention.time_format,
+        partition_field.cloned(),
+        retention.time_partition_column.clone(),
+        retention.time_partition_format,
+    )
+}

--- a/crates/runtime/src/component/dataset/acceleration.rs
+++ b/crates/runtime/src/component/dataset/acceleration.rs
@@ -274,6 +274,8 @@ pub struct Acceleration {
 
     pub retention_period: Option<String>,
 
+    pub retention_sql: Option<String>,
+
     pub retention_check_interval: Option<String>,
 
     pub retention_check_enabled: bool,
@@ -422,6 +424,7 @@ impl TryFrom<spicepod_acceleration::Acceleration> for Acceleration {
                 .map(Params::as_string_map)
                 .unwrap_or_default(),
             retention_period: acceleration.retention_period,
+            retention_sql: acceleration.retention_sql,
             retention_check_interval: acceleration.retention_check_interval,
             retention_check_enabled: acceleration.retention_check_enabled,
             disable_federation,
@@ -452,6 +455,7 @@ impl Default for Acceleration {
             refresh_jitter_max: None,
             params: HashMap::default(),
             retention_period: None,
+            retention_sql: None,
             retention_check_interval: None,
             retention_check_enabled: false,
             on_zero_results: ZeroResultsAction::ReturnEmpty,

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -471,6 +471,15 @@ impl Dataset {
     }
 
     #[must_use]
+    pub fn retention_sql(&self) -> Option<String> {
+        if let Some(acceleration) = &self.acceleration {
+            return acceleration.retention_sql.clone();
+        }
+
+        None
+    }
+
+    #[must_use]
     pub fn refresh_sql(&self) -> Option<String> {
         if let Some(acceleration) = &self.acceleration {
             return acceleration.refresh_sql.clone();

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -89,6 +89,7 @@ pub mod filter_converter;
 pub mod param_utils;
 pub mod refresh_sql;
 pub mod request_context_extension;
+pub mod retention_sql;
 pub mod schema;
 pub mod udf;
 
@@ -127,6 +128,9 @@ pub enum Error {
 
     #[snafu(display("{source}"))]
     RefreshSql { source: refresh_sql::Error },
+
+    #[snafu(display("{source}"))]
+    RetentionSql { source: retention_sql::Error },
 
     #[snafu(display("Unable to get table: {source}"))]
     UnableToGetTable { source: DataFusionError },
@@ -974,6 +978,18 @@ impl DataFusion {
             refresh,
         );
 
+        let retention_delete_expr = match dataset.retention_sql() {
+            Some(retention_sql) => Some(
+                retention_sql::parse_retention_sql(
+                    &dataset.name,
+                    retention_sql.as_str(),
+                    source_table_provider.schema(),
+                )
+                .context(RetentionSqlSnafu)?,
+            ),
+            None => None,
+        };
+
         accelerated_table_builder.retention(Retention::new(
             dataset.time_column.clone(),
             dataset.time_format,
@@ -982,6 +998,7 @@ impl DataFusion {
             dataset.retention_period(),
             dataset.retention_check_interval(),
             acceleration_settings.retention_check_enabled,
+            retention_delete_expr,
         ));
 
         accelerated_table_builder.zero_results_action(acceleration_settings.on_zero_results);

--- a/crates/runtime/src/datafusion/retention_sql.rs
+++ b/crates/runtime/src/datafusion/retention_sql.rs
@@ -1,0 +1,322 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::Schema;
+use datafusion::common::DFSchema;
+use datafusion::error::DataFusionError;
+use datafusion::prelude::{Expr, SessionContext};
+use datafusion::sql::parser::{DFParser, Statement};
+use datafusion::sql::sqlparser::ast::{Delete, Expr as SQLExpr};
+use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
+use datafusion::sql::{TableReference, sqlparser};
+use snafu::prelude::*;
+use sqlparser::ast::Statement as SQLStatement;
+
+use crate::datafusion::builder::get_df_default_config;
+use crate::object_store_registry::default_runtime_env;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "The provided Retention SQL could not be parsed.\n{source}\nCheck the SQL for syntax errors."
+    ))]
+    UnableToParseSql {
+        source: sqlparser::parser::ParserError,
+    },
+
+    #[snafu(display(
+        "Expected a single SQL statement for the retention SQL, found {num_statements}.\nRewrite the SQL to only contain a single DELETE FROM statement."
+    ))]
+    ExpectedSingleSqlStatement { num_statements: usize },
+
+    #[snafu(display("Expected a SQL query starting with DELETE FROM {expected_table}"))]
+    InvalidSqlStatement { expected_table: TableReference },
+
+    #[snafu(display(
+        "DELETE statement must have a WHERE clause for retention SQL.\nRewrite the SQL to include a WHERE clause, i.e. DELETE FROM {expected_table} WHERE column = 'value'"
+    ))]
+    MissingWhereClause { expected_table: TableReference },
+
+    #[snafu(display(
+        "Only DELETE statements are allowed in retention SQL.\nRewrite the SQL to use DELETE FROM {expected_table} WHERE <condition>"
+    ))]
+    OnlyDeleteStatements { expected_table: TableReference },
+
+    #[snafu(display(
+        "The table '{table_name}' in the retention SQL does not match the expected table '{expected_table}'.\nRewrite the SQL to use the correct table name."
+    ))]
+    TableMismatch {
+        table_name: String,
+        expected_table: TableReference,
+    },
+
+    #[snafu(display("Missing expected SQL statement - this is a bug in Spice.ai"))]
+    MissingStatement,
+
+    #[snafu(display("Failed to convert Arrow schema to DataFusion schema: {source}"))]
+    SchemaConversion { source: DataFusionError },
+
+    #[snafu(display("Failed to parse SQL expression '{expression}': {source}"))]
+    ExpressionParsing {
+        expression: String,
+        source: DataFusionError,
+    },
+}
+
+pub fn parse_retention_sql(
+    expected_table: &TableReference,
+    retention_sql: &str,
+    schema: Arc<Schema>,
+) -> Result<Expr> {
+    let mut statements = DFParser::parse_sql_with_dialect(retention_sql, &PostgreSqlDialect {})
+        .context(UnableToParseSqlSnafu)?;
+
+    if statements.len() != 1 {
+        ExpectedSingleSqlStatementSnafu {
+            num_statements: statements.len(),
+        }
+        .fail()?;
+    }
+
+    let statement = statements.pop_front().context(MissingStatementSnafu)?;
+
+    match statement {
+        Statement::Statement(statement) => match statement.as_ref() {
+            SQLStatement::Delete(Delete {
+                from, selection, ..
+            }) => {
+                // Validate the table name matches
+                validate_table_name(from, expected_table)?;
+
+                // Extract and return the WHERE clause
+                match selection {
+                    Some(where_expr) => to_df_logical_expr(where_expr, schema),
+                    None => MissingWhereClauseSnafu {
+                        expected_table: expected_table.clone(),
+                    }
+                    .fail(),
+                }
+            }
+            _ => OnlyDeleteStatementsSnafu {
+                expected_table: expected_table.clone(),
+            }
+            .fail(),
+        },
+        _ => OnlyDeleteStatementsSnafu {
+            expected_table: expected_table.clone(),
+        }
+        .fail(),
+    }
+}
+
+fn validate_table_name(
+    from: &sqlparser::ast::FromTable,
+    expected_table: &TableReference,
+) -> Result<()> {
+    let sqlparser::ast::FromTable::WithFromKeyword(from_tables) = from else {
+        return InvalidSqlStatementSnafu {
+            expected_table: expected_table.clone(),
+        }
+        .fail();
+    };
+
+    if from_tables.len() != 1 {
+        return InvalidSqlStatementSnafu {
+            expected_table: expected_table.clone(),
+        }
+        .fail();
+    }
+
+    match &from_tables[0].relation {
+        sqlparser::ast::TableFactor::Table { name, .. } => {
+            let table_name_with_schema = name
+                .0
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(".");
+
+            let table_ref = TableReference::parse_str(&table_name_with_schema);
+            ensure!(
+                table_ref == *expected_table,
+                TableMismatchSnafu {
+                    table_name: table_name_with_schema,
+                    expected_table: expected_table.clone(),
+                }
+            );
+        }
+        _ => {
+            InvalidSqlStatementSnafu {
+                expected_table: expected_table.clone(),
+            }
+            .fail()?;
+        }
+    }
+
+    Ok(())
+}
+
+fn to_df_logical_expr(sql_expr: &SQLExpr, schema: Arc<Schema>) -> Result<Expr> {
+    let df_schema = DFSchema::try_from(schema).context(SchemaConversionSnafu)?;
+
+    let ctx = SessionContext::new_with_config_rt(get_df_default_config(), default_runtime_env());
+
+    // To convert SQLExpr to DataFusion Expr, we need SqlToRel, which requires a ContextProvider.
+    // SessionContextProvider used by DataFusion is not exposed publicly, so we provide the filter as a string
+    // and let DataFusion handle the parsing and conversion instead of implementing our own ContextProvider.
+    let expr_string = format!("{sql_expr}");
+    ctx.state()
+        .create_logical_expr(&expr_string, &df_schema)
+        .context(ExpressionParsingSnafu {
+            expression: expr_string,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    fn create_test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("deleted", DataType::Boolean, true),
+            Field::new("created_at", DataType::Utf8, true),
+        ]))
+    }
+
+    #[test]
+    fn test_valid_delete_statement() -> Result<()> {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "DELETE FROM test_table WHERE deleted = true";
+
+        let result = parse_retention_sql(&table, sql, schema)?;
+        // The result should be the WHERE clause expression
+        assert!(matches!(result, Expr::BinaryExpr { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_missing_where_clause() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "DELETE FROM test_table";
+
+        let result = parse_retention_sql(&table, sql, schema);
+        assert!(matches!(result, Err(Error::MissingWhereClause { .. })));
+    }
+
+    #[test]
+    fn test_wrong_table_name() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "DELETE FROM wrong_table WHERE deleted = true";
+
+        let result = parse_retention_sql(&table, sql, schema);
+        assert!(matches!(result, Err(Error::TableMismatch { .. })));
+    }
+
+    #[test]
+    fn test_select_statement_not_allowed() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "SELECT * FROM test_table WHERE deleted = true";
+
+        let result = parse_retention_sql(&table, sql, schema);
+        assert!(matches!(result, Err(Error::OnlyDeleteStatements { .. })));
+    }
+
+    #[test]
+    fn test_multiple_statements() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql =
+            "DELETE FROM test_table WHERE deleted = true; DELETE FROM test_table WHERE old = true";
+
+        let result = parse_retention_sql(&table, sql, schema);
+        assert!(matches!(
+            result,
+            Err(Error::ExpectedSingleSqlStatement { .. })
+        ));
+    }
+
+    #[test]
+    fn test_complex_where_clause() -> Result<()> {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "DELETE FROM test_table WHERE deleted = true OR created_at < NOW() - INTERVAL '10 days'";
+
+        let result = parse_retention_sql(&table, sql, schema)?;
+        assert!(matches!(result, Expr::BinaryExpr { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_qualified_table_name() -> Result<()> {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("schema.test_table");
+        let sql = "DELETE FROM schema.test_table WHERE deleted = true";
+
+        let result = parse_retention_sql(&table, sql, schema)?;
+        assert!(matches!(result, Expr::BinaryExpr { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_case_sensitive_table_and_column_names() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("ID", DataType::Int64, false),
+            Field::new("Deleted", DataType::Boolean, true),
+            Field::new("Created_At", DataType::Utf8, true),
+        ]));
+        let table = TableReference::parse_str("Test_Table");
+        let sql = "DELETE FROM Test_Table WHERE Deleted = true";
+
+        let result = parse_retention_sql(&table, sql, schema)?;
+        assert!(matches!(result, Expr::BinaryExpr { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_quoted_table_and_column_names() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("is deleted", DataType::Boolean, true),
+            Field::new("created at", DataType::Utf8, true),
+        ]));
+        let table = TableReference::parse_str("\"Test Table\"");
+        let sql = "DELETE FROM \"Test Table\" WHERE \"is deleted\" = true";
+
+        let result = parse_retention_sql(&table, sql, schema)?;
+        assert!(matches!(result, Expr::BinaryExpr { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_nonexistent_column() {
+        let schema = create_test_schema();
+        let table = TableReference::parse_str("test_table");
+        let sql = "DELETE FROM test_table WHERE nonexistent_column = true";
+
+        let result = parse_retention_sql(&table, sql, schema);
+        assert!(matches!(result, Err(Error::ExpressionParsing { .. })));
+    }
+}

--- a/crates/runtime/src/init/eval.rs
+++ b/crates/runtime/src/init/eval.rs
@@ -122,6 +122,7 @@ impl Runtime {
             Some(Duration::from_secs(24 * 3600)), // Keep data for last 24 hours
             Some(Duration::from_secs(1800)),      // Check every 30 minutes
             true,
+            None,
         );
 
         let table = create_internal_accelerated_table(
@@ -154,6 +155,7 @@ impl Runtime {
             Some(Duration::from_secs(24 * 3600)), // Keep data for last 24 hours
             Some(Duration::from_secs(1800)),      // Check every 30 minutes
             true,
+            None,
         );
 
         let table = create_internal_accelerated_table(

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -102,6 +102,7 @@ pub async fn register_metrics_table(
         Some(Duration::from_secs(1800)), // delete metrics older then 30 minutes
         Some(Duration::from_secs(300)),  // run retention every 5 minutes
         true,
+        None,
     );
 
     let table = create_internal_accelerated_table(

--- a/crates/runtime/src/task_history/mod.rs
+++ b/crates/runtime/src/task_history/mod.rs
@@ -100,6 +100,7 @@ impl TaskSpan {
             Some(Duration::from_secs(retention_period_secs)), // 1 day
             Some(Duration::from_secs(retention_check_interval_secs)),
             true,
+            None,
         );
         let tbl_reference =
             TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE);

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -174,6 +174,7 @@ impl SpiceExtension {
             Some(Duration::from_secs(1800)), // delete metrics older then 30 minutes
             Some(Duration::from_secs(300)),  // run retention every 5 minutes
             true,
+            None,
         );
 
         let refresh = Refresh::new(RefreshMode::Full)

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -179,6 +179,9 @@ pub struct Acceleration {
     pub retention_period: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_sql: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention_check_interval: Option<String>,
 
     #[serde(default, skip_serializing_if = "is_false")]
@@ -236,6 +239,7 @@ impl Default for Acceleration {
             refresh_jitter_max: None,
             params: None,
             retention_period: None,
+            retention_sql: None,
             retention_check_interval: None,
             retention_check_enabled: false,
             on_zero_results: ZeroResultsAction::ReturnEmpty,


### PR DESCRIPTION
## 📝 Summary

This PR adds support for the `retention_sql` parameter for acceleration, which defines a custom filter to evict data from the accelerator. 

When both `retention_sql` and `retention_period` are defined, `retention_sql` takes precedence. Unlike `retention_period`, `retention_sql` does not require a `time_column`


## 🔗 Related

Implements basic functionality for
- https://github.com/spiceai/spiceai/issues/6418

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Next steps:
1. Add integration tests (for both retention modes)
2. Add support for simultaneous `retention_sql` and `retention_period` defined
3. Review if `retention_sql` must be applied during refresh to avoid fetching unnecessary data similar to retention period (can this break CDC / append modes with with upsert param ??)
