### PR TITLE
Speed up full text indexing/embeddings computation on change streams

### DIFF
--- a/crates/runtime/src/changes/mod.rs
+++ b/crates/runtime/src/changes/mod.rs
@@ -17,29 +17,63 @@ limitations under the License.
 use std::sync::Arc;
 
 use data_components::cdc::{ChangeEnvelope, StreamError, replace_change_batch_data};
+use futures::{StreamExt, stream::BoxStream};
 use runtime_datafusion_index::IndexedTableProvider;
 
 pub async fn index_change_envelope(
-    maybe_envelope: Result<ChangeEnvelope, StreamError>,
+    maybe_envelopes: Vec<Result<ChangeEnvelope, StreamError>>,
     embedding_table: Arc<IndexedTableProvider>,
-) -> Result<ChangeEnvelope, StreamError> {
-    let envelope = maybe_envelope.map_err(|e| {
-        tracing::debug!("Error in underlying base stream: {e:?}");
-        e
-    })?;
+) -> Result<Vec<ChangeEnvelope>, StreamError> {
+    let envelope = maybe_envelopes
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            tracing::debug!("Error in underlying base stream: {e:?}");
+            e
+        })?;
 
-    let (change_committer, batch) = envelope.into_parts();
-    let mut batches = vec![batch.data_batch()];
+    let (change_committers, change_batches): (Vec<_>, Vec<_>) =
+        envelope.into_iter().map(|e| e.into_parts()).unzip();
+    let mut data_batches = change_batches
+        .iter()
+        .map(|cb| cb.data_batch())
+        .collect::<Vec<_>>();
 
     for index in &embedding_table.indexes {
-        batches = index
-            .compute_index(batches)
+        data_batches = index
+            .compute_index(data_batches)
             .await
             .map_err(|e| StreamError::External(e.to_string()))?;
     }
 
-    let new_change_batch = replace_change_batch_data(&batches[0], &batch)
-        .map_err(|e| StreamError::Arrow(e.to_string()))?;
+    let new_change_envelopes: Vec<ChangeEnvelope> = data_batches
+        .into_iter()
+        .zip(change_batches.into_iter())
+        .zip(change_committers.into_iter())
+        .map(|((batch, change), committer)| {
+            Ok(ChangeEnvelope::new(
+                committer,
+                replace_change_batch_data(&batch, &change)
+                    .map_err(|e| StreamError::Arrow(e.to_string()))?,
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(ChangeEnvelope::new(change_committer, new_change_batch))
+    Ok(new_change_envelopes)
+}
+
+/// Flatten a `BoxStream` of `Result<Vec<ChangeEnvelope>, StreamError>` into a `BoxStream` of `Result<ChangeEnvelope, StreamError>`.
+#[must_use]
+pub fn flatten_change_envelope_stream(
+    input: BoxStream<'static, Result<Vec<ChangeEnvelope>, StreamError>>,
+) -> BoxStream<'static, Result<ChangeEnvelope, StreamError>> {
+    input
+        .flat_map(|result| {
+            // Convert Result<Vec<ChangeEnvelope>, StreamError> into a stream
+            match result {
+                Ok(vec) => futures::stream::iter(vec.into_iter().map(Ok)).boxed(),
+                Err(e) => futures::stream::once(async { Err(e) }).boxed(),
+            }
+        })
+        .boxed()
 }

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use crate::accelerated_table::AcceleratedTable;
+use crate::changes::flatten_change_envelope_stream;
 use crate::changes::index_change_envelope;
 use crate::component::ComponentInitialization;
 use crate::component::dataset::Dataset;
@@ -33,7 +34,6 @@ use data_components::cdc::ChangesStream;
 use data_components::cdc::StreamError;
 use data_components::cdc::replace_change_batch_data;
 use datafusion::datasource::TableProvider;
-use futures::StreamExt;
 use itertools::Itertools;
 use llms::chunking::ChunkingConfig;
 use runtime_datafusion_index::IndexedTableProvider;
@@ -42,7 +42,9 @@ use spicepod::vector::VectorStore;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
+use tokio_stream::StreamExt;
 
 use super::table::EmbeddingTable;
 
@@ -360,13 +362,14 @@ impl DataConnector for EmbeddingConnector {
                 return self.inner_connector.changes_stream(federated_table);
             };
 
-            let stream = self
-                .inner_connector
-                .changes_stream(underlying_federated_table)?
-                .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table)))
-                .boxed();
+            let stream = Box::pin(
+                self.inner_connector
+                    .changes_stream(underlying_federated_table)?
+                    .chunks_timeout(100, Duration::from_secs(2))
+                    .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table))),
+            );
 
-            return Some(stream);
+            return Some(flatten_change_envelope_stream(stream));
         }
 
         let embedding_table = Arc::new(
@@ -378,11 +381,11 @@ impl DataConnector for EmbeddingConnector {
         let underlying_table = Arc::clone(&embedding_table.base_table);
         let underlying_federated_table = Arc::new(FederatedTable::Immediate(underlying_table));
 
-        let stream = self
-            .inner_connector
-            .changes_stream(underlying_federated_table)?
-            .then(move |item| Self::embed_change_envelope(item, Arc::clone(&embedding_table)))
-            .boxed();
+        let stream = Box::pin(
+            self.inner_connector
+                .changes_stream(underlying_federated_table)?
+                .then(move |item| Self::embed_change_envelope(item, Arc::clone(&embedding_table))),
+        );
 
         Some(stream)
     }
@@ -403,13 +406,14 @@ impl DataConnector for EmbeddingConnector {
             let underlying_federated_table =
                 underlying_federated_table_for_indexed_table(&indexed_table)?;
 
-            let stream = self
-                .inner_connector
-                .append_stream(underlying_federated_table)?
-                .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table)))
-                .boxed();
+            let stream = Box::pin(
+                self.inner_connector
+                    .append_stream(underlying_federated_table)?
+                    .chunks_timeout(100, Duration::from_secs(2))
+                    .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table))),
+            );
 
-            return Some(stream);
+            return Some(flatten_change_envelope_stream(stream));
         }
 
         let embedding_table = Arc::new(
@@ -421,11 +425,11 @@ impl DataConnector for EmbeddingConnector {
         let underlying_table = Arc::clone(&embedding_table.base_table);
         let underlying_federated_table = Arc::new(FederatedTable::Immediate(underlying_table));
 
-        let stream = self
-            .inner_connector
-            .append_stream(underlying_federated_table)?
-            .then(move |item| Self::embed_change_envelope(item, Arc::clone(&embedding_table)))
-            .boxed();
+        let stream = Box::pin(
+            self.inner_connector
+                .append_stream(underlying_federated_table)?
+                .then(move |item| Self::embed_change_envelope(item, Arc::clone(&embedding_table))),
+        );
 
         Some(stream)
     }

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -29,6 +29,7 @@ use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::{ComponentInitialization, dataset::Dataset, metrics::MetricsProvider};
 use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResult};
 use crate::federated_table::FederatedTable;
+use crate::make_spice_data_sub_directory;
 
 use search::generation::text_search::index::FullTextDatabaseIndex;
 

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -19,14 +19,15 @@ use datafusion::datasource::TableProvider;
 use runtime_datafusion_index::{Index, IndexedTableProvider};
 use std::any::Any;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio_stream::StreamExt;
 
 use crate::accelerated_table::AcceleratedTable;
-use crate::changes::index_change_envelope;
+use crate::changes::{flatten_change_envelope_stream, index_change_envelope};
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::{ComponentInitialization, dataset::Dataset, metrics::MetricsProvider};
 use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResult};
 use crate::federated_table::FederatedTable;
-use futures::StreamExt;
 
 use search::generation::text_search::index::FullTextDatabaseIndex;
 
@@ -193,12 +194,12 @@ impl DataConnector for FullTextConnector {
         {
             let indexed_table = Arc::new(indexed_table);
             let underlying = indexed_table.get_underlying();
-            return Some(
+            return Some(flatten_change_envelope_stream(Box::pin(
                 self.inner_connector
                     .changes_stream(Arc::new(FederatedTable::Immediate(underlying)))?
-                    .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table)))
-                    .boxed(),
-            );
+                    .chunks_timeout(100, Duration::from_secs(2))
+                    .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table))),
+            )));
         } else {
             unreachable!(
                 "FullTextConnector didn't wrap underlying table with index - this is unexpected"
@@ -220,12 +221,12 @@ impl DataConnector for FullTextConnector {
         {
             let indexed_table = Arc::new(indexed_table);
             let underlying = indexed_table.get_underlying();
-            return Some(
+            return Some(flatten_change_envelope_stream(Box::pin(
                 self.inner_connector
                     .append_stream(Arc::new(FederatedTable::Immediate(underlying)))?
-                    .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table)))
-                    .boxed(),
-            );
+                    .chunks_timeout(100, Duration::from_secs(2))
+                    .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table))),
+            )));
         } else {
             unreachable!(
                 "FullTextConnector didn't wrap underlying table with index - this is unexpected"


### PR DESCRIPTION
## 📝 Summary

Speeds up full text indexing/embeddings creation using change streams by batching the updates instead of doing them one at a time.