### PR TITLE
feat: Add HTTP query concurrency support to testoperator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14382,6 +14382,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "dashmap",
  "duckdb",
  "flight_client",
  "futures",

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -18,6 +18,7 @@ async-openai.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 clap.workspace = true
+dashmap = "6.1.0"
 duckdb = { optional = true, workspace = true, features = [
     "bundled",
     "r2d2",

--- a/crates/test-framework/src/spicetest/datasets/mod.rs
+++ b/crates/test-framework/src/spicetest/datasets/mod.rs
@@ -67,6 +67,7 @@ pub struct NotStarted {
     validate: bool,
     disable_caching: bool,
     scale_factor: f64,
+    http_client: bool,
 }
 
 impl NotStarted {
@@ -109,6 +110,12 @@ impl NotStarted {
     #[must_use]
     pub fn with_scale_factor(mut self, scale_factor: f64) -> Self {
         self.scale_factor = scale_factor;
+        self
+    }
+
+    #[must_use]
+    pub fn with_http_client(mut self, http_client: bool) -> Self {
+        self.http_client = http_client;
         self
     }
 }
@@ -180,9 +187,11 @@ impl SpiceTest<NotStarted> {
             .spice_client(self.api_key.clone(), self.state.disable_caching)
             .await?;
 
+        let http_client = self.get_spiced()?.http_client()?;
+
         let query_workers = (0..self.state.parallel_count)
             .map(|id| {
-                let worker = SpiceTestQueryWorker::new(
+                let mut worker = SpiceTestQueryWorker::new(
                     id,
                     self.state.query_set.clone(),
                     self.state.end_condition,
@@ -195,10 +204,14 @@ impl SpiceTest<NotStarted> {
                 .with_scale_factor(self.state.scale_factor);
 
                 if let Some(multi) = &multi {
-                    worker.with_progress_bar(multi.add(self.get_new_progress_bar()))
-                } else {
-                    worker
+                    worker = worker.with_progress_bar(multi.add(self.get_new_progress_bar()));
                 }
+
+                if self.state.http_client {
+                    worker = worker.with_http_client(http_client.clone());
+                }
+
+                worker
             })
             .map(SpiceTestQueryWorker::start)
             .collect();

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -17,11 +17,12 @@ limitations under the License.
 use std::{
     collections::BTreeMap,
     panic,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant, SystemTime},
 };
 
 use anyhow::Result;
+use dashmap::DashMap;
 use futures::TryStreamExt;
 use indicatif::ProgressBar;
 use spiceai::{Client as SpiceClient, SpiceClientError};
@@ -67,19 +68,15 @@ struct QueryRunResult {
 
 impl SpiceTestQueryWorkerResult {
     pub fn try_new(
-        query_durations: &Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
+        query_durations: &Arc<DashMap<Arc<str>, Vec<Duration>>>,
         query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)>,
         query_statuses: BTreeMap<Arc<str>, QueryStatus>,
         connection_failed: bool,
         row_counts: BTreeMap<Arc<str>, Vec<usize>>,
     ) -> Result<Self> {
-        let Ok(durations_lock) = query_durations.lock() else {
-            return Err(anyhow::anyhow!("Failed to acquire lock on query durations"));
-        };
-
-        let query_durations = durations_lock
+        let query_durations = query_durations
             .iter()
-            .map(|(k, v)| (Arc::clone(k), v.clone()))
+            .map(|mapref| (Arc::clone(mapref.key()), mapref.value().clone()))
             .collect();
 
         Ok(Self {
@@ -151,8 +148,7 @@ impl SpiceTestQueryWorker {
     #[allow(clippy::too_many_lines)]
     pub fn start(self) -> JoinHandle<Result<SpiceTestQueryWorkerResult>> {
         tokio::spawn(async move {
-            let query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>> =
-                Arc::new(Mutex::new(BTreeMap::new()));
+            let query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>> = Arc::new(DashMap::new());
 
             // Keeps track of the start and end time of each query iteration
             let mut query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)> =
@@ -220,7 +216,7 @@ impl SpiceTestQueryWorker {
                         } = self
                             .run_single_query(
                                 query,
-                                Arc::new(Mutex::new(BTreeMap::new())),
+                                Arc::new(DashMap::new()),
                                 &mut BTreeMap::new(),
                                 snapshot_results,
                                 false,
@@ -322,7 +318,7 @@ impl SpiceTestQueryWorker {
     // run queries as a duration-based test
     async fn run_query_set(
         &self,
-        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
+        query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>>,
         query_statuses: &mut BTreeMap<Arc<str>, QueryStatus>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
     ) -> Result<bool> {
@@ -366,7 +362,7 @@ impl SpiceTestQueryWorker {
     async fn run_single_query(
         &self,
         query: &Query,
-        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
+        query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
         results_snapshot: bool,
         validate: bool,
@@ -409,11 +405,7 @@ impl SpiceTestQueryWorker {
                         e
                     );
 
-                    let cloned_durations_mutex = Arc::clone(&query_durations);
-                    let Ok(mut durations_lock) = cloned_durations_mutex.lock() else {
-                        return Err(anyhow::anyhow!("Failed to acquire lock on query durations"));
-                    };
-                    durations_lock.entry(Arc::clone(&query.name)).or_default();
+                    query_durations.entry(Arc::clone(&query.name)).or_default();
                     Ok(QueryRunResult {
                         connection_failed: false,
                         query_failure: Some(format!("{e}")),
@@ -427,7 +419,7 @@ impl SpiceTestQueryWorker {
     async fn execute_flight(
         &self,
         query: &Query,
-        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
+        query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
         results_snapshot: bool,
         validate: bool,
@@ -461,13 +453,7 @@ impl SpiceTestQueryWorker {
                             e
                         );
 
-                        let Ok(mut durations_lock) = query_durations.lock() else {
-                            return Err(anyhow::anyhow!(
-                                "Failed to acquire lock on query durations"
-                            ));
-                        };
-
-                        durations_lock.entry(Arc::clone(&query.name)).or_default();
+                        query_durations.entry(Arc::clone(&query.name)).or_default();
                         return Err(e.into());
                     }
                 }
@@ -541,11 +527,7 @@ impl SpiceTestQueryWorker {
 
         let duration = query_start.elapsed();
 
-        let Ok(mut durations_lock) = query_durations.lock() else {
-            return Err(anyhow::anyhow!("Failed to acquire lock on query durations"));
-        };
-
-        durations_lock
+        query_durations
             .entry(Arc::clone(&query.name))
             .or_default()
             .push(duration);
@@ -564,7 +546,7 @@ impl SpiceTestQueryWorker {
     async fn execute_http(
         &self,
         query: &Query,
-        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
+        query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>>,
     ) -> Result<()> {
         if let Some(http_client) = self.http_client.as_ref() {
             let query_start = Instant::now();
@@ -590,15 +572,10 @@ impl SpiceTestQueryWorker {
 
             let duration = query_start.elapsed();
 
-            let Ok(mut durations_lock) = query_durations.lock() else {
-                return Err(anyhow::anyhow!("Failed to acquire lock on query durations"));
-            };
-
-            durations_lock
+            query_durations
                 .entry(Arc::clone(&query.name))
                 .or_default()
                 .push(duration);
-            drop(durations_lock);
         }
 
         Ok(())
@@ -607,7 +584,7 @@ impl SpiceTestQueryWorker {
     async fn execute_query(
         &self,
         query: &Query,
-        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
+        query_durations: Arc<DashMap<Arc<str>, Vec<Duration>>>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
         results_snapshot: bool,
         validate: bool,

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -67,25 +67,25 @@ struct QueryRunResult {
 }
 
 impl SpiceTestQueryWorkerResult {
-    pub fn try_new(
+    pub fn new(
         query_durations: &Arc<DashMap<Arc<str>, Vec<Duration>>>,
         query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)>,
         query_statuses: BTreeMap<Arc<str>, QueryStatus>,
         connection_failed: bool,
         row_counts: BTreeMap<Arc<str>, Vec<usize>>,
-    ) -> Result<Self> {
+    ) -> Self {
         let query_durations = query_durations
             .iter()
             .map(|mapref| (Arc::clone(mapref.key()), mapref.value().clone()))
             .collect();
 
-        Ok(Self {
+        Self {
             query_durations,
             query_iteration_durations,
             query_statuses,
             connection_failed,
             row_counts,
-        })
+        }
     }
 }
 
@@ -180,7 +180,7 @@ impl SpiceTestQueryWorker {
                             )
                             .await?
                         {
-                            return SpiceTestQueryWorkerResult::try_new(
+                            return SpiceTestQueryWorkerResult::new(
                                 &query_durations,
                                 query_iteration_durations,
                                 query_statuses,
@@ -223,7 +223,7 @@ impl SpiceTestQueryWorker {
                             )
                             .await?;
                         if connection_failed {
-                            return SpiceTestQueryWorkerResult::try_new(
+                            return SpiceTestQueryWorkerResult::new(
                                 &query_durations,
                                 query_iteration_durations,
                                 query_statuses,
@@ -282,7 +282,7 @@ impl SpiceTestQueryWorker {
                                 .await?;
 
                             if connection_failed {
-                                return SpiceTestQueryWorkerResult::try_new(
+                                return SpiceTestQueryWorkerResult::new(
                                     &query_durations,
                                     query_iteration_durations,
                                     query_statuses,
@@ -305,7 +305,7 @@ impl SpiceTestQueryWorker {
                 }
             }
 
-            SpiceTestQueryWorkerResult::try_new(
+            SpiceTestQueryWorkerResult::new(
                 &query_durations,
                 query_iteration_durations,
                 query_statuses,

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -180,13 +180,13 @@ impl SpiceTestQueryWorker {
                             )
                             .await?
                         {
-                            return SpiceTestQueryWorkerResult::new(
+                            return Ok(SpiceTestQueryWorkerResult::new(
                                 &query_durations,
                                 query_iteration_durations,
                                 query_statuses,
                                 true,
                                 row_counts,
-                            );
+                            ));
                         }
                         query_set_count += 1;
                     }
@@ -223,13 +223,13 @@ impl SpiceTestQueryWorker {
                             )
                             .await?;
                         if connection_failed {
-                            return SpiceTestQueryWorkerResult::new(
+                            return Ok(SpiceTestQueryWorkerResult::new(
                                 &query_durations,
                                 query_iteration_durations,
                                 query_statuses,
                                 true,
                                 row_counts,
-                            );
+                            ));
                         }
 
                         if self.explain_plan_snapshot && self.id == 0 {
@@ -282,13 +282,13 @@ impl SpiceTestQueryWorker {
                                 .await?;
 
                             if connection_failed {
-                                return SpiceTestQueryWorkerResult::new(
+                                return Ok(SpiceTestQueryWorkerResult::new(
                                     &query_durations,
                                     query_iteration_durations,
                                     query_statuses,
                                     true,
                                     row_counts,
-                                );
+                                ));
                             }
 
                             if let Some(query_failure) = query_failure {
@@ -305,13 +305,13 @@ impl SpiceTestQueryWorker {
                 }
             }
 
-            SpiceTestQueryWorkerResult::new(
+            Ok(SpiceTestQueryWorkerResult::new(
                 &query_durations,
                 query_iteration_durations,
                 query_statuses,
                 false,
                 row_counts,
-            )
+            ))
         })
     }
 

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::{
     collections::BTreeMap,
     panic,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::{Duration, Instant, SystemTime},
 };
 
@@ -49,6 +49,7 @@ pub(crate) struct SpiceTestQueryWorker {
     validate: bool,
     scale_factor: f64,
     spice_client: Arc<SpiceClient>,
+    http_client: Option<reqwest::Client>,
 }
 
 pub struct SpiceTestQueryWorkerResult {
@@ -65,20 +66,29 @@ struct QueryRunResult {
 }
 
 impl SpiceTestQueryWorkerResult {
-    pub fn new(
-        query_durations: BTreeMap<Arc<str>, Vec<Duration>>,
+    pub fn try_new(
+        query_durations: &Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
         query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)>,
         query_statuses: BTreeMap<Arc<str>, QueryStatus>,
         connection_failed: bool,
         row_counts: BTreeMap<Arc<str>, Vec<usize>>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let Ok(durations_lock) = query_durations.lock() else {
+            return Err(anyhow::anyhow!("Failed to acquire lock on query durations"));
+        };
+
+        let query_durations = durations_lock
+            .iter()
+            .map(|(k, v)| (Arc::clone(k), v.clone()))
+            .collect();
+
+        Ok(Self {
             query_durations,
             query_iteration_durations,
             query_statuses,
             connection_failed,
             row_counts,
-        }
+        })
     }
 }
 
@@ -101,7 +111,13 @@ impl SpiceTestQueryWorker {
             progress_bar: None,
             validate: false,
             scale_factor: 1.0,
+            http_client: None,
         }
+    }
+
+    pub fn with_http_client(mut self, http_client: reqwest::Client) -> Self {
+        self.http_client = Some(http_client);
+        self
     }
 
     pub fn with_scale_factor(mut self, scale_factor: f64) -> Self {
@@ -135,7 +151,8 @@ impl SpiceTestQueryWorker {
     #[allow(clippy::too_many_lines)]
     pub fn start(self) -> JoinHandle<Result<SpiceTestQueryWorkerResult>> {
         tokio::spawn(async move {
-            let mut query_durations: BTreeMap<Arc<str>, Vec<Duration>> = BTreeMap::new();
+            let query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>> =
+                Arc::new(Mutex::new(BTreeMap::new()));
 
             // Keeps track of the start and end time of each query iteration
             let mut query_iteration_durations: BTreeMap<Arc<str>, (SystemTime, SystemTime)> =
@@ -161,19 +178,19 @@ impl SpiceTestQueryWorker {
 
                         if !self
                             .run_query_set(
-                                &mut query_durations,
+                                Arc::clone(&query_durations),
                                 &mut query_statuses,
                                 &mut row_counts,
                             )
                             .await?
                         {
-                            return Ok(SpiceTestQueryWorkerResult::new(
-                                query_durations,
+                            return SpiceTestQueryWorkerResult::try_new(
+                                &query_durations,
                                 query_iteration_durations,
                                 query_statuses,
                                 true,
                                 row_counts,
-                            ));
+                            );
                         }
                         query_set_count += 1;
                     }
@@ -203,20 +220,20 @@ impl SpiceTestQueryWorker {
                         } = self
                             .run_single_query(
                                 query,
-                                &mut BTreeMap::new(),
+                                Arc::new(Mutex::new(BTreeMap::new())),
                                 &mut BTreeMap::new(),
                                 snapshot_results,
                                 false,
                             )
                             .await?;
                         if connection_failed {
-                            return Ok(SpiceTestQueryWorkerResult::new(
-                                query_durations,
+                            return SpiceTestQueryWorkerResult::try_new(
+                                &query_durations,
                                 query_iteration_durations,
                                 query_statuses,
                                 true,
                                 row_counts,
-                            ));
+                            );
                         }
 
                         if self.explain_plan_snapshot && self.id == 0 {
@@ -261,7 +278,7 @@ impl SpiceTestQueryWorker {
                             } = self
                                 .run_single_query(
                                     query,
-                                    &mut query_durations,
+                                    Arc::clone(&query_durations),
                                     &mut row_counts,
                                     false, // don't attempt to snapshot results more than once
                                     self.validate,
@@ -269,13 +286,13 @@ impl SpiceTestQueryWorker {
                                 .await?;
 
                             if connection_failed {
-                                return Ok(SpiceTestQueryWorkerResult::new(
-                                    query_durations,
+                                return SpiceTestQueryWorkerResult::try_new(
+                                    &query_durations,
                                     query_iteration_durations,
                                     query_statuses,
                                     true,
                                     row_counts,
-                                ));
+                                );
                             }
 
                             if let Some(query_failure) = query_failure {
@@ -292,20 +309,20 @@ impl SpiceTestQueryWorker {
                 }
             }
 
-            Ok(SpiceTestQueryWorkerResult::new(
-                query_durations,
+            SpiceTestQueryWorkerResult::try_new(
+                &query_durations,
                 query_iteration_durations,
                 query_statuses,
                 false,
                 row_counts,
-            ))
+            )
         })
     }
 
     // run queries as a duration-based test
     async fn run_query_set(
         &self,
-        query_durations: &mut BTreeMap<Arc<str>, Vec<Duration>>,
+        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
         query_statuses: &mut BTreeMap<Arc<str>, QueryStatus>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
     ) -> Result<bool> {
@@ -314,7 +331,13 @@ impl SpiceTestQueryWorker {
                 connection_failed,
                 query_failure,
             } = self
-                .run_single_query(query, query_durations, row_counts, false, false)
+                .run_single_query(
+                    query,
+                    Arc::clone(&query_durations),
+                    row_counts,
+                    false,
+                    false,
+                )
                 .await?;
             if connection_failed {
                 return Ok(false);
@@ -343,7 +366,7 @@ impl SpiceTestQueryWorker {
     async fn run_single_query(
         &self,
         query: &Query,
-        query_durations: &mut BTreeMap<Arc<str>, Vec<Duration>>,
+        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
         results_snapshot: bool,
         validate: bool,
@@ -351,7 +374,7 @@ impl SpiceTestQueryWorker {
         match self
             .execute_query(
                 query,
-                query_durations,
+                Arc::clone(&query_durations),
                 row_counts,
                 results_snapshot,
                 validate,
@@ -385,7 +408,12 @@ impl SpiceTestQueryWorker {
                         query.name,
                         e
                     );
-                    query_durations.entry(Arc::clone(&query.name)).or_default();
+
+                    let cloned_durations_mutex = Arc::clone(&query_durations);
+                    let Ok(mut durations_lock) = cloned_durations_mutex.lock() else {
+                        return Err(anyhow::anyhow!("Failed to acquire lock on query durations"));
+                    };
+                    durations_lock.entry(Arc::clone(&query.name)).or_default();
                     Ok(QueryRunResult {
                         connection_failed: false,
                         query_failure: Some(format!("{e}")),
@@ -396,15 +424,16 @@ impl SpiceTestQueryWorker {
     }
 
     #[allow(clippy::too_many_lines)]
-    async fn execute_query(
+    async fn execute_flight(
         &self,
         query: &Query,
-        query_durations: &mut BTreeMap<Arc<str>, Vec<Duration>>,
+        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
         row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
         results_snapshot: bool,
         validate: bool,
     ) -> Result<()> {
         let query_start = Instant::now();
+
         let mut result_stream = self
             .spice_client
             .query_with_params(&query.sql, query.get_parameters_batch().transpose()?)
@@ -431,7 +460,14 @@ impl SpiceTestQueryWorker {
                             query.name,
                             e
                         );
-                        query_durations.entry(Arc::clone(&query.name)).or_default();
+
+                        let Ok(mut durations_lock) = query_durations.lock() else {
+                            return Err(anyhow::anyhow!(
+                                "Failed to acquire lock on query durations"
+                            ));
+                        };
+
+                        durations_lock.entry(Arc::clone(&query.name)).or_default();
                         return Err(e.into());
                     }
                 }
@@ -504,7 +540,12 @@ impl SpiceTestQueryWorker {
         }
 
         let duration = query_start.elapsed();
-        query_durations
+
+        let Ok(mut durations_lock) = query_durations.lock() else {
+            return Err(anyhow::anyhow!("Failed to acquire lock on query durations"));
+        };
+
+        durations_lock
             .entry(Arc::clone(&query.name))
             .or_default()
             .push(duration);
@@ -517,6 +558,72 @@ impl SpiceTestQueryWorker {
         if let Some(pb) = self.progress_bar.as_ref() {
             pb.inc(1);
         }
+        Ok(())
+    }
+
+    async fn execute_http(
+        &self,
+        query: &Query,
+        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
+    ) -> Result<()> {
+        if let Some(http_client) = self.http_client.as_ref() {
+            let query_start = Instant::now();
+            let http_response = http_client
+                .post("http://localhost:8090/v1/sql")
+                .body(query.sql.to_string())
+                .send()
+                .await?;
+
+            if !http_response.status().is_success() {
+                eprintln!(
+                    "{} FAIL - Worker {} - Query '{}' HTTP request failed: {}",
+                    chrono::Utc::now(),
+                    self.id,
+                    query.name,
+                    http_response.status()
+                );
+                return Err(anyhow::anyhow!(
+                    "Query HTTP request failed: {}",
+                    http_response.status()
+                ));
+            }
+
+            let duration = query_start.elapsed();
+
+            let Ok(mut durations_lock) = query_durations.lock() else {
+                return Err(anyhow::anyhow!("Failed to acquire lock on query durations"));
+            };
+
+            durations_lock
+                .entry(Arc::clone(&query.name))
+                .or_default()
+                .push(duration);
+            drop(durations_lock);
+        }
+
+        Ok(())
+    }
+
+    async fn execute_query(
+        &self,
+        query: &Query,
+        query_durations: Arc<Mutex<BTreeMap<Arc<str>, Vec<Duration>>>>,
+        row_counts: &mut BTreeMap<Arc<str>, Vec<usize>>,
+        results_snapshot: bool,
+        validate: bool,
+    ) -> Result<()> {
+        futures::future::try_join(
+            self.execute_flight(
+                query,
+                Arc::clone(&query_durations),
+                row_counts,
+                results_snapshot,
+                validate,
+            ),
+            self.execute_http(query, Arc::clone(&query_durations)),
+        )
+        .await?;
+
         Ok(())
     }
 }

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -140,3 +140,12 @@ pub struct DataConsistencyArgs {
     #[arg(long)]
     pub(crate) compare_spicepod: PathBuf,
 }
+
+#[derive(Parser, Debug)]
+pub struct LoadTestArgs {
+    #[command(flatten)]
+    pub(crate) test_args: DatasetTestArgs,
+
+    #[arg(long)]
+    pub(crate) no_error: bool,
+}

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -43,6 +43,10 @@ pub struct DatasetTestArgs {
     /// Whether to disable results caching, by supplying the cache control header through flight
     #[arg(long)]
     pub(crate) disable_caching: bool,
+
+    /// Whether to add HTTP clients for the test
+    #[arg(long)]
+    pub(crate) http_clients: bool,
 }
 
 #[derive(Clone, ValueEnum, Debug)]

--- a/tools/testoperator/src/args/mod.rs
+++ b/tools/testoperator/src/args/mod.rs
@@ -22,7 +22,7 @@ mod http;
 pub use http::{HttpConsistencyTestArgs, HttpOverheadTestArgs, HttpTestArgs};
 
 mod dataset;
-pub use dataset::{DataConsistencyArgs, DatasetTestArgs};
+pub use dataset::{DataConsistencyArgs, DatasetTestArgs, LoadTestArgs};
 
 pub mod dispatch;
 use dispatch::DispatchArgs;
@@ -48,7 +48,7 @@ pub enum Commands {
 #[derive(Subcommand)]
 pub enum TestCommands {
     Throughput(DatasetTestArgs),
-    Load(DatasetTestArgs),
+    Load(LoadTestArgs),
     Bench(DatasetTestArgs),
     DataConsistency(DataConsistencyArgs),
     HttpConsistency(HttpConsistencyTestArgs),

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -59,7 +59,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
             .with_end_condition(EndCondition::QuerySetCompleted(5))
             .with_validate(args.validate)
             .with_disable_caching(args.disable_caching)
-            .with_scale_factor(args.scale_factor.unwrap_or(1.0)),
+            .with_scale_factor(args.scale_factor.unwrap_or(1.0))
+            .with_http_client(args.http_clients),
     )
     .with_spiced_instance(spiced_instance)
     .with_explain_plan_snapshot()

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use super::get_app_and_start_request;
-use crate::{args::DatasetTestArgs, wait_test_and_memory};
+use crate::{args::LoadTestArgs, wait_test_and_memory};
 use std::time::Duration;
 use test_framework::{
     TestType, anyhow,
@@ -32,25 +32,29 @@ use test_framework::{
 };
 
 #[allow(clippy::too_many_lines)]
-pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
-    if args.common.concurrency < 2 {
+pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
+    if args.test_args.common.concurrency < 2 {
         return Err(anyhow::anyhow!(
             "Concurrency should be greater than 1 for a load test"
         ));
     }
 
-    let query_set = QuerySet::from(args.query_set.clone());
-    let query_overrides = args.query_overrides.clone().map(QueryOverrides::from);
+    let query_set = QuerySet::from(args.test_args.query_set.clone());
+    let query_overrides = args
+        .test_args
+        .query_overrides
+        .clone()
+        .map(QueryOverrides::from);
     let queries = query_set.get_queries(query_overrides);
 
-    let (app, start_request) = get_app_and_start_request(&args.common).await?;
+    let (app, start_request) = get_app_and_start_request(&args.test_args.common).await?;
     let mut spiced_instance = SpicedInstance::start(start_request).await?;
 
     spiced_instance
-        .wait_for_ready(Duration::from_secs(args.common.ready_wait))
+        .wait_for_ready(Duration::from_secs(args.test_args.common.ready_wait))
         .await?;
 
-    let test_duration = Duration::from_secs(args.common.duration);
+    let test_duration = Duration::from_secs(args.test_args.common.duration);
     let test_hours = (test_duration.as_secs() / 60 / 60).max(1);
 
     // baseline run
@@ -58,14 +62,14 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     let baseline_test = SpiceTest::new(
         app.name.clone(),
         NotStarted::new()
-            .with_parallel_count(args.common.concurrency)
+            .with_parallel_count(args.test_args.common.concurrency)
             .with_query_set(queries.clone())
             .with_end_condition(EndCondition::QuerySetCompleted(test_hours.try_into()?))
-            .with_disable_caching(args.disable_caching)
-            .with_http_client(args.http_clients),
+            .with_disable_caching(args.test_args.disable_caching)
+            .with_http_client(args.test_args.http_clients),
     )
     .with_spiced_instance(spiced_instance)
-    .with_progress_bars(!args.common.disable_progress_bars)
+    .with_progress_bars(!args.test_args.common.disable_progress_bars)
     .start()
     .await?;
 
@@ -88,16 +92,16 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     let throughput_test = SpiceTest::<NotStarted>::new(
         app.name.clone(),
         NotStarted::new()
-            .with_parallel_count(args.common.concurrency)
+            .with_parallel_count(args.test_args.common.concurrency)
             .with_query_set(queries.clone())
             .with_end_condition(EndCondition::Duration(Duration::from_secs(
-                args.common.duration,
+                args.test_args.common.duration,
             )))
-            .with_disable_caching(args.disable_caching)
-            .with_http_client(args.http_clients),
+            .with_disable_caching(args.test_args.disable_caching)
+            .with_http_client(args.test_args.http_clients),
     )
     .with_spiced_instance(spiced_instance)
-    .with_progress_bars(!args.common.disable_progress_bars)
+    .with_progress_bars(!args.test_args.common.disable_progress_bars)
     .start()
     .await?;
 
@@ -162,11 +166,11 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
         }
     }
 
-    if yellow_measurements >= 3 {
+    if !args.no_error && yellow_measurements >= 3 {
         return Err(anyhow::anyhow!(
             "Load test failed due to too many yellow measurements"
         ));
-    } else if !test_passed {
+    } else if !args.no_error && !test_passed {
         return Err(anyhow::anyhow!("Load test failed."));
     }
 

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -61,7 +61,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
             .with_parallel_count(args.common.concurrency)
             .with_query_set(queries.clone())
             .with_end_condition(EndCondition::QuerySetCompleted(test_hours.try_into()?))
-            .with_disable_caching(args.disable_caching),
+            .with_disable_caching(args.disable_caching)
+            .with_http_client(args.http_clients),
     )
     .with_spiced_instance(spiced_instance)
     .with_progress_bars(!args.common.disable_progress_bars)
@@ -92,7 +93,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
             .with_end_condition(EndCondition::Duration(Duration::from_secs(
                 args.common.duration,
             )))
-            .with_disable_caching(args.disable_caching),
+            .with_disable_caching(args.disable_caching)
+            .with_http_client(args.http_clients),
     )
     .with_spiced_instance(spiced_instance)
     .with_progress_bars(!args.common.disable_progress_bars)

--- a/tools/testoperator/src/commands/throughput/mod.rs
+++ b/tools/testoperator/src/commands/throughput/mod.rs
@@ -57,7 +57,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
             .with_parallel_count(1)
             .with_query_set(queries.clone())
             .with_end_condition(EndCondition::QuerySetCompleted(6))
-            .with_disable_caching(args.disable_caching),
+            .with_disable_caching(args.disable_caching)
+            .with_http_client(args.http_clients),
     )
     .with_spiced_instance(spiced_instance)
     .with_progress_bars(!args.common.disable_progress_bars)
@@ -77,7 +78,8 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
             .with_parallel_count(args.common.concurrency)
             .with_query_set(queries.clone())
             .with_end_condition(EndCondition::QuerySetCompleted(2))
-            .with_disable_caching(args.disable_caching),
+            .with_disable_caching(args.disable_caching)
+            .with_http_client(args.http_clients),
     )
     .with_spiced_instance(spiced_instance)
     .with_progress_bars(!args.common.disable_progress_bars)

--- a/tools/testoperator/src/commands/vector_search/mod.rs
+++ b/tools/testoperator/src/commands/vector_search/mod.rs
@@ -40,7 +40,14 @@ pub(crate) async fn run(args: &VectorSearchTestArgs) -> anyhow::Result<()> {
 
     match args.benchmark_dataset.as_deref() {
         Some("quora_retrieval") => {
-            mteb_quora::prepare_dataset(&start_request.get_tempdir_path()).await?;
+            mteb_quora::prepare_dataset(
+                &args
+                    .common
+                    .data_dir
+                    .clone()
+                    .unwrap_or(start_request.get_tempdir_path()),
+            )
+            .await?;
         }
         Some(ds) => {
             return Err(anyhow::anyhow!("Unsupported benchmark-dataset: {ds}"));

--- a/tools/testoperator/src/commands/vector_search/mteb_quora.rs
+++ b/tools/testoperator/src/commands/vector_search/mteb_quora.rs
@@ -37,6 +37,14 @@ use test_framework::{
 pub(crate) async fn prepare_dataset(spicepod_dir: &Path) -> anyhow::Result<()> {
     println!("Preparing MTEB QuoraRetrieval dataset...");
 
+    let corpus_dest = spicepod_dir.join("corpus.parquet");
+    let queries_dest = spicepod_dir.join("queries.parquet");
+    let data_dest = spicepod_dir.join("data.parquet");
+    let has_all_files = corpus_dest.exists() && queries_dest.exists() && data_dest.exists();
+    if has_all_files {
+        return Ok(());
+    }
+
     let hf_api = ApiBuilder::new()
         .with_progress(false)
         .build()
@@ -67,17 +75,14 @@ pub(crate) async fn prepare_dataset(spicepod_dir: &Path) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to download huggingface file: {e}"))?;
 
     // Copy files to spicepod directory with new names
-    let corpus_dest = spicepod_dir.join("corpus.parquet");
     std::fs::copy(&data_path, &corpus_dest)
         .map_err(|e| anyhow::anyhow!("Failed to copy corpus file: {e}"))?;
     println!("Corpus data saved to: {}", corpus_dest.display());
 
-    let queries_dest = spicepod_dir.join("queries.parquet");
     std::fs::copy(&test_queries_path, &queries_dest)
         .map_err(|e| anyhow::anyhow!("Failed to copy queries file: {e}"))?;
     println!("Queries data saved to: {}", queries_dest.display());
 
-    let data_dest = spicepod_dir.join("data.parquet");
     std::fs::copy(&scores_path, &data_dest)
         .map_err(|e| anyhow::anyhow!("Failed to copy data file: {e}"))?;
     println!("Data saved to: {}", data_dest.display());

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -23,7 +23,7 @@ mod metrics;
 
 use args::{
     Commands, DataConsistencyArgs, DatasetTestArgs, EvalsTestArgs, HttpConsistencyTestArgs,
-    HttpOverheadTestArgs, TestCommands,
+    HttpOverheadTestArgs, LoadTestArgs, TestCommands,
 };
 
 use crate::args::VectorSearchTestArgs;
@@ -46,7 +46,10 @@ async fn main() -> anyhow::Result<()> {
         Commands::Export(
             TestCommands::Throughput(DatasetTestArgs { common, .. })
             | TestCommands::Bench(DatasetTestArgs { common, .. })
-            | TestCommands::Load(DatasetTestArgs { common, .. })
+            | TestCommands::Load(LoadTestArgs {
+                test_args: DatasetTestArgs { common, .. },
+                ..
+            })
             | TestCommands::HttpConsistency(HttpConsistencyTestArgs { common, .. })
             | TestCommands::HttpOverhead(HttpOverheadTestArgs { common, .. })
             | TestCommands::Evals(EvalsTestArgs { common, .. })


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Adds support for concurrent HTTP and Flight queries via `testoperator` with `--http-clients`. The default behaviour is that, when specified, the `testoperator` will run requests simultaneously with Flight queries at the same `--concurrency` level. E.g:
  * A `--concurrency 8` with `--http-clients` will result in 16 effective concurrent queries, due to the additional HTTP queries.

* Adds a fix for `testoperator run vector-search` to not re-download the MTEB files if they already exist.
* Adds a `--no-error` option for load tests, to ignore errors and continue returning exit code 0 at the end of a test.

