### PR TITLE
Add test configurations for vector search benchmarks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,7 +47,7 @@
         "--concurrency",
         "10",
         "-p",
-        "./test/spicepods/vector_search/mteb/quora_openai-text-embedding-3-small_arrow.yaml",
+        "./test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small[chunking]]-duckdb[file].yaml",
         "--benchmark-dataset",
         "quora_retrieval"
     ],

--- a/test/spicepods/vector_search/README.md
+++ b/test/spicepods/vector_search/README.md
@@ -25,3 +25,4 @@ Examples of full spicepod names:
 * `openai[text-embedding-3-small[chunking]]-duckdb[file]` - an OpenAI `text-embedding-3-small` embedding model with chunking enabled, using DuckDB file-mode acceleration.
 * `openai[text-embedding-3-small]-s3_vectors` - an OpenAI `text-embedding-3-small` embedding model with AWS S3-based vector storage.
 * `huggingface[all-minilm-l6-v2]-arrow-hybrid_limit_2000` - a HuggingFace `all-MiniLM-L6-v2` embedding model with Arrow acceleration and hybrid search (vector + full-text search) enabled, with a test corpus data limit of 2000 records.
+* `openai[text-embedding-3-small]-federated[postgres]` - an OpenAI `text-embedding-3-small` embedding model using precomputed embeddings stored in the source PostgreSQL dataset, performing direct search against the source without additional acceleration.

--- a/test/spicepods/vector_search/README.md
+++ b/test/spicepods/vector_search/README.md
@@ -1,0 +1,27 @@
+# Vector Search Test Spicepods
+
+## Naming
+
+Test spicepod names should be formatted according to the following template:
+
+```console
+{embedding-model-provider[variant]}-{accelerator/indexer[variant]}-{test variant}
+```
+
+`[variant]` refers to the specific information about the embedding model or indexer setup. For example:
+
+* `openai[text-embedding-3-small]` - an OpenAI `text-embedding-3-small` embedding model with chunking enabled.
+* `duckdb[file]` - a DuckDB accelerator using file-mode acceleration
+
+Variants can be nested, up to 2 levels. For example, `openai[text-embedding-3-small[chunking]]` is embedding model with enabled chunking configuration.
+
+`{test variant}` refers to additional configuration information, for example, `hybrid` indicating that full text search is enabled
+
+Do not include test dataset information in the `{test variant}`. This information is supplied as a query metric dimension/attribute.
+
+Examples of full spicepod names:
+
+* `openai[text-embedding-3-small]-arrow` - an OpenAI `text-embedding-3-small` embedding model with Arrow acceleration.
+* `openai[text-embedding-3-small[chunking]]-duckdb[file]` - an OpenAI `text-embedding-3-small` embedding model with chunking enabled, using DuckDB file-mode acceleration.
+* `openai[text-embedding-3-small]-s3_vectors` - an OpenAI `text-embedding-3-small` embedding model with AWS S3-based vector storage.
+* `huggingface[all-minilm-l6-v2]-arrow-hybrid_limit_2000` - a HuggingFace `all-MiniLM-L6-v2` embedding model with Arrow acceleration and hybrid search (vector + full-text search) enabled, with a test corpus data limit of 2000 records.

--- a/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small[chunking]]-duckdb[file].yaml
+++ b/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small[chunking]]-duckdb[file].yaml
@@ -1,0 +1,41 @@
+version: v1
+kind: Spicepod
+name: openai[text-embedding-3-small[chunking]]-duckdb[file]
+datasets:
+
+  # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/tree/main
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        embeddings:
+          - from: openai_embed
+            row_id:
+              - _id
+            chunking:
+              enabled: true
+              target_chunk_size: 512
+              overlap_size: 128
+              trim_whitespace: false
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: openai:text-embedding-3-small
+    name: openai_embed
+    params:
+      openai_api_key: ${ secrets:OPENAI_API_KEY }

--- a/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-arrow.yaml
+++ b/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-arrow.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: mteb_quora_openai-text-embedding-3-small_arrow
+name: openai[text-embedding-3-small]-arrow
 datasets:
 
   # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.

--- a/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-s3_vectors.yaml
+++ b/test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-s3_vectors.yaml
@@ -1,0 +1,43 @@
+version: v1
+kind: Spicepod
+name: openai[text-embedding-3-small]-s3_vectors
+datasets:
+
+  # MTEB Quora Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/QuoraRetrieval_test_top_250_only_w_correct-v2/tree/main
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+    vectors:
+      enabled: true
+      engine: s3_vectors
+      params:
+        s3_vectors_bucket: spice-ci-search-benchmarks-variant-001
+        s3_vectors_index: default
+        s3_vectors_aws_region: us-east-2
+        s3_vectors_aws_access_key_id: ${env:AWS_S3_VECTORS_KEY}
+        s3_vectors_aws_secret_access_key: ${env:AWS_S3_VECTORS_SECRET}
+    columns:
+      - name: text
+        embeddings:
+          - from: openai_embed
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: openai:text-embedding-3-small
+    name: openai_embed
+    params:
+      openai_api_key: ${ secrets:OPENAI_API_KEY }


### PR DESCRIPTION
## 📝 Summary

Example results based on **10% of corpus data** (`refresh_sql: SELECT * from corpus limit 17000`)

**openai[text-embedding-3-small]-arrow.yaml**

```
testoperator run vector-search --ready-wait 1800 \
  --concurrency 10 \
  --benchmark-dataset quora_retrieval \
  -p "./test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-arrow.yaml"


Search requests completed, calculating results...
Max memory usage: 0.70 GB
Median memory usage: 0.68 GB
+--------------------------------------+----------------+--------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+------------------+-------------+---------------------+
| run_id                               | spiced_version | run_name                             | commit_sha      | branch_name                            | test_type     | started_at    | finished_at   | status | query_execution_count | memory_usage | rps              | p95_time_ms | score               |
+--------------------------------------+----------------+--------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+------------------+-------------+---------------------+
| 2ad09496-b84d-4076-8b27-c70cdf85d47a | v1.6.0         | openai[text-embedding-3-small]-arrow | a420f9216-dirty | sgrebnov/07-29-vss-test-configurations | vector_search | 1753850839907 | 1753851224903 | passed | 1000                  | 0.69921875   | 2.59742970512352 | 7179.0      | 0.08110085196725834 |
+--------------------------------------+----------------+--------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+------------------+-------------+---------------------+
```

**openai[text-embedding-3-small[chunking]]-duckdb[file].yaml**

```
testoperator run vector-search --ready-wait 1800 \
  --concurrency 10 \
  --benchmark-dataset quora_retrieval \
  -p "./test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small[chunking]]-duckdb[file].yaml"

+--------------------------------------+----------------+-------------------------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+--------------------+-------------+---------------------+
| run_id                               | spiced_version | run_name                                              | commit_sha      | branch_name                            | test_type     | started_at    | finished_at   | status | query_execution_count | memory_usage | rps                | p95_time_ms | score               |
+--------------------------------------+----------------+-------------------------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+--------------------+-------------+---------------------+
| 29564480-11ca-467d-a860-dca81e6b8341 | v1.6.0         | openai[text-embedding-3-small[chunking]]-duckdb[file] | a420f9216-dirty | sgrebnov/07-29-vss-test-configurations | vector_search | 1753851427194 | 1753851514210 | passed | 1000                  | 1.9658203125 | 11.492156281557461 | 1126.0      | 0.08087537204274035 |
+--------------------------------------+----------------+-------------------------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+--------------------+-------------+---------------------+
```

**quora/openai[text-embedding-3-small]-s3_vectors.yaml**

```
testoperator run vector-search --ready-wait 1800 \
  --concurrency 10 \
  --benchmark-dataset quora_retrieval \
  -p "./test/spicepods/vector_search/mteb/quora/openai[text-embedding-3-small]-s3_vectors.yaml"


+--------------------------------------+----------------+-------------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+--------------------+-------------+--------------------+
| run_id                               | spiced_version | run_name                                  | commit_sha      | branch_name                            | test_type     | started_at    | finished_at   | status | query_execution_count | memory_usage | rps                | p95_time_ms | score              |
+--------------------------------------+----------------+-------------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+--------------------+-------------+--------------------+
| 19fa0416-59a3-4dc8-849e-d325c3d24153 | v1.6.0         | openai[text-embedding-3-small]-s3_vectors | a420f9216-dirty | sgrebnov/07-29-vss-test-configurations | vector_search | 1753851754990 | 1753851850365 | passed | 1000                  | 0.9951171875 | 10.484895375842397 | 1267.0      | 0.0793507970388918 |
+--------------------------------------+----------------+-------------------------------------------+-----------------+----------------------------------------+---------------+---------------+---------------+--------+-----------------------+--------------+--------------------+-------------+--------------------+
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
