### PR TITLE
Add runtime parameter to enable more permissive parquet reading when page indexes are missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3652,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3753,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "futures",
  "log",
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3821,7 +3821,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3899,12 +3899,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 
 [[package]]
 name = "datafusion-execution"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "dashmap",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "chrono",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3966,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4058,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "chrono",
@@ -4126,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4147,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4178,7 +4178,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4207,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
+source = "git+https://github.com/spiceai/datafusion.git?rev=e568d4b3fec0b5c80d427a426107a5f171f9cde5#e568d4b3fec0b5c80d427a426107a5f171f9cde5"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,8 +331,8 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -351,8 +351,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -364,8 +364,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -380,8 +380,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "bytes",
  "half",
@@ -390,8 +390,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -410,8 +410,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -419,14 +419,13 @@ dependencies = [
  "chrono",
  "csv",
  "csv-core",
- "lazy_static",
  "regex",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -436,8 +435,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -462,8 +461,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -475,8 +474,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -509,8 +508,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -521,8 +520,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -533,8 +532,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "bitflags 2.9.1",
  "serde",
@@ -542,8 +541,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -555,8 +554,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "55.1.0"
-source = "git+https://github.com/spiceai/arrow-rs.git?rev=aecc3402c5b1120200c8ce1b6d62c7ef700a698f#aecc3402c5b1120200c8ce1b6d62c7ef700a698f"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3653,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3707,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3732,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3754,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3777,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "futures",
  "log",
@@ -3787,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3822,7 +3821,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3846,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3870,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3900,12 +3899,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 
 [[package]]
 name = "datafusion-execution"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "dashmap",
@@ -3923,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "chrono",
@@ -3943,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3967,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3995,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4015,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4039,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4059,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4074,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -4090,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4099,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -4109,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "chrono",
@@ -4127,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4148,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4161,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4179,7 +4178,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4208,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4231,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "47.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=4e258ff048c7558e08e2eab9af2665dfbfb8f8b3#4e258ff048c7558e08e2eab9af2665dfbfb8f8b3"
+source = "git+https://github.com/spiceai/datafusion.git?rev=821f8a7565956e2e66fdfef49f53b45d9f223df5#821f8a7565956e2e66fdfef49f53b45d9f223df5"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -9811,9 +9810,8 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "55.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7b2d778f6b841d37083ebdf32e33a524acde1266b5884a8ca29bf00dfa1231"
+version = "55.2.0"
+source = "git+https://github.com/spiceai/arrow-rs.git?rev=53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2#53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,11 +210,11 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" }            # kczimm/spiceai-47-parquet-offset-patch
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" }     # kczimm/spiceai-47-parquet-offset-patch
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" } # kczimm/spiceai-47-parquet-offset-patch
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" }  # kczimm/spiceai-47-parquet-offset-patch
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" }       # kczimm/spiceai-47-parquet-offset-patch
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "e568d4b3fec0b5c80d427a426107a5f171f9cde5" }            # spiceai-47
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "e568d4b3fec0b5c80d427a426107a5f171f9cde5" }     # spiceai-47
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "e568d4b3fec0b5c80d427a426107a5f171f9cde5" } # spiceai-47
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "e568d4b3fec0b5c80d427a426107a5f171f9cde5" }  # spiceai-47
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "e568d4b3fec0b5c80d427a426107a5f171f9cde5" }       # spiceai-47
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9db74a4b360df6be1bb554c59a474a2fd4bfb7e9" }                      # spiceai-47
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "2e0bdfd5e7809ae53106f3e63bbfbebbad4aff69" } # spiceai
@@ -240,7 +240,6 @@ candle-core = { git = "https://github.com/spiceai/candle.git", rev = "afd4f32312
 candle-metal-kernels = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d63f86cf819ad3dffe0fa796155a0" } # spiceai-0.8.4-cudarc-0.12
 
 # Use patched arrow-rs 55.2 until next release
-parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }      # spiceai-55.2
 arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }        # spiceai-55.2
 arrow-arith = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }  # spiceai-55.2
 arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }  # spiceai-55.2
@@ -256,3 +255,4 @@ arrow-row = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30f
 arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" } # spiceai-55.2
 arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" } # spiceai-55.2
 arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" } # spiceai-55.2
+parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }      # spiceai-55.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ opentelemetry_sdk = { version = "0.27", default-features = false, features = [
     "rt-tokio",
     "trace",
 ] }
-parquet = "55"
+parquet = "55.2"
 paste = "1.0.15"
 pem = "3.0.4"
 percent-encoding = "2.3.1"
@@ -210,12 +210,11 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" }            # spiceai-47
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" }     # spiceai-47
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" } # spiceai-47
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" }  # spiceai-47
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "4e258ff048c7558e08e2eab9af2665dfbfb8f8b3" }       # spiceai-47
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" }            # kczimm/spiceai-47-parquet-offset-patch
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" }     # kczimm/spiceai-47-parquet-offset-patch
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" } # kczimm/spiceai-47-parquet-offset-patch
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" }  # kczimm/spiceai-47-parquet-offset-patch
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "821f8a7565956e2e66fdfef49f53b45d9f223df5" }       # kczimm/spiceai-47-parquet-offset-patch
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "9db74a4b360df6be1bb554c59a474a2fd4bfb7e9" }                      # spiceai-47
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "2e0bdfd5e7809ae53106f3e63bbfbebbad4aff69" } # spiceai
@@ -240,19 +239,20 @@ cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40
 candle-core = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d63f86cf819ad3dffe0fa796155a0" }          # spiceai-0.8.4-cudarc-0.12
 candle-metal-kernels = { git = "https://github.com/spiceai/candle.git", rev = "afd4f323122d63f86cf819ad3dffe0fa796155a0" } # spiceai-0.8.4-cudarc-0.12
 
-# Use patched arrow-rs 55.1 untill next release
-arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }        # spiceai-55.1
-arrow-arith = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }  # spiceai-55.1
-arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }  # spiceai-55.1
-arrow-buffer = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
-arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }   # spiceai-55.1
-arrow-csv = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }    # spiceai-55.1
-arrow-data = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }   # spiceai-55.1
-arrow-flight = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
-arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }    # spiceai-55.1
-arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }   # spiceai-55.1
-arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }    # spiceai-55.1
-arrow-row = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" }    # spiceai-55.1
-arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
-arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
-arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "aecc3402c5b1120200c8ce1b6d62c7ef700a698f" } # spiceai-55.1
+# Use patched arrow-rs 55.2 until next release
+parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }      # spiceai-55.2
+arrow = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }        # spiceai-55.2
+arrow-arith = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }  # spiceai-55.2
+arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }  # spiceai-55.2
+arrow-buffer = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" } # spiceai-55.2
+arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }   # spiceai-55.2
+arrow-csv = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }    # spiceai-55.2
+arrow-data = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }   # spiceai-55.2
+arrow-flight = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" } # spiceai-55.2
+arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }    # spiceai-55.2
+arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }   # spiceai-55.2
+arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }    # spiceai-55.2
+arrow-row = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" }    # spiceai-55.2
+arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" } # spiceai-55.2
+arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" } # spiceai-55.2
+arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "53162ed30fe6a2ed219b0af4dbbcd5d14745d7c2" } # spiceai-55.2

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -478,7 +478,10 @@ async fn create_s3_provider(
 
     // Add required file_format parameter for S3
     params.insert("file_format".into(), input_format.file_format().into());
-    let s3 = S3 { params };
+    let s3 = S3 {
+        params,
+        runtime: Some(Arc::unwrap_or_clone(dataset.runtime())),
+    };
 
     dataset.from = from;
 

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -40,6 +40,7 @@ use object_store::{ObjectMeta, ObjectStore, path::Path};
 use snafu::prelude::*;
 use url::Url;
 
+use crate::Runtime;
 use crate::accelerated_table::AcceleratedTable;
 use crate::component::dataset::Dataset;
 use crate::dataconnector::{
@@ -114,7 +115,11 @@ pub trait ListingTableConnector: DataConnector {
             })
     }
 
-    fn construct_metadata_provider(
+    fn get_runtime(&self) -> Option<Runtime> {
+        None
+    }
+
+    async fn construct_metadata_provider(
         &self,
         dataset: &Dataset,
     ) -> DataConnectorResult<Arc<dyn TableProvider>>
@@ -123,7 +128,7 @@ pub trait ListingTableConnector: DataConnector {
     {
         let store_url: Url = self.get_object_store_url(dataset, None)?;
         let store = self.get_object_store(dataset)?;
-        let (_, extension) = self.get_file_format_and_extension(dataset)?;
+        let (_, extension) = self.get_file_format_and_extension(dataset).await?;
 
         let table = ObjectStoreMetadataTable::try_new(store, &store_url, Some(extension.clone()))
             .context(crate::dataconnector::InvalidConfigurationSnafu {
@@ -149,7 +154,7 @@ pub trait ListingTableConnector: DataConnector {
     ///
     /// For unstructured text formats, the [`Dataset`]'s `file_format` param key must be set. `Ok`
     /// responses, are always of the format `Ok((None, String))`. The data must be UTF8 compatible.
-    fn get_file_format_and_extension(
+    async fn get_file_format_and_extension(
         &self,
         dataset: &Dataset,
     ) -> DataConnectorResult<(Option<Arc<dyn FileFormat>>, String)>
@@ -186,7 +191,7 @@ pub trait ListingTableConnector: DataConnector {
             )),
             (Some("parquet"), _) | (None, Some("parquet"))=> Ok((
                 Some(Arc::new(
-                    ParquetFormat::default().with_options(self.get_table_parquet_options(dataset)?),
+                    ParquetFormat::default().with_options(self.get_table_parquet_options(dataset).await?),
                 )),
                 extension.unwrap_or(".parquet".to_string()),
             )),
@@ -371,7 +376,7 @@ pub trait ListingTableConnector: DataConnector {
         ))
     }
 
-    fn get_table_parquet_options(
+    async fn get_table_parquet_options(
         &self,
         dataset: &Dataset,
     ) -> DataConnectorResult<TableParquetOptions>
@@ -388,6 +393,37 @@ pub trait ListingTableConnector: DataConnector {
                     source: Box::new(e),
                 },
             )?;
+
+        if let Some(runtime) = self.get_runtime() {
+            let page_index_options = parquet_page_index_options(&runtime).await;
+
+            table_parquet_options
+                .set(
+                    "enable_page_index",
+                    &page_index_options.enable_page_index.to_string(),
+                )
+                .map_err(
+                    |e| crate::dataconnector::DataConnectorError::UnableToConnectInternal {
+                        dataconnector: format!("{self}"),
+                        connector_component: ConnectorComponent::from(dataset),
+                        source: Box::new(e),
+                    },
+                )?;
+
+            table_parquet_options
+                .set(
+                    "tolerate_missing_page_index",
+                    &page_index_options.tolerate_missing_page_index.to_string(),
+                )
+                .map_err(
+                    |e| crate::dataconnector::DataConnectorError::UnableToConnectInternal {
+                        dataconnector: format!("{self}"),
+                        connector_component: ConnectorComponent::from(dataset),
+                        source: Box::new(e),
+                    },
+                )?;
+        }
+
         Ok(table_parquet_options)
     }
 
@@ -608,7 +644,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
             return None;
         }
 
-        Some(self.construct_metadata_provider(dataset))
+        Some(self.construct_metadata_provider(dataset).await)
     }
 
     async fn read_provider(
@@ -617,7 +653,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
     ) -> DataConnectorResult<Arc<dyn TableProvider>> {
         let url = self.get_object_store_url(dataset, None)?;
 
-        let (file_format_opt, extension) = self.get_file_format_and_extension(dataset)?;
+        let (file_format_opt, extension) = self.get_file_format_and_extension(dataset).await?;
         match file_format_opt {
             None => {
                 // Assume its unstructured text data. Use a [`ObjectStoreTextTable`].
@@ -883,6 +919,55 @@ impl SensitiveListingTableUrl {
     }
 }
 
+struct ParquetPageIndexOptions {
+    enable_page_index: bool,
+    tolerate_missing_page_index: bool,
+}
+
+impl Default for ParquetPageIndexOptions {
+    fn default() -> Self {
+        Self {
+            enable_page_index: true,
+            tolerate_missing_page_index: false,
+        }
+    }
+}
+
+/// Returns the parquet page index options to use when reading Parquet files
+///
+/// Expects the user to configure the spicepod runtime params:
+///
+/// ```yaml
+/// runtime:
+///   params:
+///     parquet_page_index: required # skip, auto
+/// ```
+async fn parquet_page_index_options(runtime: &Runtime) -> ParquetPageIndexOptions {
+    let runtime_app = runtime.app();
+    let app = runtime_app.read().await;
+    let parquet_page_index_param =
+        app::App::get_runtime_param(&*app, "parquet_page_index", "required".to_string());
+
+    match parquet_page_index_param.as_str() {
+        "auto" => ParquetPageIndexOptions {
+            enable_page_index: true,
+            tolerate_missing_page_index: true,
+        },
+        "skip" => ParquetPageIndexOptions {
+            enable_page_index: false,
+            tolerate_missing_page_index: false,
+        },
+        "required" => ParquetPageIndexOptions::default(),
+        _ => {
+            tracing::warn!(
+                "Invalid value '{}' for runtime.params.parquet_page_index, valid options are: 'auto', 'skip', 'required'. Using 'required'.",
+                parquet_page_index_param
+            );
+            ParquetPageIndexOptions::default()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::{TimeZone, Utc};
@@ -993,7 +1078,7 @@ mod tests {
     async fn test_get_file_format_and_extension_require_file_format() {
         let (connector, dataset) = setup_connector("test:test/".to_string(), HashMap::new()).await;
 
-        match connector.get_file_format_and_extension(&dataset) {
+        match connector.get_file_format_and_extension(&dataset).await {
             Ok(_) => panic!("Unexpected success"),
             Err(e) => assert_eq!(
                 e.to_string(),
@@ -1008,7 +1093,7 @@ mod tests {
             setup_connector("test:test.csv".to_string(), HashMap::new()).await;
 
         if let Ok((Some(_file_format), extension)) =
-            connector.get_file_format_and_extension(&dataset)
+            connector.get_file_format_and_extension(&dataset).await
         {
             assert_eq!(extension, ".csv");
         } else {
@@ -1022,7 +1107,7 @@ mod tests {
             setup_connector("test:test.parquet".to_string(), HashMap::new()).await;
 
         if let Ok((Some(_file_format), extension)) =
-            connector.get_file_format_and_extension(&dataset)
+            connector.get_file_format_and_extension(&dataset).await
         {
             assert_eq!(extension, ".parquet");
         } else {
@@ -1037,7 +1122,7 @@ mod tests {
         let (connector, dataset) = setup_connector("test:test.parquet".to_string(), params).await;
 
         if let Ok((Some(_file_format), extension)) =
-            connector.get_file_format_and_extension(&dataset)
+            connector.get_file_format_and_extension(&dataset).await
         {
             assert_eq!(extension, ".csv");
         } else {
@@ -1052,7 +1137,7 @@ mod tests {
         let (connector, dataset) = setup_connector("test:test.parquet".to_string(), params).await;
 
         if let Ok((Some(_file_format), extension)) =
-            connector.get_file_format_and_extension(&dataset)
+            connector.get_file_format_and_extension(&dataset).await
         {
             assert_eq!(extension, ".tsv");
         } else {
@@ -1067,7 +1152,7 @@ mod tests {
         let (connector, dataset) = setup_connector("test:test.csv".to_string(), params).await;
 
         if let Ok((Some(_file_format), extension)) =
-            connector.get_file_format_and_extension(&dataset)
+            connector.get_file_format_and_extension(&dataset).await
         {
             assert_eq!(extension, ".parquet");
         } else {
@@ -1394,5 +1479,87 @@ mod tests {
     fn test_get_url_prefix_without_host() {
         let url = Url::parse("file:///absolute/path").expect("to parse url");
         assert_eq!(get_url_prefix(&url), "file:///");
+    }
+
+    #[tokio::test]
+    async fn test_parquet_page_index_options_default() {
+        let app = app::AppBuilder::new("test").build();
+        let runtime = crate::Runtime::builder()
+            .with_app_opt(Some(Arc::new(app)))
+            .build()
+            .await;
+
+        let options = parquet_page_index_options(&runtime).await;
+        assert!(options.enable_page_index);
+        assert!(!options.tolerate_missing_page_index);
+    }
+
+    #[tokio::test]
+    async fn test_parquet_page_index_options_auto() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("parquet_page_index".to_string(), "auto".to_string());
+        let app = app::AppBuilder::new("test")
+            .with_runtime_params(params)
+            .build();
+        let runtime = crate::Runtime::builder()
+            .with_app_opt(Some(Arc::new(app)))
+            .build()
+            .await;
+
+        let options = parquet_page_index_options(&runtime).await;
+        assert!(options.enable_page_index);
+        assert!(options.tolerate_missing_page_index);
+    }
+
+    #[tokio::test]
+    async fn test_parquet_page_index_options_skip() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("parquet_page_index".to_string(), "skip".to_string());
+        let app = app::AppBuilder::new("test")
+            .with_runtime_params(params)
+            .build();
+        let runtime = crate::Runtime::builder()
+            .with_app_opt(Some(Arc::new(app)))
+            .build()
+            .await;
+
+        let options = parquet_page_index_options(&runtime).await;
+        assert!(!options.enable_page_index);
+        assert!(!options.tolerate_missing_page_index);
+    }
+
+    #[tokio::test]
+    async fn test_parquet_page_index_options_required() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("parquet_page_index".to_string(), "required".to_string());
+        let app = app::AppBuilder::new("test")
+            .with_runtime_params(params)
+            .build();
+        let runtime = crate::Runtime::builder()
+            .with_app_opt(Some(Arc::new(app)))
+            .build()
+            .await;
+
+        let options = parquet_page_index_options(&runtime).await;
+        assert!(options.enable_page_index);
+        assert!(!options.tolerate_missing_page_index);
+    }
+
+    #[tokio::test]
+    async fn test_parquet_page_index_options_invalid() {
+        let mut params = std::collections::HashMap::new();
+        params.insert("parquet_page_index".to_string(), "invalid".to_string());
+        let app = app::AppBuilder::new("test")
+            .with_runtime_params(params)
+            .build();
+        let runtime = crate::Runtime::builder()
+            .with_app_opt(Some(Arc::new(app)))
+            .build()
+            .await;
+
+        let options = parquet_page_index_options(&runtime).await;
+        // Should fall back to default
+        assert!(options.enable_page_index);
+        assert!(!options.tolerate_missing_page_index);
     }
 }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -946,7 +946,7 @@ async fn parquet_page_index_options(runtime: &Runtime) -> ParquetPageIndexOption
     let runtime_app = runtime.app();
     let app = runtime_app.read().await;
     let parquet_page_index_param =
-        app::App::get_runtime_param(&*app, "parquet_page_index", "required".to_string());
+        app::App::get_runtime_param(&app, "parquet_page_index", "required".to_string());
 
     match parquet_page_index_param.as_str() {
         "auto" => ParquetPageIndexOptions {

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -24,7 +24,9 @@ use super::{
     },
 };
 
-use crate::{component::dataset::Dataset, dataconnector::listing::LISTING_TABLE_PARAMETERS};
+use crate::{
+    Runtime, component::dataset::Dataset, dataconnector::listing::LISTING_TABLE_PARAMETERS,
+};
 
 use snafu::prelude::*;
 use std::any::Any;
@@ -97,9 +99,15 @@ pub enum Error {
     InsecureEndpointWithoutAllowHTTP { endpoint: String },
 }
 
-#[derive(Debug)]
 pub struct S3 {
     pub(crate) params: Parameters,
+    pub(crate) runtime: Option<Runtime>,
+}
+
+impl std::fmt::Debug for S3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "S3(params: {:?})", self.params)
+    }
 }
 
 #[derive(Default, Copy, Clone)]
@@ -172,6 +180,7 @@ impl DataConnectorFactory for S3Factory {
 
             let s3 = S3 {
                 params: params.parameters,
+                runtime: params.runtime.map(Arc::unwrap_or_clone),
             };
             Ok(Arc::new(s3) as Arc<dyn DataConnector>)
         })
@@ -231,6 +240,10 @@ impl ListingTableConnector for S3 {
         )));
 
         Ok(s3_url)
+    }
+
+    fn get_runtime(&self) -> Option<Runtime> {
+        self.runtime.clone()
     }
 
     fn handle_object_store_error(


### PR DESCRIPTION
## 📝 Summary

Supports the following runtime parameter: `parquet_page_index`

```yaml
# Runtime configuration for Parquet file handling
runtime:
  params:
    # Configures how Spice processes Parquet files without page indexes
    parquet_page_index: required  # Options: required, skip, auto
```

- **`parquet_page_index`**: Determines how Spice handles Parquet files that lack page indexes.
  - `required`: (Default) Expects page indexes in Parquet files. Raises an error if absent.
  - `skip`: Bypasses page index reading. May reduce query performance due to limited pruning.
  - `auto`: Uses page indexes if available; otherwise, skips them without error.

## 🔗 Related

Integrates the following dependency changes:
- https://github.com/spiceai/arrow-rs/pull/6
- https://github.com/spiceai/datafusion/pull/93

## 📚 Docs

Ideally we will deprecate this in a future release so that docs aren't required.

## 👀 Notes for Reviewers

- I've decided to make the core change in https://github.com/spiceai/arrow-rs/pull/6 optional because we don't know for sure if it will break compatibility with all parquet files. Ideally, we can validate that this change to read the page indexes if they are available and otherwise fallback works as expected. Then we can just make this the default behavior and potentially deprecate the `parquet_page_index` runtime parameter entirely.
- Users need to explicitly opt-in to the new parquet reading behavior by setting `parquet_page_index: auto`, otherwise the previous behavior of expecting indexes is used.
