### PR TITLE
Suppress the warning from the AWS SDK if it can't load credentials

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -69,7 +69,7 @@ const INTERNAL_COMPONENTS: &[&str] = &[
     "workers",
 ];
 
-const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off,aws_config::imds::region=off";
+const OFF_FILTERS: &str = "reqwest_retry::middleware=off,opentelemetry_sdk=off,delta_kernel::log_segment=off,aws_config::imds::region=off,aws_config::meta::credentials::chain=off";
 
 impl From<LogVerbosity> for EnvFilter {
     fn from(v: LogVerbosity) -> Self {


### PR DESCRIPTION
Suppresses the warning from the AWS SDK when it can't load credentials - we handle that explicitly in our code.


https://github.com/spiceai/spiceai/actions/runs/16422238811/job/46409290978
```
2025-07-21T16:29:15.954917Z  WARN aws_config::meta::credentials::chain: provider failed to provide credentials provider=Ec2InstanceMetadata error=an error occurred while loading credentials: failed to load IMDS session token: service error: invalid token (ProviderError(ProviderError { source: FailedToLoadToken(FailedToLoadToken { source: ServiceError(ServiceError { source: TokenError { kind: InvalidToken }, raw: Response { status: StatusCode(411), headers: Headers { headers: {"content-type": HeaderValue { _private: H1("text/html; charset=us-ascii") }, "server": HeaderValue { _private: H1("Microsoft-HTTPAPI/2.0") }, "date": HeaderValue { _private: H1("Mon, 21 Jul 2025 16:29:15 GMT") }, "connection": HeaderValue { _private: H1("close") }, "content-length": HeaderValue { _private: H1("344") }} }, body: SdkBody { inner: Once(Some(b"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\"[http://www.w3.org/TR/html4/strict.dtd\](http://www.w3.org/TR/html4/strict.dtd/)">\r\n<HTML><HEAD><TITLE>Length Required</TITLE>\r\n<META HTTP-EQUIV=\"Content-Type\" Content=\"text/html; charset=us-ascii\"></HEAD>\r\n<BODY><h2>Length Required</h2>\r\n<hr><p>HTTP Error 411. The request must be chunked or have a content length.</p>\r\n</BODY></HTML>\r\n")), retryable: true }, extensions: Extensions { extensions_02x: Extensions, extensions_1x: Extensions } } }) }) }))
2025-07-21T[16](https://github.com/spiceai/spiceai/actions/runs/16422238811/job/46409290978#step:10:17):29:16.122244Z  INFO runtime::init::dataset: Dataset test_parquet_table registered (s3://spiceai-public-datasets/test_parquet_table/), results cache enabled.
```