### PR TITLE
use ref: `github.event.pull_request.head.sha` in integration_models.yml

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -93,6 +93,8 @@ jobs:
     runs-on: 'spiceai-macos'
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download test binary
         uses: actions/download-artifact@v5
@@ -137,6 +139,8 @@ jobs:
     runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download test binary
         uses: actions/download-artifact@v5
@@ -176,6 +180,8 @@ jobs:
     runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download test binary
         uses: actions/download-artifact@v5
@@ -200,6 +206,8 @@ jobs:
     runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download test binary
         uses: actions/download-artifact@v5
@@ -226,6 +234,8 @@ jobs:
     runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download test binary
         uses: actions/download-artifact@v5
@@ -259,6 +269,8 @@ jobs:
     runs-on: [self-hosted, macOS]
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download test binary
         uses: actions/download-artifact@v5


### PR DESCRIPTION
## 📝 Summary
 - Snapshot updates to in `integration_models.yml` are not used in PR branch CI because workflow:
   -  Uses `pull_request_target`
   - Did not explicitly set what reference of spiceai/spiceai to checkout in `actions/checkout@v5`. 