### PR TITLE
fix: Explicitly error when chunking is defined for vector engines

### DIFF
--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -88,16 +88,29 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
         // If the dataset is enabled for a vector engine, use this instead of JIT.
         if let Some(vector_engine) = &dataset.vectors {
             // We have a vector engine configured with no explicit acceleration, add the void acceleration to force indexing.
-            tracing::debug!(
-                "Dataset {} configured for vector engine and no explicit acceleration, adding void acceleration for indexing.",
-                dataset.name
-            );
             if vector_engine.enabled && acceleration.is_none() {
+                tracing::debug!(
+                    "Dataset {} configured for vector engine and no explicit acceleration, adding void acceleration for indexing.",
+                    dataset.name
+                );
                 acceleration = Some(acceleration::Acceleration {
                     enabled: true,
                     engine: Engine::Void,
                     ..Default::default()
                 });
+            }
+
+            // Chunking with vector engines is not supported (yet).
+            for column in &dataset.columns {
+                for embedding in &column.embeddings {
+                    if embedding.chunking.is_some() {
+                        return Err(crate::Error::InvalidSpicepodDataset {
+                            source: Error::ChunkingNotSupportedForVectorEngine {
+                                column: column.name.clone(),
+                            },
+                        });
+                    }
+                }
             }
         }
 

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -101,6 +101,11 @@ pub enum Error {
         "Both a 'refresh_cron' and 'refresh_check_interval' were specified.\nOnly one of these options can be specified for a given dataset.\nFor details, visit: https://spiceai.org/docs/features/data-acceleration/data-refresh"
     ))]
     MultipleRefreshExpressionSpecified,
+
+    #[snafu(display(
+        "Chunking is not supported for vector engines. Disable chunking for the column '{column}', or disable the vector engine, and try again."
+    ))]
+    ChunkingNotSupportedForVectorEngine { column: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Moves the debug log for adding a void engine to inside the statement that checks acceleration, so it is actually accurate
* Adds an explicit check for chunking with vector engines as it is not supported yet: https://github.com/spiceai/spiceai/issues/6555