### PR TITLE
Use latest commit in our fork of async-openai

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "async-openai"
 version = "0.29.1"
-source = "git+https://github.com/spiceai/async-openai?rev=e1580b0cdccfbf9b6e52321650324cd2ddb023d0#e1580b0cdccfbf9b6e52321650324cd2ddb023d0"
+source = "git+https://github.com/spiceai/async-openai?rev=60e8643bc089502bb2bd76c33adb60bdb489b475#60e8643bc089502bb2bd76c33adb60bdb489b475"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "async-openai-macros"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/async-openai?rev=e1580b0cdccfbf9b6e52321650324cd2ddb023d0#e1580b0cdccfbf9b6e52321650324cd2ddb023d0"
+source = "git+https://github.com/spiceai/async-openai?rev=60e8643bc089502bb2bd76c33adb60bdb489b475#60e8643bc089502bb2bd76c33adb60bdb489b475"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ arrow-ipc = "55.1"
 arrow-json = "55.1"
 arrow-odbc = "16"
 arrow-schema = "55.1"
-async-openai = { git = "https://github.com/spiceai/async-openai", rev = "e1580b0cdccfbf9b6e52321650324cd2ddb023d0", features = [
+async-openai = { git = "https://github.com/spiceai/async-openai", rev = "60e8643bc089502bb2bd76c33adb60bdb489b475", features = [
     "byot",
 ] }
 async-stream = "0.3.5"


### PR DESCRIPTION
## 📝 Summary
- See title
- This is necessary to support the Responses API from our HTTP endpoint

## 🔗 Related
- Related to and necessary for #6666 

