### PR TITLE
docs: Update qa_analytics.csv

### DIFF
--- a/docs/release_notes/qa_analytics.csv
+++ b/docs/release_notes/qa_analytics.csv
@@ -18,4 +18,4 @@ version,qa_start_time,qa_end_time,human_count,human_hours,recipes_total,recipes_
 1.5.0-rc.1,2025-07-07T07:20:00Z,2025-07-08T02:20:00Z,10,10,74,74,0,AI QA engineer testing skipped—default release installation unavailable.
 1.5.0-rc.2,2025-07-14T08:00:00Z,2025-07-15T03:22:00Z,10,10,74,74,0,AI QA engineer testing skipped—default release installation unavailable.
 1.5.0,2025-07-21T07:10:00Z,2025-07-22T05:20:00Z,7,12,74,74,3,AI QA engineer runs recipes post-release.
-1.5.1,2025-07-28T19:45:00Z,2025-07-29T09:00:00Z,5,10,74,74,3,AI QA engineer runs recipes post-release.
+1.5.1,2025-07-28T19:45:00Z,2025-07-29T09:00:00Z,5,10,74,74,6,AI QA engineer runs recipes post-release.


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates the SpiceQA count to 6, as the previous count was on 1.5.0+models as the app had not been updated.