### PR TITLE
Limit Concurrent Requests for GitHub

### DIFF
--- a/crates/data_components/src/graphql/builder.rs
+++ b/crates/data_components/src/graphql/builder.rs
@@ -20,6 +20,7 @@ use super::{Result, client::GraphQLClient, client::UnnestBehavior};
 use arrow::datatypes::SchemaRef;
 use std::sync::Arc;
 use token_provider::TokenProvider;
+use tokio::sync::Semaphore;
 
 use url::Url;
 
@@ -32,6 +33,7 @@ pub struct GraphQLClientBuilder {
     pass: Option<String>,
     schema: Option<SchemaRef>,
     rate_limiter: Option<Arc<dyn RateLimiter>>,
+    semaphore: Option<Arc<Semaphore>>,
 }
 
 impl GraphQLClientBuilder {
@@ -46,6 +48,7 @@ impl GraphQLClientBuilder {
             pass: None,
             schema: None,
             rate_limiter: None,
+            semaphore: None,
         }
     }
 
@@ -85,6 +88,12 @@ impl GraphQLClientBuilder {
         self
     }
 
+    #[must_use]
+    pub fn with_semaphore(mut self, semaphore: Option<Arc<Semaphore>>) -> Self {
+        self.semaphore = semaphore;
+        self
+    }
+
     pub fn build(self, client: reqwest::Client) -> Result<GraphQLClient> {
         GraphQLClient::new(
             client,
@@ -96,6 +105,7 @@ impl GraphQLClientBuilder {
             self.unnest_behavior,
             self.schema,
             self.rate_limiter,
+            self.semaphore,
         )
     }
 }

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -803,8 +803,10 @@ impl GraphQLClient {
 
         let body = format!(r#"{{"query": {}}}"#, json!(query_string));
 
+        let mut request = self.client.post(self.endpoint.clone()).body(body);
+        request = request_with_auth(request, self.auth.as_ref());
+
         let permit = if let Some(semaphore) = &self.semaphore {
-            tracing::info!("Acquiring semaphore permit for GraphQL query execution");
             Some(
                 semaphore
                     .acquire()
@@ -817,20 +819,13 @@ impl GraphQLClient {
             None
         };
 
-        let mut request = self.client.post(self.endpoint.clone()).body(body);
-        request = request_with_auth(request, self.auth.as_ref());
-
         let response = request.send().await.context(ReqwestInternalSnafu)?;
 
-        if let Some(_) = permit {
-            tracing::info!("Releasing permit");
+        if let Some(permit) = permit {
+            drop(permit);
         }
 
-        permit.map(drop);
-
         let response_headers = response.headers().clone();
-
-        tracing::info!("{response_headers:?}");
 
         // Update rate limiter with response headers
         if let Some(rate_limiter) = &self.rate_limiter {

--- a/crates/data_components/src/graphql/client.rs
+++ b/crates/data_components/src/graphql/client.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use crate::rate_limit::RateLimiter;
 use token_provider::TokenProvider;
+use tokio::sync::Semaphore;
 
 use super::{ArrowInternalSnafu, Error, ErrorChecker, ReqwestInternalSnafu, Result};
 use arrow::{
@@ -647,6 +648,7 @@ pub struct GraphQLClient {
     auth: Option<Auth>,
     schema: Option<SchemaRef>,
     rate_limiter: Option<Arc<dyn RateLimiter>>,
+    semaphore: Option<Arc<Semaphore>>,
 }
 
 #[derive(Clone)]
@@ -752,6 +754,7 @@ impl GraphQLClient {
         unnest_behavior: UnnestBehavior,
         schema: Option<SchemaRef>,
         rate_limiter: Option<Arc<dyn RateLimiter>>,
+        semaphore: Option<Arc<Semaphore>>,
     ) -> Result<Self> {
         let auth = match (token, user, pass) {
             (None, Some(user), pass) => Some(Auth::Basic(user, pass)),
@@ -774,6 +777,7 @@ impl GraphQLClient {
             auth,
             schema,
             rate_limiter,
+            semaphore,
         })
     }
 
@@ -799,11 +803,34 @@ impl GraphQLClient {
 
         let body = format!(r#"{{"query": {}}}"#, json!(query_string));
 
+        let permit = if let Some(semaphore) = &self.semaphore {
+            tracing::info!("Acquiring semaphore permit for GraphQL query execution");
+            Some(
+                semaphore
+                    .acquire()
+                    .await
+                    .map_err(|e| Error::InternalError {
+                        message: e.to_string(),
+                    })?,
+            )
+        } else {
+            None
+        };
+
         let mut request = self.client.post(self.endpoint.clone()).body(body);
         request = request_with_auth(request, self.auth.as_ref());
 
         let response = request.send().await.context(ReqwestInternalSnafu)?;
+
+        if let Some(_) = permit {
+            tracing::info!("Releasing permit");
+        }
+
+        permit.map(drop);
+
         let response_headers = response.headers().clone();
+
+        tracing::info!("{response_headers:?}");
 
         // Update rate limiter with response headers
         if let Some(rate_limiter) = &self.rate_limiter {

--- a/crates/data_components/src/graphql/mod.rs
+++ b/crates/data_components/src/graphql/mod.rs
@@ -30,7 +30,7 @@ pub mod rate_limit;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Reqwest Internal: {source}"))]
+    #[snafu(display("{source}"))]
     ReqwestInternal { source: reqwest::Error },
 
     #[snafu(display("HTTP {status}: {message}"))]

--- a/crates/data_components/src/graphql/mod.rs
+++ b/crates/data_components/src/graphql/mod.rs
@@ -30,7 +30,7 @@ pub mod rate_limit;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("{source}"))]
+    #[snafu(display("Reqwest Internal: {source}"))]
     ReqwestInternal { source: reqwest::Error },
 
     #[snafu(display("HTTP {status}: {message}"))]
@@ -64,6 +64,10 @@ pub enum Error {
     ResultTransformError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+    #[snafu(display(
+        "Internal error: {message}. Report a bug at https://github.com/spiceai/spiceai/issues."
+    ))]
+    InternalError { message: String },
 
     #[snafu(display(
         "GraphQL Query Error:

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -73,6 +73,8 @@ mod stargazers;
 static GITHUB_CONCURRENCY_LIMITS: LazyLock<Mutex<HashMap<String, Arc<Semaphore>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+const GITHUB_DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 10;
+
 #[derive(Debug)]
 pub struct Github {
     params: Parameters,
@@ -410,7 +412,7 @@ impl DataConnectorFactory for GithubFactory {
                     .cloned()
             })
             .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(10);
+            .unwrap_or(GITHUB_DEFAULT_MAX_CONCURRENT_CONNECTIONS);
 
         Box::pin(async move {
             let (token_provider, semaphore_key): (Option<Arc<dyn TokenProvider>>, Option<String>) =

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -54,6 +54,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::{any::Any, future::Future, pin::Pin, str::FromStr, sync::Arc};
 use token_provider::{StaticTokenProvider, TokenProvider};
+use tokio::sync::Semaphore;
 use url::Url;
 
 use super::{
@@ -73,6 +74,7 @@ pub struct Github {
     params: Parameters,
     token: Option<Arc<dyn TokenProvider>>,
     rate_limiter: Arc<GitHubRateLimiter>,
+    semaphore: Arc<Semaphore>,
 }
 
 pub struct GitHubTableGraphQLParams {
@@ -135,6 +137,7 @@ impl Github {
         .with_json_pointer(gql_client_params.json_pointer)
         .with_schema(gql_client_params.schema)
         .with_rate_limiter(Some(Arc::clone(&self.rate_limiter) as Arc<dyn RateLimiter>))
+        .with_semaphore(Some(Arc::clone(&self.semaphore)))
         .build(client)
         .boxed()
     }
@@ -419,6 +422,7 @@ impl DataConnectorFactory for GithubFactory {
                 params: params.parameters,
                 token: token_provider,
                 rate_limiter: Arc::new(GitHubRateLimiter::new()),
+                semaphore: Arc::new(Semaphore::new(50)),
             }) as Arc<dyn DataConnector>)
         })
     }

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -48,13 +48,14 @@ use graphql_parser::query::{
 use issues::IssuesTableArgs;
 use pull_requests::PullRequestTableArgs;
 use rate_limit::GitHubRateLimiter;
+use secrecy::ExposeSecret;
 use snafu::ResultExt;
 use stargazers::StargazersTableArgs;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::{any::Any, future::Future, pin::Pin, str::FromStr, sync::Arc};
 use token_provider::{StaticTokenProvider, TokenProvider};
-use tokio::sync::Semaphore;
+use tokio::sync::{Mutex, Semaphore};
 use url::Url;
 
 use super::{
@@ -68,6 +69,9 @@ mod members;
 mod pull_requests;
 mod rate_limit;
 mod stargazers;
+
+static GITHUB_CONCURRENCY_LIMITS: LazyLock<Mutex<HashMap<String, Arc<Semaphore>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug)]
 pub struct Github {
@@ -397,32 +401,60 @@ impl DataConnectorFactory for GithubFactory {
             .ok()
             .map(ToString::to_string);
 
+        let max_concurrent_connections = params
+            .app
+            .and_then(|app| {
+                app.runtime
+                    .params
+                    .get("github_max_concurrent_connections")
+                    .cloned()
+            })
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(10);
+
         Box::pin(async move {
-            let token_provider: Option<Arc<dyn TokenProvider>> =
+            let (token_provider, semaphore_key): (Option<Arc<dyn TokenProvider>>, Option<String>) =
                 match (token, client_id, private_key, installation_id) {
                     (Some(token), _, _, _) => {
-                        Some(Arc::new(StaticTokenProvider::new(token.clone())))
+                        let key = token.clone().expose_secret().to_string();
+                        (
+                            Some(Arc::new(StaticTokenProvider::new(token.clone()))),
+                            Some(key),
+                        )
                     }
 
                     (None, Some(client_id), Some(private_key), Some(installation_id)) => {
-                        Some(Arc::new(
+                        let key = client_id.clone();
+                        let provider = Arc::new(
                             GitHubAppTokenProvider::try_new(
                                 client_id.into(),
                                 private_key.into(),
                                 installation_id.into(),
                             )
                             .await?,
-                        ))
+                        );
+                        (Some(provider), Some(key))
                     }
 
-                    _ => None,
+                    _ => (None, None),
                 };
+
+            let semaphore = if let Some(key) = semaphore_key {
+                let mut limits = GITHUB_CONCURRENCY_LIMITS.lock().await;
+                Arc::clone(
+                    limits
+                        .entry(key)
+                        .or_insert_with(|| Arc::new(Semaphore::new(max_concurrent_connections))),
+                )
+            } else {
+                Arc::new(Semaphore::new(max_concurrent_connections))
+            };
 
             Ok(Arc::new(Github {
                 params: params.parameters,
                 token: token_provider,
                 rate_limiter: Arc::new(GitHubRateLimiter::new()),
-                semaphore: Arc::new(Semaphore::new(50)),
+                semaphore,
             }) as Arc<dyn DataConnector>)
         })
     }

--- a/crates/runtime/src/dataconnector/graphql.rs
+++ b/crates/runtime/src/dataconnector/graphql.rs
@@ -170,6 +170,7 @@ impl GraphQL {
             graphql::client::UnnestBehavior::Depth(unnest_depth),
             None,
             None,
+            None,
         )
         .boxed()
         .context(super::InternalWithSourceSnafu {


### PR DESCRIPTION
## 📝 Summary
- See title
- Necessary as it helps prevent rate limiting in most situations
- Can configure via the following:
```yaml
runtime:
    params:
        github_max_concurrent_connections: 5 # Defaults to 10
```

## 🔗 Related
- Related to #6662 


## 📚 Docs
- Docs will need to be updated 

