### PR TITLE
Kafka: support specifying a target consumer group ID

### DIFF
--- a/crates/data_components/src/kafka.rs
+++ b/crates/data_components/src/kafka.rs
@@ -111,6 +111,7 @@ pub struct KafkaConfig {
     pub ssl_ca_location: Option<String>,
     pub enable_ssl_certificate_verification: bool,
     pub ssl_endpoint_identification_algorithm: SslIdentification,
+    pub consumer_group_id: Option<String>,
     pub metrics_store: Option<Arc<KafkaMetrics>>,
 }
 
@@ -134,6 +135,7 @@ impl std::fmt::Debug for KafkaConfig {
                 "ssl_endpoint_identification_algorithm",
                 &self.ssl_endpoint_identification_algorithm,
             )
+            .field("consumer_group_id", &self.consumer_group_id)
             .field(
                 "metrics_store",
                 &self.metrics_store.as_ref().map(|_| "Some(KafkaMetrics)"),
@@ -190,8 +192,8 @@ impl rdkafka::ClientContext for KafkaConsumerContext {
 
         for topic in statistics.topics.values() {
             for partition in topic.partitions.values() {
-                // Skip internal partitions (partition id -1)
-                if partition.partition >= 0 {
+                // Skip internal partitions (partition id -1), and only consider partitions with known lag (-1 means unknown)
+                if partition.partition >= 0 && partition.consumer_lag >= 0 {
                     total_lag += partition.consumer_lag as u64;
                     has_valid_partitions = true;
                 }
@@ -241,11 +243,15 @@ impl KafkaConsumer {
         Self::create(group_id.into(), kafka_config)
     }
 
-    pub fn create_with_generated_group_id(
+    pub fn create_for_dataset(
         dataset: &str,
+        group_id: Option<String>,
         kafka_config: &KafkaConfig,
     ) -> Result<Self> {
-        Self::create(Self::generate_group_id(dataset), kafka_config)
+        Self::create(
+            group_id.unwrap_or_else(|| Self::generate_group_id(dataset)),
+            kafka_config,
+        )
     }
 
     #[must_use]

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -140,6 +140,11 @@ impl Debezium {
                     tracing::warn!("Invalid value for 'kafka_ssl_endpoint_identification_algorithm'. Supported values: 'none', 'https'. Defaulting to 'https'.");
                     data_components::kafka::SslIdentification::Https
                 }),
+            consumer_group_id: params
+                .get("kafka_consumer_group_id")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
             // Metrics instance that will be used by the Kafka consumer to update statistics
             metrics_store: Some(Arc::new(KafkaMetrics::new())),
         };
@@ -198,6 +203,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("kafka_ssl_endpoint_identification_algorithm")
         .default("https")
         .description("SSL/TLS endpoint identification algorithm. Default: 'https'. Options: 'none', 'https'."),
+    ParameterSpec::runtime("kafka_consumer_group_id")
+        .description("Kafka consumer group id to use for this dataset. If not set, a unique id will be generated."),
 ];
 
 impl DataConnectorFactory for DebeziumFactory {
@@ -402,12 +409,16 @@ async fn get_metadata_from_kafka(
     kafka_config: &KafkaConfig,
 ) -> super::DataConnectorResult<(KafkaConsumer, DebeziumKafkaMetadata, SchemaRef)> {
     let dataset_name = dataset.name.to_string();
-    let kafka_consumer = KafkaConsumer::create_with_generated_group_id(&dataset_name, kafka_config)
-        .boxed()
-        .context(super::UnableToGetReadProviderSnafu {
-            dataconnector: "debezium",
-            connector_component: ConnectorComponent::from(dataset),
-        })?;
+    let kafka_consumer = KafkaConsumer::create_for_dataset(
+        &dataset_name,
+        kafka_config.consumer_group_id.clone(),
+        kafka_config,
+    )
+    .boxed()
+    .context(super::UnableToGetReadProviderSnafu {
+        dataconnector: "debezium",
+        connector_component: ConnectorComponent::from(dataset),
+    })?;
 
     kafka_consumer
         .subscribe(topic)

--- a/crates/runtime/src/dataconnector/kafka.rs
+++ b/crates/runtime/src/dataconnector/kafka.rs
@@ -121,6 +121,11 @@ impl Kafka {
                     tracing::warn!("Invalid value for 'kafka_ssl_endpoint_identification_algorithm'. Supported values: 'none', 'https'. Defaulting to 'https'.");
                     data_components::kafka::SslIdentification::Https
                 }),
+            consumer_group_id: params
+                .get("consumer_group_id")
+                .expose()
+                .ok()
+                .map(ToString::to_string),
             // Metrics instance that will be used by the Kafka consumer to update statistics
             metrics_store: Some(Arc::new(KafkaMetrics::new())),
         };
@@ -210,6 +215,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("flatten_json")
         .description("Set true to flatten nested structs in JSON as separate columns.")
         .is_boolean(),
+    ParameterSpec::component("consumer_group_id")
+        .description("Kafka consumer group id to use for this dataset. If not set, a unique id will be generated."),
 ];
 
 impl DataConnectorFactory for KafkaFactory {
@@ -357,6 +364,20 @@ async fn init_kafka_consumer(
         }
     );
 
+    if let Some(ref group_id) = kafka_config.consumer_group_id {
+        ensure!(
+            group_id == &metadata.consumer_group_id,
+            super::InvalidConfigurationNoSourceSnafu {
+                dataconnector: "kafka",
+                message: format!(
+                    "Locally accelerated data belongs to a different Kafka consumer group (was '{}', now '{group_id}'). Remove the acceleration file or rename the dataset to proceed.",
+                    metadata.consumer_group_id
+                ),
+                connector_component: ConnectorComponent::from(dataset),
+            }
+        );
+    }
+
     let kafka_consumer =
         KafkaConsumer::create_with_existing_group_id(&metadata.consumer_group_id, kafka_config)
             .boxed()
@@ -403,12 +424,16 @@ async fn bootstrap_new_kafka_consumer(
     json_options: &Arc<SpiceJsonOptions>,
 ) -> super::DataConnectorResult<(KafkaConsumer, SchemaRef)> {
     let dataset_name = dataset.name.to_string();
-    let kafka_consumer = KafkaConsumer::create_with_generated_group_id(&dataset_name, kafka_config)
-        .boxed()
-        .context(super::UnableToGetReadProviderSnafu {
-            dataconnector: "kafka",
-            connector_component: ConnectorComponent::from(dataset),
-        })?;
+    let kafka_consumer = KafkaConsumer::create_for_dataset(
+        &dataset_name,
+        kafka_config.consumer_group_id.clone(),
+        kafka_config,
+    )
+    .boxed()
+    .context(super::UnableToGetReadProviderSnafu {
+        dataconnector: "kafka",
+        connector_component: ConnectorComponent::from(dataset),
+    })?;
 
     kafka_consumer
         .subscribe(topic)


### PR DESCRIPTION
## 📝 Summary

PR adds support for specifying a target consumer group id for Kafka/Debezium connectors via `kafka_consumer_group_id` param. This enabled multiple Spice instances to read data from the same topic/group in cooperative mode or using specific group id

```yaml
- from: kafka:orders_events
    name: orders
    params:
      ...
      kafka_consumer_group_id: spice-orders-group-1
    acceleration:
      enabled: true
      engine: duckdb
      mode: file
      refresh_mode: append
```

## 🔗 Related

Implements
- https://github.com/spiceai/spiceai/issues/6898 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

Despite cooperate mode via shared `kafka_consumer_group_id` might NOT be useful for Debezium as parallel processing of CDC might impact correctness/order, decided to still enable `kafka_consumer_group_id` support as it could be used for naming as well