### PR TITLE
Bedrock: Tool use without inputs must empty Document

### DIFF
--- a/crates/llms/src/bedrock/chat/mod.rs
+++ b/crates/llms/src/bedrock/chat/mod.rs
@@ -181,9 +181,10 @@ impl BedrockConverse {
                                     ..
                                 } = t;
 
-                                let tool_input = serde_json::from_str(arguments)
-                                    .ok()
-                                    .map_or(Document::Object(HashMap::default()), value_to_document);
+                                let tool_input = serde_json::from_str(arguments).ok().map_or(
+                                    Document::Object(HashMap::default()),
+                                    value_to_document,
+                                );
                                 Some(ContentBlock::ToolUse(
                                     ToolUseBlockBuilder::default()
                                         .set_tool_use_id(Some(id.clone()))

--- a/crates/llms/src/bedrock/chat/mod.rs
+++ b/crates/llms/src/bedrock/chat/mod.rs
@@ -180,13 +180,15 @@ impl BedrockConverse {
                                     ..
                                 } = t;
 
-                                let tool_input =
-                                    serde_json::from_str(arguments).ok().map(value_to_document);
+                                let tool_input = serde_json::from_str(arguments)
+                                    .ok()
+                                    .map(value_to_document)
+                                    .unwrap_or(Document::Object(HashMap::default()));
                                 Some(ContentBlock::ToolUse(
                                     ToolUseBlockBuilder::default()
                                         .set_tool_use_id(Some(id.clone()))
                                         .set_name(Some(name.clone()))
-                                        .set_input(tool_input)
+                                        .set_input(Some(tool_input))
                                         .build()
                                         .ok()?,
                                 ))

--- a/crates/llms/src/bedrock/chat/mod.rs
+++ b/crates/llms/src/bedrock/chat/mod.rs
@@ -59,6 +59,7 @@ use aws_sdk_bedrockruntime::types::{
     MessageStartEvent, MessageStopEvent, SystemContentBlock, ToolResultContentBlock,
     ToolResultStatus, ToolUseBlockDelta, ToolUseBlockStart,
 };
+use aws_smithy_types::Document;
 use futures::stream::StreamExt;
 use itertools::Itertools;
 use serde_json::{Value, json};

--- a/crates/llms/src/bedrock/chat/mod.rs
+++ b/crates/llms/src/bedrock/chat/mod.rs
@@ -183,8 +183,7 @@ impl BedrockConverse {
 
                                 let tool_input = serde_json::from_str(arguments)
                                     .ok()
-                                    .map(value_to_document)
-                                    .unwrap_or(Document::Object(HashMap::default()));
+                                    .map_or(Document::Object(HashMap::default()), value_to_document);
                                 Some(ContentBlock::ToolUse(
                                     ToolUseBlockBuilder::default()
                                         .set_tool_use_id(Some(id.clone()))


### PR DESCRIPTION
## 📝 Summary
For Assistant tool use messages which do not have inputs (e.g. `list_datasets`), do not have an input. Bedrock requires an empty input map regardless.
