### PR TITLE
Change DataType list nullability from true to false

### DIFF
--- a/crates/runtime/src/embeddings/index/scan_table.rs
+++ b/crates/runtime/src/embeddings/index/scan_table.rs
@@ -120,7 +120,7 @@ impl VectorScanTableProvider {
             Some(TableReference::parse_str("vector_index")),
             Arc::new(Field::new(
                 embedding_col!(self.index.search_column()),
-                DataType::new_list(DataType::Float32, true),
+                DataType::new_list(DataType::Float32, false),
                 true,
             )),
         ));
@@ -159,7 +159,7 @@ impl TableProvider for VectorScanTableProvider {
             &self.table_provider.schema(),
             vec![Arc::new(Field::new(
                 embedding_col!(self.index.search_column()),
-                DataType::new_list(DataType::Float32, true),
+                DataType::new_list(DataType::Float32, false),
                 true,
             ))],
         )


### PR DESCRIPTION
## 📝 Summary
 - `VectorScanTableProvider` should be more strict on the nullity of embeddings. Null entries are okay, but within a single vector, no `float32` can be null.

## 🔗 Related
 - Fixes bug from https://github.com/spiceai/spiceai/issues/7214 
 - Appears to only be an explicit issue with SQL planning/optimising when index has no data (see #7214 for separate indexing issue found). 
