### PR TITLE
fix: Ensure vector search UDTF respects the supplied projection

### DIFF
--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -1,0 +1,26 @@
+name: 'Add benchmark snapshots to PR'
+description: 'Commits and pushes any updated benchmark snapshots to the current branch.'
+inputs:
+  token:
+    description: 'GitHub token with permissions to push to the repository'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload benchmark snapshots to branch
+      shell: bash
+      run: |
+        git config --global user.name 'Spice Snapshot Update Bot'
+        git config --global user.email 'spiceaibot@spice.ai'
+        git add '*.snap'
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "fix: Update the integration test snapshots"
+          if git ls-remote --exit-code --heads origin HEAD; then
+            git pull --rebase origin HEAD
+          fi
+          git push origin HEAD
+        fi
+      env:
+        GH_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -39,6 +39,14 @@ on:
         type: boolean
         required: false
         default: false
+      update_snapshots:
+        description: 'Update the snapshots?'
+        required: false
+        default: 'no'
+        type: choice
+        options:
+          - 'always'
+          - 'no'
 
 concurrency:
   # Allow only one workflow per any non-trunk branch.
@@ -113,6 +121,7 @@ jobs:
 
       - name: Run integration test
         env:
+          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
         run: |
           if [ -z "$SPICE_SECRET_OPENAI_API_KEY" ] ; then
@@ -123,6 +132,7 @@ jobs:
 
       - name: Run Beta functionality embeddings test
         env:
+          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
         run: |
           if [ -z "$SPICE_SECRET_OPENAI_API_KEY" ] ; then
@@ -130,6 +140,12 @@ jobs:
             exit 1
           fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture openai_embeddings_beta_requirements
+      
+      - name: Push snapshots to branch
+        if: github.event.inputs.update_snapshots == 'always'
+        uses: ./.github/actions/push-snap-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   test-hf:
     name: Test Huggingface Models
@@ -155,6 +171,7 @@ jobs:
 
       - name: Run integration test
         env:
+          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
         run: |
           if [ -z "$SPICE_HF_TOKEN" ] ; then
@@ -165,6 +182,7 @@ jobs:
 
       - name: Run Beta functionality embedding tests
         env:
+          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
         run: |
           if [ -z "$SPICE_HF_TOKEN" ] ; then
@@ -172,6 +190,12 @@ jobs:
             exit 1
           fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture hf_embeddings_beta_requirements
+      
+      - name: Push snapshots to branch
+        if: github.event.inputs.update_snapshots == 'always'
+        uses: ./.github/actions/push-snap-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   test-local:
     name: Test Local Models
@@ -195,8 +219,16 @@ jobs:
           chmod +x ./integration_test/ai_integration_test
 
       - name: Run Beta functionality embedding tests
+        env:
+          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
         run: |
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture local_embeddings_beta_requirements
+      
+      - name: Push snapshots to branch
+        if: github.event.inputs.update_snapshots == 'always'
+        uses: ./.github/actions/push-snap-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   test-bedrock:
     name: Test Bedrock Models
@@ -222,10 +254,17 @@ jobs:
 
       - name: Run Beta functionality embedding tests
         env:
+          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
           AWS_BEDROCK_KEY: ${{ secrets.AWS_BEDROCK_KEY }}
           AWS_BEDROCK_SECRET: ${{ secrets.AWS_BEDROCK_SECRET }}
         run: |
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture bedrock_test
+      
+      - name: Push snapshots to branch
+        if: github.event.inputs.update_snapshots == 'always'
+        uses: ./.github/actions/push-snap-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   test-workers:
     name: Test Workers
@@ -254,6 +293,7 @@ jobs:
 
       - name: Run integration test
         env:
+          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
         run: |
           if [ -z "$SPICE_SECRET_OPENAI_API_KEY" ] ; then
@@ -261,6 +301,12 @@ jobs:
             exit 1
           fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture workers
+      
+      - name: Push snapshots to branch
+        if: github.event.inputs.update_snapshots == 'always'
+        uses: ./.github/actions/push-snap-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   test-search:
     name: Test Search
@@ -289,6 +335,7 @@ jobs:
 
       - name: Run integration test
         env:
+          INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
           AWS_S3_VECTORS_KEY: ${{ secrets.AWS_S3_VECTORS_KEY }}
           AWS_S3_VECTORS_SECRET: ${{ secrets.AWS_S3_VECTORS_SECRET }}
@@ -298,3 +345,9 @@ jobs:
             exit 1
           fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture search
+      
+      - name: Push snapshots to branch
+        if: github.event.inputs.update_snapshots == 'always'
+        uses: ./.github/actions/push-snap-changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -48,7 +48,7 @@ use datafusion::{
     scalar::ScalarValue,
     sql::TableReference,
 };
-use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl};
+use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl, SubqueryAlias};
 use itertools::Itertools;
 use std::cmp::min;
 use std::sync::LazyLock;
@@ -504,7 +504,12 @@ impl TableProvider for VectorSearchUDTFProvider {
             None,
         )?);
 
-        let mut base_expr: Vec<Expr> = self
+        let search_field_index = self
+            .schema()
+            .index_of(SEARCH_SCORE_COLUMN_NAME)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+        let mut final_expr: Vec<Expr> = self
             .schema()
             .fields()
             .iter()
@@ -522,6 +527,7 @@ impl TableProvider for VectorSearchUDTFProvider {
                 }
             })
             .collect();
+        let mut base_expr = final_expr.clone();
 
         base_expr.push(Expr::Alias(Alias {
             expr: Box::from(Expr::BinaryExpr(BinaryExpr::new(
@@ -540,6 +546,13 @@ impl TableProvider for VectorSearchUDTFProvider {
             metadata: None,
         }));
 
+        // only include score in the projection if it is requested.
+        // Otherwise, if the query is `SELECT a FROM vector_search(...)`, it will fail because we supplied too many columns in the response!
+        if projection.is_none() || projection.is_some_and(|proj| proj.contains(&search_field_index))
+        {
+            final_expr.push(Expr::Column(Column::from_name(SEARCH_SCORE_COLUMN_NAME)));
+        }
+
         let proj = LogicalPlan::Projection(Projection::try_new(base_expr, Arc::new(scan))?);
         let sort = LogicalPlan::Sort(Sort {
             expr: vec![SortExpr::new(
@@ -551,6 +564,13 @@ impl TableProvider for VectorSearchUDTFProvider {
             fetch: self.limit_to_use(limit),
         });
 
-        state.create_physical_plan(&sort).await
+        // wrap the score calculation in a subquery before final projection, to avoid collapsing away the score calculation.
+        let score_subquery =
+            LogicalPlan::SubqueryAlias(SubqueryAlias::try_new(Arc::new(sort), "tbl")?);
+
+        let final_proj =
+            LogicalPlan::Projection(Projection::try_new(final_expr, Arc::new(score_subquery))?);
+
+        state.create_physical_plan(&final_proj).await
     }
 }

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -369,7 +369,6 @@ pub(crate) async fn run_search_w_explain(
 }
 
 #[tokio::test]
-#[ignore = "bug issue"] // https://github.com/spiceai/spiceai/issues/6815
 async fn test_multi_column_search() -> Result<(), anyhow::Error> {
     let mut ds = catalog_page_tpcds_dataset_w_embeddings(
         "multi_column_search",
@@ -614,6 +613,12 @@ async fn test_hybrid_search_single_column() -> Result<(), anyhow::Error> {
                 "hybrid_single_column_sql_vector_search",
                 SearchTestType::Sql(
                     "SELECT id, question, trunc(score, 3) FROM vector_search(qs, 'second') order by score desc LIMIT 4",
+                ),
+            ),
+            SearchTestCase::new(
+                "hybrid_single_column_sql_vector_search_no_score",
+                SearchTestType::Sql(
+                    "SELECT question FROM vector_search(qs, 'second') order by score desc LIMIT 4",
                 ),
             ),
         ],
@@ -1007,7 +1012,6 @@ async fn test_text_search_multiple_columns() -> Result<(), anyhow::Error> {
 
 #[cfg(feature = "flightsql")]
 #[tokio::test]
-#[ignore = "bug issue"] // https://github.com/spiceai/spiceai/issues/6816
 async fn test_multi_column_w_existing_embedding() -> Result<(), anyhow::Error> {
     use spicepod::{acceleration::Acceleration, param::Params};
 

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_sql_vector_search_no_score.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_single_column_sql_vector_search_no_score.snap
@@ -1,0 +1,18 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp?
+---
+[
+  {
+    "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants."
+  },
+  {
+    "question": "How many groups of 2 are in 14?"
+  },
+  {
+    "question": "How many groups of 5 are in 25?"
+  },
+  {
+    "question": "How many groups of 3 are in 18?"
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_additional_response.snap
@@ -11,13 +11,12 @@ expression: normalize_search_response(resp)
       },
       "dataset": "multi_column_search",
       "matches": {
-        "cp_department": "DEPARTMENT",
-        "cp_description": "In general basic characters welcome. Clearly lively friends con"
+        "cp_description": "Heavily direct problems try eventually on a nurses. Courses may make "
       },
       "primary_key": {
-        "cp_catalog_page_sk": 1
+        "cp_catalog_page_sk": 8
       },
-      "score": 0.03
+      "score": 0.01
     },
     {
       "data": {
@@ -25,10 +24,10 @@ expression: normalize_search_response(resp)
       },
       "dataset": "multi_column_search",
       "matches": {
-        "cp_description": "Close customers might struggle away different mem"
+        "cp_department": "DEPARTMENT"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 15
+        "cp_catalog_page_sk": 2
       },
       "score": 0.01
     }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_basic_response.snap
@@ -8,21 +8,20 @@ expression: normalize_search_response(resp)
     {
       "dataset": "multi_column_search",
       "matches": {
-        "cp_department": "DEPARTMENT",
-        "cp_description": "In general basic characters welcome. Clearly lively friends con"
+        "cp_description": "Heavily direct problems try eventually on a nurses. Courses may make "
       },
       "primary_key": {
-        "cp_catalog_page_sk": 1
+        "cp_catalog_page_sk": 8
       },
-      "score": 0.03
+      "score": 0.01
     },
     {
       "dataset": "multi_column_search",
       "matches": {
-        "cp_description": "Close customers might struggle away different mem"
+        "cp_department": "DEPARTMENT"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 15
+        "cp_catalog_page_sk": 2
       },
       "score": 0.01
     }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_column_where_response.snap
@@ -8,32 +8,30 @@ expression: normalize_search_response(resp)
     {
       "dataset": "multi_column_search",
       "matches": {
-        "cp_department": "DEPARTMENT",
-        "cp_description": "In general basic characters welcome. Clearly lively friends con"
+        "cp_description": "Years must understand. Well fat thousands take. Good police "
       },
       "primary_key": {
-        "cp_catalog_page_sk": 1
+        "cp_catalog_page_sk": 7
       },
-      "score": 0.03
+      "score": 0.01
     },
     {
       "dataset": "multi_column_search",
       "matches": {
-        "cp_department": "DEPARTMENT",
-        "cp_description": "Earlier different differences get just to a methods; masses inclu"
+        "cp_department": "DEPARTMENT"
       },
       "primary_key": {
         "cp_catalog_page_sk": 3
       },
-      "score": 0.03
+      "score": 0.01
     },
     {
       "dataset": "multi_column_search",
       "matches": {
-        "cp_description": "Close customers might struggle away different mem"
+        "cp_description": "Good questions borrow only base children. Remarkably present "
       },
       "primary_key": {
-        "cp_catalog_page_sk": 15
+        "cp_catalog_page_sk": 19
       },
       "score": 0.01
     }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_additional_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_additional_response.snap
@@ -11,13 +11,12 @@ expression: normalize_search_response(resp)
       },
       "dataset": "multiple_columns",
       "matches": {
-        "cp_department": "DEPARTMENT",
-        "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+        "cp_description": "Heavily direct problems try eventually on a nurses. Courses may make a"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 1
+        "cp_catalog_page_sk": 8
       },
-      "score": 0.03
+      "score": 0.01
     },
     {
       "data": {
@@ -25,10 +24,10 @@ expression: normalize_search_response(resp)
       },
       "dataset": "multiple_columns",
       "matches": {
-        "cp_description": "Close customers might struggle away different memb"
+        "cp_department": "DEPARTMENT"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 15
+        "cp_catalog_page_sk": 2
       },
       "score": 0.01
     }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_basic_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_basic_response.snap
@@ -8,21 +8,20 @@ expression: normalize_search_response(resp)
     {
       "dataset": "multiple_columns",
       "matches": {
-        "cp_department": "DEPARTMENT",
-        "cp_description": "In general basic characters welcome. Clearly lively friends conv"
+        "cp_description": "Heavily direct problems try eventually on a nurses. Courses may make a"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 1
+        "cp_catalog_page_sk": 8
       },
-      "score": 0.03
+      "score": 0.01
     },
     {
       "dataset": "multiple_columns",
       "matches": {
-        "cp_description": "Close customers might struggle away different memb"
+        "cp_department": "DEPARTMENT"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 15
+        "cp_catalog_page_sk": 2
       },
       "score": 0.01
     }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_where_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_embedding_parent_child_where_response.snap
@@ -8,12 +8,22 @@ expression: normalize_search_response(resp)
     {
       "dataset": "multiple_columns",
       "matches": {
+        "cp_description": "Heavily direct problems try eventually on a nurses. Courses may make a"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 8
+      },
+      "score": 0.01
+    },
+    {
+      "dataset": "multiple_columns",
+      "matches": {
         "cp_department": "DEPARTMENT"
       },
       "primary_key": {
         "cp_catalog_page_sk": 2
       },
-      "score": 0.95
+      "score": 0.01
     }
   ]
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Ensures that the supplied projection into the `vector_search` UDTF is respected, including removing the score column from the projection.
  * To accomplish this, we need to wrap the projection with score calculation into a subquery, otherwise DataFusion will eagerly drop the column because it is unused in the final projection. The query would then fail, because we still need to sort on `score` even if it is not projected.
* Re-enables some disabled search tests

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #6844
* Closes #6816
* Closes #6815