### PR TITLE
Disable Metal precomplation in `integration_llms.yml`

### DIFF
--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -77,6 +77,10 @@ jobs:
           os: darwin
 
       - name: Build LLMs integration test binary
+        env:
+          # Metal runners do not have `xcrun metal`
+          # See `https://github.com/EricLBuehler/mistral.rs/pull/1311`
+          MISTRALRS_METAL_PRECOMPILE: 0
         run: |
           TEST_BINARY_PATH=$(cargo test -p llms --test integration --features metal --no-run --message-format=json | jq -r 'select(.reason == "compiler-artifact" and (.target.kind | contains(["test"])) and .executable != null) | .executable')
           cp $TEST_BINARY_PATH ./llms_integration_test


### PR DESCRIPTION
## 📝 Summary

Fix error in [integration_llms.yml CI](https://github.com/spiceai/spiceai/actions/runs/16613964666/job/47002686528#step:4:475) in same manner as [integration_models.yaml](https://github.com/spiceai/spiceai/blob/trunk/.github/workflows/integration_models.yml#L67). 

**Error in integration_llms.yml CI:**
```
error: failed to run custom build command for `mistralrs-quant v0.6.0 (https://github.com/spiceai/mistral.rs?rev=cf3749e243ebdd2d9dfa1b895261147ff9ba64e3#cf3749e2)`

Caused by:
  process didn't exit successfully: `/opt/github-runner/_work/spiceai/spiceai/target/debug/build/mistralrs-quant-d790fd990c90ed89/build-script-build` (exit status: 101)
  --- stdout
  cargo::rerun-if-changed=src/metal_kernels/bitwise.metal
  cargo::rerun-if-changed=src/metal_kernels/blockwise_fp8.metal
  cargo::rerun-if-changed=src/metal_kernels/bnb_dequantize.metal
  cargo::rerun-if-changed=src/metal_kernels/hqq_dequantize.metal
  cargo::rerun-if-changed=src/metal_kernels/quantized.metal
  cargo::rerun-if-changed=src/metal_kernels/scan.metal
  cargo::rerun-if-changed=src/metal_kernels/sort.metal
  cargo::rerun-if-changed=src/metal_kernels/copy.metal
  cargo::rerun-if-changed=src/metal_kernels/utils.metal
  cargo::rerun-if-changed=src/metal_kernels/bf16.metal
  cargo::rerun-if-changed=src/metal_kernels/scan_impl.metal
  cargo::rerun-if-changed=src/metal_kernels/sort_impl.metal
  cargo::rerun-if-changed=src/metal_kernels/copy_impl.metal
  cargo::rerun-if-changed=build.rs
  cargo:rerun-if-env-changed=MISTRALRS_METAL_PRECOMPILE

  --- stderr
  xcrun: error: unable to find utility "metal", not a developer tool or in PATH
  xcrun: error: unable to find utility "metal", not a developer tool or in PATH

  thread 'main' panicked at /Users/runner/.cargo/git/checkouts/mistral.rs-c97717a1051da368/cf3749e/mistralrs-quant/build.rs:259:25:
  Compiling metal -> air failed. Exit with status: exit status: 72
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
