### PR TITLE
Add integration tests for GitHub PRs with comments

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           app-id: ${{ vars.ORG_MEMBERS_GITHUB_APP_ID }}
           private-key: ${{ secrets.ORG_MEMBERS_GITHUB_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          owner: spiceai
           repositories: |
             spiceai
 

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -273,9 +273,9 @@ impl GraphQLTableProviderExec {
 impl std::fmt::Debug for GraphQLTableProviderExec {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let limit_str = if let Some(limit) = self.limit {
-            format!("limit=[{}]", limit)
+            format!("limit=[{limit}]")
         } else {
-            "".to_string()
+            String::new()
         };
         write!(f, "GraphQLTableProviderExec {limit_str}")
     }
@@ -284,9 +284,9 @@ impl std::fmt::Debug for GraphQLTableProviderExec {
 impl DisplayAs for GraphQLTableProviderExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
         let limit_str = if let Some(limit) = self.limit {
-            format!("limit=[{}]", limit)
+            format!("limit=[{limit}]")
         } else {
-            "".to_string()
+            String::new()
         };
         write!(f, "GraphQLTableProviderExec {limit_str}")
     }

--- a/crates/data_components/src/graphql/provider.rs
+++ b/crates/data_components/src/graphql/provider.rs
@@ -272,13 +272,23 @@ impl GraphQLTableProviderExec {
 
 impl std::fmt::Debug for GraphQLTableProviderExec {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "GraphQLTableProviderExec")
+        let limit_str = if let Some(limit) = self.limit {
+            format!("limit=[{}]", limit)
+        } else {
+            "".to_string()
+        };
+        write!(f, "GraphQLTableProviderExec {limit_str}")
     }
 }
 
 impl DisplayAs for GraphQLTableProviderExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "GraphQLTableProviderExec")
+        let limit_str = if let Some(limit) = self.limit {
+            format!("limit=[{}]", limit)
+        } else {
+            "".to_string()
+        };
+        write!(f, "GraphQLTableProviderExec {limit_str}")
     }
 }
 

--- a/crates/runtime/tests/github/mod.rs
+++ b/crates/runtime/tests/github/mod.rs
@@ -75,6 +75,7 @@ fn make_github_dataset(
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn test_github_issues() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/github/mod.rs
+++ b/crates/runtime/tests/github/mod.rs
@@ -41,7 +41,11 @@ enum GithubDatasetType {
     },
 }
 
-fn make_github_dataset(kind: GithubDatasetType, query_mode: &str) -> Dataset {
+fn make_github_dataset(
+    kind: GithubDatasetType,
+    query_mode: &str,
+    additional_params: Option<HashMap<String, String>>,
+) -> Dataset {
     let mut dataset = match kind {
         GithubDatasetType::RepoSpecific {
             owner,
@@ -56,13 +60,16 @@ fn make_github_dataset(kind: GithubDatasetType, query_mode: &str) -> Dataset {
             format!("{org}_{query_type}_{query_mode}"),
         ),
     };
-    let params = HashMap::from([
+    let mut params = HashMap::from([
         ("github_query_mode".to_string(), query_mode.to_string()),
         (
             "github_token".to_string(),
             "${secrets:GITHUB_TOKEN}".to_string(),
         ),
     ]);
+
+    params.extend(additional_params.unwrap_or_default());
+
     dataset.params = Some(DatasetParams::from_string_map(params));
     dataset
 }
@@ -81,6 +88,7 @@ async fn test_github_issues() -> Result<(), String> {
                         query_type: "issues".to_string(),
                     },
                     "auto",
+                    None,
                 ))
                 .with_dataset(make_github_dataset(
                     GithubDatasetType::RepoSpecific {
@@ -89,6 +97,7 @@ async fn test_github_issues() -> Result<(), String> {
                         query_type: "issues".to_string(),
                     },
                     "search",
+                    None,
                 ))
                 .build();
             let mut rt = Runtime::builder()
@@ -199,6 +208,7 @@ async fn test_github_commits() -> Result<(), String> {
                         query_type: "commits".to_string(),
                     },
                     "auto",
+                    None,
                 ))
                 .build();
 
@@ -260,6 +270,7 @@ async fn test_github_stargazers() -> Result<(), String> {
                         query_type: "stargazers".to_string(),
                     },
                     "auto",
+                    None,
                 ))
                 .build();
 
@@ -320,6 +331,7 @@ async fn test_github_org_members() -> Result<(), String> {
                         query_type: "members".to_string(),
                     },
                     "auto",
+                    None,
                 ))
                 .build();
 
@@ -354,6 +366,167 @@ async fn test_github_org_members() -> Result<(), String> {
                 })),
             )
             .await?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_github_pull_requests_projection_limit_pushdown() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("github_integration_test")
+                .with_dataset(make_github_dataset(
+                    GithubDatasetType::RepoSpecific {
+                        owner: "spiceai".to_string(),
+                        repo: "spiceai".to_string(),
+                        query_type: "pulls".to_string(),
+                    },
+                    "auto",
+                    Some(HashMap::from([
+                        ("github_include_comments".to_string(), "all".to_string()),
+                        ("github_max_comments_fetched".to_string(), "100".to_string()),
+                    ])),
+                ))
+                .build();
+
+            let mut rt = Runtime::builder()
+                .with_app(app)
+                .with_datafusion_configuration_fn(configure_test_datafusion)
+                .build()
+                .await;
+
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err("Timed out waiting for datasets to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            run_query_and_check_results(
+                &mut rt,
+                "test_github_pull_requests_auto",
+                "SELECT additions, review_comments, discussion FROM spiceai_pulls_auto LIMIT 10",
+                true,
+                Some(Box::new(|result_batches| {
+                    let mut row_count = 0;
+                    for batch in result_batches {
+                        let batch: RecordBatch = batch; // Rust can't type infer here for some reason
+                        assert_eq!(batch.num_columns(), 3, "num_cols: {}", batch.num_columns());
+                        row_count += batch.num_rows();
+                    }
+                    assert_eq!(row_count, 10, "num_rows: {row_count}");
+                })),
+            )
+            .await?;
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_github_pull_requests_schema_changes() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let app = AppBuilder::new("github_integration_test")
+                .with_dataset(make_github_dataset(
+                    GithubDatasetType::RepoSpecific {
+                        owner: "spiceai".to_string(),
+                        repo: "spiceai".to_string(),
+                        query_type: "pulls".to_string(),
+                    },
+                    "auto",
+                    Some(HashMap::from([
+                        ("github_include_comments".to_string(), "review".to_string()),
+                        ("github_max_comments_fetched".to_string(), "100".to_string()),
+                    ])),
+                ))
+                .with_dataset(make_github_dataset(
+                    GithubDatasetType::RepoSpecific {
+                        owner: "apache".to_string(),
+                        repo: "datafusion".to_string(),
+                        query_type: "pulls".to_string(),
+                    },
+                    "auto",
+                    Some(HashMap::from([
+                        (
+                            "github_include_comments".to_string(),
+                            "discussion".to_string(),
+                        ),
+                        ("github_max_comments_fetched".to_string(), "100".to_string()),
+                    ])),
+                ))
+                .build();
+
+            let mut rt = Runtime::builder()
+                .with_app(app)
+                .with_datafusion_configuration_fn(configure_test_datafusion)
+                .build()
+                .await;
+
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                    return Err("Timed out waiting for datasets to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            let dataset_columns_tests = vec![
+                ("spiceai_pulls_auto", "review_comments"),
+                ("datafusion_pulls_auto", "discussion"),
+            ];
+
+            for (dataset_name, column_name) in dataset_columns_tests {
+                // Check that the schema is the right shape
+                run_query_and_check_results(
+                    &mut rt,
+                    "test_github_pull_requests_auto",
+                    format!("SELECT * FROM {dataset_name} LIMIT 10;").as_str(),
+                    false,
+                    Some(Box::new(|result_batches| {
+                        let mut row_count = 0;
+                        for batch in result_batches {
+                            let batch: RecordBatch = batch; // Rust can't type infer here for some reason
+                            assert_eq!(
+                                batch.num_columns(),
+                                20,
+                                "num_cols: {}",
+                                batch.num_columns()
+                            );
+                            row_count += batch.num_rows();
+                        }
+                        assert_eq!(row_count, 10, "num_rows: {row_count}");
+                    })),
+                )
+                .await?;
+
+                run_query_and_check_results(
+                    &mut rt,
+                    "test_github_pull_requests_schema",
+                    format!("SELECT {column_name} FROM {dataset_name} LIMIT 10;").as_str(),
+                    false,
+                    Some(Box::new(|result_batches| {
+                        let mut row_count = 0;
+                        for batch in result_batches {
+                            let batch: RecordBatch = batch; // Rust can't type infer here for some reason
+                            assert_eq!(batch.num_columns(), 1, "num_cols: {}", batch.num_columns());
+                            row_count += batch.num_rows();
+                        }
+                        assert_eq!(row_count, 10, "num_rows: {row_count}");
+                    })),
+                )
+                .await?;
+            }
 
             Ok(())
         })

--- a/crates/runtime/tests/snapshots/integration__test_github_commits_auto.snap
+++ b/crates/runtime/tests/snapshots/integration__test_github_commits_auto.snap
@@ -10,6 +10,6 @@ description: "Query: SELECT * FROM spiceai_commits_auto LIMIT 10"
 |               |     TableScan: spiceai_commits_auto projection=[sha, id, author_name, author_email, committed_date, message, message_body, message_head_line, additions, deletions], fetch=10 |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                             |
 |               |   BytesProcessedExec                                                                                                                                                          |
-|               |     GraphQLTableProviderExec                                                                                                                                                  |
+|               |     GraphQLTableProviderExec limit=[10]                                                                                                                                       |
 |               |                                                                                                                                                                               |
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/runtime/tests/snapshots/integration__test_github_pull_requests_auto.snap
+++ b/crates/runtime/tests/snapshots/integration__test_github_pull_requests_auto.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/integration.rs
+description: "Query: SELECT additions, review_comments, discussion FROM spiceai_pulls_auto LIMIT 10"
+---
++---------------+---------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                      |
++---------------+---------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Projection: spiceai_pulls_auto.additions, spiceai_pulls_auto.review_comments, spiceai_pulls_auto.discussion               |
+|               |   Limit: skip=0, fetch=10                                                                                                 |
+|               |     BytesProcessedNode                                                                                                    |
+|               |       TableScan: spiceai_pulls_auto projection=[additions, discussion, review_comments], fetch=10                         |
+| physical_plan | ProjectionExec: expr=[additions@0 as additions, review_comments@2 as review_comments, discussion@1 as discussion]         |
+|               |   GlobalLimitExec: skip=0, fetch=10                                                                                       |
+|               |     BytesProcessedExec                                                                                                    |
+|               |       ProjectionExec: expr=[additions@0 as additions, discussion@19 as discussion, review_comments@20 as review_comments] |
+|               |         GraphQLTableProviderExec                                                                                          |
+|               |                                                                                                                           |
++---------------+---------------------------------------------------------------------------------------------------------------------------+

--- a/crates/runtime/tests/snapshots/integration__test_github_pull_requests_auto.snap
+++ b/crates/runtime/tests/snapshots/integration__test_github_pull_requests_auto.snap
@@ -13,6 +13,6 @@ description: "Query: SELECT additions, review_comments, discussion FROM spiceai_
 |               |   GlobalLimitExec: skip=0, fetch=10                                                                                       |
 |               |     BytesProcessedExec                                                                                                    |
 |               |       ProjectionExec: expr=[additions@0 as additions, discussion@19 as discussion, review_comments@20 as review_comments] |
-|               |         GraphQLTableProviderExec                                                                                          |
+|               |         GraphQLTableProviderExec limit=[10]                                                                               |
 |               |                                                                                                                           |
 +---------------+---------------------------------------------------------------------------------------------------------------------------+

--- a/crates/runtime/tests/snapshots/integration__test_github_stargazers_auto.snap
+++ b/crates/runtime/tests/snapshots/integration__test_github_stargazers_auto.snap
@@ -10,6 +10,6 @@ description: "Query: SELECT * FROM spiceai_stargazers_auto LIMIT 10"
 |               |     TableScan: spiceai_stargazers_auto projection=[starred_at, login, email, name, company, x_username, location, avatar_url, bio], fetch=10 |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                            |
 |               |   BytesProcessedExec                                                                                                                         |
-|               |     GraphQLTableProviderExec                                                                                                                 |
+|               |     GraphQLTableProviderExec limit=[10]                                                                                                      |
 |               |                                                                                                                                              |
 +---------------+----------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
## 📝 Summary
- Adds integration tests for the GitHub data connector's pull requests table type

## 🔗 Related
- Closes #6529 

