### PR TITLE
Fix mongo tests: ignore container_registry() when building image name

### DIFF
--- a/crates/runtime/tests/mongo/common.rs
+++ b/crates/runtime/tests/mongo/common.rs
@@ -58,7 +58,7 @@ pub async fn start_mongodb_docker_container(
     let container_name = format!("{MONGODB_DOCKER_CONTAINER}-{port}");
     let container_name: &'static str = Box::leak(container_name.into_boxed_str());
     let running_container = ContainerRunnerBuilder::new(container_name)
-        .image(format!("{}mongo:latest", container_registry()))
+        .image("mongo:latest".to_string())
         .add_port_binding(27017, port)
         .add_env_var("MONGO_INITDB_ROOT_USERNAME", "root")
         .add_env_var("MONGO_INITDB_ROOT_PASSWORD", MONGODB_ROOT_PASSWORD)

--- a/crates/runtime/tests/mongo/common.rs
+++ b/crates/runtime/tests/mongo/common.rs
@@ -22,10 +22,7 @@ use spicepod::{
 };
 use tracing::instrument;
 
-use crate::{
-    container_registry,
-    docker::{ContainerRunnerBuilder, RunningContainer},
-};
+use crate::docker::{ContainerRunnerBuilder, RunningContainer};
 
 const MONGODB_ROOT_PASSWORD: &str = "integration-test-pw";
 const MONGODB_DOCKER_CONTAINER: &str = "runtime-integration-test-mongo";


### PR DESCRIPTION
## 📝 Summary

Currently tests are failing because we we override `CONTAINER_REGISTRY` during integration test execution: https://github.com/spiceai/spiceai/blob/trunk/.github/workflows/integration.yml#L49C3-L49C21

Which results in a docker image which doesn't exist: `spiceaitestimages.azurecr.io/mongo/mongo:latest`
