### PR TITLE
Use `RwLock` on tantivy index in `FullTextDatabaseIndex` for update concurrency

### DIFF
--- a/crates/runtime/src/search/full_text/index.rs
+++ b/crates/runtime/src/search/full_text/index.rs
@@ -128,7 +128,7 @@ impl FullTextDatabaseIndex {
     /// an exact match on either a primary key (if one primary key column), or `INDEX_UNIQUE_FIELD_NAME`.
     fn existing_terms_to_delete(
         &self,
-        index_schema: tantivy::schema::Schema,
+        index_schema: &tantivy::schema::Schema,
         rb: &[RecordBatch],
     ) -> Result<Vec<tantivy::Term>, Error> {
         let Some(pk) = self.primary_key.first() else {
@@ -193,7 +193,7 @@ impl FullTextDatabaseIndex {
             .context(IndexCreationSnafu)?;
 
         // Deletion.
-        for t in self.existing_terms_to_delete(index_writable.schema(), &rb)? {
+        for t in self.existing_terms_to_delete(&index_writable.schema(), &rb)? {
             index_writer.delete_term(t);
         }
 

--- a/crates/runtime/src/search/full_text/index.rs
+++ b/crates/runtime/src/search/full_text/index.rs
@@ -18,6 +18,17 @@ use std::{any::Any, sync::Arc};
 
 use arrow::{array::RecordBatch, datatypes::DataType};
 
+use crate::search::{
+    full_text::util::{array_to_terms, with_json_subset_column},
+    util::get_primary_keys,
+};
+use crate::{datafusion::query::write_to_json_string, search::full_text::Error};
+use crate::{
+    object_store_registry::SpiceObjectStoreRegistry,
+    search::full_text::{
+        FailedToInsertDataIntoIndexSnafu, IndexCreationSnafu, InvalidIndexingSnafu,
+    },
+};
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
@@ -32,18 +43,7 @@ use snafu::ResultExt;
 use std::collections::HashSet;
 use tantivy::schema::DocParsingError;
 use tantivy::{TantivyDocument, TantivyError};
-
-use crate::search::{
-    full_text::util::{array_to_terms, with_json_subset_column},
-    util::get_primary_keys,
-};
-use crate::{datafusion::query::write_to_json_string, search::full_text::Error};
-use crate::{
-    object_store_registry::SpiceObjectStoreRegistry,
-    search::full_text::{
-        FailedToInsertDataIntoIndexSnafu, IndexCreationSnafu, InvalidIndexingSnafu,
-    },
-};
+use tokio::sync::RwLock;
 
 /// The minimum number of bytes to support writing to in-memory [`tantivy::Index`].
 pub static MINIMUM_MEMORY_BUDGET_FOR_MEMORY_INDEX: usize = 15_000_000;
@@ -54,7 +54,7 @@ pub struct FullTextDatabaseIndex {
     pub search_fields: Vec<String>,
     pub primary_key: Vec<String>,
     pub base_table: Arc<dyn TableProvider>,
-    pub index: Arc<tantivy::Index>,
+    pub index: Arc<RwLock<tantivy::Index>>,
 }
 
 impl std::fmt::Debug for FullTextDatabaseIndex {
@@ -86,7 +86,7 @@ impl Index for FullTextDatabaseIndex {
     }
 
     async fn compute_index(&self, batches: Vec<RecordBatch>) {
-        if let Err(e) = self.update_index(batches.as_slice()) {
+        if let Err(e) = self.update_index(batches.as_slice()).await {
             tracing::error!("Failed to update full text search index: {e}");
         }
     }
@@ -126,14 +126,18 @@ impl FullTextDatabaseIndex {
 
     /// Given a [`RecordBatch`] of new data, find all [`Term`]s we need to delete. These terms are
     /// an exact match on either a primary key (if one primary key column), or `INDEX_UNIQUE_FIELD_NAME`.
-    fn existing_terms_to_delete(&self, rb: &[RecordBatch]) -> Result<Vec<tantivy::Term>, Error> {
+    fn existing_terms_to_delete(
+        &self,
+        index_schema: tantivy::schema::Schema,
+        rb: &[RecordBatch],
+    ) -> Result<Vec<tantivy::Term>, Error> {
         let Some(pk) = self.primary_key.first() else {
             // Should not occur, but no primary key implies none must be deleted.
             return Ok(vec![]);
         };
 
         let (pk_field, pk) = if self.primary_key.len() == 1 {
-            let Some((pk_field, _)) = self.index.schema().find_field(pk.as_str()) else {
+            let Some((pk_field, _)) = index_schema.find_field(pk.as_str()) else {
                 return Err(Error::FailedToRetrieveDataFromIndex {
                     source: TantivyError::FieldNotFound(pk.clone()),
                 });
@@ -141,8 +145,7 @@ impl FullTextDatabaseIndex {
             (pk_field, pk.clone())
         } else {
             // Primary key has multiple columns. Therefore tantivy::Index has derived field `INDEX_UNIQUE_FIELD_NAME`.
-            let Some((pk_field, _)) = self.index.schema().find_field(INDEX_UNIQUE_FIELD_NAME)
-            else {
+            let Some((pk_field, _)) = index_schema.find_field(INDEX_UNIQUE_FIELD_NAME) else {
                 return Err(Error::InvalidIndexingError {
                     source: Box::from(TantivyError::FieldNotFound(pk.clone())),
                     context: format!(
@@ -170,7 +173,7 @@ impl FullTextDatabaseIndex {
     /// columns present will be ignored.
     ///
     /// If there is a multi-column primary key (as specified by [`Self::primary_key`]), an additional column is used in the [`tantivy::Index`] for unique lookup (required since updates = deletion -> insertion).
-    fn update_index(&self, rb: &[RecordBatch]) -> Result<(), Error> {
+    async fn update_index(&self, rb: &[RecordBatch]) -> Result<(), Error> {
         // Construct column for `INDEX_UNIQUE_FIELD_NAME` if needed.
         let rb = if self.primary_key.len() > 1 {
             rb.iter()
@@ -183,14 +186,14 @@ impl FullTextDatabaseIndex {
             rb.to_vec()
         };
 
+        let index_writable = self.index.write().await;
         // Updates in tantivy are a deletion then insertion.
-        let mut index_writer: tantivy::IndexWriter = self
-            .index
+        let mut index_writer: tantivy::IndexWriter = index_writable
             .writer(MINIMUM_MEMORY_BUDGET_FOR_MEMORY_INDEX)
             .context(IndexCreationSnafu)?;
 
         // Deletion.
-        for t in self.existing_terms_to_delete(&rb)? {
+        for t in self.existing_terms_to_delete(index_writable.schema(), &rb)? {
             index_writer.delete_term(t);
         }
 
@@ -198,7 +201,7 @@ impl FullTextDatabaseIndex {
         let doc_json = write_to_json_string(&rb).context(InvalidIndexingSnafu {
             context: "Failed to write data to intermediate JSON string for indexing".to_string(),
         })?;
-        let docs = parse_json_array(&self.index.schema(), doc_json.as_str())
+        let docs = parse_json_array(&index_writable.schema(), doc_json.as_str())
             .context(FailedToInsertDataIntoIndexSnafu)?;
 
         for doc in docs {
@@ -207,7 +210,6 @@ impl FullTextDatabaseIndex {
         index_writer
             .commit()
             .context(FailedToInsertDataIntoIndexSnafu)?;
-
         Ok(())
     }
 
@@ -238,7 +240,7 @@ impl FullTextDatabaseIndex {
         base_table: &Arc<dyn TableProvider>,
         search_fields: &[String],
         primary_key: &[String],
-    ) -> Result<Arc<tantivy::Index>, Error> {
+    ) -> Result<Arc<RwLock<tantivy::Index>>, Error> {
         let schema = base_table.schema();
         let mut schema_builder = tantivy::schema::Schema::builder();
         for p in primary_key {
@@ -306,7 +308,7 @@ impl FullTextDatabaseIndex {
             schema_builder.add_text_field(s, tantivy::schema::TEXT | tantivy::schema::STORED);
         }
         let schema = schema_builder.build();
-        Ok(Arc::new(tantivy::Index::create_in_ram(schema)))
+        Ok(Arc::new(RwLock::new(tantivy::Index::create_in_ram(schema))))
     }
 
     fn new_ctx() -> Result<Arc<SessionContext>, DataFusionError> {
@@ -320,12 +322,13 @@ impl FullTextDatabaseIndex {
         )))
     }
 
-    pub fn full_text_search_field_index(
+    pub async fn full_text_search_field_index(
         &self,
         search_field: &str,
     ) -> Result<FullTextSearchFieldIndex, search::generation::text_search::Error> {
+        let index_read = self.index.read().await;
         let mut search_index = FullTextSearchFieldIndex::try_new(
-            Arc::clone(&self.index),
+            &index_read,
             search_field.to_string(),
             self.primary_key.clone(),
             Some(vec![]), // Explicitly do not return other `self.search_fields` columns in search results.
@@ -335,13 +338,14 @@ impl FullTextDatabaseIndex {
     }
 
     /// Constructs a [`CandidateGeneration`] for full text search on the underlying [`tantivy::Index`] with full filter and column support via the underlying [`TableProvider`].
-    pub fn as_candidate_generations(
+    pub async fn as_candidate_generations(
         &self,
     ) -> Result<Vec<Arc<dyn CandidateGeneration>>, search::generation::Error> {
         let mut generators = vec![];
         for search_field in self.search_fields.as_slice() {
             let base = self
                 .full_text_search_field_index(search_field.as_str())
+                .await
                 .map_err(|source| search::generation::Error::TextSearchError { source })?;
 
             let post_apply = PostApplyCandidateGeneration::new(

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -296,7 +296,7 @@ impl TextSearchUDTFProvider {
     }
 
     fn search_field_index_schema(field_index: &FullTextSearchFieldIndex) -> SchemaRef {
-        let tantivy_schema = field_index.tantivy_schema();
+        let tantivy_schema = &field_index.search_schema;
 
         let fields = field_index
             .all_columns()
@@ -363,7 +363,12 @@ impl TableProvider for TextSearchUDTFProvider {
 
         let col = self.column()?;
 
-        let Some(field_index) = self.index.full_text_search_field_index(col.as_str()).ok() else {
+        let Some(field_index) = self
+            .index
+            .full_text_search_field_index(col.as_str())
+            .await
+            .ok()
+        else {
             // This shouldn't be reachable as we checked `col` above. Instead of `unreachable!`, provide user friendly error.
             return Err(DataFusionError::Internal(format!(
                 "User function 'text_search' is called on table '{tbl}'. Unexpectedly, text search cannot be performed on '{col}' column. Report an issue on GitHub: https://github.com/spiceai/spiceai/issues."

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -237,6 +237,7 @@ pub async fn full_text_search_candidates(
     Some(
         fts.with_new_base(table_provider)
             .as_candidate_generations()
+            .await
             .context(SearchGenerationSnafu),
     )
 }

--- a/crates/search/src/generation/post_apply.rs
+++ b/crates/search/src/generation/post_apply.rs
@@ -397,7 +397,7 @@ mod tests {
     #[tokio::test]
     async fn test_filter() {
         let fts = FullTextSearchFieldIndex::try_new(
-            Arc::new(create_basic_index()),
+            &create_basic_index(),
             "body".to_string(),
             vec!["title".to_string()],
             None,
@@ -423,7 +423,7 @@ mod tests {
     #[tokio::test]
     async fn test_projection() {
         let fts = FullTextSearchFieldIndex::try_new(
-            Arc::new(create_basic_index()),
+            &create_basic_index(),
             "body".to_string(),
             vec![],
             None,

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -31,7 +31,7 @@ use futures::{Stream, StreamExt};
 use serde_json::{Number, Value};
 use snafu::{ResultExt, Snafu};
 use tantivy::{
-    Index, ReloadPolicy, Searcher, TantivyError,
+    Index, ReloadPolicy, TantivyError,
     collector::TopDocs,
     query::{Occur, QueryParser, QueryParserError},
     query_grammar::{Delimiter, UserInputAst, UserInputLeaf, UserInputLiteral},
@@ -494,8 +494,6 @@ pub fn tantivy_to_arrow_type(t: &FieldType) -> Option<arrow::datatypes::DataType
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
-
     use datafusion::{execution::SendableRecordBatchStream, physical_plan::common::collect};
     use serde_json::Value;
     use tantivy::{

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -94,10 +94,26 @@ impl Error {
     }
 }
 
-/// A [`FullTextSearchFieldIndex`] is a [`tantivy::Index`] that is used to search a single field of a table.
-#[derive(Clone, Debug)]
+impl std::fmt::Debug for FullTextSearchFieldIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FullTextSearchFieldIndex")
+            .field("schema", &self.search_schema)
+            .field("field", &self.field)
+            .field("primary_key", &self.primary_key)
+            .field("additional_columns", &self.additional_columns)
+            .field("type_hints", &self.type_hints)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A [`FullTextSearchFieldIndex`] performs a search on a [`tantivy::Index`]  for a single field of a table.
+#[derive(Clone)]
 pub struct FullTextSearchFieldIndex {
-    idx: Arc<Index>,
+    // These are components from a [`tantivy::Index`] required to perform a search on a  [`tantivy::Index`] at a given commit.
+    pub search_schema: tantivy::schema::Schema,
+    reader: tantivy::Searcher,
+    tokenizer_manager: tantivy::tokenizer::TokenizerManager,
+
     field: String,
     primary_key: Vec<String>,
 
@@ -113,13 +129,20 @@ pub struct FullTextSearchFieldIndex {
 
 impl FullTextSearchFieldIndex {
     pub fn try_new(
-        index: Arc<Index>,
+        index: &Index,
         field: String,
         primary_key: Vec<String>,
         additional_columns: Option<Vec<String>>,
     ) -> Result<Self> {
         let fts = Self {
-            idx: index,
+            search_schema: index.schema(),
+            reader: index
+                .reader_builder()
+                .reload_policy(ReloadPolicy::OnCommitWithDelay)
+                .try_into()
+                .context(TextSearchSnafu)?
+                .searcher(),
+            tokenizer_manager: index.tokenizers().clone(),
             field,
             primary_key,
             additional_columns,
@@ -187,8 +210,7 @@ impl FullTextSearchFieldIndex {
 
     #[must_use]
     pub fn all_columns(&self) -> Vec<String> {
-        self.idx
-            .schema()
+        self.search_schema
             .fields()
             .filter_map(|(_, f)| {
                 let name = f.name().to_string();
@@ -208,29 +230,17 @@ impl FullTextSearchFieldIndex {
             .collect()
     }
 
-    #[must_use]
-    pub fn tantivy_schema(&self) -> tantivy::schema::Schema {
-        self.idx.schema()
-    }
-
-    fn index_searcher(&self) -> Result<Searcher> {
-        Ok(self
-            .idx
-            .reader_builder()
-            .reload_policy(ReloadPolicy::OnCommitWithDelay)
-            .try_into()
-            .context(TextSearchSnafu)?
-            .searcher())
-    }
-
     fn query_parser(&self) -> QueryParser {
         let default_field = self
-            .idx
-            .schema()
+            .search_schema
             .find_field(self.field.as_str())
             .map(|(f, _)| vec![f])
             .unwrap_or_default();
-        QueryParser::for_index(&self.idx, default_field)
+        QueryParser::new(
+            self.search_schema.clone(),
+            default_field,
+            self.tokenizer_manager.clone(),
+        )
     }
 
     /// If `keep_search_field`, `self.field` will be kept in result (as well as [`SEARCH_VALUE_COLUMN_NAME`]).
@@ -248,22 +258,20 @@ impl FullTextSearchFieldIndex {
                 query: literal.to_string(),
             })?;
 
-        let schema = self.idx.schema();
-        let searcher = self.index_searcher()?;
-
         let all_cols = self.all_columns();
 
-        let top_docs = searcher
+        let top_docs = self
+            .reader
             .search(&q, &TopDocs::with_limit(limit).and_offset(offset))
             .context(TextSearchSnafu)?
             .into_iter()
             .map(|(score, addr)| {
                 let doc: HashMap<tantivy::schema::Field, OwnedValue> =
-                    searcher.doc(addr).context(TextSearchSnafu)?;
+                    self.reader.doc(addr).context(TextSearchSnafu)?;
 
                 let mut doc_w_col_names = doc
                     .into_iter()
-                    .map(|(f, v)| (schema.get_field_name(f), v))
+                    .map(|(f, v)| (self.search_schema.get_field_name(f), v))
                     .filter(|(name, _)| all_cols.contains(&(*name).to_string()))
                     .collect::<HashMap<_, _>>();
 
@@ -582,7 +590,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_basic_index() {
         let fts = FullTextSearchFieldIndex::try_new(
-            Arc::new(create_basic_index()),
+            &create_basic_index(),
             "body".to_string(),
             vec![],
             None,


### PR DESCRIPTION
## 📝 Summary
 - Implementations of [`runtime_datafusion_index::Index`](https://github.com/spiceai/spiceai/blob/67cf32b1d45474d5afe888e1eafb2588d64d6e8b/crates/runtime-datafusion-index/src/lib.rs#L27) must handle concurrent calls to [`compute_index`](https://github.com/spiceai/spiceai/blob/67cf32b1d45474d5afe888e1eafb2588d64d6e8b/crates/runtime-datafusion-index/src/lib.rs#L33). 
 - The current full text search index implementation [`FullTextDatabaseIndex`](https://github.com/spiceai/spiceai/blob/67cf32b1d45474d5afe888e1eafb2588d64d6e8b/crates/runtime/src/search/full_text/index.rs#L88) does not handle this. If parallel `compute_index` calls are made, the following error will occur
 ```
 Failed to create a full text search index: Failed to acquire Lockfile: LockBusy.
 ```
- This is due to the underlying `tantivy::Index`. As [recommended](https://github.com/quickwit-oss/tantivy/issues/550) an`Arc<RwLock<Index>>` should be used. This PR does two things:
  1. Use a `Arc<RwLock<Index>>` in `FullTextDatabaseIndex`.
  2. Removes the use of `Arc<Index>` from `FullTextSearchFieldIndex`. Instead, provide it with the minimal required components (e.g. `tantivy::Searcher`), since `FullTextSearchFieldIndex` is short-lived, and serve to handle a given search request (`FullTextDatabaseIndex` is the long-lived state). 