### PR TITLE
Run E2E Test CI macOS build on bigger runners

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -77,7 +77,7 @@ jobs:
                 target_arch_go: "amd64"
               }, {
                 name: "macOS aarch64 (Apple Silicon)",
-                builder: "macos-14",
+                builder: "spiceai-macos",
                 runner: "macos-14",
                 target_os: "darwin",
                 target_arch: "aarch64",


### PR DESCRIPTION
## 📝 Summary

Runs the build for the macOS aarch64 E2E Test CI on the `spiceai-macos` runners.

Test run: https://github.com/spiceai/spiceai/actions/runs/17181875628