### PR TITLE
Truncate `text_embed` task_history trace

### DIFF
--- a/crates/runtime/src/embeddings/task.rs
+++ b/crates/runtime/src/embeddings/task.rs
@@ -161,6 +161,7 @@ fn add_request_labels_to_span(req: &CreateEmbeddingRequest, span: &Span) {
     }
 }
 
+#[must_use]
 pub fn to_truncated_string(input: &EmbeddingInput) -> String {
     match input {
         EmbeddingInput::String(s) => serde_json::to_string(&s).unwrap_or_default(),

--- a/crates/runtime/src/embeddings/task.rs
+++ b/crates/runtime/src/embeddings/task.rs
@@ -54,6 +54,13 @@ impl Embed for TaskEmbed {
         let request_context = RequestContext::current(AsyncMarker::new().await);
         telemetry::track_text_embedding(&request_context.to_dimensions());
 
+        let num_items = match &input {
+            EmbeddingInput::StringArray(arr) => arr.len(),
+            EmbeddingInput::ArrayOfIntegerArray(arr) => arr.len(),
+            EmbeddingInput::String(_) => 1,
+            EmbeddingInput::IntegerArray(arr) => arr.len(),
+        };
+
         let start = std::time::Instant::now();
         let span = tracing::span!(target: "task_history", tracing::Level::INFO, "text_embed", input = to_truncated_string(&input));
 
@@ -67,6 +74,13 @@ impl Embed for TaskEmbed {
                 Err(e)
             }
         };
+
+        tracing::debug!(
+            "Embedded {num_items} records in {duration:?} using {name}",
+            duration = start.elapsed(),
+            name = self.name
+        );
+
         handle_metrics(
             start.elapsed(),
             result.is_err(),

--- a/crates/runtime/src/embeddings/task.rs
+++ b/crates/runtime/src/embeddings/task.rs
@@ -55,7 +55,7 @@ impl Embed for TaskEmbed {
         telemetry::track_text_embedding(&request_context.to_dimensions());
 
         let start = std::time::Instant::now();
-        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "text_embed", input = %serde_json::to_string(&input).unwrap_or_default());
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "text_embed", input = to_truncated_string(&input));
 
         let result = match self.inner.embed(input).instrument(span.clone()).await {
             Ok(response) => {
@@ -108,7 +108,7 @@ impl Embed for TaskEmbed {
         telemetry::track_text_embedding(&request_context.to_dimensions());
 
         let start = Instant::now();
-        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "text_embed", input = %serde_json::to_string(&req.input).unwrap_or_default());
+        let span = tracing::span!(target: "task_history", tracing::Level::INFO, "text_embed", input = to_truncated_string(&req.input));
 
         add_request_labels_to_span(&req, &span);
         let metric_labels = request_labels(&req);
@@ -144,5 +144,77 @@ fn add_request_labels_to_span(req: &CreateEmbeddingRequest, span: &Span) {
 
     if let Some(dims) = req.dimensions {
         tracing::info!(target: "task_history", dimensions = %dims, "labels");
+    }
+}
+
+pub fn to_truncated_string(input: &EmbeddingInput) -> String {
+    match input {
+        EmbeddingInput::String(s) => serde_json::to_string(&s).unwrap_or_default(),
+        EmbeddingInput::StringArray(arr) => format_array(arr),
+        EmbeddingInput::IntegerArray(arr) => serde_json::to_string(&arr).unwrap_or_default(),
+        EmbeddingInput::ArrayOfIntegerArray(arrs) => format_array(arrs),
+    }
+}
+
+const TRUNCATE_LIMIT: usize = 3;
+
+/// Formats arrays for tracing/logging, showing up to 3 items, followed by `...` if there are more.
+fn format_array<T: serde::Serialize>(arr: &[T]) -> String {
+    let mut parts = Vec::new();
+    for (i, v) in arr.iter().enumerate() {
+        if i >= TRUNCATE_LIMIT {
+            parts.push("...".to_string());
+            break;
+        }
+        parts.push(serde_json::to_string(v).unwrap_or_default());
+    }
+    format!("[{}]", parts.join(","))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string() {
+        let input = EmbeddingInput::String("hello".into());
+        assert_eq!(to_truncated_string(&input), r#""hello""#);
+    }
+
+    #[test]
+    fn test_string_array_under_limit() {
+        let input = EmbeddingInput::StringArray(vec!["a".into(), "b".into(), "c".into()]);
+        assert_eq!(to_truncated_string(&input), r#"["a","b","c"]"#);
+    }
+
+    #[test]
+    fn test_string_array_over_limit() {
+        let input =
+            EmbeddingInput::StringArray(vec!["a".into(), "b".into(), "c".into(), "d".into()]);
+        assert_eq!(to_truncated_string(&input), r#"["a","b","c",...]"#);
+    }
+
+    #[test]
+    fn test_integer_array_under_limit() {
+        let input = EmbeddingInput::IntegerArray(vec![1, 2]);
+        assert_eq!(to_truncated_string(&input), "[1,2]");
+    }
+
+    #[test]
+    fn test_integer_array_over_limit() {
+        let input = EmbeddingInput::IntegerArray(vec![1, 2, 3, 4]);
+        assert_eq!(to_truncated_string(&input), "[1,2,3,4]");
+    }
+
+    #[test]
+    fn test_array_of_integer_array_under_limit() {
+        let input = EmbeddingInput::ArrayOfIntegerArray(vec![vec![1, 2], vec![3, 4]]);
+        assert_eq!(to_truncated_string(&input), "[[1,2],[3,4]]");
+    }
+
+    #[test]
+    fn test_array_of_integer_array_over_limit() {
+        let input = EmbeddingInput::ArrayOfIntegerArray(vec![vec![1], vec![2], vec![3], vec![4]]);
+        assert_eq!(to_truncated_string(&input), "[[1],[2],[3],...]");
     }
 }


### PR DESCRIPTION
## 📝 Summary

When a `text_embed` record is added into `task_history`, we should truncate the input; otherwise, it produces a very large payload.
This PR improves the behavior to include only the first 3 example strings, followed by `...` if the input contains more than 3 items to calculate embeddings for.

The PR also adds tracing (`trace::debug!`) for embedding creation time across all supported models.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Moving the following improvements from surge demo branch into trunk:
 - https://github.com/spiceai/spiceai/pull/7044
 - https://github.com/spiceai/spiceai/pull/7040
