### PR TITLE
Pin cargo-deny to 0.18.3

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -49,7 +49,8 @@ jobs:
           os: macos
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny || true
+        run: cargo install cargo-deny --version 0.18.3 || true
+        # TODO: Unpin cargo-deny version after upgrading to Rust 1.88.0
 
       - name: Check Rust Licenses
         run: cargo deny check licenses


### PR DESCRIPTION
## 📝 Summary

Licence check CI fails because the latest `cargo-deny`[ requires Rust 1.88.0](https://github.com/EmbarkStudios/cargo-deny/blame/main/Cargo.toml#L18).

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
