### PR TITLE
Set E2E Test CI models build to 90 minute timeout

### DIFF
--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -59,7 +59,7 @@ concurrency:
 jobs:
   build:
     name: Build ${{ matrix.target.name }} binaries
-    timeout-minutes: 30
+    timeout-minutes: 90
     runs-on: ${{ matrix.target.builder }}
     env:
       GOVER: 1.24.2


### PR DESCRIPTION
## 📝 Summary

We're regularly running into timeouts on building the binaries for the E2E models test. i.e. https://github.com/spiceai/spiceai/actions/runs/16956623801/job/48060041827?pr=6754
