### PR TITLE
Add `kind/documentation` to `.schema/openapi.json` auto-PRs

### DIFF
--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -79,6 +79,7 @@ jobs:
             gh pr create \
               --title "Update openapi.json" \
               --body $'Updated OpenAPI specification\n\n**Remember**\n- [ ] Updated in [spiceai/docs](https://github.com/spiceai/docs).' \
+              --label 'kind/documentation' \
               --base trunk \
               --head openapi/${GITHUB_RUN_ID}
           fi


### PR DESCRIPTION
## 📝 Summary
- We check that PRs have certain labels. [_"Generate Spiceschema OpenAPI"_](https://github.com/spiceai/spiceai/actions/workflows/generate-openapi.yml) is a github action that automatically updates `.schema/openapi.json` when appropriate and creates a PR ([example](https://github.com/spiceai/spiceai/pull/6575)). 
- This PR ensures that the automatically created PRs have the `kind/documentation` label.