### PR TITLE
fix: Make search matches response the same API for multiple matches

### DIFF
--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -193,12 +193,18 @@ spice search --cloud
 					}
 				}
 
-				withColumns := len(match.Matches) > 0
+				withColumns := len(match.Matches) > 1
 				for col, values := range match.Matches {
-					for _, value := range values {
-						if withColumns {
+					withMatchNumber := len(values) > 1
+					for i, value := range values {
+						switch {
+						case withColumns && withMatchNumber:
+							cmd.Printf("\n%s[match #%d]: %s", col, i+1, value)
+						case withColumns:
 							cmd.Printf("\n%s: %s", col, value)
-						} else {
+						case withMatchNumber:
+							cmd.Printf("\nmatch #%d: %s", i+1, value)
+						default:
 							cmd.Printf("\n%s", value)
 						}
 					}

--- a/bin/spice/cmd/search.go
+++ b/bin/spice/cmd/search.go
@@ -49,7 +49,7 @@ type SearchRequest struct {
 }
 
 type SearchMatch struct {
-	Matches    map[string]string      `json:"matches"`
+	Matches    map[string][]string    `json:"matches"`
 	Score      float64                `json:"score"`
 	Dataset    string                 `json:"dataset"`
 	PrimaryKey map[string]interface{} `json:"primary_key"`
@@ -192,14 +192,15 @@ spice search --cloud
 						cmd.Printf(" %s=%v", key, value)
 					}
 				}
-				if len(match.Matches) == 1 {
-					// This will only print a single line.
-					for _, value := range match.Matches {
-						cmd.Printf("\n%s", value)
-					}
-				} else {
-					for col, value := range match.Matches {
-						cmd.Printf("\n%s: %s", col, value)
+
+				withColumns := len(match.Matches) > 0
+				for col, values := range match.Matches {
+					for _, value := range values {
+						if withColumns {
+							cmd.Printf("\n%s: %s", col, value)
+						} else {
+							cmd.Printf("\n%s", value)
+						}
 					}
 				}
 				cmd.Print("\n\n")

--- a/crates/runtime/src/search/types.rs
+++ b/crates/runtime/src/search/types.rs
@@ -37,7 +37,7 @@ pub type VectorSearchResult = HashMap<TableReference, AggregationResult>;
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Match {
     /// The matches for this result
-    matches: HashMap<String, MatchType>,
+    matches: HashMap<String, Matches>,
 
     /// Addditional data from the `dataset` requested by the user.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
@@ -59,21 +59,11 @@ pub struct Match {
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(untagged)]
-pub enum MatchType {
-    Single(Value),
-    Multiple(Vec<Value>),
-}
+pub struct Matches(Vec<Value>);
 
-impl From<Vec<Value>> for MatchType {
+impl From<Vec<Value>> for Matches {
     fn from(mut value: Vec<Value>) -> Self {
-        if value.len() == 1 {
-            let Some(v) = value.pop() else {
-                unreachable!("The value array must have one element");
-            };
-            return MatchType::Single(v);
-        }
-        MatchType::Multiple(value)
+        Matches(std::mem::take(&mut value))
     }
 }
 
@@ -203,7 +193,7 @@ pub async fn to_matches(
 /// Convert a map of {column name -> column values}, to a per-row representation.
 fn transpose_and_convert(
     column_format: HashMap<String, Vec<Vec<Value>>>,
-) -> Vec<HashMap<String, MatchType>> {
+) -> Vec<HashMap<String, Matches>> {
     let max_rows = column_format
         .values()
         .map(std::vec::Vec::len)
@@ -233,12 +223,12 @@ mod tests {
     use serde_json::Value;
     use std::collections::HashMap;
 
-    fn sort_result(v: Vec<HashMap<String, MatchType>>) -> Vec<Vec<(String, MatchType)>> {
+    fn sort_result(v: Vec<HashMap<String, Matches>>) -> Vec<Vec<(String, Matches)>> {
         v.into_iter()
             .map(|x| {
                 x.into_iter()
                     .sorted_by_key(|(a, _)| a.clone())
-                    .collect::<Vec<(String, MatchType)>>()
+                    .collect::<Vec<(String, Matches)>>()
             })
             .collect::<Vec<_>>()
     }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Changes the response API from `matches: string | []string` to only `matches: []string`. This improves the usability of the API for consumers, by providing a single expected response type (array of strings).
* Updates the Go `spice search` CLI to match the new response format.
  * Prefixes the result with `match #{i}` when there are multiple matches.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6789