### PR TITLE
Add environment variable for org token

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -180,6 +180,7 @@ jobs:
       - name: Run integration test
         env:
           SPICE_SECRET_SPICEAI_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_KEY }}
+          GITHUB_ORG_TOKEN: ${{ steps.github-app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
           # old dbc instance
           TEST_DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}


### PR DESCRIPTION
## 📝 Summary
- Adds an environment variable for the token used to test GitHub organizations specifically
- Necessary because, to separate the tokens we use for our GitHub integration tests (and see if the separation works on PR), the trunk branch must have the required environment variables. This PR ensures this is the case.

