### PR TITLE
Better error message when credentials aren't loaded for S3 Vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,6 +3656,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-credential-bridge",
  "aws-sdk-dynamodb",
  "base64 0.22.1",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -17,6 +17,7 @@ arrow-flight.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 aws-config = { workspace = true, optional = true }
+aws-credential-types.workspace = true
 aws-sdk-credential-bridge = { path = "../aws-sdk-credential-bridge" }
 aws-sdk-dynamodb = { workspace = true, optional = true }
 base64.workspace = true

--- a/crates/data_components/src/s3_vectors/mod.rs
+++ b/crates/data_components/src/s3_vectors/mod.rs
@@ -79,6 +79,9 @@ pub enum Error {
         "S3 vector does not exist, and cannot be created from an S3 vector ARN. Specify a s3 vector bucket and index name."
     ))]
     CreateIndexUsingArn,
+
+    #[snafu(display("Failed to load AWS credentials. {message}"))]
+    UnableToLoadCredentials { message: String },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, error::Error as StdError, sync::Arc};
 
 use crate::s3_vectors::{
     MetadataColumn, MetadataColumns, S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
@@ -22,6 +22,7 @@ use crate::s3_vectors::{
 
 use super::{Error, Result, S3VectorIdentifier};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use aws_credential_types::provider::error::CredentialsError;
 use datafusion::common::{Constraint, Constraints};
 use s3_vectors::{
     CreateIndexInput, CreateVectorBucketInput, DistanceMetric, Document, GetIndexError,
@@ -259,9 +260,26 @@ impl S3VectorsTable {
             {
                 Ok(false)
             }
-            Err(e) => Err(Error::S3VectorGetBucketError {
-                source: e.into_service_error(),
-            }),
+            Err(e) => match &e {
+                SdkError::DispatchFailure(d) => {
+                    if let Some(credentials_error) = d
+                        .as_connector_error()
+                        .and_then(|e| e.source())
+                        .and_then(|s| s.downcast_ref::<CredentialsError>())
+                        .map(ToString::to_string)
+                    {
+                        return Err(Error::UnableToLoadCredentials {
+                            message: credentials_error,
+                        });
+                    }
+                    Err(Error::S3VectorGetBucketError {
+                        source: e.into_service_error(),
+                    })
+                }
+                _ => Err(Error::S3VectorGetBucketError {
+                    source: e.into_service_error(),
+                }),
+            },
         }
     }
 

--- a/crates/runtime/src/embeddings/index/retry_client.rs
+++ b/crates/runtime/src/embeddings/index/retry_client.rs
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::error::Error;
+
 use async_trait::async_trait;
+use aws_credential_types::provider::error::CredentialsError;
 use s3_vectors::{
     Client, CreateIndexError, CreateIndexInput, CreateIndexOutput, CreateVectorBucketError,
     CreateVectorBucketInput, CreateVectorBucketOutput, DeleteIndexError, DeleteIndexInput,
@@ -114,7 +117,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | CreateIndexError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -149,7 +166,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | CreateVectorBucketError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -184,7 +215,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | DeleteIndexError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -219,7 +264,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | DeleteVectorBucketError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -254,7 +313,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | DeleteVectorBucketPolicyError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -294,7 +367,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | DeleteVectorsError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -330,7 +417,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | GetIndexError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -365,7 +466,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | GetVectorBucketError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -400,7 +515,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | GetVectorBucketPolicyError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -443,7 +572,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | GetVectorsError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -482,7 +625,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | ListIndexesError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -517,7 +674,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | ListVectorBucketsError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -559,7 +730,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | ListVectorsError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -595,7 +780,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | PutVectorBucketPolicyError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -636,7 +835,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | PutVectorsError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }
@@ -681,7 +894,21 @@ impl S3Vectors for S3VectorRetryClient {
                         | QueryVectorsError::ServiceQuotaExceededException(_)
                         | _ => Err(RetryError::permanent(e)),
                     },
-                    SdkError::DispatchFailure(_) => Err(RetryError::transient(e)),
+                    SdkError::DispatchFailure(d) => {
+                        let credentials_not_loaded = d
+                            .as_connector_error()
+                            .and_then(|e| e.source())
+                            .and_then(|s| s.downcast_ref::<CredentialsError>())
+                            .is_some_and(|ce| {
+                                matches!(ce, CredentialsError::CredentialsNotLoaded(_))
+                            });
+
+                        if credentials_not_loaded {
+                            Err(RetryError::permanent(e))
+                        } else {
+                            Err(RetryError::transient(e))
+                        }
+                    }
                     _ => Err(RetryError::permanent(e)),
                 },
             }


### PR DESCRIPTION
## 📝 Summary

Prevents the S3 Vectors client from retrying when the credentials aren't loading (which leads to a poor experience of waiting for the Spice instance to do something, just to finally error out).

Also fixes the error message to actually indicate what the error is.

## 🔗 Related

- Closes #6733
