### PR TITLE
Increase DoPut write timeout for the next batch from 30 to 120 seconds

### DIFF
--- a/crates/runtime/src/flight/do_put.rs
+++ b/crates/runtime/src/flight/do_put.rs
@@ -191,9 +191,9 @@ fn create_response_stream(
 
         loop {
             tokio::select! {
-                () = sleep(Duration::from_secs(30)) => {
-                    tracing::error!("Timeout: no record batch received within 30 seconds");
-                    yield Err(Status::deadline_exceeded("Timeout: no record batch received within 30 seconds"));
+                () = sleep(Duration::from_secs(120)) => {
+                    tracing::error!("Timeout: no record batch received within 120 seconds");
+                    yield Err(Status::deadline_exceeded("Timeout: no record batch received within 120 seconds"));
                     break;
                 }
                 // Poll the writing task to check if it has completed with an error while processing the data

--- a/crates/runtime/tests/flight/do_put.rs
+++ b/crates/runtime/tests/flight/do_put.rs
@@ -305,9 +305,9 @@ async fn test_do_put_read_timeout() -> Result<(), Box<dyn std::error::Error>> {
 
     let first_batch =
         stream::once(async { Ok(record_batch_1) as Result<RecordBatch, FlightError> });
-    // batch with 40s delay
+    // batch with 130s delay
     let second_batch = stream::once(async {
-        sleep(Duration::from_secs(40)).await;
+        sleep(Duration::from_secs(130)).await;
         Ok(record_batch_2) as Result<RecordBatch, FlightError>
     });
     let third_batch =


### PR DESCRIPTION
## 📝 Summary

Make management extension more robust when handling large task_history records preventing the following error

>2025-09-04T19:07:38.547604Z  WARN runtime::management: Error exporting task_history records: Unable to execute the table insert for scp.task_history: External error: Unable to publish data to Flight endpoint: Failed to publish data to flight endpoint. Deadline expired before operation could complete. DoPut send error: EOF
DoPut proxy recv error: rpc error: code = DeadlineExceeded desc = Timeout: no record batch received within 30 seconds. Retrying in 5 seconds

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
