### PR TITLE
Remove duplicate pg_port configuration in test

### DIFF
--- a/crates/runtime/tests/acceleration/refresh/refresh_postgres.rs
+++ b/crates/runtime/tests/acceleration/refresh/refresh_postgres.rs
@@ -41,7 +41,6 @@ async fn test_acceleration_refresh_duckdb_append() -> Result<(), anyhow::Error> 
                 ("pg_db".to_string(), "acceleration".to_string()),
                 ("pg_sslmode".to_string(), "disable".to_string()),
                 ("pg_port".to_string(), port.to_string()),
-                ("pg_port".to_string(), port.to_string()),
             ]
             .iter()
             .cloned()


### PR DESCRIPTION
This pull request makes a minor cleanup to the test configuration in `refresh_postgres.rs` by removing a duplicate entry for the `"pg_port"` parameter in the connection settings. This improves clarity and prevents potential confusion in the test setup.