### PR TITLE
Fix mongodb benchmark

### DIFF
--- a/test/spicepods/tpch/sf1/accelerated/mongodb-arrow.yaml
+++ b/test/spicepods/tpch/sf1/accelerated/mongodb-arrow.yaml
@@ -8,6 +8,7 @@ definitions:
   - &mongodb_params
     mongodb_host: ${env:MONGODB_HOST}
     mongodb_port: 27017
+    mongodb_auth_source: admin
     mongodb_db: tpch_sf1
     mongodb_user: root
     mongodb_pass: ${env:MONGODB_PASSWORD}

--- a/test/spicepods/tpch/sf1/accelerated/mongodb-duckdb[file].yaml
+++ b/test/spicepods/tpch/sf1/accelerated/mongodb-duckdb[file].yaml
@@ -8,6 +8,7 @@ definitions:
   - &mongodb_params
     mongodb_host: ${env:MONGODB_HOST}
     mongodb_port: 27017
+    mongodb_auth_source: admin
     mongodb_db: tpch_sf1
     mongodb_user: root
     mongodb_pass: ${env:MONGODB_PASSWORD}

--- a/test/spicepods/tpch/sf1/federated/mongodb.yaml
+++ b/test/spicepods/tpch/sf1/federated/mongodb.yaml
@@ -8,6 +8,7 @@ definitions:
   - &mongodb_params
     mongodb_host: ${env:MONGODB_HOST}
     mongodb_port: 27017
+    mongodb_auth_source: admin
     mongodb_db: tpch_sf1
     mongodb_user: root
     mongodb_pass: ${env:MONGODB_PASSWORD}


### PR DESCRIPTION
## 📝 Summary

The benchmark spicepod needed to specify the `mongodb_auth_source` explicitly to work.
