### PR TITLE
Update the UnableToLoadCredentials error with a pointer to docs

### DIFF
--- a/crates/data_components/src/s3_vectors/mod.rs
+++ b/crates/data_components/src/s3_vectors/mod.rs
@@ -80,7 +80,9 @@ pub enum Error {
     ))]
     CreateIndexUsingArn,
 
-    #[snafu(display("Failed to load AWS credentials. {message}"))]
+    #[snafu(display(
+        "Failed to load AWS credentials to connect to S3 Vectors. Verify the AWS credentials are available in the environment. For help configuring AWS authentication visit https://spiceai.org/docs/components/vectors/s3_vectors#authentication"
+    ))]
     UnableToLoadCredentials { message: String },
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
## 📝 Summary

Updates the `UnableToLoadCredentials` error with a pointer to the relevant documentation for connecting to S3 Vectors:

`Failed to load AWS credentials to connect to S3 Vectors. Verify the AWS credentials are available in the environment. For help configuring AWS authentication visit https://spiceai.org/docs/components/vectors/s3_vectors#authentication`

The current error message from the SDK is not very helpful unfortunately, so don't display it.

Previous error message:

<img width="1563" height="117" alt="image (3)" src="https://github.com/user-attachments/assets/1e85bff7-26d9-4520-a29a-0e17e5926837" />
