### PR TITLE
Fix spiced_docker_nightly workflow

### DIFF
--- a/.github/workflows/spiced_docker_nightly.yml
+++ b/.github/workflows/spiced_docker_nightly.yml
@@ -245,6 +245,7 @@ jobs:
         with:
           path: /tmp
           pattern: images-*
+          merge-multiple: true
 
       - name: Verify artifacts
         run: |


### PR DESCRIPTION
## 📝 Summary

Ensure all images are downloaded to /tmp w/o additional subfolders

`download-artifact@5.0.0` contains a breaking change, when output path may change if single vs multiple files match download pattern. Using `merge-multiple: true` makes this behavior consistent and always download artifacts to path root
https://github.com/actions/download-artifact/releases/tag/v5.0.0

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
