### PR TITLE
Use multiple S3 indexes as single logical vector index.

### DIFF
--- a/crates/data_components/src/s3_vectors/index_query_provider.rs
+++ b/crates/data_components/src/s3_vectors/index_query_provider.rs
@@ -57,11 +57,11 @@ pub static S3_VECTOR_MAX_TOPK: i64 = 30;
 
 /// An S3 Vector index that implements [`TableProvider`] as a `QueryVector` API operation for a given query vector.
 #[derive(Debug)]
-pub struct S3VectorsQueryTable {
+pub struct S3VectorsQueryIndexTable {
     table: S3VectorsTable,
     query: Vec<f32>,
 }
-impl S3VectorsQueryTable {
+impl S3VectorsQueryIndexTable {
     #[must_use]
     pub fn new(table: S3VectorsTable, query: Vec<f32>) -> Self {
         Self { table, query }
@@ -69,7 +69,7 @@ impl S3VectorsQueryTable {
 }
 
 #[async_trait]
-impl TableProvider for S3VectorsQueryTable {
+impl TableProvider for S3VectorsQueryIndexTable {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -137,14 +137,14 @@ impl TableProvider for S3VectorsQueryTable {
         let limit: i64 = match limit {
             Some(l) if (l as i64) > S3_VECTOR_MAX_TOPK => {
                 tracing::warn!(
-                    "S3VectorsQueryTable: limit {l} exceeds maximum of {S3_VECTOR_MAX_TOPK}, truncating."
+                    "S3VectorsQueryIndexTable: limit {l} exceeds maximum of {S3_VECTOR_MAX_TOPK}, truncating."
                 );
                 S3_VECTOR_MAX_TOPK
             }
             None => S3_VECTOR_MAX_TOPK,
             Some(l) => l as i64,
         };
-        Ok(Arc::new(S3VectorsQueryExec::new(
+        Ok(Arc::new(S3VectorsQueryIndexExec::new(
             self,
             projection,
             limit,
@@ -154,13 +154,14 @@ impl TableProvider for S3VectorsQueryTable {
     }
 }
 
-impl std::fmt::Debug for S3VectorsQueryExec {
+impl std::fmt::Debug for S3VectorsQueryIndexExec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("S3VectorsQueryExec").finish_non_exhaustive()
+        f.debug_struct("S3VectorsQueryIndexExec")
+            .finish_non_exhaustive()
     }
 }
 
-struct S3VectorsQueryExec {
+struct S3VectorsQueryIndexExec {
     idx: S3VectorIdentifier,
     client: Arc<dyn S3Vectors + Send + Sync>,
     plan_properties: PlanProperties,
@@ -169,9 +170,9 @@ struct S3VectorsQueryExec {
     filters: Vec<Expr>,
 }
 
-impl DisplayAs for S3VectorsQueryExec {
+impl DisplayAs for S3VectorsQueryIndexExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "S3VectorsQueryExec: ")?;
+        write!(f, "S3VectorsQueryIndexExec: ")?;
         if let Ok(Some(filter)) = convert_datafusion_filters_to_s3_vectors(&self.filters) {
             write!(f, "filter={filter} ")?;
         }
@@ -180,9 +181,9 @@ impl DisplayAs for S3VectorsQueryExec {
     }
 }
 
-impl S3VectorsQueryExec {
+impl S3VectorsQueryIndexExec {
     pub fn new(
-        table: &S3VectorsQueryTable,
+        table: &S3VectorsQueryIndexTable,
         projection: Option<&Vec<usize>>,
         limit: i64,
         query: Vec<f32>,
@@ -206,7 +207,7 @@ impl S3VectorsQueryExec {
         );
 
         Self {
-            idx: table.table.idx.clone(),
+            idx: table.table.identifier.clone(),
             client: Arc::clone(&table.table.client),
             plan_properties: properties,
             query,
@@ -216,9 +217,9 @@ impl S3VectorsQueryExec {
     }
 }
 
-impl ExecutionPlan for S3VectorsQueryExec {
+impl ExecutionPlan for S3VectorsQueryIndexExec {
     fn name(&self) -> &'static str {
-        "S3VectorsQueryExec"
+        "S3VectorsQueryIndexExec"
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/data_components/src/s3_vectors/list_provider.rs
+++ b/crates/data_components/src/s3_vectors/list_provider.rs
@@ -152,7 +152,7 @@ impl S3VectorsListExec {
         );
 
         Self {
-            idx: table.as_ref().idx.clone(),
+            idx: table.as_ref().identifier.clone(),
             client: Arc::clone(&table.as_ref().client),
             plan_properties: properties,
             limit,
@@ -294,68 +294,81 @@ async fn list_vector_segment(
     let mut next_token = None;
     let mut segment_vectors_retrieved = 0;
 
-    while remaining_limit > 0 {
-        let ListVectorsOutput {
-            next_token: next_token_opt,
-            vectors,
+    let index_names = match idx {
+        S3VectorIdentifier::PartitionedIndex {
+            index_name,
+            num_partitions,
             ..
-        } = client
-            .list_vectors(
-                ListVectorsInput::builder()
-                    .set_vector_bucket_name(bucket_name.clone())
-                    .set_index_arn(arn.clone())
-                    .set_index_name(index_name.clone())
-                    .max_results(
-                        i32::try_from(remaining_limit.min(LIST_VECTORS_MAX_RESULTS))
-                            .unwrap_or(i32::MAX),
-                    )
-                    .set_next_token(next_token.clone())
-                    .return_data(true)
-                    .return_metadata(true)
-                    .segment_count(i32::try_from(segment_count).unwrap_or(i32::MAX))
-                    .segment_index(i32::try_from(segment_index).unwrap_or(i32::MAX))
-                    .build()
-                    .boxed()
-                    .map_err(DataFusionError::External)?,
-            )
-            .await
-            .boxed()
-            .map_err(DataFusionError::External)?;
+        } => (0..num_partitions)
+            .map(|i| Some(format!("{index_name}-{i}")))
+            .collect(),
+        _ => vec![index_name],
+    };
 
-        remaining_limit = remaining_limit.saturating_sub(vectors.len());
-        let num_vectors = vectors.len();
-        segment_vectors_retrieved += num_vectors;
-        next_token = next_token_opt;
+    for index_name in index_names {
+        while remaining_limit > 0 {
+            let ListVectorsOutput {
+                next_token: next_token_opt,
+                vectors,
+                ..
+            } = client
+                .list_vectors(
+                    ListVectorsInput::builder()
+                        .set_vector_bucket_name(bucket_name.clone())
+                        .set_index_arn(arn.clone())
+                        .set_index_name(index_name.clone())
+                        .max_results(
+                            i32::try_from(remaining_limit.min(LIST_VECTORS_MAX_RESULTS))
+                                .unwrap_or(i32::MAX),
+                        )
+                        .set_next_token(next_token.clone())
+                        .return_data(true)
+                        .return_metadata(true)
+                        .segment_count(i32::try_from(segment_count).unwrap_or(i32::MAX))
+                        .segment_index(i32::try_from(segment_index).unwrap_or(i32::MAX))
+                        .build()
+                        .boxed()
+                        .map_err(DataFusionError::External)?,
+                )
+                .await
+                .boxed()
+                .map_err(DataFusionError::External)?;
 
-        let rows: Vec<_> = vectors.into_iter().map(to_flat_value).collect();
-        decoder.serialize(rows.as_slice()).map_err(|e| {
-            DataFusionError::ArrowError(
-                e,
-                Some(
-                    "could not convert ListVectors JSON response into expected Arrow format"
-                        .to_string(),
-                ),
-            )
-        })?;
+            remaining_limit = remaining_limit.saturating_sub(vectors.len());
+            let num_vectors = vectors.len();
+            segment_vectors_retrieved += num_vectors;
+            next_token = next_token_opt;
 
-        match decoder.flush() {
-            Ok(Some(rb)) => {
-                let _ = tx.send(Ok(rb)).await;
+            let rows: Vec<_> = vectors.into_iter().map(to_flat_value).collect();
+            decoder.serialize(rows.as_slice()).map_err(|e| {
+                DataFusionError::ArrowError(
+                    e,
+                    Some(
+                        "could not convert ListVectors JSON response into expected Arrow format"
+                            .to_string(),
+                    ),
+                )
+            })?;
+
+            match decoder.flush() {
+                Ok(Some(rb)) => {
+                    let _ = tx.send(Ok(rb)).await;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    let _ = tx
+                        .send(Err(DataFusionError::ArrowError(
+                            e,
+                            Some("Received only partial JSON payload from ListVectors".to_string()),
+                        )))
+                        .await;
+                }
             }
-            Ok(None) => {}
-            Err(e) => {
-                let _ = tx
-                    .send(Err(DataFusionError::ArrowError(
-                        e,
-                        Some("Received only partial JSON payload from ListVectors".to_string()),
-                    )))
-                    .await;
-            }
-        }
 
-        // No more results for this segment
-        if next_token.is_none() {
-            break;
+            // No more results for this segment
+            if next_token.is_none() {
+                break;
+            }
         }
     }
 

--- a/crates/data_components/src/s3_vectors/mod.rs
+++ b/crates/data_components/src/s3_vectors/mod.rs
@@ -16,13 +16,14 @@ limitations under the License.
 use arrow::error::ArrowError;
 use s3_vectors::{
     BuildError, CreateIndexError, CreateVectorBucketError, DistanceMetric, Document, GetIndexError,
-    GetVectorBucketError, PutVectorsError, QueryVectorsError,
+    GetVectorBucketError, ListIndexesError, PutVectorsError, QueryVectorsError,
 };
 use s3_vectors_metadata_filter::MetadataFilter;
 use snafu::Snafu;
 
+pub mod index_query_provider;
 pub mod list_provider;
-pub mod query_provider;
+pub mod partitioned_index_query_provider;
 mod vector_table;
 pub use vector_table::{S3VectorTableResult, S3VectorsTable};
 mod metadata_column;
@@ -65,6 +66,9 @@ pub enum Error {
 
     #[snafu(display("Failed to get bucket from S3 Vectors. {source}"))]
     S3VectorGetBucketError { source: GetVectorBucketError },
+
+    #[snafu(display("Failed to list indexes from S3 Vectors. {source}"))]
+    S3VectorListIndexesError { source: ListIndexesError },
 
     #[snafu(display("Failed to get index from S3 Vectors. {source}"))]
     S3VectorGetIndexError { source: GetIndexError },
@@ -110,6 +114,11 @@ pub enum S3VectorIdentifier {
         bucket_name: String,
         index_name: String,
     },
+    PartitionedIndex {
+        bucket_name: String,
+        index_name: String,
+        num_partitions: usize,
+    },
 }
 
 impl S3VectorIdentifier {
@@ -120,6 +129,11 @@ impl S3VectorIdentifier {
             Self::Index {
                 bucket_name,
                 index_name,
+            }
+            | Self::PartitionedIndex {
+                bucket_name,
+                index_name,
+                ..
             } => (None, Some(bucket_name.clone()), Some(index_name.clone())),
             Self::IndexArn(arn) => (Some(arn.clone()), None, None),
         }

--- a/crates/data_components/src/s3_vectors/partitioned_index_query_provider.rs
+++ b/crates/data_components/src/s3_vectors/partitioned_index_query_provider.rs
@@ -1,0 +1,194 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+use std::{any::Any, sync::Arc};
+
+use crate::s3_vectors::{S3VectorIdentifier, vector_table::S3VectorsTable};
+
+use super::{
+    Error,
+    index_query_provider::{S3_VECTOR_DISTANCE_NAME, S3VectorsQueryIndexTable},
+};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::{
+    catalog::{Session, TableProvider},
+    common::Constraints,
+    datasource::TableType,
+    error::{DataFusionError, Result as DataFusionResult},
+    logical_expr::TableProviderFilterPushDown,
+    physical_plan::{ExecutionPlan, empty::EmptyExec, limit::GlobalLimitExec, union::UnionExec},
+    prelude::Expr,
+};
+use s3_vectors::ListIndexesInput;
+use s3_vectors_metadata_filter;
+use snafu::ResultExt;
+
+/// An S3 Vector bucket that implements [`TableProvider`] as a `QueryVector` API operation for all indexes in the bucket.
+#[derive(Debug)]
+pub struct S3VectorsQueryPartitionedIndexTable {
+    table: S3VectorsTable,
+    query: Vec<f32>,
+}
+
+impl S3VectorsQueryPartitionedIndexTable {
+    #[must_use]
+    pub fn new(table: S3VectorsTable, query: Vec<f32>) -> Self {
+        Self { table, query }
+    }
+}
+
+#[async_trait]
+impl TableProvider for S3VectorsQueryPartitionedIndexTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        let mut base_fields = self
+            .table
+            .schema
+            .fields()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        base_fields.push(Arc::new(Field::new(
+            S3_VECTOR_DISTANCE_NAME,
+            DataType::Float64,
+            false,
+        )));
+
+        Arc::new(Schema::new(base_fields))
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn constraints(&self) -> Option<&Constraints> {
+        Some(&self.table.constraints)
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        // Filters can only possibly be pushed down for columns in underlying metadata (i.e. not derived columns like `S3_VECTOR_DISTANCE_NAME`).
+        let columns: Vec<_> = self
+            .table
+            .schema
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .filter(|c| self.table.is_filterable_column(c.as_str()))
+            .collect();
+
+        Ok(filters
+            .iter()
+            .map(|f| {
+                if s3_vectors_metadata_filter::supports_filter_expr(columns.as_slice(), f) {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if limit == Some(0) {
+            return Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema()))));
+        }
+
+        let (_, Some(bucket_name), Some(index_name)) =
+            self.table.identifier.index_identifier_variables()
+        else {
+            return Err(DataFusionError::Execution(format!(
+                "No bucket name or index name for bucket query"
+            )));
+        };
+
+        let list_indexes_output = self
+            .table
+            .client
+            .list_indexes(
+                ListIndexesInput::builder()
+                    .set_vector_bucket_name(Some(bucket_name.clone()))
+                    .build()
+                    .boxed()
+                    .map_err(DataFusionError::External)?,
+            )
+            .await
+            .map_err(|e| {
+                DataFusionError::External(
+                    Error::S3VectorListIndexesError {
+                        source: e.into_service_error(),
+                    }
+                    .into(),
+                )
+            })?;
+
+        let index_names: Vec<_> = list_indexes_output
+            .indexes()
+            .iter()
+            .filter_map(|idx| {
+                let name = idx.index_name().to_string();
+                // Avoid `index_name.len() == name.len()` as this will be a non-partitioned index we don't expect.
+                if name.starts_with(&index_name) && index_name.len() > name.len() {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if index_names.is_empty() {
+            return Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema()))));
+        }
+
+        let mut index_plans: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
+        for index_name in index_names {
+            let index_table_identifier = S3VectorIdentifier::Index {
+                bucket_name: bucket_name.clone(),
+                index_name,
+            };
+
+            let index_table = S3VectorsTable {
+                client: Arc::clone(&self.table.client),
+                identifier: index_table_identifier,
+                schema: Arc::clone(&self.table.schema),
+                constraints: self.table.constraints.clone(),
+            };
+
+            let query_table = S3VectorsQueryIndexTable::new(index_table, self.query.clone());
+
+            let index_plan = query_table.scan(state, projection, filters, limit).await?;
+            index_plans.push(index_plan);
+        }
+
+        let union_plan = Arc::new(UnionExec::new(index_plans));
+
+        let limit_plan = Arc::new(GlobalLimitExec::new(union_plan, 0, limit));
+
+        Ok(limit_plan)
+    }
+}

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -13,7 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use std::{collections::HashMap, error::Error as StdError, sync::Arc};
+use std::{
+    collections::HashMap,
+    error::Error as StdError,
+    hash::{DefaultHasher, Hash, Hasher},
+    sync::Arc,
+};
 
 use crate::s3_vectors::{
     MetadataColumn, MetadataColumns, S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
@@ -424,29 +429,69 @@ impl S3VectorsTable {
 
         let (index_arn, vector_bucket_name, index_name) = self.idx.index_identifier_variables();
 
-        for chunk in vectors.chunks(PUT_VECTORS_MAX_ITEMS) {
-            self.client
-                .put_vectors(
-                    PutVectorsInput::builder()
-                        .set_index_arn(index_arn.clone())
-                        .set_index_name(index_name.clone())
-                        .set_vector_bucket_name(vector_bucket_name.clone())
-                        .set_vectors(Some(chunk.to_vec()))
-                        .build()
-                        .context(S3VectorBuildSnafu)?,
-                )
-                .await
-                .map_err(|e| Error::S3VectorPutVectorError {
-                    source: e.into_service_error(),
-                })?;
+        let num_partitions = match self.identifier {
+            S3VectorIdentifier::PartitionedIndex { num_partitions, .. } => Some(num_partitions),
+            _ => None,
+        };
+
+        let index_name = index_name.unwrap();
+        let vectors_len = vectors.len();
+
+        for (i, chunk) in bucket_by(vectors, num_partitions.unwrap_or(1), |put_input| {
+            let mut h = DefaultHasher::new();
+            put_input.key.hash(&mut h);
+            h.finish() as usize
+        })
+        .into_iter()
+        .enumerate()
+        {
+            let index_name = match num_partitions {
+                Some(n) => format!("{index_name}-{}", i % n),
+                None => index_name.clone(),
+            };
+
+            for c in chunk.chunks(PUT_VECTORS_MAX_ITEMS) {
+                // TODO: Don't do these `put_vectors` in serial
+                self.client
+                    .put_vectors(
+                        PutVectorsInput::builder()
+                            .set_index_arn(index_arn.clone())
+                            .set_index_name(Some(index_name.clone()))
+                            .set_vector_bucket_name(vector_bucket_name.clone())
+                            .set_vectors(Some(c.to_vec()))
+                            .build()
+                            .context(S3VectorBuildSnafu)?,
+                    )
+                    .await
+                    .map_err(|e| Error::S3VectorPutVectorError {
+                        source: e.into_service_error(),
+                    })?;
+            }
         }
 
         tracing::info!(
-            "S3 Vectors Index updated; records={} records, duration={duration:?}",
-            vectors.len(),
+            "S3 Vectors Index updated for index '{index_name}'; records={vectors_len} records, duration={duration:?}",
             duration = start.elapsed()
         );
 
         Ok(())
     }
+}
+
+fn bucket_by<T, F>(items: Vec<T>, n_buckets: usize, mut by: F) -> Vec<Vec<T>>
+where
+    F: FnMut(&T) -> usize,
+{
+    if n_buckets <= 1 {
+        return vec![items];
+    }
+
+    let mut buckets: Vec<Vec<T>> = (0..n_buckets).map(|_| Vec::new()).collect();
+
+    for item in items {
+        let b = by(&item) % n_buckets;
+        buckets[b].push(item);
+    }
+
+    buckets
 }

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -39,10 +39,10 @@ use s3_vectors_metadata_filter::json_value_to_document;
 use serde_json::Value;
 use snafu::ResultExt;
 
-/// An S3 Vector index.
+/// An S3 Vector index or bucket.
 #[derive(Clone)]
 pub struct S3VectorsTable {
-    pub(super) idx: S3VectorIdentifier,
+    pub identifier: S3VectorIdentifier,
     pub(super) client: Arc<dyn S3Vectors + Send + Sync>,
 
     // The SQL schema of the index. Expects to have:
@@ -59,7 +59,7 @@ impl std::fmt::Debug for S3VectorsTable {
         f.debug_struct("S3VectorsListTable")
             .field("schema", &self.schema)
             .field("constraints", &self.constraints)
-            .field("index_identifier", &self.idx)
+            .field("identifier", &self.identifier)
             .finish_non_exhaustive()
     }
 }
@@ -91,24 +91,42 @@ impl S3VectorsTable {
         if !Self::check_if_bucket_exists(&client, &id).await? {
             return Ok(S3VectorTableResult::BucketDoesNotExist);
         }
-        match Self::get_index_if_exists(&id, &client).await? {
-            Some(GetIndexOutput {
-                index: Some(index), ..
-            }) => {
-                if index.distance_metric() != distance_metric {
-                    return Err(Error::IncompatibleDistanceMetric {
-                        exists: index.distance_metric,
-                        specified: distance_metric.clone(),
-                    });
+
+        if let S3VectorIdentifier::PartitionedIndex {
+            bucket_name,
+            index_name,
+            num_partitions,
+        } = id.clone()
+        {
+            for i in 0..num_partitions {
+                let index_name = format!("{index_name}-{i}");
+                let identifier = S3VectorIdentifier::Index {
+                    bucket_name: bucket_name.clone(),
+                    index_name,
+                };
+                match Self::get_index_if_exists(&identifier, &client).await? {
+                    Some(GetIndexOutput {
+                        index: Some(index), ..
+                    }) => {
+                        if index.distance_metric() != distance_metric {
+                            return Err(Error::IncompatibleDistanceMetric {
+                                exists: index.distance_metric,
+                                specified: distance_metric.clone(),
+                            });
+                        }
+                    }
+                    None => return Ok(S3VectorTableResult::IndexDoesNotExist),
+                    Some(_) => {}
                 }
             }
-            None => return Ok(S3VectorTableResult::IndexDoesNotExist),
-            Some(_) => {}
+        } else if !Self::check_if_index_exists(&id, &client).await? {
+            return Ok(S3VectorTableResult::IndexDoesNotExist);
         }
+
         let schema = Self::compute_schema(columns);
         let constraints = Self::primary_key(&schema);
         Ok(S3VectorTableResult::Table(Self {
-            idx: id,
+            identifier: id,
             client,
             schema,
             constraints,
@@ -172,21 +190,6 @@ impl S3VectorsTable {
         }
     }
 
-    #[must_use]
-    pub fn new(
-        index: S3VectorIdentifier,
-        client: Arc<dyn S3Vectors + Send + Sync>,
-        schema: SchemaRef,
-    ) -> Self {
-        let constraints = Self::primary_key(&schema);
-        Self {
-            idx: index,
-            client,
-            schema,
-            constraints,
-        }
-    }
-
     async fn create_index(
         client: &Arc<dyn S3Vectors + Send + Sync>,
         dimension: i64,
@@ -194,12 +197,17 @@ impl S3VectorsTable {
         non_filterable_metadata_columns: Vec<String>,
         distance_metric: &DistanceMetric,
     ) -> Result<()> {
-        let S3VectorIdentifier::Index {
-            bucket_name,
-            index_name,
-        } = vector_id
-        else {
-            return Err(Error::CreateIndexUsingArn);
+        let (bucket_name, index_name, num_partitions) = match vector_id {
+            S3VectorIdentifier::IndexArn(_) => return Err(Error::CreateIndexUsingArn),
+            S3VectorIdentifier::Index {
+                bucket_name,
+                index_name,
+            } => (bucket_name, index_name, None),
+            S3VectorIdentifier::PartitionedIndex {
+                bucket_name,
+                index_name,
+                num_partitions,
+            } => (bucket_name, index_name, Some(num_partitions)),
         };
 
         let metadata_configuration = if non_filterable_metadata_columns.is_empty() {
@@ -213,22 +221,32 @@ impl S3VectorsTable {
             )
         };
 
-        client
-            .create_index(
-                CreateIndexInput::builder()
-                    .data_type(s3_vectors::DataType::Float32)
-                    .dimension(dimension.try_into().unwrap_or(i32::MAX))
-                    .distance_metric(distance_metric.clone())
-                    .index_name(index_name)
-                    .set_metadata_configuration(metadata_configuration)
-                    .vector_bucket_name(bucket_name)
-                    .build()
-                    .context(S3VectorBuildSnafu)?,
-            )
-            .await
-            .map_err(|e| Error::S3VectorCreateIndexError {
-                source: e.into_service_error(),
-            })?;
+        let index_names = match num_partitions {
+            Some(num_partitions) => (0..*num_partitions)
+                .map(|i| format!("{index_name}-{i}"))
+                .collect(),
+            None => vec![index_name.clone()],
+        };
+
+        for index_name in index_names {
+            client
+                .create_index(
+                    CreateIndexInput::builder()
+                        .data_type(s3_vectors::DataType::Float32)
+                        .dimension(dimension.try_into().unwrap_or(i32::MAX))
+                        .distance_metric(distance_metric.clone())
+                        .index_name(index_name)
+                        .set_metadata_configuration(metadata_configuration.clone())
+                        .vector_bucket_name(bucket_name)
+                        .build()
+                        .context(S3VectorBuildSnafu)?,
+                )
+                .await
+                .map_err(|e| Error::S3VectorCreateIndexError {
+                    source: e.into_service_error(),
+                })?;
+        }
+
         Ok(())
     }
 
@@ -236,9 +254,11 @@ impl S3VectorsTable {
         client: &Arc<dyn S3Vectors + Send + Sync>,
         id: &S3VectorIdentifier,
     ) -> Result<()> {
-        let S3VectorIdentifier::Index { bucket_name, .. } = id else {
-            return Err(Error::CreateIndexUsingArn);
+        let bucket_name = match id {
+            S3VectorIdentifier::Index { bucket_name, .. } => bucket_name,
+            _ => return Err(Error::CreateIndexUsingArn),
         };
+
         client
             .create_vector_bucket(
                 CreateVectorBucketInput::builder()
@@ -253,12 +273,42 @@ impl S3VectorsTable {
         Ok(())
     }
 
+    /// Returns whether the index exists.
+    async fn check_if_index_exists(
+        identifier: &S3VectorIdentifier,
+        client: &Arc<dyn S3Vectors + Send + Sync>,
+    ) -> Result<bool> {
+        let (index_arn, vector_bucket_name, index_name) = identifier.index_identifier_variables();
+        match client
+            .get_index(
+                GetIndexInput::builder()
+                    .set_index_arn(index_arn)
+                    .set_vector_bucket_name(vector_bucket_name)
+                    .set_index_name(index_name)
+                    .build()
+                    .context(S3VectorBuildSnafu)?,
+            )
+            .await
+        {
+            Err(SdkError::ServiceError(e))
+                if matches!(&e.err(), GetIndexError::NotFoundException(_msg)) =>
+            {
+                Ok(false)
+            }
+            Ok(_) => Ok(true),
+            Err(e) => Err(Error::S3VectorGetIndexError {
+                source: e.into_service_error(),
+            }),
+        }
+    }
+
     async fn check_if_bucket_exists(
         client: &Arc<dyn S3Vectors + Send + Sync>,
         id: &S3VectorIdentifier,
     ) -> Result<bool> {
         let bucket_name_opt = match id {
-            S3VectorIdentifier::Index { bucket_name, .. } => Some(bucket_name.clone()),
+            S3VectorIdentifier::Index { bucket_name, .. }
+            | S3VectorIdentifier::PartitionedIndex { bucket_name, .. } => Some(bucket_name.clone()),
             S3VectorIdentifier::IndexArn(_) => None,
         };
         match client
@@ -427,7 +477,8 @@ impl S3VectorsTable {
             })
             .collect();
 
-        let (index_arn, vector_bucket_name, index_name) = self.idx.index_identifier_variables();
+        let (index_arn, vector_bucket_name, index_name) =
+            self.identifier.index_identifier_variables();
 
         let num_partitions = match self.identifier {
             S3VectorIdentifier::PartitionedIndex { num_partitions, .. } => Some(num_partitions),
@@ -449,24 +500,20 @@ impl S3VectorsTable {
                 Some(n) => format!("{index_name}-{}", i % n),
                 None => index_name.clone(),
             };
-
-            for c in chunk.chunks(PUT_VECTORS_MAX_ITEMS) {
-                // TODO: Don't do these `put_vectors` in serial
-                self.client
-                    .put_vectors(
-                        PutVectorsInput::builder()
-                            .set_index_arn(index_arn.clone())
-                            .set_index_name(Some(index_name.clone()))
-                            .set_vector_bucket_name(vector_bucket_name.clone())
-                            .set_vectors(Some(c.to_vec()))
-                            .build()
-                            .context(S3VectorBuildSnafu)?,
-                    )
-                    .await
-                    .map_err(|e| Error::S3VectorPutVectorError {
-                        source: e.into_service_error(),
-                    })?;
-            }
+            self.client
+                .put_vectors(
+                    PutVectorsInput::builder()
+                        .set_index_arn(index_arn.clone())
+                        .set_index_name(Some(index_name))
+                        .set_vector_bucket_name(vector_bucket_name.clone())
+                        .set_vectors(Some(chunk.to_vec()))
+                        .build()
+                        .context(S3VectorBuildSnafu)?,
+                )
+                .await
+                .map_err(|e| Error::S3VectorPutVectorError {
+                    source: e.into_service_error(),
+                })?;
         }
 
         tracing::info!(

--- a/crates/runtime/src/embeddings/index/s3/index.rs
+++ b/crates/runtime/src/embeddings/index/s3/index.rs
@@ -21,8 +21,10 @@ use arrow_schema::{DataType, Field};
 use async_openai::types::EmbeddingInput;
 use async_trait::async_trait;
 use data_components::s3_vectors::{
-    MetadataColumns, S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME, S3VectorsTable,
-    list_provider::S3VectorsListTable, query_provider::S3VectorsQueryTable,
+    MetadataColumns, S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME, S3VectorIdentifier,
+    S3VectorsTable, index_query_provider::S3VectorsQueryIndexTable,
+    list_provider::S3VectorsListTable,
+    partitioned_index_query_provider::S3VectorsQueryPartitionedIndexTable,
 };
 use futures::future::try_join_all;
 use llms::embeddings::Embed;
@@ -191,7 +193,20 @@ impl VectorIndex for S3Vector {
         // TODO: Restructure [`S3VectorsQueryTable`] to take an async function (probably a trait)
         // like `async fn(&str) -> vec<f32>`, to avoid early embedding request.
         let vector = self.query_vector(query).await?;
-        let tp = Arc::new(S3VectorsQueryTable::new(self.table.clone(), vector));
+
+        let tp = if matches!(
+            self.table.identifier,
+            S3VectorIdentifier::PartitionedIndex { .. }
+        ) {
+            // Table Provider for the S3V Bucket will perform cross-index queries
+            Arc::new(S3VectorsQueryPartitionedIndexTable::new(
+                self.table.clone(),
+                vector,
+            )) as Arc<dyn TableProvider>
+        } else {
+            Arc::new(S3VectorsQueryIndexTable::new(self.table.clone(), vector))
+                as Arc<dyn TableProvider>
+        };
 
         table_with_projection(tp, projection).boxed()
     }

--- a/crates/runtime/src/embeddings/index/s3/mod.rs
+++ b/crates/runtime/src/embeddings/index/s3/mod.rs
@@ -74,6 +74,9 @@ pub(crate) const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("aws_session_token")
         .description("The AWS session token to use.")
         .secret(),
+    ParameterSpec::component("num_partitions")
+        .description("The number of index partitions to use.")
+        .secret(),
 ];
 
 /// Attempt to construct a  S3 `VectorIndex` for the provided dataset on the given column.
@@ -108,12 +111,11 @@ pub async fn try_from_dataset(
 
     let params = get_store_params(vector_store_config, Arc::clone(&secrets)).await?;
 
+    let default_s3_index_name = format!("{ds_name}-{column}-{}", config.model).replace('_', "-");
     let table = try_vector_table(
         metadata_columns.clone(),
         params,
-        format!("{}-{}-{}", ds_name, column, config.model)
-            .replace('_', "-")
-            .as_str(),
+        &default_s3_index_name,
         Arc::clone(&embedding_models),
         config.model.as_str(),
     )
@@ -153,6 +155,8 @@ async fn try_vector_table(
     let s3_vectors_arn = string_from_params(&params, "arn");
     let s3_vectors_bucket = string_from_params(&params, "bucket");
     let s3_vectors_index = string_from_params(&params, "index");
+    let s3_num_partitions =
+        string_from_params(&params, "num_partitions").and_then(|s| s.parse().ok());
 
     let id = match (s3_vectors_arn, s3_vectors_bucket, s3_vectors_index) {
         (Some(_), Some(_), Some(_)) => Err("Cannot specify both 's3_vectors_arn' and 's3_vectors_bucket'.".to_string()),
@@ -174,6 +178,24 @@ async fn try_vector_table(
     .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
         Box::from(format!("Invalid S3 Vectors bucket defined: {e}"))
     })?;
+
+    let id = match s3_num_partitions {
+        Some(num_partitions) => {
+            let S3VectorIdentifier::Index {
+                bucket_name,
+                index_name,
+            } = id
+            else {
+                return Err(Box::from("Vector Index via ARN cannot be partitioned"));
+            };
+            S3VectorIdentifier::PartitionedIndex {
+                bucket_name,
+                index_name,
+                num_partitions,
+            }
+        }
+        None => id,
+    };
 
     let config = load_config(
         "S3Vectors",

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -45,7 +45,6 @@ use datafusion::{
     sql::TableReference,
 };
 use itertools::Itertools;
-use runtime_datafusion_index::IndexedTableProvider;
 use std::cmp::min;
 use std::{
     any::Any,


### PR DESCRIPTION
## 📝 Summary

Adds a new `TableProvider` that will join queries to indexes within an S3 bucket.

## 🔗 Related

Closes: 
- #6958 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->
Once UX is determined and approved, this will require docs updates.

## 👀 Notes for Reviewers

UX is not approved. I'm developing the idea right now.
