### PR TITLE
fix: Allow v1/search with only FTS indexes

### DIFF
--- a/crates/runtime/src/http/v1/search.rs
+++ b/crates/runtime/src/http/v1/search.rs
@@ -186,7 +186,7 @@ pub(crate) async fn post(
         },
         Err(e) => {
             let error_type = match e {
-                VectorSearchError::NoTablesWithEmbeddingsFound {}
+                VectorSearchError::NoTablesWithSearchFound {}
                 | VectorSearchError::CannotVectorSearchDataset { .. } => StatusCode::BAD_REQUEST,
                 VectorSearchError::SearchPipelineError { ref source } if source.is_user_error() => {
                     StatusCode::BAD_REQUEST

--- a/crates/runtime/src/search/mod.rs
+++ b/crates/runtime/src/search/mod.rs
@@ -35,9 +35,9 @@ pub enum Error {
     DataSourceNotFound { table: TableReference },
 
     #[snafu(display(
-        "Vector search failed: No tables with embeddings are available. Ensure embeddings are configured and try again."
+        "Vector search failed: No tables with embeddings or full text search indexes are available. Ensure embeddings or full text search indexes are configured and try again."
     ))]
-    NoTablesWithEmbeddingsFound {},
+    NoTablesWithSearchFound {},
 
     #[snafu(display("Vector search cannot be run on {}.", data_source.to_quoted_string()))]
     CannotVectorSearchDataset { data_source: TableReference },

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -145,18 +145,27 @@ pub async fn get_primary_keys_with_overrides(
     Ok(tbl_to_pks)
 }
 
-pub async fn user_tables_with_embeddings(df: &Arc<DataFusion>) -> Result<Vec<TableReference>> {
-    let mut tables_with_embeddings = Vec::new();
+pub async fn user_tables_that_can_search(df: &Arc<DataFusion>) -> Result<Vec<TableReference>> {
+    let mut searchable_tables = Vec::new();
 
     for t in df.get_user_table_names() {
         if embedding_columns_from_table(df, &t)
             .await
             .is_some_and(|cols| !cols.is_empty())
         {
-            tables_with_embeddings.push(t);
+            searchable_tables.push(t);
+            continue;
+        }
+
+        if full_text_search_candidates(df, &t)
+            .await
+            .is_some_and(|fts_res| fts_res.is_ok_and(|c| !c.is_empty()))
+        {
+            searchable_tables.push(t);
         }
     }
-    Ok(tables_with_embeddings)
+
+    Ok(searchable_tables)
 }
 
 /// Returns the column names of a [`TableReference`] that have associated embedding column(s)

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::{collections::HashMap, sync::Arc};
 
 use super::request::SearchRequest;
-use super::util::user_tables_with_embeddings;
+use super::util::user_tables_that_can_search;
 use super::{Error, Result};
 use crate::embeddings::table::EmbeddingTable;
 use crate::request::{AsyncMarker, CacheControl, CacheKeyType, RequestContext};
@@ -245,11 +245,11 @@ impl VectorSearch {
 
         let tables = match data_source_opt {
             Some(ts) => ts.iter().map(TableReference::from).collect(),
-            None => user_tables_with_embeddings(&self.df).await?,
+            None => user_tables_that_can_search(&self.df).await?,
         };
 
         if tables.is_empty() {
-            return Err(Error::NoTablesWithEmbeddingsFound {});
+            return Err(Error::NoTablesWithSearchFound {});
         }
 
         let span = match Span::current() {

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -634,6 +634,13 @@ async fn test_text_search() -> Result<(), anyhow::Error> {
                     "limit": 4,
                 }),
             },
+            SearchTestCase {
+                name: "text_search_basic_without_defined_dataset",
+                body: json!({
+                    "text": "second",
+                    "limit": 4,
+                })
+            }
         ],
         vec![
             (

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_basic_without_defined_dataset_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__text_search_basic_without_defined_dataset_response.snap
@@ -1,0 +1,29 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: normalize_search_response(response)
+---
+{
+  "duration_ms": "duration_ms_val",
+  "results": [
+    {
+      "dataset": "spice.public.qs",
+      "matches": {
+        "answer": "\\[\nP(\\text{First faulty and second faulty}) = \\frac{2}{3} \\times \\frac{1}{2} = \\boxed{\\frac{1}{3}}\n\\]"
+      },
+      "primary_key": {
+        "id": 525
+      },
+      "score": 6.33
+    },
+    {
+      "dataset": "spice.public.qs",
+      "matches": {
+        "answer": "The degree of the differential equation is \\(\\boxed{2}\\), as the highest derivative present is the second derivative \\( y'' \\)."
+      },
+      "primary_key": {
+        "id": 772
+      },
+      "score": 6.19
+    }
+  ]
+}


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates the vector search struct to allow performing a search when only columns with full text indexes are defined (no embeddings).
* Adds an integration test to validate as such. It would previously work if you supplied the dataset names, but now it works without having to specify a dataset name!

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->

* The description of the `v1/search` route probably needs updating, given we (for some time) now search across both FTS and Vector search
