### PR TITLE
Enable configuration of the Responses API for the Azure model provider

### DIFF
--- a/crates/runtime/src/model/params/azure.rs
+++ b/crates/runtime/src/model/params/azure.rs
@@ -25,7 +25,7 @@ pub(crate) const PARAMETERS: &[ParameterSpec] =
         { AZURE_PARAM_LEN + PARAM_WITH_DEPRE_LEN },
     >(AZURE_PARAMETERS, COMMON_MODEL_PARAMETERS_WITH_DEPRECATED);
 
-const AZURE_PARAM_LEN: usize = 5;
+const AZURE_PARAM_LEN: usize = 7;
 
 pub(crate) const AZURE_PARAMETERS: [ParameterSpec; AZURE_PARAM_LEN] = [
     ParameterSpec::runtime("endpoint").description(
@@ -38,4 +38,12 @@ pub(crate) const AZURE_PARAMETERS: [ParameterSpec; AZURE_PARAM_LEN] = [
         .description("The Azure OpenAI API key from the models deployment page."),
     ParameterSpec::component("entra_token")
         .description("The Azure Entra token for authentication."),
+    ParameterSpec::component("openai_responses_tools")
+        .description(
+            "The OpenAI Responses tools to use when calling the model from the Responses API",
+        )
+        .default(""),
+    ParameterSpec::runtime("responses_api")
+        .description("Whether to enable use of this model via the Responses API. If `endpoint` is set to OpenAI's API endpoint, this is `enabled` by default. If not, it is `disabled`.")
+        .default("disabled"),
 ];

--- a/crates/runtime/src/model/params/azure.rs
+++ b/crates/runtime/src/model/params/azure.rs
@@ -47,5 +47,5 @@ pub(crate) const AZURE_PARAMETERS: [ParameterSpec; AZURE_PARAM_LEN] = [
         .description(
             "Whether to enable use of this model via the Responses API. `enabled` by default.",
         )
-        .default("disabled"),
+        .default("enabled"),
 ];

--- a/crates/runtime/src/model/params/azure.rs
+++ b/crates/runtime/src/model/params/azure.rs
@@ -40,10 +40,12 @@ pub(crate) const AZURE_PARAMETERS: [ParameterSpec; AZURE_PARAM_LEN] = [
         .description("The Azure Entra token for authentication."),
     ParameterSpec::component("openai_responses_tools")
         .description(
-            "The OpenAI Responses tools to use when calling the model from the Responses API",
+            "The OpenAI Responses hosted tools to allow when calling the model from the Responses API",
         )
         .default(""),
     ParameterSpec::runtime("responses_api")
-        .description("Whether to enable use of this model via the Responses API. If `endpoint` is set to OpenAI's API endpoint, this is `enabled` by default. If not, it is `disabled`.")
+        .description(
+            "Whether to enable use of this model via the Responses API. `enabled` by default.",
+        )
         .default("disabled"),
 ];

--- a/crates/runtime/src/model/params/azure.rs
+++ b/crates/runtime/src/model/params/azure.rs
@@ -40,7 +40,7 @@ pub(crate) const AZURE_PARAMETERS: [ParameterSpec; AZURE_PARAM_LEN] = [
         .description("The Azure Entra token for authentication."),
     ParameterSpec::component("openai_responses_tools")
         .description(
-            "The OpenAI Responses hosted tools to allow when calling the model from the Responses API",
+            "Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.",
         )
         .default(""),
     ParameterSpec::runtime("responses_api")


### PR DESCRIPTION
## 📝 Summary
- See title

Spicepod:
```yaml
models:
  - from: azure:gpt-4o-mini
    name: gpt-4o-mini
    params:
      endpoint: ${ secrets:SPICE_AZURE_AI_ENDPOINT }
      azure_api_version: 2024-08-01-preview
      azure_deployment_name: gpt-4o-mini
      azure_api_key: ${ secrets:SPICE_AZURE_API_KEY }
      azure_openai_responses_tools: web_search, code_interpreter # NEW
      responses_api: enabled # NEW
```

## 🔗 Related
- Related to #6875 


