### PR TITLE
Update build_and_release macOS pipeline to skip updating cmake if installed

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -168,8 +168,9 @@ jobs:
       - name: Install missing tools (Mac)
         if: matrix.target.target_os == 'darwin'
         run: |
+          brew update
           brew install protobuf
-          brew install cmake
+          brew list cmake || brew install cmake
           brew install unixodbc
           echo "RUSTFLAGS=-L /opt/homebrew/lib" >> $GITHUB_ENV
 


### PR DESCRIPTION
## 📝 Summary

Works around the CI issue introduced by the hosted macos runners in https://github.com/actions/runner-images/issues/12912

Skips calling `brew install cmake` if cmake is already installed.

## 🔗 Related

- https://github.com/actions/runner-images/issues/12912