### PR TITLE
fix: Use head ref for PR checks concurrency group

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -8,7 +8,7 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Uses `head_ref` instead of `ref` for concurrency group. This is because `github.ref` for `pull_request_target` is an alias for `github.base_ref` - for most cases, `trunk`.
