### PR TITLE
Fix SF100 benchmark tests dispatch

### DIFF
--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use clap::{ArgAction, Parser, ValueEnum};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::path::PathBuf;
 use test_framework::{TestType, queries::QuerySet};
 
@@ -102,8 +102,28 @@ pub struct BenchArgs {
     pub update_snapshots: Option<UpdateSnapshots>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub validate_results: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_scale_factor"
+    )]
     pub scale_factor: Option<f64>,
+}
+
+fn serialize_scale_factor<S>(x: &Option<f64>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match x {
+        Some(v) => {
+            if v.fract() == 0.0 {
+                // no fractional part → serialize as integer
+                s.serialize_i64(*v as i64)
+            } else {
+                s.serialize_f64(*v)
+            }
+        }
+        None => s.serialize_none(),
+    }
 }
 
 impl BenchArgs {

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -109,6 +109,8 @@ pub struct BenchArgs {
     pub scale_factor: Option<f64>,
 }
 
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::ref_option)]
 fn serialize_scale_factor<S>(x: &Option<f64>, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,


### PR DESCRIPTION
## 📝 Summary

The `scale_factor` parameter is currently represented and read as a decimal, while paths and logic expect it to be an integer (defined as `100` in yaml configuration).
This PR updates the serialization logic so that `scale_factor` values without a fractional part are converted to integers, fixing the mismatch.

## 🔗 Related

Fixes 
 - https://github.com/spiceai/spiceai/issues/7092

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
