### PR TITLE
Use `Instant` + `saturating_sub` to handle time drift

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -19,8 +19,8 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hasher;
 use std::sync::Arc;
-use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+use std::time::{Instant, SystemTime};
 
 use async_trait::async_trait;
 use byte_unit::Byte;
@@ -457,14 +457,6 @@ impl Display for QueryResultsCacheProvider {
         )
     }
 }
-
-pub(crate) fn current_time_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
-}
-
 #[cfg(test)]
 mod tests {
     use utils::tests::parse_sql_to_logical_plan;

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -19,8 +19,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hasher;
 use std::sync::Arc;
-use std::time::UNIX_EPOCH;
-use std::time::{Instant, SystemTime};
 
 use async_trait::async_trait;
 use byte_unit::Byte;

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -198,8 +198,8 @@ impl<
         let now_seconds = self.initial_instant.elapsed().as_secs();
         let last_emitted = self.metrics_last_reported_time.load(Ordering::Relaxed);
 
-        if now_seconds.saturating_sub(last_emitted) >= 5 {
-            if self
+        if now_seconds.saturating_sub(last_emitted) >= 5
+            && self
                 .metrics_last_reported_time
                 .compare_exchange(
                     last_emitted,
@@ -208,11 +208,10 @@ impl<
                     Ordering::Relaxed,
                 )
                 .is_ok()
-            {
-                V::record_item_count(self.item_count());
-                V::record_size(self.size_bytes());
-                V::record_max_size(self.max_size() as u64);
-            }
+        {
+            V::record_item_count(self.item_count());
+            V::record_size(self.size_bytes());
+            V::record_max_size(self.max_size() as u64);
         }
     }
 
@@ -222,8 +221,8 @@ impl<
         let now_seconds = self.initial_instant.elapsed().as_secs();
         let last_emitted = self.metrics_last_reported_time.load(Ordering::Relaxed);
 
-        if now_seconds.saturating_sub(last_emitted) >= 5 {
-            if self
+        if now_seconds.saturating_sub(last_emitted) >= 5
+            && self
                 .metrics_last_reported_time
                 .compare_exchange(
                     last_emitted,
@@ -232,10 +231,9 @@ impl<
                     Ordering::Relaxed,
                 )
                 .is_ok()
-            {
-                V::record_item_count(self.item_count());
-                V::record_size(self.size_bytes());
-            }
+        {
+            V::record_item_count(self.item_count());
+            V::record_size(self.size_bytes());
         }
     }
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -21,7 +21,6 @@ use crate::HashProvider;
 use crate::Result;
 use crate::Sizeable;
 use crate::TabledCacheProvider;
-use crate::current_time_secs;
 use crate::metrics::CacheMetrics;
 use crate::{CacheProvider, get_hash_builder};
 use async_trait::async_trait;

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -193,7 +193,7 @@ impl<
         self.cache.insert(*key, value).await;
 
         let now_seconds = current_time_secs();
-        if now_seconds - self.metrics_last_reported_time.load(Ordering::Relaxed) >= 5 {
+        if now_seconds.saturating_sub(self.metrics_last_reported_time.load(Ordering::Relaxed)) >= 5 {
             self.metrics_last_reported_time
                 .store(now_seconds, Ordering::Relaxed);
 
@@ -207,7 +207,7 @@ impl<
         self.cache.invalidate_all();
 
         let now_seconds = current_time_secs();
-        if now_seconds - self.metrics_last_reported_time.load(Ordering::Relaxed) >= 5 {
+        if now_seconds.saturating_sub(self.metrics_last_reported_time.load(Ordering::Relaxed)) >= 5 {
             self.metrics_last_reported_time
                 .store(now_seconds, Ordering::Relaxed);
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -36,7 +36,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // 'static is required by a bound from moka::Cache
 pub struct LruCache<
@@ -48,6 +48,7 @@ pub struct LruCache<
     max_size: u64,
     metrics_last_reported_time: AtomicU64,
     ttl: Duration,
+    initial_instant: Instant,
 }
 
 impl<
@@ -138,12 +139,15 @@ impl<
             .support_invalidation_closures()
             .build_with_hasher(hasher.clone());
 
+        V::init();
+
         LruCache {
             cache,
             hasher,
             max_size: cache_max_size,
             metrics_last_reported_time: AtomicU64::new(0),
             ttl,
+            initial_instant: Instant::now(),
         }
     }
 
@@ -192,29 +196,47 @@ impl<
     async fn put_raw_key(&self, key: &u64, value: V) {
         self.cache.insert(*key, value).await;
 
-        let now_seconds = current_time_secs();
-        if now_seconds.saturating_sub(self.metrics_last_reported_time.load(Ordering::Relaxed)) >= 5
-        {
-            self.metrics_last_reported_time
-                .store(now_seconds, Ordering::Relaxed);
+        let now_seconds = self.initial_instant.elapsed().as_secs();
+        let last_emitted = self.metrics_last_reported_time.load(Ordering::Relaxed);
 
-            V::record_item_count(self.item_count());
-            V::record_size(self.size_bytes());
-            V::record_max_size(self.max_size() as u64);
+        if now_seconds.saturating_sub(last_emitted) >= 5 {
+            if self
+                .metrics_last_reported_time
+                .compare_exchange(
+                    last_emitted,
+                    now_seconds,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                V::record_item_count(self.item_count());
+                V::record_size(self.size_bytes());
+                V::record_max_size(self.max_size() as u64);
+            }
         }
     }
 
     fn invalidate_all(&self) {
         self.cache.invalidate_all();
 
-        let now_seconds = current_time_secs();
-        if now_seconds.saturating_sub(self.metrics_last_reported_time.load(Ordering::Relaxed)) >= 5
-        {
-            self.metrics_last_reported_time
-                .store(now_seconds, Ordering::Relaxed);
+        let now_seconds = self.initial_instant.elapsed().as_secs();
+        let last_emitted = self.metrics_last_reported_time.load(Ordering::Relaxed);
 
-            V::record_item_count(self.item_count());
-            V::record_size(self.size_bytes());
+        if now_seconds.saturating_sub(last_emitted) >= 5 {
+            if self
+                .metrics_last_reported_time
+                .compare_exchange(
+                    last_emitted,
+                    now_seconds,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                V::record_item_count(self.item_count());
+                V::record_size(self.size_bytes());
+            }
         }
     }
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -193,7 +193,8 @@ impl<
         self.cache.insert(*key, value).await;
 
         let now_seconds = current_time_secs();
-        if now_seconds.saturating_sub(self.metrics_last_reported_time.load(Ordering::Relaxed)) >= 5 {
+        if now_seconds.saturating_sub(self.metrics_last_reported_time.load(Ordering::Relaxed)) >= 5
+        {
             self.metrics_last_reported_time
                 .store(now_seconds, Ordering::Relaxed);
 
@@ -207,7 +208,8 @@ impl<
         self.cache.invalidate_all();
 
         let now_seconds = current_time_secs();
-        if now_seconds.saturating_sub(self.metrics_last_reported_time.load(Ordering::Relaxed)) >= 5 {
+        if now_seconds.saturating_sub(self.metrics_last_reported_time.load(Ordering::Relaxed)) >= 5
+        {
             self.metrics_last_reported_time
                 .store(now_seconds, Ordering::Relaxed);
 

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -78,6 +78,15 @@ generate_cache_metrics!("search_results", search_results);
 generate_cache_metrics!("embeddings", embeddings);
 
 pub trait CacheMetrics: Send + Sync {
+    fn init()
+    where
+        Self: Sized,
+    {
+        Self::record_item_count(0);
+        Self::record_size(0);
+        Self::record_max_size(0);
+    }
+
     fn record_hit()
     where
         Self: Sized;


### PR DESCRIPTION
## 📝 Summary

Previously we were using `SystemTime` which may result in time skew. To avoid this we are now using a combination of:
 * `Instant.elapsed().as_secs` (which gives us "current time")
 * `saturating_sub` (which makes sure subtracting u64 from u64 will never panic)

Additionally added proper metrics initialization to `CacheMetrics` trait

## 🔗 Related

https://github.com/spiceai/spiceai/issues/7035

PR with alternative approach (`Instant` + `Mutex`) which eventaully was discarded: https://github.com/spiceai/spiceai/pull/7190