### PR TITLE
fix: Use TPCH paths for TPCH parameterized spicepods

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -97,7 +97,11 @@ jobs:
       - name: Set spicepod path
         id: set_spicepod_path
         run: |
-          SPICEPOD_PATH="./test/spicepods/${{ github.event.inputs.query_set}}/sf${{ github.event.inputs.scale_factor }}/${{ github.event.inputs.spicepod_path }}"
+          if [[ ${{ github.event.inputs.query_set }} == "tpch[parameterized]" ]]; then
+            SPICEPOD_PATH="./test/spicepods/tpch/sf${{ github.event.inputs.scale_factor }}/${{ github.event.inputs.spicepod_path }}"
+          else
+            SPICEPOD_PATH="./test/spicepods/${{ github.event.inputs.query_set}}/sf${{ github.event.inputs.scale_factor }}/${{ github.event.inputs.spicepod_path }}"
+          fi
           echo "SPICEPOD_PATH=${SPICEPOD_PATH}" >> $GITHUB_OUTPUT
 
       - name: Install MinIO


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Sets the spicepod path for `tpch[parameterized]` spicepods to `tpch`, as they reuse the same spicepods.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6842
