### PR TITLE
fix: Hadoop integration test

### DIFF
--- a/.github/workflows/integration_data_components.yaml
+++ b/.github/workflows/integration_data_components.yaml
@@ -42,8 +42,8 @@ env:
   CONTAINER_REGISTRY: spiceaitestimages.azurecr.io/
 
 jobs:
-  build:
-    name: Build Data Components Test Binary
+  test:
+    name: Test Data Components (Hadoop Catalog)
     runs-on: spiceai-dev-runners
     steps:
       - uses: actions/checkout@v4
@@ -60,77 +60,10 @@ jobs:
 
       - name: Set up cc
         uses: ./.github/actions/setup-cc
-      
-      - name: Check if sccache can be set up
-        run: |
-          if [ -z "${{ secrets.TEST_MINIO_ENDPOINT }}" ]; then
-            echo "SCCACHE_SETUP=false" >> $GITHUB_ENV
-            echo "RUSTC_WRAPPER=" >> $GITHUB_ENV
-          else
-            echo "SCCACHE_SETUP=true" >> $GITHUB_ENV
-            echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          fi
 
-      - name: Set up sccache
-        if: ${{ env.SCCACHE_SETUP == 'true' }}
-        uses: ./.github/actions/setup-sccache
-        with:
-          minio_endpoint: ${{ secrets.TEST_MINIO_ENDPOINT }}
-          os: 'linux'
-
-      - name: Install Nextest
-        run: |
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-
-      - name: Build test binary
+      - name: Run tests
         env:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           CARGO_INCREMENTAL: 0
         run: |
-          cargo nextest archive -p data_components --archive-file data_components_test.tar.zst
-
-      - name: Upload test archive
-        uses: actions/upload-artifact@v4
-        with:
-          name: data-components-test-archive
-          path: ./data_components_test.tar.zst
-          retention-days: 1
-
-  test:
-    name: Data Components Integration Tests
-    needs: build
-    permissions: read-all
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          os: 'linux'
-
-      - name: Download test archive
-        uses: actions/download-artifact@v4
-        with:
-          name: data-components-test-archive
-          path: ./data_components_test
-
-      - name: Install Nextest
-        run: |
-          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-
-      - name: Login to ACR
-        uses: docker/login-action@v3
-        if: github.repository == 'spiceai/spiceai'
-        with:
-          registry: spiceaitestimages.azurecr.io
-          username: spiceai-repo-pull
-          password: ${{ secrets.AZCR_PASSWORD }}
-
-      - name: Use public ECR for forks
-        if: github.repository != 'spiceai/spiceai'
-        run: echo "CONTAINER_REGISTRY=public.ecr.aws/docker/library/" >> $GITHUB_ENV
-
-      - name: Run integration test
-        run: |
-          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./data_components_test/data_components_test.tar.zst
+          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo test -p data_components --test hadoop_catalog_test

--- a/.github/workflows/integration_data_components.yaml
+++ b/.github/workflows/integration_data_components.yaml
@@ -61,9 +61,23 @@ jobs:
       - name: Set up cc
         uses: ./.github/actions/setup-cc
 
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
+      - name: Start compose
+        working-directory: ./crates/data_components/tests/hadoop_data
+        run: |
+          docker compose up -d --wait --remove-orphans
+
       - name: Run tests
         env:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           CARGO_INCREMENTAL: 0
         run: |
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo test -p data_components --test hadoop_catalog_test
+      
+      - name: Stop compose
+        if: always()
+        working-directory: ./crates/data_components/tests/hadoop_data
+        run: |
+          docker compose down --remove-orphans -v || true

--- a/.github/workflows/integration_data_components.yaml
+++ b/.github/workflows/integration_data_components.yaml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   test:
-    name: Test Data Components (Hadoop Catalog)
+    name: Test Data Components
     runs-on: spiceai-dev-runners
     steps:
       - uses: actions/checkout@v4
@@ -61,23 +61,12 @@ jobs:
       - name: Set up cc
         uses: ./.github/actions/setup-cc
 
-      - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
-
-      - name: Start compose
-        working-directory: ./crates/data_components/tests/hadoop_data
-        run: |
-          docker compose up -d --wait --remove-orphans
-
-      - name: Run tests
+      - name: Run tests (hadoop)
         env:
           RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}
           CARGO_INCREMENTAL: 0
+          MINIO_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          MINIO_ACCESS_KEY_ID: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          MINIO_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
         run: |
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo test -p data_components --test hadoop_catalog_test
-      
-      - name: Stop compose
-        if: always()
-        working-directory: ./crates/data_components/tests/hadoop_data
-        run: |
-          docker compose down --remove-orphans -v || true

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -120,6 +120,8 @@ sqlite = [
     "datafusion-table-providers/sqlite-federation",
 ]
 
+test_hadoop_catalog_docker = []
+
 [dev-dependencies]
 arrow = { workspace = true, features = ["prettyprint"] }
 arrow-array = { workspace = true }

--- a/crates/data_components/tests/hadoop_catalog_test.rs
+++ b/crates/data_components/tests/hadoop_catalog_test.rs
@@ -14,19 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(feature = "test_hadoop_catalog_docker")]
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 
 use arrow_array::RecordBatch;
+#[cfg(feature = "test_hadoop_catalog_docker")]
 use ctor::{ctor, dtor};
 use data_components::iceberg::catalog::hadoop::{HadoopCatalog, HadoopCatalogBuilder};
 use futures::TryStreamExt;
 use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_REGION, S3_SECRET_ACCESS_KEY};
 use iceberg::{Catalog, NamespaceIdent};
 use iceberg_test_utils::docker::DockerCompose;
+#[cfg(feature = "test_hadoop_catalog_docker")]
 use iceberg_test_utils::normalize_test_name;
 
+#[cfg(feature = "test_hadoop_catalog_docker")]
 const MINIO_PORT: u16 = 9000;
+
+#[cfg(feature = "test_hadoop_catalog_docker")]
 static DOCKER_COMPOSE_ENV: RwLock<Option<DockerCompose>> = RwLock::new(None);
 
 fn get_file_hadoop_catalog() -> HadoopCatalogBuilder {
@@ -35,19 +41,29 @@ fn get_file_hadoop_catalog() -> HadoopCatalogBuilder {
 
 #[allow(clippy::expect_used)]
 fn get_s3a_hadoop_catalog() -> HadoopCatalogBuilder {
-    let guard = DOCKER_COMPOSE_ENV
-        .read()
-        .expect("Should acquire read lock on DOCKER_COMPOSE_ENV");
-    let docker_compose = guard.as_ref().expect("Should have DockerCompose instance");
-    let minio_ip = docker_compose.get_container_ip("minio");
-    let minio_socket_addr = SocketAddr::new(minio_ip, MINIO_PORT);
+    let minio_endpoint = std::env::var("MINIO_ENDPOINT")
+        .expect("Should have MINIO_ENDPOINT environment variable set");
+
+    #[cfg(feature = "test_hadoop_catalog_docker")]
+    let minio_endpoint = {
+        let guard = DOCKER_COMPOSE_ENV
+            .read()
+            .expect("Should acquire read lock on DOCKER_COMPOSE_ENV");
+        let docker_compose = guard.as_ref().expect("Should have DockerCompose instance");
+        let minio_ip = docker_compose.get_container_ip("minio");
+        let minio_socket_addr = SocketAddr::new(minio_ip, MINIO_PORT);
+        format!("http://{minio_socket_addr}")
+    };
+
+    let access_key = std::env::var("MINIO_ACCESS_KEY_ID").unwrap_or("admin".to_string());
+    let secret_key = std::env::var("MINIO_SECRET_ACCESS_KEY").unwrap_or("password".to_string());
 
     HadoopCatalogBuilder::default()
         .with_warehouse_root("s3a://hadoop/")
         .set_property(S3_REGION, "us-east-1")
-        .set_property(S3_ENDPOINT, format!("http://{minio_socket_addr}"))
-        .set_property(S3_ACCESS_KEY_ID, "admin")
-        .set_property(S3_SECRET_ACCESS_KEY, "password")
+        .set_property(S3_ENDPOINT, minio_endpoint)
+        .set_property(S3_ACCESS_KEY_ID, access_key)
+        .set_property(S3_SECRET_ACCESS_KEY, secret_key)
 }
 
 #[cfg(feature = "test_hadoop_catalog_docker")]

--- a/crates/data_components/tests/hadoop_catalog_test.rs
+++ b/crates/data_components/tests/hadoop_catalog_test.rs
@@ -16,7 +16,9 @@ limitations under the License.
 
 #[cfg(feature = "test_hadoop_catalog_docker")]
 use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+#[cfg(feature = "test_hadoop_catalog_docker")]
+use std::sync::RwLock;
 
 use arrow_array::RecordBatch;
 #[cfg(feature = "test_hadoop_catalog_docker")]
@@ -25,6 +27,7 @@ use data_components::iceberg::catalog::hadoop::{HadoopCatalog, HadoopCatalogBuil
 use futures::TryStreamExt;
 use iceberg::io::{S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_REGION, S3_SECRET_ACCESS_KEY};
 use iceberg::{Catalog, NamespaceIdent};
+#[cfg(feature = "test_hadoop_catalog_docker")]
 use iceberg_test_utils::docker::DockerCompose;
 #[cfg(feature = "test_hadoop_catalog_docker")]
 use iceberg_test_utils::normalize_test_name;
@@ -35,6 +38,7 @@ const MINIO_PORT: u16 = 9000;
 #[cfg(feature = "test_hadoop_catalog_docker")]
 static DOCKER_COMPOSE_ENV: RwLock<Option<DockerCompose>> = RwLock::new(None);
 
+#[cfg(feature = "test_hadoop_catalog_docker")]
 fn get_file_hadoop_catalog() -> HadoopCatalogBuilder {
     HadoopCatalogBuilder::default().with_warehouse_root("file:///tmp/hadoop_warehouse")
 }
@@ -96,8 +100,9 @@ fn after_all() {
 }
 
 #[allow(clippy::expect_used)]
-async fn build_catalogs() -> [(&'static str, HadoopCatalog); 2] {
-    [
+async fn build_catalogs() -> Vec<(&'static str, HadoopCatalog)> {
+    vec![
+        #[cfg(feature = "test_hadoop_catalog_docker")]
         (
             "file",
             get_file_hadoop_catalog()

--- a/crates/data_components/tests/hadoop_catalog_test.rs
+++ b/crates/data_components/tests/hadoop_catalog_test.rs
@@ -50,6 +50,7 @@ fn get_s3a_hadoop_catalog() -> HadoopCatalogBuilder {
         .set_property(S3_SECRET_ACCESS_KEY, "password")
 }
 
+#[cfg(feature = "test_hadoop_catalog_docker")]
 #[ctor]
 #[allow(clippy::expect_used)]
 fn before_all() {
@@ -65,6 +66,7 @@ fn before_all() {
     guard.replace(docker_compose);
 }
 
+#[cfg(feature = "test_hadoop_catalog_docker")]
 #[dtor]
 #[allow(clippy::expect_used)]
 fn after_all() {


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates the Hadoop integration test to run using a pre-existing Hadoop Catalog in MinIO. The file-based catalog is disabled unless the `test_hadoop_catalog_docker` feature is enabled, which uses `docker compose` to create the catalog locally.

Successful run: https://github.com/spiceai/spiceai/actions/runs/16664711742