### PR TITLE
fix: Use head ref from merge group event in pulls-with-spice concurrency group

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -8,7 +8,7 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.event.merge_group.head_ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* `github.head_ref` is an empty value when used in a merge group. It instead must pull from the event payload for the merge group event, which contains a `head_ref` property
