### PR TITLE
Add missing param in release notes

### DIFF
--- a/docs/release_notes/v1.6.0.md
+++ b/docs/release_notes/v1.6.0.md
@@ -111,6 +111,7 @@ models:
       openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
       tools: sql, list_datasets
       openai_responses_tools: web_search, code_interpreter #  'code_interpreter' or 'web_search'
+      responses_api: enabled
 ```
 
 These OpenAI-specific tools are only available from the `/v1/responses` endpoint. Any other tools specified via the `tools` parameter are available from both the `/v1/chat/completions` and `/v1/responses` endpoints.


### PR DESCRIPTION
## 📝 Summary
- Brings over changes from https://github.com/spiceai/docs/pull/1129 into this repo
- The missing Spicepod added in the PR above isn't missing in the release notes in this repo
