### PR TITLE
fix: Set S3 vectors default limit to 30, add more tracing

### DIFF
--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -286,8 +286,6 @@ async fn query_vector_stream(
 ) -> DataFusionResult<()> {
     let start = std::time::Instant::now();
 
-    tracing::debug!("QueryVector expected schema: {schema:?}");
-
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
     let mut decoder = ReaderBuilder::new(Arc::clone(&schema)).build_decoder()?;
 
@@ -342,10 +340,7 @@ async fn query_vector_stream(
 
     let num_vectors = vectors.len();
 
-    tracing::debug!("OutputVectors from S3Vectors: {vectors:?}");
-
     let rows: Vec<_> = vectors.into_iter().map(to_flat_value).collect();
-    tracing::debug!("S3VectorsQueryTable: prepared rows: {rows:?}");
     decoder.serialize(rows.as_slice()).map_err(|e| {
         DataFusionError::ArrowError(
             e,
@@ -409,10 +404,6 @@ fn to_flat_value(output: QueryOutputVector) -> serde_json::Value {
             );
         }
     }
-
-    tracing::debug!(
-        "S3VectorsQueryTable: converted QueryOutputVector to flat JSON value: {result:?}"
-    );
 
     serde_json::Value::Object(result)
 }

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -250,7 +250,7 @@ impl ExecutionPlan for S3VectorsQueryExec {
 
         let client = Arc::clone(&self.client);
         let idx = self.idx.clone();
-        let limit: i32 = self.limit.try_into().unwrap_or(i32::MAX);
+        let limit: i32 = self.limit.try_into().unwrap_or(30); // https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-limitations.html
         let q = self.query.clone();
         let filters = self.filters.clone();
 
@@ -285,6 +285,8 @@ async fn query_vector_stream(
     tx: Sender<DataFusionResult<RecordBatch, DataFusionError>>,
 ) -> DataFusionResult<()> {
     let start = std::time::Instant::now();
+
+    tracing::debug!("QueryVector expected schema: {schema:?}");
 
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
     let mut decoder = ReaderBuilder::new(Arc::clone(&schema)).build_decoder()?;
@@ -340,7 +342,10 @@ async fn query_vector_stream(
 
     let num_vectors = vectors.len();
 
+    tracing::debug!("OutputVectors from S3Vectors: {vectors:?}");
+
     let rows: Vec<_> = vectors.into_iter().map(to_flat_value).collect();
+    tracing::debug!("S3VectorsQueryTable: prepared rows: {rows:?}");
     decoder.serialize(rows.as_slice()).map_err(|e| {
         DataFusionError::ArrowError(
             e,
@@ -404,6 +409,10 @@ fn to_flat_value(output: QueryOutputVector) -> serde_json::Value {
             );
         }
     }
+
+    tracing::debug!(
+        "S3VectorsQueryTable: converted QueryOutputVector to flat JSON value: {result:?}"
+    );
 
     serde_json::Value::Object(result)
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* The `topK` limit in the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-limitations.html) is 30. When no `LIMIT` is defined, we supply `i32::MAX`. Updates to instead supply a default of `30`.
* Adds some additional debug tracing for Runtime debugging.

