### PR TITLE
Ensure integration tests run against the PR codebase

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -122,6 +122,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust


### PR DESCRIPTION
## 📝 Summary

With the [recent change](https://github.com/spiceai/spiceai/pull/6585/files#diff-82454b2fc887e9985b9348b8f3bca03d2f839645a4c3ba1f3f850014d7da5c8b) to use `pull_request_target` instead of `pull_request` base context is used resulting in checking out base branch instead of PR. Similar to build step checkout correct commit to run tests against (correct version of snapshots - added/modified)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
