### PR TITLE
Fix spiced_docker workflows for new actions/download-artifact@v5 behavior

### DIFF
--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -277,8 +277,6 @@ jobs:
       - name: Verify artifacts
         run: |
           ls -l /tmp
-          ls -l /tmp/images-amd64
-          ls -l /tmp/images-arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -318,10 +316,10 @@ jobs:
 
             # Load both architecture images
             echo "Loading AMD64 image"
-            docker load -i /tmp/images-amd64/image-amd64-${variant}.tar
+            docker load -i /tmp/image-amd64-${variant}.tar
 
             echo "Loading ARM64 image"
-            docker load -i /tmp/images-arm64/image-arm64-${variant}.tar
+            docker load -i /tmp/image-arm64-${variant}.tar
 
             # Push images to local registry
             echo "Pushing images to local registry"
@@ -375,7 +373,7 @@ jobs:
 
       - name: Verify artifacts
         run: |
-          ls -l /tmp/images-amd64-cuda
+          ls -l /tmp
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -406,7 +404,7 @@ jobs:
         run: |
           echo "Handling CUDA models..."
 
-          docker load -i /tmp/images-amd64-cuda/images-amd64-cuda.tar
+          docker load -i /tmp/images-amd64-cuda.tar
           docker push localhost:5000/spiceai:models-cuda-amd64
 
           if [[ "${PUBLISH}" == "true" ]]; then

--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -249,8 +249,6 @@ jobs:
       - name: Verify artifacts
         run: |
           ls -l /tmp
-          ls -l /tmp/images-amd64
-          ls -l /tmp/images-arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -283,9 +281,9 @@ jobs:
 
             # Load both architecture images
             echo "Loading AMD64 image"
-            docker load -i /tmp/images-amd64/image-amd64-${variant}.tar
+            docker load -i /tmp/image-amd64-${variant}.tar
             echo "Loading ARM64 image"
-            docker load -i /tmp/images-arm64/image-arm64-${variant}.tar
+            docker load -i /tmp/image-arm64-${variant}.tar
 
             # Push images to local registry
             echo "Pushing images to local registry"

--- a/crates/runtime/tests/mongo/common.rs
+++ b/crates/runtime/tests/mongo/common.rs
@@ -68,10 +68,10 @@ pub async fn start_mongodb_docker_container(
                 "--eval".to_string(),
                 "db.runCommand('ping').ok".to_string(),
             ]),
-            interval: Some(500_000_000),
-            timeout: Some(500_000_000),
-            retries: Some(10),
-            start_period: Some(3_000_000_000),
+            interval: Some(2_000_000_000), // 2 seconds
+            timeout: Some(10_000_000_000), // 10 seconds
+            retries: Some(15),
+            start_period: Some(10_000_000_000), // 10 seconds
             start_interval: None,
         })
         .build()?


### PR DESCRIPTION
## 📝 Summary

`actions/download-artifact@v5` has a breaking change in how artifacts that are downloaded by pattern are placed onto the filesystem. The `v4` behavior was to place each artifact its its own sub-folder with the artifact in that subfolder, i.e.:

```yaml
      - name: Download all artifacts
        uses: actions/download-artifact@v5
        with:
          path: /tmp
          pattern: images-*
```

With the artifacts `images-amd64` and `images-arm64` that both contained a single `images-amd64.tar` and `images-arm64.tar` file would be placed onto the filesystem like:

```bash
images-amd64/images-amd64.tar
images-arm64/images-arm64.tar
```

Now they are placed onto the filesystem at the root:

```bash
images-amd64.tar
images-arm64.tar
```

Ref: https://github.com/actions/download-artifact/releases/tag/v5.0.0


This PR also includes a small change to make the MongoDB integration tests more resilient in CI by waiting longer for the container to start and become healthy.