### PR TITLE
feat: Add Hadoop Catalog connectors for Iceberg

### DIFF
--- a/.github/workflows/integration_data_components.yaml
+++ b/.github/workflows/integration_data_components.yaml
@@ -60,23 +60,6 @@ jobs:
 
       - name: Set up cc
         uses: ./.github/actions/setup-cc
-      
-      - name: Check if sccache can be set up
-        run: |
-          if [ -z "${{ secrets.TEST_MINIO_ENDPOINT }}" ]; then
-            echo "SCCACHE_SETUP=false" >> $GITHUB_ENV
-            echo "RUSTC_WRAPPER=" >> $GITHUB_ENV
-          else
-            echo "SCCACHE_SETUP=true" >> $GITHUB_ENV
-            echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          fi
-
-      - name: Set up sccache
-        if: ${{ env.SCCACHE_SETUP == 'true' }}
-        uses: ./.github/actions/setup-sccache
-        with:
-          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          os: 'linux'
 
       - name: Install Nextest
         run: |

--- a/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
@@ -368,9 +368,6 @@ impl Catalog for HadoopCatalog {
                 .await?
             {
                 tables.push(table_ident);
-            } else {
-                // TODO: Add something like a `MetadataMissingBehavior` to choose whether to fail or not
-                tracing::warn!("Table {} does not have metadata, skipping", table_ident);
             }
         }
 

--- a/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::any::Any;
 use std::collections::HashMap;
 
 use async_trait::async_trait;
 use futures::TryStreamExt;
-use iceberg::io::{FileIO, InputFile};
+use iceberg::io::{Extensions, FileIO, InputFile};
 use iceberg::spec::TableMetadata;
 use iceberg::table::Table;
 use iceberg::{
@@ -46,6 +47,7 @@ pub struct HadoopCatalogBuilder {
     file_io: Option<FileIO>,
     metadata_mode: MetadataMode,
     properties: HashMap<String, String>,
+    file_io_extensions: Extensions,
 }
 
 impl HadoopCatalogBuilder {
@@ -64,6 +66,13 @@ impl HadoopCatalogBuilder {
         self
     }
 
+    /// Sets the `FileIO` extensions for the Hadoop catalog.
+    #[must_use]
+    pub fn with_file_io_extension<T: Any + Send + Sync>(mut self, extension: T) -> Self {
+        self.file_io_extensions.add(extension);
+        self
+    }
+
     /// Sets the metadata mode for the Hadoop catalog.
     #[must_use]
     pub fn with_metadata_mode(mut self, metadata_mode: MetadataMode) -> Self {
@@ -78,6 +87,13 @@ impl HadoopCatalogBuilder {
         self
     }
 
+    /// Sets properties for the `FileIO` connection.
+    #[must_use]
+    pub fn with_properties(mut self, properties: HashMap<String, String>) -> Self {
+        self.properties.extend(properties);
+        self
+    }
+
     /// Builds the `HadoopCatalog` instance.
     ///
     /// # Errors
@@ -89,11 +105,16 @@ impl HadoopCatalogBuilder {
             Error::new(ErrorKind::DataInvalid, "Warehouse root must be specified")
         })?;
 
+        if !warehouse_root.ends_with('/') {
+            warehouse_root.push('/');
+        }
+
         let file_io = if let Some(file_io) = self.file_io {
             file_io
         } else {
             FileIO::from_path(&warehouse_root)?
                 .with_props(self.properties)
+                .with_extensions(self.file_io_extensions)
                 .build()?
         };
 
@@ -109,10 +130,6 @@ impl HadoopCatalogBuilder {
                 ErrorKind::DataInvalid,
                 "Warehouse root must be a directory",
             ));
-        }
-
-        if !warehouse_root.ends_with('/') {
-            warehouse_root.push('/');
         }
 
         Ok(HadoopCatalog {

--- a/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
@@ -467,18 +467,16 @@ impl HadoopCatalog {
         if let Some(metadata_file) = metadata_file_path {
             self.file_io.new_input(&metadata_file)
         } else {
-            #[allow(clippy::similar_names)] // txt and text are indeed similar
-            let hint_txt = self
+            let hint_one = self
                 .file_io
                 .new_input(self.version_hint_path(table_identifier, "txt"))?;
-            #[allow(clippy::similar_names)] // txt and text are indeed similar
-            let hint_text = self
+            let hint_two = self
                 .file_io
                 .new_input(self.version_hint_path(table_identifier, "text"))?;
-            let hint_input = if hint_txt.exists().await? {
-                Some(hint_txt)
-            } else if hint_text.exists().await? {
-                Some(hint_text)
+            let hint_input = if hint_one.exists().await? {
+                Some(hint_one)
+            } else if hint_two.exists().await? {
+                Some(hint_two)
             } else {
                 None
             };

--- a/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
@@ -467,11 +467,23 @@ impl HadoopCatalog {
         if let Some(metadata_file) = metadata_file_path {
             self.file_io.new_input(&metadata_file)
         } else {
-            // TODO: version hint could be .txt or .text. refactor this to support both later
-            let version_hint_path = self.version_hint_path(table_identifier, "txt");
+            #[allow(clippy::similar_names)] // txt and text are indeed similar
+            let hint_txt = self
+                .file_io
+                .new_input(self.version_hint_path(table_identifier, "txt"))?;
+            #[allow(clippy::similar_names)] // txt and text are indeed similar
+            let hint_text = self
+                .file_io
+                .new_input(self.version_hint_path(table_identifier, "text"))?;
+            let hint_input = if hint_txt.exists().await? {
+                Some(hint_txt)
+            } else if hint_text.exists().await? {
+                Some(hint_text)
+            } else {
+                None
+            };
 
-            let input = self.file_io.new_input(&version_hint_path)?;
-            if input.exists().await? {
+            if let Some(input) = hint_input {
                 // Load the version hint file to get the latest metadata file
                 let metadata_version = input.read().await?;
                 let metadata_version = std::str::from_utf8(&metadata_version).map_err(|e| {

--- a/crates/data_components/src/iceberg/catalog/mod.rs
+++ b/crates/data_components/src/iceberg/catalog/mod.rs
@@ -14,5 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use snafu::prelude::*;
+
 pub mod hadoop;
 pub mod rest;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "An unknown error occurred while interacting with the Iceberg catalog.\nReport an issue at https://github.com/spiceai/spiceai/issues\n{source}"
+    ))]
+    Unknown { source: iceberg::Error },
+
+    #[snafu(display(
+        "The data in the Iceberg table is invalid. The table may be corrupted or incomplete.\n{source}"
+    ))]
+    DataInvalid { source: iceberg::Error },
+
+    #[snafu(display(
+        "This Iceberg feature is not yet supported.\nReport an issue at https://github.com/spiceai/spiceai/issues\n{source}"
+    ))]
+    FeatureUnsupported { source: iceberg::Error },
+
+    #[snafu(display(
+        "The namespace '{namespace}' does not exist in the Iceberg catalog, verify the namespace name and try again."
+    ))]
+    NamespaceDoesNotExist { namespace: String },
+
+    #[snafu(display(
+        "Failed to connect to the Iceberg catalog or object store at {url}, verify the Iceberg catalog is accessible and try again."
+    ))]
+    FailedToConnect { url: String, source: iceberg::Error },
+
+    #[snafu(display(
+        "Internal error: could not acquire a semaphore permit for concurrency control: {source}"
+    ))]
+    SemaphoreError { source: tokio::sync::AcquireError },
+}

--- a/crates/data_components/src/iceberg/catalog/rest/mod.rs
+++ b/crates/data_components/src/iceberg/catalog/rest/mod.rs
@@ -16,6 +16,3 @@ limitations under the License.
 
 mod catalog;
 pub use catalog::*;
-
-mod provider;
-pub use provider::*;

--- a/crates/data_components/src/iceberg/mod.rs
+++ b/crates/data_components/src/iceberg/mod.rs
@@ -15,3 +15,4 @@ limitations under the License.
 */
 
 pub mod catalog;
+pub mod provider;

--- a/crates/data_components/src/iceberg/provider.rs
+++ b/crates/data_components/src/iceberg/provider.rs
@@ -26,45 +26,10 @@ use datafusion::error::Result as DFResult;
 use futures::future::try_join_all;
 use iceberg::{Catalog, NamespaceIdent, TableIdent};
 use iceberg_datafusion::IcebergTableProvider;
-use snafu::prelude::*;
 use tokio::sync::Semaphore;
 
 use crate::RefreshableCatalogProvider;
-
-use super::catalog::RestCatalog;
-
-#[derive(Debug, Snafu)]
-pub enum Error {
-    #[snafu(display(
-        "An unknown error occurred while interacting with the Iceberg catalog.\nReport an issue at https://github.com/spiceai/spiceai/issues\n{source}"
-    ))]
-    Unknown { source: iceberg::Error },
-
-    #[snafu(display(
-        "The data in the Iceberg table is invalid. The table may be corrupted or incomplete.\n{source}"
-    ))]
-    DataInvalid { source: iceberg::Error },
-
-    #[snafu(display(
-        "This Iceberg feature is not yet supported.\nReport an issue at https://github.com/spiceai/spiceai/issues\n{source}"
-    ))]
-    FeatureUnsupported { source: iceberg::Error },
-
-    #[snafu(display(
-        "The namespace '{namespace}' does not exist in the Iceberg catalog, verify the namespace name and try again."
-    ))]
-    NamespaceDoesNotExist { namespace: String },
-
-    #[snafu(display(
-        "Failed to connect to the Iceberg catalog or object store at {url}, verify the Iceberg catalog is accessible and try again."
-    ))]
-    FailedToConnect { url: String, source: iceberg::Error },
-
-    #[snafu(display(
-        "Internal error: could not acquire a semaphore permit for concurrency control: {source}"
-    ))]
-    SemaphoreError { source: tokio::sync::AcquireError },
-}
+use crate::iceberg::catalog::Error;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -90,7 +55,7 @@ impl IcebergCatalogProvider {
     /// attempts to create a schema provider for each namespace, and
     /// collects these providers into a `HashMap`.
     pub async fn try_new(
-        client: Arc<RestCatalog>,
+        client: Arc<dyn Catalog>,
         root_namespace: Option<NamespaceIdent>,
     ) -> Result<Self> {
         // Create the semaphore first, so we can use it in the closures below
@@ -191,7 +156,7 @@ impl IcebergSchemaProvider {
     /// attempts to create a table provider for each table name, and
     /// collects these providers into a `HashMap`.
     pub(crate) async fn try_new(
-        client: Arc<RestCatalog>,
+        client: Arc<dyn Catalog>,
         namespace: NamespaceIdent,
         load_semaphore: Arc<Semaphore>,
     ) -> Result<Self> {
@@ -231,7 +196,7 @@ impl IcebergSchemaProvider {
     }
 
     async fn load_table(
-        client: Arc<RestCatalog>,
+        client: Arc<dyn Catalog>,
         table_name: Arc<TableIdent>,
         semaphore: Arc<Semaphore>,
     ) -> Result<Option<Arc<dyn TableProvider>>> {

--- a/crates/data_components/tests/hadoop_data/README.md
+++ b/crates/data_components/tests/hadoop_data/README.md
@@ -38,3 +38,30 @@ The configured warehouse for each source is the same, with 2 namespaces:
 The `setup_file_hadoop.sh` and `setup_minio_hadoop.sh` files setup each respective catalog, which is used in the `Dockerfile` to build the testing image.
 
 `setup_file_hadoop.sh` is configured to call `setup_minio_hadoop.sh`, and expects to be used within the Dockerfile image.
+
+## Importing TPCH
+
+This example shows how to import a TPCH dataset from CSV into Iceberg tables under Hadoop, on the local filesystem:
+
+```scala
+spark.conf.set("spark.sql.catalog.hadoop_prod", "org.apache.iceberg.spark.SparkCatalog")
+spark.conf.set("spark.sql.catalog.hadoop_prod.type", "hadoop")
+spark.conf.set("spark.sql.catalog.hadoop_prod.warehouse", "file:///tmp/hadoop_warehouse")
+
+val csv_df = spark.read.option("header", "true").option("inferSchema", "true").csv("./lineitem.csv")
+csv_df.writeTo("hadoop_prod.tpch.lineitem").using("iceberg").create()
+val csv_df = spark.read.option("header", "true").option("inferSchema", "true").csv("./customer.csv")
+csv_df.writeTo("hadoop_prod.tpch.customer").using("iceberg").create()
+val csv_df = spark.read.option("header", "true").option("inferSchema", "true").csv("./orders.csv")
+csv_df.writeTo("hadoop_prod.tpch.orders").using("iceberg").create()
+val csv_df = spark.read.option("header", "true").option("inferSchema", "true").csv("./supplier.csv")
+csv_df.writeTo("hadoop_prod.tpch.supplier").using("iceberg").create()
+val csv_df = spark.read.option("header", "true").option("inferSchema", "true").csv("./part.csv")
+csv_df.writeTo("hadoop_prod.tpch.part").using("iceberg").create()
+val csv_df = spark.read.option("header", "true").option("inferSchema", "true").csv("./partsupp.csv")
+csv_df.writeTo("hadoop_prod.tpch.partsupp").using("iceberg").create()
+val csv_df = spark.read.option("header", "true").option("inferSchema", "true").csv("./nation.csv")
+csv_df.writeTo("hadoop_prod.tpch.nation").using("iceberg").create()
+val csv_df = spark.read.option("header", "true").option("inferSchema", "true").csv("./region.csv")
+csv_df.writeTo("hadoop_prod.tpch.region").using("iceberg").create()
+```

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -24,7 +24,13 @@ use crate::{
 use async_trait::async_trait;
 use data_components::{
     RefreshableCatalogProvider,
-    iceberg::catalog::rest::{IcebergCatalogProvider, RestCatalog},
+    iceberg::{
+        catalog::{
+            hadoop::{HadoopCatalogBuilder, MetadataMode},
+            rest::RestCatalog,
+        },
+        provider::IcebergCatalogProvider,
+    },
 };
 use iceberg::{Namespace, NamespaceIdent};
 use iceberg_aws_sdk::S3CredentialProvider;
@@ -58,6 +64,9 @@ pub enum Error {
 
     #[snafu(display("Failed to parse URL: {}", source))]
     UrlParse { source: url::ParseError },
+
+    #[snafu(display("Failed to parse catalog URL"))]
+    UrlParseNoSource,
 
     #[snafu(display(
         "Failed to connect to the S3 endpoint at '{url}'.\nVerify the S3 endpoint is accessible and try again."
@@ -199,6 +208,33 @@ impl CatalogConnector for IcebergCatalog {
                 },
             );
         };
+
+        if catalog_id.starts_with("file://") || catalog_id.starts_with("s3://") {
+            // Not much we can check with this path for Hadoop, because a namespace could be an empty folder, there could be no namespaces, etc.
+            let hadoop_catalog = HadoopCatalogBuilder::default()
+                .with_warehouse_root(&catalog_id)
+                .with_metadata_mode(MetadataMode::Infer)
+                .build()
+                .await
+                .map_err(|e| super::Error::InvalidConfiguration {
+                    connector: "iceberg".into(),
+                    message: format!(
+                        "Failed to create Hadoop Catalog for Iceberg with base URI: {catalog_id}",
+                    ),
+                    connector_component: ConnectorComponent::from(catalog),
+                    source: Box::new(e),
+                })?;
+
+            let catalog_provider = IcebergCatalogProvider::try_new(Arc::new(hadoop_catalog), None)
+                .await
+                .map_err(|e| super::Error::UnableToGetCatalogProvider {
+                    connector: "iceberg".into(),
+                    connector_component: ConnectorComponent::from(catalog),
+                    source: Box::new(e),
+                })?;
+
+            return Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>);
+        }
 
         let (base_uri, mut props, namespace) = match parse_catalog_url(catalog_id.as_str()) {
             Ok(result) => result,
@@ -542,9 +578,146 @@ fn get_warehouse(url: &Url) -> Option<String> {
     None
 }
 
+pub fn parse_hadoop_table_url(
+    url: &str,
+    warehouse_uri: Option<&str>,
+) -> Result<(String, Namespace, String)> {
+    // There's no definite position for a root namespace in Hadoop, so all we can do is validate the URL and return the base URI.
+    // If an optional root is provided, it will be used as the warehouse root.
+    let parsed = Url::parse(url).context(UrlParseSnafu)?;
+
+    match parsed.scheme() {
+        "file" | "s3" => {} // OK
+        other => {
+            return InvalidSchemeSnafu {
+                scheme: other.to_string(),
+            }
+            .fail();
+        }
+    }
+
+    let count = parsed
+        .path_segments()
+        .map(std::iter::Iterator::count)
+        .context(UrlParseNoSourceSnafu)?;
+
+    let table_name = parsed
+        .path_segments()
+        .and_then(std::iter::Iterator::last)
+        .context(UrlParseNoSourceSnafu)?;
+    let namespace_ident = parsed
+        .path_segments()
+        .and_then(|mut segments| {
+            segments
+                .nth(count - 2)
+                .map(|s| NamespaceIdent::new(s.to_string()))
+        })
+        .context(MissingNamespaceSnafu)?;
+
+    let nodes = parsed
+        .path_segments()
+        .map(|segments| segments.take(count - 2).collect::<Vec<_>>())
+        .context(UrlParseNoSourceSnafu)?;
+
+    let mut base_uri = if let Some(host) = parsed.host_str() {
+        format!("{}://{}/{}", parsed.scheme(), host, nodes.join("/"))
+    } else {
+        format!("{}://{}", parsed.scheme(), nodes.join("/"))
+    };
+
+    let mut namespace = Namespace::new(namespace_ident);
+
+    if let Some(warehouse_uri) = warehouse_uri {
+        base_uri = warehouse_uri.to_string();
+
+        let warehouse_uri = Url::parse(warehouse_uri).context(UrlParseSnafu)?;
+        if warehouse_uri.scheme() != parsed.scheme() {
+            return InvalidSchemeSnafu {
+                scheme: warehouse_uri.scheme().to_string(),
+            }
+            .fail();
+        }
+
+        // inverse union of the nodes with the warehouse URI paths gives any namespace segments
+        let warehouse_segments: Vec<_> = warehouse_uri
+            .path_segments()
+            .map(|s| s.collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        let namespace_segments: Vec<_> = nodes
+            .iter()
+            .filter(|segment| !warehouse_segments.contains(segment))
+            .map(|s| s.to_string())
+            .collect();
+
+        if !namespace_segments.is_empty() {
+            let namespace_ident = NamespaceIdent::from_vec(namespace_segments)
+                .map_err(|_| Error::MissingNamespace)?;
+            namespace = Namespace::new(namespace_ident);
+        }
+    }
+
+    Ok((base_uri, namespace, table_name.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_hadoop_table_url() {
+        let url = "s3://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
+        let (base_uri, namespace, table_name) =
+            parse_hadoop_table_url(url, Some("s3://my-bucket/my-prefix/warehouse"))
+                .expect("Failed to parse Hadoop table URL");
+        assert_eq!(base_uri, "s3://my-bucket/my-prefix/warehouse");
+        assert_eq!(namespace.name().to_url_string().as_str(), "spiceai_sandbox");
+        assert_eq!(table_name, "my_table");
+
+        let url = "file:///my/local/path/to/warehouse/spiceai_sandbox/my_table";
+        let (base_uri, namespace, table_name) =
+            parse_hadoop_table_url(url, Some("file:///my/local/path/to/warehouse"))
+                .expect("Failed to parse Hadoop table URL");
+        assert_eq!(base_uri, "file:///my/local/path/to/warehouse");
+        assert_eq!(namespace.name().to_url_string().as_str(), "spiceai_sandbox");
+        assert_eq!(table_name, "my_table");
+
+        // should infer the base URI when no warehouse is provided
+        let url = "s3://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
+        let (base_uri, namespace, table_name) =
+            parse_hadoop_table_url(url, None).expect("Failed to parse Hadoop table URL");
+        assert_eq!(base_uri, "s3://my-bucket/my-prefix/warehouse");
+        assert_eq!(namespace.name().to_url_string().as_str(), "spiceai_sandbox");
+        assert_eq!(table_name, "my_table");
+
+        let url = "file://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
+        let (base_uri, namespace, table_name) =
+            parse_hadoop_table_url(url, None).expect("Failed to parse Hadoop table URL");
+        assert_eq!(base_uri, "file://my-bucket/my-prefix/warehouse");
+        assert_eq!(namespace.name().to_url_string().as_str(), "spiceai_sandbox");
+        assert_eq!(table_name, "my_table");
+
+        // should support nested namespaces when a warehouse URI is provided
+        let url = "s3://my-bucket/my-prefix/warehouse/spiceai_sandbox/nested/my_table";
+        let (base_uri, namespace, table_name) =
+            parse_hadoop_table_url(url, Some("s3://my-bucket/my-prefix/warehouse"))
+                .expect("Failed to parse Hadoop table URL");
+        assert_eq!(base_uri, "s3://my-bucket/my-prefix/warehouse");
+        assert_eq!(
+            namespace.name().to_string().as_str(),
+            "spiceai_sandbox.nested",
+        );
+        assert_eq!(table_name, "my_table");
+
+        // should deny unknown schemes, or schemes from warehouses that don't match
+        let url = "ftp://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
+        let result = parse_hadoop_table_url(url, Some("ftp://my-bucket/my-prefix/warehouse"));
+        assert!(result.is_err());
+
+        let url = "s3://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
+        let result = parse_hadoop_table_url(url, Some("file:///my/local/path/to/warehouse"));
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_parse_catalog_url_no_prefix() {

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -649,6 +649,8 @@ pub fn parse_hadoop_table_url(
         .path_segments()
         .and_then(std::iter::Iterator::last)
         .context(UrlParseNoSourceSnafu)?;
+
+    // Set initial namespace - this falls through if warehouse URI is not provided
     let namespace_ident = parsed
         .path_segments()
         .and_then(|mut segments| {
@@ -660,13 +662,22 @@ pub fn parse_hadoop_table_url(
 
     let nodes = parsed
         .path_segments()
-        .map(|segments| segments.take(count - 2).collect::<Vec<_>>())
+        .map(|segments| segments.take(count - 1).collect::<Vec<_>>())
         .context(UrlParseNoSourceSnafu)?;
 
+    let warehouse_leaves = nodes
+        .clone()
+        .iter()
+        .map(ToString::to_string)
+        .take(count - 2)
+        .collect::<Vec<_>>()
+        .join("/");
+
     let mut base_uri = if let Some(host) = parsed.host_str() {
-        format!("{}://{}/{}", parsed.scheme(), host, nodes.join("/"))
+        format!("{}://{host}/{warehouse_leaves}", parsed.scheme())
     } else {
-        format!("{}://{}", parsed.scheme(), nodes.join("/"))
+        // nodes includes the inferred namespace, which needs to be excluded from the inferred base URI
+        format!("{}://{warehouse_leaves}", parsed.scheme())
     };
 
     let mut namespace = Namespace::new(namespace_ident);

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -32,7 +32,7 @@ use data_components::{
         provider::IcebergCatalogProvider,
     },
 };
-use iceberg::{Namespace, NamespaceIdent};
+use iceberg::{Namespace, NamespaceIdent, io::CustomAwsCredentialLoader};
 use iceberg_aws_sdk::S3CredentialProvider;
 use iceberg_catalog_rest::RestCatalogConfig;
 use ns_lookup::verify_ns_lookup_and_tcp_connect;
@@ -44,7 +44,10 @@ use url::Url;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Invalid URL scheme '{}'. Must be http or https", scheme))]
+    #[snafu(display(
+        "Invalid URL scheme '{}'. Must be 'http', 'https', 'file', 's3', or 's3a'.",
+        scheme
+    ))]
     InvalidScheme { scheme: String },
 
     #[snafu(display("URL is missing a host"))]
@@ -93,6 +96,46 @@ impl IcebergCatalog {
         Arc::new(Self {
             params: params.parameters,
         })
+    }
+
+    async fn load_hadoop_catalog(
+        props: HashMap<String, String>,
+        custom_credential_loader: Option<CustomAwsCredentialLoader>,
+        catalog: &Catalog,
+        catalog_id: &str,
+    ) -> super::Result<Arc<dyn RefreshableCatalogProvider>> {
+        // Not much we can check with this path for Hadoop, because a namespace could be an empty folder, there could be no namespaces, etc.
+        let mut catalog_builder = HadoopCatalogBuilder::default()
+            .with_warehouse_root(catalog_id)
+            .with_metadata_mode(MetadataMode::Infer)
+            .with_properties(props);
+
+        if let Some(loader) = custom_credential_loader {
+            catalog_builder = catalog_builder.with_file_io_extension(loader);
+        }
+
+        let hadoop_catalog =
+            catalog_builder
+                .build()
+                .await
+                .map_err(|e| super::Error::InvalidConfiguration {
+                    connector: "iceberg".into(),
+                    message: format!(
+                        "Failed to create Hadoop Catalog for Iceberg with base URI: {catalog_id}",
+                    ),
+                    connector_component: ConnectorComponent::from(catalog),
+                    source: Box::new(e),
+                })?;
+
+        let catalog_provider = IcebergCatalogProvider::try_new(Arc::new(hadoop_catalog), None)
+            .await
+            .map_err(|e| super::Error::UnableToGetCatalogProvider {
+                connector: "iceberg".into(),
+                connector_component: ConnectorComponent::from(catalog),
+                source: Box::new(e),
+            })?;
+
+        Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>)
     }
 }
 
@@ -194,6 +237,7 @@ impl CatalogConnector for IcebergCatalog {
         self
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn refreshable_catalog_provider(
         self: Arc<Self>,
         _runtime: Arc<Runtime>,
@@ -209,34 +253,76 @@ impl CatalogConnector for IcebergCatalog {
             );
         };
 
-        if catalog_id.starts_with("file://") || catalog_id.starts_with("s3://") {
-            // Not much we can check with this path for Hadoop, because a namespace could be an empty folder, there could be no namespaces, etc.
-            let hadoop_catalog = HadoopCatalogBuilder::default()
-                .with_warehouse_root(&catalog_id)
-                .with_metadata_mode(MetadataMode::Infer)
-                .build()
+        let mut props = HashMap::new();
+        for (key, value) in &self.params {
+            if let Some(prop_vec) = map_param_name_to_iceberg_prop(key.as_str()) {
+                for prop in prop_vec {
+                    props.insert(prop.clone(), value.expose_secret().to_string());
+                }
+            }
+        }
+
+        let custom_credential_loader = if let Some(endpoint) = props.get("s3.endpoint") {
+            verify_s3_endpoint(endpoint)
                 .await
                 .map_err(|e| super::Error::InvalidConfiguration {
                     connector: "iceberg".into(),
-                    message: format!(
-                        "Failed to create Hadoop Catalog for Iceberg with base URI: {catalog_id}",
-                    ),
+                    message: e.to_string(),
                     connector_component: ConnectorComponent::from(catalog),
                     source: Box::new(e),
                 })?;
 
-            let catalog_provider = IcebergCatalogProvider::try_new(Arc::new(hadoop_catalog), None)
-                .await
-                .map_err(|e| super::Error::UnableToGetCatalogProvider {
-                    connector: "iceberg".into(),
-                    connector_component: ConnectorComponent::from(catalog),
-                    source: Box::new(e),
-                })?;
+            let aws_sdk_config = load_config(
+                "IcebergCatalogConnector",
+                "s3_region",
+                "s3_access_key_id",
+                "s3_secret_access_key",
+                "s3_session_token",
+                &self.params,
+            )
+            .await
+            .map_err(|e| super::Error::InvalidConfiguration {
+                connector: "iceberg".into(),
+                message: e.to_string(),
+                connector_component: ConnectorComponent::from(catalog),
+                source: Box::new(e),
+            })?;
 
-            return Ok(Arc::new(catalog_provider) as Arc<dyn RefreshableCatalogProvider>);
+            Some(
+                S3CredentialProvider::from_config(&aws_sdk_config)
+                    .map_err(|e| super::Error::InvalidConfiguration {
+                        connector: "iceberg".into(),
+                        message: e.to_string(),
+                        connector_component: ConnectorComponent::from(catalog),
+                        source: Box::new(e),
+                    })?
+                    .into_custom_loader(),
+            )
+        } else {
+            None
+        };
+
+        if catalog_id.starts_with("file://")
+            || catalog_id.starts_with("s3://")
+            || catalog_id.starts_with("s3a://")
+        {
+            let catalog_id = if catalog_id.starts_with("s3://") {
+                // s3 needs to be s3a for Hadoop Catalog: https://github.com/apache/iceberg-rust/issues/434
+                catalog_id.replace("s3://", "s3a://")
+            } else {
+                catalog_id.to_string()
+            };
+
+            return IcebergCatalog::load_hadoop_catalog(
+                props,
+                custom_credential_loader,
+                catalog,
+                &catalog_id,
+            )
+            .await;
         }
 
-        let (base_uri, mut props, namespace) = match parse_catalog_url(catalog_id.as_str()) {
+        let (base_uri, new_props, namespace) = match parse_catalog_url(catalog_id.as_str()) {
             Ok(result) => result,
             Err(e) => {
                 return Err(super::Error::InvalidConfiguration {
@@ -250,54 +336,12 @@ impl CatalogConnector for IcebergCatalog {
             }
         };
 
-        for (key, value) in &self.params {
-            if let Some(prop_vec) = map_param_name_to_iceberg_prop(key.as_str()) {
-                for prop in prop_vec {
-                    props.insert(prop.clone(), value.expose_secret().to_string());
-                }
-            }
-        }
-
-        if let Some(endpoint) = props.get("s3.endpoint") {
-            verify_s3_endpoint(endpoint)
-                .await
-                .map_err(|e| super::Error::InvalidConfiguration {
-                    connector: "iceberg".into(),
-                    message: e.to_string(),
-                    connector_component: ConnectorComponent::from(catalog),
-                    source: Box::new(e),
-                })?;
-        }
-
-        let aws_sdk_config = load_config(
-            "IcebergCatalogConnector",
-            "s3_region",
-            "s3_access_key_id",
-            "s3_secret_access_key",
-            "s3_session_token",
-            &self.params,
-        )
-        .await
-        .map_err(|e| super::Error::InvalidConfiguration {
-            connector: "iceberg".into(),
-            message: e.to_string(),
-            connector_component: ConnectorComponent::from(catalog),
-            source: Box::new(e),
-        })?;
-
-        let custom_credential_loader = S3CredentialProvider::from_config(&aws_sdk_config)
-            .map_err(|e| super::Error::InvalidConfiguration {
-                connector: "iceberg".into(),
-                message: e.to_string(),
-                connector_component: ConnectorComponent::from(catalog),
-                source: Box::new(e),
-            })?
-            .into_custom_loader();
-
+        props.extend(new_props);
         let catalog_config = get_rest_catalog_config(base_uri, props);
-
-        let catalog_client =
-            RestCatalog::new(catalog_config).with_file_io_extension(custom_credential_loader);
+        let mut catalog_client = RestCatalog::new(catalog_config);
+        if let Some(loader) = custom_credential_loader {
+            catalog_client = catalog_client.with_file_io_extension(loader);
+        }
 
         let catalog_provider = IcebergCatalogProvider::try_new(
             Arc::new(catalog_client),
@@ -587,7 +631,7 @@ pub fn parse_hadoop_table_url(
     let parsed = Url::parse(url).context(UrlParseSnafu)?;
 
     match parsed.scheme() {
-        "file" | "s3" => {} // OK
+        "file" | "s3a" => {} // OK
         other => {
             return InvalidSchemeSnafu {
                 scheme: other.to_string(),
@@ -641,13 +685,13 @@ pub fn parse_hadoop_table_url(
         // inverse union of the nodes with the warehouse URI paths gives any namespace segments
         let warehouse_segments: Vec<_> = warehouse_uri
             .path_segments()
-            .map(|s| s.collect::<Vec<_>>())
+            .map(Iterator::collect::<Vec<_>>)
             .unwrap_or_default();
 
         let namespace_segments: Vec<_> = nodes
             .iter()
             .filter(|segment| !warehouse_segments.contains(segment))
-            .map(|s| s.to_string())
+            .map(ToString::to_string)
             .collect();
 
         if !namespace_segments.is_empty() {

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -710,11 +710,11 @@ mod tests {
 
     #[test]
     fn test_parse_hadoop_table_url() {
-        let url = "s3://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
+        let url = "s3a://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
         let (base_uri, namespace, table_name) =
-            parse_hadoop_table_url(url, Some("s3://my-bucket/my-prefix/warehouse"))
+            parse_hadoop_table_url(url, Some("s3a://my-bucket/my-prefix/warehouse"))
                 .expect("Failed to parse Hadoop table URL");
-        assert_eq!(base_uri, "s3://my-bucket/my-prefix/warehouse");
+        assert_eq!(base_uri, "s3a://my-bucket/my-prefix/warehouse");
         assert_eq!(namespace.name().to_url_string().as_str(), "spiceai_sandbox");
         assert_eq!(table_name, "my_table");
 
@@ -727,10 +727,10 @@ mod tests {
         assert_eq!(table_name, "my_table");
 
         // should infer the base URI when no warehouse is provided
-        let url = "s3://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
+        let url = "s3a://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
         let (base_uri, namespace, table_name) =
             parse_hadoop_table_url(url, None).expect("Failed to parse Hadoop table URL");
-        assert_eq!(base_uri, "s3://my-bucket/my-prefix/warehouse");
+        assert_eq!(base_uri, "s3a://my-bucket/my-prefix/warehouse");
         assert_eq!(namespace.name().to_url_string().as_str(), "spiceai_sandbox");
         assert_eq!(table_name, "my_table");
 
@@ -742,11 +742,11 @@ mod tests {
         assert_eq!(table_name, "my_table");
 
         // should support nested namespaces when a warehouse URI is provided
-        let url = "s3://my-bucket/my-prefix/warehouse/spiceai_sandbox/nested/my_table";
+        let url = "s3a://my-bucket/my-prefix/warehouse/spiceai_sandbox/nested/my_table";
         let (base_uri, namespace, table_name) =
-            parse_hadoop_table_url(url, Some("s3://my-bucket/my-prefix/warehouse"))
+            parse_hadoop_table_url(url, Some("s3a://my-bucket/my-prefix/warehouse"))
                 .expect("Failed to parse Hadoop table URL");
-        assert_eq!(base_uri, "s3://my-bucket/my-prefix/warehouse");
+        assert_eq!(base_uri, "s3a://my-bucket/my-prefix/warehouse");
         assert_eq!(
             namespace.name().to_string().as_str(),
             "spiceai_sandbox.nested",
@@ -758,7 +758,7 @@ mod tests {
         let result = parse_hadoop_table_url(url, Some("ftp://my-bucket/my-prefix/warehouse"));
         assert!(result.is_err());
 
-        let url = "s3://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
+        let url = "s3a://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
         let result = parse_hadoop_table_url(url, Some("file:///my/local/path/to/warehouse"));
         assert!(result.is_err());
     }

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -20,6 +20,7 @@ limitations under the License.
 use std::{any::Any, future::Future, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
+use data_components::iceberg::catalog::hadoop::{HadoopCatalogBuilder, MetadataMode};
 use datafusion::catalog::TableProvider;
 use iceberg::TableIdent;
 use iceberg_aws_sdk::S3CredentialProvider;
@@ -30,8 +31,8 @@ use secrecy::ExposeSecret;
 use super::DataConnectorFactory;
 use crate::{
     catalogconnector::iceberg::{
-        get_rest_catalog_config, map_param_name_to_iceberg_prop, parse_table_url,
-        verify_s3_endpoint,
+        get_rest_catalog_config, map_param_name_to_iceberg_prop, parse_hadoop_table_url,
+        parse_table_url, verify_s3_endpoint,
     },
     component::dataset::Dataset,
     dataconnector::{
@@ -107,6 +108,45 @@ impl DataConnector for IcebergDataConnector {
         dataset: &Dataset,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         let source = dataset.path();
+
+        if source.starts_with("file://") || source.starts_with("s3://") {
+            let (base_uri, namespace, table_name) = parse_hadoop_table_url(source, None).map_err(|e| {
+                Error::InvalidConfiguration {
+                    dataconnector: "iceberg".into(),
+                    message: format!(
+                        "A Dataset Path is required for Iceberg in the format of: file:///tmp/hadoop_warehouse/<namespace>/<table_name> or s3://<bucket>/<namespace>/<table_name>.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/iceberg#from\n{e}"
+                    ),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: Box::new(e),
+                }
+            })?;
+
+            // Load the specific table
+            let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
+
+            let catalog_client = HadoopCatalogBuilder::default()
+                .with_warehouse_root(base_uri)
+                .with_metadata_mode(MetadataMode::Infer)
+                .build()
+                .await
+                .map_err(|e| Error::UnableToGetReadProvider {
+                    dataconnector: "iceberg".into(),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: Box::new(e),
+                })?;
+
+            // Create a DataFusion TableProvider from the Iceberg table
+            let table_provider =
+                IcebergTableProvider::try_new(Arc::new(catalog_client), table_identifier)
+                    .await
+                    .map_err(|e| Error::UnableToGetReadProvider {
+                        dataconnector: "iceberg".into(),
+                        connector_component: ConnectorComponent::from(dataset),
+                        source: Box::new(e),
+                    })?;
+
+            return Ok(Arc::new(table_provider));
+        }
 
         let (base_uri, mut props, namespace, table_name) = match parse_table_url(source) {
             Ok(result) => result,

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -17,12 +17,12 @@ limitations under the License.
 //! The Iceberg Data Connector is a thin layer over the Iceberg Catalog Connector.
 //! It takes the same parameters as the Catalog Connector.
 
-use std::{any::Any, future::Future, pin::Pin, sync::Arc};
+use std::{any::Any, collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
 use data_components::iceberg::catalog::hadoop::{HadoopCatalogBuilder, MetadataMode};
 use datafusion::catalog::TableProvider;
-use iceberg::TableIdent;
+use iceberg::{TableIdent, io::CustomAwsCredentialLoader};
 use iceberg_aws_sdk::S3CredentialProvider;
 use iceberg_catalog_rest::RestCatalog;
 use iceberg_datafusion::IcebergTableProvider;
@@ -95,6 +95,58 @@ impl IcebergDataConnector {
             params: params.parameters,
         })
     }
+
+    async fn load_hadoop_catalog(
+        props: HashMap<String, String>,
+        custom_credential_loader: Option<CustomAwsCredentialLoader>,
+        dataset: &Dataset,
+        source: &str,
+    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
+        let (base_uri, namespace, table_name) = parse_hadoop_table_url(source, None).map_err(|e| {
+                Error::InvalidConfiguration {
+                    dataconnector: "iceberg".into(),
+                    message: format!(
+                        "A Dataset Path is required for Iceberg in the format of: file:///tmp/hadoop_warehouse/<namespace>/<table_name> or s3://<bucket>/<namespace>/<table_name>.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/iceberg#from\n{e}"
+                    ),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: Box::new(e),
+                }
+            })?;
+
+        // Load the specific table
+        let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
+
+        let mut catalog_builder = HadoopCatalogBuilder::default()
+            .with_warehouse_root(base_uri)
+            .with_metadata_mode(MetadataMode::Infer)
+            .with_properties(props);
+
+        if let Some(custom_loader) = custom_credential_loader {
+            catalog_builder = catalog_builder.with_file_io_extension(custom_loader);
+        }
+
+        let catalog_client =
+            catalog_builder
+                .build()
+                .await
+                .map_err(|e| Error::UnableToGetReadProvider {
+                    dataconnector: "iceberg".into(),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: Box::new(e),
+                })?;
+
+        // Create a DataFusion TableProvider from the Iceberg table
+        let table_provider =
+            IcebergTableProvider::try_new(Arc::new(catalog_client), table_identifier)
+                .await
+                .map_err(|e| Error::UnableToGetReadProvider {
+                    dataconnector: "iceberg".into(),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: Box::new(e),
+                })?;
+
+        Ok(Arc::new(table_provider))
+    }
 }
 
 #[async_trait]
@@ -109,46 +161,76 @@ impl DataConnector for IcebergDataConnector {
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         let source = dataset.path();
 
-        if source.starts_with("file://") || source.starts_with("s3://") {
-            let (base_uri, namespace, table_name) = parse_hadoop_table_url(source, None).map_err(|e| {
-                Error::InvalidConfiguration {
-                    dataconnector: "iceberg".into(),
-                    message: format!(
-                        "A Dataset Path is required for Iceberg in the format of: file:///tmp/hadoop_warehouse/<namespace>/<table_name> or s3://<bucket>/<namespace>/<table_name>.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/iceberg#from\n{e}"
-                    ),
-                    connector_component: ConnectorComponent::from(dataset),
-                    source: Box::new(e),
+        let mut props = HashMap::new();
+        for (key, value) in &self.params {
+            if let Some(prop_vec) = map_param_name_to_iceberg_prop(key.as_str()) {
+                for prop in prop_vec {
+                    props.insert(prop.clone(), value.expose_secret().to_string());
                 }
-            })?;
+            }
+        }
 
-            // Load the specific table
-            let table_identifier = TableIdent::new(namespace.name().clone(), table_name);
-
-            let catalog_client = HadoopCatalogBuilder::default()
-                .with_warehouse_root(base_uri)
-                .with_metadata_mode(MetadataMode::Infer)
-                .build()
+        let custom_credential_loader = if let Some(endpoint) = props.get("s3.endpoint") {
+            verify_s3_endpoint(endpoint)
                 .await
-                .map_err(|e| Error::UnableToGetReadProvider {
+                .map_err(|e| Error::InvalidConfiguration {
                     dataconnector: "iceberg".into(),
+                    message: e.to_string(),
                     connector_component: ConnectorComponent::from(dataset),
                     source: Box::new(e),
                 })?;
 
-            // Create a DataFusion TableProvider from the Iceberg table
-            let table_provider =
-                IcebergTableProvider::try_new(Arc::new(catalog_client), table_identifier)
-                    .await
-                    .map_err(|e| Error::UnableToGetReadProvider {
+            let aws_sdk_config = load_config(
+                "IcebergDataConnector",
+                "s3_region",
+                "s3_access_key_id",
+                "s3_secret_access_key",
+                "s3_session_token",
+                &self.params,
+            )
+            .await
+            .map_err(|e| Error::InvalidConfiguration {
+                dataconnector: "iceberg".into(),
+                message: e.to_string(),
+                connector_component: ConnectorComponent::from(dataset),
+                source: Box::new(e),
+            })?;
+
+            Some(
+                S3CredentialProvider::from_config(&aws_sdk_config)
+                    .map_err(|e| Error::InvalidConfiguration {
                         dataconnector: "iceberg".into(),
+                        message: e.to_string(),
                         connector_component: ConnectorComponent::from(dataset),
                         source: Box::new(e),
-                    })?;
+                    })?
+                    .into_custom_loader(),
+            )
+        } else {
+            None
+        };
 
-            return Ok(Arc::new(table_provider));
+        if source.starts_with("file://")
+            || source.starts_with("s3://")
+            || source.starts_with("s3a://")
+        {
+            let source = if source.starts_with("s3://") {
+                // s3 needs to be s3a for Hadoop Catalog: https://github.com/apache/iceberg-rust/issues/434
+                source.replace("s3://", "s3a://")
+            } else {
+                source.to_string()
+            };
+
+            return IcebergDataConnector::load_hadoop_catalog(
+                props,
+                custom_credential_loader,
+                dataset,
+                &source,
+            )
+            .await;
         }
 
-        let (base_uri, mut props, namespace, table_name) = match parse_table_url(source) {
+        let (base_uri, new_props, namespace, table_name) = match parse_table_url(source) {
             Ok(result) => result,
             Err(e) => {
                 return Err(Error::InvalidConfiguration {
@@ -162,54 +244,15 @@ impl DataConnector for IcebergDataConnector {
             }
         };
 
-        for (key, value) in &self.params {
-            if let Some(prop_vec) = map_param_name_to_iceberg_prop(key.as_str()) {
-                for prop in prop_vec {
-                    props.insert(prop.clone(), value.expose_secret().to_string());
-                }
-            }
-        }
-
-        if let Some(endpoint) = props.get("s3.endpoint") {
-            verify_s3_endpoint(endpoint)
-                .await
-                .map_err(|e| Error::InvalidConfiguration {
-                    dataconnector: "iceberg".into(),
-                    message: e.to_string(),
-                    connector_component: ConnectorComponent::from(dataset),
-                    source: Box::new(e),
-                })?;
-        }
-
-        let aws_sdk_config = load_config(
-            "IcebergDataConnector",
-            "s3_region",
-            "s3_access_key_id",
-            "s3_secret_access_key",
-            "s3_session_token",
-            &self.params,
-        )
-        .await
-        .map_err(|e| Error::InvalidConfiguration {
-            dataconnector: "iceberg".into(),
-            message: e.to_string(),
-            connector_component: ConnectorComponent::from(dataset),
-            source: Box::new(e),
-        })?;
-
-        let custom_credential_loader = S3CredentialProvider::from_config(&aws_sdk_config)
-            .map_err(|e| Error::InvalidConfiguration {
-                dataconnector: "iceberg".into(),
-                message: e.to_string(),
-                connector_component: ConnectorComponent::from(dataset),
-                source: Box::new(e),
-            })?
-            .into_custom_loader();
+        props.extend(new_props);
 
         let catalog_config = get_rest_catalog_config(base_uri, props);
 
-        let catalog_client =
-            RestCatalog::new(catalog_config).with_file_io_extension(custom_credential_loader);
+        let mut catalog_client = RestCatalog::new(catalog_config);
+        if let Some(custom_loader) = custom_credential_loader {
+            catalog_client = catalog_client.with_file_io_extension(custom_loader);
+        }
+
         let catalog_client = Arc::new(catalog_client);
 
         // Load the specific table


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds support for `file://`, `s3://` and `s3a://` Hadoop Catalog endpoints as both a Data Connector and Catalog Connector with Iceberg.

* Example spicepod:
```yaml
version: v1
kind: Spicepod
name: hadoop
catalogs:
  - from: iceberg:file:///tmp/hadoop_warehouse/
    name: local_hadoop
datasets:
  - from: iceberg:file:///tmp/hadoop_warehouse/test/my_table_1
    name: local_hadoop
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6647
