### PR TITLE
Respect default MAX_DECODING_MESSAGE_SIZE (100MB) in Flight API

### DIFF
--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -393,7 +393,8 @@ pub async fn start(
         channel_map: Arc::new(RwLock::new(HashMap::new())),
         basic_auth: endpoint_auth.flight_basic_auth.as_ref().map(Arc::clone),
     };
-    let svc = FlightServiceServer::new(service);
+    let svc = FlightServiceServer::new(service)
+        .max_decoding_message_size(flight_client::MAX_DECODING_MESSAGE_SIZE);
 
     tracing::info!("Spice Runtime Flight listening on {bind_address}");
     runtime_metrics::spiced_runtime::FLIGHT_SERVER_START.add(1, &[]);


### PR DESCRIPTION
## 📝 Summary

Ensure Flight API uses MAX_DECODING_MESSAGE_SIZE (100MB; currently 4MB default values is used), consistent with Flight Client behavior

https://github.com/spiceai/spiceai/blob/d4f6ad5968156fa95f067d36a59b11ef6577a424/crates/flight_client/src/lib.rs#L49-L50

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/6697

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

A potential next improvement could be adding support for a `max_message_size` parameter to override the default value.

```yaml
runtime:
  flight:
    max_message_size: 1G
```
