### PR TITLE
fix: Avoid redundant search embedding

### DIFF
--- a/crates/runtime/src/search/candidate/vector.rs
+++ b/crates/runtime/src/search/candidate/vector.rs
@@ -353,13 +353,13 @@ impl CandidateGeneration for VectorGeneration {
         addition_projection: &[&Expr],
         limit: usize,
     ) -> search::generation::Result<SendableRecordBatchStream> {
-        let embedding = self
-            .embed_query(query.as_str())
-            .await
-            .boxed()
-            .map_err(|e| SearchGenerationError::InternalError { source: e })?;
-
         let query = if self.is_chunked {
+            let embedding = self
+                .embed_query(query.as_str())
+                .await
+                .boxed()
+                .map_err(|e| SearchGenerationError::InternalError { source: e })?;
+
             let query = self.chunked_sql(
                 addition_projection,
                 embedding.as_slice(),


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Avoids embedding the search column twice during a search pipeline operation