### PR TITLE
Make dataset refresh progress tracing less verbose

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -336,7 +336,7 @@ impl RefreshTask {
                     if let Some(batch) = stream.next().await {
                         match batch {
                             Ok(batch) => {
-                                tracing::info!(
+                                tracing::trace!(
                                     "Dataset {ds_name} received {} records",
                                     batch.num_rows()
                                 );


### PR DESCRIPTION
## 📝 Summary

This trace is executed for each record batch received resulting into tracing like this for large datasets. Update tracing level to only be shown in -vv / very verbose level. The change has been introduced in recent S3 Vectors PR.

```bash
2025-07-18T05:53:25.373294Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:25.453814Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:25.533872Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:25.614411Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:25.694609Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:25.775512Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:25.855310Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:25.936995Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.021790Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.103948Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.186134Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.268772Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.349978Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.431918Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.515283Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.597364Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.679226Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.759492Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.840686Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:26.921674Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:27.002233Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:27.082685Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
2025-07-18T05:53:27.162844Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 4000 records
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
