### PR TITLE
[Debezium] Support for VariableScaleDecimal

### DIFF
--- a/crates/data_components/src/debezium/arrow.rs
+++ b/crates/data_components/src/debezium/arrow.rs
@@ -30,10 +30,10 @@ use arrow::{
 };
 use base64::prelude::*;
 use chrono::{DateTime, NaiveTime, Timelike, Utc};
-use snafu::prelude::*;
-use std::sync::Arc;
 use serde_json::Value as Json;
+use snafu::prelude::*;
 use std::cmp::Ordering::*;
+use std::sync::Arc;
 
 pub mod changes;
 
@@ -199,9 +199,7 @@ fn append_field_value_to_builder(
         }
         DataType::Decimal128(_, scale) => {
             let decimal_builder = downcast_builder::<Decimal128Builder>(builder)?;
-            decimal_builder.append_value(
-                convert_json_to_decimal(field_value, *scale)?,
-            );
+            decimal_builder.append_value(convert_json_to_decimal(field_value, *scale)?);
         }
         DataType::Timestamp(unit, time_zone) => match (unit, time_zone) {
             (TimeUnit::Microsecond, None) => {
@@ -443,16 +441,18 @@ fn rescale_i128(unscaled: i128, src_scale: i8, dst_scale: i8) -> Result<i128> {
         Equal => Ok(unscaled),
         Less => {
             let diff = dst_scale - src_scale;
-            let mul = pow10_i128(diff)
-                .context(InvalidDecimalJsonSnafu { reason: format!("overflow computing 10^{}", diff) })?;
-            unscaled.checked_mul(mul).context(
-                InvalidDecimalJsonSnafu { reason: "overflow during rescale (multiply)".to_string() }
-            )
+            let mul = pow10_i128(diff).context(InvalidDecimalJsonSnafu {
+                reason: format!("overflow computing 10^{}", diff),
+            })?;
+            unscaled.checked_mul(mul).context(InvalidDecimalJsonSnafu {
+                reason: "overflow during rescale (multiply)".to_string(),
+            })
         }
         Greater => {
             let diff = src_scale - dst_scale;
-            let div = pow10_i128(diff)
-                .context(InvalidDecimalJsonSnafu { reason: format!("overflow computing 10^{}", diff) })?;
+            let div = pow10_i128(diff).context(InvalidDecimalJsonSnafu {
+                reason: format!("overflow computing 10^{}", diff),
+            })?;
             Ok(unscaled / div)
         }
     }
@@ -463,26 +463,33 @@ fn rescale_i128(unscaled: i128, src_scale: i8, dst_scale: i8) -> Result<i128> {
 /// - JSON string: base64-encoded
 /// - JSON object: {"scale": <int>, "value": <base64>}
 pub fn convert_json_to_decimal(v: &Json, target_scale: i8) -> Result<i128> {
-    if target_scale < 0 || target_scale > 38 {
-        return InvalidDecimalJsonSnafu { reason: "target_scale must be in 0..=38".to_string() }.fail();
+    if !(0..=38).contains(&target_scale) {
+        return InvalidDecimalJsonSnafu {
+            reason: "target_scale must be in 0..=38".to_string(),
+        }
+        .fail();
     }
 
     match v {
-        Json::String(s) => {
-            convert_string_to_decimal(s)
-        }
+        Json::String(s) => convert_string_to_decimal(s),
 
         Json::Object(m) => {
             let src_scale = m
                 .get("scale")
-                .context(InvalidDecimalJsonSnafu { reason: "missing 'scale'".to_string() })?
+                .context(InvalidDecimalJsonSnafu {
+                    reason: "missing 'scale'".to_string(),
+                })?
                 .as_i64()
-                .context(InvalidDecimalJsonSnafu { reason: "'scale' must be integer".to_string() })? as i8;
+                .context(InvalidDecimalJsonSnafu {
+                    reason: "'scale' must be integer".to_string(),
+                })? as i8;
 
-            let value = m
-                .get("value")
-                .and_then(|x| x.as_str())
-                .context(InvalidDecimalJsonSnafu { reason: "missing string field 'value'".to_string() })?;
+            let value =
+                m.get("value")
+                    .and_then(|x| x.as_str())
+                    .context(InvalidDecimalJsonSnafu {
+                        reason: "missing string field 'value'".to_string(),
+                    })?;
 
             let unscaled = convert_string_to_decimal(value)?;
             let normalized = rescale_i128(unscaled, src_scale, target_scale)?;
@@ -490,7 +497,10 @@ pub fn convert_json_to_decimal(v: &Json, target_scale: i8) -> Result<i128> {
             Ok(normalized)
         }
 
-        _ => InvalidDecimalJsonSnafu { reason: "expected string or object".to_string() }.fail(),
+        _ => InvalidDecimalJsonSnafu {
+            reason: "expected string or object".to_string(),
+        }
+        .fail(),
     }
 }
 
@@ -568,7 +578,7 @@ fn convert_to_arrow_data_type(field: &ChangeEventField) -> Result<DataType> {
                 _ => DebeziumFieldNotSupportedSnafu {
                     field_type: field.field_type.clone(),
                 }
-                .fail()?
+                .fail()?,
             }
         }
         _ => DebeziumFieldNotSupportedSnafu {

--- a/crates/data_components/src/debezium/arrow.rs
+++ b/crates/data_components/src/debezium/arrow.rs
@@ -32,7 +32,7 @@ use base64::prelude::*;
 use chrono::{DateTime, NaiveTime, Timelike, Utc};
 use serde_json::Value as Json;
 use snafu::prelude::*;
-use std::cmp::Ordering::*;
+use std::cmp::Ordering::{Equal, Greater, Less};
 use std::sync::Arc;
 
 pub mod changes;
@@ -442,7 +442,7 @@ fn rescale_i128(unscaled: i128, src_scale: i8, dst_scale: i8) -> Result<i128> {
         Less => {
             let diff = dst_scale - src_scale;
             let mul = pow10_i128(diff).context(InvalidDecimalJsonSnafu {
-                reason: format!("overflow computing 10^{}", diff),
+                reason: format!("overflow computing 10^{diff}"),
             })?;
             unscaled.checked_mul(mul).context(InvalidDecimalJsonSnafu {
                 reason: "overflow during rescale (multiply)".to_string(),
@@ -451,7 +451,7 @@ fn rescale_i128(unscaled: i128, src_scale: i8, dst_scale: i8) -> Result<i128> {
         Greater => {
             let diff = src_scale - dst_scale;
             let div = pow10_i128(diff).context(InvalidDecimalJsonSnafu {
-                reason: format!("overflow computing 10^{}", diff),
+                reason: format!("overflow computing 10^{diff}"),
             })?;
             Ok(unscaled / div)
         }
@@ -474,6 +474,7 @@ pub fn convert_json_to_decimal(v: &Json, target_scale: i8) -> Result<i128> {
         Json::String(s) => convert_string_to_decimal(s),
 
         Json::Object(m) => {
+            #[allow(clippy::cast_possible_truncation)]
             let src_scale = m
                 .get("scale")
                 .context(InvalidDecimalJsonSnafu {
@@ -605,7 +606,7 @@ mod tests {
         let n: i128 = 12_345;
         let input = json!(i128_to_base64(n));
         let result = convert_json_to_decimal(&input, 2);
-        assert_eq!(result.unwrap(), n);
+        assert_eq!(result.expect("Parse decimal"), n);
     }
 
     #[test]
@@ -613,7 +614,7 @@ mod tests {
         let n: i128 = 12_345;
         let input = json!({"scale": 2, "value": i128_to_base64(n)});
         let result = convert_json_to_decimal(&input, 2);
-        assert_eq!(result.unwrap(), 12_345);
+        assert_eq!(result.expect("Parse decimal"), 12_345);
     }
 
     #[test]
@@ -621,7 +622,7 @@ mod tests {
         let n: i128 = 12345;
         let input = json!({"scale": 2, "value": i128_to_base64(n)});
         let result = convert_json_to_decimal(&input, 4);
-        assert_eq!(result.unwrap(), 1_234_500);
+        assert_eq!(result.expect("Parse decimal"), 1_234_500);
     }
 
     #[test]
@@ -629,7 +630,7 @@ mod tests {
         let n: i128 = 1_234_500;
         let input = json!({"scale": 4, "value": i128_to_base64(n)});
         let result = convert_json_to_decimal(&input, 2);
-        assert_eq!(result.unwrap(), 12_345);
+        assert_eq!(result.expect("Parse decimal"), 12_345);
     }
 
     #[test]

--- a/crates/data_components/src/debezium/arrow.rs
+++ b/crates/data_components/src/debezium/arrow.rs
@@ -32,6 +32,8 @@ use base64::prelude::*;
 use chrono::{DateTime, NaiveTime, Timelike, Utc};
 use snafu::prelude::*;
 use std::sync::Arc;
+use serde_json::Value as Json;
+use std::cmp::Ordering::*;
 
 pub mod changes;
 
@@ -109,6 +111,9 @@ pub enum Error {
 
     #[snafu(display("A deletion change was received without a 'before' field."))]
     DeleteOpWithoutBeforeField,
+
+    #[snafu(display("Invalid decimal JSON: {reason}"))]
+    InvalidDecimalJson { reason: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -192,13 +197,10 @@ fn append_field_value_to_builder(
             let bool_builder = downcast_builder::<BooleanBuilder>(builder)?;
             bool_builder.append_option(field_value.as_bool());
         }
-        DataType::Decimal128(_, _) => {
+        DataType::Decimal128(_, scale) => {
             let decimal_builder = downcast_builder::<Decimal128Builder>(builder)?;
-            decimal_builder.append_option(
-                field_value
-                    .as_str()
-                    .map(convert_string_to_decimal)
-                    .transpose()?,
+            decimal_builder.append_value(
+                convert_json_to_decimal(field_value, *scale)?,
             );
         }
         DataType::Timestamp(unit, time_zone) => match (unit, time_zone) {
@@ -427,6 +429,71 @@ fn convert_string_to_decimal(field_value: &str) -> Result<i128> {
     Ok(decimal_i128)
 }
 
+#[inline]
+fn pow10_i128(exp: i8) -> Option<i128> {
+    let mut acc: i128 = 1;
+    for _ in 0..exp {
+        acc = acc.checked_mul(10)?;
+    }
+    Some(acc)
+}
+
+fn rescale_i128(unscaled: i128, src_scale: i8, dst_scale: i8) -> Result<i128> {
+    match src_scale.cmp(&dst_scale) {
+        Equal => Ok(unscaled),
+        Less => {
+            let diff = dst_scale - src_scale;
+            let mul = pow10_i128(diff)
+                .context(InvalidDecimalJsonSnafu { reason: format!("overflow computing 10^{}", diff) })?;
+            unscaled.checked_mul(mul).context(
+                InvalidDecimalJsonSnafu { reason: "overflow during rescale (multiply)".to_string() }
+            )
+        }
+        Greater => {
+            let diff = src_scale - dst_scale;
+            let div = pow10_i128(diff)
+                .context(InvalidDecimalJsonSnafu { reason: format!("overflow computing 10^{}", diff) })?;
+            Ok(unscaled / div)
+        }
+    }
+}
+
+/// Parse a decimal from JSON.
+/// Supported inputs:
+/// - JSON string: base64-encoded
+/// - JSON object: {"scale": <int>, "value": <base64>}
+pub fn convert_json_to_decimal(v: &Json, target_scale: i8) -> Result<i128> {
+    if target_scale < 0 || target_scale > 38 {
+        return InvalidDecimalJsonSnafu { reason: "target_scale must be in 0..=38".to_string() }.fail();
+    }
+
+    match v {
+        Json::String(s) => {
+            convert_string_to_decimal(s)
+        }
+
+        Json::Object(m) => {
+            let src_scale = m
+                .get("scale")
+                .context(InvalidDecimalJsonSnafu { reason: "missing 'scale'".to_string() })?
+                .as_i64()
+                .context(InvalidDecimalJsonSnafu { reason: "'scale' must be integer".to_string() })? as i8;
+
+            let value = m
+                .get("value")
+                .and_then(|x| x.as_str())
+                .context(InvalidDecimalJsonSnafu { reason: "missing string field 'value'".to_string() })?;
+
+            let unscaled = convert_string_to_decimal(value)?;
+            let normalized = rescale_i128(unscaled, src_scale, target_scale)?;
+            // ensure_precision(normalized, precision)?;
+            Ok(normalized)
+        }
+
+        _ => InvalidDecimalJsonSnafu { reason: "expected string or object".to_string() }.fail(),
+    }
+}
+
 fn convert_to_arrow_field(field: &ChangeEventField) -> Result<Field> {
     Ok(Field::new(
         field.field.as_deref().context(MissingFieldNameSnafu)?,
@@ -491,6 +558,19 @@ fn convert_to_arrow_data_type(field: &ChangeEventField) -> Result<DataType> {
             let item_type = convert_to_arrow_data_type(items)?;
             DataType::List(Arc::new(Field::new("item", item_type, items.optional)))
         }
+        "struct" => {
+            match field.name.as_deref() {
+                Some("io.debezium.data.VariableScaleDecimal") => {
+                    // Variable length decimals where each value has its own scale.
+                    // We picked these numbers to match with oracle and postgres default values.
+                    DataType::Decimal128(38, 20)
+                }
+                _ => DebeziumFieldNotSupportedSnafu {
+                    field_type: field.field_type.clone(),
+                }
+                .fail()?
+            }
+        }
         _ => DebeziumFieldNotSupportedSnafu {
             field_type: field.field_type.clone(),
         }
@@ -498,4 +578,94 @@ fn convert_to_arrow_data_type(field: &ChangeEventField) -> Result<DataType> {
     };
 
     Ok(data_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn i128_to_base64(n: i128) -> String {
+        let bytes = n.to_be_bytes();
+        BASE64_STANDARD.encode(bytes)
+    }
+
+    #[test]
+    fn test_string_valid_no_scale() {
+        let n: i128 = 12_345;
+        let input = json!(i128_to_base64(n));
+        let result = convert_json_to_decimal(&input, 2);
+        assert_eq!(result.unwrap(), n);
+    }
+
+    #[test]
+    fn test_object_valid_same_scale() {
+        let n: i128 = 12_345;
+        let input = json!({"scale": 2, "value": i128_to_base64(n)});
+        let result = convert_json_to_decimal(&input, 2);
+        assert_eq!(result.unwrap(), 12_345);
+    }
+
+    #[test]
+    fn test_object_rescale_up() {
+        let n: i128 = 12345;
+        let input = json!({"scale": 2, "value": i128_to_base64(n)});
+        let result = convert_json_to_decimal(&input, 4);
+        assert_eq!(result.unwrap(), 1_234_500);
+    }
+
+    #[test]
+    fn test_object_rescale_down() {
+        let n: i128 = 1_234_500;
+        let input = json!({"scale": 4, "value": i128_to_base64(n)});
+        let result = convert_json_to_decimal(&input, 2);
+        assert_eq!(result.unwrap(), 12_345);
+    }
+
+    #[test]
+    fn test_target_scale_too_low() {
+        let n: i128 = 1;
+        let input = json!(i128_to_base64(n));
+        let result = convert_json_to_decimal(&input, -1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_target_scale_too_high() {
+        let n: i128 = 1;
+        let input = json!(i128_to_base64(n));
+        let result = convert_json_to_decimal(&input, 39);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_object_missing_scale() {
+        let n: i128 = 12_345;
+        let input = json!({"value": i128_to_base64(n)});
+        let result = convert_json_to_decimal(&input, 2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_object_scale_not_integer() {
+        let n: i128 = 12_345;
+        let input = json!({"scale": "abc", "value": i128_to_base64(n)});
+        let result = convert_json_to_decimal(&input, 2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_object_missing_value() {
+        let input = json!({"scale": 2});
+        let result = convert_json_to_decimal(&input, 2);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wrong_json_type() {
+        let n: i128 = 12345;
+        let input = json!(n); // Not a string or object
+        let result = convert_json_to_decimal(&input, 2);
+        assert!(result.is_err());
+    }
 }

--- a/crates/data_components/src/debezium/arrow.rs
+++ b/crates/data_components/src/debezium/arrow.rs
@@ -114,6 +114,21 @@ pub enum Error {
 
     #[snafu(display("Invalid decimal JSON: {reason}"))]
     InvalidDecimalJson { reason: String },
+
+    #[snafu(display("Overflow during decimal parsing"))]
+    VariableScaleDecimalParsingOverflow,
+
+    #[snafu(display("Missing the `scale` parameter for VariableScaleDecimal"))]
+    MissingScaleForVariableScaleDecimal,
+
+    #[snafu(display("Missing the `value` parameter for VariableScaleDecimal"))]
+    MissingValueForVariableScaleDecimal,
+
+    #[snafu(display("VariableScaleDecimal expects either string or object"))]
+    UnsupportedTypeForVariableScaleDecimal,
+
+    #[snafu(display("scale must be integer"))]
+    NonIntegerScaleForVariableScaleDecimal,
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -441,18 +456,14 @@ fn rescale_i128(unscaled: i128, src_scale: i8, dst_scale: i8) -> Result<i128> {
         Equal => Ok(unscaled),
         Less => {
             let diff = dst_scale - src_scale;
-            let mul = pow10_i128(diff).context(InvalidDecimalJsonSnafu {
-                reason: format!("overflow computing 10^{diff}"),
-            })?;
-            unscaled.checked_mul(mul).context(InvalidDecimalJsonSnafu {
-                reason: "overflow during rescale (multiply)".to_string(),
-            })
+            let mul = pow10_i128(diff).context(VariableScaleDecimalParsingOverflowSnafu)?;
+            unscaled
+                .checked_mul(mul)
+                .context(VariableScaleDecimalParsingOverflowSnafu)
         }
         Greater => {
             let diff = src_scale - dst_scale;
-            let div = pow10_i128(diff).context(InvalidDecimalJsonSnafu {
-                reason: format!("overflow computing 10^{diff}"),
-            })?;
+            let div = pow10_i128(diff).context(VariableScaleDecimalParsingOverflowSnafu)?;
             Ok(unscaled / div)
         }
     }
@@ -475,33 +486,23 @@ pub fn convert_json_to_decimal(v: &Json, target_scale: i8) -> Result<i128> {
 
         Json::Object(m) => {
             #[allow(clippy::cast_possible_truncation)]
-            let src_scale = m
-                .get("scale")
-                .context(InvalidDecimalJsonSnafu {
-                    reason: "missing 'scale'".to_string(),
-                })?
-                .as_i64()
-                .context(InvalidDecimalJsonSnafu {
-                    reason: "'scale' must be integer".to_string(),
-                })? as i8;
+            let src_scale =
+                m.get("scale")
+                    .context(MissingScaleForVariableScaleDecimalSnafu)?
+                    .as_i64()
+                    .context(NonIntegerScaleForVariableScaleDecimalSnafu)? as i8;
 
-            let value =
-                m.get("value")
-                    .and_then(|x| x.as_str())
-                    .context(InvalidDecimalJsonSnafu {
-                        reason: "missing string field 'value'".to_string(),
-                    })?;
+            let value = m
+                .get("value")
+                .and_then(|x| x.as_str())
+                .context(MissingValueForVariableScaleDecimalSnafu)?;
 
             let unscaled = convert_string_to_decimal(value)?;
             let normalized = rescale_i128(unscaled, src_scale, target_scale)?;
-            // ensure_precision(normalized, precision)?;
             Ok(normalized)
         }
 
-        _ => InvalidDecimalJsonSnafu {
-            reason: "expected string or object".to_string(),
-        }
-        .fail(),
+        _ => UnsupportedTypeForVariableScaleDecimalSnafu.fail(),
     }
 }
 

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -425,7 +425,7 @@ async fn get_metadata_from_kafka(
     };
 
     let Some(key) = msg.key() else {
-        let src = &msg.value().clone().payload.source;
+        let src = &msg.value().payload.source;
         let table_name = format!("{}.{}", src.db, src.table);
 
         return Err(super::DataConnectorError::UnableToGetReadProvider {

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -432,9 +432,8 @@ async fn get_metadata_from_kafka(
             dataconnector: "debezium".to_string(),
             source: format!(
                 "CDC message key is missing. \
-         Most likely, table \"{}\" doesn't have a configured primary key. \
-         Verify Debezium CDC configuration and try again.",
-                table_name
+         Most likely, table \"{table_name}\" doesn't have a configured primary key. \
+         Verify Debezium CDC configuration and try again."
             )
             .into(),
             connector_component: ConnectorComponent::from(dataset),

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -425,10 +425,18 @@ async fn get_metadata_from_kafka(
     };
 
     let Some(key) = msg.key() else {
+
+        let src = &msg.value().clone().payload.source;
+        let table_name = format!("{}.{}", src.db, src.table);
+
         return Err(super::DataConnectorError::UnableToGetReadProvider {
             dataconnector: "debezium".to_string(),
-            source: "CDC message key is missing. Verify Debezium CDC configuration and try again."
-                .into(),
+            source: format!(
+                "CDC message key is missing. \
+         Most likely, table \"{}\" doesn't have a configured primary key. \
+         Verify Debezium CDC configuration and try again.",
+                table_name
+            ).into(),
             connector_component: ConnectorComponent::from(dataset),
         });
     };

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -425,7 +425,6 @@ async fn get_metadata_from_kafka(
     };
 
     let Some(key) = msg.key() else {
-
         let src = &msg.value().clone().payload.source;
         let table_name = format!("{}.{}", src.db, src.table);
 
@@ -436,7 +435,8 @@ async fn get_metadata_from_kafka(
          Most likely, table \"{}\" doesn't have a configured primary key. \
          Verify Debezium CDC configuration and try again.",
                 table_name
-            ).into(),
+            )
+            .into(),
             connector_component: ConnectorComponent::from(dataset),
         });
     };


### PR DESCRIPTION
## 📝 Summary

In certain cases (for example when postgres uses `numeric` type which has no predefined precision/scale), Debezium uses `VariableScaleDecimal` type. 

However arrow needs a pre-defined scale in order to create a schema.

This requires:
* Having a default Arrow datatype: We will use `DataType::Decimal128(38, 20)` to make it consistent withe oracle/postgres default values
* Special logic to handle value which was added in this PR

Additionally I've included a better error message for `CDC message key is missing` error: now it mentions that the most likely cause for the error is a specific table not having a primary key

## 🔗 Related
https://github.com/spiceai/spiceai/issues/6264

## 📚 Docs

Needs update [Debezium Connector Docs](https://github.com/spiceai/docs/blob/trunk/website/docs/components/data-connectors/debezium.md) to mention that for `VariableScaleDecimal` we will use `DataType::Decimal128(38, 20)`
