### PR TITLE
Add periodic tracing of data loading progress during dataset refresh

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -31,6 +31,7 @@ use futures::{StreamExt, stream};
 use opentelemetry::KeyValue;
 use runtime_datafusion_index::analyzer::IndexTableScanOptimizerRule;
 use snafu::{OptionExt, ResultExt};
+use tokio::time::Instant;
 use tracing::{Instrument, Span};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{RetryError, retry};
@@ -58,7 +59,7 @@ use super::synchronized_table::SynchronizedTable;
 use super::{UnableToCreateMemTableFromUpdateSnafu, metrics};
 
 use crate::component::dataset::TimeFormat;
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 use std::{cmp::Ordering, sync::Arc, time::SystemTime};
 use tokio::sync::{RwLock, Semaphore, oneshot};
 
@@ -331,25 +332,41 @@ impl RefreshTask {
                     RefreshStat::default(),
                     dataset_name.to_string(),
                     notify_written_data_stat_available,
+                    DataLoadTracing::new(&self.dataset_name),
                 ),
-                move |(mut stream, mut stat, ds_name, notify_refresh_stat_available)| async move {
+                move |(
+                    mut stream,
+                    mut stat,
+                    ds_name,
+                    notify_refresh_stat_available,
+                    mut tracing,
+                )| async move {
                     if let Some(batch) = stream.next().await {
                         match batch {
                             Ok(batch) => {
-                                tracing::trace!(
-                                    "Dataset {ds_name} received {} records",
-                                    batch.num_rows()
-                                );
+                                tracing.on_new_batch_received(&batch);
                                 stat.num_rows += batch.num_rows();
                                 stat.memory_size += batch.get_array_memory_size();
                                 Some((
                                     Ok(batch),
-                                    (stream, stat, ds_name, notify_refresh_stat_available),
+                                    (
+                                        stream,
+                                        stat,
+                                        ds_name,
+                                        notify_refresh_stat_available,
+                                        tracing,
+                                    ),
                                 ))
                             }
                             Err(err) => Some((
                                 Err(err),
-                                (stream, stat, ds_name, notify_refresh_stat_available),
+                                (
+                                    stream,
+                                    stat,
+                                    ds_name,
+                                    notify_refresh_stat_available,
+                                    tracing,
+                                ),
                             )),
                         }
                     } else {
@@ -918,6 +935,46 @@ impl RefreshTask {
         );
         self.set_refresh_status(refresh_sql, status::ComponentStatus::Error)
             .await;
+    }
+}
+
+#[derive(Debug)]
+/// Tracks and logs data load progress for a dataset, periodically reporting the number of records received
+struct DataLoadTracing {
+    dataset: TableReference,
+    num_records_received: usize,
+    last_updated_time: Instant,
+    log_interval: Duration,
+}
+
+impl DataLoadTracing {
+    fn new(dataset: &TableReference) -> Self {
+        Self {
+            dataset: dataset.clone(),
+            num_records_received: 0,
+            last_updated_time: Instant::now(),
+            log_interval: Duration::from_secs(10),
+        }
+    }
+
+    fn on_new_batch_received(&mut self, batch: &RecordBatch) {
+        let num_rows = batch.num_rows();
+        tracing::trace!("Dataset {} received {num_rows} records", self.dataset,);
+        self.num_records_received += num_rows;
+
+        // trace num loaded records and reset every 10 seconds
+        if self.last_updated_time.elapsed() > self.log_interval {
+            let pretty_records = util::pretty_print_number(self.num_records_received);
+
+            if is_spice_internal_dataset(&self.dataset) {
+                tracing::debug!("Dataset {} received {pretty_records} records", self.dataset);
+            } else {
+                tracing::info!("Dataset {} received {pretty_records} records", self.dataset);
+            }
+
+            self.num_records_received = 0;
+            self.last_updated_time = Instant::now();
+        }
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

If dataset loading is not yet complete, the number of records received so far will be logged every 10 seconds. This helps monitor loading progress in real time.

As per https://github.com/spiceai/spiceai/pull/6489#discussion_r2215721780

>2025-07-19T19:22:39.359362Z  INFO runtime::init::dataset: Dataset supplier registered (oracle:"TPCH_SF1"."SUPPLIER"), acceleration (arrow), results cache enabled.
2025-07-19T19:22:39.360520Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
2025-07-19T19:22:39.670660Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (1.87 MiB) for dataset supplier in 310ms.
2025-07-19T19:22:47.860220Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 904,000 records
2025-07-19T19:22:49.287607Z  INFO runtime::accelerated_table::refresh_task: Dataset partsupp received 604,000 records
2025-07-19T19:22:49.360574Z  INFO runtime::accelerated_table::refresh_task: Dataset orders received 1,104,000 records
2025-07-19T19:22:50.760185Z  INFO runtime::accelerated_table::refresh_task: Loaded 800,000 rows (133.68 MiB) for dataset partsupp in 13s 627ms.
2025-07-19T19:22:52.344419Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,500,000 rows (228.36 MiB) for dataset orders in 14s 102ms.
2025-07-19T19:22:59.388866Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 1,200,000 records
2025-07-19T19:23:11.364714Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 1,100,000 records
2025-07-19T19:23:22.366388Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 1,008,000 records
2025-07-19T19:23:33.470826Z  INFO runtime::accelerated_table::refresh_task: Dataset lineitem received 1,192,000 records
2025-07-19T19:23:37.766573Z  INFO runtime::accelerated_table::refresh_task: Loaded 6,001,215 rows (1.05 GiB) for dataset lineitem in 1m 1s 289ms.
2025-07-19T19:23:37.803066Z  INFO runtime: All components are loaded. Spice runtime is ready!

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
