### PR TITLE
Enforce max limit on comments fetched per PR

### DIFF
--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -464,6 +464,8 @@ fn warn_if_provided(
     }
 }
 
+const MAX_COMMENTS_FETCHED: u32 = 100;
+
 #[async_trait]
 #[allow(clippy::too_many_lines)]
 impl DataConnector for Github {
@@ -531,13 +533,23 @@ impl DataConnector for Github {
 
         match (parts.next(), parts.next(), parts.next(), parts.next()) {
             (Some("github.com"), Some(owner), Some(repo), Some("pulls")) => {
+                let max_comments_fetched = match max_comments_fetched.unwrap_or(MAX_COMMENTS_FETCHED) {
+                    value if value > MAX_COMMENTS_FETCHED => {
+                        tracing::warn!(
+                            "The maximum number of comments fetched per pull request is capped at {MAX_COMMENTS_FETCHED} for {component}. The value {MAX_COMMENTS_FETCHED} will be used instead."
+                        );
+                        MAX_COMMENTS_FETCHED
+                    }
+                    value => value,
+                };
+
                 let table_args = Arc::new(PullRequestTableArgs {
                     owner: owner.to_string(),
                     repo: repo.to_string(),
                     query_mode,
-                    component: ConnectorComponent::from(dataset),
+                    component,
                     include_comments: include_comments.unwrap_or(PullRequestCommentType::None),
-                    max_comments_fetched: max_comments_fetched.unwrap_or(100),
+                    max_comments_fetched,
                 });
                 self.create_gql_table_provider(
                     Arc::clone(&table_args) as Arc<dyn GitHubTableArgs>,

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -536,7 +536,7 @@ impl DataConnector for Github {
                 let max_comments_fetched = match max_comments_fetched.unwrap_or(MAX_COMMENTS_FETCHED) {
                     value if value > MAX_COMMENTS_FETCHED => {
                         tracing::warn!(
-                            "The maximum number of comments fetched per pull request is capped at {MAX_COMMENTS_FETCHED} for {component}. The value {MAX_COMMENTS_FETCHED} will be used instead."
+                            "Due to GitHub API rate limits, the number of comments fetched for {component} per pull request is limited to {MAX_COMMENTS_FETCHED}."
                         );
                         MAX_COMMENTS_FETCHED
                     }


### PR DESCRIPTION
## 📝 Summary
- See title
- This max limit is part of the specification of comments support for PRs, and also surfaces errors relating to node volume earlier.

## 🔗 Related
- Related to #6486 

## 📚 Docs
- The current docs PR I have open will be updated accordingly
