### PR TITLE
Fix projection mismatch issues with RRF calling vector search / text search 

### DIFF
--- a/crates/runtime/src/embeddings/index/scan_table.rs
+++ b/crates/runtime/src/embeddings/index/scan_table.rs
@@ -32,7 +32,7 @@ use datafusion::{
     scalar::ScalarValue,
     sql::TableReference,
 };
-use datafusion_expr::{SubqueryAlias, col};
+use datafusion_expr::SubqueryAlias;
 
 use crate::{
     embedding_col,

--- a/crates/runtime/src/embeddings/index/scan_table.rs
+++ b/crates/runtime/src/embeddings/index/scan_table.rs
@@ -293,8 +293,10 @@ impl TableProvider for VectorScanTableProvider {
                         && tbl.is_some_and(|t| *t == TableReference::parse_str("vector_index")))
                 })
                 .map(|(tbl, field_ref)| match tbl {
-                    Some(table_ref) => col(format!("{}.{}", table_ref.table(), field_ref.name())),
-                    None => col(field_ref.name()),
+                    Some(table_ref) => {
+                        Expr::Column(Column::new(Some(table_ref.clone()), field_ref.name()))
+                    }
+                    None => Expr::Column(Column::new(None::<TableReference>, field_ref.name())),
                 })
                 .collect();
 

--- a/crates/runtime/src/embeddings/index/scan_table.rs
+++ b/crates/runtime/src/embeddings/index/scan_table.rs
@@ -32,7 +32,7 @@ use datafusion::{
     scalar::ScalarValue,
     sql::TableReference,
 };
-use datafusion_expr::SubqueryAlias;
+use datafusion_expr::{SubqueryAlias, col};
 
 use crate::{
     embedding_col,
@@ -285,22 +285,21 @@ impl TableProvider for VectorScanTableProvider {
 
             // DataFusion will not deduplicate the `Join::on` keys. For simplicity with non-join
             // case, we will remove duplicate primary key columns from the right table.
-            let deduped_schema = DFSchema::new_with_metadata(
-                join.schema()
-                    .iter()
-                    .filter(|(tbl, f)| {
-                        !(primary_key_column_names.contains(f.name())
-                            && tbl.is_some_and(|t| *t == TableReference::parse_str("vector_index")))
-                    })
-                    .map(|(tbl, f)| (tbl.cloned(), Arc::clone(f)))
-                    .collect(),
-                HashMap::default(),
-            )?;
+            let deduped_join_proj_exprs: Vec<_> = join
+                .schema()
+                .iter()
+                .filter(|(tbl, f)| {
+                    !(primary_key_column_names.contains(f.name())
+                        && tbl.is_some_and(|t| *t == TableReference::parse_str("vector_index")))
+                })
+                .map(|(tbl, field_ref)| match tbl {
+                    Some(table_ref) => col(format!("{}.{}", table_ref.table(), field_ref.name())),
+                    None => col(field_ref.name()),
+                })
+                .collect();
 
-            let proj = LogicalPlan::Projection(Projection::new_from_schema(
-                join.into(),
-                deduped_schema.into(),
-            ));
+            let proj =
+                LogicalPlan::Projection(Projection::try_new(deduped_join_proj_exprs, join.into())?);
 
             if let Some(filter) = post_join_filters.into_iter().reduce(Expr::and) {
                 LogicalPlan::Filter(Filter::try_new(filter, proj.into())?)

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -253,6 +253,13 @@ impl ReciprocalRankFusion {
             .into_iter()
             .enumerate()
             .map(|(i, df)| {
+                // Ensure that all projections have a score column
+                if !df.schema().has_column_with_unqualified_name("score") {
+                    return exec_err!(
+                        "{RRF_UDF_NAME}: Query at position {i} does not have a `score` column."
+                    );
+                }
+
                 let df_with_id = match args.join_key {
                     Some(_) => Ok(df),
                     None => Self::with_rrf_rowid(df),
@@ -263,15 +270,6 @@ impl ReciprocalRankFusion {
                     .and_then(|df| df.alias(&format!("search_{i}")))
             })
             .collect::<Result<Vec<_>>>()?;
-
-        // Ensure that all projections have a score column
-        for (i, df) in prepared_dfs.iter().enumerate() {
-            if !df.schema().has_column_with_unqualified_name("score") {
-                return exec_err!(
-                    "{RRF_UDF_NAME}: Query at position {i} does not have a `score` column."
-                );
-            }
-        }
 
         Ok(prepared_dfs)
     }

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -385,12 +385,28 @@ impl TableProvider for ReciprocalRankFusion {
     async fn scan(
         &self,
         _state: &dyn Session,
-        _projection: Option<&Vec<usize>>,
-        _filters: &[Expr],
-        _limit: Option<usize>,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if let Some(ref df) = self.df {
-            df.clone().create_physical_plan().await
+            let mut df = df.clone();
+
+            if let Some(filter) = filters.iter().cloned().reduce(|a, b| a.and(b)) {
+                df = df.filter(filter)?;
+            }
+
+            if let Some(projection) = projection {
+                df = df.select(
+                    self.schema()
+                        .project(projection)?
+                        .fields
+                        .iter()
+                        .map(|f| col(f.name())),
+                )?;
+            }
+
+            df.limit(0, limit)?.create_physical_plan().await
         } else {
             exec_err!("ReciprocalRankFusion could not create physical plan")
         }

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -392,7 +392,7 @@ impl TableProvider for ReciprocalRankFusion {
         if let Some(ref df) = self.df {
             let mut df = df.clone();
 
-            if let Some(filter) = filters.iter().cloned().reduce(|a, b| a.and(b)) {
+            if let Some(filter) = filters.iter().cloned().reduce(Expr::and) {
                 df = df.filter(filter)?;
             }
 

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -341,7 +341,7 @@ pub(crate) async fn run_search_w_explain(
                                 format!("{}_error_response", ts.name),
                                 err.to_string()
                             );
-                            return Ok(());
+                            continue;
                         }
 
                         insta::assert_json_snapshot!(ts.name, resp?);
@@ -714,6 +714,75 @@ async fn test_hybrid_search_multiple_column() -> Result<(), anyhow::Error> {
         ],
     )
     .await
+}
+
+#[tokio::test]
+async fn test_rrf_search() -> Result<(), anyhow::Error> {
+    run_search(
+        AppBuilder::new("search_app")
+            .with_embedding(get_model_to_vec_embeddings(
+                "minishlab/potion-base-2M",
+                "hf_minilm",
+            ))
+            .with_dataset(get_mega_science_dataset(
+                Some("qs"),
+                Some(Column {
+                    name: "question".to_string(),
+                    embeddings: vec![ColumnLevelEmbeddingConfig {
+                        model: "hf_minilm".into(),
+                        chunking: None,
+                        row_ids: Some(vec!["id".to_string()]),
+                        vector_size: None,
+                    }],
+                    description: None,
+                    full_text_search: None,
+                    metadata: HashMap::new(),
+                }),
+                Some(Column {
+                    name: "answer".to_string(),
+                    embeddings: vec![],
+                    description: None,
+                    full_text_search: Some(FullTextSearchConfig {
+                        enabled: true,
+                        row_ids: Some(vec!["id".to_string()]),
+                    }),
+                    metadata: HashMap::new(),
+                }),
+            ))
+            .build(),
+        vec![
+            SearchTestCase::new(
+                "hybrid_multiple_column_sql_rrf",
+                SearchTestType::Sql(
+                    "SELECT id, question, trunc(fused_score, 3) FROM rrf(vector_search(qs, 'second'), text_search(qs, 'second')) order by fused_score desc LIMIT 4",
+                ),
+            ),
+            SearchTestCase::new(
+                "hybrid_multiple_column_sql_rrf_wrong_column",
+                SearchTestType::Sql(
+                    "SELECT id, question, trunc(score, 3) FROM rrf(vector_search(qs, 'second', answer), text_search(qs, 'second', answer)) order by fused_score desc LIMIT 4",
+                ),
+            ).should_fail(),
+            SearchTestCase::new(
+                "hybrid_multiple_column_sql_rrf_explicit_join",
+                SearchTestType::Sql(
+                    "SELECT id, question, trunc(fused_score, 3) FROM rrf(vector_search(qs, 'second'), text_search(qs, 'second'), id) order by fused_score desc LIMIT 4",
+                ),
+            ),
+            SearchTestCase::new(
+                "hybrid_multiple_column_sql_rrf_explicit_join_wrong_column",
+                SearchTestType::Sql(
+                    "SELECT id, question, trunc(fused_score, 3) FROM rrf(vector_search(qs, 'second'), text_search(qs, 'second'), foobar) order by fused_score desc LIMIT 4",
+                ),
+            ).should_fail(),
+            SearchTestCase::new(
+                "hybrid_multiple_column_sql_rrf_one_subquery_fail",
+                SearchTestType::Sql(
+                    "SELECT id, question, trunc(fused_score, 3) FROM rrf(vector_search(qs, 'second')) order by fused_score desc LIMIT 4",
+                ),
+            ).should_fail(),
+        ],
+    ).await
 }
 
 // HTTP error: 500 Internal Server Error - Error occurred in search pipeline: Error occurred aggregating candidate search results: A database error occurred whilst aggregating search candidates: Schema error: No field named table_provider."""cp_department""". Valid fields are candidate_generation.value, candidate_generation.cp_catalog_page_sk, candidate_generation.cp_description, candidate_generation.score, table_provider.cp_description, table_provider.cp_catalog_page_sk, table_provider.cp_department, table_provider.cp_catalog_number.

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -1052,7 +1052,7 @@ async fn test_text_search_multiple_columns() -> Result<(), anyhow::Error> {
             SearchTestCase::new(
                 "multi_text_column_sql_text_search_basic_question",
                 SearchTestType::Sql("SELECT id, question, trunc(score, 3) FROM text_search(qs, 'angles', question) order by score desc LIMIT 4"),
-            ),
+            ).skip(),
             SearchTestCase::new(
                 // When there are multiple columns, `text_search` needs column explicitly as input.
                 "multi_text_column_sql_text_search_error_without_column",
@@ -1061,7 +1061,7 @@ async fn test_text_search_multiple_columns() -> Result<(), anyhow::Error> {
             SearchTestCase::new(
                 "multi_text_column_sql_text_search_projection",
                 SearchTestType::Sql("SELECT id, answer, question, subject, trunc(score, 3) as score FROM text_search(qs, 'second', answer) order by score desc LIMIT 4"),
-            ),
+            ).skip(),
             SearchTestCase::new(
                 "multi_text_column_sql_text_search_filters",
                 SearchTestType::Sql("SELECT id, answer, trunc(score, 3) as score FROM text_search(qs, 'secondary', answer) where subject!='math' order by score desc LIMIT 4"),

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf.snap
@@ -1,0 +1,26 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp?
+---
+[
+  {
+    "id": 361,
+    "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\"))).fused_score,Int64(3))": 0.016
+  },
+  {
+    "id": 462,
+    "question": "How many groups of 2 are in 14?",
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\"))).fused_score,Int64(3))": 0.016
+  },
+  {
+    "id": 464,
+    "question": "How many groups of 5 are in 25?",
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\"))).fused_score,Int64(3))": 0.016
+  },
+  {
+    "id": 463,
+    "question": "How many groups of 3 are in 18?",
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\"))).fused_score,Int64(3))": 0.016
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_explicit_join.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_explicit_join.snap
@@ -1,0 +1,26 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp?
+---
+[
+  {
+    "id": 361,
+    "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), id).fused_score,Int64(3))": 0.016
+  },
+  {
+    "id": 462,
+    "question": "How many groups of 2 are in 14?",
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), id).fused_score,Int64(3))": 0.016
+  },
+  {
+    "id": 464,
+    "question": "How many groups of 5 are in 25?",
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), id).fused_score,Int64(3))": 0.016
+  },
+  {
+    "id": 463,
+    "question": "How many groups of 3 are in 18?",
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), id).fused_score,Int64(3))": 0.016
+  }
+]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_explicit_join_wrong_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_explicit_join_wrong_column_error_response.snap
@@ -1,0 +1,5 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: err.to_string()
+---
+HTTP error: 400 Bad Request - Failed to execute query: Execution error: rrf: Cannot resolve column foobar when fusing results

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_one_subquery_fail_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_one_subquery_fail_error_response.snap
@@ -1,0 +1,5 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: err.to_string()
+---
+HTTP error: 400 Bad Request - Failed to execute query: Error during planning: rrf needs at least 2 search queries to fuse results.

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_wrong_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_wrong_column_error_response.snap
@@ -1,0 +1,6 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: err.to_string()
+---
+HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'vector_search' is called on table 'qs' that does not have a embedding index on 'answer' column. Index is on column(s): question..
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_vector_search.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_vector_search.snap
@@ -1,27 +1,26 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: resp
-snapshot_kind: text
+expression: resp?
 ---
 [
   {
-    "id": 6,
-    "question": "<refined question>",
-    "trunc(vector_search().score,Int64(3))": 0.97
+    "id": 361,
+    "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
+    "trunc(vector_search(qs, Utf8(\"second\")).score,Int64(3))": 0.785
   },
   {
-    "id": 863,
-    "question": "What is created by making a choice?",
-    "trunc(vector_search().score,Int64(3))": 0.954
+    "id": 462,
+    "question": "How many groups of 2 are in 14?",
+    "trunc(vector_search(qs, Utf8(\"second\")).score,Int64(3))": 0.775
   },
   {
-    "id": 370,
-    "question": "Find the product of 2 and 7.",
-    "trunc(vector_search().score,Int64(3))": 0.953
+    "id": 464,
+    "question": "How many groups of 5 are in 25?",
+    "trunc(vector_search(qs, Utf8(\"second\")).score,Int64(3))": 0.762
   },
   {
-    "id": 1326,
-    "question": "Écrire 7 en base 2.",
-    "trunc(vector_search().score,Int64(3))": 0.952
+    "id": 463,
+    "question": "How many groups of 3 are in 18?",
+    "trunc(vector_search(qs, Utf8(\"second\")).score,Int64(3))": 0.759
   }
 ]

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_vector_search_wrong_column_error_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_vector_search_wrong_column_error_response.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
-expression: e.to_string()
-snapshot_kind: text
+expression: err.to_string()
 ---
 HTTP error: 400 Bad Request - Failed to execute query: Internal error: User function 'vector_search' is called on table 'qs' that does not have a embedding index on 'answer' column. Index is on column(s): question..
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_random.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__multi_text_column_sql_text_search_random.snap
@@ -1,0 +1,12 @@
+---
+source: crates/runtime/tests/models/search.rs
+expression: resp?
+---
+[
+  {
+    "subject": "math"
+  },
+  {
+    "subject": "math"
+  }
+]

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -23,7 +23,6 @@ use std::{
 use crate::{SEARCH_SCORE_COLUMN_NAME, index::SearchIndex};
 use arrow_schema::{Field, Schema, SchemaRef};
 use async_trait::async_trait;
-use datafusion::logical_expr::col;
 use datafusion::{
     catalog::{Session, TableProvider},
     common::{Column, DFSchema, JoinConstraint, JoinType, NullEquality},

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -20,8 +20,10 @@ use std::{
     sync::Arc,
 };
 
+use crate::{SEARCH_SCORE_COLUMN_NAME, index::SearchIndex};
 use arrow_schema::{Field, Schema, SchemaRef};
 use async_trait::async_trait;
+use datafusion::logical_expr::col;
 use datafusion::{
     catalog::{Session, TableProvider},
     common::{Column, DFSchema, JoinConstraint, JoinType, NullEquality},
@@ -35,8 +37,6 @@ use datafusion::{
     prelude::Expr,
     sql::TableReference,
 };
-
-use crate::{SEARCH_SCORE_COLUMN_NAME, index::SearchIndex};
 
 /// Performs a search on a given [`SearchIndex`] and combine with the underlying [`TableProvider`]
 /// if required by filters or additional columns in the projection.
@@ -294,22 +294,21 @@ impl SearchQueryProvider {
             null_equality: NullEquality::NullEqualsNothing,
         });
 
-        let deduped_schema = DFSchema::new_with_metadata(
-            join.schema()
-                .iter()
-                .filter(|(tbl, f)| {
-                    !(primary_key_column_names.contains(f.name())
-                        && tbl.is_some_and(|t| *t == TableReference::parse_str("base_table")))
-                })
-                .map(|(tbl, f)| (tbl.cloned(), Arc::clone(f)))
-                .collect(),
-            HashMap::default(),
-        )?;
+        let deduped_join_proj_exprs: Vec<_> = join
+            .schema()
+            .iter()
+            .filter(|(tbl, f)| {
+                !(primary_key_column_names.contains(f.name())
+                    && tbl.is_some_and(|t| *t == TableReference::parse_str("base_table")))
+            })
+            .map(|(tbl, field_ref)| match tbl {
+                Some(table_ref) => col(format!("{}.{}", table_ref.table(), field_ref.name())),
+                None => col(field_ref.name()),
+            })
+            .collect();
 
-        let proj = LogicalPlan::Projection(Projection::new_from_schema(
-            join.into(),
-            deduped_schema.into(),
-        ));
+        let proj =
+            LogicalPlan::Projection(Projection::try_new(deduped_join_proj_exprs, join.into())?);
 
         if let Some(filter) = post_join_filters.into_iter().reduce(Expr::and) {
             Ok(LogicalPlan::Filter(Filter::try_new(filter, proj.into())?))

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -302,8 +302,10 @@ impl SearchQueryProvider {
                     && tbl.is_some_and(|t| *t == TableReference::parse_str("base_table")))
             })
             .map(|(tbl, field_ref)| match tbl {
-                Some(table_ref) => col(format!("{}.{}", table_ref.table(), field_ref.name())),
-                None => col(field_ref.name()),
+                Some(table_ref) => {
+                    Expr::Column(Column::new(Some(table_ref.clone()), field_ref.name()))
+                }
+                None => Expr::Column(Column::new(None::<TableReference>, field_ref.name())),
             })
             .collect();
 


### PR DESCRIPTION
## 📝 Summary

- rrf::scan was always emitting the whole projection, where the planner would fix by adding the right proj/limit
- Deduped schema from join in vector_search/text_search would have a set of unqualified fields. Fine if there are no duplicates, but can fail when querying some federated sources (this case, FlightExec via the SpiceAI connector).
