### PR TITLE
feat: Add Hadoop `metadata_path` parameter

### DIFF
--- a/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
+++ b/crates/data_components/src/iceberg/catalog/hadoop/catalog.rs
@@ -135,7 +135,7 @@ impl HadoopCatalogBuilder {
         Ok(HadoopCatalog {
             warehouse_root,
             file_io,
-            metadata_mode: MetadataMode::Infer,
+            metadata_mode: self.metadata_mode,
         })
     }
 }

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -143,7 +143,8 @@ impl IcebergCatalog {
     }
 }
 
-pub(crate) const PARAMETERS: &[ParameterSpec] = &[
+pub(crate) const ICEBERG_PARAM_LEN: usize = 16;
+pub(crate) const PARAMETERS: [ParameterSpec; ICEBERG_PARAM_LEN] = [
     ParameterSpec::component("token")
         .secret()
         .description("Bearer token value to use for Authorization header."),

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -138,7 +138,7 @@ pub async fn register_all() {
         CatalogConnectorFactory::new(
             iceberg::IcebergCatalog::new_connector,
             "iceberg",
-            iceberg::PARAMETERS,
+            &iceberg::PARAMETERS,
         ),
     );
 

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -31,14 +31,15 @@ use secrecy::ExposeSecret;
 use super::DataConnectorFactory;
 use crate::{
     catalogconnector::iceberg::{
-        get_rest_catalog_config, map_param_name_to_iceberg_prop, parse_hadoop_table_url,
-        parse_table_url, verify_s3_endpoint,
+        ICEBERG_PARAM_LEN, get_rest_catalog_config, map_param_name_to_iceberg_prop,
+        parse_hadoop_table_url, parse_table_url, verify_s3_endpoint,
     },
     component::dataset::Dataset,
     dataconnector::{
         ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError as Error,
         parameters::aws::load_config,
     },
+    model::params::concat_arrays,
     parameters::{ParameterSpec, Parameters},
 };
 
@@ -57,11 +58,22 @@ impl IcebergDataConnectorFactory {
     }
 }
 
-pub(crate) const PARAMETERS: &[ParameterSpec] = &[
+const HADOOP_PARAM_LEN: usize = 1;
+pub(crate) const HADOOP_PARAMETERS: [ParameterSpec; HADOOP_PARAM_LEN] = [
     // Hadoop options
     ParameterSpec::runtime("metadata_path")
         .description("The path including scheme to the metadata file for the Hadoop table. Must specify a path to a `.json` file. For example, `s3a://my-bucket/warehouse/namespace/table/metadata/v1.metadata.json`")
 ];
+
+pub(crate) const PARAMETERS: &[ParameterSpec] = &concat_arrays::<
+    ParameterSpec,
+    HADOOP_PARAM_LEN,
+    ICEBERG_PARAM_LEN,
+    { HADOOP_PARAM_LEN + ICEBERG_PARAM_LEN },
+>(
+    HADOOP_PARAMETERS,
+    crate::catalogconnector::iceberg::PARAMETERS,
+);
 
 impl DataConnectorFactory for IcebergDataConnectorFactory {
     fn as_any(&self) -> &dyn Any {

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -59,7 +59,7 @@ impl IcebergDataConnectorFactory {
 
 pub(crate) const PARAMETERS: &[ParameterSpec] = &[
     // Hadoop options
-    ParameterSpec::component("metadata_path")
+    ParameterSpec::runtime("metadata_path")
         .description("The path including scheme to the metadata file for the Hadoop table. Must specify a path to a `.json` file. For example, `s3a://my-bucket/warehouse/namespace/table/metadata/v1.metadata.json`")
 ];
 
@@ -167,6 +167,7 @@ impl DataConnector for IcebergDataConnector {
         self
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn read_provider(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -97,12 +97,7 @@ impl DataConnectorFactory for IcebergDataConnectorFactory {
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
-        // Concat the data connector specific parameters with the catalog parameters
-        let iceberg_params = PARAMETERS.to_vec();
-        let catalog_params = crate::catalogconnector::iceberg::PARAMETERS.to_vec();
-        let mut params = iceberg_params;
-        params.extend(catalog_params);
-        Box::leak(Box::new(params)) // Leak the memory to return a static slice
+        PARAMETERS
     }
 }
 

--- a/crates/runtime/src/dataconnector/iceberg.rs
+++ b/crates/runtime/src/dataconnector/iceberg.rs
@@ -57,6 +57,12 @@ impl IcebergDataConnectorFactory {
     }
 }
 
+pub(crate) const PARAMETERS: &[ParameterSpec] = &[
+    // Hadoop options
+    ParameterSpec::component("metadata_path")
+        .description("The path including scheme to the metadata file for the Hadoop table. Must specify a path to a `.json` file. For example, `s3a://my-bucket/warehouse/namespace/table/metadata/v1.metadata.json`")
+];
+
 impl DataConnectorFactory for IcebergDataConnectorFactory {
     fn as_any(&self) -> &dyn Any {
         self
@@ -79,7 +85,12 @@ impl DataConnectorFactory for IcebergDataConnectorFactory {
     }
 
     fn parameters(&self) -> &'static [ParameterSpec] {
-        crate::catalogconnector::iceberg::PARAMETERS
+        // Concat the data connector specific parameters with the catalog parameters
+        let iceberg_params = PARAMETERS.to_vec();
+        let catalog_params = crate::catalogconnector::iceberg::PARAMETERS.to_vec();
+        let mut params = iceberg_params;
+        params.extend(catalog_params);
+        Box::leak(Box::new(params)) // Leak the memory to return a static slice
     }
 }
 
@@ -101,6 +112,7 @@ impl IcebergDataConnector {
         custom_credential_loader: Option<CustomAwsCredentialLoader>,
         dataset: &Dataset,
         source: &str,
+        metadata_mode: MetadataMode,
     ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
         let (base_uri, namespace, table_name) = parse_hadoop_table_url(source, None).map_err(|e| {
                 Error::InvalidConfiguration {
@@ -118,7 +130,7 @@ impl IcebergDataConnector {
 
         let mut catalog_builder = HadoopCatalogBuilder::default()
             .with_warehouse_root(base_uri)
-            .with_metadata_mode(MetadataMode::Infer)
+            .with_metadata_mode(metadata_mode)
             .with_properties(props);
 
         if let Some(custom_loader) = custom_credential_loader {
@@ -221,13 +233,27 @@ impl DataConnector for IcebergDataConnector {
                 source.to_string()
             };
 
+            let metadata_mode = self
+                .params
+                .get("metadata_path")
+                .ok()
+                .map(|path| MetadataMode::Exact(path.expose_secret().to_string()))
+                .unwrap_or_default();
+
             return IcebergDataConnector::load_hadoop_catalog(
                 props,
                 custom_credential_loader,
                 dataset,
                 &source,
+                metadata_mode,
             )
             .await;
+        }
+
+        if self.params.get("metadata_path").ok().is_some() {
+            tracing::warn!(
+                "The `metadata_path` parameter is valid only for Hadoop Catalogs. The parameter will be ignored for REST Catalogs."
+            );
         }
 
         let (base_uri, new_props, namespace, table_name) = match parse_table_url(source) {

--- a/crates/runtime/src/model/mod.rs
+++ b/crates/runtime/src/model/mod.rs
@@ -25,7 +25,7 @@ mod embed;
 pub(crate) mod eval;
 mod metrics;
 mod model_context;
-mod params;
+pub(crate) mod params;
 mod tool_use;
 mod wrapper;
 

--- a/crates/runtime/src/model/params/mod.rs
+++ b/crates/runtime/src/model/params/mod.rs
@@ -44,7 +44,7 @@ pub(crate) fn get_params_spec(source: &ModelSource) -> Option<&'static [Paramete
 }
 
 // Use the const function to reduce the duplicated common model parameters definition in each model provider param spec.
-const fn concat_arrays<T: Copy, const N: usize, const M: usize, const S: usize>(
+pub(crate) const fn concat_arrays<T: Copy, const N: usize, const M: usize, const S: usize>(
     a: [T; N],
     b: [T; M],
 ) -> [T; S] {


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds the Hadoop `metadata_path` parameter for the Iceberg data connector.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6669
