### PR TITLE
Delta Lake: Support read pruning on timestamp columns using maxValues stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4474,8 +4474,7 @@ checksum = "aafbece59594ed57696a1a69e8bb3ca1683fbc9cdb41d5c02726070b2cd8f19d"
 [[package]]
 name = "delta_kernel"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac0f0eae6345b0cfb67c4304da961e590370860aa51e88315e808c5d496629f"
+source = "git+https://github.com/spiceai/delta-kernel-rs.git?rev=0e5d8bca9b6f76087b88d7554c09a6cc43e87183#0e5d8bca9b6f76087b88d7554c09a6cc43e87183"
 dependencies = [
  "arrow",
  "bytes",
@@ -4503,8 +4502,7 @@ dependencies = [
 [[package]]
 name = "delta_kernel_derive"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064456b054cf26b607f4cbcef6d2ca102f64ed8e4fa702d2e307ce67b5b93569"
+source = "git+https://github.com/spiceai/delta-kernel-rs.git?rev=0e5d8bca9b6f76087b88d7554c09a6cc43e87183#0e5d8bca9b6f76087b88d7554c09a6cc43e87183"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,6 +234,7 @@ datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "6e
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5ad2f52b9bafc6eaa50851f2e1fcf0585fb5184d" }                      # spiceai-49
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "3437d0103e3577e6615498802d55e67581a2bad2" } # spiceai
 
+delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "0e5d8bca9b6f76087b88d7554c09a6cc43e87183" } # spiceai-0.14.0
 
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a4b83432acfe1dfdd140e35d4603701ae76f6607" } # spiceai-1.3.2
 


### PR DESCRIPTION
## 📝 Summary

Make reads from Delta Lake more efficient by [enabling file skipping on timestamp columns using maxValues stats](https://github.com/spiceai/delta-kernel-rs/pull/2).

This improves filtering and pruning when queries involve timestamp predicates. For example, retrieving data from the last N days can now prune irrelevant files earlier, reducing the amount of data scanned and improving overall query performance.

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/7163

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

I'm working on integration tests that will be added next
