### PR TITLE
Use the UTC offset for the `start_time` and `end_time` fields in the task history

### DIFF
--- a/crates/runtime/src/task_history/mod.rs
+++ b/crates/runtime/src/task_history/mod.rs
@@ -138,12 +138,12 @@ impl TaskSpan {
             Field::new("captured_output", DataType::Utf8, true),
             Field::new(
                 "start_time",
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
                 false,
             ), // Note: Used for time column of Retention
             Field::new(
                 "end_time",
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
                 false,
             ),
             Field::new("execution_duration_ms", DataType::Float64, false),


### PR DESCRIPTION
## 📝 Summary

Explicitly specify the "UTC" timezone for the `start_time` and `end_time` fields in the runtime.task_history table. 
Note: This is consistent with the runtime.metrics table.

```console
sql> describe runtime.metrics;
+-------------------------+--------------------------------------------------+
| column_name             | data_type                          | is_nullable |
+-------------------------+--------------------------------------------------+
| time_unix_nano          | Timestamp(Nanosecond, Some("UTC")) | NO          |
| start_time_unix_nano    | Timestamp(Nanosecond, Some("UTC")) | YES         |
+-------------------------+--------------------------------------------------+

sql> describe runtime.task_history;
+-------------------------+------------------------------------+-------------+
| column_name             | data_type                          | is_nullable |
+-------------------------+------------------------------------+-------------+
| start_time              | Timestamp(Nanosecond, None)        | NO          |
| end_time                | Timestamp(Nanosecond, None)        | NO          |
+-------------------------+------------------------------------+-------------+
```

After:

```console
sql> describe runtime.task_history;
+-------------------------+------------------------------------+-------------+
| column_name             | data_type                          | is_nullable |
+-------------------------+------------------------------------+-------------+
| start_time              | Timestamp(Nanosecond, Some("UTC")) | NO          |
| end_time                | Timestamp(Nanosecond, Some("UTC")) | NO          |
+-------------------------+------------------------------------+-------------+
```
