### PR TITLE
Fix spicecloud benchmark

### DIFF
--- a/test/spicepods/tpch/sf1/federated/spicecloud[catalog].yaml
+++ b/test/spicepods/tpch/sf1/federated/spicecloud[catalog].yaml
@@ -7,4 +7,4 @@ catalogs:
     include:
       - 'tpch.*'
     params:
-      spiceai_api_key: ${secrets:SPICEAI_TPCH_API_KEY}
+      spiceai_api_key: ${secrets:SPICEAI_TEST_TPCH_API_KEY}


### PR DESCRIPTION
## 📝 Summary

Fix spicecloud benchmark. It's been failing since after this change https://github.com/spiceai/spiceai/pull/6576

## 🔗 Related

https://github.com/spiceai/spiceai/issues/6906