### PR TITLE
Make `FullTextSearchExec` robust to RecordBatch column ordering.

### DIFF
--- a/crates/search/src/generation/text_search/exec.rs
+++ b/crates/search/src/generation/text_search/exec.rs
@@ -120,7 +120,7 @@ impl ExecutionPlan for FullTextSearchExec {
         let query = self.query.clone();
 
         let s = stream! {
-        // TODO: Support filters.
+          // TODO: Support filters.
             match idx
                 .search(query, &[], &[&Expr::Identifier(Ident::new(idx.field.clone()))], limit)
                 .await
@@ -130,14 +130,14 @@ impl ExecutionPlan for FullTextSearchExec {
                         match item {
                             Err(e) => yield Err(e),
                             Ok(rb) => {
-                                // Apply projection, as per `self.schema()`, to record batch from FTS.
-                                let proj = rb.schema().fields().iter().enumerate().filter_map(|(i, f)| {
-                                    if schema.column_with_name(f.name()).is_some() {
-                                        Some(i)
-                                    } else {
-                                        None
-                                    }
+                                let data_columns: Vec<_> = rb.schema().fields().iter().map(|f| f.name().clone()).collect();
+
+                                // Apply projection. Must return in the order it exists in
+                                // `self.schema()`, not in the record batch.
+                                let proj = schema.fields().iter().filter_map(|f| {
+                                    data_columns.iter().position(|data_col| data_col == f.name())
                                 }).collect::<Vec<_>>();
+
                                 yield rb.project(proj.as_slice()).map_err(DataFusionError::from)
                             }
                         }


### PR DESCRIPTION
## 📝 Summary
Issue with how `FullTextSearchExec` applies its projection from its source of data (i.e an `impl CandidateGeneration`) to the schema it returns in `ExecutionPlan::schema`, pertaining to out of order columns.

The fix is to create the projection array in the order of `ExecutionPlan::schema` columns. 

### Example
- Happy case:
  - Schema: `["i_item_sk", "i_item_desc", "score"]` (i.e. primary key, column, score).
  - Schema of data `["value", "i_item_sk", "i_item_desc", "score"]`

- Error case:
  - Schema: `["i_item_sk", "i_item_desc", "score"]` (i.e. primary key, column, score).
  - Schema of data `["i_item_desc", "value", "i_item_sk", "score"]`
  - Error: `column types must match schema types, expected Int32 but found LargeUtf8 at column index 0`
  - Current output schema `["i_item_desc", "i_item_sk", "score"] != ["i_item_sk", "i_item_desc", "score"]` 

