### PR TITLE
Refactor how models supporting the Responses API are loaded

### DIFF
--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -69,7 +69,7 @@ impl Runtime {
         if let Some(model) = &responses_model {
             if model.health().await.is_err() {
                 tracing::warn!(
-                    "Failed to load Responses API endpoint for model '{}'. Verify the Spicepod configuration and try again",
+                    "Failed to load Responses API endpoint for model '{}'. Verify the Spicepod configuration and try again.",
                     m.name.clone()
                 );
                 responses_model = None;

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -26,33 +26,16 @@ use llms::{
     responses::Responses,
 };
 use secrecy::SecretString;
-use serde_json::Value;
 use snafu::ResultExt;
-use spicepod::component::model::{Model as SpicepodModel, ModelSource};
+use spicepod::component::model::Model as SpicepodModel;
 
-static DEFAULT_OPENAI_ENDPOINT: &str = "https://api.openai.com/v1";
-
-fn supports_responses_api(
-    spicepod_model: &SpicepodModel,
-    params: &HashMap<String, SecretString>,
-) -> bool {
-    if let Some(value) = params.get("responses_api") {
-        return secrecy::ExposeSecret::expose_secret(value)
-            .trim()
-            .eq_ignore_ascii_case("enabled");
-    }
-
-    if !matches!(
-        spicepod_model.get_source(),
-        Some(ModelSource::OpenAi | ModelSource::Azure)
-    ) {
-        return false;
-    }
-    match spicepod_model.params.get("endpoint") {
-        None => true,
-        Some(Value::String(s)) => s == DEFAULT_OPENAI_ENDPOINT,
-        _ => false,
-    }
+fn supports_responses_api(params: &HashMap<String, SecretString>) -> bool {
+    return params
+        .get("responses_api")
+        .map(secrecy::ExposeSecret::expose_secret)
+        .unwrap_or_default()
+        .trim()
+        .eq_ignore_ascii_case("enabled");
 }
 
 impl Runtime {
@@ -61,12 +44,21 @@ impl Runtime {
         &self,
         m: SpicepodModel,
         params: HashMap<String, SecretString>,
-    ) -> Result<(Option<Arc<dyn Chat>>, Option<Arc<dyn Responses>>)> {
+    ) -> Result<(Arc<dyn Chat>, Option<Arc<dyn Responses>>)> {
         let completions_model = try_to_chat_model(&m, &params, Arc::new(self.clone()))
             .await
-            .ok();
+            .boxed()
+            .map_err(try_map_boxed_error_to_box)
+            .context(UnableToInitializeLlmSnafu)?;
 
-        let responses_model = if supports_responses_api(&m, &params) {
+        completions_model
+            .health()
+            .await
+            .boxed()
+            .map_err(try_map_boxed_error_to_box)
+            .context(UnableToInitializeLlmSnafu)?;
+
+        let mut responses_model = if supports_responses_api(&params) {
             try_to_responses_model(&m, &params, Arc::new(self.clone()))
                 .await
                 .ok()
@@ -74,21 +66,14 @@ impl Runtime {
             None
         };
 
-        // Perform only one health check, preferring the Responses API to Chat Completions
         if let Some(model) = &responses_model {
-            model
-                .health()
-                .await
-                .boxed()
-                .map_err(try_map_boxed_error_to_box)
-                .context(UnableToInitializeLlmSnafu)?;
-        } else if let Some(model) = &completions_model {
-            model
-                .health()
-                .await
-                .boxed()
-                .map_err(try_map_boxed_error_to_box)
-                .context(UnableToInitializeLlmSnafu)?;
+            if model.health().await.is_err() {
+                tracing::warn!(
+                    "Failed to load Responses API endpoint for model '{}'. Verify the Spicepod configuration and try again",
+                    m.name.clone()
+                );
+                responses_model = None;
+            }
         }
 
         Ok((completions_model, responses_model))

--- a/crates/runtime/src/init/llm.rs
+++ b/crates/runtime/src/init/llm.rs
@@ -30,12 +30,12 @@ use snafu::ResultExt;
 use spicepod::component::model::Model as SpicepodModel;
 
 fn supports_responses_api(params: &HashMap<String, SecretString>) -> bool {
-    return params
+    params
         .get("responses_api")
         .map(secrecy::ExposeSecret::expose_secret)
         .unwrap_or_default()
         .trim()
-        .eq_ignore_ascii_case("enabled");
+        .eq_ignore_ascii_case("enabled")
 }
 
 impl Runtime {

--- a/crates/runtime/src/init/model.rs
+++ b/crates/runtime/src/init/model.rs
@@ -121,27 +121,19 @@ impl Runtime {
         tracing::trace!("Model type for {} is {:#?}", m.name, model_type.clone());
         let result: Result<(), Error> = match model_type {
             Some(ModelType::Llm) => match self.load_llm(m.clone(), params).await {
-                Ok((Some(l), Some(responses_model))) => {
+                Ok((completions_model, Some(responses_model))) => {
                     let mut llm_map = self.completion_llms.write().await;
-                    llm_map.insert(m.name.clone(), l);
+                    llm_map.insert(m.name.clone(), completions_model);
                     drop(llm_map);
                     let mut responses_llm_map = self.responses_llms.write().await;
                     responses_llm_map.insert(m.name.clone(), responses_model);
                     Ok(())
                 }
-                Ok((None, Some(responses))) => {
-                    let mut responses_llm_map = self.responses_llms.write().await;
-                    responses_llm_map.insert(m.name.clone(), responses);
-                    Ok(())
-                }
-                Ok((Some(l), None)) => {
+                Ok((model, None)) => {
                     let mut llm_map = self.completion_llms.write().await;
-                    llm_map.insert(m.name.clone(), l);
+                    llm_map.insert(m.name.clone(), model);
                     Ok(())
                 }
-                Ok((None, None)) => unreachable!(
-                    "All LLMs are required to implement either `Chat` or `Responses` or both in order to be inserted into a registry"
-                ),
                 Err(e) => Err(Error::FailedToLoadLLM {
                     name: m.name.clone(),
                     source: Box::new(e),

--- a/crates/runtime/src/model/params/azure.rs
+++ b/crates/runtime/src/model/params/azure.rs
@@ -45,7 +45,7 @@ pub(crate) const AZURE_PARAMETERS: [ParameterSpec; AZURE_PARAM_LEN] = [
         .default(""),
     ParameterSpec::runtime("responses_api")
         .description(
-            "Whether to enable use of this model via the Responses API. `enabled` by default.",
+            "Whether to enable use of this model via the Responses API. `disabled` by default.",
         )
-        .default("enabled"),
+        .default("disabled"),
 ];

--- a/crates/runtime/src/model/params/openai.rs
+++ b/crates/runtime/src/model/params/openai.rs
@@ -40,7 +40,7 @@ pub(crate) const OPENAI_PARAMETERS: [ParameterSpec; OPENAI_PARAM_LEN] = [
         .description("The current usage tier for the OpenAI account associated with the API key: 'free', 'tier1', 'tier2', 'tier3', 'tier4', or 'tier5'.")
         .default("tier1"),
     ParameterSpec::runtime("responses_api")
-        .description("Whether to enable use of this model via the Responses API. If `endpoint` is set to OpenAI's API endpoint, this is `enabled` by default. If not, it is `disabled`.")
+        .description("Whether to enable use of this model via the Responses API. `disabled` by default.")
         .default("disabled"),
     ParameterSpec::component("responses_tools")
         .description("The OpenAI Responses tools to use when calling the model from the Responses API")


### PR DESCRIPTION
## 📝 Summary
- Refactors the loading of models supporting the Responses API to be opt-in. The loading stage fails completely if the Chat completions health check fails, but only warns when the Responses API health check fails.

