### PR TITLE
Fixes for Databricks OpenAI compatibility

### DIFF
--- a/crates/llms/src/databricks.rs
+++ b/crates/llms/src/databricks.rs
@@ -29,6 +29,7 @@ use async_openai::{
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 use snafu::ResultExt;
 use std::sync::Arc;
 use token_provider::TokenProvider;
@@ -46,6 +47,50 @@ pub struct Databricks {
     pub model: String,
     client: Client<HostedModelConfig>,
     health_check: HealthCheck,
+}
+impl Databricks {
+    /// Changes to `req` to accomodate Databricks not being `OpenAI` compatible.
+    fn alter_request(&self, mut req: CreateChatCompletionRequest) -> CreateChatCompletionRequest {
+        req.model.clone_from(&self.model);
+        // Databricks should set Option::None parameters to a schema with no inputs, but doesn't.
+        // Must be done explicitly.
+        if let Some(ref mut tools) = req.tools {
+            for t in tools.iter_mut() {
+                if t.function.parameters.is_none() {
+                    t.function.parameters.replace(json!(
+                        {
+                            "$schema": "http://json-schema.org/draft-07/schema#",
+                            "properties": {},
+                            "required": [],
+                            "title": "",
+                            "type": "object"
+                        }
+                    ));
+                }
+
+                // For tools that want to have Uint as inputs, they will set `minimum=0`.
+                // This is valid JSON schema, but not supported in Databricks.
+                if let Some(Some(serde_json::Value::Object(properties))) = t
+                    .function
+                    .parameters
+                    .as_mut()
+                    .map(|v| v.get_mut("properties"))
+                {
+                    for (_field, value) in properties.iter_mut() {
+                        if let Some(Value::String(value_type)) = value.get("type") {
+                            if value_type != "integer" {
+                                continue;
+                            }
+                            if let Some(value_map) = value.as_object_mut() {
+                                value_map.remove("minimum");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        req
+    }
 }
 
 #[must_use]
@@ -207,7 +252,10 @@ impl Chat for Databricks {
         // Must use `post_stream` instead of `chat().create(...` to avoid concatenation of `chat/completions`.
         Ok(Box::pin(
             self.client
-                .post_stream::<_, DatabricksCreateChatCompletionStreamResponse, _>("", inner_req)
+                .post_stream::<_, DatabricksCreateChatCompletionStreamResponse, _>(
+                    "",
+                    self.alter_request(req),
+                )
                 .await
                 .map_ok(Into::into),
         ))
@@ -217,9 +265,7 @@ impl Chat for Databricks {
         &self,
         req: CreateChatCompletionRequest,
     ) -> Result<CreateChatCompletionResponse, OpenAIError> {
-        let mut inner_req = req.clone();
-        inner_req.model.clone_from(&self.model);
-        self.client.post("", inner_req).await
+        self.client.post("", self.alter_request(req)).await
     }
 }
 


### PR DESCRIPTION
## 📝 Summary
 - Fixes for Databricks OpenAI compatibility, specifically to ensure `databricks-llama-4-maverick` works.
 - Note: Since Maverick does not support multi-turn tool usage, it cannot be used with `list_datasets` (or `auto`), since Spice will default use this tool before the initial tool call.