### PR TITLE
Catalog connection error: fix connector name from 'iceberg' to 'spice.ai'

### DIFF
--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -80,7 +80,7 @@ impl SpiceCloudPlatformCatalog {
         )
         .await
         .map_err(|e| super::Error::UnableToGetCatalogProvider {
-            connector: "iceberg".into(),
+            connector: "spice.ai".into(),
             connector_component: ConnectorComponent::from(catalog),
             source: Box::new(e),
         })?;


### PR DESCRIPTION
## 📝 Summary

Despite Spice uses iceberg protocol  internally it should be advertised as spice.ai in error, not iceberg.

>2025-09-22T02:16:37.076402Z ERROR runtime::init::catalog: Failed to setup the catalog tpch (iceberg). Failed to list namespaces for the Spice Cloud Catalog. 

->


>2025-09-22T02:16:37.076402Z ERROR runtime::init::catalog: Failed to setup the catalog tpch (spice.ai). Failed to list namespaces for the Spice Cloud Catalog. 


```yaml
catalogs:
  - from: spice.ai:spiceai/tpch
    name: tpch
    include:
      - 'tpch.*'
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
