### PR TITLE
Fix Hugging Face models and embeddings loading in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,8 +107,6 @@ RUN chown -R 65534:65534 /spice_sandbox/app
 RUN mkdir -p /spice_sandbox/.cache/huggingface/hub
 RUN chown -R 65534:65534 /spice_sandbox/.cache
 RUN chmod -R 755 /spice_sandbox/.cache
-ENV HF_HOME=/spice_sandbox/.cache/huggingface
-ENV HF_HUB_CACHE=/spice_sandbox/.cache/huggingface/hub
 
 FROM scratch
 
@@ -119,5 +117,8 @@ USER 65534:65534
 EXPOSE 8090 50051
 
 WORKDIR /app
+
+ENV HF_HOME=/.cache/huggingface
+ENV HF_HUB_CACHE=/.cache/huggingface/hub
 
 ENTRYPOINT ["/usr/local/bin/spiced"]

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ run:
 
 .PHONY: docker
 docker:
-	docker buildx build -t spiceai-rust:local-dev .
+	docker buildx build --build-arg RUST_PROFILE=release -t spiceai-rust:local-dev .
 
 .PHONY: docker-run
 docker-run:

--- a/crates/llms/src/embeddings/candle/util.rs
+++ b/crates/llms/src/embeddings/candle/util.rs
@@ -99,9 +99,24 @@ pub(crate) fn inputs_from_openai(input: &EmbeddingInput) -> Vec<EncodingInput> {
 }
 
 fn get_api(model_id: &str, revision: Option<&str>, hf_token: Option<&str>) -> Result<ApiRepo> {
-    let api = ApiBuilder::new()
+    let mut builder = ApiBuilder::new()
         .with_progress(false)
-        .with_token(hf_token.map(ToString::to_string))
+        .with_token(hf_token.map(ToString::to_string));
+
+    if let Ok(cache_dir) = std::env::var("HF_HUB_CACHE") {
+        let cache_path: PathBuf = cache_dir.into();
+        if cache_path.exists() {
+            tracing::debug!("Using HF_HUB_CACHE directory {:?}", cache_path);
+            builder = builder.with_cache_dir(cache_path);
+        } else {
+            tracing::debug!(
+                "HF_HUB_CACHE directory {:?} does not exist, ignoring.",
+                cache_path
+            );
+        }
+    }
+
+    let api = builder
         .build()
         .boxed()
         .context(FailedToInstantiateEmbeddingModelSnafu)?;


### PR DESCRIPTION
## 📝 Summary

Fixed the Hugging Face cache environment variables (`HF_HOME` and `HF_HUB_CACHE`) to use the correct cache folder path and moved to the final stage of the Dockerfile.

Updated the Hugging Face `get_api` utility helper to respect the `HF_HUB_CACHE` environment variable if it is set.

Fixed `make docker` to use release rust profile by default.

## 🔗 Related

closes #6776 