### PR TITLE
Add retry for exporting task history records

### DIFF
--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2024-2025 The Spice.ai OSS Authors
 

--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -1,3 +1,4 @@
+
 /*
 Copyright 2024-2025 The Spice.ai OSS Authors
 

--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -40,6 +40,11 @@ use snafu::{ResultExt, Snafu};
 use spicepod::component::management::Management as SpicepodManagement;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
+use util::{
+    RetryError,
+    fibonacci_backoff::{FibonacciBackoff, FibonacciBackoffBuilder},
+    retry,
+};
 
 use crate::{
     Runtime,
@@ -322,10 +327,14 @@ async fn write_task_history_records_to_remote(
         update_type: UpdateType::Append,
     };
 
-    df.write_data(&TASK_HISTORY_SINK_TABLE.into(), data_update)
-        .await
-        .boxed()
-        .context(UnableToExportTaskHistoryDataSnafu)?;
+    let _ = retry(retry_strategy(), || async {
+        df.write_data(&TASK_HISTORY_SINK_TABLE.into(), data_update.clone())
+            .await
+            .map_err(RetryError::transient)
+    })
+    .await
+    .boxed()
+    .context(UnableToExportTaskHistoryDataSnafu)?;
 
     tracing::debug!("Exported {num_records} task history records");
 
@@ -389,4 +398,9 @@ async fn resolve_secret(secrets: &Arc<RwLock<Secrets>>, key: &str) -> SecretStri
     } else {
         SecretString::new(key.to_string().into())
     }
+}
+
+fn retry_strategy() -> FibonacciBackoff {
+    // Retry up to 10 times, with a maximum interval of 55 seconds between retries
+    FibonacciBackoffBuilder::new().max_retries(Some(10)).build()
 }

--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -327,7 +327,7 @@ async fn write_task_history_records_to_remote(
         update_type: UpdateType::Append,
     };
 
-    let _ = retry(retry_strategy(), || async {
+    retry(retry_strategy(), || async {
         df.write_data(&TASK_HISTORY_SINK_TABLE.into(), data_update.clone())
             .await
             .map_err(RetryError::transient)


### PR DESCRIPTION
## 📝 Summary

Add 10 retry attempts when exporting task history records (management extension)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
