### PR TITLE
Ensure we find vector index when it also has text search

### DIFF
--- a/crates/runtime-datafusion-index/src/provider.rs
+++ b/crates/runtime-datafusion-index/src/provider.rs
@@ -84,6 +84,7 @@ impl IndexedTableProvider {
         Arc::clone(&self.underlying)
     }
 
+    #[must_use]
     pub fn get_underlying_ref(&self) -> &Arc<dyn TableProvider> {
         &self.underlying
     }

--- a/crates/runtime-datafusion-index/src/provider.rs
+++ b/crates/runtime-datafusion-index/src/provider.rs
@@ -83,6 +83,10 @@ impl IndexedTableProvider {
     pub fn get_underlying(&self) -> Arc<dyn TableProvider> {
         Arc::clone(&self.underlying)
     }
+
+    pub fn get_underlying_ref(&self) -> &Arc<dyn TableProvider> {
+        &self.underlying
+    }
 }
 
 #[async_trait]

--- a/crates/runtime-datafusion-index/src/provider.rs
+++ b/crates/runtime-datafusion-index/src/provider.rs
@@ -45,9 +45,16 @@ pub struct IndexedTableProvider {
 
 impl IndexedTableProvider {
     pub fn new(underlying: Arc<dyn TableProvider>) -> Self {
+        IndexedTableProvider::with_indexes(underlying, vec![])
+    }
+
+    pub fn with_indexes(
+        underlying: Arc<dyn TableProvider>,
+        indexes: Vec<Arc<dyn Index + Send + Sync>>,
+    ) -> Self {
         Self {
             underlying,
-            indexes: Vec::new(),
+            indexes,
         }
     }
 

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -552,6 +552,11 @@ impl AcceleratedTable {
     }
 
     #[must_use]
+    pub fn get_federated_table_ref(&self) -> &Arc<FederatedTable> {
+        &self.federated
+    }
+
+    #[must_use]
     pub fn get_accelerator(&self) -> Arc<dyn TableProvider> {
         Arc::clone(&self.accelerator)
     }

--- a/crates/runtime/src/embeddings/table.rs
+++ b/crates/runtime/src/embeddings/table.rs
@@ -327,6 +327,11 @@ impl EmbeddingTable {
         self.base_table.schema()
     }
 
+    #[must_use]
+    pub fn get_underlying_ref(&self) -> &Arc<dyn TableProvider> {
+        &self.base_table
+    }
+
     /// Makes a [`Chunker`] from [`ChunkingConfig`] and a column's embedding model in [`EmbeddingModelStore`].
     async fn construct_chunker(
         model_name: &str,

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -45,7 +45,6 @@ use datafusion::{
     sql::TableReference,
 };
 use itertools::Itertools;
-use runtime_datafusion_index::IndexedTableProvider;
 use std::cmp::min;
 use std::{
     any::Any,

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -106,7 +106,7 @@ impl VectorSearchTableFuncArgs {
             ))),
             (None, _) => {
                 if embedded_columns.len() > 1 {
-                    return Err(DataFusionError::Internal(format!(
+                    return Err(DataFusionError::Plan(format!(
                         "User function 'vector_search' is called on table '{}' that has {} vector search columns. Must call 'vector_search' with column parameter, e.g. `vector_search(\"my table\", 'my query', my_embedded_col)`.",
                         self.tbl,
                         embedded_columns.len()
@@ -115,7 +115,7 @@ impl VectorSearchTableFuncArgs {
                 if let Some((col, cfg)) = embedded_columns.iter().next() {
                     Ok((col.clone(), cfg.clone()))
                 } else {
-                    Err(DataFusionError::Internal(format!(
+                    Err(DataFusionError::Plan(format!(
                         "User function 'vector_search' is called on table '{}' that has no associated full text search index.",
                         self.tbl,
                     )))
@@ -275,13 +275,11 @@ impl VectorSearchTableFunc {
         tbl: &Arc<dyn TableProvider>,
         args: &VectorSearchTableFuncArgs,
     ) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
-        // TODO: we might actually not want to recurse over accelerated table here.
-
-        use crate::embeddings::index::s3::S3Vector;
-        let Some(indexed) = find_concrete_table_provider::<IndexedTableProvider>(tbl) else {
+        use crate::{embeddings::index::s3::S3Vector, search::util::find_index_in_table_provider};
+        let Some(mut vector_indexes) = find_index_in_table_provider::<S3Vector>(tbl) else {
             return Ok(None);
         };
-        let mut vector_indexes = indexed.get_indexes::<S3Vector>();
+
         let vector_index_opt = if let Some(col) = &args.column {
             vector_indexes
                 .into_iter()

--- a/crates/runtime/src/federated_table/mod.rs
+++ b/crates/runtime/src/federated_table/mod.rs
@@ -27,7 +27,7 @@ limitations under the License.
 //! Unlike the `AcceleratedTable` struct, this struct does not implement the `TableProvider` trait itself.
 //! It only provides a way to get the underlying table provider and schema.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use arrow::datatypes::SchemaRef;
 use arrow_tools::schema::schema_difference;
@@ -57,12 +57,13 @@ pub enum FederatedTable {
 enum DeferredState {
     Waiting(oneshot::Receiver<Arc<dyn TableProvider>>),
     InProgress,
-    Done(Arc<dyn TableProvider>),
+    Done,
 }
 
 #[derive(Debug)]
 pub struct DeferredTableProvider {
     state: RwLock<DeferredState>,
+    table: OnceLock<Arc<dyn TableProvider>>,
     schema: SchemaRef,
 }
 
@@ -130,14 +131,21 @@ impl FederatedTable {
     ///   1. Active write on the [`DeferredTableProvider`]'s state.
     ///   2. The [`DeferredTableProvider`] is not Ready.
     pub fn try_table_provider_sync(&self) -> Option<Arc<dyn TableProvider>> {
+        Some(Arc::clone(self.try_table_provider_sync_ref()?))
+    }
+
+    /// Attempts to return the [`TableProvider`] without waiting for a deferred [`TableProvider`] that is not done (i.e. not in `DeferredState::Done`).
+    ///
+    /// Returns None if
+    ///   1. Active write on the [`DeferredTableProvider`]'s state.
+    ///   2. The [`DeferredTableProvider`] is not Ready.
+    pub fn try_table_provider_sync_ref(&self) -> Option<&Arc<dyn TableProvider>> {
         let deferred_table_provider = match self {
-            Self::Immediate(table_provider) => return Some(Arc::clone(table_provider)),
+            Self::Immediate(table_provider) => return Some(table_provider),
             Self::Deferred(deferred_table_provider) => deferred_table_provider,
         };
-        match &*deferred_table_provider.state.try_read().ok()? {
-            DeferredState::Done(tbl) => Some(Arc::clone(tbl)),
-            _ => None,
-        }
+
+        deferred_table_provider.table.get()
     }
 
     pub async fn table_provider(&self) -> Arc<dyn TableProvider> {
@@ -147,12 +155,14 @@ impl FederatedTable {
         };
 
         // If the table provider is not available immediately, see if we already have it from the deferred task.
-        let mut deferred_state_guard = deferred_table_provider.state.write().await;
 
         // If the table provider is available now, return it.
-        if let DeferredState::Done(table_provider) = &*deferred_state_guard {
+        if let Some(table_provider) = deferred_table_provider.table.get() {
             return Arc::clone(table_provider);
         }
+
+        // If the table provider is not available immediately, see if we already have it from the deferred task.
+        let mut deferred_state_guard = deferred_table_provider.state.write().await;
 
         // We need to own the deferred state to be able to wait on the receiver. Temporarily replace it with InProgress.
         let deferred_state_owned =
@@ -167,10 +177,13 @@ impl FederatedTable {
                         "deferred task should not be dropped before sending the table provider"
                     );
                 };
-                *deferred_state_guard = DeferredState::Done(Arc::clone(&table_provider));
+                let _ = deferred_table_provider
+                    .table
+                    .set(Arc::clone(&table_provider));
+                *deferred_state_guard = DeferredState::Done;
                 table_provider
             }
-            DeferredState::InProgress | DeferredState::Done(_) => {
+            DeferredState::InProgress | DeferredState::Done => {
                 unreachable!("deferred state should only be Waiting at this point");
             }
         }
@@ -242,6 +255,7 @@ impl FederatedTable {
         DeferredTableProvider {
             state: RwLock::new(DeferredState::Waiting(rx)),
             schema,
+            table: OnceLock::new(),
         }
     }
 

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -52,7 +52,7 @@ use crate::{
     datafusion::DataFusion,
     embeddings::udtf::parse_limit_scalar,
     request::{AsyncMarker, RequestContext},
-    search::util::{find_concrete_table_provider, table_ref_from_column_expr, to_column_expr},
+    search::util::{find_index_in_table_provider, table_ref_from_column_expr, to_column_expr},
 };
 
 pub static TEXT_SEARCH_UDTF_NAME: &str = "text_search";
@@ -246,22 +246,13 @@ impl TableFunctionImpl for TextSearchTableFunc {
             )));
         };
 
-        let index_table_provider = find_concrete_table_provider::<IndexedTableProvider>(
-            &table_provider,
-        )
-        .ok_or_else(|| {
-            DataFusionError::Plan(format!(
-                "Table '{}' does not have a full text search index.",
-                args.tbl.clone()
-            ))
-        })?;
-
-        let Some(fts_index) = index_table_provider.get_index::<FullTextDatabaseIndex>() else {
-            return Err(DataFusionError::Plan(format!(
-                "Table '{}' does not have a full text search index.",
-                args.tbl.clone()
-            )));
-        };
+        let fts_index = find_index_in_table_provider::<FullTextDatabaseIndex>(&table_provider)
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "Table '{}' does not have a full text search index.",
+                    args.tbl.clone()
+                ))
+            })?;
 
         let column = args.column(&fts_index.search_fields)?;
         Ok(Arc::new(TextSearchIndexProviderWrapper {

--- a/crates/runtime/src/search/full_text/udtf.rs
+++ b/crates/runtime/src/search/full_text/udtf.rs
@@ -43,7 +43,6 @@ use datafusion::{
     scalar::ScalarValue,
     sql::TableReference,
 };
-use runtime_datafusion_index::IndexedTableProvider;
 use search::generation::text_search::{
     index::FullTextDatabaseIndex, udtf::TextSearchIndexProvider,
 };
@@ -246,13 +245,22 @@ impl TableFunctionImpl for TextSearchTableFunc {
             )));
         };
 
-        let fts_index = find_index_in_table_provider::<FullTextDatabaseIndex>(&table_provider)
-            .ok_or_else(|| {
-                DataFusionError::Plan(format!(
-                    "Table '{}' does not have a full text search index.",
-                    args.tbl.clone()
-                ))
-            })?;
+        let mut fts_indexes = find_index_in_table_provider::<FullTextDatabaseIndex>(
+            &table_provider,
+        )
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "Table '{}' does not have a full text search index.",
+                args.tbl.clone()
+            ))
+        })?;
+
+        let Some(fts_index) = fts_indexes.pop() else {
+            return Err(DataFusionError::Plan(format!(
+                "Table '{}' does not have a full text search index.",
+                args.tbl.clone()
+            )));
+        };
 
         let column = args.column(&fts_index.search_fields)?;
         Ok(Arc::new(TextSearchIndexProviderWrapper {

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -39,22 +39,24 @@ use crate::search::full_text::as_candidate_generations;
 use super::{Error, Result};
 
 /// Attempt to return a concrete [`TableProvider`] type from a given [`impl TableProvider`]. This includes if the [`TableProvider`] is a base table for an [`AcceleratedTable`] or [`FederatedTableProviderAdaptor`] or other known [`TableProvider`] that wrap a table.
-pub(crate) fn find_concrete_table_provider<T: TableProvider + Clone + 'static>(
+
+/// Attempt to return a concrete [`TableProvider`] type from a given [`impl TableProvider`]. This includes if the [`TableProvider`] is a base table for an [`AcceleratedTable`] or [`FederatedTableProviderAdaptor`] or other known [`TableProvider`] that wrap a table.
+pub(crate) fn find_concrete_table_provider<T: TableProvider + 'static>(
     tbl: &Arc<dyn TableProvider>,
-) -> Option<Arc<T>> {
-    let mut current_tbl = Arc::clone(tbl);
+) -> Option<&T> {
+    let mut current_tbl = tbl;
 
     // For the many possible wrapping [`TableProvider`], attempt to find the concrete `impl TableProvider`.
     // Also avoids having to [`Box::pin`] for recursive `async fn`.
     loop {
         // Attempt to downcast the current table to the desired type.
         if let Some(found_table) = current_tbl.as_any().downcast_ref::<T>() {
-            return Some(Arc::new(found_table.clone()));
+            return Some(found_table);
         }
 
         // Handle specific table wrapping logic.
         if let Some(index_table) = current_tbl.as_any().downcast_ref::<IndexedTableProvider>() {
-            current_tbl = index_table.get_underlying();
+            current_tbl = index_table.get_underlying_ref();
             continue;
         }
 
@@ -62,16 +64,21 @@ pub(crate) fn find_concrete_table_provider<T: TableProvider + Clone + 'static>(
             .as_any()
             .downcast_ref::<FederatedTableProviderAdaptor>()
         {
-            if let Some(adapted_tbl) = adaptor.table_provider.clone() {
+            if let Some(adapted_tbl) = adaptor.table_provider.as_ref() {
                 current_tbl = adapted_tbl;
                 continue;
             }
         }
 
+        if let Some(embedding_table) = current_tbl.as_any().downcast_ref::<EmbeddingTable>() {
+            current_tbl = embedding_table.get_underlying_ref();
+            continue;
+        }
+
         if let Some(accelerated_table) = current_tbl.as_any().downcast_ref::<AcceleratedTable>() {
             current_tbl = accelerated_table
-                .get_federated_table()
-                .try_table_provider_sync()?;
+                .get_federated_table_ref()
+                .try_table_provider_sync_ref()?;
             continue;
         }
 
@@ -90,7 +97,7 @@ pub(crate) fn find_index_in_table_provider<T: Index + 'static>(
             return Some(indexes);
         }
         indexed_table_opt =
-            find_concrete_table_provider::<IndexedTableProvider>(&indexed_table_opt.underlying);
+            find_concrete_table_provider::<IndexedTableProvider>(&indexed_table.underlying);
     }
     None
 }
@@ -226,10 +233,12 @@ pub async fn full_text_search_candidates(
     df: &Arc<DataFusion>,
     tbl: &TableReference,
 ) -> Option<Result<Vec<Arc<dyn CandidateGeneration>>>> {
-    let table_provider = df.get_table(tbl).await?;
+    let base_table_provider = df.get_table(tbl).await?;
+    let index_table_provider = Arc::clone(&base_table_provider);
 
     // If the table exists, but does not have full text search support, return no candidates.
-    let Some(indexed_table) = find_concrete_table_provider::<IndexedTableProvider>(&table_provider)
+    let Some(indexed_table) =
+        find_concrete_table_provider::<IndexedTableProvider>(&index_table_provider)
     else {
         return Some(Ok(vec![]));
     };
@@ -240,7 +249,7 @@ pub async fn full_text_search_candidates(
 
     Some(
         as_candidate_generations(
-            &fts.with_new_base(table_provider),
+            &fts.with_new_base(base_table_provider),
             Arc::clone(df),
             tbl.clone(),
         )

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -39,8 +39,6 @@ use crate::search::full_text::as_candidate_generations;
 use super::{Error, Result};
 
 /// Attempt to return a concrete [`TableProvider`] type from a given [`impl TableProvider`]. This includes if the [`TableProvider`] is a base table for an [`AcceleratedTable`] or [`FederatedTableProviderAdaptor`] or other known [`TableProvider`] that wrap a table.
-
-/// Attempt to return a concrete [`TableProvider`] type from a given [`impl TableProvider`]. This includes if the [`TableProvider`] is a base table for an [`AcceleratedTable`] or [`FederatedTableProviderAdaptor`] or other known [`TableProvider`] that wrap a table.
 pub(crate) fn find_concrete_table_provider<T: TableProvider + 'static>(
     tbl: &Arc<dyn TableProvider>,
 ) -> Option<&T> {

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -89,7 +89,8 @@ pub(crate) fn find_index_in_table_provider<T: Index + 'static>(
         if !indexes.is_empty() {
             return Some(indexes);
         }
-        indexed_table_opt = find_concrete_table_provider::<IndexedTableProvider>(&z.underlying);
+        indexed_table_opt =
+            find_concrete_table_provider::<IndexedTableProvider>(&indexed_table_opt.underlying);
     }
     None
 }

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -22,7 +22,7 @@ use app::App;
 use datafusion::common::Column;
 use datafusion::{datasource::TableProvider, sql::TableReference};
 use datafusion_federation::FederatedTableProviderAdaptor;
-use runtime_datafusion_index::IndexedTableProvider;
+use runtime_datafusion_index::{Index, IndexedTableProvider};
 use search::generation::CandidateGeneration;
 use search::generation::text_search::index::FullTextDatabaseIndex;
 use search::generation::util::get_primary_keys;
@@ -78,6 +78,20 @@ pub(crate) fn find_concrete_table_provider<T: TableProvider + Clone + 'static>(
         // Exit if no further wrapping is found.
         return None;
     }
+}
+
+pub(crate) fn find_index_in_table_provider<T: Index + 'static>(
+    tbl: &Arc<dyn TableProvider>,
+) -> Option<Vec<&T>> {
+    let mut indexed_table_opt = find_concrete_table_provider::<IndexedTableProvider>(tbl);
+    while let Some(indexed_table) = indexed_table_opt {
+        let indexes = indexed_table.get_indexes::<T>();
+        if !indexes.is_empty() {
+            return Some(indexes);
+        }
+        indexed_table_opt = find_concrete_table_provider::<IndexedTableProvider>(&z.underlying);
+    }
+    None
 }
 
 /// Compute the primary keys for each table in the app. Primary Keys can be explicitly defined in the Spicepod.yaml

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -89,9 +89,10 @@ impl VectorSearch {
     ) -> Option<Arc<dyn Embed>> {
         #[cfg(feature = "s3_vectors")]
         {
-            use crate::embeddings::index::s3::S3Vector;
-            let index = find_concrete_table_provider::<IndexedTableProvider>(tbl)?;
-            for s3v in index.get_indexes::<S3Vector>() {
+            use crate::{
+                embeddings::index::s3::S3Vector, search::util::find_index_in_table_provider,
+            };
+            for s3v in find_index_in_table_provider::<S3Vector>(tbl)? {
                 if s3v.embedded_column == embedding_column {
                     return s3v.embedding_model().await;
                 }

--- a/crates/runtime/src/search/vector_search.rs
+++ b/crates/runtime/src/search/vector_search.rs
@@ -45,7 +45,6 @@ use datafusion::sql::{TableReference, sqlparser::ast::Expr};
 use futures::StreamExt;
 use itertools::Itertools;
 use llms::embeddings::Embed;
-use runtime_datafusion_index::IndexedTableProvider;
 use search::{
     aggregation::{AggregationResult, reciprocal_rank::ReciprocalRankFusion},
     generation::CandidateGeneration,


### PR DESCRIPTION
## 📝 Summary
 - Fixes introduced so that v1/search and UDTFs can find the `IndexedTableProvider` they expect when there are multiple nested. 