### PR TITLE
Kafka/Debezium: make poll timeout error friendlier

### DIFF
--- a/crates/data_components/src/cdc/stream.rs
+++ b/crates/data_components/src/cdc/stream.rs
@@ -26,11 +26,12 @@ use futures::stream::BoxStream;
 use snafu::prelude::*;
 
 use crate::cdc::{CommitChange, CommitError};
+use crate::kafka;
 
 #[derive(Debug)]
 pub enum StreamError {
     /// Error from the Kafka client, such as failure to consume messages.
-    Kafka(String),
+    Kafka(kafka::Error),
     /// Error from Serde JSON, such as failure to serialize or deserialize data.
     SerdeJsonError(String),
     /// Error from Arrow Flight, such as failure during streaming or subscription.

--- a/crates/data_components/src/debezium_kafka.rs
+++ b/crates/data_components/src/debezium_kafka.rs
@@ -97,12 +97,8 @@ impl DebeziumKafka {
             .map(move |msg| {
                 let schema = Arc::clone(&schema);
                 let pk = primary_keys.clone();
-                let Ok(msg) = msg else {
-                    return Err(cdc::StreamError::Kafka(format!(
-                        "Unable to read message: {:?}",
-                        msg.err()
-                    )));
-                };
+
+                let msg = msg.map_err(cdc::StreamError::Kafka)?;
 
                 let val = msg.value();
                 changes::to_change_batch(&schema, &pk, val)

--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -396,12 +396,7 @@ impl Kafka {
             .stream_json::<serde_json::Value, serde_json::Value>()
             .map(move |msg| {
                 let schema = Arc::clone(&schema);
-                let Ok(msg) = msg else {
-                    return Err(cdc::StreamError::Kafka(format!(
-                        "Unable to read message: {:?}",
-                        msg.err()
-                    )));
-                };
+                let msg = msg.map_err(cdc::StreamError::Kafka)?;
 
                 let json_str = match flatten_json {
                     Some(ref delimiter) => {
@@ -454,4 +449,25 @@ impl TableProvider for Kafka {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema))) as Arc<dyn ExecutionPlan>)
     }
+}
+
+/// Returns `true` if the provided [`StreamError`] represents a Kafka poll interval error.
+/// This error occurs when the application's poll interval exceeds the maximum allowed by Kafka.
+/// It is generally nonfatal and often indicates that the consumer should retry or continue polling.
+#[must_use]
+pub fn is_max_poll_interval_err(err: &cdc::StreamError) -> bool {
+    let cdc::StreamError::Kafka(kafka_stream_err) = err else {
+        return false;
+    };
+
+    let Error::UnableToReceiveMessage { source } = kafka_stream_err else {
+        return false;
+    };
+
+    matches!(
+        source,
+        rdkafka::error::KafkaError::MessageConsumption(
+            rdkafka::types::RDKafkaErrorCode::PollExceeded
+        )
+    )
 }

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -138,6 +138,15 @@ impl RefreshTask {
                     }
                 }
                 Err(e) => {
+                    // rdkafka will automatically recover from poll timeout errors, so we can continue.
+                    // warning is logged to inform the user about potential performance or connectivity issues.
+                    if data_components::kafka::is_max_poll_interval_err(&e) {
+                        tracing::warn!(
+                            "Kafka poll interval exceeded for dataset '{dataset_name}': connection lost or consumer too slow. Retrying."
+                        );
+                        continue;
+                    }
+
                     tracing::error!("Changes stream error for {dataset_name}: {e}");
                     self.set_refresh_status(
                         refresh.read().await.sql.clone().as_deref(),

--- a/crates/runtime/src/accelerated_table/refresh_task/changes.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/changes.rs
@@ -141,7 +141,7 @@ impl RefreshTask {
                     // rdkafka will automatically recover from poll timeout errors, so we can continue.
                     // warning is logged to inform the user about potential performance or connectivity issues.
                     if data_components::kafka::is_max_poll_interval_err(&e) {
-                        tracing::warn!(
+                        tracing::debug!(
                             "Kafka poll interval exceeded for dataset '{dataset_name}': connection lost or consumer too slow. Retrying."
                         );
                         continue;


### PR DESCRIPTION
## 📝 Summary

It is safe to warn as rdkafka will re-establish connection/re-join the group and will continue. Still keep as warning instead of fully ignoring to inform about potential problem (slow consumer performance or connectivity).  We might also add corresponding param to increase poll interval if needed.

>Kafka poll interval exceeded for dataset '{dataset_name}': connection lost or consumer too slow. Retrying.

<img width="800" height="59" alt="image" src="https://github.com/user-attachments/assets/e8cfb1fe-4d3e-4cf1-8612-592af72555fd" />


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
