### PR TITLE
Fix lint for xxhash feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ lint: lint-go lint-rust
 lint-rust:
 	cargo fmt --all -- --check
 	## All except metal, cuda
-	cargo clippy $(CARGO_PROFILE) --all-targets --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp --workspace -- \
+	cargo clippy $(CARGO_PROFILE) --all-targets --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,xxhash --workspace -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \
@@ -85,7 +85,7 @@ lint-rust:
 lint-rust-fix:
 	cargo fmt --all -- --check
 	## All except metal, cuda
-	cargo clippy $(CARGO_PROFILE) --fix --allow-dirty --all-targets --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp --workspace -- \
+	cargo clippy $(CARGO_PROFILE) --fix --allow-dirty --all-targets --features aws-secrets-manager,keyring-secret-store,models,odbc,release,mcp,xxhash --workspace -- \
 		-Dwarnings \
 		-Dclippy::pedantic \
 		-Dclippy::unwrap_used \

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -189,8 +189,9 @@ mod xxhash_compat {
     }
 
     impl Hasher for XxHash3_128Wrapper {
+        #[allow(clippy::cast_possible_truncation)]
         fn finish(&self) -> u64 {
-            let mut hasher_copy = self.hasher.clone();
+            let hasher_copy = self.hasher.clone();
             let hash128 = hasher_copy.finish_128();
 
             let high = (hash128 >> 64) as u64;


### PR DESCRIPTION
## 📝 Summary

Fixes a lint failure when the `xxhash` feature is enabled