### PR TITLE
EmbeddingInput cache keys to include model name

### DIFF
--- a/crates/cache/src/key.rs
+++ b/crates/cache/src/key.rs
@@ -69,7 +69,7 @@ pub enum CacheKey<'a> {
     // Embedding keys could either be the full request (for distinguising between dimension count, encoding format, etc)
     // or just the individual input for less complex requests (e.g. via `.embed()` for some models instead of `.embed_request()`)
     EmbeddingRequest(&'a CreateEmbeddingRequest),
-    EmbeddingInput(&'a EmbeddingInput),
+    EmbeddingInput(&'a str, &'a EmbeddingInput),
 }
 
 impl<'a> From<&'a CreateEmbeddingRequest> for CacheKey<'a> {
@@ -78,9 +78,10 @@ impl<'a> From<&'a CreateEmbeddingRequest> for CacheKey<'a> {
     }
 }
 
-impl<'a> From<&'a EmbeddingInput> for CacheKey<'a> {
-    fn from(embedding_input: &'a EmbeddingInput) -> Self {
-        Self::EmbeddingInput(embedding_input)
+impl<'a> From<(&'a str, &'a EmbeddingInput)> for CacheKey<'a> {
+    fn from(input: (&'a str, &'a EmbeddingInput)) -> Self {
+        let (model_name, input) = input;
+        Self::EmbeddingInput(model_name, input)
     }
 }
 
@@ -91,7 +92,10 @@ impl CacheKey<'_> {
             Self::LogicalPlan(logical_plan) => logical_plan.hash(&mut hasher),
             Self::Search(search_key) => search_key.hash(&mut hasher),
             Self::EmbeddingRequest(embedding_request) => embedding_request.hash(&mut hasher),
-            Self::EmbeddingInput(embedding_input) => embedding_input.hash(&mut hasher),
+            Self::EmbeddingInput(model_name, embedding_input) => {
+                model_name.hash(&mut hasher);
+                embedding_input.hash(&mut hasher);
+            }
             Self::Query(sql, param_values) => {
                 sql.hash(&mut hasher);
                 if let Some(params) = param_values {

--- a/crates/llms/src/bedrock/embed/mod.rs
+++ b/crates/llms/src/bedrock/embed/mod.rs
@@ -35,6 +35,7 @@ use async_openai::types::{
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::types::error::ThrottlingException as BedrockThrottlingException;
 use cache::CacheProvider;
+use cache::key::CacheKey;
 use cache::result::embeddings::CachedEmbeddingResult;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -235,6 +236,10 @@ where
         self.cache.as_ref().map(Arc::clone)
     }
 
+    fn model_name(&self) -> Option<&str> {
+        Some(self.config.model_id())
+    }
+
     async fn embed_request(
         &self,
         req: CreateEmbeddingRequest,
@@ -279,9 +284,15 @@ where
     }
 
     async fn embed(&self, input: EmbeddingInput) -> EmbedResult<Vec<Vec<f32>>> {
-        if let Some(CachedEmbeddingResult::Vector(cached)) =
-            self.get_cached_embed((&input).into()).await
-        {
+        let cache_key: Option<CacheKey> = self.embedding_input_cache_key(&input);
+
+        let cached_response = if let Some(key) = cache_key {
+            self.get_cached_embed(key).await
+        } else {
+            None
+        };
+
+        if let Some(CachedEmbeddingResult::Vector(cached)) = cached_response {
             return Ok(cached);
         }
 
@@ -308,11 +319,10 @@ where
             self.config.model_id()
         );
 
-        self.put_cached_embed(
-            (&input).into(),
-            CachedEmbeddingResult::Vector(vectors.clone()),
-        )
-        .await;
+        if let Some(key) = cache_key {
+            self.put_cached_embed(key, CachedEmbeddingResult::Vector(vectors.clone()))
+                .await;
+        }
 
         Ok(vectors)
     }

--- a/crates/llms/src/databricks.rs
+++ b/crates/llms/src/databricks.rs
@@ -291,6 +291,10 @@ impl Embed for Databricks {
         self.cache.as_ref().map(Arc::clone)
     }
 
+    fn model_name(&self) -> Option<&str> {
+        Some(self.model.as_str())
+    }
+
     async fn health(&self) -> super::embeddings::Result<()> {
         if matches!(self.health_check, HealthCheck::Skip) {
             return Ok(());
@@ -333,9 +337,15 @@ impl Embed for Databricks {
     }
 
     async fn embed(&self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>> {
-        if let Some(CachedEmbeddingResult::Vector(cached)) =
-            self.get_cached_embed((&input).into()).await
-        {
+        let cache_key = self.embedding_input_cache_key(&input);
+
+        let cached_response = if let Some(key) = cache_key {
+            self.get_cached_embed(key).await
+        } else {
+            None
+        };
+
+        if let Some(CachedEmbeddingResult::Vector(cached)) = cached_response {
             return Ok(cached);
         }
 
@@ -357,11 +367,10 @@ impl Embed for Databricks {
             .map(|emb| emb.embedding.into())
             .collect();
 
-        self.put_cached_embed(
-            (&input).into(),
-            CachedEmbeddingResult::Vector(vectors.clone()),
-        )
-        .await;
+        if let Some(key) = cache_key {
+            self.put_cached_embed(key, CachedEmbeddingResult::Vector(vectors.clone()))
+                .await;
+        }
 
         Ok(vectors)
     }

--- a/crates/llms/src/embeddings/candle/tei.rs
+++ b/crates/llms/src/embeddings/candle/tei.rs
@@ -258,9 +258,15 @@ impl Embed for TeiEmbed {
     }
 
     async fn embed(&self, input: EmbeddingInput) -> Result<Vec<Vec<f32>>> {
-        if let Some(CachedEmbeddingResult::Vector(cached)) =
-            self.get_cached_embed((&input).into()).await
-        {
+        let cache_key = self.embedding_input_cache_key(&input);
+
+        let cached_response = if let Some(key) = cache_key {
+            self.get_cached_embed(key).await
+        } else {
+            None
+        };
+
+        if let Some(CachedEmbeddingResult::Vector(cached)) = cached_response {
             return Ok(cached);
         }
 
@@ -273,11 +279,11 @@ impl Embed for TeiEmbed {
                 })?;
 
         let results: Vec<Vec<f32>> = resp.into_iter().map(|r| r.results).collect();
-        self.put_cached_embed(
-            (&input).into(),
-            CachedEmbeddingResult::Vector(results.clone()),
-        )
-        .await;
+
+        if let Some(key) = cache_key {
+            self.put_cached_embed(key, CachedEmbeddingResult::Vector(results.clone()))
+                .await;
+        }
 
         Ok(results)
     }

--- a/crates/llms/src/embeddings/mod.rs
+++ b/crates/llms/src/embeddings/mod.rs
@@ -148,6 +148,22 @@ pub trait Embed: Debug + Sync + Send {
         None
     }
 
+    fn model_name(&self) -> Option<&str> {
+        None
+    }
+
+    fn embedding_input_cache_key<'a>(&'a self, input: &'a EmbeddingInput) -> Option<CacheKey<'a>> {
+        if let Some(model_name) = self.model_name() {
+            Some((model_name, input).into())
+        } else {
+            tracing::trace!(
+                "dyn Embed does not implement model_name, therefore cannot generate cache key solely against embedding input: {:?} ",
+                self
+            );
+            None
+        }
+    }
+
     async fn get_cached_embed(&self, key: CacheKey<'_>) -> Option<CachedEmbeddingResult> {
         if let Some(embeddings_cache) = self.cache()
             && let Some(cached) = embeddings_cache

--- a/crates/llms/src/model2vec.rs
+++ b/crates/llms/src/model2vec.rs
@@ -124,23 +124,32 @@ impl Embed for Model2Vec {
         self.cache.as_ref().map(Arc::clone)
     }
 
+    fn model_name(&self) -> Option<&str> {
+        Some(self.name.as_str())
+    }
+
     async fn embed(
         &self,
         input: EmbeddingInput,
     ) -> Result<Vec<Vec<f32>>, super::embeddings::Error> {
-        if let Some(CachedEmbeddingResult::Vector(cached)) =
-            self.get_cached_embed((&input).into()).await
-        {
+        let cache_key = self.embedding_input_cache_key(&input);
+
+        let cached_response = if let Some(key) = cache_key {
+            self.get_cached_embed(key).await
+        } else {
+            None
+        };
+
+        if let Some(CachedEmbeddingResult::Vector(cached)) = cached_response {
             return Ok(cached);
         }
 
         let vectors = self.embed_sync(input.clone())?;
 
-        self.put_cached_embed(
-            (&input).into(),
-            CachedEmbeddingResult::Vector(vectors.clone()),
-        )
-        .await;
+        if let Some(key) = cache_key {
+            self.put_cached_embed(key, CachedEmbeddingResult::Vector(vectors.clone()))
+                .await;
+        }
 
         Ok(vectors)
     }

--- a/crates/runtime/src/embeddings/task.rs
+++ b/crates/runtime/src/embeddings/task.rs
@@ -16,15 +16,15 @@ limitations under the License.
 
 use std::{sync::Arc, time::Instant};
 
+use crate::request::{AsyncMarker, RequestContext};
 use async_openai::types::{
     CreateEmbeddingRequest, CreateEmbeddingResponse, EmbeddingInput, EncodingFormat,
 };
 use async_trait::async_trait;
+use cache::key::CacheKey;
 use chunking::{Chunker, ChunkingConfig};
 use llms::embeddings::{Embed, Result as EmbedResult, get_or_infer_size};
 use tracing::{Instrument, Span};
-
-use crate::request::{AsyncMarker, RequestContext};
 
 use super::metrics::{handle_metrics, request_labels, simple_labels};
 
@@ -89,6 +89,14 @@ impl Embed for TaskEmbed {
 
     async fn health<'b>(&'b self) -> EmbedResult<()> {
         self.inner.health().await
+    }
+
+    fn model_name(&self) -> Option<&str> {
+        self.inner.model_name()
+    }
+
+    fn embedding_input_cache_key<'a>(&'a self, input: &'a EmbeddingInput) -> Option<CacheKey<'a>> {
+        self.inner.embedding_input_cache_key(input)
     }
 
     fn size(&self) -> i32 {


### PR DESCRIPTION
## 📝 Summary

Resolves #7274.

Adds `model_name` and `embedding_input_cache_key` functions to `Embed` and uses the latter wherever caching is done on `EmbeddingInput`. If `embedding_input_cache_key` yields None, caching is skipped to prefer correctness.

AFAICT the "None" case should not exist, however, I added a trace just in case.
