### PR TITLE
Use twox-hash version 2.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,7 +2528,7 @@ dependencies = [
  "spicepod",
  "tokio",
  "tracing",
- "twox-hash 1.6.3",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -8934,7 +8934,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "twox-hash 2.1.0",
+ "twox-hash 2.1.2",
  "url",
 ]
 
@@ -10216,7 +10216,7 @@ dependencies = [
  "snap",
  "thrift",
  "tokio",
- "twox-hash 2.1.0",
+ "twox-hash 2.1.2",
  "zstd",
 ]
 
@@ -12148,7 +12148,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tract-core 0.21.10",
- "twox-hash 1.6.3",
+ "twox-hash 2.1.2",
  "url",
  "util",
  "utoipa",
@@ -15702,15 +15702,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
  "static_assertions",
 ]
 
 [[package]]
 name = "twox-hash"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "type1-encoding-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ tracing = "0.1.41"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry = "0.28"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-twox-hash = "1.6"
+twox-hash = "2.1.2"
 url = "2.5"
 uuid = "1"
 x509-certificate = "0.23.1"

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -202,9 +202,7 @@ mod xxhash_compat {
             self.hasher.write(bytes);
         }
     }
-
 }
-
 
 #[derive(Default)]
 pub struct Caching {

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -117,13 +117,13 @@ pub enum HashBuilder {
     Ahash(ahash::RandomState),
     Siphash(std::hash::RandomState),
     #[cfg(feature = "xxhash")]
-    XxHash3(twox_hash::xxh3::RandomHashBuilder64),
+    XxHash3(std::hash::BuildHasherDefault<twox_hash::XxHash3_64>),
     #[cfg(feature = "xxhash")]
-    XxHash32(twox_hash::RandomXxHashBuilder32),
+    XxHash32(std::hash::BuildHasherDefault<twox_hash::XxHash32>),
     #[cfg(feature = "xxhash")]
-    XxHash64(twox_hash::RandomXxHashBuilder64),
+    XxHash64(std::hash::BuildHasherDefault<twox_hash::XxHash64>),
     #[cfg(feature = "xxhash")]
-    XxHash128(twox_hash::xxh3::RandomHashBuilder128),
+    XxHash128,
 }
 
 impl std::hash::BuildHasher for HashBuilder {
@@ -140,7 +140,7 @@ impl std::hash::BuildHasher for HashBuilder {
             #[cfg(feature = "xxhash")]
             HashBuilder::XxHash64(builder) => Box::new(builder.build_hasher()),
             #[cfg(feature = "xxhash")]
-            HashBuilder::XxHash128(builder) => Box::new(builder.build_hasher()),
+            HashBuilder::XxHash128 => Box::new(xxhash_compat::XxHash3_128Wrapper::new()),
         }
     }
 }
@@ -154,25 +154,57 @@ pub fn get_hash_builder(hashing_algorithm: HashingAlgorithm) -> Result<HashBuild
         HashingAlgorithm::Siphash => Ok(HashBuilder::Siphash(std::hash::RandomState::default())),
         HashingAlgorithm::Ahash => Ok(HashBuilder::Ahash(ahash::RandomState::default())),
         #[cfg(feature = "xxhash")]
-        HashingAlgorithm::XXH3 => Ok(HashBuilder::XxHash3(
-            twox_hash::xxh3::RandomHashBuilder64::default(),
-        )),
+        HashingAlgorithm::XXH3 => Ok(HashBuilder::XxHash3(std::hash::BuildHasherDefault::<
+            twox_hash::XxHash3_64,
+        >::default())),
         #[cfg(feature = "xxhash")]
-        HashingAlgorithm::XXH32 => Ok(HashBuilder::XxHash32(
-            twox_hash::RandomXxHashBuilder32::default(),
-        )),
+        HashingAlgorithm::XXH32 => Ok(HashBuilder::XxHash32(std::hash::BuildHasherDefault::<
+            twox_hash::XxHash32,
+        >::default())),
         #[cfg(feature = "xxhash")]
-        HashingAlgorithm::XXH64 => Ok(HashBuilder::XxHash64(
-            twox_hash::RandomXxHashBuilder64::default(),
-        )),
+        HashingAlgorithm::XXH64 => Ok(HashBuilder::XxHash64(std::hash::BuildHasherDefault::<
+            twox_hash::XxHash64,
+        >::default())),
         #[cfg(feature = "xxhash")]
-        HashingAlgorithm::XXH128 => Ok(HashBuilder::XxHash128(
-            twox_hash::xxh3::RandomHashBuilder128::default(),
-        )),
+        HashingAlgorithm::XXH128 => Ok(HashBuilder::XxHash128),
         #[allow(unreachable_patterns)]
         _ => Err(Error::InvalidHashingAlgorithm),
     }
 }
+
+#[cfg(feature = "xxhash")]
+mod xxhash_compat {
+    use std::hash::Hasher;
+
+    pub struct XxHash3_128Wrapper {
+        hasher: twox_hash::XxHash3_128,
+    }
+
+    impl XxHash3_128Wrapper {
+        pub fn new() -> Self {
+            Self {
+                hasher: twox_hash::XxHash3_128::with_seed(0),
+            }
+        }
+    }
+
+    impl Hasher for XxHash3_128Wrapper {
+        fn finish(&self) -> u64 {
+            let mut hasher_copy = self.hasher.clone();
+            let hash128 = hasher_copy.finish_128();
+
+            let high = (hash128 >> 64) as u64;
+            let low = hash128 as u64;
+            high ^ low
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            self.hasher.write(bytes);
+        }
+    }
+
+}
+
 
 #[derive(Default)]
 pub struct Caching {


### PR DESCRIPTION
## 📝 Summary

Update `twox-hash` to version `2.1.2`

## 🔗 Related

https://github.com/spiceai/spiceai/issues/7085#issuecomment-3290390600

## 🚨 Breaking Changes
N/A

## 📚 Docs

N/A

## 👀 Notes for Reviewers

In the updated version `twox_hash::XxHash3_128` does not implement `std::hash::Hasher`, so I've added a wrapper
