### PR TITLE
Mark append-stream and CDC datasets as ready after first message

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -16,7 +16,6 @@ limitations under the License.
 
 use super::RefreshTask;
 use crate::accelerated_table::refresh::Refresh;
-use crate::component::dataset::acceleration::RefreshMode;
 use crate::datafusion::error::find_datafusion_root;
 use crate::{dataupdate::StreamingDataUpdateExecutionPlan, status};
 use arrow::array::{Int32Array, Int64Array, RecordBatch, StringArray};
@@ -74,10 +73,6 @@ impl RefreshTask {
         let dataset_name = self.dataset_name.clone();
         let sql = refresh.read().await.sql.clone();
 
-        // The DataConnector's `append_stream(&mut self, append_stream: ChangesStream)` implementation is based on the same `start_changes_stream`
-        // method, as both rely on the ChangesStream. The `is_append_mode_stream` flag can be used to differentiate between append and changes/CDC-specific logic.
-        let is_append_mode_stream = matches!(refresh.read().await.mode, RefreshMode::Append);
-
         self.set_refresh_status(sql.as_deref(), status::ComponentStatus::Refreshing)
             .await;
 
@@ -94,11 +89,9 @@ impl RefreshTask {
                             }
                             initial_load_completed.store(true, Ordering::Relaxed);
 
-                            // In Append mode, mark the dataset as ready immediately after the first message is received
-                            if is_append_mode_stream {
-                                self.update_component_status(status::ComponentStatus::Ready)
-                                    .await;
-                            }
+                            // Mark the dataset as ready after the first message is received. This covers both streaming append and CDC modes.
+                            self.update_component_status(status::ComponentStatus::Ready)
+                                .await;
 
                             if let Err(e) = change_envelope.commit() {
                                 tracing::debug!("Failed to commit CDC change envelope: {e}");

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -74,7 +74,7 @@ impl RefreshTask {
         let dataset_name = self.dataset_name.clone();
         let sql = refresh.read().await.sql.clone();
 
-        // The DataConnector's `append_stream(&mut self, append_stream: ChangesStream)` implementation is based on this same `start_changes_stream`
+        // The DataConnector's `append_stream(&mut self, append_stream: ChangesStream)` implementation is based on the same `start_changes_stream`
         // method, as both rely on the ChangesStream. The `is_append_mode_stream` flag can be used to differentiate between append and changes/CDC-specific logic.
         let is_append_mode_stream = matches!(refresh.read().await.mode, RefreshMode::Append);
 

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use super::RefreshTask;
 use crate::accelerated_table::refresh::Refresh;
+use crate::component::dataset::acceleration::RefreshMode;
 use crate::datafusion::error::find_datafusion_root;
 use crate::{dataupdate::StreamingDataUpdateExecutionPlan, status};
 use arrow::array::{Int32Array, Int64Array, RecordBatch, StringArray};
@@ -72,6 +73,11 @@ impl RefreshTask {
     ) -> crate::accelerated_table::Result<()> {
         let dataset_name = self.dataset_name.clone();
         let sql = refresh.read().await.sql.clone();
+
+        // The DataConnector's `append_stream(&mut self, append_stream: ChangesStream)` implementation is based on this same `start_changes_stream`
+        // method, as both rely on the ChangesStream. The `is_append_mode_stream` flag can be used to differentiate between append and changes/CDC-specific logic.
+        let is_append_mode_stream = matches!(refresh.read().await.mode, RefreshMode::Append);
+
         self.set_refresh_status(sql.as_deref(), status::ComponentStatus::Refreshing)
             .await;
 
@@ -87,6 +93,12 @@ impl RefreshTask {
                                 ready_sender.notify_waiters();
                             }
                             initial_load_completed.store(true, Ordering::Relaxed);
+
+                            // In Append mode, mark the dataset as ready immediately after the first message is received
+                            if is_append_mode_stream {
+                                self.update_component_status(status::ComponentStatus::Ready)
+                                    .await;
+                            }
 
                             if let Err(e) = change_envelope.commit() {
                                 tracing::debug!("Failed to commit CDC change envelope: {e}");


### PR DESCRIPTION
## 📝 Summary

In streaming append mode (for example Kafka connector), a dataset should be marked `Ready` as soon as the first message is successfully received. This ensures that the Spice runtime can successfully set the status to `Ready`, indicating that querying may begin.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
