### PR TITLE
Add Guardrails for AWS bedrock models

### DIFF
--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -36,7 +36,6 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 util = { path = "../util" }
-
 ## For Chunking
 text-splitter = { git = "https://github.com/spiceai/text-splitter.git", rev = "58f9c21006e01e5e968c5de80a0398b3f5ec439a", features = [
     "markdown",
@@ -69,13 +68,13 @@ token_provider = { path = "../token_provider" }
 
 [dev-dependencies]
 anyhow = "1.0.86"
+aws-credential-types.workspace = true
 dotenvy.workspace = true
 insta.workspace = true
 jsonpath-rust = "0.7.3"
 paste.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
-aws-credential-types.workspace = true
 
 [features]
 cuda = [

--- a/crates/llms/src/bedrock/chat/guardrail.rs
+++ b/crates/llms/src/bedrock/chat/guardrail.rs
@@ -1,0 +1,171 @@
+use aws_sdk_bedrockruntime::{
+    error::BuildError,
+    types::{
+        GuardrailConfiguration, GuardrailStreamConfiguration, GuardrailTrace,
+        builders::{GuardrailConfigurationBuilder, GuardrailStreamConfigurationBuilder},
+    },
+};
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use regex::Regex;
+use snafu::Snafu;
+use std::sync::LazyLock;
+
+pub struct GuardRail {
+    trace: GuardrailTrace,
+    id: GuardrailIdentifier,
+    version: GuardrailVersion,
+}
+
+impl GuardRail {
+    pub fn try_new(
+        id: &str,
+        version: &str,
+        trace: Option<&str>,
+    ) -> Result<GuardRail, GuardrailError> {
+        let trace = trace
+            .map(|t| {
+                GuardrailTrace::try_parse(t).map_err(|_| GuardrailError::UnknownTrace {
+                    variant: t.to_string(),
+                })
+            })
+            .transpose()?
+            .unwrap_or(GuardrailTrace::Disabled);
+
+        Ok(Self {
+            id: validate_guardrail_identifier(id)?,
+            trace,
+            version: validate_guardrail_version(version)?,
+        })
+    }
+}
+
+impl TryFrom<&GuardRail> for GuardrailStreamConfiguration {
+    type Error = BuildError;
+
+    fn try_from(value: &GuardRail) -> Result<Self, Self::Error> {
+        let GuardRail { trace, id, version } = value;
+        GuardrailStreamConfigurationBuilder::default()
+            .guardrail_identifier(id)
+            .trace(trace.clone())
+            .guardrail_version(version.to_string())
+            .build()
+    }
+}
+
+impl TryFrom<&GuardRail> for GuardrailConfiguration {
+    type Error = BuildError;
+
+    fn try_from(value: &GuardRail) -> Result<Self, Self::Error> {
+        let GuardRail { trace, id, version } = value;
+        GuardrailConfigurationBuilder::default()
+            .guardrail_identifier(id)
+            .trace(trace.clone())
+            .guardrail_version(version.to_string())
+            .build()
+    }
+}
+
+// Pattern: `(([a-z0-9]+) | (arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:guardrail/[a-z0-9]+))`. Length: 0-2048."
+pub type GuardrailIdentifier = String;
+static GUARDRAIL_ID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?x)                                   # allow whitespace and comments
+        ^                                         # beginning of string
+        (
+            [a-z0-9]+                             # simple id
+            |
+            arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:guardrail/[a-z0-9]+
+        )
+        $                                         # end of string
+        ",
+    )
+    .unwrap_or_else(|_| unreachable!("The regex is a valid regex, so it should compile"))
+});
+
+#[derive(Debug, Snafu)]
+pub enum GuardrailError {
+    #[snafu(display("Identifier does not match the required pattern. Got: {id}"))]
+    IdentifierPatternMismatch { id: String },
+    #[snafu(display("Identifier is not within length bounds (0-2048). Got: {len}"))]
+    IdentifierLengthError { len: usize },
+    #[snafu(display("Version does not match required pattern. Got: {version}"))]
+    VersionPatternMismatch { version: String },
+    #[snafu(display("Version number out of range (must fit in u32): {number}"))]
+    VersionOutOfRange { number: String },
+    #[snafu(display("Guardrail trace is not valid: {variant}"))]
+    UnknownTrace { variant: String },
+}
+
+pub fn validate_guardrail_identifier(
+    s: impl Into<String>,
+) -> Result<GuardrailIdentifier, GuardrailError> {
+    let value = s.into();
+    let len = value.len();
+    if len == 0 || len > 2048 {
+        return Err(GuardrailError::IdentifierLengthError { len });
+    }
+    if !GUARDRAIL_ID_RE.is_match(&value) {
+        return Err(GuardrailError::IdentifierPatternMismatch { id: value });
+    }
+    Ok(value)
+}
+
+static GUARDRAIL_VERSION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:([1-9][0-9]{0,7})|(DRAFT))$")
+        .unwrap_or_else(|_| unreachable!("The regex is a valid regex, so it should compile"))
+});
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardrailVersion {
+    Number(u32),
+    Draft,
+}
+
+impl std::fmt::Display for GuardrailVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GuardrailVersion::Number(n) => write!(f, "{n}"),
+            GuardrailVersion::Draft => write!(f, "DRAFT"),
+        }
+    }
+}
+
+pub fn validate_guardrail_version(
+    s: impl Into<String>,
+) -> Result<GuardrailVersion, GuardrailError> {
+    let value = s.into();
+    if let Some(caps) = GUARDRAIL_VERSION_RE.captures(&value) {
+        // Check if it matched a number
+        if let Some(number_str) = caps.get(1) {
+            // Parse to u32, but ensure within range
+            let number = number_str.as_str();
+            let num: u32 = number
+                .parse()
+                .map_err(|_| GuardrailError::VersionOutOfRange {
+                    number: number.to_string(),
+                })?;
+            return Ok(GuardrailVersion::Number(num));
+        }
+        // Check if it matched "DRAFT"
+        if let Some(draft) = caps.get(2) {
+            if draft.as_str() == "DRAFT" {
+                return Ok(GuardrailVersion::Draft);
+            }
+        }
+    }
+    Err(GuardrailError::VersionPatternMismatch { version: value })
+}

--- a/crates/llms/src/bedrock/chat/mod.rs
+++ b/crates/llms/src/bedrock/chat/mod.rs
@@ -85,7 +85,8 @@ impl BedrockConverse {
         }
     }
 
-    #[must_use] pub fn with_guardrail(mut self, g: GuardRail) -> Self {
+    #[must_use]
+    pub fn with_guardrail(mut self, g: GuardRail) -> Self {
         self.guardrail = Some(g);
         self
     }

--- a/crates/llms/src/bedrock/chat/mod.rs
+++ b/crates/llms/src/bedrock/chat/mod.rs
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
+pub mod guardrail;
 pub(super) mod util;
 
 use crate::bedrock::BedrockClient;
+use crate::bedrock::chat::guardrail::GuardRail;
 use crate::bedrock::chat::util::{
     chat_choice_stream, chat_completion_stream, convert_usage, extract_from_content_block,
     into_fallible_stream, to_api_error, tool_config, try_convert_finish_reason, try_convert_role,
@@ -53,8 +55,9 @@ use aws_sdk_bedrockruntime::types::{
     ContentBlock, ContentBlockDelta as ContentBlockDeltaType, ContentBlockDeltaEvent,
     ContentBlockStart as ContentBlockStartInner, ContentBlockStartEvent, ConversationRole,
     ConverseStreamMetadataEvent, ConverseStreamOutput as ConverseStreamOutputPacket,
-    InferenceConfiguration, Message, MessageStartEvent, MessageStopEvent, SystemContentBlock,
-    ToolResultContentBlock, ToolResultStatus, ToolUseBlockDelta, ToolUseBlockStart,
+    GuardrailConfiguration, GuardrailStreamConfiguration, InferenceConfiguration, Message,
+    MessageStartEvent, MessageStopEvent, SystemContentBlock, ToolResultContentBlock,
+    ToolResultStatus, ToolUseBlockDelta, ToolUseBlockStart,
 };
 use futures::stream::StreamExt;
 use itertools::Itertools;
@@ -69,12 +72,22 @@ use tracing::Span;
 pub struct BedrockConverse {
     client: Arc<BedrockClient>,
     model_id: String,
+    guardrail: Option<GuardRail>,
 }
 
 impl BedrockConverse {
     #[must_use]
     pub fn new(client: Arc<BedrockClient>, model_id: String) -> Self {
-        Self { client, model_id }
+        Self {
+            client,
+            model_id,
+            guardrail: None,
+        }
+    }
+
+    #[must_use] pub fn with_guardrail(mut self, g: GuardRail) -> Self {
+        self.guardrail = Some(g);
+        self
     }
 
     /// Alter the  [`CreateChatCompletionRequest`] in a way that Bedrock understands.
@@ -324,6 +337,13 @@ impl BedrockConverse {
         let messages =
             Self::convert_non_system_messages(messages).map_err(|e| to_api_error(e.to_string()))?;
 
+        let guardrails: Option<GuardrailStreamConfiguration> = self
+            .guardrail
+            .as_ref()
+            .map(std::convert::TryInto::try_into)
+            .transpose()
+            .map_err(|e: BuildError| to_api_error(e.to_string()))?;
+
         let mut bldr = client
             .client
             .converse_stream()
@@ -331,6 +351,7 @@ impl BedrockConverse {
             .set_messages(Some(messages))
             .inference_config(inf_cfg)
             .set_system(Some(system))
+            .set_guardrail_config(guardrails)
             .set_tool_config(tool_config(tools, tool_choice));
 
         if let Some(Value::Object(m)) = metadata {
@@ -373,6 +394,13 @@ impl BedrockConverse {
         let messages =
             Self::convert_non_system_messages(messages).map_err(|e| to_api_error(e.to_string()))?;
 
+        let guardrails: Option<GuardrailConfiguration> = self
+            .guardrail
+            .as_ref()
+            .map(std::convert::TryInto::try_into)
+            .transpose()
+            .map_err(|e: BuildError| to_api_error(e.to_string()))?;
+
         let mut bldr = client
             .client
             .converse()
@@ -380,6 +408,7 @@ impl BedrockConverse {
             .set_messages(Some(messages))
             .inference_config(inf_cfg)
             .set_system(Some(system))
+            .set_guardrail_config(guardrails)
             .set_tool_config(tool_config(tools, tool_choice));
 
         if let Some(Value::Object(m)) = metadata {

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -169,6 +169,8 @@ pub async fn construct_model(
 
 #[cfg(feature = "bedrock")]
 async fn bedrock(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>, LlmError> {
+    use llms::bedrock::chat::guardrail::GuardRail;
+
     let Some(model_id) = model_id else {
         return Err(LlmError::ModelNotProvided {
             model_source: "bedrock".to_string(),
@@ -179,7 +181,19 @@ async fn bedrock(model_id: Option<String>, params: &Parameters) -> Result<Arc<dy
         .await
         .map_err(|e| LlmError::FailedToLoadModel { source: e })?;
 
-    Ok(Arc::new(BedrockConverse::new(client.into(), model_id)) as Arc<dyn Chat>)
+    let id = params.get("guardrail_identifier").expose().ok();
+    let version = params.get("guardrail_version").expose().ok();
+    let trace = params.get("trace").expose().ok();
+    let mut converse = BedrockConverse::new(client.into(), model_id);
+
+    if let (Some(id), Some(version)) = (id, version) {
+        let g = GuardRail::try_new(id, version, trace)
+            .boxed()
+            .map_err(|e| LlmError::FailedToLoadModel { source: e })?;
+        converse = converse.with_guardrail(g);
+    }
+
+    Ok(Arc::new(converse) as Arc<dyn Chat>)
 }
 
 fn xai(model_id: Option<&str>, params: &Parameters) -> Result<Arc<dyn Chat>, LlmError> {

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use llms::{
     HealthCheck,
     anthropic::Anthropic,
-    bedrock::chat::BedrockConverse,
+    bedrock::chat::{BedrockConverse, guardrail::GuardRail},
     chat::{Chat, Error as LlmError},
     perplexity::PerplexitySonar,
     xai::Xai,
@@ -169,8 +169,6 @@ pub async fn construct_model(
 
 #[cfg(feature = "bedrock")]
 async fn bedrock(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>, LlmError> {
-    use llms::bedrock::chat::guardrail::GuardRail;
-
     let Some(model_id) = model_id else {
         return Err(LlmError::ModelNotProvided {
             model_source: "bedrock".to_string(),
@@ -186,6 +184,7 @@ async fn bedrock(model_id: Option<String>, params: &Parameters) -> Result<Arc<dy
     let trace = params.get("trace").expose().ok();
     let mut converse = BedrockConverse::new(client.into(), model_id);
 
+    // Add Guardrail if added by user.
     if let (Some(id), Some(version)) = (id, version) {
         let g = GuardRail::try_new(id, version, trace)
             .boxed()

--- a/crates/runtime/src/model/params/bedrock.rs
+++ b/crates/runtime/src/model/params/bedrock.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use super::{COMMON_MODEL_PARAMETERS_WITH_DEPRECATED, PARAM_WITH_DEPRE_LEN, concat_arrays};
 use crate::parameters::ParameterSpec;
 
-pub(crate) const BEDROCK_PARAMETERS: [ParameterSpec; 4] = [
+pub(crate) const BEDROCK_PARAMETERS: [ParameterSpec; 7] = [
     ParameterSpec::runtime("aws_access_key_id")
         .description("The AWS access key ID to use for Bedrock models")
         .secret(),
@@ -28,9 +28,12 @@ pub(crate) const BEDROCK_PARAMETERS: [ParameterSpec; 4] = [
         .description("The AWS session token to use for Bedrock models.")
         .secret(),
     ParameterSpec::runtime("aws_region").description("The AWS region to use for Bedrock models."),
+    ParameterSpec::component("guardrail_identifier").description("Identifier for the guardrail. Pattern: `(([a-z0-9]+) | (arn:aws(-[^:]+)?:bedrock:[a-z0-9-]{1,20}:[0-9]{12}:guardrail/[a-z0-9]+))`. Length: 0-2048."),
+    ParameterSpec::component("guardrail_version").description("Guardrail version. Pattern: `(([1-9][0-9]{0,7})|(DRAFT))`"),
+    ParameterSpec::component("trace").description("Trace behavior for the guardrail. Valid values: `enabled`, `disabled`, `enabled_full`"),
 ];
 pub(crate) const PARAMETERS: &[ParameterSpec] =
-    &concat_arrays::<ParameterSpec, 4, PARAM_WITH_DEPRE_LEN, { 4 + PARAM_WITH_DEPRE_LEN }>(
+    &concat_arrays::<ParameterSpec, 7, PARAM_WITH_DEPRE_LEN, { 7 + PARAM_WITH_DEPRE_LEN }>(
         BEDROCK_PARAMETERS,
         COMMON_MODEL_PARAMETERS_WITH_DEPRECATED,
     );


### PR DESCRIPTION
## 📝 Summary
- Adds support for AWS Bedrock [guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html). 

## 🔗 Related
#6340 
