### PR TITLE
Tune retry settings for Kafka/Debezium connectors

### DIFF
--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -265,6 +265,11 @@ impl KafkaConsumer {
         config
             .set("group.id", group_id.clone())
             .set("bootstrap.servers", &kafka_config.brokers)
+            .set("retry.backoff.ms", "1000")
+            .set("retry.backoff.max.ms", "30000")
+            .set("reconnect.backoff.ms", "1000")
+            .set("reconnect.backoff.max.ms", "30000")
+            .set("debug", "broker,cgrp,fetch")
             // For new consumer groups, start reading at the beginning of the topic
             .set("auto.offset.reset", "smallest")
             // Commit offsets automatically


### PR DESCRIPTION
## 📝 Summary

Tune `librdkafka` client backoff to reduce rapid retries during outages, lowering the risk of hammering or overwhelming brokers, DNS, or other infrastructure during failover. The change increases the base interval from `100ms` to `1000ms` and raises the maximum backoff from `1s` to `30s`, providing a smoother retry cadence and reducing trace volume in the output

https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/7086

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

