### PR TITLE
Score and P95 latency calculation for MTEB Quora-based vector search tests in Test Operator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,7 @@
         "--concurrency",
         "10",
         "-p",
-        "./test/spicepods/vector_search/mteb/quora_openai-text-embedding-3-small_arrow.yaml",
+        "./test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small[chunking]]-duckdb[file].yaml",
         "--benchmark-dataset",
         "quora_retrieval"
     ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,28 @@
       "preLaunchTask": "rust: cargo build testoperator"
     },
     {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug testoperator (Search)",
+      "program": "${workspaceFolder}/target/debug/testoperator",
+      "args": [
+        "run",
+        "vector-search",
+        "--ready-wait",
+        "1800",
+        "--concurrency",
+        "10",
+        "-p",
+        "./test/spicepods/vector_search/mteb/quora_openai-text-embedding-3-small_arrow.yaml",
+        "--benchmark-dataset",
+        "quora_retrieval"
+    ],
+      "env": {
+      },
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "rust: cargo build testoperator"
+    },
+    {
       "name": "spice version",
       "type": "go",
       "request": "launch",

--- a/crates/test-framework/src/spicetest/vector_search/evaluate.rs
+++ b/crates/test-framework/src/spicetest/vector_search/evaluate.rs
@@ -1,0 +1,69 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::collections::HashMap;
+
+/// Evaluate the search results using NDCG@10 metric.
+/// Reference: `https://github.com/embeddings-benchmark/mteb/blob/03347ebfe4809056e0fd2894fcae69dcdd2ed964/mteb/evaluation/evaluators/RetrievalEvaluator.py#L500`
+#[allow(clippy::cast_precision_loss)]
+#[must_use]
+pub(crate) fn evaluate_search_results<S: ::std::hash::BuildHasher>(
+    qrels: &HashMap<String, HashMap<String, i32, S>, S>,
+    results: &HashMap<String, HashMap<String, f64, S>, S>,
+) -> f64 {
+    // Similar to MTEB report NDCG@10 as the main metric
+    const K: usize = 10;
+    let mut ndcg_at_k_values = Vec::new();
+
+    for (query_id, relevance) in qrels {
+        if let Some(ranked_results) = results.get(query_id) {
+            let relevance_scores: Vec<f64> = ranked_results
+                .iter()
+                .map(|(doc_id, _score)| f64::from(*relevance.get(doc_id).unwrap_or(&0)))
+                .collect();
+            ndcg_at_k_values.push(ndcg_at_k(&relevance_scores, K));
+        } else {
+            println!("No search results found for test query {query_id}");
+        }
+    }
+    let len = ndcg_at_k_values.len();
+    ndcg_at_k_values.into_iter().sum::<f64>() / len as f64
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn dcg_at_k(relevance_scores: &[f64], k: usize) -> f64 {
+    relevance_scores
+        .iter()
+        .take(k)
+        .enumerate()
+        .map(|(i, &rel)| rel / (i as f64 + 2f64).log2())
+        .sum()
+}
+
+fn idcg_at_k(relevance_scores: &[f64], k: usize) -> f64 {
+    let mut sorted_relevance_scores = relevance_scores.to_owned();
+    sorted_relevance_scores.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    dcg_at_k(&sorted_relevance_scores, k)
+}
+
+fn ndcg_at_k(relevance_scores: &[f64], k: usize) -> f64 {
+    let dcg = dcg_at_k(relevance_scores, k);
+    let idcg = idcg_at_k(relevance_scores, k);
+    if idcg == 0.0 {
+        return 0.0;
+    }
+    dcg / idcg
+}

--- a/crates/test-framework/src/spicetest/vector_search/evaluate.rs
+++ b/crates/test-framework/src/spicetest/vector_search/evaluate.rs
@@ -16,16 +16,29 @@ limitations under the License.
 
 use std::collections::HashMap;
 
-/// Evaluate the search results using NDCG@10 metric.
-/// Reference: `https://github.com/embeddings-benchmark/mteb/blob/03347ebfe4809056e0fd2894fcae69dcdd2ed964/mteb/evaluation/evaluators/RetrievalEvaluator.py#L500`
+/// Calculates the average Normalized Discounted Cumulative Gain (NDCG@k) across all search queries.
+///
+/// NDCG@k measures the quality of ranking by considering both relevance and position,
+/// with higher-ranked relevant documents contributing more to the score. This implementation
+/// follows the MTEB (Massive Text Embedding Benchmark) methodology.
+///
+/// # Arguments
+/// * `qrels` - Query relevance judgments mapping `query_id` -> (`doc_id` -> `relevance_score`)
+/// * `results` - Search results mapping `query_id` -> (`doc_id` -> `similarity_score`)
+/// * `k` - Number of top results to consider for NDCG calculation
+///
+/// # Returns
+/// Average NDCG@k score across all queries (0.0 to 1.0, where 1.0 is perfect ranking)
+///
+/// # Reference
+/// MTEB `RetrievalEvaluator`: <https://github.com/embeddings-benchmark/mteb/blob/03347ebfe4809056e0fd2894fcae69dcdd2ed964/mteb/evaluation/evaluators/RetrievalEvaluator.py#L500>
 #[allow(clippy::cast_precision_loss)]
 #[must_use]
-pub(crate) fn evaluate_search_results<S: ::std::hash::BuildHasher>(
+pub(crate) fn calculate_ndcg<S: ::std::hash::BuildHasher>(
     qrels: &HashMap<String, HashMap<String, i32, S>, S>,
     results: &HashMap<String, HashMap<String, f64, S>, S>,
+    k: usize,
 ) -> f64 {
-    // Similar to MTEB report NDCG@10 as the main metric
-    const K: usize = 10;
     let mut ndcg_at_k_values = Vec::new();
 
     for (query_id, relevance) in qrels {
@@ -34,7 +47,7 @@ pub(crate) fn evaluate_search_results<S: ::std::hash::BuildHasher>(
                 .iter()
                 .map(|(doc_id, _score)| f64::from(*relevance.get(doc_id).unwrap_or(&0)))
                 .collect();
-            ndcg_at_k_values.push(ndcg_at_k(&relevance_scores, K));
+            ndcg_at_k_values.push(ndcg_at_k(&relevance_scores, k));
         } else {
             println!("No search results found for test query {query_id}");
         }

--- a/crates/test-framework/src/spicetest/vector_search/mod.rs
+++ b/crates/test-framework/src/spicetest/vector_search/mod.rs
@@ -14,11 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::BTreeMap, time::SystemTime};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::SystemTime,
+};
 
-use crate::metrics::{
-    Builder, BuilderTarget, ExtendedMetrics, MetricCollector, NoExtendedMetrics, QueryMetric,
-    QueryStatus, system_time_to_unix_epoch_ms,
+use crate::{
+    metrics::{
+        Builder, BuilderTarget, ExtendedMetrics, MetricCollector, QueryMetric, QueryStatus,
+        StatisticsCollector, system_time_to_unix_epoch_ms,
+    },
+    spicetest::vector_search::evaluate::evaluate_search_results,
 };
 use anyhow::{Context, Result};
 use arrow::{
@@ -29,7 +35,9 @@ use tokio::task::JoinHandle;
 
 use super::{SpiceTest, TestCompleted, TestNotStarted, TestState};
 
+mod evaluate;
 mod worker;
+pub use worker::SearchResult;
 pub use worker::{SearchConfig, SearchRequest};
 use worker::{VectorSearchWorker, VectorSearchWorkerResult};
 
@@ -66,7 +74,7 @@ pub struct Running {
 
 pub struct Completed {
     end_time: SystemTime,
-    results: Vec<VectorSearchWorkerResult>,
+    search_results: BTreeMap<String, worker::SearchResult>,
 }
 
 impl TestState for NotStarted {}
@@ -87,9 +95,20 @@ impl SpiceTest<NotStarted> {
             .context("Spiced instance should be present")?
             .http_client()?;
 
-        let workers = (0..self.state.parallel_count)
-            .map(|_| {
-                VectorSearchWorker::new(http_client.clone(), self.state.config.clone()).start()
+        // Split the requests among workers based on the parallel_count
+        let requests = self.state.config.into_requests();
+        let chunk_size = if self.state.parallel_count > 0 {
+            requests.len().div_ceil(self.state.parallel_count)
+        } else {
+            requests.len()
+        };
+
+        let workers = requests
+            .chunks(chunk_size)
+            .enumerate()
+            .map(|(worker_id, chunk)| {
+                let worker_config = SearchConfig::new().add_requests(chunk.iter().cloned());
+                VectorSearchWorker::new(worker_id, http_client.clone(), worker_config).start()
             })
             .collect();
 
@@ -110,14 +129,15 @@ impl SpiceTest<NotStarted> {
 
 impl SpiceTest<Running> {
     pub async fn wait(self) -> Result<SpiceTest<Completed>> {
-        let mut results = vec![];
+        let mut search_results = BTreeMap::new();
+
         for worker in self.state.vector_workers {
-            // TODO: combine results from multiple workers?
-            results.push(
-                worker
-                    .await
-                    .context("Error waiting for vector search worker")??,
-            );
+            let worker_result = worker
+                .await
+                .context("Error waiting for vector search worker")??;
+
+            // Combine all worker results
+            search_results.extend(worker_result.search_results);
         }
 
         Ok(SpiceTest {
@@ -130,13 +150,60 @@ impl SpiceTest<Running> {
             results_snapshot_predicate: self.results_snapshot_predicate,
             state: Completed {
                 end_time: SystemTime::now(),
-                results,
+                search_results,
             },
         })
     }
 }
 
-impl MetricCollector<SearchScoreMetric, NoExtendedMetrics> for SpiceTest<Completed> {
+impl SpiceTest<Completed> {
+    #[must_use]
+    pub fn get_search_results(&self) -> &BTreeMap<String, worker::SearchResult> {
+        &self.state.search_results
+    }
+
+    pub fn get_p95_response_time_metric(&self) -> Result<f64> {
+        let durations = self
+            .state
+            .search_results
+            .values()
+            .map(|result| result.duration) // Convert to milliseconds
+            .collect::<Vec<_>>();
+
+        #[allow(clippy::cast_precision_loss)]
+        let p95 = durations.percentile(95.0)?.as_millis() as f64;
+        Ok(p95)
+    }
+
+    pub fn get_rps_metric(&self) -> Result<f64> {
+        let total_duration = self.state.end_time.duration_since(self.start_time)?;
+
+        #[allow(clippy::cast_precision_loss)]
+        let total_requests = self.state.search_results.len() as f64;
+        if total_duration.as_secs() == 0 {
+            return Ok(total_requests);
+        }
+        Ok(total_requests / total_duration.as_secs_f64())
+    }
+
+    /// Calculate overall search score metric based on the search results and query relevance data.
+    /// The `transform` function is used to convert the search results into a format suitable for
+    /// evaluation
+    pub fn calculate_search_score_metric<S, F>(
+        &self,
+        qrels: &HashMap<String, HashMap<String, i32, S>, S>,
+        transform: F,
+    ) -> Result<f64>
+    where
+        S: ::std::hash::BuildHasher,
+        F: Fn(&BTreeMap<String, SearchResult>) -> HashMap<String, HashMap<String, f64, S>, S>,
+    {
+        let transformed_results = transform(&self.state.search_results);
+        Ok(evaluate_search_results(qrels, &transformed_results))
+    }
+}
+
+impl MetricCollector<SearchScoreMetric, SearchRunMetric> for SpiceTest<Completed> {
     fn start_time(&self) -> SystemTime {
         self.start_time
     }
@@ -160,9 +227,6 @@ impl MetricCollector<SearchScoreMetric, NoExtendedMetrics> for SpiceTest<Complet
 
     fn metrics(&self) -> Result<Vec<QueryMetric<SearchScoreMetric>>> {
         self.state
-            .results
-            .first()
-            .context("No results found")?
             .search_results
             .iter()
             .map(|(id, result)| {
@@ -204,5 +268,49 @@ impl SearchScoreMetric {
     #[must_use]
     pub fn new(score: f64) -> Self {
         Self { score }
+    }
+}
+
+pub struct SearchRunMetric {
+    pub rps: f64,
+    pub p95_latency_ms: f64,
+    pub score: f64,
+}
+impl ExtendedMetrics for SearchRunMetric {
+    fn fields() -> Vec<Field> {
+        vec![
+            Field::new("rps", DataType::Float64, false),
+            Field::new("p95_latency_ms", DataType::Float64, false),
+            Field::new("score", DataType::Float64, false),
+        ]
+    }
+
+    fn builders() -> BTreeMap<String, Builder> {
+        let mut builders = BTreeMap::new();
+        builders.insert("rps".to_string(), Builder::Float64(Float64Builder::new()));
+        builders.insert(
+            "latency_p95_ms".to_string(),
+            Builder::Float64(Float64Builder::new()),
+        );
+        builders.insert("score".to_string(), Builder::Float64(Float64Builder::new()));
+        builders
+    }
+
+    fn build(&self) -> Result<Vec<BuilderTarget>> {
+        Ok(vec![
+            BuilderTarget::Float64(("rps".to_string(), self.rps)),
+            BuilderTarget::Float64(("p95_latency_ms".to_string(), self.p95_latency_ms)),
+            BuilderTarget::Float64(("score".to_string(), self.score)),
+        ])
+    }
+}
+impl SearchRunMetric {
+    #[must_use]
+    pub fn new(rps: f64, p95_latency_ms: f64, score: f64) -> Self {
+        Self {
+            rps,
+            p95_latency_ms,
+            score,
+        }
     }
 }

--- a/crates/test-framework/src/spicetest/vector_search/mod.rs
+++ b/crates/test-framework/src/spicetest/vector_search/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         Builder, BuilderTarget, ExtendedMetrics, MetricCollector, QueryMetric, QueryStatus,
         StatisticsCollector, system_time_to_unix_epoch_ms,
     },
-    spicetest::vector_search::evaluate::evaluate_search_results,
+    spicetest::vector_search::evaluate::calculate_ndcg,
 };
 use anyhow::{Context, Result};
 use arrow::{
@@ -199,7 +199,8 @@ impl SpiceTest<Completed> {
         F: Fn(&BTreeMap<String, SearchResult>) -> HashMap<String, HashMap<String, f64, S>, S>,
     {
         let transformed_results = transform(&self.state.search_results);
-        Ok(evaluate_search_results(qrels, &transformed_results))
+        // Similar to MTEB, use NDCG@10 as the main metric for search score
+        Ok(calculate_ndcg(qrels, &transformed_results, 10))
     }
 }
 
@@ -289,7 +290,7 @@ impl ExtendedMetrics for SearchRunMetric {
         let mut builders = BTreeMap::new();
         builders.insert("rps".to_string(), Builder::Float64(Float64Builder::new()));
         builders.insert(
-            "latency_p95_ms".to_string(),
+            "p95_latency_ms".to_string(),
             Builder::Float64(Float64Builder::new()),
         );
         builders.insert("score".to_string(), Builder::Float64(Float64Builder::new()));

--- a/crates/test-framework/src/spicetest/vector_search/worker.rs
+++ b/crates/test-framework/src/spicetest/vector_search/worker.rs
@@ -109,6 +109,16 @@ impl SearchConfig {
         self.requests.extend(requests);
         self
     }
+
+    #[must_use]
+    pub fn requests(&self) -> &[SearchRequest] {
+        &self.requests
+    }
+
+    #[must_use]
+    pub fn into_requests(self) -> Vec<SearchRequest> {
+        self.requests
+    }
 }
 
 pub(crate) struct VectorSearchWorkerResult {
@@ -116,40 +126,42 @@ pub(crate) struct VectorSearchWorkerResult {
 }
 
 #[allow(dead_code)]
-pub(crate) struct SearchResult {
-    pub(crate) response: SearchResponse,
-    pub(crate) score: f64,
-    pub(crate) duration: Duration,
+pub struct SearchResult {
+    pub response: SearchResponse,
+    pub score: f64,
+    pub duration: Duration,
 }
 
 pub(crate) struct VectorSearchWorker {
+    worker_id: usize,
     http_client: Client,
     config: SearchConfig,
 }
 
 #[derive(Deserialize)]
 #[allow(dead_code)]
-pub(crate) struct SearchResponse {
-    results: Vec<SearchResponseResult>,
-    duration_ms: Option<u64>,
+pub struct SearchResponse {
+    pub results: Vec<SearchResponseResult>,
+    pub duration_ms: Option<u64>,
 }
 
 #[derive(Deserialize)]
 #[allow(dead_code)]
-pub(crate) struct SearchResponseResult {
+pub struct SearchResponseResult {
     // `matches` is left as a generic JSON value (`serde_json::Value`) instead of a strongly typed struct.
     // The search API can return different sets of fields here depending on dataset or configuration
-    matches: serde_json::Value,
-    score: f64,
-    dataset: String,
+    pub matches: serde_json::Value,
+    pub score: f64,
+    pub dataset: String,
     /// Primary key can be different types depending on the dataset. Default to empty map, if not present.
     #[serde(default)]
-    primary_key: HashMap<String, serde_json::Value>,
+    pub primary_key: HashMap<String, serde_json::Value>,
 }
 
 impl VectorSearchWorker {
-    pub fn new(http_client: Client, config: SearchConfig) -> Self {
+    pub fn new(worker_id: usize, http_client: Client, config: SearchConfig) -> Self {
         Self {
+            worker_id,
             http_client,
             config,
         }
@@ -158,7 +170,15 @@ impl VectorSearchWorker {
     pub fn start(self) -> JoinHandle<Result<VectorSearchWorkerResult>> {
         tokio::spawn(async move {
             let mut results: BTreeMap<String, SearchResult> = BTreeMap::new();
-            for request in self.config.requests {
+            let total_requests = self.config.requests.len();
+            let mut last_progress_time = Instant::now();
+
+            println!(
+                "[SearchWorker-{:02}] STARTED, {total_requests} remaining",
+                self.worker_id
+            );
+
+            for (index, request) in self.config.requests.into_iter().enumerate() {
                 let start = Instant::now();
                 let res = self
                     .http_client
@@ -182,7 +202,24 @@ impl VectorSearchWorker {
                         duration,
                     },
                 );
+
+                // Trace progress every 10 seconds
+                if last_progress_time.elapsed() >= Duration::from_secs(10) {
+                    let completed = index + 1;
+                    #[allow(clippy::cast_precision_loss)]
+                    let completed_percent = (completed as f64 / total_requests as f64) * 100.0;
+                    println!(
+                        "[SearchWorker-{:02}]: {completed}/{total_requests} completed ({completed_percent:.1}%)",
+                        self.worker_id
+                    );
+                    last_progress_time = Instant::now();
+                }
             }
+
+            println!(
+                "[SearchWorker-{:02}]: DONE, {total_requests} completed",
+                self.worker_id
+            );
 
             Ok(VectorSearchWorkerResult {
                 search_results: results,

--- a/test/spicepods/vector_search/README.md
+++ b/test/spicepods/vector_search/README.md
@@ -25,3 +25,4 @@ Examples of full spicepod names:
 * `openai[text-embedding-3-small[chunking]]-duckdb[file]` - an OpenAI `text-embedding-3-small` embedding model with chunking enabled, using DuckDB file-mode acceleration.
 * `openai[text-embedding-3-small]-s3_vectors` - an OpenAI `text-embedding-3-small` embedding model with AWS S3-based vector storage.
 * `huggingface[all-minilm-l6-v2]-arrow-hybrid_limit_2000` - a HuggingFace `all-MiniLM-L6-v2` embedding model with Arrow acceleration and hybrid search (vector + full-text search) enabled, with a test corpus data limit of 2000 records.
+* `openai[text-embedding-3-small]-federated[postgres]` - an OpenAI `text-embedding-3-small` embedding model using precomputed embeddings stored in the source PostgreSQL dataset, performing direct search against the source without additional acceleration.

--- a/test/spicepods/vector_search/README.md
+++ b/test/spicepods/vector_search/README.md
@@ -1,0 +1,27 @@
+# Vector Search Test Spicepods
+
+## Naming
+
+Test spicepod names should be formatted according to the following template:
+
+```console
+{embedding-model-provider[variant]}-{accelerator/indexer[variant]}-{test variant}
+```
+
+`[variant]` refers to the specific information about the embedding model or indexer setup. For example:
+
+* `openai[text-embedding-3-small]` - an OpenAI `text-embedding-3-small` embedding model with chunking enabled.
+* `duckdb[file]` - a DuckDB accelerator using file-mode acceleration
+
+Variants can be nested, up to 2 levels. For example, `openai[text-embedding-3-small[chunking]]` is embedding model with enabled chunking configuration.
+
+`{test variant}` refers to additional configuration information, for example, `hybrid` indicating that full text search is enabled
+
+Do not include test dataset information in the `{test variant}`. This information is supplied as a query metric dimension/attribute.
+
+Examples of full spicepod names:
+
+* `openai[text-embedding-3-small]-arrow` - an OpenAI `text-embedding-3-small` embedding model with Arrow acceleration.
+* `openai[text-embedding-3-small[chunking]]-duckdb[file]` - an OpenAI `text-embedding-3-small` embedding model with chunking enabled, using DuckDB file-mode acceleration.
+* `openai[text-embedding-3-small]-s3_vectors` - an OpenAI `text-embedding-3-small` embedding model with AWS S3-based vector storage.
+* `huggingface[all-minilm-l6-v2]-arrow-hybrid_limit_2000` - a HuggingFace `all-MiniLM-L6-v2` embedding model with Arrow acceleration and hybrid search (vector + full-text search) enabled, with a test corpus data limit of 2000 records.

--- a/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small[chunking]]-duckdb[file].yaml
+++ b/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small[chunking]]-duckdb[file].yaml
@@ -1,0 +1,41 @@
+version: v1
+kind: Spicepod
+name: openai[text-embedding-3-small[chunking]]-duckdb[file]
+datasets:
+
+  # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/tree/main
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        embeddings:
+          - from: openai_embed
+            row_id:
+              - _id
+            chunking:
+              enabled: true
+              target_chunk_size: 512
+              overlap_size: 128
+              trim_whitespace: false
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: openai:text-embedding-3-small
+    name: openai_embed
+    params:
+      openai_api_key: ${ secrets:OPENAI_API_KEY }

--- a/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-arrow.yaml
+++ b/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mteb_quora_openai-text-embedding-3-small_arrow
+name: openai[text-embedding-3-small]-arrow
 datasets:
 
   # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.

--- a/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-s3_vectors.yaml
+++ b/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-s3_vectors.yaml
@@ -1,0 +1,43 @@
+version: v1
+kind: Spicepod
+name: openai[text-embedding-3-small]-s3_vectors
+datasets:
+
+  # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/tree/main
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+    vectors:
+      enabled: true
+      engine: s3_vectors
+      params:
+        s3_vectors_bucket: spice-ci-search-benchmarks-variant-001
+        s3_vectors_index: default
+        s3_vectors_aws_region: us-east-2
+        s3_vectors_aws_access_key_id: ${env:AWS_S3_VECTORS_KEY}
+        s3_vectors_aws_secret_access_key: ${env:AWS_S3_VECTORS_SECRET}
+    columns:
+      - name: text
+        embeddings:
+          - from: openai_embed
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: openai:text-embedding-3-small
+    name: openai_embed
+    params:
+      openai_api_key: ${ secrets:OPENAI_API_KEY }

--- a/test/spicepods/vector_search/mteb/quora_openai-text-embedding-3-small_arrow.yaml
+++ b/test/spicepods/vector_search/mteb/quora_openai-text-embedding-3-small_arrow.yaml
@@ -23,7 +23,7 @@ datasets:
       enabled: true
 
   - from: file:./data.parquet
-    name: test_data
+    name: relevance_data
     acceleration:
       enabled: true
 

--- a/tools/testoperator/src/commands/vector_search/mod.rs
+++ b/tools/testoperator/src/commands/vector_search/mod.rs
@@ -20,11 +20,15 @@ use super::get_app_and_start_request;
 use crate::{args::VectorSearchTestArgs, wait_test_and_memory};
 use std::time::{Duration, SystemTime};
 use test_framework::{
-    anyhow, git,
+    TestType, anyhow, git,
+    metrics::{MetricCollector, QueryMetrics},
     opentelemetry::KeyValue,
     opentelemetry_sdk::Resource,
     spiced::SpicedInstance,
-    spicetest::{SpiceTest, vector_search::NotStarted},
+    spicetest::{
+        SpiceTest,
+        vector_search::{NotStarted, SearchRunMetric},
+    },
     telemetry::Telemetry,
     tokio_util::sync::CancellationToken,
     utils::observe_memory,
@@ -67,24 +71,42 @@ pub(crate) async fn run(args: &VectorSearchTestArgs) -> anyhow::Result<()> {
 
     println!("Running search");
 
-    // Only QuoraRetrieval dataset is currently supported. no need to use `benchmark_dataset` function to determine what config to use.
+    // Only QuoraRetrieval dataset is currently supported; no need to use `benchmark_dataset` function to determine what config to use.
     let config = mteb_quora::init_search_config(&spiced_instance, Some(10)).await?;
+
+    // retrieve query relevance data
+    let qrels = mteb_quora::get_query_relevance_data(&spiced_instance).await?;
 
     let search_started_at = SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
 
     let vector_test = SpiceTest::new(
         app.name.clone(),
-        NotStarted::new().with_config(config).with_parallel_count(1),
+        NotStarted::new()
+            .with_config(config)
+            .with_parallel_count(args.common.concurrency),
     )
     .with_spiced_instance(spiced_instance)
     .start()?;
 
     let test = wait_test_and_memory!(vector_test, memory_token, memory_readings);
-    let mut spiced_instance = test.end()?;
-
     let finished_at = SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
 
     println!("Search requests completed, calculating results...");
+
+    let p95 = test.get_p95_response_time_metric()?;
+    let rps = test.get_rps_metric()?;
+    let score = test.calculate_search_score_metric(&qrels, |results| {
+        mteb_quora::transform_search_results_for_eval(results)
+    })?;
+
+    let metrics: QueryMetrics<_, _> = test
+        .collect(TestType::VectorSearch)?
+        .with_run_metric(SearchRunMetric::new(rps, p95, score));
+
+    let mut spiced_instance = test.end()?;
+    let (max_memory, median_memory) = observe_memory(memory_token, memory_readings).await?;
+
+    metrics.with_memory_usage(max_memory).show_run(None)?; // no additional test pass logic applies
 
     let spiced_commit_sha = std::env::var("SPICED_COMMIT").unwrap_or(git::get_commit_sha());
 
@@ -97,35 +119,31 @@ pub(crate) async fn run(args: &VectorSearchTestArgs) -> anyhow::Result<()> {
         KeyValue::new("spiced_commit_sha", spiced_commit_sha),
         KeyValue::new("testoperator_commit_sha", git::get_commit_sha()),
         KeyValue::new("branch_name", git::get_branch_name()),
-    ]);
-
-    let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
-
-    let attributes = vec![
         KeyValue::new("config_name", app.name), // use app name as search configuration
         KeyValue::new(
             "benchmark_dataset",
             args.benchmark_dataset.clone().unwrap_or_default(),
         ),
-    ];
+    ]);
 
-    crate::metrics::TEST_DURATION.record(
-        u64::try_from((finished_at - started_at).as_millis())?,
-        &attributes,
-    );
+    let telemetry = Telemetry::new(&benchmark_resource, "SPICEAI_BENCHMARK_METRICS_KEY");
+
+    crate::metrics::TEST_DURATION
+        .record(u64::try_from((finished_at - started_at).as_millis())?, &[]);
     crate::metrics::VECTOR_INDEX_CREATION_DURATION.record(
         u64::try_from((index_finished_at - started_at).as_millis())?,
-        &attributes,
+        &[],
     );
     crate::metrics::SEARCH_DURATION.record(
         u64::try_from((finished_at - search_started_at).as_millis())?,
-        &attributes,
+        &[],
     );
 
-    // TODO: Calculation to be added next: https://github.com/spiceai/spiceai/issues/6143
-    crate::metrics::SEARCH_RPS.record(0.0, &attributes);
-    crate::metrics::SEARCH_P95_RESPONSE_TIME.record(0.0, &attributes);
-    crate::metrics::SCORE.record(0.0, &attributes);
+    crate::metrics::SEARCH_RPS.record(rps, &[]);
+    crate::metrics::SEARCH_P95_RESPONSE_TIME.record(p95, &[]);
+    crate::metrics::SCORE.record(score, &[]);
+    crate::metrics::PEAK_MEMORY_USAGE.record(max_memory * 1024.0, &[]);
+    crate::metrics::MEDIAN_MEMORY_USAGE.record(median_memory * 1024.0, &[]);
 
     telemetry.emit().await?;
 

--- a/tools/testoperator/src/commands/vector_search/mteb_quora.rs
+++ b/tools/testoperator/src/commands/vector_search/mteb_quora.rs
@@ -164,9 +164,7 @@ pub(crate) async fn get_query_relevance_data(
     )
     .await?;
 
-    let qrels = extract_query_relevance_from_batches(&records)?;
-
-    Ok(qrels)
+    extract_query_relevance_from_batches(&records)
 }
 
 fn extract_query_relevance_from_batches(

--- a/tools/testoperator/src/commands/vector_search/mteb_quora.rs
+++ b/tools/testoperator/src/commands/vector_search/mteb_quora.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::path::Path;
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::Path,
+};
 
 use hf_hub::{Repo, RepoType, api::tokio::ApiBuilder};
 use test_framework::{
@@ -22,7 +25,7 @@ use test_framework::{
     arrow::{self, array::RecordBatch},
     futures::TryStreamExt,
     spiced::SpicedInstance,
-    spicetest::vector_search::{SearchConfig, SearchRequest},
+    spicetest::vector_search::{SearchConfig, SearchRequest, SearchResult},
 };
 
 /// The `QuoraRetrieval` MTEB dataset is a benchmark dataset used for evaluating retrieval models.
@@ -148,6 +151,101 @@ fn to_search_requests(
         .collect::<Vec<SearchRequest>>();
 
     Ok(queries)
+}
+
+pub(crate) async fn get_query_relevance_data(
+    spiced_instance: &SpicedInstance,
+) -> anyhow::Result<HashMap<String, HashMap<String, i32>>> {
+    let mut spice_client = spiced_instance.spice_client(None, false).await?;
+
+    let records = execute_sql(
+        &mut spice_client,
+        r#"SELECT "query-id", "corpus-id", score FROM relevance_data"#,
+    )
+    .await?;
+
+    let qrels = extract_query_relevance_from_batches(&records)?;
+
+    Ok(qrels)
+}
+
+fn extract_query_relevance_from_batches(
+    records: &[RecordBatch],
+) -> anyhow::Result<HashMap<String, HashMap<String, i32>>> {
+    let mut query_relevance = HashMap::new();
+
+    for batch in records {
+        let query_id_column = batch
+            .column_by_name("query-id")
+            .ok_or_else(|| anyhow::anyhow!("Missing 'query-id' column"))?
+            .as_any()
+            .downcast_ref::<arrow::array::LargeStringArray>()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Failed to downcast 'query-id' column to LargeStringArray")
+            })?;
+
+        let corpus_id_column = batch
+            .column_by_name("corpus-id")
+            .ok_or_else(|| anyhow::anyhow!("Missing 'corpus-id' column"))?
+            .as_any()
+            .downcast_ref::<arrow::array::LargeStringArray>()
+            .ok_or_else(|| {
+                anyhow::anyhow!("Failed to downcast 'corpus-id' column to LargeStringArray")
+            })?;
+
+        let score_column = batch
+            .column_by_name("score")
+            .ok_or_else(|| anyhow::anyhow!("Missing 'score' column"))?
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .ok_or_else(|| anyhow::anyhow!("Failed to downcast 'score' column to Int64Array"))?;
+
+        for i in 0..batch.num_rows() {
+            let query_id = query_id_column.value(i).to_string();
+            let corpus_id = corpus_id_column.value(i).to_string();
+            let score = i32::try_from(score_column.value(i))
+                .map_err(|e| anyhow::anyhow!("Failed to convert score to i32: {e}"))?;
+
+            query_relevance
+                .entry(query_id)
+                .or_insert_with(HashMap::new)
+                .insert(corpus_id, score);
+        }
+    }
+
+    Ok(query_relevance)
+}
+
+/// Converts raw vector search results into a structure suitable for evaluation.
+/// The key is the search query ID, and the value is a map of matched corpus IDs and their scores.
+/// Using query relevance data from the same dataset, this allows for evaluation of the search results.
+pub(crate) fn transform_search_results_for_eval(
+    search: &BTreeMap<String, SearchResult>,
+) -> HashMap<String, HashMap<String, f64>> {
+    let mut eval_results = HashMap::new();
+
+    for (query_id, search_result) in search {
+        let mut corpus_scores = HashMap::new();
+
+        // Extract corpus IDs and scores from search response results
+        for result in &search_result.response.results {
+            // Try to extract corpus ID from primary key (looking for "_id" field)
+            if let Some(corpus_id_value) = result.primary_key.get("_id") {
+                let corpus_id = match corpus_id_value {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    _ => {
+                        continue;
+                    }
+                };
+                corpus_scores.insert(corpus_id, result.score);
+            }
+        }
+
+        eval_results.insert(query_id.clone(), corpus_scores);
+    }
+
+    eval_results
 }
 
 async fn execute_sql(


### PR DESCRIPTION

## 📝 Summary

PR migrates remaining functionality from existing search benchmark into test operator:
 - Similar to MTEB and existing logic NDCG@10  score calculation for MTEB/Quora dataset. The algorithm is moved from benchmark test, [link](https://github.com/spiceai/spiceai/blob/d4683b76e36acab79e65379bc721fa7eecd2ecc8/crates/runtime/benches/bench_search/evaluator.rs#L22), original logic will be removed after search tests are fully migrated into test operator
 - Search response time P95
 - Logic to run test search queries in parallel using multiple workers (configurable via `--concurrency` parameter)

Next steps:
 - Add other test configurations / Spicepods for vector search via test operator
 - Update vector search GH workflow with test operator

## 🔗 Related

Part of 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
