### PR TITLE
Add override parameter to force support for the Responses API

### DIFF
--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -33,6 +33,15 @@ use spicepod::component::model::{Model as SpicepodModel, ModelSource};
 static DEFAULT_OPENAI_ENDPOINT: &str = "https://api.openai.com/v1";
 
 fn supports_responses_api(spicepod_model: &SpicepodModel) -> bool {
+    if *spicepod_model
+        .params
+        .get("supports_responses")
+        .unwrap_or(&Value::Bool(false))
+        == Value::Bool(true)
+    {
+        return true;
+    }
+
     if spicepod_model.get_source() != Some(ModelSource::OpenAi) {
         return false;
     }

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -32,13 +32,14 @@ use spicepod::component::model::{Model as SpicepodModel, ModelSource};
 
 static DEFAULT_OPENAI_ENDPOINT: &str = "https://api.openai.com/v1";
 
-fn supports_responses_api(spicepod_model: &SpicepodModel) -> bool {
-    let responses_api_override = spicepod_model.params.get("responses_api");
-    if let Some(value) = responses_api_override {
-        if let Value::String(s) = value {
-            return s.to_lowercase() == "enabled";
-        }
-        return false;
+fn supports_responses_api(
+    spicepod_model: &SpicepodModel,
+    params: &HashMap<String, SecretString>,
+) -> bool {
+    if let Some(value) = params.get("responses_api") {
+        return secrecy::ExposeSecret::expose_secret(value)
+            .trim()
+            .eq_ignore_ascii_case("enabled");
     }
 
     if spicepod_model.get_source() != Some(ModelSource::OpenAi) {
@@ -62,7 +63,7 @@ impl Runtime {
             .await
             .ok();
 
-        let responses_model = if supports_responses_api(&m) {
+        let responses_model = if supports_responses_api(&m, &params) {
             try_to_responses_model(&m, &params, Arc::new(self.clone()))
                 .await
                 .ok()

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -35,7 +35,10 @@ static DEFAULT_OPENAI_ENDPOINT: &str = "https://api.openai.com/v1";
 fn supports_responses_api(spicepod_model: &SpicepodModel) -> bool {
     let responses_api_override = spicepod_model.params.get("responses_api");
     if let Some(value) = responses_api_override {
-        return value == &Value::String("enabled".to_string());
+        if let Value::String(s) = value {
+            return s.to_lowercase() == "enabled";
+        }
+        return false;
     }
 
     if spicepod_model.get_source() != Some(ModelSource::OpenAi) {

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -33,13 +33,9 @@ use spicepod::component::model::{Model as SpicepodModel, ModelSource};
 static DEFAULT_OPENAI_ENDPOINT: &str = "https://api.openai.com/v1";
 
 fn supports_responses_api(spicepod_model: &SpicepodModel) -> bool {
-    if *spicepod_model
-        .params
-        .get("supports_responses")
-        .unwrap_or(&Value::Bool(false))
-        == Value::Bool(true)
-    {
-        return true;
+    let responses_api_override = spicepod_model.params.get("responses_api");
+    if let Some(value) = responses_api_override {
+        return value == &Value::String("enabled".to_string());
     }
 
     if spicepod_model.get_source() != Some(ModelSource::OpenAi) {

--- a/crates/runtime/src/model/params/openai.rs
+++ b/crates/runtime/src/model/params/openai.rs
@@ -39,7 +39,7 @@ pub(crate) const OPENAI_PARAMETERS: [ParameterSpec; OPENAI_PARAM_LEN] = [
     ParameterSpec::component("usage_tier")
         .description("The current usage tier for the OpenAI account associated with the API key: 'free', 'tier1', 'tier2', 'tier3', 'tier4', or 'tier5'.")
         .default("tier1"),
-    ParameterSpec::runtime("supports_responses")
-        .description("Whether the model provider supports OpenAI's Responses API.")
-        .default("false"),
+    ParameterSpec::runtime("responses_api")
+        .description("Whether to enable use of this model via the Responses API. If `endpoint` is set to OpenAI's API endpoint, this is `enabled` by default. If not, it is `disabled`.")
+        .default("disabled"),
 ];

--- a/crates/runtime/src/model/params/openai.rs
+++ b/crates/runtime/src/model/params/openai.rs
@@ -23,7 +23,7 @@ pub(crate) const PARAMETERS: &[ParameterSpec] =
         COMMON_MODEL_PARAMETERS,
     );
 
-const OPENAI_PARAM_LEN: usize = 5;
+const OPENAI_PARAM_LEN: usize = 6;
 
 pub(crate) const OPENAI_PARAMETERS: [ParameterSpec; OPENAI_PARAM_LEN] = [
     ParameterSpec::runtime("endpoint")
@@ -39,4 +39,7 @@ pub(crate) const OPENAI_PARAMETERS: [ParameterSpec; OPENAI_PARAM_LEN] = [
     ParameterSpec::component("usage_tier")
         .description("The current usage tier for the OpenAI account associated with the API key: 'free', 'tier1', 'tier2', 'tier3', 'tier4', or 'tier5'.")
         .default("tier1"),
+    ParameterSpec::runtime("supports_responses")
+        .description("Whether the model provider supports OpenAI's Responses API.")
+        .default("false"),
 ];


### PR DESCRIPTION
## 📝 Summary
- See title
- By default, Spice will only add a model to the Responses API registry if it is from OpenAI and OpenAI's API only. However, in certain cases, custom endpoints supporting the Responses API may be available (e.g, like Spice's `/v1/responses`). In these cases, the default behavior will fail. This PR adds support for a parameter that forces the specified model into the Responses API registry, assuming the health succeeds.

Sample Spicepod:
```yaml
models:
    - from: openai:my-model
      name: my-model
      params:
          responses_api: enabled # enabled by default for OpenAI and Azure OpenAI, disabled for every other provider
          endpoint: https://endpoint.responses-api-compatible.com/v1
```

## 🔗 Related
- Closes #6849 
