### PR TITLE
Make S3vector a FixedSizeListArray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,6 +3677,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-flight",
+ "arrow_tools",
  "async-stream",
  "async-trait",
  "aws-config",

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -274,6 +274,53 @@ fn is_numeric_list(field: &Arc<Field>) -> bool {
     }
 }
 
+/// For a given [`RecordBatch`], replace a given column, by name, with a new [`ArrayRef`] data.
+///
+/// If `col` is not in [`RecordBatch`], no change occurs.
+///
+/// # Errors
+///
+/// This function will return an error if it unexpectedly fails to create a new [`RecordBatch`].
+pub fn replace_column_in_record(
+    rb: RecordBatch,
+    col: &str,
+    data: &ArrayRef,
+) -> Result<RecordBatch, ArrowError> {
+    let Some((idx, _)) = rb.schema().column_with_name(col) else {
+        return Ok(rb);
+    };
+    let schema = Schema::new(
+        rb.schema()
+            .fields()
+            .iter()
+            .map(|f| {
+                if f.name() == col {
+                    Arc::unwrap_or_clone(Arc::clone(f))
+                        .with_data_type(data.data_type().clone())
+                        .into()
+                } else {
+                    Arc::clone(f)
+                }
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    let columns = rb
+        .columns()
+        .iter()
+        .enumerate()
+        .map(|(i, arr)| {
+            if i == idx {
+                Arc::clone(data)
+            } else {
+                Arc::clone(arr)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    RecordBatch::try_new(schema.into(), columns)
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -16,6 +16,7 @@ arrow-buffer.workspace = true
 arrow-flight.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
+arrow_tools = { path = "../arrow_tools" }
 aws-config = { workspace = true, optional = true }
 aws-credential-types.workspace = true
 aws-sdk-credential-bridge = { path = "../aws-sdk-credential-bridge" }

--- a/crates/data_components/src/s3_vectors/list_provider.rs
+++ b/crates/data_components/src/s3_vectors/list_provider.rs
@@ -16,7 +16,8 @@ limitations under the License.
 use std::{any::Any, sync::Arc};
 
 use crate::s3_vectors::{
-    S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME, vector_table::S3VectorsTable,
+    S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
+    vector_table::{S3VectorsTable, loosen_vector_schema, send_vector_data},
 };
 
 /// Num of segments to use for parallel `ListVectors` API calls.
@@ -288,7 +289,8 @@ async fn list_vector_segment(
     let start_segment = std::time::Instant::now();
 
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
-    let mut decoder = ReaderBuilder::new(Arc::clone(&schema)).build_decoder()?;
+    let (json_schema, vector_size) = loosen_vector_schema(&schema, S3_VECTOR_EMBEDDING_NAME);
+    let mut decoder = ReaderBuilder::new(Arc::clone(&json_schema)).build_decoder()?;
 
     let mut remaining_limit = limit;
     let mut next_token = None;
@@ -339,9 +341,7 @@ async fn list_vector_segment(
         })?;
 
         match decoder.flush() {
-            Ok(Some(rb)) => {
-                let _ = tx.send(Ok(rb)).await;
-            }
+            Ok(Some(rb)) => send_vector_data(&tx, rb, vector_size).await,
             Ok(None) => {}
             Err(e) => {
                 let _ = tx

--- a/crates/data_components/src/s3_vectors/list_provider.rs
+++ b/crates/data_components/src/s3_vectors/list_provider.rs
@@ -289,7 +289,7 @@ async fn list_vector_segment(
     let start_segment = std::time::Instant::now();
 
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
-    let (json_schema, vector_size) = loosen_vector_schema(&schema, S3_VECTOR_EMBEDDING_NAME);
+    let (json_schema, vector_sizes) = loosen_vector_schema(&schema);
     let mut decoder = ReaderBuilder::new(Arc::clone(&json_schema)).build_decoder()?;
 
     let mut remaining_limit = limit;
@@ -341,7 +341,7 @@ async fn list_vector_segment(
         })?;
 
         match decoder.flush() {
-            Ok(Some(rb)) => send_vector_data(&tx, rb, vector_size).await,
+            Ok(Some(rb)) => send_vector_data(&tx, rb, &vector_sizes).await,
             Ok(None) => {}
             Err(e) => {
                 let _ = tx

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -16,7 +16,8 @@ limitations under the License.
 use std::{any::Any, sync::Arc};
 
 use crate::s3_vectors::{
-    S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME, vector_table::S3VectorsTable,
+    S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
+    vector_table::{S3VectorsTable, loosen_vector_schema, send_vector_data},
 };
 
 use super::{Error, S3VectorIdentifier};
@@ -288,7 +289,8 @@ async fn query_vector_stream(
     let start = std::time::Instant::now();
 
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
-    let mut decoder = ReaderBuilder::new(Arc::clone(&schema)).build_decoder()?;
+    let (json_schema, vector_size) = loosen_vector_schema(&schema, S3_VECTOR_EMBEDDING_NAME);
+    let mut decoder = ReaderBuilder::new(Arc::clone(&json_schema)).build_decoder()?;
 
     let s3_filter_pre = convert_datafusion_filters_to_s3_vectors(&filters)?;
     let s3_filter: Option<Document> = s3_filter_pre.clone().map(Into::into);
@@ -354,9 +356,7 @@ async fn query_vector_stream(
     })?;
 
     match decoder.flush() {
-        Ok(Some(rb)) => {
-            let _ = tx.send(Ok(rb)).await;
-        }
+        Ok(Some(rb)) => send_vector_data(&tx, rb, vector_size).await,
         Ok(None) => {}
         Err(e) => {
             let _ = tx

--- a/crates/data_components/src/s3_vectors/query_provider.rs
+++ b/crates/data_components/src/s3_vectors/query_provider.rs
@@ -289,7 +289,7 @@ async fn query_vector_stream(
     let start = std::time::Instant::now();
 
     let (arn, bucket_name, index_name) = idx.index_identifier_variables();
-    let (json_schema, vector_size) = loosen_vector_schema(&schema, S3_VECTOR_EMBEDDING_NAME);
+    let (json_schema, vector_sizes) = loosen_vector_schema(&schema);
     let mut decoder = ReaderBuilder::new(Arc::clone(&json_schema)).build_decoder()?;
 
     let s3_filter_pre = convert_datafusion_filters_to_s3_vectors(&filters)?;
@@ -356,7 +356,7 @@ async fn query_vector_stream(
     })?;
 
     match decoder.flush() {
-        Ok(Some(rb)) => send_vector_data(&tx, rb, vector_size).await,
+        Ok(Some(rb)) => send_vector_data(&tx, rb, &vector_sizes).await,
         Ok(None) => {}
         Err(e) => {
             let _ = tx

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -13,17 +13,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use std::{collections::HashMap, error::Error as StdError, sync::Arc};
-
 use crate::s3_vectors::{
     MetadataColumn, MetadataColumns, S3_VECTOR_EMBEDDING_NAME, S3_VECTOR_PRIMARY_KEY_NAME,
     S3VectorBuildSnafu,
 };
+use arrow_tools::record_batch::replace_column_in_record;
+use std::{collections::HashMap, error::Error as StdError, sync::Arc};
 
 use super::{Error, Result, S3VectorIdentifier};
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::{
+    array::RecordBatch,
+    compute::cast,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+};
 use aws_credential_types::provider::error::CredentialsError;
-use datafusion::common::{Constraint, Constraints};
+use datafusion::{
+    common::{Constraint, Constraints},
+    error::DataFusionError,
+};
+
 use s3_vectors::{
     CreateIndexInput, CreateVectorBucketInput, DistanceMetric, Document, GetIndexError,
     GetIndexInput, GetIndexOutput, GetVectorBucketError, GetVectorBucketInput,
@@ -33,6 +41,7 @@ use s3_vectors::{
 use s3_vectors_metadata_filter::json_value_to_document;
 use serde_json::Value;
 use snafu::ResultExt;
+use tokio::sync::mpsc::Sender;
 
 /// An S3 Vector index.
 #[derive(Clone)]
@@ -96,18 +105,19 @@ impl S3VectorsTable {
                         specified: distance_metric.clone(),
                     });
                 }
+                let schema = Self::compute_schema(index.dimension(), columns);
+                let constraints = Self::primary_key(&schema);
+                Ok(S3VectorTableResult::Table(Self {
+                    idx: id,
+                    client,
+                    schema,
+                    constraints,
+                }))
             }
-            None => return Ok(S3VectorTableResult::IndexDoesNotExist),
-            Some(_) => {}
+            None | Some(GetIndexOutput { index: None, .. }) => {
+                Ok(S3VectorTableResult::IndexDoesNotExist)
+            }
         }
-        let schema = Self::compute_schema(columns);
-        let constraints = Self::primary_key(&schema);
-        Ok(S3VectorTableResult::Table(Self {
-            idx: id,
-            client,
-            schema,
-            constraints,
-        }))
     }
 
     pub async fn try_create_new_table(
@@ -164,21 +174,6 @@ impl S3VectorsTable {
                     .await
                     .map(S3VectorTableResult::table)
             }
-        }
-    }
-
-    #[must_use]
-    pub fn new(
-        index: S3VectorIdentifier,
-        client: Arc<dyn S3Vectors + Send + Sync>,
-        schema: SchemaRef,
-    ) -> Self {
-        let constraints = Self::primary_key(&schema);
-        Self {
-            idx: index,
-            client,
-            schema,
-            constraints,
         }
     }
 
@@ -330,7 +325,7 @@ impl S3VectorsTable {
         f.metadata().get("filterable").eq(&Some(&true.to_string()))
     }
 
-    fn compute_schema(columns: MetadataColumns) -> SchemaRef {
+    fn compute_schema(embedding_dimension: i32, columns: MetadataColumns) -> SchemaRef {
         Arc::new(Schema::new(
             [
                 columns
@@ -349,10 +344,11 @@ impl S3VectorsTable {
                     })
                     .collect(),
                 vec![
-                    Arc::new(Field::new_list(
+                    Arc::new(Field::new_fixed_size_list(
                         S3_VECTOR_EMBEDDING_NAME,
                         Field::new("item", DataType::Float32, false),
-                        true,
+                        embedding_dimension,
+                        false,
                     )),
                     Arc::new(Field::new(
                         S3_VECTOR_PRIMARY_KEY_NAME,
@@ -448,5 +444,68 @@ impl S3VectorsTable {
         );
 
         Ok(())
+    }
+}
+
+// For a [`SchemaRef`] with a single [`FixedSizeListArray`], convert it to a [`ListArray`] and return the associated size.
+//
+// This is useful when JSON decoding data with [`FixedSizeListArray`] since arrow_json has not implemented JSON reading of [`FixedSizeListArray`].
+pub(super) fn loosen_vector_schema(s: &SchemaRef, col: &str) -> (SchemaRef, i32) {
+    let mut len = 0;
+    let fields: Vec<_> = s
+        .fields()
+        .iter()
+        .map(|f| {
+            if f.name() != col {
+                return Arc::clone(f);
+            }
+
+            match f.data_type() {
+                DataType::FixedSizeList(inner, n) => {
+                    len = *n;
+                    Arc::unwrap_or_clone(Arc::clone(f))
+                        .with_data_type(DataType::List(Arc::clone(inner)))
+                        .into()
+                }
+                _ => Arc::clone(f),
+            }
+        })
+        .collect();
+
+    (Arc::new(Schema::new(fields)), len)
+}
+
+pub(super) async fn send_vector_data(
+    tx: &Sender<Result<RecordBatch, DataFusionError>>,
+    rb: RecordBatch,
+    vector_size: i32,
+) {
+    // if vectors are returned, cast back to FixedSizeList
+    match rb.column_by_name(S3_VECTOR_EMBEDDING_NAME).map(|v| {
+        cast(
+            v,
+            &DataType::new_fixed_size_list(DataType::Float32, vector_size, false),
+        )
+    }) {
+        Some(Ok(v)) => {
+            let _ = tx
+                .send(
+                    replace_column_in_record(rb, S3_VECTOR_EMBEDDING_NAME, &v)
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
+                )
+                .await;
+        }
+        None => {
+            // No 'S3_VECTOR_EMBEDDING_NAME', send original RecordBatch.
+            let _ = tx.send(Ok(rb)).await;
+        }
+        Some(Err(e)) => {
+            let _ = tx
+                .send(Err(DataFusionError::ArrowError(
+                    Box::new(e),
+                    Some(format!("Successfully decoded S3 vector JSON response, but could not convert {S3_VECTOR_EMBEDDING_NAME} from 'ListArray' to `FixedSizeListArray`.")),
+                )))
+                .await;
+        }
     }
 }

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -460,7 +460,7 @@ pub(super) fn loosen_vector_schema(s: &SchemaRef) -> (SchemaRef, HashMap<String,
             DataType::FixedSizeList(inner, n) => {
                 sizes.insert(
                     f.name().clone(),
-                    DataType::FixedSizeList(Arc::clone(&inner), *n),
+                    DataType::FixedSizeList(Arc::clone(inner), *n),
                 );
                 Arc::unwrap_or_clone(Arc::clone(f))
                     .with_data_type(DataType::List(Arc::clone(inner)))
@@ -479,7 +479,7 @@ pub(super) fn make_fixed_sizes(
 ) -> Result<RecordBatch, ArrowError> {
     for (col, fixed_size_type) in vector_sizes {
         if let Some(arr) = rb.column_by_name(col) {
-            rb = replace_column_in_record(rb.clone(), col, &cast(arr, &fixed_size_type)?)?;
+            rb = replace_column_in_record(rb.clone(), col, &cast(arr, fixed_size_type)?)?;
         }
     }
     Ok(rb)
@@ -498,7 +498,7 @@ pub(super) async fn send_vector_data(
             tx
                 .send(Err(DataFusionError::ArrowError(
                     Box::new(e),
-                    Some(format!("Successfully decoded S3 vector JSON response, but could not convert appropriate vectors or metadata to `FixedSizeListArray`.")),
+                    Some("Successfully decoded S3 vector JSON response, but could not convert appropriate vectors or metadata to `FixedSizeListArray`.".to_string())
                 )))
                 .await
         }

--- a/crates/data_components/src/s3_vectors/vector_table.rs
+++ b/crates/data_components/src/s3_vectors/vector_table.rs
@@ -25,6 +25,7 @@ use arrow::{
     array::RecordBatch,
     compute::cast,
     datatypes::{DataType, Field, Schema, SchemaRef},
+    error::ArrowError,
 };
 use aws_credential_types::provider::error::CredentialsError;
 use datafusion::{
@@ -53,7 +54,7 @@ pub struct S3VectorsTable {
     // - `data` Float32
     // - `key` Utf8
     // - `metadata` will be flattened. types will be inferred as per `arrow_json`.
-    pub(super) schema: SchemaRef,
+    pub schema: SchemaRef,
 
     pub(super) constraints: Constraints,
 }
@@ -447,65 +448,59 @@ impl S3VectorsTable {
     }
 }
 
-// For a [`SchemaRef`] with a single [`FixedSizeListArray`], convert it to a [`ListArray`] and return the associated size.
+// For a [`SchemaRef`] with [`FixedSizeListArray`]s, convert them to [`ListArray`] and return the associated size for each column name.
 //
 // This is useful when JSON decoding data with [`FixedSizeListArray`] since arrow_json has not implemented JSON reading of [`FixedSizeListArray`].
-pub(super) fn loosen_vector_schema(s: &SchemaRef, col: &str) -> (SchemaRef, i32) {
-    let mut len = 0;
+pub(super) fn loosen_vector_schema(s: &SchemaRef) -> (SchemaRef, HashMap<String, DataType>) {
+    let mut sizes: HashMap<String, DataType> = HashMap::default();
     let fields: Vec<_> = s
         .fields()
         .iter()
-        .map(|f| {
-            if f.name() != col {
-                return Arc::clone(f);
+        .map(|f| match f.data_type() {
+            DataType::FixedSizeList(inner, n) => {
+                sizes.insert(
+                    f.name().clone(),
+                    DataType::FixedSizeList(Arc::clone(&inner), *n),
+                );
+                Arc::unwrap_or_clone(Arc::clone(f))
+                    .with_data_type(DataType::List(Arc::clone(inner)))
+                    .into()
             }
-
-            match f.data_type() {
-                DataType::FixedSizeList(inner, n) => {
-                    len = *n;
-                    Arc::unwrap_or_clone(Arc::clone(f))
-                        .with_data_type(DataType::List(Arc::clone(inner)))
-                        .into()
-                }
-                _ => Arc::clone(f),
-            }
+            _ => Arc::clone(f),
         })
         .collect();
 
-    (Arc::new(Schema::new(fields)), len)
+    (Arc::new(Schema::new(fields)), sizes)
+}
+
+pub(super) fn make_fixed_sizes(
+    mut rb: RecordBatch,
+    vector_sizes: &HashMap<String, DataType>,
+) -> Result<RecordBatch, ArrowError> {
+    for (col, fixed_size_type) in vector_sizes {
+        if let Some(arr) = rb.column_by_name(col) {
+            rb = replace_column_in_record(rb.clone(), col, &cast(arr, &fixed_size_type)?)?;
+        }
+    }
+    Ok(rb)
 }
 
 pub(super) async fn send_vector_data(
     tx: &Sender<Result<RecordBatch, DataFusionError>>,
     rb: RecordBatch,
-    vector_size: i32,
+    vector_sizes: &HashMap<String, DataType>,
 ) {
-    // if vectors are returned, cast back to FixedSizeList
-    match rb.column_by_name(S3_VECTOR_EMBEDDING_NAME).map(|v| {
-        cast(
-            v,
-            &DataType::new_fixed_size_list(DataType::Float32, vector_size, false),
-        )
-    }) {
-        Some(Ok(v)) => {
-            let _ = tx
-                .send(
-                    replace_column_in_record(rb, S3_VECTOR_EMBEDDING_NAME, &v)
-                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None)),
-                )
-                .await;
+    let _ = match make_fixed_sizes(rb, vector_sizes) {
+        Ok(v) => {
+            tx.send(Ok(v)).await
         }
-        None => {
-            // No 'S3_VECTOR_EMBEDDING_NAME', send original RecordBatch.
-            let _ = tx.send(Ok(rb)).await;
-        }
-        Some(Err(e)) => {
-            let _ = tx
+        Err(e) => {
+            tx
                 .send(Err(DataFusionError::ArrowError(
                     Box::new(e),
-                    Some(format!("Successfully decoded S3 vector JSON response, but could not convert {S3_VECTOR_EMBEDDING_NAME} from 'ListArray' to `FixedSizeListArray`.")),
+                    Some(format!("Successfully decoded S3 vector JSON response, but could not convert appropriate vectors or metadata to `FixedSizeListArray`.")),
                 )))
-                .await;
+                .await
         }
-    }
+    };
 }

--- a/crates/runtime/src/embeddings/index/mod.rs
+++ b/crates/runtime/src/embeddings/index/mod.rs
@@ -34,6 +34,8 @@ pub trait VectorIndex: SearchIndex {
     ///
     /// The associated embedding vector column will be [`SearchIndex::search_column`] with `_embedding` appended (e.g. `body_embedding`).
     fn list_table_provider(&self) -> Result<LogicalPlan, Box<dyn std::error::Error + Send + Sync>>;
+
+    fn dimension(&self) -> i32;
 }
 
 // Returns true if the search index table has all requested columns and can handle all filters (i.e. filters pertain to search index columns, even if they must be post-applied in DataFusion).
@@ -284,6 +286,17 @@ pub mod tests {
 
     #[async_trait]
     impl VectorIndex for PretendVectorIndex {
+        fn dimension(&self) -> i32 {
+            self.schema
+                .column_with_name(self.search_column().as_str())
+                .map(|(_, f)| {
+                    match f.data_type() {
+                        DataType::FixedSizeList(_, dim) => *dim,
+                        _ => 0, // Should not be reachable
+                    }
+                })
+                .unwrap_or_default()
+        }
         fn list_table_provider(
             &self,
         ) -> Result<LogicalPlan, Box<dyn std::error::Error + Send + Sync>> {

--- a/crates/runtime/src/embeddings/index/s3/index.rs
+++ b/crates/runtime/src/embeddings/index/s3/index.rs
@@ -219,6 +219,19 @@ impl VectorIndex for S3Vector {
         )
         .boxed()
     }
+
+    fn dimension(&self) -> i32 {
+        self.table
+            .schema
+            .column_with_name(S3_VECTOR_EMBEDDING_NAME)
+            .map(|(_, f)| {
+                match f.data_type() {
+                    DataType::FixedSizeList(_, dim) => *dim,
+                    _ => 0, // Should not be reachable
+                }
+            })
+            .unwrap_or_default()
+    }
 }
 
 /// Convert a [`MetadataColumns`] into a set of [`Expr`]s suitable for a projection.

--- a/crates/runtime/src/embeddings/index/s3/write.rs
+++ b/crates/runtime/src/embeddings/index/s3/write.rs
@@ -17,7 +17,8 @@ limitations under the License.
 use std::{collections::HashMap, num::TryFromIntError, sync::Arc};
 
 use arrow::array::{
-    Array, Float32Builder, LargeStringArray, ListBuilder, RecordBatch, StringArray, StringViewArray,
+    Array, FixedSizeListBuilder, Float32Builder, LargeStringArray, RecordBatch, StringArray,
+    StringViewArray,
 };
 use arrow_json::{EncoderOptions, writer::make_encoder};
 use arrow_schema::{DataType, Field};
@@ -419,6 +420,7 @@ fn update_embedding_column_in_batch(
 }
 
 /// Create an Arrow array from embedding vectors.
+#[allow(clippy::cast_sign_loss)]
 fn create_embedding_array(
     embedding_vectors: &[Option<Vec<f32>>],
 ) -> Result<Arc<dyn Array>, Box<Error>> {
@@ -438,18 +440,19 @@ fn create_embedding_array(
             .map_err(Box::from)?;
     }
 
-    let mut builder = ListBuilder::new(Float32Builder::new());
+    let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dimension);
     let field = Field::new_list_field(DataType::Float32, false);
     builder = builder.with_field(field);
 
     for embedding_opt in embedding_vectors {
         if let Some(embedding) = embedding_opt {
-            let float_builder = builder.values();
-            for &value in embedding {
-                float_builder.append_value(value);
-            }
+            builder.values().append_values(
+                embedding,
+                &(0..embedding.len()).map(|_| true).collect::<Vec<_>>(),
+            );
             builder.append(true);
         } else {
+            builder.values().append_nulls(dimension as usize);
             builder.append(false);
         }
     }
@@ -496,28 +499,30 @@ fn filter_zero_vectors(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Float32Array, Float32Builder, ListArray, ListBuilder, StringArray};
+    use arrow::array::{FixedSizeListArray, Float32Array, Float32Builder, StringArray};
     use arrow::datatypes::{DataType, Schema};
 
     // Helper function to create a test RecordBatch with text and embedding columns
+    #[allow(clippy::cast_sign_loss)]
     fn create_test_record_batch_with_embeddings(
         texts: Vec<Option<&str>>,
         embeddings: Vec<Option<Vec<f32>>>,
+        dim: i32,
     ) -> RecordBatch {
         let text_array = StringArray::from(texts);
 
         // Create embedding array
-        let mut builder = ListBuilder::new(Float32Builder::new());
+        let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dim);
         let field = Field::new_list_field(DataType::Float32, false);
         builder = builder.with_field(field);
         for embedding_opt in embeddings {
             if let Some(embedding) = embedding_opt {
-                let float_builder = builder.values();
-                for &value in &embedding {
-                    float_builder.append_value(value);
-                }
+                builder
+                    .values()
+                    .append_values(&embedding, &(0..dim).map(|_| true).collect::<Vec<_>>());
                 builder.append(true);
             } else {
+                builder.values().append_nulls(dim as usize);
                 builder.append(false);
             }
         }
@@ -527,7 +532,10 @@ mod tests {
             Field::new("text", DataType::Utf8, true),
             Field::new(
                 "text_embedding",
-                DataType::List(Arc::new(Field::new("item", DataType::Float32, false))),
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, false)),
+                    dim,
+                ),
                 true,
             ),
         ]);
@@ -557,8 +565,8 @@ mod tests {
 
         let list_array = result
             .as_any()
-            .downcast_ref::<ListArray>()
-            .expect("Result should be ListArray");
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("Result should be FixedSizeListArray");
 
         assert_eq!(list_array.len(), 3);
         assert!(!list_array.is_null(0));
@@ -596,6 +604,7 @@ mod tests {
         let record = create_test_record_batch_with_embeddings(
             vec![Some("hello"), Some("world")],
             vec![None, None], // Existing embeddings are null
+            3,
         );
 
         let new_embeddings = vec![Some(vec![0.1, 0.2, 0.3]), Some(vec![0.4, 0.5, 0.6])];
@@ -607,8 +616,8 @@ mod tests {
         let embedding_column = result.column(1);
         let list_array = embedding_column
             .as_any()
-            .downcast_ref::<ListArray>()
-            .expect("Embedding column should be ListArray");
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("Embedding column should be FixedSizeListArray");
 
         assert!(!list_array.is_null(0));
         assert!(!list_array.is_null(1));
@@ -647,8 +656,8 @@ mod tests {
         let embedding_column = result.column(result.num_columns() - 1);
         let list_array = embedding_column
             .as_any()
-            .downcast_ref::<ListArray>()
-            .expect("Embedding column should be ListArray");
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("Embedding column should be FixedSizeListArray");
 
         assert!(!list_array.is_null(0));
         assert!(!list_array.is_null(1));

--- a/crates/runtime/src/embeddings/index/scan_table.rs
+++ b/crates/runtime/src/embeddings/index/scan_table.rs
@@ -120,7 +120,7 @@ impl VectorScanTableProvider {
             Some(TableReference::parse_str("vector_index")),
             Arc::new(Field::new(
                 embedding_col!(self.index.search_column()),
-                DataType::new_list(DataType::Float32, false),
+                DataType::new_fixed_size_list(DataType::Float32, self.index.dimension(), false),
                 true,
             )),
         ));
@@ -159,7 +159,7 @@ impl TableProvider for VectorScanTableProvider {
             &self.table_provider.schema(),
             vec![Arc::new(Field::new(
                 embedding_col!(self.index.search_column()),
-                DataType::new_list(DataType::Float32, false),
+                DataType::new_fixed_size_list(DataType::Float32, self.index.dimension(), false),
                 true,
             ))],
         )

--- a/crates/runtime/tests/models/s3_vectors.rs
+++ b/crates/runtime/tests/models/s3_vectors.rs
@@ -40,7 +40,7 @@ mod search {
     use app::AppBuilder;
     use serde_json::json;
     use spicepod::{
-        semantic::{Column, ColumnLevelEmbeddingConfig},
+        semantic::{Column, ColumnLevelEmbeddingConfig, FullTextSearchConfig},
         vector::VectorStore,
     };
     use std::{collections::HashMap, sync::Arc};
@@ -142,6 +142,125 @@ mod search {
                 ),
                 SearchTestCase::new(
                     "s3vectors_basic_vector_search_sql_vectors",
+                    SearchTestType::Sql(
+                        "SELECT id, answer, array_length(answer_embedding), round(score, 1) FROM vector_search(qs, 'second') order by score desc LIMIT 4;",
+                    ))
+            ],
+            true
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn hybrid_w_vector_engine() -> Result<(), anyhow::Error> {
+        let mut ds = get_mega_science_dataset(
+            Some("qs"),
+            Some(Column {
+                name: "question".to_string(),
+                embeddings: vec![],
+                description: None,
+                full_text_search: Some(FullTextSearchConfig {
+                    enabled: true,
+                    row_ids: Some(vec!["id".to_string()]),
+                }),
+                metadata: HashMap::new(),
+            }),
+            Some(Column {
+                name: "answer".to_string(),
+                embeddings: vec![ColumnLevelEmbeddingConfig {
+                    model: "hf_minilm".to_string(),
+                    row_ids: Some(vec!["id".to_string()]),
+                    chunking: None,
+                    vector_size: None,
+                }],
+                description: None,
+                full_text_search: None,
+                metadata: HashMap::new(),
+            }),
+        );
+        let bucket_name = "spice-ci-tests-s3-vectors-hybrid";
+        let vector_store = init_vector_store(bucket_name, true).await?;
+        ds.vectors = Some(vector_store);
+
+        run_search_w_explain(
+            AppBuilder::new("search_app")
+                .with_embedding(get_huggingface_embeddings(
+                    "sentence-transformers/all-MiniLM-L6-v2",
+                    "hf_minilm",
+                ))
+                .with_dataset(ds)
+                .build(),
+            vec![
+                SearchTestCase::new(
+                    "s3vectors_hybrid_basic",
+                    SearchTestType::Http(json!({
+                        "text": "second",
+                        "limit": 4,
+                        "datasets": ["qs"],
+                    })),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_additional_columns",
+                    SearchTestType::Http(json!({
+                        "text": "second",
+                        "limit": 4,
+                        "datasets": ["qs"],
+                        "additional_columns": ["question"],
+                    })),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_with_where",
+                    SearchTestType::Http(json!({
+                        "text": "secondary",
+                        "datasets": ["qs"],
+                        "where": "subject!='math'",
+                        "limit": 4,
+                    })),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_vector_search_sql_basic",
+                    SearchTestType::Sql(
+                        "SELECT id, answer, trunc(score, 3) FROM vector_search(qs, 'second') order by score desc LIMIT 4",
+                    ),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_vector_search_text_search",
+                    SearchTestType::Sql(
+                        "SELECT id, answer, trunc(score, 3) FROM text_search(qs, 'second') order by score desc LIMIT 4",
+                    ),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_vector_search_text_search_w_embedding",
+                    SearchTestType::Sql(
+                        "SELECT id, answer, length(answer_embedding), trunc(score, 3) FROM text_search(qs, 'second') order by score desc LIMIT 4",
+                    ),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_vector_search_sql_projection",
+                    SearchTestType::Sql(
+                        "SELECT id, answer, question, subject, trunc(score, 3) as score FROM vector_search(qs, 'second') order by score desc LIMIT 4",
+                    ),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_vector_search_sql_filters",
+                    SearchTestType::Sql(
+                        "SELECT id, answer, trunc(score, 3) as score FROM vector_search(qs, 'secondary') where subject!='math' order by score desc LIMIT 4",
+                    ),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_vector_search_sql_no_score",
+                    SearchTestType::Sql(
+                        "SELECT id, answer FROM vector_search(qs, 'second') order by score desc LIMIT 4",
+                    ),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_vector_search_sql_random",
+                    SearchTestType::Sql(
+                        "SELECT subject FROM vector_search(qs, 'second') order by score desc LIMIT 4",
+                    ),
+                ),
+                SearchTestCase::new(
+                    "s3vectors_hybrid_vector_search_sql_vectors",
                     SearchTestType::Sql(
                         "SELECT id, answer, array_length(answer_embedding), round(score, 1) FROM vector_search(qs, 'second') order by score desc LIMIT 4;",
                     ))

--- a/crates/runtime/tests/models/s3_vectors.rs
+++ b/crates/runtime/tests/models/s3_vectors.rs
@@ -40,7 +40,7 @@ mod search {
     use app::AppBuilder;
     use serde_json::json;
     use spicepod::{
-        semantic::{Column, ColumnLevelEmbeddingConfig, FullTextSearchConfig},
+        semantic::{Column, ColumnLevelEmbeddingConfig},
         vector::VectorStore,
     };
     use std::{collections::HashMap, sync::Arc};
@@ -142,125 +142,6 @@ mod search {
                 ),
                 SearchTestCase::new(
                     "s3vectors_basic_vector_search_sql_vectors",
-                    SearchTestType::Sql(
-                        "SELECT id, answer, array_length(answer_embedding), round(score, 1) FROM vector_search(qs, 'second') order by score desc LIMIT 4;",
-                    ))
-            ],
-            true
-        )
-        .await
-    }
-
-    #[tokio::test]
-    async fn hybrid_w_vector_engine() -> Result<(), anyhow::Error> {
-        let mut ds = get_mega_science_dataset(
-            Some("qs"),
-            Some(Column {
-                name: "question".to_string(),
-                embeddings: vec![],
-                description: None,
-                full_text_search: Some(FullTextSearchConfig {
-                    enabled: true,
-                    row_ids: Some(vec!["id".to_string()]),
-                }),
-                metadata: HashMap::new(),
-            }),
-            Some(Column {
-                name: "answer".to_string(),
-                embeddings: vec![ColumnLevelEmbeddingConfig {
-                    model: "hf_minilm".to_string(),
-                    row_ids: Some(vec!["id".to_string()]),
-                    chunking: None,
-                    vector_size: None,
-                }],
-                description: None,
-                full_text_search: None,
-                metadata: HashMap::new(),
-            }),
-        );
-        let bucket_name = "spice-ci-tests-s3-vectors-hybrid";
-        let vector_store = init_vector_store(bucket_name, true).await?;
-        ds.vectors = Some(vector_store);
-
-        run_search_w_explain(
-            AppBuilder::new("search_app")
-                .with_embedding(get_huggingface_embeddings(
-                    "sentence-transformers/all-MiniLM-L6-v2",
-                    "hf_minilm",
-                ))
-                .with_dataset(ds)
-                .build(),
-            vec![
-                SearchTestCase::new(
-                    "s3vectors_hybrid_basic",
-                    SearchTestType::Http(json!({
-                        "text": "second",
-                        "limit": 4,
-                        "datasets": ["qs"],
-                    })),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_additional_columns",
-                    SearchTestType::Http(json!({
-                        "text": "second",
-                        "limit": 4,
-                        "datasets": ["qs"],
-                        "additional_columns": ["question"],
-                    })),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_with_where",
-                    SearchTestType::Http(json!({
-                        "text": "secondary",
-                        "datasets": ["qs"],
-                        "where": "subject!='math'",
-                        "limit": 4,
-                    })),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_vector_search_sql_basic",
-                    SearchTestType::Sql(
-                        "SELECT id, answer, trunc(score, 3) FROM vector_search(qs, 'second') order by score desc LIMIT 4",
-                    ),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_vector_search_text_search",
-                    SearchTestType::Sql(
-                        "SELECT id, answer, trunc(score, 3) FROM text_search(qs, 'second') order by score desc LIMIT 4",
-                    ),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_vector_search_text_search_w_embedding",
-                    SearchTestType::Sql(
-                        "SELECT id, answer, length(answer_embedding), trunc(score, 3) FROM text_search(qs, 'second') order by score desc LIMIT 4",
-                    ),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_vector_search_sql_projection",
-                    SearchTestType::Sql(
-                        "SELECT id, answer, question, subject, trunc(score, 3) as score FROM vector_search(qs, 'second') order by score desc LIMIT 4",
-                    ),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_vector_search_sql_filters",
-                    SearchTestType::Sql(
-                        "SELECT id, answer, trunc(score, 3) as score FROM vector_search(qs, 'secondary') where subject!='math' order by score desc LIMIT 4",
-                    ),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_vector_search_sql_no_score",
-                    SearchTestType::Sql(
-                        "SELECT id, answer FROM vector_search(qs, 'second') order by score desc LIMIT 4",
-                    ),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_vector_search_sql_random",
-                    SearchTestType::Sql(
-                        "SELECT subject FROM vector_search(qs, 'second') order by score desc LIMIT 4",
-                    ),
-                ),
-                SearchTestCase::new(
-                    "s3vectors_hybrid_vector_search_sql_vectors",
                     SearchTestType::Sql(
                         "SELECT id, answer, array_length(answer_embedding), round(score, 1) FROM vector_search(qs, 'second') order by score desc LIMIT 4;",
                     ))


### PR DESCRIPTION
## 📝 Summary
An extension of #7201  that fixes schema correctness issues with `VectorScanTableProvider`, and enables `FixedSizeListArray` to be used in S3Vector metadata fields (issue akin to issue with vector field).

## 🔗 Related
 - For #6555 
 - Moved out of larger PR #7143 
