### PR TITLE
Fix spacing on video links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Spice is built-on industry leading technologies including [Apache DataFusion](ht
 </div>
 
 🎥 [Watch the CMU Databases Accelerating Data and AI with Spice.ai Open-Source](https://www.youtube.com/watch?v=tyM-ec1lKfU)
+
 🎥 [Watch How to Query Data using Spice, OpenAI, and MCP](https://www.youtube.com/watch?v=TFAu4qxjTPk&list=PLesJrUXEx3U-dQul0PqLV3TGTdUmr3B6e&index=8)
+
 🎥 [Watch How to search with Amazon S3 Vectors](https://www.youtube.com/watch?v=QPbqPf5W36g)
 
 ## Why Spice?


### PR DESCRIPTION
Old:

<img width="940" height="195" alt="Screenshot 2025-07-24 at 3 54 41 PM" src="https://github.com/user-attachments/assets/e2c9397e-3da8-4934-b46d-db5dbef64596" />

Diff:

<img width="1009" height="242" alt="Screenshot 2025-07-24 at 3 55 56 PM" src="https://github.com/user-attachments/assets/2bcd25e4-0822-44f8-9aae-76c23bb42e74" />
