### PR TITLE
Fix for nested VectorScanTableProvider

### DIFF
--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -379,7 +379,7 @@ impl DataConnector for EmbeddingConnector {
         {
             let indexed_table = Arc::new(indexed_table);
             let underlying_federated_table =
-                underlying_federated_table_for_indexed_table(&indexed_table)?;
+                underlying_federated_table_for_indexed_table(&table_provider)?;
 
             let stream = self
                 .inner_connector
@@ -422,7 +422,7 @@ impl DataConnector for EmbeddingConnector {
         {
             let indexed_table = Arc::new(indexed_table);
             let underlying_federated_table =
-                underlying_federated_table_for_indexed_table(&indexed_table)?;
+                underlying_federated_table_for_indexed_table(&table_provider)?;
 
             let stream = self
                 .inner_connector
@@ -453,17 +453,25 @@ impl DataConnector for EmbeddingConnector {
 }
 
 fn underlying_federated_table_for_indexed_table(
-    indexed_table: &Arc<IndexedTableProvider>,
+    src_table_provider: &Arc<dyn TableProvider>,
 ) -> Option<Arc<FederatedTable>> {
     #[cfg(feature = "s3_vectors")]
     {
-        let vector_scan = indexed_table
-            .underlying
+        if let Some(vector_scan) = src_table_provider
             .as_any()
-            .downcast_ref::<super::index::VectorScanTableProvider>()?;
-        Some(Arc::new(FederatedTable::Immediate(Arc::clone(
-            &vector_scan.table_provider,
-        ))))
+            .downcast_ref::<super::index::VectorScanTableProvider>()
+        {
+            return underlying_federated_table_for_indexed_table(&vector_scan.table_provider);
+        }
+
+        if let Some(indexed_scan) = src_table_provider
+            .as_any()
+            .downcast_ref::<IndexedTableProvider>()
+        {
+            return underlying_federated_table_for_indexed_table(&indexed_scan.underlying);
+        }
+
+        Some(Arc::new(FederatedTable::Immediate(Arc::clone(src_table_provider))))
     }
     #[cfg(not(feature = "s3_vectors"))]
     {

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -471,7 +471,9 @@ fn underlying_federated_table_for_indexed_table(
             return underlying_federated_table_for_indexed_table(&indexed_scan.underlying);
         }
 
-        Some(Arc::new(FederatedTable::Immediate(Arc::clone(src_table_provider))))
+        Some(Arc::new(FederatedTable::Immediate(Arc::clone(
+            src_table_provider,
+        ))))
     }
     #[cfg(not(feature = "s3_vectors"))]
     {


### PR DESCRIPTION
## 📝 Summary

For each index in a dataset, we currently create a nested `VectorScanTableProvider`, which unless properly unpacked will result in failed s3 vectors initialization in case of 2 and more indexes.

Not sure about the proper fix, maybe we should not create nested `VectorScanTableProvider`s. But in order to unblock Friday's demo I updated logic of unpacking them.