### PR TITLE
fix: Move search telemetry calls in UDTF to scan

### DIFF
--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -44,7 +44,6 @@ use datafusion::{
     scalar::ScalarValue,
     sql::TableReference,
 };
-use futures::FutureExt;
 use itertools::Itertools;
 use runtime_datafusion_index::IndexedTableProvider;
 use std::cmp::min;
@@ -274,12 +273,6 @@ impl VectorSearchTableFunc {
 
 impl TableFunctionImpl for VectorSearchTableFunc {
     fn call(&self, args: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
-        async {
-            let request_context = RequestContext::current(AsyncMarker::new().await);
-            telemetry::track_vector_search(&request_context.to_dimensions());
-        }
-        .now_or_never();
-
         let args = Self::parse_args(args)?;
         let df = self.df.upgrade().ok_or_else(|| {
             DataFusionError::Plan(format!(
@@ -415,6 +408,9 @@ impl TableProvider for VectorSearchUDTFProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let request_context = RequestContext::current(AsyncMarker::new().await);
+        telemetry::track_vector_search(&request_context.to_dimensions());
+
         let (col, cfg) = self.args.get_column_and_config(&self.embedded_columns)?;
 
         let query_vector = self

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -27,13 +27,17 @@ limitations under the License.
 //! The schema of the resultant table will be: `schema(tbl) ∪ {score}`, where:
 //!  - `score` (f32): The similarity score of the row with the request `query`.
 
-use std::sync::{Arc, Weak};
+use std::{
+    borrow::Cow,
+    sync::{Arc, Weak},
+};
 
 use datafusion::{
     catalog::{Session, TableFunctionImpl, TableProvider},
-    common::Column,
+    common::{Column, Constraints, Statistics},
     datasource::TableType,
     error::{DataFusionError, Result as DataFusionResult},
+    logical_expr::{LogicalPlan, TableProviderFilterPushDown, dml::InsertOp},
     physical_plan::ExecutionPlan,
     prelude::Expr,
     scalar::ScalarValue,
@@ -247,6 +251,42 @@ impl TableProvider for TextSearchIndexProviderWrapper {
 
     fn table_type(&self) -> TableType {
         self.inner.table_type()
+    }
+
+    fn constraints(&self) -> Option<&Constraints> {
+        self.inner.constraints()
+    }
+
+    fn get_table_definition(&self) -> Option<&str> {
+        self.inner.get_table_definition()
+    }
+
+    fn get_logical_plan(&self) -> Option<Cow<LogicalPlan>> {
+        self.inner.get_logical_plan()
+    }
+
+    fn get_column_default(&self, column: &str) -> Option<&Expr> {
+        self.inner.get_column_default(column)
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    fn statistics(&self) -> Option<Statistics> {
+        self.inner.statistics()
+    }
+
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        insert_op: InsertOp,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        self.inner.insert_into(state, input, insert_op).await
     }
 
     async fn scan(

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -30,14 +30,15 @@ limitations under the License.
 use std::sync::{Arc, Weak};
 
 use datafusion::{
-    catalog::{TableFunctionImpl, TableProvider},
+    catalog::{Session, TableFunctionImpl, TableProvider},
     common::Column,
+    datasource::TableType,
     error::{DataFusionError, Result as DataFusionResult},
+    physical_plan::ExecutionPlan,
     prelude::Expr,
     scalar::ScalarValue,
     sql::TableReference,
 };
-use futures::FutureExt;
 use runtime_datafusion_index::IndexedTableProvider;
 use search::generation::text_search::{
     index::FullTextDatabaseIndex, udtf::TextSearchIndexProvider,
@@ -186,12 +187,6 @@ impl TextSearchTableFunc {
 
 impl TableFunctionImpl for TextSearchTableFunc {
     fn call(&self, args: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
-        async {
-            let request_context = RequestContext::current(AsyncMarker::new().await);
-            telemetry::track_text_search(&request_context.to_dimensions());
-        }
-        .now_or_never();
-
         let args = Self::parse_args(args)?;
 
         let df = self.df.upgrade().ok_or_else(|| {
@@ -223,12 +218,47 @@ impl TableFunctionImpl for TextSearchTableFunc {
         };
 
         let column = args.column(&fts_index.search_fields)?;
-        Ok(Arc::new(TextSearchIndexProvider {
-            query: args.query.clone(),
-            column,
-            pre_limit: args.limit,
-            index: fts_index.clone(),
-            underlying: table_provider,
+        Ok(Arc::new(TextSearchIndexProviderWrapper {
+            inner: Arc::new(TextSearchIndexProvider {
+                query: args.query.clone(),
+                column,
+                pre_limit: args.limit,
+                index: fts_index.clone(),
+                underlying: table_provider,
+            }),
         }))
+    }
+}
+
+#[derive(Debug)]
+struct TextSearchIndexProviderWrapper {
+    inner: Arc<TextSearchIndexProvider>,
+}
+
+#[async_trait::async_trait]
+impl TableProvider for TextSearchIndexProviderWrapper {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.inner.as_any()
+    }
+
+    fn schema(&self) -> datafusion::arrow::datatypes::SchemaRef {
+        self.inner.schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.inner.table_type()
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let request_context = RequestContext::current(AsyncMarker::new().await);
+        telemetry::track_text_search(&request_context.to_dimensions());
+
+        self.inner.scan(state, projection, filters, limit).await
     }
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Moves the telemetry tracking calls for search into their UDTF table provider `.scan()` functions, instead of in the sync `TableFunctionImpl::call` which dropped the request context in a sync scope.
