### PR TITLE
Kafka Data Connector: basic connector functionality

### DIFF
--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -52,6 +52,7 @@ clickhouse = ["runtime/clickhouse"]
 cuda = ["runtime/cuda"]
 databricks = ["runtime/databricks"]
 debezium = ["runtime/debezium"]
+kafka = ["runtime/kafka"]
 default = [
   "duckdb",
   "postgres",
@@ -67,6 +68,7 @@ default = [
   "spark",
   "ftp",
   "debezium",
+  "kafka",
   "anonymous_telemetry",
   "mssql",
   "dynamodb",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -91,6 +91,7 @@ rdkafka = { version = "0.38.0", features = ["cmake-build"], optional = true }
 clickhouse = ["dep:clickhouse-rs"]
 databricks = ["delta_lake", "spark_connect"]
 debezium = ["dep:rdkafka"]
+kafka = ["dep:rdkafka"]
 delta_lake = ["dep:delta_kernel"]
 duckdb = [
     "dep:duckdb",

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -18,9 +18,10 @@ use std::{fmt::Display, sync::Arc};
 
 use arrow::error::ArrowError;
 use arrow::{
-    array::{Array, ListArray, RecordBatch, StringArray, StructArray},
+    array::{Array, ArrayRef, ListArray, RecordBatch, StringArray, StructArray},
     datatypes::{DataType, Field, Schema, SchemaRef},
 };
+use arrow_buffer::OffsetBuffer;
 use futures::stream::BoxStream;
 use snafu::prelude::*;
 
@@ -289,5 +290,109 @@ impl ChangeBatch {
         }
 
         Ok(())
+    }
+}
+
+/// Wraps an arbitrary data `RecordBatch` as a `ChangeBatch` with "create" operations.
+pub fn wrap_data_as_change_batch(
+    table_schema: &SchemaRef,
+    data: &RecordBatch,
+) -> Result<ChangeBatch, ChangeBatchError> {
+    let num_rows = data.num_rows();
+    let schema = changes_schema(table_schema);
+
+    // 1) op column ("create" operations)
+    let op_array = Arc::new(arrow::array::StringArray::from(vec![
+        "c".to_string();
+        num_rows
+    ]));
+
+    // 2) Dummy primary_keys: List<Utf8> with EMPTY LIST per row
+    // Offsets must be length = num_rows + 1. All zeros => [] for every row.
+    let offsets = vec![0i32; num_rows + 1];
+    let values = Arc::new(StringArray::from(Vec::<&str>::new())) as ArrayRef;
+    let primary_keys_array: ArrayRef = Arc::new(ListArray::new(
+        Arc::new(Field::new("item", DataType::Utf8, false)),
+        OffsetBuffer::new(offsets.into()),
+        values,
+        None, // no validity bitmap (all non-null lists)
+    ));
+
+    // 3) data: Struct matching the input batch's schema/columns
+    let data_array = Arc::new(StructArray::new(
+        data.schema().fields().clone(),
+        data.columns().to_vec(),
+        None,
+    ));
+
+    let columns = vec![op_array, primary_keys_array, data_array];
+    let record_batch = RecordBatch::try_new(schema.into(), columns).context(ArrowSnafu)?;
+
+    ChangeBatch::try_new(record_batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow_array::{Int32Array, StringArray};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_wrap_batch_as_change_batch() {
+        // Create a test schema
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        // Create test data
+        let id_array = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let name_array = Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie"]));
+        let data_batch = RecordBatch::try_new(Arc::clone(&schema), vec![id_array, name_array])
+            .expect("to create data batch");
+
+        let change_batch =
+            wrap_data_as_change_batch(&schema, &data_batch).expect("to create change batch");
+
+        let record = &change_batch.record;
+
+        // Verify the schema has the expected fields
+        assert_eq!(record.schema().fields().len(), 3);
+        // Verify the number of rows
+        assert_eq!(record.num_rows(), 3);
+
+        // Verify the op column
+        let op_column = record
+            .column_by_name("op")
+            .expect("op column exists")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("op column is StringArray");
+        for i in 0..3 {
+            assert_eq!(op_column.value(i), "c");
+        }
+
+        // Verify the primary_keys column (should be empty lists)
+        let pk_column = record
+            .column_by_name("primary_keys")
+            .expect("primary_keys column exists")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("primary_keys column is ListArray");
+        assert_eq!(pk_column.len(), 3);
+        for i in 0..3 {
+            assert_eq!(pk_column.value_length(i), 0);
+        }
+
+        // Verify the data column
+        let data_column = record
+            .column_by_name("data")
+            .expect("data column exists")
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("data column is StructArray");
+        assert_eq!(data_column.len(), 3);
+        assert_eq!(data_column.num_columns(), 2);
     }
 }

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -98,9 +98,10 @@ impl DebeziumKafka {
                 let schema = Arc::clone(&schema);
                 let pk = primary_keys.clone();
                 let Ok(msg) = msg else {
-                    return Err(cdc::StreamError::Kafka(
-                        "Unable to read message".to_string(),
-                    ));
+                    return Err(cdc::StreamError::Kafka(format!(
+                        "Unable to read message: {:?}",
+                        msg.err()
+                    )));
                 };
 
                 let val = msg.value();

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -14,6 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::{any::Any, sync::Arc};
+
+use arrow::{datatypes::SchemaRef, json::ReaderBuilder};
+use datafusion::{
+    catalog::Session,
+    datasource::{TableProvider, TableType},
+    error::Result as DataFusionResult,
+    logical_expr::Expr,
+    physical_plan::{ExecutionPlan, empty::EmptyExec},
+};
 use futures::{Stream, StreamExt};
 use rdkafka::{
     ClientConfig, Message, Offset,
@@ -24,8 +34,9 @@ use rdkafka::{
 };
 use serde::de::DeserializeOwned;
 use snafu::prelude::*;
+use tonic::async_trait;
 
-use crate::cdc::{self, CommitChange, CommitError};
+use crate::cdc::{self, ChangeEnvelope, ChangesStream, CommitChange, CommitError};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -172,14 +183,17 @@ impl KafkaConsumer {
                 Err(e) => return Some(Err(Error::UnableToReceiveMessage { source: e })),
             };
 
-            let key_bytes = msg.key()?;
-            let payload = msg.payload()?;
-
-            let key = match serde_json::from_slice(key_bytes) {
-                Ok(key) => key,
-                Err(e) => return Some(Err(Error::UnableToDeserializeJsonMessage { source: e })),
+            let key = match msg.key() {
+                Some(key_bytes) => match serde_json::from_slice(key_bytes) {
+                    Ok(key) => Some(key),
+                    Err(e) => {
+                        return Some(Err(Error::UnableToDeserializeJsonMessage { source: e }));
+                    }
+                },
+                None => None,
             };
 
+            let payload = msg.payload()?;
             let value = match serde_json::from_slice(payload) {
                 Ok(value) => value,
                 Err(e) => return Some(Err(Error::UnableToDeserializeJsonMessage { source: e })),
@@ -298,12 +312,17 @@ impl KafkaConsumer {
 pub struct KafkaMessage<'a, K, V> {
     consumer: &'a StreamConsumer,
     msg: BorrowedMessage<'a>,
-    key: K,
+    key: Option<K>,
     value: V,
 }
 
 impl<'a, K, V> KafkaMessage<'a, K, V> {
-    fn new(consumer: &'a StreamConsumer, msg: BorrowedMessage<'a>, key: K, value: V) -> Self {
+    fn new(
+        consumer: &'a StreamConsumer,
+        msg: BorrowedMessage<'a>,
+        key: Option<K>,
+        value: V,
+    ) -> Self {
         Self {
             consumer,
             msg,
@@ -312,8 +331,8 @@ impl<'a, K, V> KafkaMessage<'a, K, V> {
         }
     }
 
-    pub fn key(&self) -> &K {
-        &self.key
+    pub fn key(&self) -> Option<&K> {
+        self.key.as_ref()
     }
 
     pub fn value(&self) -> &V {
@@ -333,5 +352,89 @@ impl<K, V> CommitChange for KafkaMessage<'_, K, V> {
             .boxed()
             .map_err(|e| cdc::CommitError::UnableToCommitChange { source: e })?;
         Ok(())
+    }
+}
+
+pub struct Kafka {
+    schema: SchemaRef,
+    consumer: &'static KafkaConsumer,
+}
+
+impl std::fmt::Debug for Kafka {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Kafka")
+            .field("schema", &self.schema)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Kafka {
+    #[must_use]
+    pub fn new(schema: SchemaRef, consumer: KafkaConsumer) -> Self {
+        Self {
+            schema,
+            consumer: Box::leak(Box::new(consumer)),
+        }
+    }
+
+    #[must_use]
+    pub fn stream_changes(&self) -> ChangesStream {
+        let schema = Arc::clone(&self.schema);
+        let stream = self
+            .consumer
+            .stream_json::<serde_json::Value, serde_json::Value>()
+            .map(move |msg| {
+                let schema = Arc::clone(&schema);
+                let Ok(msg) = msg else {
+                    return Err(cdc::StreamError::Kafka(format!(
+                        "Unable to read message: {:?}",
+                        msg.err()
+                    )));
+                };
+
+                // convert JSON string to Arrow record batch
+                let json_str = msg.value().to_string();
+                let rb = ReaderBuilder::new(Arc::clone(&schema))
+                    .build(std::io::Cursor::new(json_str.as_bytes()))
+                    .map_err(|e| cdc::StreamError::Arrow(e.to_string()))?
+                    .next()
+                    .transpose()
+                    .map_err(|e| cdc::StreamError::Arrow(e.to_string()))?
+                    .ok_or_else(|| {
+                        cdc::StreamError::Arrow("No record batch found in JSON message".to_string())
+                    })?;
+
+                // Wrap the record batch to emulate a change event
+                cdc::wrap_data_as_change_batch(&schema, &rb)
+                    .map(|rb| ChangeEnvelope::new(Box::new(msg), rb))
+                    .map_err(|e| cdc::StreamError::SerdeJsonError(e.to_string()))
+            });
+
+        Box::pin(stream)
+    }
+}
+
+#[async_trait]
+impl TableProvider for Kafka {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema))) as Arc<dyn ExecutionPlan>)
     }
 }

--- a/crates/data_components/src/lib.rs
+++ b/crates/data_components/src/lib.rs
@@ -40,7 +40,7 @@ pub mod flight;
 #[cfg(feature = "flightsql")]
 pub mod flightsql;
 pub mod iceberg;
-#[cfg(feature = "debezium")]
+#[cfg(any(feature = "debezium", feature = "kafka"))]
 pub mod kafka;
 #[cfg(feature = "mongodb")]
 pub mod mongodb;

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -213,11 +213,13 @@ clickhouse = [
 cuda = ["llms/cuda"]
 databricks = ["data_components/databricks"]
 debezium = ["data_components/debezium"]
+kafka = ["data_components/kafka"]
 default = [
     "keyring-secret-store",
     "aws-secrets-manager",
     "sharepoint",
     "bedrock",
+    "kafka",
 ]
 delta_lake = ["data_components/delta_lake"]
 dev = ["openapi", "otel-arrow/dev", "mcp"]

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -424,7 +424,16 @@ async fn get_metadata_from_kafka(
         }
     };
 
-    let primary_keys = msg.key().get_primary_key();
+    let Some(key) = msg.key() else {
+        return Err(super::DataConnectorError::UnableToGetReadProvider {
+            dataconnector: "debezium".to_string(),
+            source: "CDC message key is missing. Verify Debezium CDC configuration and try again."
+                .into(),
+            connector_component: ConnectorComponent::from(dataset),
+        });
+    };
+
+    let primary_keys = key.get_primary_key();
 
     let Some(schema_fields) = msg.value().get_schema_fields() else {
         return Err(super::DataConnectorError::UnableToGetReadProvider {

--- a/crates/runtime/src/dataconnector/kafka.rs
+++ b/crates/runtime/src/dataconnector/kafka.rs
@@ -1,0 +1,335 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{any::Any, pin::Pin, sync::Arc};
+
+use arrow_schema::SchemaRef;
+use async_stream::stream;
+use data_components::{
+    cdc::ChangesStream,
+    kafka::{KafkaConfig, KafkaConsumer},
+};
+use datafusion::catalog::TableProvider;
+use futures::StreamExt;
+use snafu::prelude::*;
+use tonic::async_trait;
+
+use crate::{
+    component::dataset::{Dataset, acceleration::RefreshMode},
+    dataconnector::{
+        ConnectorComponent, DataConnector, DataConnectorFactory, parameters::ConnectorParams,
+    },
+    datafusion::refresh_sql,
+    federated_table::FederatedTable,
+    parameters::{ParameterSpec, Parameters},
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "Missing required parameter: 'kafka_bootstrap_servers'. Specify a value.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/kafka#parameters"
+    ))]
+    MissingKafkaBootstrapServers,
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub struct Kafka {
+    kafka_config: KafkaConfig,
+}
+
+impl Kafka {
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new(params: Parameters) -> Result<Self> {
+        let kafka_config = KafkaConfig {
+            brokers: params
+                .get("kafka_bootstrap_servers")
+                .expose()
+                .ok()
+                .context(MissingKafkaBootstrapServersSnafu)?
+                .to_string(),
+            security_protocol: params
+                .get("kafka_security_protocol")
+                .expose()
+                .ok()
+                .unwrap_or("sasl_ssl")
+                .to_string(),
+            sasl_mechanism: params
+                .get("kafka_sasl_mechanism")
+                .expose()
+                .ok()
+                .unwrap_or("SCRAM-SHA-512")
+                .to_string(),
+            sasl_username: params
+                .get("kafka_sasl_username")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
+            sasl_password: params
+                .get("kafka_sasl_password")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
+            ssl_ca_location: params
+                .get("kafka_ssl_ca_location")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
+            enable_ssl_certificate_verification: params
+                .get("kafka_enable_ssl_certificate_verification")
+                .expose()
+                .ok()
+                .unwrap_or("true")
+                .to_string()
+                .parse()
+                .unwrap_or(true),
+            ssl_endpoint_identification_algorithm: params
+                .get("kafka_ssl_endpoint_identification_algorithm")
+                .expose()
+                .ok()
+                .unwrap_or("https")
+                .try_into()
+                .unwrap_or_else(|()| {
+                    tracing::warn!("Invalid value for 'kafka_ssl_endpoint_identification_algorithm'. Supported values: 'none', 'https'. Defaulting to 'https'.");
+                    data_components::kafka::SslIdentification::Https
+                }),
+        };
+
+        Ok(Self { kafka_config })
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone)]
+pub struct KafkaFactory {}
+
+impl KafkaFactory {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    #[must_use]
+    pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
+        Arc::new(Self {}) as Arc<dyn DataConnectorFactory>
+    }
+}
+
+const PARAMETERS: &[ParameterSpec] = &[
+    ParameterSpec::runtime("kafka_bootstrap_servers")
+        .required()
+        .description(
+            "A list of host/port pairs for establishing the initial Kafka cluster connection.",
+        ),
+     ParameterSpec::runtime("kafka_security_protocol")
+        .default("sasl_ssl")
+        .description("Security protocol for Kafka connections. Default: 'sasl_ssl'. Options: 'plaintext', 'ssl', 'sasl_plaintext', 'sasl_ssl'."),
+    ParameterSpec::runtime("kafka_sasl_mechanism")
+        .default("SCRAM-SHA-512")
+        .description("SASL authentication mechanism. Default: 'SCRAM-SHA-512'. Options: 'PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512'."),
+    ParameterSpec::runtime("kafka_sasl_username")
+        .secret()
+        .description("SASL username."),
+    ParameterSpec::runtime("kafka_sasl_password")
+        .secret()
+        .description("SASL password."),
+    ParameterSpec::runtime("kafka_ssl_ca_location")
+        .secret()
+        .description("Path to the SSL/TLS CA certificate file for server verification."),
+    ParameterSpec::runtime("kafka_enable_ssl_certificate_verification")
+        .default("true")
+        .description("Enable SSL/TLS certificate verification. Default: 'true'."),
+    ParameterSpec::runtime("kafka_ssl_endpoint_identification_algorithm")
+        .default("https")
+        .description("SSL/TLS endpoint identification algorithm. Default: 'https'. Options: 'none', 'https'."),
+];
+
+impl DataConnectorFactory for KafkaFactory {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn create(
+        &self,
+        params: ConnectorParams,
+    ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
+        Box::pin(async move {
+            let kafka = Kafka::new(params.parameters)?;
+            Ok(Arc::new(kafka) as Arc<dyn DataConnector>)
+        })
+    }
+
+    fn prefix(&self) -> &'static str {
+        "kafka"
+    }
+
+    fn parameters(&self) -> &'static [ParameterSpec] {
+        PARAMETERS
+    }
+
+    fn supports_unsupported_type_action(&self) -> bool {
+        false
+    }
+
+    fn reserved_keywords(&self) -> &'static [&'static str] {
+        &[]
+    }
+}
+
+#[async_trait]
+impl DataConnector for Kafka {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn read_provider(
+        &self,
+        dataset: &Dataset,
+    ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
+        ensure!(
+            dataset.is_accelerated(),
+            super::InvalidConfigurationNoSourceSnafu {
+                dataconnector: "kafka",
+                message: "The Kafka data connector requires an accelerated dataset.\nFor details, visit: https://spiceai.org/docs/components/data-connectors/kafka",
+                connector_component: ConnectorComponent::from(dataset),
+            }
+        );
+        let Some(ref acceleration) = dataset.acceleration else {
+            unreachable!("Dataset acceleration already verified. This should never be None here.");
+        };
+        ensure!(
+            acceleration.refresh_mode == Some(RefreshMode::Append),
+            super::InvalidConfigurationNoSourceSnafu {
+                dataconnector: "kafka",
+                message: "The Kafka connector is only compatible with refresh mode 'append'. For details, visit: https://spiceai.org/docs/components/data-connectors/kafka",
+                connector_component: ConnectorComponent::from(dataset),
+            }
+        );
+
+        let dataset_name = dataset.name.to_string();
+
+        if !dataset.is_file_accelerated() {
+            tracing::warn!(
+                "Dataset {dataset_name} is not file accelerated. This may result in full message replay from Kafka on restarts. It is recommended to use file acceleration with the Kafka connector for optimal performance. For details, visit: https://spiceai.org/docs/components/data-connectors/kafka",
+            );
+        }
+
+        let topic = dataset.path();
+
+        let (kafka_consumer, schema) =
+            bootstrap_kafka_consumer(dataset, topic, self.kafka_config.clone()).await?;
+
+        let refresh_sql = dataset.refresh_sql();
+        let schema = if let Some(refresh_sql) = &refresh_sql {
+            refresh_sql::validate_refresh_sql(dataset.name.clone(), refresh_sql.as_str(), schema)
+                .boxed()
+                .map_err(|e| super::DataConnectorError::InvalidConfiguration {
+                    dataconnector: "kafka".to_string(),
+                    message: format!("The refresh SQL is invalid: {e}"),
+                    connector_component: ConnectorComponent::from(dataset),
+                    source: e,
+                })?
+        } else {
+            schema
+        };
+
+        let kafka = Arc::new(data_components::kafka::Kafka::new(schema, kafka_consumer));
+
+        Ok(kafka)
+    }
+
+    fn supports_append_stream(&self) -> bool {
+        true
+    }
+
+    fn append_stream(&self, federated_table: Arc<FederatedTable>) -> Option<ChangesStream> {
+        Some(Box::pin(stream! {
+            let table_provider = federated_table.table_provider().await;
+            let Some(kafka) = table_provider.as_any().downcast_ref::<data_components::kafka::Kafka>() else {
+                return;
+            };
+
+            let mut changes_stream = kafka.stream_changes();
+
+            while let Some(item) = changes_stream.next().await {
+                yield item;
+            }
+        }))
+    }
+}
+
+async fn bootstrap_kafka_consumer(
+    dataset: &Dataset,
+    topic: &str,
+    kafka_config: KafkaConfig,
+) -> super::DataConnectorResult<(KafkaConsumer, SchemaRef)> {
+    let dataset_name = dataset.name.to_string();
+    let kafka_consumer = KafkaConsumer::create_with_generated_group_id(&dataset_name, kafka_config)
+        .boxed()
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "kafka",
+            connector_component: ConnectorComponent::from(dataset),
+        })?;
+
+    kafka_consumer
+        .subscribe(topic)
+        .boxed()
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "kafka",
+            connector_component: ConnectorComponent::from(dataset),
+        })?;
+
+    let msg = match kafka_consumer
+        .next_json::<serde_json::Value, serde_json::Value>()
+        .await
+    {
+        Ok(Some(msg)) => msg,
+        Ok(None) => {
+            return Err(super::DataConnectorError::UnableToGetReadProvider {
+                dataconnector: "kafka".to_string(),
+                source: "No message received from Kafka.".into(),
+                connector_component: ConnectorComponent::from(dataset),
+            });
+        }
+        Err(e) => {
+            return Err(e).boxed().context(super::UnableToGetReadProviderSnafu {
+                dataconnector: "kafka",
+                connector_component: ConnectorComponent::from(dataset),
+            });
+        }
+    };
+
+    // Infer Arrow schema from the JSON value in the message
+    let schema = datafusion::arrow::json::reader::infer_json_schema_from_iterator(std::iter::once(
+        Ok(msg.value()),
+    ))
+    .map_err(|e| super::DataConnectorError::UnableToGetReadProvider {
+        dataconnector: "kafka".to_string(),
+        source: format!("Failed to infer schema from Kafka message: {e}").into(),
+        connector_component: ConnectorComponent::from(dataset),
+    })?;
+
+    // Restart the stream from the beginning
+    kafka_consumer
+        .restart_topic(topic)
+        .boxed()
+        .context(super::UnableToGetReadProviderSnafu {
+            dataconnector: "kafka",
+            connector_component: ConnectorComponent::from(dataset),
+        })?;
+
+    Ok((kafka_consumer, Arc::new(schema)))
+}

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -79,6 +79,8 @@ pub mod ftp;
 pub mod github;
 pub mod graphql;
 pub mod https;
+#[cfg(feature = "kafka")]
+pub mod kafka;
 pub mod localpod;
 pub mod memory;
 #[cfg(feature = "mongodb")]
@@ -421,6 +423,8 @@ pub async fn register_all() {
     register_connector_factory("snowflake", snowflake::SnowflakeFactory::new_arc()).await;
     #[cfg(feature = "debezium")]
     register_connector_factory("debezium", debezium::DebeziumFactory::new_arc()).await;
+    #[cfg(feature = "kafka")]
+    register_connector_factory("kafka", kafka::KafkaFactory::new_arc()).await;
     register_connector_factory("localpod", localpod::LocalPodFactory::new_arc()).await;
     #[cfg(feature = "dynamodb")]
     register_connector_factory("dynamodb", dynamodb::DynamoDBFactory::new_arc()).await;


### PR DESCRIPTION
## 📝 Summary

Add support for Kafka Data Connector (basic functionality) that enables direct acceleration of `refresh_mode: append` data from Kafka topics. 

```yaml
 - from: kafka:orders_events
   name: orders
   acceleration: 
     enabled: true
     refresh_mode: append
   params: 
     kafka_bootstrap_servers: server:9092
```

Can be used with additional indexes and constraints similar to other accelerated connectors

```yaml
 - from: kafka:orders_events
    name: orders
    acceleration: 
      enabled: true
      refresh_mode: append
      engine: duckdb
      primary_key: _index
      on_conflict:
        _index: upsert
    params: 
      kafka_bootstrap_servers: localhost:9092
```

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/6779

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Functionality and logic are very similar to the Debezium Data Connector (CDC). I’ll attempt to re-use more functionality and logic between them in the next part (below). The main difference is that the baseline Kafka connector has simplified logic and does not require additional CDC metadata or payload such as schema_fields, primary_keys, and related processing.
 - https://github.com/spiceai/spiceai/issues/6858
