### PR TITLE
Skip dataset health check for IcebergTableProvider datasets

### DIFF
--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -24,6 +24,7 @@ use std::{
 use arrow::array::{AsArray, RecordBatch};
 use datafusion::{datasource::TableProvider, error::DataFusionError, sql::TableReference};
 use futures::{future::join_all, stream::TryStreamExt};
+use iceberg_datafusion::IcebergTableProvider;
 use opentelemetry::KeyValue;
 use snafu::{ResultExt, Snafu};
 use tokio::sync::Mutex;
@@ -33,6 +34,7 @@ use crate::{
     component::dataset::{CheckAvailability, Dataset},
     datafusion::{DataFusion, error::find_datafusion_root},
     metrics,
+    search::util::find_concrete_table_provider,
 };
 
 const DATASETS_AVAILABILITY_CHECK_INTERVAL_SECONDS: u64 = 60; // every minute
@@ -133,6 +135,15 @@ impl DatasetsHealthMonitor {
         tracing::debug!("Registering dataset {dataset_name} for periodic availability check");
 
         let table_provider = self.get_table_provider(dataset.name.clone()).await?;
+
+        // Don't enable health check for IcebergTableProvider until this is fixed:
+        // https://github.com/spiceai/spiceai/issues/6994
+        if find_concrete_table_provider::<IcebergTableProvider>(&table_provider).is_some() {
+            tracing::debug!(
+                "Skipping dataset {dataset_name} for availability monitoring (Iceberg datasets are not yet supported)",
+            );
+            return Ok(());
+        }
 
         let mut monitored_datasets = self.monitored_datasets.lock().await;
         monitored_datasets.insert(

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -140,7 +140,7 @@ impl DatasetsHealthMonitor {
         // https://github.com/spiceai/spiceai/issues/6994
         if find_concrete_table_provider::<IcebergTableProvider>(&table_provider).is_some() {
             tracing::debug!(
-                "Skipping dataset {dataset_name} for availability monitoring (Iceberg datasets are not yet supported)",
+                "Availability monitoring skipped for dataset '{dataset_name}': Iceberg format unsupported. Support planned for future release.",
             );
             return Ok(());
         }


### PR DESCRIPTION
## 📝 Summary

Skips the dataset health check for Iceberg datasets due to https://github.com/spiceai/spiceai/issues/6994.

Because the IcebergTableProvider doesn't support LIMIT pushdown, the health check was doing a full table scan every time it ran.

## 🔗 Related

- #6994
