### PR TITLE
Concatenate batches for better S3Vectors writes; Change batch size to 10; split batches on s3 vectors on conflict

### DIFF
--- a/crates/runtime/src/changes/mod.rs
+++ b/crates/runtime/src/changes/mod.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use arrow::compute::concat_batches;
 use data_components::cdc::{ChangeEnvelope, StreamError, replace_change_batch_data};
 use futures::{StreamExt, stream::BoxStream};
 use runtime_datafusion_index::IndexedTableProvider;
@@ -34,19 +35,43 @@ pub async fn index_change_envelope(
 
     let (change_committers, change_batches): (Vec<_>, Vec<_>) =
         envelope.into_iter().map(|e| e.into_parts()).unzip();
-    let mut data_batches = change_batches
+    let data_batches = change_batches
         .iter()
         .map(|cb| cb.data_batch())
         .collect::<Vec<_>>();
 
+    // Store original row counts for splitting later
+    let original_row_counts: Vec<usize> =
+        data_batches.iter().map(|batch| batch.num_rows()).collect();
+
+    // Concatenate all batches into a single batch
+    let schema = data_batches[0].schema();
+    let concat_batch =
+        concat_batches(&schema, &data_batches).map_err(|e| StreamError::Arrow(e.to_string()))?;
+
+    // Compute index on the concatenated batch
+    let mut indexed_batches = vec![concat_batch];
     for index in &embedding_table.indexes {
-        data_batches = index
-            .compute_index(data_batches)
+        indexed_batches = index
+            .compute_index(indexed_batches)
             .await
             .map_err(|e| StreamError::External(e.to_string()))?;
     }
 
-    let new_change_envelopes: Vec<ChangeEnvelope> = data_batches
+    // Split the indexed batch back into original batch sizes
+    let indexed_batch = &indexed_batches[0];
+    let mut split_batches = Vec::new();
+    let mut start_row = 0;
+
+    for row_count in original_row_counts {
+        let end_row = start_row + row_count;
+        let split_batch = indexed_batch.slice(start_row, row_count);
+        split_batches.push(split_batch);
+        start_row = end_row;
+    }
+
+    // Recombine the split batches back with their original change envelope.
+    let new_change_envelopes: Vec<ChangeEnvelope> = split_batches
         .into_iter()
         .zip(change_batches.into_iter())
         .zip(change_committers.into_iter())

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -372,7 +372,7 @@ impl DataConnector for EmbeddingConnector {
 
             let stream = Box::pin(
                 changes_stream
-                    .chunks_timeout(100, Duration::from_secs(2))
+                    .chunks_timeout(10000, Duration::from_secs(1))
                     .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table))),
             );
 
@@ -425,7 +425,7 @@ impl DataConnector for EmbeddingConnector {
 
             let stream = Box::pin(
                 stream
-                    .chunks_timeout(100, Duration::from_secs(2))
+                    .chunks_timeout(10000, Duration::from_secs(1))
                     .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table))),
             );
 

--- a/crates/runtime/src/embeddings/index/s3/write.rs
+++ b/crates/runtime/src/embeddings/index/s3/write.rs
@@ -167,13 +167,41 @@ pub async fn write(index: &S3Vector, record: RecordBatch) -> Result<RecordBatch,
         update_embedding_column_in_batch(&record, &index.embedded_column, &embedding_vectors)
             .map_err(|e| *e)?;
 
-    index
-        .table
-        .write_data(embedding_vectors, primary_key, metadata)
-        .await
-        .context(CannotWriteIndexSnafu {
-            index: index.name().to_string(),
-        })?;
+    // If S3 Vectors fails due to a conflicting write, split the batch in half and retry.
+    //
+    // Example error:
+    // ValidationException: Request must not contain duplicate keys
+    let mut embedding_vectors_batches = vec![embedding_vectors];
+    loop {
+        let Some(next) = embedding_vectors_batches.pop() else {
+            break;
+        };
+        let next_len = next.len();
+        match index
+            .table
+            .write_data(next.clone(), primary_key.clone(), metadata.clone())
+            .await
+        {
+            Ok(_) => {}
+            Err(data_components::s3_vectors::Error::S3VectorPutVectorError { source })
+                if source
+                    .to_string()
+                    .contains("Request must not contain duplicate keys")
+                    && next_len > 1 =>
+            {
+                let mid = next_len / 2;
+                embedding_vectors_batches.push(next[mid..].to_vec());
+                embedding_vectors_batches.push(next[..mid].to_vec());
+                tracing::warn!(
+                    "Write to '{}' index failed due to conflicting writes. Splitting batch and retrying.",
+                    index.name()
+                );
+            }
+            Err(e) => Err(e).context(CannotWriteIndexSnafu {
+                index: index.name().to_string(),
+            })?,
+        }
+    }
 
     Ok(updated_record)
 }

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -221,7 +221,7 @@ impl DataConnector for FullTextConnector {
             return Some((
                 flatten_change_envelope_stream(Box::pin(
                     changes_stream
-                        .chunks_timeout(100, Duration::from_secs(2))
+                        .chunks_timeout(10000, Duration::from_secs(1))
                         .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table))),
                 )),
                 readiness,
@@ -256,7 +256,7 @@ impl DataConnector for FullTextConnector {
             return Some((
                 flatten_change_envelope_stream(Box::pin(
                     append_stream
-                        .chunks_timeout(100, Duration::from_secs(2))
+                        .chunks_timeout(10000, Duration::from_secs(1))
                         .then(move |item| index_change_envelope(item, Arc::clone(&indexed_table))),
                 )),
                 readiness,


### PR DESCRIPTION
## 📝 Summary

- Concatenate the batches so that there is one big batch we send to `compute_index` which will allow for batched network requests to S3 Vectors -> faster.
- Change the batch size in the CDC pipeline we send to indexes to be 10k. (I tried 100k, and it was choking, 2k was too slow - 10k seems to be about right)
- S3Vectors doesn't allow the same batch in PutVectors to have the same row multiple times. When we detect this, split the batch into half and retry each half until it works.
