### PR TITLE
Update table-providers to latest version with DuckDB fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,7 +4086,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=2f3389ab88150fe13950f300e59baf510d1edf5a#2f3389ab88150fe13950f300e59baf510d1edf5a"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=347a765a106c62cbdf2943da0f8b1f790e84492f#347a765a106c62cbdf2943da0f8b1f790e84492f"
 dependencies = [
  "arrow",
  "arrow-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" }       # spiceai-47
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9db74a4b360df6be1bb554c59a474a2fd4bfb7e9" }                      # spiceai-47
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "2f3389ab88150fe13950f300e59baf510d1edf5a" } # spiceai
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "347a765a106c62cbdf2943da0f8b1f790e84492f" } # spiceai
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "b3547f0c1b37030b623b1e03fcaea0e4e2bb753e" } # spiceai-1.3.2
 


### PR DESCRIPTION
## 📝 Summary

Updates to the latest table-providers commit which has:

- https://github.com/datafusion-contrib/datafusion-table-providers/pull/391
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/399
- https://github.com/datafusion-contrib/datafusion-table-providers/pull/400