### PR TITLE
Use installation id to group connections

### DIFF
--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -426,7 +426,8 @@ impl DataConnectorFactory for GithubFactory {
                     }
 
                     (None, Some(client_id), Some(private_key), Some(installation_id)) => {
-                        let key = client_id.clone();
+                        // GitHub rate limits are per installation, so use the installation ID as the key
+                        let key = installation_id.clone();
                         let provider = Arc::new(
                             GitHubAppTokenProvider::try_new(
                                 client_id.into(),


### PR DESCRIPTION
## 📝 Summary
- GitHub rate limits for GitHub apps are enforced by installation, not client ID. This PR adjusts the grouping of concurrent connections to be by installation ID instead of client ID.
- This change is necessary as it allows more GitHub requests to go through while still adhering to GitHub's concurrency limits
