### PR TITLE
feat: add OpenAI models rate controller

### DIFF
--- a/crates/llms/src/chunking/mod.rs
+++ b/crates/llms/src/chunking/mod.rs
@@ -172,7 +172,14 @@ mod tests {
         };
 
         let chunker = OpenaiEmbed::new(
-            new_openai_client(DEFAULT_EMBEDDING_MODEL.to_string(), None, None, None, None),
+            new_openai_client(
+                DEFAULT_EMBEDDING_MODEL.to_string(),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
             None,
         )
         .chunker(&cfg)

--- a/crates/llms/src/openai/chat.rs
+++ b/crates/llms/src/openai/chat.rs
@@ -49,7 +49,17 @@ impl<C: Config + Send + Sync> Chat for Openai<C> {
         let outer_model = req.model.clone();
         let mut inner_req = req.clone();
         inner_req.model.clone_from(&self.model);
+
+        let permit = self
+            .rate_controller
+            .acquire()
+            .await
+            .map_err(|e| OpenAIError::StreamError(e.to_string()))?;
+
         let stream = self.client.chat().create_stream(inner_req).await?;
+
+        drop(permit); // drop the permit after acquiring the stream, instead of after receiving the response
+        // semaphore permits aren't `Copy`, so we can't move it into the closure in `.map_ok`
 
         Ok(Box::pin(stream.map_ok(move |mut s| {
             s.model.clone_from(&outer_model);
@@ -95,7 +105,16 @@ impl<C: Config + Send + Sync> Chat for Openai<C> {
         let outer_model = req.model.clone();
         let mut inner_req = req.clone();
         inner_req.model.clone_from(&self.model);
+
+        let permit = self
+            .rate_controller
+            .acquire()
+            .await
+            .map_err(|e| OpenAIError::StreamError(e.to_string()))?;
+
         let mut resp = self.client.chat().create(inner_req).await?;
+
+        drop(permit);
 
         resp.model = outer_model;
         Ok(resp)

--- a/crates/llms/src/openai/embed.rs
+++ b/crates/llms/src/openai/embed.rs
@@ -17,11 +17,9 @@ limitations under the License.
 use async_openai::config::Config;
 use async_openai::error::OpenAIError;
 use bytes::Bytes;
-use governor::Quota;
 use reqwest::StatusCode;
-use runtime_rate_control::{JitterConfig, RateController};
+use runtime_rate_control::RateController;
 use std::fmt::Debug;
-use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Instant;
 use util::fibonacci_backoff::{FibonacciBackoff, FibonacciBackoffBuilder};
@@ -45,7 +43,7 @@ use snafu::ResultExt;
 use text_splitter::ChunkSizer;
 use tokenizers::Tokenizer;
 
-use super::Openai;
+use super::{Openai, default_rate_controller};
 
 pub(crate) const TEXT_EMBED_3_SMALL: &str = "text-embedding-3-small";
 
@@ -53,20 +51,6 @@ pub const DEFAULT_EMBEDDING_MODEL: &str = TEXT_EMBED_3_SMALL;
 
 fn default_retry_strategy() -> FibonacciBackoff {
     FibonacciBackoffBuilder::new().max_retries(Some(10)).build()
-}
-
-fn default_rate_controller() -> Arc<RateController> {
-    let Some(default_per_minute_quota) = NonZeroU32::new(500) else {
-        unreachable!("Default quota should always be non-zero");
-    };
-
-    Arc::new(
-        RateController::builder()
-            .with_jitter(JitterConfig::zero())
-            .with_max_concurrent_requests(4)
-            .add_quota(Quota::per_minute(default_per_minute_quota))
-            .build(),
-    )
 }
 
 /// Embedding implementation for `OpenAI` compatible embedding models.

--- a/crates/llms/src/openai/mod.rs
+++ b/crates/llms/src/openai/mod.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use async_openai::config::{AzureConfig, Config, OPENAI_API_BASE};
 use async_openai::{Client, config::OpenAIConfig};
 use governor::Quota;
-use runtime_rate_control::RateController;
+use runtime_rate_control::{JitterConfig, RateController};
 
 pub mod chat;
 pub mod embed;
@@ -97,6 +97,22 @@ impl From<UsageTier> for Arc<RateController> {
 pub struct Openai<C: Config> {
     client: Client<C>,
     model: String,
+
+    rate_controller: Arc<RateController>,
+}
+
+pub(crate) fn default_rate_controller() -> Arc<RateController> {
+    let Some(default_per_minute_quota) = NonZeroU32::new(500) else {
+        unreachable!("Default quota should always be non-zero");
+    };
+
+    Arc::new(
+        RateController::builder()
+            .with_jitter(JitterConfig::zero())
+            .with_max_concurrent_requests(4)
+            .add_quota(Quota::per_minute(default_per_minute_quota))
+            .build(),
+    )
 }
 
 #[must_use]
@@ -129,6 +145,7 @@ pub fn new_azure_client(
     Openai {
         client: Client::with_config(cfg),
         model,
+        rate_controller: default_rate_controller(),
     }
 }
 
@@ -139,6 +156,7 @@ pub fn new_openai_client(
     api_key: Option<&str>,
     org_id: Option<&str>,
     project_id: Option<&str>,
+    usage_tier: Option<UsageTier>,
 ) -> Openai<OpenAIConfig> {
     // Default to empty API key to avoid picking up ENV variable in downstream library.
     let mut cfg = OpenAIConfig::new().with_api_key("");
@@ -161,6 +179,7 @@ pub fn new_openai_client(
     Openai {
         client: Client::with_config(cfg),
         model,
+        rate_controller: usage_tier.map_or_else(default_rate_controller, Into::into),
     }
 }
 
@@ -172,6 +191,7 @@ pub fn new_openai_client_with_config<C: async_openai::config::Config>(
     Openai {
         client: Client::with_config(cfg),
         model,
+        rate_controller: default_rate_controller(),
     }
 }
 

--- a/crates/llms/tests/llms/create.rs
+++ b/crates/llms/tests/llms/create.rs
@@ -92,6 +92,7 @@ pub(crate) fn create_openai(model_id: &str) -> Arc<dyn Chat> {
         api_key.as_deref(),
         None,
         None,
+        None,
     ))
 }
 

--- a/crates/runtime-rate-control/src/lib.rs
+++ b/crates/runtime-rate-control/src/lib.rs
@@ -106,13 +106,15 @@ impl RateControllerBuilder {
     }
 }
 
+#[derive(Debug)]
 pub struct RateController {
     jitter_config: JitterConfig,
     rate_limiters: Vec<Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>>>,
     semaphore: Option<Arc<Semaphore>>,
 }
 
-#[allow(dead_code)] // will be used once the rate limiter is integrated
+#[derive(Debug)]
+#[allow(dead_code)] // The inner permit is never used, but it needs to be retained for the lifetime of the permit so it can be correctly dropped.
 pub struct Permit<'a>(Option<SemaphorePermit<'a>>);
 
 impl RateController {

--- a/crates/runtime-rate-control/src/lib.rs
+++ b/crates/runtime-rate-control/src/lib.rs
@@ -34,6 +34,10 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+// tokio::task_local! {
+//     static THREAD_RNG: LazyLock<Arc<Mutex<ThreadRng>>>
+// }
+
 #[derive(Debug, Default)]
 pub struct JitterConfig {
     min: Duration,

--- a/crates/runtime-rate-control/src/lib.rs
+++ b/crates/runtime-rate-control/src/lib.rs
@@ -34,10 +34,6 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-// tokio::task_local! {
-//     static THREAD_RNG: LazyLock<Arc<Mutex<ThreadRng>>>
-// }
-
 #[derive(Debug, Default)]
 pub struct JitterConfig {
     min: Duration,

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -19,6 +19,7 @@ use llms::{
     anthropic::Anthropic,
     bedrock::chat::{BedrockConverse, guardrail::GuardRail},
     chat::{Chat, Error as LlmError},
+    openai::UsageTier,
     perplexity::PerplexitySonar,
     xai::Xai,
 };
@@ -382,6 +383,16 @@ fn openai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>
     let api_key = params.get("api_key").expose().ok();
     let org_id = params.get("org_id").expose().ok();
     let project_id = params.get("project_id").expose().ok();
+    let usage_tier = params
+        .get("usage_tier")
+        .expose()
+        .ok()
+        .map(UsageTier::from_str)
+        .transpose()
+        .map_err(|_| LlmError::InvalidParamValueError {
+            param: "openai_usage_tier".to_string(),
+            message: "Must be 'free', 'tier1', 'tier2', 'tier3', 'tier4', or 'tier5'".to_string(),
+        })?;
 
     if let Some(temperature_str) = params.get("temperature").expose().ok() {
         match temperature_str.parse::<f64>() {
@@ -408,6 +419,7 @@ fn openai(model_id: Option<String>, params: &Parameters) -> Result<Arc<dyn Chat>
         api_key,
         org_id,
         project_id,
+        usage_tier,
     )) as Arc<dyn Chat>)
 }
 

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -386,8 +386,7 @@ async fn openai(
         .or(params.get("openai_usage_tier"))
         .map(secrecy::ExposeSecret::expose_secret)
         .map(UsageTier::from_str)
-        .transpose()?
-        .unwrap_or_default();
+        .transpose()?;
 
     let mut embed = OpenaiEmbed::new(
         llms::openai::new_openai_client(
@@ -405,8 +404,9 @@ async fn openai(
                 .get("project_id")
                 .or(params.get("openai_project_id"))
                 .map(secrecy::ExposeSecret::expose_secret),
+            openai_usage_tier,
         ),
-        Some(openai_usage_tier.into()),
+        openai_usage_tier.map(Into::into),
     );
 
     // For OpenAI compatible embedding models, we allow users to

--- a/crates/runtime/src/model/params/openai.rs
+++ b/crates/runtime/src/model/params/openai.rs
@@ -23,7 +23,7 @@ pub(crate) const PARAMETERS: &[ParameterSpec] =
         COMMON_MODEL_PARAMETERS,
     );
 
-const OPENAI_PARAM_LEN: usize = 4;
+const OPENAI_PARAM_LEN: usize = 5;
 
 pub(crate) const OPENAI_PARAMETERS: [ParameterSpec; OPENAI_PARAM_LEN] = [
     ParameterSpec::runtime("endpoint")
@@ -36,4 +36,6 @@ pub(crate) const OPENAI_PARAMETERS: [ParameterSpec; OPENAI_PARAM_LEN] = [
         .description("The OpenAI organization ID."),
     ParameterSpec::component("project_id")
         .description("The OpenAI project ID."),
+    ParameterSpec::component("usage_tier")
+        .description("The current usage tier for the OpenAI account associated with the API key."),
 ];

--- a/crates/runtime/src/model/params/openai.rs
+++ b/crates/runtime/src/model/params/openai.rs
@@ -37,5 +37,6 @@ pub(crate) const OPENAI_PARAMETERS: [ParameterSpec; OPENAI_PARAM_LEN] = [
     ParameterSpec::component("project_id")
         .description("The OpenAI project ID."),
     ParameterSpec::component("usage_tier")
-        .description("The current usage tier for the OpenAI account associated with the API key."),
+        .description("The current usage tier for the OpenAI account associated with the API key: 'free', 'tier1', 'tier2', 'tier3', 'tier4', or 'tier5'.")
+        .default("tier1"),
 ];


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds a rate controller to `Openai<C>` to control the rate of requests to chat models
* Adds `openai_usage_tier` to the openai chat models parameters

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6752
* Part of #6743
