### PR TITLE
Upgrade delta_kernel to `0.14`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,9 +4426,9 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
 name = "delta_kernel"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0b553d03fce69da6bedd91ec7e2348d52af2783a95d2dc91970df0cb614783"
+checksum = "f06f3676832e713e44f65804cebf82f46962d3e126f64f3251eb5fbeb0ad94e4"
 dependencies = [
  "arrow",
  "bytes",
@@ -4455,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "delta_kernel_derive"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deacb882456b0a3e7a5bf22a708190758cc8f572e02cd34954931e24286a4509"
+checksum = "059e70a67ae0c827a0e7f393eb05db2985533b3b612f8b33243433853570db45"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,9 +4426,9 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 
 [[package]]
 name = "delta_kernel"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06f3676832e713e44f65804cebf82f46962d3e126f64f3251eb5fbeb0ad94e4"
+checksum = "cac0f0eae6345b0cfb67c4304da961e590370860aa51e88315e808c5d496629f"
 dependencies = [
  "arrow",
  "bytes",
@@ -4455,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "delta_kernel_derive"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059e70a67ae0c827a0e7f393eb05db2985533b3b612f8b33243433853570db45"
+checksum = "064456b054cf26b607f4cbcef6d2ca102f64ed8e4fa702d2e307ce67b5b93569"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ datafusion-expr = "48.0.1"
 datafusion-federation = { version = "0.4.2", features = ["sql"] }
 datafusion-functions-json = "0.48"
 datafusion-table-providers = "0.1"
-delta_kernel = { version = "0.12", features = ["default-engine", "arrow-55"] }
+delta_kernel = { version = "0.13", features = ["default-engine", "arrow-55"] }
 dotenvy = "0.15"
 duckdb = "1.3.2"
 fundu = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ datafusion-expr = "48.0.1"
 datafusion-federation = { version = "0.4.2", features = ["sql"] }
 datafusion-functions-json = "0.48"
 datafusion-table-providers = "0.1"
-delta_kernel = { version = "0.14", features = ["default-engine", "arrow-55"] }
+delta_kernel = { version = "0.14", features = ["default-engine", "arrow-55", "internal-api"] }
 dotenvy = "0.15"
 duckdb = "1.3.2"
 fundu = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ datafusion-expr = "48.0.1"
 datafusion-federation = { version = "0.4.2", features = ["sql"] }
 datafusion-functions-json = "0.48"
 datafusion-table-providers = "0.1"
-delta_kernel = { version = "0.13", features = ["default-engine", "arrow-55"] }
+delta_kernel = { version = "0.14", features = ["default-engine", "arrow-55"] }
 dotenvy = "0.15"
 duckdb = "1.3.2"
 fundu = "2.0.1"

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -40,7 +40,6 @@ use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::TableReference;
-use delta_kernel::Table;
 use delta_kernel::engine::default::DefaultEngine;
 use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::expressions::{BinaryExpressionOp, DecimalData, Expression, Scalar};
@@ -110,7 +109,7 @@ impl Read for DeltaTableFactory {
 
 #[derive(Debug)]
 pub struct DeltaTable {
-    table: Table,
+    table_url: Url,
     engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
     arrow_schema: SchemaRef,
     delta_schema: delta_kernel::schema::SchemaRef,
@@ -118,7 +117,7 @@ pub struct DeltaTable {
 
 impl DeltaTable {
     pub fn from(table_location: String, options: HashMap<String, SecretString>) -> Result<Self> {
-        let table = Table::try_from_uri(ensure_folder_location(table_location))
+        let table_url = delta_kernel::try_parse_uri(ensure_folder_location(table_location))
             .map_err(handle_delta_error)?;
 
         let mut storage_options: HashMap<String, String> = HashMap::new();
@@ -148,12 +147,8 @@ impl DeltaTable {
         ) {
             (true, Some(sdk_config)) => {
                 let region = storage_options.get("aws_region").map(ToString::to_string);
-                aws_sdk_credential_bridge::from_s3_url_and_config(
-                    table.location(),
-                    region,
-                    sdk_config,
-                )
-                .ok()
+                aws_sdk_credential_bridge::from_s3_url_and_config(&table_url, region, sdk_config)
+                    .ok()
             }
             _ => None,
         };
@@ -165,7 +160,7 @@ impl DeltaTable {
             )),
             None => Arc::new(
                 DefaultEngine::try_new(
-                    table.location(),
+                    &table_url,
                     storage_options,
                     Arc::new(TokioBackgroundExecutor::new()),
                 )
@@ -173,15 +168,14 @@ impl DeltaTable {
             ),
         };
 
-        let snapshot = table
-            .snapshot(engine.as_ref(), None)
+        let snapshot = Snapshot::try_new(table_url.clone(), engine.as_ref(), None)
             .map_err(handle_delta_error)?;
 
         let arrow_schema = Self::get_schema(&snapshot);
         let delta_schema = snapshot.schema();
 
         Ok(Self {
-            table,
+            table_url,
             engine,
             arrow_schema: Arc::new(arrow_schema),
             delta_schema,
@@ -296,7 +290,8 @@ fn map_delta_data_type_to_arrow_data_type(
             map_delta_data_type_to_arrow_data_type(array_type.element_type()),
             array_type.contains_null(),
         ))),
-        delta_kernel::schema::DataType::Struct(struct_type) => {
+        delta_kernel::schema::DataType::Struct(struct_type)
+        | delta_kernel::schema::DataType::Variant(struct_type) => {
             let mut fields: Vec<Field> = vec![];
             for field in struct_type.fields() {
                 fields.push(Field::new(
@@ -358,16 +353,14 @@ impl TableProvider for DeltaTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>, datafusion::error::DataFusionError> {
-        let snapshot = self
-            .table
-            .snapshot(self.engine.as_ref(), None)
+        let snapshot = Snapshot::try_new(self.table_url.clone(), self.engine.as_ref(), None)
             .map_err(map_delta_error_to_datafusion_err)?;
 
         let df_schema = DFSchema::try_from(Arc::clone(&self.arrow_schema))?;
 
         let store = self
             .engine
-            .get_object_store_for_url(self.table.location())
+            .get_object_store_for_url(&self.table_url)
             .ok_or_else(|| {
                 datafusion::error::DataFusionError::Execution(
                     "Failed to get object store for table location".to_string(),


### PR DESCRIPTION
## 📝 Summary

Upgrades the `delta_kernel` package to `0.14`

The only notable breaking changes are:
1) The addition of the `Variant` data type, which we can handle for now by using our existing Struct logic (once Arrow has native Variants, we can revisit this).
2) The removal of the `Table` struct, which was really just a small wrapper on top of a Url.