### PR TITLE
Redshift read support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=347a765a106c62cbdf2943da0f8b1f790e84492f#347a765a106c62cbdf2943da0f8b1f790e84492f"
+source = "git+https://github.com/datafusion-contrib/datafusion-table-providers.git?rev=2e0bdfd5e7809ae53106f3e63bbfbebbad4aff69#2e0bdfd5e7809ae53106f3e63bbfbebbad4aff69"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -4113,6 +4113,7 @@ dependencies = [
  "bb8 0.8.6",
  "bb8-postgres",
  "bigdecimal",
+ "bitflags 2.9.1",
  "byte-unit",
  "byteorder",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev 
 datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" }       # spiceai-47
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9db74a4b360df6be1bb554c59a474a2fd4bfb7e9" }                      # spiceai-47
-datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "347a765a106c62cbdf2943da0f8b1f790e84492f" } # spiceai
+datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "2e0bdfd5e7809ae53106f3e63bbfbebbad4aff69" } # spiceai
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a4b83432acfe1dfdd140e35d4603701ae76f6607" } # spiceai-1.3.2
 


### PR DESCRIPTION
## 📝 Summary

Updates `datafusion-table-providers` to the latest `spiceai` tag with fixed Redshift schema inference: 
https://github.com/datafusion-contrib/datafusion-table-providers/pull/409

Resolves #6517
