### PR TITLE
Add tests for dataset retention logic and refactor retention code

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -689,47 +689,157 @@ impl TableProvider for AcceleratedTable {
     }
 }
 
+#[derive(Debug)]
+pub enum DataRetentionFilter {
+    Time {
+        period: Duration,
+        time_column: String,
+        time_format: Option<TimeFormat>,
+        time_partition_column: Option<String>,
+        time_partition_format: Option<TimeFormat>,
+    },
+    Expression {
+        delete_expr: Expr,
+    },
+}
+
+pub struct RetentionBuilder {
+    time_column: Option<String>,
+    time_format: Option<TimeFormat>,
+    time_period: Option<Duration>,
+    time_partition_column: Option<String>,
+    time_partition_format: Option<TimeFormat>,
+    delete_expr: Option<Expr>,
+    check_interval: Option<Duration>,
+    enabled: bool,
+}
+
+impl RetentionBuilder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            time_column: None,
+            time_format: None,
+            time_partition_column: None,
+            time_partition_format: None,
+            delete_expr: None,
+            time_period: None,
+            check_interval: None,
+            enabled: true,
+        }
+    }
+
+    #[must_use]
+    pub fn time_column<S: Into<String>>(mut self, time_column: Option<S>) -> Self {
+        self.time_column = time_column.map(Into::into);
+        self
+    }
+
+    #[must_use]
+    pub fn time_format(mut self, time_format: Option<TimeFormat>) -> Self {
+        self.time_format = time_format;
+        self
+    }
+
+    #[must_use]
+    pub fn time_partition_column<S: Into<String>>(
+        mut self,
+        time_partition_column: Option<S>,
+    ) -> Self {
+        self.time_partition_column = time_partition_column.map(Into::into);
+        self
+    }
+
+    #[must_use]
+    pub fn time_partition_format(mut self, time_partition_format: Option<TimeFormat>) -> Self {
+        self.time_partition_format = time_partition_format;
+        self
+    }
+
+    #[must_use]
+    pub fn delete_expr(mut self, delete_expr: Option<Expr>) -> Self {
+        self.delete_expr = delete_expr;
+        self
+    }
+
+    #[must_use]
+    pub fn time_period(mut self, time_period: Option<Duration>) -> Self {
+        self.time_period = time_period;
+        self
+    }
+
+    #[must_use]
+    pub fn check_interval(mut self, check_interval: Option<Duration>) -> Self {
+        self.check_interval = check_interval;
+        self
+    }
+
+    #[must_use]
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> Option<Retention> {
+        if !self.enabled {
+            return None;
+        }
+
+        let check_interval = self.check_interval?;
+        let mut filters = Vec::new();
+
+        // Add time-based filter if period and time_column are provided
+        if let Some(period) = self.time_period {
+            let Some(time_column) = self.time_column else {
+                tracing::error!(
+                    "[retention] The `time_column` must be specified for time-based retention"
+                );
+                return None;
+            };
+
+            filters.push(DataRetentionFilter::Time {
+                period,
+                time_column,
+                time_format: self.time_format,
+                time_partition_column: self.time_partition_column.clone(),
+                time_partition_format: self.time_partition_format,
+            });
+        }
+
+        // Add expression-based filter
+        if let Some(delete_expr) = self.delete_expr {
+            filters.push(DataRetentionFilter::Expression { delete_expr });
+        }
+
+        if filters.is_empty() {
+            tracing::error!(
+                "[retention] The `retention_period` or `retention_sql` must be specified for retention"
+            );
+            return None;
+        }
+
+        Some(Retention {
+            filters,
+            check_interval,
+        })
+    }
+}
+
+impl Default for RetentionBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct Retention {
-    pub(crate) time_column: Option<String>,
-    pub(crate) time_format: Option<TimeFormat>,
-    pub(crate) time_partition_column: Option<String>,
-    pub(crate) time_partition_format: Option<TimeFormat>,
-    pub(crate) delete_expr: Option<Expr>,
-    pub(crate) period: Option<Duration>,
+    pub(crate) filters: Vec<DataRetentionFilter>,
     pub(crate) check_interval: Duration,
 }
 
 impl Retention {
-    #[allow(clippy::too_many_arguments)]
     #[must_use]
-    pub fn new(
-        time_column: Option<String>,
-        time_format: Option<TimeFormat>,
-        time_partition_column: Option<String>,
-        time_partition_format: Option<TimeFormat>,
-        retention_period: Option<Duration>,
-        retention_check_interval: Option<Duration>,
-        retention_check_enabled: bool,
-        delete_expr: Option<Expr>,
-    ) -> Option<Self> {
-        if !retention_check_enabled {
-            return None;
-        }
-
-        let check_interval = retention_check_interval?;
-
-        if retention_period.is_none() && delete_expr.is_none() {
-            return None;
-        }
-
-        Some(Self {
-            time_column,
-            time_format,
-            time_partition_column,
-            time_partition_format,
-            delete_expr,
-            period: retention_period,
-            check_interval,
-        })
+    pub fn builder() -> RetentionBuilder {
+        RetentionBuilder::new()
     }
 }

--- a/crates/runtime/src/accelerated_table/retention.rs
+++ b/crates/runtime/src/accelerated_table/retention.rs
@@ -20,30 +20,19 @@ use arrow::array::UInt64Array;
 use cache::Caching;
 use data_components::delete::get_deletion_provider;
 use datafusion::{
-    catalog::TableProvider,
-    logical_expr::Operator,
-    physical_plan::collect,
-    prelude::{Expr, SessionContext},
-    sql::TableReference,
+    catalog::TableProvider, logical_expr::Operator, physical_plan::collect,
+    prelude::SessionContext, sql::TableReference,
 };
 
 use crate::{
-    accelerated_table::{Retention, refresh},
+    accelerated_table::{DataRetentionFilter, Retention, refresh},
+    component::dataset::TimeFormat,
     datafusion::{
         builder::get_df_default_config, filter_converter::TimestampFilterConvert,
         is_spice_internal_dataset,
     },
     object_store_registry::default_runtime_env,
 };
-
-enum DataRetentionFilter {
-    DeleteExpr(Expr),
-    TimeColumn {
-        converter: TimestampFilterConvert,
-        time_column: String,
-        retention_period: std::time::Duration,
-    },
-}
 
 impl super::AcceleratedTable {
     #[allow(clippy::cast_possible_wrap)]
@@ -55,89 +44,65 @@ impl super::AcceleratedTable {
         retention: Retention,
         caching: Option<Arc<Caching>>,
     ) {
-        let retention_filter = if let Some(delete_expr) = retention.delete_expr {
-            DataRetentionFilter::DeleteExpr(delete_expr)
-        } else {
-            let Some(time_column) = &retention.time_column else {
-                tracing::error!(
-                    "[retention] The `time_column` parameter must be specified for retention"
-                );
-                return;
-            };
-
-            let Some(retention_period) = retention.period else {
-                tracing::error!(
-                    "[retention] The `retention_period` parameter must be specified for retention"
-                );
-                return;
-            };
-
-            let Some(converter) =
-                create_timestamp_filter_converter(&retention, &accelerator, time_column)
-            else {
-                return;
-            };
-            DataRetentionFilter::TimeColumn {
-                converter,
-                time_column: time_column.clone(),
-                retention_period,
-            }
-        };
-
         let mut interval_timer = tokio::time::interval(retention.check_interval);
 
         loop {
             interval_timer.tick().await;
 
             if let Some(deleted_table_provider) = get_deletion_provider(Arc::clone(&accelerator)) {
-                let expr = match &retention_filter {
-                    DataRetentionFilter::DeleteExpr(expr) => {
-                        if is_spice_internal_dataset(&dataset_name) {
-                            tracing::trace!(
-                                "[retention] Evicting data for {dataset_name} with using retention sql expression"
-                            );
-                        } else {
-                            tracing::info!(
-                                "[retention] Evicting data for {dataset_name} with using retention sql expression"
-                            );
+                let mut exprs = Vec::new();
+
+                // convert retention filters into data eviction expressions
+                for filter in &retention.filters {
+                    match filter {
+                        DataRetentionFilter::Expression { delete_expr } => {
+                            log_retention_action(&dataset_name, "using SQL expression");
+                            exprs.push(delete_expr.clone());
                         }
-                        expr.clone()
-                    }
-                    DataRetentionFilter::TimeColumn {
-                        converter,
-                        time_column,
-                        retention_period,
-                    } => {
-                        let start = SystemTime::now() - *retention_period;
-                        let timestamp = refresh::get_timestamp(start);
-                        let expr = converter.convert(timestamp, Operator::Lt);
+                        DataRetentionFilter::Time {
+                            period,
+                            time_column,
+                            time_format,
+                            time_partition_column,
+                            time_partition_format,
+                        } => {
+                            let Some(converter) = create_timestamp_filter_converter(
+                                &accelerator,
+                                time_column,
+                                *time_format,
+                                time_partition_column.as_ref(),
+                                *time_partition_format,
+                            ) else {
+                                tracing::error!(
+                                    "[retention] Failed to create timestamp filter converter for retention for dataset {dataset_name}",
+                                );
+                                continue;
+                            };
 
-                        let timestamp = if let Some(value) =
-                            chrono::DateTime::from_timestamp((timestamp / 1_000_000_000) as i64, 0)
-                        {
-                            value.to_rfc3339()
-                        } else {
-                            tracing::warn!("[retention] Unable to convert timestamp");
-                            continue;
-                        };
+                            let start = SystemTime::now() - *period;
+                            let timestamp = refresh::get_timestamp(start);
+                            let expr = converter.convert(timestamp, Operator::Lt);
 
-                        if is_spice_internal_dataset(&dataset_name) {
-                            tracing::trace!(
-                                "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
-                                timestamp
+                            let timestamp = if let Some(value) = chrono::DateTime::from_timestamp(
+                                (timestamp / 1_000_000_000) as i64,
+                                0,
+                            ) {
+                                value.to_rfc3339()
+                            } else {
+                                tracing::warn!("[retention] Unable to convert timestamp");
+                                continue;
+                            };
+
+                            log_retention_action(
+                                &dataset_name,
+                                &format!("where {time_column} < {timestamp}"),
                             );
-                        } else {
-                            tracing::info!(
-                                "[retention] Evicting data for {dataset_name} where {time_column} < {}...",
-                                timestamp
-                            );
+                            exprs.push(expr);
                         }
-
-                        expr
                     }
-                };
+                }
 
-                tracing::trace!("[retention] Expr {expr:?}");
+                tracing::trace!("[retention] Exprs {exprs:?}");
 
                 let ctx = SessionContext::new_with_config_rt(
                     get_df_default_config(),
@@ -145,7 +110,7 @@ impl super::AcceleratedTable {
                 );
 
                 let plan = deleted_table_provider
-                    .delete_from(&ctx.state(), &vec![expr.clone()])
+                    .delete_from(&ctx.state(), &exprs)
                     .await;
                 match plan {
                     Ok(plan) => match collect(plan, ctx.task_ctx()).await {
@@ -160,15 +125,7 @@ impl super::AcceleratedTable {
                                     .map_or(0, |v| v.values().first().map_or(0, |f| *f))
                             });
 
-                            if is_spice_internal_dataset(&dataset_name) {
-                                tracing::trace!(
-                                    "[retention] Evicted {num_records} records for {dataset_name}"
-                                );
-                            } else {
-                                tracing::info!(
-                                    "[retention] Evicted {num_records} records for {dataset_name}"
-                                );
-                            }
+                            log_retention_result(&dataset_name, num_records);
 
                             if num_records > 0 {
                                 if let Some(cache_provider) = caching.as_ref() {
@@ -196,28 +153,264 @@ impl super::AcceleratedTable {
 }
 
 fn create_timestamp_filter_converter(
-    retention: &Retention,
     accelerator: &Arc<dyn TableProvider>,
     time_column: &str,
+    time_format: Option<TimeFormat>,
+    time_partition_column: Option<&String>,
+    time_partition_format: Option<TimeFormat>,
 ) -> Option<TimestampFilterConvert> {
     let schema = accelerator.schema();
     let field = schema.column_with_name(time_column).map(|(_, f)| f);
-    let partition_field =
-        retention
-            .time_partition_column
-            .as_ref()
-            .and_then(|time_partition_column| {
-                schema
-                    .column_with_name(time_partition_column.as_str())
-                    .map(|(_, f)| f)
-            });
+    let partition_field = time_partition_column
+        .as_ref()
+        .and_then(|time_partition_column| {
+            schema
+                .column_with_name(time_partition_column.as_str())
+                .map(|(_, f)| f)
+        });
 
     TimestampFilterConvert::create(
         field.cloned(),
         Some(time_column.to_string()),
-        retention.time_format,
+        time_format,
         partition_field.cloned(),
-        retention.time_partition_column.clone(),
-        retention.time_partition_format,
+        time_partition_column.cloned(),
+        time_partition_format,
     )
+}
+
+fn log_retention_action(dataset_name: &TableReference, filter_msg: &str) {
+    let msg = format!("[retention] Evicting data for {dataset_name} {filter_msg}");
+    if is_spice_internal_dataset(dataset_name) {
+        tracing::trace!("{msg}");
+    } else {
+        tracing::info!("{msg}");
+    }
+}
+
+fn log_retention_result(dataset_name: &TableReference, num_records: u64) {
+    let message = format!("[retention] Evicted {num_records} records for {dataset_name}");
+
+    if is_spice_internal_dataset(dataset_name) {
+        tracing::trace!("{message}");
+    } else {
+        tracing::info!("{message}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::accelerated_table::AcceleratedTable;
+
+    use super::*;
+    use arrow::{
+        array::{BooleanArray, Int64Array, RecordBatch, StringArray},
+        datatypes::{DataType, Field, Schema},
+    };
+    use data_components::{arrow::write::MemTable, delete::DeletionTableProviderAdapter};
+    use datafusion::{physical_plan::collect, prelude::SessionContext};
+    use tokio::time::{Duration, sleep};
+
+    fn create_test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("deleted", DataType::Boolean, true),
+            Field::new("created_at", DataType::Utf8, true),
+            Field::new("timestamp_col", DataType::Int64, false), // Unix timestamp in seconds
+        ]))
+    }
+
+    fn create_test_data() -> RecordBatch {
+        let schema = create_test_schema();
+
+        // Create test data with different timestamps (some old, some recent)
+        #[allow(clippy::cast_possible_wrap)]
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("to get current time")
+            .as_secs() as i64;
+
+        let old_timestamp = now_secs - (20 * 24 * 60 * 60); // 20 days ago
+        let recent_timestamp = now_secs - (5 * 24 * 60 * 60); // 5 days ago
+        let very_recent_timestamp = now_secs - (24 * 60 * 60); // 1 day ago
+
+        let id_array = Int64Array::from(vec![1, 2, 3, 4, 5]);
+        let is_deleted_array = BooleanArray::from(vec![
+            Some(false),
+            Some(true),
+            Some(false),
+            Some(true),
+            Some(false),
+        ]);
+        let created_at_array = StringArray::from(vec![
+            Some("2023-01-01"),
+            Some("2023-02-01"),
+            Some("2023-03-01"),
+            Some("2023-04-01"),
+            Some("2023-05-01"),
+        ]);
+        let timestamp_array = Int64Array::from(vec![
+            old_timestamp,
+            old_timestamp,
+            recent_timestamp,
+            recent_timestamp,
+            very_recent_timestamp,
+        ]);
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(id_array),
+                Arc::new(is_deleted_array),
+                Arc::new(created_at_array),
+                Arc::new(timestamp_array),
+            ],
+        )
+        .expect("Failed to create test batch")
+    }
+
+    async fn test_retention_scenario(
+        retention_sql: Option<&str>,
+        retention_period: Option<Duration>,
+        time_column: Option<&str>,
+        expected_remaining_count: usize,
+    ) {
+        let batch = create_test_data();
+        let schema = batch.schema();
+        let initial_count = batch.num_rows();
+
+        let mem_table =
+            MemTable::try_new(schema, vec![vec![batch]]).expect("mem table should be created");
+
+        let accelerator = Arc::new(DeletionTableProviderAdapter::new(Arc::new(mem_table)))
+            as Arc<dyn TableProvider>;
+
+        // Create retention configuration
+        let retention_delete_expr = retention_sql.map(|sql| {
+            crate::datafusion::retention_sql::parse_retention_sql(
+                &TableReference::bare("test"),
+                sql,
+                accelerator.schema(),
+            )
+            .expect("Failed to parse retention SQL")
+        });
+
+        let retention = Retention::builder()
+            .time_column(time_column.map(String::from))
+            .time_format(Some(crate::component::dataset::TimeFormat::UnixSeconds))
+            .time_period(retention_period)
+            .check_interval(Some(Duration::from_millis(100))) // Very short check interval for testing
+            .enabled(true)
+            .delete_expr(retention_delete_expr)
+            .build()
+            .expect("Retention should be configured");
+
+        let dataset_name = TableReference::bare("test");
+        let caching = None;
+
+        // Start retention check in background
+        let retention_task = tokio::spawn(AcceleratedTable::start_retention_check(
+            dataset_name.clone(),
+            Arc::clone(&accelerator),
+            retention,
+            caching,
+        ));
+
+        // Wait for retention to run
+        sleep(Duration::from_millis(500)).await;
+
+        // Verify the result
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+
+        let plan = accelerator
+            .scan(&state, None, &[], None)
+            .await
+            .expect("Scan plan can be constructed");
+
+        let result = collect(plan, ctx.task_ctx())
+            .await
+            .expect("Query successful");
+
+        let remaining_count: usize = result.iter().map(RecordBatch::num_rows).sum();
+
+        assert_eq!(
+            remaining_count, expected_remaining_count,
+            "Test failed: Initial count: {initial_count}, Expected: {expected_remaining_count}, Actual: {remaining_count}"
+        );
+
+        retention_task.abort();
+    }
+
+    #[tokio::test]
+    async fn test_retention_sql_only() {
+        // Retention SQL only - delete records where deleted = true
+        test_retention_scenario(
+            Some("DELETE FROM test WHERE deleted = true"),
+            None,
+            None,
+            3, // Should remain 3 records (where deleted = false)
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_retention_period_only() {
+        // Retention period only - delete records older than 10 days
+        test_retention_scenario(
+            None,
+            Some(Duration::from_secs(10 * 24 * 60 * 60)), // 10 days
+            Some("timestamp_col"),
+            3, // Should remain 3 records (recent ones)
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_retention_sql_and_period_sql() {
+        // Both retention SQL and period - delete old records AND where deleted = true
+        test_retention_scenario(
+            Some("DELETE FROM test WHERE deleted = true"),
+            Some(Duration::from_secs(10 * 24 * 60 * 60)),
+            Some("timestamp_col"),
+            2, // Should remain 2 records (where deleted = false and recent)
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_retention_very_short_period() {
+        // Very short retention period - delete almost everything
+        test_retention_scenario(
+            None,
+            Some(Duration::from_secs(2 * 24 * 60 * 60)), // 2 days
+            Some("timestamp_col"),
+            1, // Should remain 1 record (very recent)
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_retention_complex_sql() {
+        // Complex retention SQL - delete records that are both old and marked as deleted
+        test_retention_scenario(
+                Some("DELETE FROM test WHERE deleted = true AND timestamp_col < to_unixtime(NOW() - INTERVAL '7 days')"),
+                None,
+                None,
+                4, // Should remain 4 records (keeping non-deleted and recent deleted ones)
+            )
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_retention_sql_never_matches() {
+        // Retention SQL that never matches - nothing should be deleted
+        test_retention_scenario(
+            Some("DELETE FROM test WHERE created_at < '2023-01-01'"),
+            None,
+            None,
+            5, // Should remain all 5 records
+        )
+        .await;
+    }
 }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -990,16 +990,18 @@ impl DataFusion {
             None => None,
         };
 
-        accelerated_table_builder.retention(Retention::new(
-            dataset.time_column.clone(),
-            dataset.time_format,
-            dataset.time_partition_column.clone(),
-            dataset.time_partition_format,
-            dataset.retention_period(),
-            dataset.retention_check_interval(),
-            acceleration_settings.retention_check_enabled,
-            retention_delete_expr,
-        ));
+        let retention = Retention::builder()
+            .time_column(dataset.time_column.clone())
+            .time_format(dataset.time_format)
+            .time_partition_column(dataset.time_partition_column.clone())
+            .time_partition_format(dataset.time_partition_format)
+            .time_period(dataset.retention_period())
+            .check_interval(dataset.retention_check_interval())
+            .enabled(acceleration_settings.retention_check_enabled)
+            .delete_expr(retention_delete_expr)
+            .build();
+
+        accelerated_table_builder.retention(retention);
 
         accelerated_table_builder.zero_results_action(acceleration_settings.on_zero_results);
 

--- a/crates/runtime/src/init/eval.rs
+++ b/crates/runtime/src/init/eval.rs
@@ -114,16 +114,13 @@ impl Runtime {
     }
 
     pub(crate) async fn load_eval_results_table(self: Arc<Self>) -> Result<()> {
-        let retention = Retention::new(
-            Some(EVAL_RESULTS_TABLE_TIME_COLUMN.to_string()),
-            Some(TimeFormat::Timestamptz),
-            None,
-            None,
-            Some(Duration::from_secs(24 * 3600)), // Keep data for last 24 hours
-            Some(Duration::from_secs(1800)),      // Check every 30 minutes
-            true,
-            None,
-        );
+        let retention = Retention::builder()
+            .time_column(Some(EVAL_RESULTS_TABLE_TIME_COLUMN.to_string()))
+            .time_format(Some(TimeFormat::Timestamptz))
+            .time_period(Some(Duration::from_secs(24 * 3600))) // Keep data for last 24 hours
+            .check_interval(Some(Duration::from_secs(1800))) // Check every 30 minutes
+            .enabled(true)
+            .build();
 
         let table = create_internal_accelerated_table(
             self.status(),
@@ -147,16 +144,13 @@ impl Runtime {
     }
 
     pub(crate) async fn load_eval_run_table(self: Arc<Self>) -> Result<()> {
-        let retention = Retention::new(
-            Some(EVAL_RUNS_TABLE_TIME_COLUMN.to_string()),
-            Some(TimeFormat::Timestamptz),
-            None,
-            None,
-            Some(Duration::from_secs(24 * 3600)), // Keep data for last 24 hours
-            Some(Duration::from_secs(1800)),      // Check every 30 minutes
-            true,
-            None,
-        );
+        let retention = Retention::builder()
+            .time_column(Some(EVAL_RUNS_TABLE_TIME_COLUMN.to_string()))
+            .time_format(Some(TimeFormat::Timestamptz))
+            .time_period(Some(Duration::from_secs(24 * 3600))) // Keep data for last 24 hours
+            .check_interval(Some(Duration::from_secs(1800))) // Check every 30 minutes
+            .enabled(true)
+            .build();
 
         let table = create_internal_accelerated_table(
             self.status(),

--- a/crates/runtime/src/spice_metrics.rs
+++ b/crates/runtime/src/spice_metrics.rs
@@ -94,16 +94,13 @@ pub async fn register_metrics_table(
 ) -> Result<(), Error> {
     let metrics_table_reference = get_metrics_table_reference();
 
-    let retention = Retention::new(
-        Some("time_unix_nano".to_string()),
-        Some(TimeFormat::Timestamptz),
-        None,
-        None,
-        Some(Duration::from_secs(1800)), // delete metrics older then 30 minutes
-        Some(Duration::from_secs(300)),  // run retention every 5 minutes
-        true,
-        None,
-    );
+    let retention = Retention::builder()
+        .time_column(Some("time_unix_nano"))
+        .time_format(Some(TimeFormat::Timestamptz))
+        .time_period(Some(Duration::from_secs(1800))) // delete metrics older than 30 minutes
+        .check_interval(Some(Duration::from_secs(300))) // run retention every 5 minutes
+        .enabled(true)
+        .build();
 
     let table = create_internal_accelerated_table(
         datafusion.runtime_status(),

--- a/crates/runtime/src/task_history/mod.rs
+++ b/crates/runtime/src/task_history/mod.rs
@@ -92,16 +92,14 @@ impl TaskSpan {
             "Task history retention check interval: {retention_check_interval_secs} seconds"
         );
 
-        let retention = Retention::new(
-            time_column.clone(),
-            time_format,
-            None,
-            None,
-            Some(Duration::from_secs(retention_period_secs)), // 1 day
-            Some(Duration::from_secs(retention_check_interval_secs)),
-            true,
-            None,
-        );
+        let retention = Retention::builder()
+            .time_column(time_column.clone())
+            .time_format(time_format)
+            .time_period(Some(Duration::from_secs(retention_period_secs)))
+            .check_interval(Some(Duration::from_secs(retention_check_interval_secs)))
+            .enabled(true)
+            .build();
+
         let tbl_reference =
             TableReference::partial(SPICE_RUNTIME_SCHEMA, DEFAULT_TASK_HISTORY_TABLE);
 

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -77,6 +77,7 @@ mod ready_state;
 mod refresh_retry;
 mod refresh_sql;
 mod results_cache;
+mod retention;
 mod s3;
 #[cfg(feature = "postgres")]
 mod schema_evolution;

--- a/crates/runtime/tests/retention/mod.rs
+++ b/crates/runtime/tests/retention/mod.rs
@@ -1,0 +1,101 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use arrow::array::RecordBatch;
+use futures::TryStreamExt;
+use std::{sync::Arc, time::Duration};
+
+use app::AppBuilder;
+
+use runtime::Runtime;
+use spicepod::{acceleration::Acceleration, component::dataset::Dataset};
+
+use crate::{
+    configure_test_datafusion, init_tracing,
+    utils::{runtime_ready_check, test_request_context},
+};
+
+fn make_spiceai_dataset(path: &str, name: &str, retention_sql: String) -> Dataset {
+    let mut ds = Dataset::new(format!("spice.ai/{path}"), name.to_string());
+    ds.acceleration = Some(Acceleration {
+        enabled: true,
+        retention_sql: Some(retention_sql),
+        retention_check_enabled: true,
+        retention_check_interval: Some("200ms".to_string()),
+        ..Default::default()
+    });
+    ds
+}
+
+#[tokio::test]
+async fn test_retention_sql() -> Result<(), anyhow::Error> {
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+    let _tracing = init_tracing(None);
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("retention_sql")
+                .with_dataset(make_spiceai_dataset(
+                    "spiceai/tpch/datasets/tpch.nation",
+                    "nation",
+                    "DELETE FROM nation WHERE n_nationkey >= 5 OR n_name NOT LIKE '%A'".to_string(),
+                ))
+                .build();
+
+            let rt = Runtime::builder()
+                .with_app(app)
+                .with_datafusion_configuration_fn(configure_test_datafusion)
+                .build()
+                .await;
+
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            tokio::time::sleep(Duration::from_secs(1)).await; // Allow retention to complete
+
+            let query = rt
+                .datafusion()
+                .query_builder("SELECT * FROM nation")
+                .build()
+                .run()
+                .await?;
+
+            let results: Vec<RecordBatch> = query.data.try_collect::<Vec<RecordBatch>>().await?;
+            // keep only ALGERIA, ARGENTINA and CANADA
+            assert_eq!(
+                results.iter().map(RecordBatch::num_rows).sum::<usize>(),
+                3,
+                "Expected retention SQL to filter out all rows except ALGERIA, ARGENTINA and CANADA"
+            );
+
+            let results_str =
+                arrow::util::pretty::pretty_format_batches(&results).expect("pretty batches");
+            insta::assert_snapshot!(results_str);
+
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/retention/snapshots/integration__retention__retention_sql.snap
+++ b/crates/runtime/tests/retention/snapshots/integration__retention__retention_sql.snap
@@ -1,0 +1,11 @@
+---
+source: crates/runtime/tests/retention/mod.rs
+expression: results_str
+---
++-------------+-----------+-------------+-------------------------------------------------------------------------------------------------------+
+| n_nationkey | n_name    | n_regionkey | n_comment                                                                                             |
++-------------+-----------+-------------+-------------------------------------------------------------------------------------------------------+
+| 0           | ALGERIA   | 0           | furiously regular requests. platelets affix furious                                                   |
+| 1           | ARGENTINA | 1           | instructions wake quickly. final deposits haggle. final, silent theodolites                           |
+| 3           | CANADA    | 1           | ss deposits wake across the pending foxes. packages after the carefully bold requests integrate caref |
++-------------+-----------+-------------+-------------------------------------------------------------------------------------------------------+

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -166,16 +166,13 @@ impl SpiceExtension {
         runtime: Arc<Runtime>,
         from: String,
     ) -> Result<()> {
-        let retention = Retention::new(
-            Some("timestamp".to_string()),
-            Some(TimeFormat::UnixSeconds),
-            None,
-            None,
-            Some(Duration::from_secs(1800)), // delete metrics older then 30 minutes
-            Some(Duration::from_secs(300)),  // run retention every 5 minutes
-            true,
-            None,
-        );
+        let retention = Retention::builder()
+            .time_column(Some("timestamp".to_string()))
+            .time_format(Some(TimeFormat::UnixSeconds))
+            .time_period(Some(Duration::from_secs(1800))) // delete metrics older than 30 minutes
+            .check_interval(Some(Duration::from_secs(300))) // run retention every 5 minutes
+            .enabled(true)
+            .build();
 
         let refresh = Refresh::new(RefreshMode::Full)
             .time_column("timestamp".to_string())


### PR DESCRIPTION
## 📝 Summary

PR introduces `RetentionBuilder` and `DataRetentionFilter` to simplify retention logic and enable multiple retention strategies to be applied simultaneously.

Includes unit and integration tests for retention.

## 🔗 Related

Closes #6418 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
