### PR TITLE
fix: Disable HuggingFace models integration tests

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -132,7 +132,7 @@ jobs:
   test-hf:
     name: Test Huggingface Models
     needs: build
-    if: !always()
+    if: ${{ github.event.inputs.run_all_tests == 'true' }}
     permissions: read-all
     runs-on: [self-hosted, macOS]
     steps:

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -132,6 +132,7 @@ jobs:
   test-hf:
     name: Test Huggingface Models
     needs: build
+    if: !always()
     permissions: read-all
     runs-on: [self-hosted, macOS]
     steps:


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Disables the HuggingFace integration models tests because they are hanging. Raised https://github.com/spiceai/spiceai/issues/6608 to track
