### PR TITLE
Add `output_level` to runtime config

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -242,7 +242,7 @@ pub async fn run(args: Args) -> Result<()> {
             args.verbose == 1,                      // -v or --verbose
             args.verbose >= 2 || args.very_verbose, // -vv or --very-verbose
             "SPICED_LOG",
-            app.as_ref().and_then(|a| a.runtime.log_level),
+            app.as_ref().and_then(|a| a.runtime.output_level),
         ),
     )
     .await

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -238,10 +238,11 @@ pub async fn run(args: Args) -> Result<()> {
         app.as_ref(),
         tracing_config.as_ref(),
         rt.datafusion(),
-        LogVerbosity::from_flags_and_env(
+        LogVerbosity::from_flags_and_env_and_config(
             args.verbose == 1,                      // -v or --verbose
             args.verbose >= 2 || args.very_verbose, // -vv or --very-verbose
             "SPICED_LOG",
+            app.and_then(|a| a.runtime.log_level),
         ),
     )
     .await

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -242,7 +242,7 @@ pub async fn run(args: Args) -> Result<()> {
             args.verbose == 1,                      // -v or --verbose
             args.verbose >= 2 || args.very_verbose, // -vv or --very-verbose
             "SPICED_LOG",
-            app.and_then(|a| a.runtime.log_level),
+            app.as_ref().and_then(|a| a.runtime.log_level),
         ),
     )
     .await

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::{borrow::Cow, sync::Arc};
 
-use app::spicepod::component::runtime::LogLevel;
+use app::spicepod::component::runtime::OutputLevel;
 use app::{App, spicepod::component::runtime::TracingConfig};
 use futures::future::BoxFuture;
 use opentelemetry::InstrumentationScope;
@@ -43,13 +43,13 @@ impl LogVerbosity {
         verbose: bool,
         very_verbose: bool,
         env_var: &str,
-        config_log_level: Option<LogLevel>,
+        config_output_level: Option<OutputLevel>,
     ) -> Self {
-        if very_verbose || config_log_level == Some(LogLevel::VeryVerbose) {
+        if very_verbose || config_output_level == Some(OutputLevel::VeryVerbose) {
             return LogVerbosity::VeryVerbose;
         }
 
-        if verbose || config_log_level == Some(LogLevel::Verbose) {
+        if verbose || config_output_level == Some(OutputLevel::Verbose) {
             return LogVerbosity::Verbose;
         }
 

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::{borrow::Cow, sync::Arc};
 
+use app::spicepod::component::runtime::LogLevel;
 use app::{App, spicepod::component::runtime::TracingConfig};
 use futures::future::BoxFuture;
 use opentelemetry::InstrumentationScope;
@@ -38,12 +39,17 @@ pub enum LogVerbosity {
 }
 
 impl LogVerbosity {
-    pub(crate) fn from_flags_and_env(verbose: bool, very_verbose: bool, env_var: &str) -> Self {
-        if very_verbose {
+    pub(crate) fn from_flags_and_env_and_config(
+        verbose: bool,
+        very_verbose: bool,
+        env_var: &str,
+        config_log_level: Some<LogLevel>,
+    ) -> Self {
+        if very_verbose || config_log_level == Some(LogLevel::VeryVerbose) {
             return LogVerbosity::VeryVerbose;
         }
 
-        if verbose {
+        if verbose || config_log_level == Some(LogLevel::Verbose) {
             return LogVerbosity::Verbose;
         }
 

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -45,11 +45,11 @@ impl LogVerbosity {
         env_var: &str,
         config_output_level: Option<OutputLevel>,
     ) -> Self {
-        if very_verbose || config_output_level == Some(OutputLevel::VeryVerbose) {
+
+        if very_verbose {
             return LogVerbosity::VeryVerbose;
         }
-
-        if verbose || config_output_level == Some(OutputLevel::Verbose) {
+        if verbose {
             return LogVerbosity::Verbose;
         }
 
@@ -57,7 +57,11 @@ impl LogVerbosity {
             return LogVerbosity::Specific(filter);
         }
 
-        LogVerbosity::Default
+        match config_output_level {
+            Some(OutputLevel::VeryVerbose) => LogVerbosity::VeryVerbose,
+            Some(OutputLevel::Verbose) => LogVerbosity::Verbose,
+            None | Some(OutputLevel::Info) => LogVerbosity::Default,
+        }
     }
 }
 

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 use tracing::Subscriber;
 use tracing_subscriber::{EnvFilter, filter, fmt, layer::Layer, prelude::*, registry::LookupSpan};
 
+#[derive(PartialEq, Debug)]
 pub enum LogVerbosity {
     Default,
     Verbose,
@@ -45,10 +46,10 @@ impl LogVerbosity {
         env_var: &str,
         config_output_level: Option<OutputLevel>,
     ) -> Self {
-
         if very_verbose {
             return LogVerbosity::VeryVerbose;
         }
+
         if verbose {
             return LogVerbosity::Verbose;
         }
@@ -296,5 +297,64 @@ impl SpanExporter for OtelExportMultiplexer {
         for exporter in &mut self.exporters {
             exporter.set_resource(resource);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_very_verbose_if_flag_set() {
+        unsafe {
+            std::env::set_var("TEST_LOG_ENV", "custom");
+        }
+        let result = LogVerbosity::from_flags_and_env_and_config(
+            false,
+            true,
+            "TEST_LOG_ENV",
+            Some(OutputLevel::Verbose),
+        );
+        unsafe {
+            std::env::remove_var("TEST_LOG_ENV");
+        }
+
+        assert_eq!(result, LogVerbosity::VeryVerbose);
+    }
+
+    #[test]
+    fn returns_specific_if_env_set() {
+        unsafe {
+            std::env::set_var("TEST_LOG_ENV", "custom");
+        }
+        let result = LogVerbosity::from_flags_and_env_and_config(
+            false,
+            false,
+            "TEST_LOG_ENV",
+            Some(OutputLevel::VeryVerbose),
+        );
+        unsafe {
+            std::env::remove_var("TEST_LOG_ENV");
+        }
+
+        assert_eq!(result, LogVerbosity::Specific("custom".to_string()));
+    }
+
+    #[test]
+    fn returns_very_verbose_from_config() {
+        let result = LogVerbosity::from_flags_and_env_and_config(
+            false,
+            false,
+            "NON_EXISTENT_ENV",
+            Some(OutputLevel::VeryVerbose),
+        );
+        assert_eq!(result, LogVerbosity::VeryVerbose);
+    }
+
+    #[test]
+    fn returns_default_when_none() {
+        let result =
+            LogVerbosity::from_flags_and_env_and_config(false, false, "NON_EXISTENT_ENV", None);
+        assert_eq!(result, LogVerbosity::Default);
     }
 }

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -43,7 +43,7 @@ impl LogVerbosity {
         verbose: bool,
         very_verbose: bool,
         env_var: &str,
-        config_log_level: Some<LogLevel>,
+        config_log_level: Option<LogLevel>,
     ) -> Self {
         if very_verbose || config_log_level == Some(LogLevel::VeryVerbose) {
             return LogVerbosity::VeryVerbose;

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -82,7 +82,7 @@ pub struct Runtime {
     /// Configures log level for the runtime. Can be overriden if flags or environment variables
     /// are set to higher verbosity.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub log_level: Option<LogLevel>,
+    pub output_level: Option<OutputLevel>,
 }
 
 impl Runtime {
@@ -386,7 +386,7 @@ impl AsRef<str> for ApiKey {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
-pub enum LogLevel {
+pub enum OutputLevel {
     #[default]
     Info,
     Verbose,

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -78,6 +78,11 @@ pub struct Runtime {
     /// and components to shut down cleanly during runtime termination
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shutdown_timeout: Option<String>,
+
+    /// Configures log level for the runtime. Can be overriden if flags or environment variables
+    /// are set to higher verbosity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_level: Option<LogLevel>,
 }
 
 impl Runtime {
@@ -376,6 +381,16 @@ impl AsRef<str> for ApiKey {
             ApiKey::ReadOnly { key } | ApiKey::ReadWrite { key } => key.as_str(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum LogLevel {
+    #[default]
+    Info,
+    Verbose,
+    VeryVerbose,
 }
 
 #[cfg(test)]

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -80,7 +80,7 @@ pub struct Runtime {
     pub shutdown_timeout: Option<String>,
 
     /// Configures log level for the runtime. Can be overriden if flags or environment variables
-    /// are set to higher verbosity.
+    /// are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_level: Option<OutputLevel>,
 }


### PR DESCRIPTION
## 📝 Summary

Adds `output_level` parameter to runtime:
```yaml
runtime:
  output_level: info | verbose | very_verbose
```

The values will be applied in the following priority:
1. CLI
2. Environment variables
3. Yaml configuration


## 🔗 Related

https://github.com/spiceai/spiceai/issues/7106

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

No breaking changes

## 📚 Docs

https://github.com/spiceai/docs/pull/1147