### PR TITLE
Bump iceberg-rust version to include limit push down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6828,7 +6828,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.5.2"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc#cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a8c97cc951ff051153974ebbd6d39eaca6304f4a#a8c97cc951ff051153974ebbd6d39eaca6304f4a"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -6880,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.5.2"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc#cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a8c97cc951ff051153974ebbd6d39eaca6304f4a#a8c97cc951ff051153974ebbd6d39eaca6304f4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6897,7 +6897,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.5.2"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc#cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a8c97cc951ff051153974ebbd6d39eaca6304f4a#a8c97cc951ff051153974ebbd6d39eaca6304f4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6923,7 +6923,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.5.2"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc#cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a8c97cc951ff051153974ebbd6d39eaca6304f4a#a8c97cc951ff051153974ebbd6d39eaca6304f4a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6936,7 +6936,7 @@ dependencies = [
 [[package]]
 name = "iceberg_test_utils"
 version = "0.5.2"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc#cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=a8c97cc951ff051153974ebbd6d39eaca6304f4a#a8c97cc951ff051153974ebbd6d39eaca6304f4a"
 dependencies = [
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,11 +243,11 @@ rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af72
 dotenvy = { git = "https://github.com/spiceai/dotenvy.git", rev = "e5cef1871b08003198949dfe2da988633eaad78f" }
 
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc" }              # spiceai-0.5.2
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc" } # spiceai-0.5.2
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc" } # spiceai-0.5.2
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc" }   # spiceai-0.5.2
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "cc4f03fc7a91a7c9395d4807c4cbf102a1bda8cc" }   # spiceai-0.5.2
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a8c97cc951ff051153974ebbd6d39eaca6304f4a" }              # spiceai-0.5.2
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a8c97cc951ff051153974ebbd6d39eaca6304f4a" } # spiceai-0.5.2
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a8c97cc951ff051153974ebbd6d39eaca6304f4a" } # spiceai-0.5.2
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a8c97cc951ff051153974ebbd6d39eaca6304f4a" }   # spiceai-0.5.2
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "a8c97cc951ff051153974ebbd6d39eaca6304f4a" }   # spiceai-0.5.2
 
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "f6e5bf51153d40e34eb1262b98895ac1235b6422" }
 


### PR DESCRIPTION
## 📝 Summary

Bumps `iceberg-rust` version which includes limit push down

## 🔗 Related
https://github.com/spiceai/spiceai/issues/6994
