### PR TITLE
refactor: Decouple full text search candidate from UDTF

### DIFF
--- a/crates/runtime/src/search/full_text/mod.rs
+++ b/crates/runtime/src/search/full_text/mod.rs
@@ -15,17 +15,12 @@ limitations under the License.
 */
 use std::sync::Arc;
 
-use datafusion::{
-    execution::runtime_env::RuntimeEnvBuilder,
-    prelude::{SessionConfig, SessionContext},
-};
+use datafusion::prelude::SessionContext;
 use search::generation::{
-    CandidateGeneration, post_apply::PostApplyCandidateGeneration,
-    text_search::index::FullTextDatabaseIndex,
+    CandidateGeneration,
+    post_apply::PostApplyCandidateGeneration,
+    text_search::{FullTextSearchCandidate, index::FullTextDatabaseIndex},
 };
-use snafu::ResultExt;
-
-use runtime_object_store::registry::SpiceObjectStoreRegistry;
 
 pub mod connector;
 pub mod udtf;
@@ -35,6 +30,7 @@ pub mod udtf;
 /// `https://github.com/spiceai/spiceai/issues/6471` will move, like [`udtf::TextSearchTableFunc`] in favour of using [`search::generation::text_search::udtf::TextSearchIndexProvider`].
 pub async fn as_candidate_generations(
     database_index: &FullTextDatabaseIndex,
+    session_context: Arc<SessionContext>,
 ) -> Result<Vec<Arc<dyn CandidateGeneration>>, search::generation::Error> {
     let mut generators = vec![];
     for search_field in database_index.search_fields.as_slice() {
@@ -43,21 +39,14 @@ pub async fn as_candidate_generations(
             .await
             .map_err(|source| search::generation::Error::TextSearchError { source })?;
 
+        let candidate: FullTextSearchCandidate = base.into();
+
         let post_apply = PostApplyCandidateGeneration::new(
             Arc::clone(&database_index.base_table),
-            Arc::new(base),
+            Arc::new(candidate),
             database_index.primary_key.clone(),
         )
-        .with_ctx(Arc::new(SessionContext::new_with_config_rt(
-            SessionConfig::default(),
-            Arc::new(
-                RuntimeEnvBuilder::default()
-                    .with_object_store_registry(Arc::new(SpiceObjectStoreRegistry::default()))
-                    .build()
-                    .boxed()
-                    .map_err(|source| search::generation::Error::InternalError { source })?,
-            ),
-        )));
+        .with_ctx(Arc::clone(&session_context));
         generators.push(Arc::new(post_apply) as Arc<dyn CandidateGeneration>);
     }
 

--- a/crates/runtime/src/search/full_text/mod.rs
+++ b/crates/runtime/src/search/full_text/mod.rs
@@ -15,12 +15,18 @@ limitations under the License.
 */
 use std::sync::Arc;
 
-use datafusion::prelude::SessionContext;
+use datafusion::{
+    execution::runtime_env::RuntimeEnvBuilder,
+    prelude::{SessionConfig, SessionContext},
+};
 use search::generation::{
     CandidateGeneration,
     post_apply::PostApplyCandidateGeneration,
     text_search::{FullTextSearchCandidate, index::FullTextDatabaseIndex},
 };
+use snafu::ResultExt;
+
+use runtime_object_store::registry::SpiceObjectStoreRegistry;
 
 pub mod connector;
 pub mod udtf;
@@ -30,7 +36,6 @@ pub mod udtf;
 /// `https://github.com/spiceai/spiceai/issues/6471` will move, like [`udtf::TextSearchTableFunc`] in favour of using [`search::generation::text_search::udtf::TextSearchIndexProvider`].
 pub async fn as_candidate_generations(
     database_index: &FullTextDatabaseIndex,
-    session_context: Arc<SessionContext>,
 ) -> Result<Vec<Arc<dyn CandidateGeneration>>, search::generation::Error> {
     let mut generators = vec![];
     for search_field in database_index.search_fields.as_slice() {
@@ -46,7 +51,16 @@ pub async fn as_candidate_generations(
             Arc::new(candidate),
             database_index.primary_key.clone(),
         )
-        .with_ctx(Arc::clone(&session_context));
+        .with_ctx(Arc::new(SessionContext::new_with_config_rt(
+            SessionConfig::default(),
+            Arc::new(
+                RuntimeEnvBuilder::default()
+                    .with_object_store_registry(Arc::new(SpiceObjectStoreRegistry::default()))
+                    .build()
+                    .boxed()
+                    .map_err(|source| search::generation::Error::InternalError { source })?,
+            ),
+        )));
         generators.push(Arc::new(post_apply) as Arc<dyn CandidateGeneration>);
     }
 

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -224,7 +224,7 @@ pub async fn full_text_search_candidates(
     };
 
     Some(
-        as_candidate_generations(&fts.with_new_base(table_provider))
+        as_candidate_generations(&fts.with_new_base(table_provider), Arc::clone(&df.ctx))
             .await
             .context(SearchGenerationSnafu),
     )

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -224,7 +224,7 @@ pub async fn full_text_search_candidates(
     };
 
     Some(
-        as_candidate_generations(&fts.with_new_base(table_provider), Arc::clone(&df.ctx))
+        as_candidate_generations(&fts.with_new_base(table_provider))
             .await
             .context(SearchGenerationSnafu),
     )

--- a/crates/search/src/generation/post_apply.rs
+++ b/crates/search/src/generation/post_apply.rs
@@ -319,6 +319,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::generation::CandidateGeneration;
+    use crate::generation::text_search::FullTextSearchCandidate;
     use crate::generation::text_search::tests::{create_basic_index, validate_result};
     use crate::generation::{
         post_apply::PostApplyCandidateGeneration, text_search::FullTextSearchFieldIndex,
@@ -412,10 +413,12 @@ mod tests {
         )
         .expect("failed to create FullTextSearch");
 
+        let candidate: FullTextSearchCandidate = fts.into();
+
         let table_provider = create_table_provider();
         let post_apply = PostApplyCandidateGeneration::new(
             table_provider,
-            Arc::new(fts),
+            Arc::new(candidate),
             vec!["title".to_string()],
         );
 
@@ -438,10 +441,12 @@ mod tests {
         )
         .expect("failed to create FullTextSearch");
 
+        let candidate: FullTextSearchCandidate = fts.into();
+
         let table_provider = create_table_provider();
         let post_apply = PostApplyCandidateGeneration::new(
             table_provider,
-            Arc::new(fts),
+            Arc::new(candidate),
             vec!["title".to_string()],
         );
 

--- a/crates/search/src/generation/text_search/exec.rs
+++ b/crates/search/src/generation/text_search/exec.rs
@@ -29,7 +29,7 @@ use datafusion::{
 
 use futures::StreamExt;
 
-use super::{CandidateGeneration, FullTextSearchFieldIndex};
+use super::FullTextSearchFieldIndex;
 
 /// Executes a search on a [`FullTextSearchFieldIndex`] with a given query.
 pub struct FullTextSearchExec {

--- a/crates/search/src/generation/text_search/mod.rs
+++ b/crates/search/src/generation/text_search/mod.rs
@@ -311,6 +311,59 @@ impl FullTextSearchFieldIndex {
         )
     }
 
+    pub async fn search(
+        &self,
+        query: String,
+        opt_filters: &[&Expr],
+        addition_projection: &[&Expr],
+        limit: usize,
+    ) -> GenerationResult<SendableRecordBatchStream> {
+        if !opt_filters.is_empty() {
+            return Err(Error::UnsupportedFiltersError).context(GenerationTextSearchSnafu)?;
+        }
+
+        // If search field is explicitly request, must keep in Tantivy response (instead of `value`).
+        let mut keep_search_field = false;
+        let cols = self.all_columns();
+        for proj in addition_projection {
+            let is_supported = match proj {
+                Expr::Identifier(Ident { value, .. }) => {
+                    if *value == self.field {
+                        keep_search_field = true;
+                    }
+                    cols.contains(value)
+                }
+                _ => false,
+            };
+            if !is_supported {
+                return Err(Error::UnsupportedAdditionalColumnsError)
+                    .context(GenerationTextSearchSnafu)?;
+            }
+        }
+
+        for pk in &self.primary_key {
+            // keep the field if it is part of the primary key
+            if pk == &self.field {
+                keep_search_field = true;
+                break;
+            }
+        }
+
+        let strm = make_stream(self.clone(), query, keep_search_field, limit);
+        let mut strm = Box::pin(strm.peekable());
+        let schema = match strm.as_mut().peek().await {
+            None => Arc::new(Schema::empty()),
+            Some(Ok(rb)) => rb.schema(),
+            Some(Err(e)) => {
+                return Err(GenerationError::internal(
+                    format!("Failed to parse schema of full text search results: {e}").as_str(),
+                ));
+            }
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, strm)) as SendableRecordBatchStream)
+    }
+
     /// If `keep_search_field`, `self.field` will be kept in result (as well as [`SEARCH_VALUE_COLUMN_NAME`]).
     fn search_query_literal(
         &self,
@@ -434,8 +487,28 @@ fn parse_query_literal(q: &str) -> UserInputAst {
     )
 }
 
+impl From<FullTextSearchFieldIndex> for FullTextSearchCandidate {
+    fn from(inner: FullTextSearchFieldIndex) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+}
+
+impl From<Arc<FullTextSearchFieldIndex>> for FullTextSearchCandidate {
+    fn from(inner: Arc<FullTextSearchFieldIndex>) -> Self {
+        Self {
+            inner: Arc::clone(&inner),
+        }
+    }
+}
+
+pub struct FullTextSearchCandidate {
+    inner: Arc<FullTextSearchFieldIndex>,
+}
+
 #[async_trait]
-impl CandidateGeneration for FullTextSearchFieldIndex {
+impl CandidateGeneration for FullTextSearchCandidate {
     async fn search(
         &self,
         query: String,
@@ -443,50 +516,9 @@ impl CandidateGeneration for FullTextSearchFieldIndex {
         addition_projection: &[&Expr],
         limit: usize,
     ) -> GenerationResult<SendableRecordBatchStream> {
-        if !opt_filters.is_empty() {
-            return Err(Error::UnsupportedFiltersError).context(GenerationTextSearchSnafu)?;
-        }
-
-        // If search field is explicitly request, must keep in Tantivy response (instead of `value`).
-        let mut keep_search_field = false;
-        let cols = self.all_columns();
-        for proj in addition_projection {
-            let is_supported = match proj {
-                Expr::Identifier(Ident { value, .. }) => {
-                    if *value == self.field {
-                        keep_search_field = true;
-                    }
-                    cols.contains(value)
-                }
-                _ => false,
-            };
-            if !is_supported {
-                return Err(Error::UnsupportedAdditionalColumnsError)
-                    .context(GenerationTextSearchSnafu)?;
-            }
-        }
-
-        for pk in &self.primary_key {
-            // keep the field if it is part of the primary key
-            if pk == &self.field {
-                keep_search_field = true;
-                break;
-            }
-        }
-
-        let strm = make_stream(self.clone(), query, keep_search_field, limit);
-        let mut strm = Box::pin(strm.peekable());
-        let schema = match strm.as_mut().peek().await {
-            None => Arc::new(Schema::empty()),
-            Some(Ok(rb)) => rb.schema(),
-            Some(Err(e)) => {
-                return Err(GenerationError::internal(
-                    format!("Failed to parse schema of full text search results: {e}").as_str(),
-                ));
-            }
-        };
-
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, strm)) as SendableRecordBatchStream)
+        self.inner
+            .search(query, opt_filters, addition_projection, limit)
+            .await
     }
 
     fn supports_filters_pushdown(&self, filters: &[&Expr]) -> GenerationResult<Vec<bool>> {
@@ -495,7 +527,7 @@ impl CandidateGeneration for FullTextSearchFieldIndex {
 
     /// Whether additional columns of the underlying source can also be retrieved during generation.
     fn supports_columns(&self, projection: &[&Expr]) -> GenerationResult<Vec<bool>> {
-        let columns = self.all_columns();
+        let columns = self.inner.all_columns();
 
         let cols_found = projection
             .iter()
@@ -513,7 +545,7 @@ impl CandidateGeneration for FullTextSearchFieldIndex {
 
     /// Returns the name of the column that is used to derive the value in the [`SEARCH_VALUE_COLUMN_NAME`] column.
     fn value_derived_from(&self) -> String {
-        self.field.clone()
+        self.inner.field.clone()
     }
 }
 
@@ -582,7 +614,7 @@ pub(crate) mod tests {
         aggregation::write_to_json_string,
         generation::{
             CandidateGeneration, Result as GenerationResult,
-            text_search::{FullTextSearchFieldIndex, parse_query_literal},
+            text_search::{FullTextSearchCandidate, FullTextSearchFieldIndex, parse_query_literal},
         },
     };
 
@@ -672,7 +704,9 @@ pub(crate) mod tests {
         )
         .expect("failed to create FullTextSearch");
 
-        let rb_as_value = validate_result(fts.search("fish".into(), &[], &[], 3).await).await;
+        let candidate: FullTextSearchCandidate = fts.into();
+
+        let rb_as_value = validate_result(candidate.search("fish".into(), &[], &[], 3).await).await;
 
         insta::assert_json_snapshot!(rb_as_value);
     }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

First stage in re-implementing text search for `v1/search` using the UDTF.

* This PR decouples the `CandidateGeneration` from the UDTF for full text searches. 
* Before:
  * UDTF -> `TextSearchIndexProvider` -> Candidate Generation -> Search
  * `v1/search` -> Full text search index -> Candidate Generation -> Search
* After:
  * UDTF -> `TextSearchIndexProvider` -> Search
  * `v1/search` -> Full text search index -> Full text search candidate -> Search

In a follow-up PR, this will enable doing the following:
* `v1/search` -> `TextSearchIndexProvider` -> Search

`FullTextSearchCandidate` can then be replaced by implementating `CandidateGeneration` directly on the `TextSearchIndexProvider`.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #6471
