### PR TITLE
Update duckdb version to make ICU statically linked by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4902,7 +4902,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 [[package]]
 name = "duckdb"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a4b83432acfe1dfdd140e35d4603701ae76f6607#a4b83432acfe1dfdd140e35d4603701ae76f6607"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=394325a8527df459f79e15f19ea5e97693339db2#394325a8527df459f79e15f19ea5e97693339db2"
 dependencies = [
  "arrow",
  "cast",
@@ -7693,7 +7693,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 [[package]]
 name = "libduckdb-sys"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a4b83432acfe1dfdd140e35d4603701ae76f6607#a4b83432acfe1dfdd140e35d4603701ae76f6607"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=394325a8527df459f79e15f19ea5e97693339db2#394325a8527df459f79e15f19ea5e97693339db2"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,7 +236,7 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "0e5d8bca9b6f76087b88d7554c09a6cc43e87183" } # spiceai-0.14.0
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a4b83432acfe1dfdd140e35d4603701ae76f6607" } # spiceai-1.3.2
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "394325a8527df459f79e15f19ea5e97693339db2" } # spiceai-1.3.2
 
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af725caf5d3e952e349746706e00d0ea5" }
 


### PR DESCRIPTION
## 📝 Summary

Update duckdb version to include this fix https://github.com/spiceai/duckdb-rs/pull/23

This will make ICU extensions be statically linked by default.

## 🔗 Related

https://github.com/spiceai/spiceai/issues/7196

