### PR TITLE
Allow integration/e2e tests to run properly for PRs on forks

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -25,7 +25,7 @@ on:
       - 'acknowledgements.md'
       - 'Dockerfile*'
 
-  pull_request:
+  pull_request_target:
     branches:
       - trunk
     paths-ignore:
@@ -102,6 +102,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -1,7 +1,7 @@
 name: E2E Test CI (models)
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - trunk
       - release-*
@@ -78,6 +78,8 @@ jobs:
             target_arch: 'aarch64'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py

--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -1,7 +1,7 @@
 name: Enforce Pulls with Spice
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       [labeled, unlabeled, opened, edited, synchronize, assigned, unassigned]
   merge_group:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - trunk
       - release/*
-  pull_request:
+  pull_request_target:
     branches:
       - trunk
       - release-*
@@ -54,6 +54,8 @@ jobs:
     runs-on: spiceai-dev-runners
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
@@ -148,17 +150,10 @@ jobs:
 
       - name: Login to ACR
         uses: docker/login-action@v3
-        # This will fail for forks, so we only run it for the main repo
-        if: github.repository == 'spiceai/spiceai'
         with:
           registry: spiceaitestimages.azurecr.io
           username: spiceai-repo-pull
           password: ${{ secrets.AZCR_PASSWORD }}
-
-      # Change the CONTAINER_REGISTRY to public.ecr.aws/docker/library/ if this is a fork
-      - name: Use public ECR for forks
-        if: github.repository != 'spiceai/spiceai'
-        run: echo "CONTAINER_REGISTRY=public.ecr.aws/docker/library/" >> $GITHUB_ENV
 
       - name: Pull the Postgres/MySQL images
         run: |

--- a/.github/workflows/integration_aws_sdk.yml
+++ b/.github/workflows/integration_aws_sdk.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - trunk
       - release/*
-  pull_request:
+  pull_request_target:
     branches:
       - trunk
       - release-*
@@ -44,6 +44,8 @@ jobs:
     runs-on: spiceai-dev-runners
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -51,6 +51,8 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/integration_runtime_table_partition.yaml
+++ b/.github/workflows/integration_runtime_table_partition.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - trunk
       - release/*
-  pull_request:
+  pull_request_target:
     branches:
       - trunk
       - release-*
@@ -53,6 +53,8 @@ jobs:
     runs-on: spiceai-dev-runners
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust


### PR DESCRIPTION
## 📝 Summary

Moves the test workflows that require secret access to be keyed off of `pull_request_target` which provides secrets.