### PR TITLE
Enable configurations of max invocations for Bedrock models

### DIFF
--- a/crates/llms/src/bedrock/embed/mod.rs
+++ b/crates/llms/src/bedrock/embed/mod.rs
@@ -54,7 +54,7 @@ pub mod titan;
 const TITAN_TEXT_EMBED_V2: &str = "amazon.titan-embed-text-v2:0";
 // Maximum number of concurrently running requests.
 // The overall request rate is controlled by the rate_limiter.
-const EMBED_TEXT_MAX_CONCURRENT_INVOCATIONS: usize = 40;
+const DEFAULT_MAX_CONCURRENT_INVOCATIONS: usize = 40;
 
 fn default_retry_strategy() -> FibonacciBackoff {
     FibonacciBackoffBuilder::new().max_retries(Some(10)).build()
@@ -373,6 +373,12 @@ pub struct BedrockRateLimitConfigBuilder {
     max_concurrent_invocations: Option<usize>,
 }
 
+impl Default for BedrockRateLimitConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BedrockRateLimitConfigBuilder {
     #[must_use]
     pub fn new() -> Self {
@@ -400,7 +406,7 @@ impl BedrockRateLimitConfigBuilder {
             requests_per_minute_limit: self.requests_per_minute_limit.unwrap_or(1_500),
             max_concurrent_invocations: self
                 .max_concurrent_invocations
-                .unwrap_or(EMBED_TEXT_MAX_CONCURRENT_INVOCATIONS),
+                .unwrap_or(DEFAULT_MAX_CONCURRENT_INVOCATIONS),
         }
     }
 }
@@ -413,14 +419,6 @@ pub struct BedrockRateLimitConfig {
 
 impl BedrockRateLimitConfig {
     #[must_use]
-    pub fn with_requests_per_minute(requests_per_minute_limit: u32) -> Self {
-        Self {
-            requests_per_minute_limit,
-            max_concurrent_invocations: EMBED_TEXT_MAX_CONCURRENT_INVOCATIONS,
-        }
-    }
-
-    #[must_use]
     pub fn to_quota(&self) -> Quota {
         Quota::per_minute(
             NonZeroU32::new(self.requests_per_minute_limit).unwrap_or_else(|| {
@@ -429,14 +427,5 @@ impl BedrockRateLimitConfig {
                 )
             }),
         )
-    }
-}
-
-impl Default for BedrockRateLimitConfig {
-    fn default() -> Self {
-        Self {
-            requests_per_minute_limit: 1_500,
-            max_concurrent_invocations: EMBED_TEXT_MAX_CONCURRENT_INVOCATIONS,
-        }
     }
 }

--- a/crates/llms/src/bedrock/embed/mod.rs
+++ b/crates/llms/src/bedrock/embed/mod.rs
@@ -82,7 +82,7 @@ pub fn new_titan_v2(
     client: BedrockClient,
     normalize: bool,
     dimensions: u32,
-    rate_config: Option<BedrockRateLimitConfig>,
+    rate_config: BedrockRateLimitConfig,
 ) -> BedrockEmbed<TitanEmbedRequest, TitanEmbedResponse> {
     tracing::debug!(
         "Initializing Titan v2 embedder: normalize={normalize}, dimensions={dimensions}, rate_limit={rate_config:?}"
@@ -94,7 +94,6 @@ pub fn new_titan_v2(
         dimensions,
     }) as Arc<dyn BedrockEmbeddingConfig<TitanEmbedRequest, TitanEmbedResponse>>;
 
-    let rate_config = rate_config.unwrap_or_default();
     let rate_limiter = Arc::new(RateLimiter::direct(rate_config.to_quota()));
 
     BedrockEmbed::<TitanEmbedRequest, TitanEmbedResponse> {
@@ -114,7 +113,7 @@ pub fn new_cohere(
     truncate: CohereEmbeddingTruncate,
     input_type: CohereEmbeddingInputType,
     embedding_type: CohereEmbeddingType,
-    rate_config: Option<BedrockRateLimitConfig>,
+    rate_config: BedrockRateLimitConfig,
 ) -> BedrockEmbed<CohereEmbedRequest, CohereEmbedResponse> {
     tracing::debug!(
         "Initializing Cohere embedder: model_name={model_name}, truncate={truncate:?}, input_type={input_type}, embedding_type={embedding_type}, rate_limit={rate_config:?}"
@@ -127,7 +126,6 @@ pub fn new_cohere(
         embedding_type,
     }) as Arc<dyn BedrockEmbeddingConfig<CohereEmbedRequest, CohereEmbedResponse>>;
 
-    let rate_config = rate_config.unwrap_or_default();
     let rate_limiter = Arc::new(RateLimiter::direct(rate_config.to_quota()));
 
     BedrockEmbed::<CohereEmbedRequest, CohereEmbedResponse> {
@@ -366,6 +364,44 @@ where
 
     fn size(&self) -> i32 {
         self.config.dimensions()
+    }
+}
+
+#[derive(Debug)]
+pub struct BedrockRateLimitConfigBuilder {
+    requests_per_minute_limit: Option<u32>,
+    max_concurrent_invocations: Option<usize>,
+}
+
+impl BedrockRateLimitConfigBuilder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            requests_per_minute_limit: None,
+            max_concurrent_invocations: None,
+        }
+    }
+
+    #[must_use]
+    pub fn requests_per_minute(&mut self, limit: u32) -> &Self {
+        self.requests_per_minute_limit = Some(limit);
+        self
+    }
+
+    #[must_use]
+    pub fn max_concurrent_invocations(&mut self, limit: usize) -> &Self {
+        self.max_concurrent_invocations = Some(limit);
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> BedrockRateLimitConfig {
+        BedrockRateLimitConfig {
+            requests_per_minute_limit: self.requests_per_minute_limit.unwrap_or(1_500),
+            max_concurrent_invocations: self
+                .max_concurrent_invocations
+                .unwrap_or(EMBED_TEXT_MAX_CONCURRENT_INVOCATIONS),
+        }
     }
 }
 

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -136,30 +136,25 @@ async fn bedrock(
                 let _ = rate_limit_builder.requests_per_minute(limit);
                 Ok(())
             }
-            Err(e) => {
-                return Err(EmbedError::FailedToInstantiateEmbeddingModel {
-                    source: format!("Failed to parse 'requests_per_min_limit' parameter: {e}")
-                        .into(),
-                });
-            }
-        });
+            Err(e) => Err(EmbedError::FailedToInstantiateEmbeddingModel {
+                source: format!("Failed to parse 'requests_per_min_limit' parameter: {e}").into(),
+            }),
+        })
+        .transpose()?;
 
-    params.get("max_concurrent_invocations").map(|mci| {
-        match mci.expose_secret().parse::<usize>() {
+    params
+        .get("max_concurrent_invocations")
+        .map(|mci| match mci.expose_secret().parse::<usize>() {
             Ok(limit) => {
                 let _ = rate_limit_builder.max_concurrent_invocations(limit);
                 Ok(())
             }
-            Err(e) => {
-                return Err(EmbedError::FailedToInstantiateEmbeddingModel {
-                    source: format!("Failed to parse 'max_concurrent_invocations' parameter: {e}")
-                        .into(),
-                });
-            }
-        }
-    });
-
-    tracing::debug!("Rate limit config: {rate_limit_builder:?}");
+            Err(e) => Err(EmbedError::FailedToInstantiateEmbeddingModel {
+                source: format!("Failed to parse 'max_concurrent_invocations' parameter: {e}")
+                    .into(),
+            }),
+        })
+        .transpose()?;
 
     let rate_limit = rate_limit_builder.build();
 

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -89,6 +89,8 @@ async fn bedrock(
     model_id: Option<String>,
     params: &HashMap<String, SecretString>,
 ) -> Result<Arc<dyn Embed>, EmbedError> {
+    use llms::bedrock::embed::BedrockRateLimitConfigBuilder;
+
     let Some(model_id) = model_id else {
         return Err(EmbedError::ModelNotProvided {
             model_source: "bedrock".to_string(),
@@ -126,10 +128,13 @@ async fn bedrock(
         config_builder = config_builder.credentials_provider(credentials);
     }
 
-    let rate_limit = if let Some(rpm) = params.get("requests_per_min_limit") {
-        match rpm.expose_secret().parse::<u32>() {
+    let mut rate_limit_builder = BedrockRateLimitConfigBuilder::new();
+    params
+        .get("requests_per_min_limit")
+        .map(|rpm| match rpm.expose_secret().parse::<u32>() {
             Ok(limit) => {
-                Some(bedrock::embed::BedrockRateLimitConfig::with_requests_per_minute(limit))
+                let _ = rate_limit_builder.requests_per_minute(limit);
+                Ok(())
             }
             Err(e) => {
                 return Err(EmbedError::FailedToInstantiateEmbeddingModel {
@@ -137,10 +142,26 @@ async fn bedrock(
                         .into(),
                 });
             }
+        });
+
+    params.get("max_concurrent_invocations").map(|mci| {
+        match mci.expose_secret().parse::<usize>() {
+            Ok(limit) => {
+                let _ = rate_limit_builder.max_concurrent_invocations(limit);
+                Ok(())
+            }
+            Err(e) => {
+                return Err(EmbedError::FailedToInstantiateEmbeddingModel {
+                    source: format!("Failed to parse 'max_concurrent_invocations' parameter: {e}")
+                        .into(),
+                });
+            }
         }
-    } else {
-        None
-    };
+    });
+
+    tracing::debug!("Rate limit config: {rate_limit_builder:?}");
+
+    let rate_limit = rate_limit_builder.build();
 
     let config = config_builder.load().await;
     let client = BedrockClient::new(&config);


### PR DESCRIPTION
## 📝 Summary
- See title
- Necessary to avoid rate limiting/throttling

Example Spicepod:
```yaml
version: v1
kind: Spicepod
name: ILoveBedrock

embeddings:
    - from: bedrock:cohere.embed-english-v3
      name: cohere-embeddings
      params:
          aws_region: us-east-1
          input_type: search_document
          max_concurrent_invocations: '41' # NEW
          requests_per_min_limit: '1000'
          aws_access_key_id: ${secrets:AWS_BEDROCK_KEY}
          aws_secret_access_key: ${secrets:AWS_BEDROCK_SECRET}
          truncate: END
```

## 🔗 Related
- Closes #6543  


## 📚 Docs
Docs will need to be updated to show that this parameter can be configured

