### PR TITLE
Make S3vector a FixedSizeListArray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,6 +3676,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-flight",
+ "arrow_tools",
  "async-stream",
  "async-trait",
  "aws-config",

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -274,6 +274,53 @@ fn is_numeric_list(field: &Arc<Field>) -> bool {
     }
 }
 
+/// For a given [`RecordBatch`], replace a given column, by name, with a new ['ArrayRef`] data.
+///
+/// If `col` is not in [`RecordBatch`], no change occurs.
+///
+/// # Errors
+///
+/// This function will return an error if it unexpectedly fails to create a new [`RecordBatch`].
+pub fn replace_column_in_record(
+    rb: RecordBatch,
+    col: &str,
+    data: &ArrayRef,
+) -> Result<RecordBatch, ArrowError> {
+    let Some((idx, _)) = rb.schema().column_with_name(col) else {
+        return Ok(rb);
+    };
+    let schema = Schema::new(
+        rb.schema()
+            .fields()
+            .iter()
+            .map(|f| {
+                if f.name() == col {
+                    Arc::unwrap_or_clone(Arc::clone(f))
+                        .with_data_type(data.data_type().clone())
+                        .into()
+                } else {
+                    Arc::clone(f)
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    let columns = rb
+        .columns()
+        .iter()
+        .enumerate()
+        .map(|(i, arr)| {
+            if i == idx {
+                Arc::clone(data)
+            } else {
+                Arc::clone(arr)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    RecordBatch::try_new(schema.into(), columns)
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -274,7 +274,7 @@ fn is_numeric_list(field: &Arc<Field>) -> bool {
     }
 }
 
-/// For a given [`RecordBatch`], replace a given column, by name, with a new ['ArrayRef`] data.
+/// For a given [`RecordBatch`], replace a given column, by name, with a new [`ArrayRef`] data.
 ///
 /// If `col` is not in [`RecordBatch`], no change occurs.
 ///

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -16,6 +16,7 @@ arrow-buffer.workspace = true
 arrow-flight.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
+arrow_tools = { path = "../arrow_tools" }
 aws-config = { workspace = true, optional = true }
 aws-credential-types.workspace = true
 aws-sdk-credential-bridge = { path = "../aws-sdk-credential-bridge" }

--- a/crates/data_components/src/s3_vectors/list_provider.rs
+++ b/crates/data_components/src/s3_vectors/list_provider.rs
@@ -24,8 +24,10 @@ const LIST_S3_VECTORS_NUM_READ_SEGMENTS: usize = 10;
 
 use super::S3VectorIdentifier;
 use arrow::{
-    array::RecordBatch,
-    datatypes::{Schema, SchemaRef},
+    array::{ArrayRef, RecordBatch},
+    compute::cast,
+    datatypes::{DataType, Schema, SchemaRef},
+    error::ArrowError,
     json::ReaderBuilder,
 };
 use async_trait::async_trait;
@@ -276,6 +278,74 @@ async fn list_vector_stream(
     Ok(())
 }
 
+// For a [`SchemaRef`] with a single [`FixedSizeListArray`], convert it to a [`ListArray`] and return the associated size.
+//
+// This is useful when JSON decoding data with [`FixedSizeListArray`] since arrow_json has not implemented JSON reading of [`FixedSizeListArray`].
+fn loosen_vector_schema(s: &SchemaRef, col: &str) -> (SchemaRef, i32) {
+    let mut len = 0;
+    let fields: Vec<_> = s
+        .fields()
+        .iter()
+        .map(|f| {
+            if f.name() != col {
+                return Arc::clone(f);
+            }
+
+            match f.data_type() {
+                DataType::FixedSizeList(inner, n) => {
+                    len = *n;
+                    Arc::unwrap_or_clone(f.clone())
+                        .with_data_type(DataType::List(Arc::clone(inner)))
+                        .into()
+                }
+                _ => Arc::clone(f),
+            }
+        })
+        .collect();
+
+    (Arc::new(Schema::new(fields)), len)
+}
+
+fn replace_column_in_record(
+    rb: RecordBatch,
+    col: &str,
+    data: ArrayRef,
+) -> Result<RecordBatch, ArrowError> {
+    let Some((idx, _)) = rb.schema().column_with_name(col) else {
+        return Ok(rb);
+    };
+    let schema = Schema::new(
+        rb.schema()
+            .fields()
+            .iter()
+            .map(|f| {
+                if f.name() == col {
+                    Arc::unwrap_or_clone(f.clone())
+                        .with_data_type(data.data_type().clone())
+                        .into()
+                } else {
+                    f.clone()
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    let columns = rb
+        .columns()
+        .iter()
+        .enumerate()
+        .map(|(i, arr)| {
+            if i == idx {
+                Arc::clone(&data)
+            } else {
+                Arc::clone(arr)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    RecordBatch::try_new(schema.into(), columns)
+}
+
 async fn list_vector_segment(
     client: Arc<dyn S3Vectors + Send + Sync>,
     idx: S3VectorIdentifier,
@@ -288,7 +358,8 @@ async fn list_vector_segment(
     let start_segment = std::time::Instant::now();
 
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
-    let mut decoder = ReaderBuilder::new(Arc::clone(&schema)).build_decoder()?;
+    let (json_schema, vector_size) = loosen_vector_schema(&schema, S3_VECTOR_EMBEDDING_NAME);
+    let mut decoder = ReaderBuilder::new(Arc::clone(&json_schema)).build_decoder()?;
 
     let mut remaining_limit = limit;
     let mut next_token = None;
@@ -340,7 +411,32 @@ async fn list_vector_segment(
 
         match decoder.flush() {
             Ok(Some(rb)) => {
-                let _ = tx.send(Ok(rb)).await;
+                // if vectors are returned, cast back to FixedSizeList
+                match rb.column_by_name(S3_VECTOR_EMBEDDING_NAME).map(|v| cast(
+                        v,
+                        &DataType::new_fixed_size_list(DataType::Float32, vector_size, false),
+                    )) {
+                    Some(Ok(v)) => {
+                        let _ = tx
+                            .send(
+                                replace_column_in_record(rb, S3_VECTOR_EMBEDDING_NAME, v)
+                                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
+                            )
+                            .await;
+                    }
+                    None => {
+                        // No 'S3_VECTOR_EMBEDDING_NAME', send original RecordBatch.
+                        let _ = tx.send(Ok(rb)).await;
+                    }
+                    Some(Err(e)) => {
+                        let _ = tx
+                            .send(Err(DataFusionError::ArrowError(
+                                Box::new(e),
+                                Some(format!("Successfully decoded ListVectors JSON, but could not convert {S3_VECTOR_EMBEDDING_NAME} from 'ListArray' to `FixedSizeListArray`.")),
+                            )))
+                            .await;
+                    }
+                }
             }
             Ok(None) => {}
             Err(e) => {

--- a/crates/data_components/src/s3_vectors/list_provider.rs
+++ b/crates/data_components/src/s3_vectors/list_provider.rs
@@ -16,7 +16,8 @@ limitations under the License.
 use std::{any::Any, sync::Arc};
 
 use crate::s3_vectors::{
-    S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME, vector_table::S3VectorsTable,
+    S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
+    vector_table::{S3VectorsTable, loosen_vector_schema, send_vector_data},
 };
 
 /// Num of segments to use for parallel `ListVectors` API calls.
@@ -24,10 +25,8 @@ const LIST_S3_VECTORS_NUM_READ_SEGMENTS: usize = 10;
 
 use super::S3VectorIdentifier;
 use arrow::{
-    array::{ArrayRef, RecordBatch},
-    compute::cast,
-    datatypes::{DataType, Schema, SchemaRef},
-    error::ArrowError,
+    array::RecordBatch,
+    datatypes::{Schema, SchemaRef},
     json::ReaderBuilder,
 };
 use async_trait::async_trait;
@@ -278,74 +277,6 @@ async fn list_vector_stream(
     Ok(())
 }
 
-// For a [`SchemaRef`] with a single [`FixedSizeListArray`], convert it to a [`ListArray`] and return the associated size.
-//
-// This is useful when JSON decoding data with [`FixedSizeListArray`] since arrow_json has not implemented JSON reading of [`FixedSizeListArray`].
-fn loosen_vector_schema(s: &SchemaRef, col: &str) -> (SchemaRef, i32) {
-    let mut len = 0;
-    let fields: Vec<_> = s
-        .fields()
-        .iter()
-        .map(|f| {
-            if f.name() != col {
-                return Arc::clone(f);
-            }
-
-            match f.data_type() {
-                DataType::FixedSizeList(inner, n) => {
-                    len = *n;
-                    Arc::unwrap_or_clone(f.clone())
-                        .with_data_type(DataType::List(Arc::clone(inner)))
-                        .into()
-                }
-                _ => Arc::clone(f),
-            }
-        })
-        .collect();
-
-    (Arc::new(Schema::new(fields)), len)
-}
-
-fn replace_column_in_record(
-    rb: RecordBatch,
-    col: &str,
-    data: ArrayRef,
-) -> Result<RecordBatch, ArrowError> {
-    let Some((idx, _)) = rb.schema().column_with_name(col) else {
-        return Ok(rb);
-    };
-    let schema = Schema::new(
-        rb.schema()
-            .fields()
-            .iter()
-            .map(|f| {
-                if f.name() == col {
-                    Arc::unwrap_or_clone(f.clone())
-                        .with_data_type(data.data_type().clone())
-                        .into()
-                } else {
-                    f.clone()
-                }
-            })
-            .collect::<Vec<_>>(),
-    );
-
-    let columns = rb
-        .columns()
-        .iter()
-        .enumerate()
-        .map(|(i, arr)| {
-            if i == idx {
-                Arc::clone(&data)
-            } else {
-                Arc::clone(arr)
-            }
-        })
-        .collect::<Vec<_>>();
-
-    RecordBatch::try_new(schema.into(), columns)
-}
-
 async fn list_vector_segment(
     client: Arc<dyn S3Vectors + Send + Sync>,
     idx: S3VectorIdentifier,
@@ -410,34 +341,7 @@ async fn list_vector_segment(
         })?;
 
         match decoder.flush() {
-            Ok(Some(rb)) => {
-                // if vectors are returned, cast back to FixedSizeList
-                match rb.column_by_name(S3_VECTOR_EMBEDDING_NAME).map(|v| cast(
-                        v,
-                        &DataType::new_fixed_size_list(DataType::Float32, vector_size, false),
-                    )) {
-                    Some(Ok(v)) => {
-                        let _ = tx
-                            .send(
-                                replace_column_in_record(rb, S3_VECTOR_EMBEDDING_NAME, v)
-                                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
-                            )
-                            .await;
-                    }
-                    None => {
-                        // No 'S3_VECTOR_EMBEDDING_NAME', send original RecordBatch.
-                        let _ = tx.send(Ok(rb)).await;
-                    }
-                    Some(Err(e)) => {
-                        let _ = tx
-                            .send(Err(DataFusionError::ArrowError(
-                                Box::new(e),
-                                Some(format!("Successfully decoded ListVectors JSON, but could not convert {S3_VECTOR_EMBEDDING_NAME} from 'ListArray' to `FixedSizeListArray`.")),
-                            )))
-                            .await;
-                    }
-                }
-            }
+            Ok(Some(rb)) => send_vector_data(&tx, rb, vector_size).await,
             Ok(None) => {}
             Err(e) => {
                 let _ = tx

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -16,12 +16,14 @@ limitations under the License.
 use std::{any::Any, sync::Arc};
 
 use crate::s3_vectors::{
-    S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME, vector_table::S3VectorsTable,
+    S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
+    vector_table::{S3VectorsTable, loosen_vector_schema, replace_column_in_record},
 };
 
 use super::{Error, S3VectorIdentifier};
 use arrow::{
     array::RecordBatch,
+    compute::cast,
     datatypes::{DataType, Field, Schema, SchemaRef},
     json::ReaderBuilder,
 };
@@ -288,7 +290,8 @@ async fn query_vector_stream(
     let start = std::time::Instant::now();
 
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
-    let mut decoder = ReaderBuilder::new(Arc::clone(&schema)).build_decoder()?;
+    let (json_schema, vector_size) = loosen_vector_schema(&schema, S3_VECTOR_EMBEDDING_NAME);
+    let mut decoder = ReaderBuilder::new(Arc::clone(&json_schema)).build_decoder()?;
 
     let s3_filter_pre = convert_datafusion_filters_to_s3_vectors(&filters)?;
     let s3_filter: Option<Document> = s3_filter_pre.clone().map(Into::into);
@@ -355,7 +358,32 @@ async fn query_vector_stream(
 
     match decoder.flush() {
         Ok(Some(rb)) => {
-            let _ = tx.send(Ok(rb)).await;
+            // if vectors are returned, cast back to FixedSizeList
+            match rb.column_by_name(S3_VECTOR_EMBEDDING_NAME).map(|v| cast(
+                    v,
+                    &DataType::new_fixed_size_list(DataType::Float32, vector_size, false),
+                )) {
+                Some(Ok(v)) => {
+                    let _ = tx
+                        .send(
+                            replace_column_in_record(rb, S3_VECTOR_EMBEDDING_NAME, v)
+                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
+                        )
+                        .await;
+                }
+                None => {
+                    // No 'S3_VECTOR_EMBEDDING_NAME', send original RecordBatch.
+                    let _ = tx.send(Ok(rb)).await;
+                }
+                Some(Err(e)) => {
+                    let _ = tx
+                        .send(Err(DataFusionError::ArrowError(
+                            Box::new(e),
+                            Some(format!("Successfully decoded ListVectors JSON, but could not convert {S3_VECTOR_EMBEDDING_NAME} from 'ListArray' to `FixedSizeListArray`.")),
+                        )))
+                        .await;
+                }
+            }
         }
         Ok(None) => {}
         Err(e) => {

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -17,13 +17,12 @@ use std::{any::Any, sync::Arc};
 
 use crate::s3_vectors::{
     S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
-    vector_table::{S3VectorsTable, loosen_vector_schema, replace_column_in_record},
+    vector_table::{S3VectorsTable, loosen_vector_schema, send_vector_data},
 };
 
 use super::{Error, S3VectorIdentifier};
 use arrow::{
     array::RecordBatch,
-    compute::cast,
     datatypes::{DataType, Field, Schema, SchemaRef},
     json::ReaderBuilder,
 };
@@ -357,34 +356,7 @@ async fn query_vector_stream(
     })?;
 
     match decoder.flush() {
-        Ok(Some(rb)) => {
-            // if vectors are returned, cast back to FixedSizeList
-            match rb.column_by_name(S3_VECTOR_EMBEDDING_NAME).map(|v| cast(
-                    v,
-                    &DataType::new_fixed_size_list(DataType::Float32, vector_size, false),
-                )) {
-                Some(Ok(v)) => {
-                    let _ = tx
-                        .send(
-                            replace_column_in_record(rb, S3_VECTOR_EMBEDDING_NAME, v)
-                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
-                        )
-                        .await;
-                }
-                None => {
-                    // No 'S3_VECTOR_EMBEDDING_NAME', send original RecordBatch.
-                    let _ = tx.send(Ok(rb)).await;
-                }
-                Some(Err(e)) => {
-                    let _ = tx
-                        .send(Err(DataFusionError::ArrowError(
-                            Box::new(e),
-                            Some(format!("Successfully decoded ListVectors JSON, but could not convert {S3_VECTOR_EMBEDDING_NAME} from 'ListArray' to `FixedSizeListArray`.")),
-                        )))
-                        .await;
-                }
-            }
-        }
+        Ok(Some(rb)) => send_vector_data(&tx, rb, vector_size).await,
         Ok(None) => {}
         Err(e) => {
             let _ = tx

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -339,7 +339,7 @@ impl S3VectorsTable {
                         S3_VECTOR_EMBEDDING_NAME,
                         Field::new("item", DataType::Float32, false),
                         embedding_dimension,
-                        true,
+                        false,
                     )),
                     Arc::new(Field::new(
                         S3_VECTOR_PRIMARY_KEY_NAME,

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -21,7 +21,11 @@ use crate::s3_vectors::{
 };
 
 use super::{Error, Result, S3VectorIdentifier};
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::{
+    array::{ArrayRef, RecordBatch},
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    error::ArrowError,
+};
 use aws_credential_types::provider::error::CredentialsError;
 use datafusion::common::{Constraint, Constraints};
 use s3_vectors::{
@@ -106,7 +110,7 @@ impl S3VectorsTable {
                 }))
             }
             None | Some(GetIndexOutput { index: None, .. }) => {
-                return Ok(S3VectorTableResult::IndexDoesNotExist);
+                Ok(S3VectorTableResult::IndexDoesNotExist)
             }
         }
     }
@@ -436,4 +440,72 @@ impl S3VectorsTable {
 
         Ok(())
     }
+}
+
+// For a [`SchemaRef`] with a single [`FixedSizeListArray`], convert it to a [`ListArray`] and return the associated size.
+//
+// This is useful when JSON decoding data with [`FixedSizeListArray`] since arrow_json has not implemented JSON reading of [`FixedSizeListArray`].
+pub(super) fn loosen_vector_schema(s: &SchemaRef, col: &str) -> (SchemaRef, i32) {
+    let mut len = 0;
+    let fields: Vec<_> = s
+        .fields()
+        .iter()
+        .map(|f| {
+            if f.name() != col {
+                return Arc::clone(f);
+            }
+
+            match f.data_type() {
+                DataType::FixedSizeList(inner, n) => {
+                    len = *n;
+                    Arc::unwrap_or_clone(f.clone())
+                        .with_data_type(DataType::List(Arc::clone(inner)))
+                        .into()
+                }
+                _ => Arc::clone(f),
+            }
+        })
+        .collect();
+
+    (Arc::new(Schema::new(fields)), len)
+}
+
+pub(super) fn replace_column_in_record(
+    rb: RecordBatch,
+    col: &str,
+    data: ArrayRef,
+) -> Result<RecordBatch, ArrowError> {
+    let Some((idx, _)) = rb.schema().column_with_name(col) else {
+        return Ok(rb);
+    };
+    let schema = Schema::new(
+        rb.schema()
+            .fields()
+            .iter()
+            .map(|f| {
+                if f.name() == col {
+                    Arc::unwrap_or_clone(f.clone())
+                        .with_data_type(data.data_type().clone())
+                        .into()
+                } else {
+                    f.clone()
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    let columns = rb
+        .columns()
+        .iter()
+        .enumerate()
+        .map(|(i, arr)| {
+            if i == idx {
+                Arc::clone(&data)
+            } else {
+                Arc::clone(arr)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    RecordBatch::try_new(schema.into(), columns)
 }

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -23,11 +23,16 @@ use crate::s3_vectors::{
 use super::{Error, Result, S3VectorIdentifier};
 use arrow::{
     array::{ArrayRef, RecordBatch},
+    compute::cast,
     datatypes::{DataType, Field, Schema, SchemaRef},
     error::ArrowError,
 };
 use aws_credential_types::provider::error::CredentialsError;
-use datafusion::common::{Constraint, Constraints};
+use datafusion::{
+    common::{Constraint, Constraints},
+    error::DataFusionError,
+};
+
 use s3_vectors::{
     CreateIndexInput, CreateVectorBucketInput, DistanceMetric, Document, GetIndexError,
     GetIndexInput, GetIndexOutput, GetVectorBucketError, GetVectorBucketInput,
@@ -37,6 +42,7 @@ use s3_vectors::{
 use s3_vectors_metadata_filter::json_value_to_document;
 use serde_json::Value;
 use snafu::ResultExt;
+use tokio::sync::mpsc::Sender;
 
 /// An S3 Vector index.
 #[derive(Clone)]
@@ -458,7 +464,7 @@ pub(super) fn loosen_vector_schema(s: &SchemaRef, col: &str) -> (SchemaRef, i32)
             match f.data_type() {
                 DataType::FixedSizeList(inner, n) => {
                     len = *n;
-                    Arc::unwrap_or_clone(f.clone())
+                    Arc::unwrap_or_clone(Arc::clone(f))
                         .with_data_type(DataType::List(Arc::clone(inner)))
                         .into()
                 }
@@ -473,7 +479,7 @@ pub(super) fn loosen_vector_schema(s: &SchemaRef, col: &str) -> (SchemaRef, i32)
 pub(super) fn replace_column_in_record(
     rb: RecordBatch,
     col: &str,
-    data: ArrayRef,
+    data: &ArrayRef,
 ) -> Result<RecordBatch, ArrowError> {
     let Some((idx, _)) = rb.schema().column_with_name(col) else {
         return Ok(rb);
@@ -484,11 +490,11 @@ pub(super) fn replace_column_in_record(
             .iter()
             .map(|f| {
                 if f.name() == col {
-                    Arc::unwrap_or_clone(f.clone())
+                    Arc::unwrap_or_clone(Arc::clone(f))
                         .with_data_type(data.data_type().clone())
                         .into()
                 } else {
-                    f.clone()
+                    Arc::clone(f)
                 }
             })
             .collect::<Vec<_>>(),
@@ -500,7 +506,7 @@ pub(super) fn replace_column_in_record(
         .enumerate()
         .map(|(i, arr)| {
             if i == idx {
-                Arc::clone(&data)
+                Arc::clone(data)
             } else {
                 Arc::clone(arr)
             }
@@ -508,4 +514,39 @@ pub(super) fn replace_column_in_record(
         .collect::<Vec<_>>();
 
     RecordBatch::try_new(schema.into(), columns)
+}
+
+pub(super) async fn send_vector_data(
+    tx: &Sender<Result<RecordBatch, DataFusionError>>,
+    rb: RecordBatch,
+    vector_size: i32,
+) -> () {
+    // if vectors are returned, cast back to FixedSizeList
+    match rb.column_by_name(S3_VECTOR_EMBEDDING_NAME).map(|v| {
+        cast(
+            v,
+            &DataType::new_fixed_size_list(DataType::Float32, vector_size, false),
+        )
+    }) {
+        Some(Ok(v)) => {
+            let _ = tx
+                .send(
+                    replace_column_in_record(rb, S3_VECTOR_EMBEDDING_NAME, &v)
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
+                )
+                .await;
+        }
+        None => {
+            // No 'S3_VECTOR_EMBEDDING_NAME', send original RecordBatch.
+            let _ = tx.send(Ok(rb)).await;
+        }
+        Some(Err(e)) => {
+            let _ = tx
+                .send(Err(DataFusionError::ArrowError(
+                    Box::new(e),
+                    Some(format!("Successfully decoded S3 vector JSON response, but could not convert {S3_VECTOR_EMBEDDING_NAME} from 'ListArray' to `FixedSizeListArray`.")),
+                )))
+                .await;
+        }
+    }
 }

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -96,18 +96,19 @@ impl S3VectorsTable {
                         specified: distance_metric.clone(),
                     });
                 }
+                let schema = Self::compute_schema(index.dimension(), columns);
+                let constraints = Self::primary_key(&schema);
+                Ok(S3VectorTableResult::Table(Self {
+                    idx: id,
+                    client,
+                    schema,
+                    constraints,
+                }))
             }
-            None => return Ok(S3VectorTableResult::IndexDoesNotExist),
-            Some(_) => {}
+            None | Some(GetIndexOutput { index: None, .. }) => {
+                return Ok(S3VectorTableResult::IndexDoesNotExist);
+            }
         }
-        let schema = Self::compute_schema(columns);
-        let constraints = Self::primary_key(&schema);
-        Ok(S3VectorTableResult::Table(Self {
-            idx: id,
-            client,
-            schema,
-            constraints,
-        }))
     }
 
     pub async fn try_create_new_table(
@@ -164,21 +165,6 @@ impl S3VectorsTable {
                     .await
                     .map(S3VectorTableResult::table)
             }
-        }
-    }
-
-    #[must_use]
-    pub fn new(
-        index: S3VectorIdentifier,
-        client: Arc<dyn S3Vectors + Send + Sync>,
-        schema: SchemaRef,
-    ) -> Self {
-        let constraints = Self::primary_key(&schema);
-        Self {
-            idx: index,
-            client,
-            schema,
-            constraints,
         }
     }
 
@@ -330,7 +316,7 @@ impl S3VectorsTable {
         f.metadata().get("filterable").eq(&Some(&true.to_string()))
     }
 
-    fn compute_schema(columns: MetadataColumns) -> SchemaRef {
+    fn compute_schema(embedding_dimension: i32, columns: MetadataColumns) -> SchemaRef {
         Arc::new(Schema::new(
             [
                 columns
@@ -349,9 +335,10 @@ impl S3VectorsTable {
                     })
                     .collect(),
                 vec![
-                    Arc::new(Field::new_list(
+                    Arc::new(Field::new_fixed_size_list(
                         S3_VECTOR_EMBEDDING_NAME,
                         Field::new("item", DataType::Float32, false),
+                        embedding_dimension,
                         true,
                     )),
                     Arc::new(Field::new(

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -13,19 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use std::{collections::HashMap, error::Error as StdError, sync::Arc};
-
 use crate::s3_vectors::{
     MetadataColumn, MetadataColumns, S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
     S3VectorBuildSnafu,
 };
+use arrow_tools::record_batch::replace_column_in_record;
+use std::{collections::HashMap, error::Error as StdError, sync::Arc};
 
 use super::{Error, Result, S3VectorIdentifier};
 use arrow::{
-    array::{ArrayRef, RecordBatch},
+    array::RecordBatch,
     compute::cast,
     datatypes::{DataType, Field, Schema, SchemaRef},
-    error::ArrowError,
 };
 use aws_credential_types::provider::error::CredentialsError;
 use datafusion::{
@@ -476,51 +475,11 @@ pub(super) fn loosen_vector_schema(s: &SchemaRef, col: &str) -> (SchemaRef, i32)
     (Arc::new(Schema::new(fields)), len)
 }
 
-pub(super) fn replace_column_in_record(
-    rb: RecordBatch,
-    col: &str,
-    data: &ArrayRef,
-) -> Result<RecordBatch, ArrowError> {
-    let Some((idx, _)) = rb.schema().column_with_name(col) else {
-        return Ok(rb);
-    };
-    let schema = Schema::new(
-        rb.schema()
-            .fields()
-            .iter()
-            .map(|f| {
-                if f.name() == col {
-                    Arc::unwrap_or_clone(Arc::clone(f))
-                        .with_data_type(data.data_type().clone())
-                        .into()
-                } else {
-                    Arc::clone(f)
-                }
-            })
-            .collect::<Vec<_>>(),
-    );
-
-    let columns = rb
-        .columns()
-        .iter()
-        .enumerate()
-        .map(|(i, arr)| {
-            if i == idx {
-                Arc::clone(data)
-            } else {
-                Arc::clone(arr)
-            }
-        })
-        .collect::<Vec<_>>();
-
-    RecordBatch::try_new(schema.into(), columns)
-}
-
 pub(super) async fn send_vector_data(
     tx: &Sender<Result<RecordBatch, DataFusionError>>,
     rb: RecordBatch,
     vector_size: i32,
-) -> () {
+) {
     // if vectors are returned, cast back to FixedSizeList
     match rb.column_by_name(S3_VECTOR_EMBEDDING_NAME).map(|v| {
         cast(

--- a/crates/runtime/src/embeddings/index/s3/write.rs
+++ b/crates/runtime/src/embeddings/index/s3/write.rs
@@ -17,7 +17,8 @@ limitations under the License.
 use std::{collections::HashMap, num::TryFromIntError, sync::Arc};
 
 use arrow::array::{
-    Array, Float32Builder, LargeStringArray, ListBuilder, RecordBatch, StringArray, StringViewArray,
+    Array, FixedSizeListBuilder, Float32Builder, LargeStringArray, ListBuilder, RecordBatch,
+    StringArray, StringViewArray,
 };
 use arrow_json::{EncoderOptions, writer::make_encoder};
 use arrow_schema::{DataType, Field};
@@ -438,16 +439,17 @@ fn create_embedding_array(
             .map_err(Box::from)?;
     }
 
-    let mut builder = ListBuilder::new(Float32Builder::new());
+    let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dimension);
     let field = Field::new_list_field(DataType::Float32, false);
     builder = builder.with_field(field);
 
     for embedding_opt in embedding_vectors {
         if let Some(embedding) = embedding_opt {
             let float_builder = builder.values();
-            for &value in embedding {
-                float_builder.append_value(value);
-            }
+            float_builder.append_values(
+                embedding,
+                &(0..embedding.len()).map(|_| true).collect::<Vec<_>>(),
+            );
             builder.append(true);
         } else {
             builder.append(false);

--- a/crates/runtime/src/embeddings/index/s3/write.rs
+++ b/crates/runtime/src/embeddings/index/s3/write.rs
@@ -420,6 +420,7 @@ fn update_embedding_column_in_batch(
 }
 
 /// Create an Arrow array from embedding vectors.
+#[allow(clippy::cast_sign_loss)]
 fn create_embedding_array(
     embedding_vectors: &[Option<Vec<f32>>],
 ) -> Result<Arc<dyn Array>, Box<Error>> {
@@ -498,12 +499,11 @@ fn filter_zero_vectors(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{
-        FixedSizeListArray, Float32Array, Float32Builder, ListArray, ListBuilder, StringArray,
-    };
+    use arrow::array::{FixedSizeListArray, Float32Array, Float32Builder, StringArray};
     use arrow::datatypes::{DataType, Schema};
 
     // Helper function to create a test RecordBatch with text and embedding columns
+    #[allow(clippy::cast_sign_loss)]
     fn create_test_record_batch_with_embeddings(
         texts: Vec<Option<&str>>,
         embeddings: Vec<Option<Vec<f32>>>,
@@ -517,7 +517,7 @@ mod tests {
         builder = builder.with_field(field);
         for embedding_opt in embeddings {
             if let Some(embedding) = embedding_opt {
-                let float_builder = builder
+                builder
                     .values()
                     .append_values(&embedding, &(0..dim).map(|_| true).collect::<Vec<_>>());
                 builder.append(true);

--- a/crates/runtime/src/embeddings/index/s3/write.rs
+++ b/crates/runtime/src/embeddings/index/s3/write.rs
@@ -17,8 +17,8 @@ limitations under the License.
 use std::{collections::HashMap, num::TryFromIntError, sync::Arc};
 
 use arrow::array::{
-    Array, FixedSizeListBuilder, Float32Builder, LargeStringArray, ListBuilder, RecordBatch,
-    StringArray, StringViewArray,
+    Array, FixedSizeListBuilder, Float32Builder, LargeStringArray, RecordBatch, StringArray,
+    StringViewArray,
 };
 use arrow_json::{EncoderOptions, writer::make_encoder};
 use arrow_schema::{DataType, Field};

--- a/crates/runtime/src/embeddings/index/s3/write.rs
+++ b/crates/runtime/src/embeddings/index/s3/write.rs
@@ -445,13 +445,13 @@ fn create_embedding_array(
 
     for embedding_opt in embedding_vectors {
         if let Some(embedding) = embedding_opt {
-            let float_builder = builder.values();
-            float_builder.append_values(
+            builder.values().append_values(
                 embedding,
                 &(0..embedding.len()).map(|_| true).collect::<Vec<_>>(),
             );
             builder.append(true);
         } else {
+            builder.values().append_nulls(dimension as usize);
             builder.append(false);
         }
     }
@@ -498,28 +498,31 @@ fn filter_zero_vectors(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Float32Array, Float32Builder, ListArray, ListBuilder, StringArray};
+    use arrow::array::{
+        FixedSizeListArray, Float32Array, Float32Builder, ListArray, ListBuilder, StringArray,
+    };
     use arrow::datatypes::{DataType, Schema};
 
     // Helper function to create a test RecordBatch with text and embedding columns
     fn create_test_record_batch_with_embeddings(
         texts: Vec<Option<&str>>,
         embeddings: Vec<Option<Vec<f32>>>,
+        dim: i32,
     ) -> RecordBatch {
         let text_array = StringArray::from(texts);
 
         // Create embedding array
-        let mut builder = ListBuilder::new(Float32Builder::new());
+        let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dim);
         let field = Field::new_list_field(DataType::Float32, false);
         builder = builder.with_field(field);
         for embedding_opt in embeddings {
             if let Some(embedding) = embedding_opt {
-                let float_builder = builder.values();
-                for &value in &embedding {
-                    float_builder.append_value(value);
-                }
+                let float_builder = builder
+                    .values()
+                    .append_values(&embedding, &(0..dim).map(|_| true).collect::<Vec<_>>());
                 builder.append(true);
             } else {
+                builder.values().append_nulls(dim as usize);
                 builder.append(false);
             }
         }
@@ -529,7 +532,10 @@ mod tests {
             Field::new("text", DataType::Utf8, true),
             Field::new(
                 "text_embedding",
-                DataType::List(Arc::new(Field::new("item", DataType::Float32, false))),
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, false)),
+                    dim,
+                ),
                 true,
             ),
         ]);
@@ -559,8 +565,8 @@ mod tests {
 
         let list_array = result
             .as_any()
-            .downcast_ref::<ListArray>()
-            .expect("Result should be ListArray");
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("Result should be FixedSizeListArray");
 
         assert_eq!(list_array.len(), 3);
         assert!(!list_array.is_null(0));
@@ -598,6 +604,7 @@ mod tests {
         let record = create_test_record_batch_with_embeddings(
             vec![Some("hello"), Some("world")],
             vec![None, None], // Existing embeddings are null
+            3,
         );
 
         let new_embeddings = vec![Some(vec![0.1, 0.2, 0.3]), Some(vec![0.4, 0.5, 0.6])];
@@ -609,8 +616,8 @@ mod tests {
         let embedding_column = result.column(1);
         let list_array = embedding_column
             .as_any()
-            .downcast_ref::<ListArray>()
-            .expect("Embedding column should be ListArray");
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("Embedding column should be FixedSizeListArray");
 
         assert!(!list_array.is_null(0));
         assert!(!list_array.is_null(1));
@@ -649,8 +656,8 @@ mod tests {
         let embedding_column = result.column(result.num_columns() - 1);
         let list_array = embedding_column
             .as_any()
-            .downcast_ref::<ListArray>()
-            .expect("Embedding column should be ListArray");
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("Embedding column should be FixedSizeListArray");
 
         assert!(!list_array.is_null(0));
         assert!(!list_array.is_null(1));


### PR DESCRIPTION
## 📝 Summary
 - Use the dimension return when finding or creating a S3 vector index to construct a `FixedSizeListArray` type (instead of a more generic `ListArray`. 
- Also, S3vector does not allow empty/null vector data, so remove nullability of `FixedSizeListArray` elements. 
- We cannot convert JSON (from S3 vectors) into `FixedSizeListArray` directly, so a manual `arrow::compute::cast` is required. 