### PR TITLE
Use 8-core runners for Winsows CUDA builds

### DIFF
--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -106,31 +106,31 @@ jobs:
               },
               {
                 compute_cap: "80",
-                runner: "windows-latest",
+                runner: "windows-latest-8core",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "86",
-                runner: "windows-latest",
+                runner: "windows-latest-8core",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "87",
-                runner: "windows-latest",
+                runner: "windows-latest-8core",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "89",
-                runner: "windows-latest",
+                runner: "windows-latest-8core",
                 target_os: "windows",
                 target_arch: "x86_64"
               },
               {
                 compute_cap: "90",
-                runner: "windows-latest",
+                runner: "windows-latest-8core",
                 target_os: "windows",
                 target_arch: "x86_64"
               }


### PR DESCRIPTION
## 📝 Summary

Cherry-picking the following improvement by @lukekim from 1.7 release branch:
https://github.com/spiceai/spiceai/commit/f5a5954128ddb9ed4befedda78df70cbbb258a03

Use 8-core runners for Windows CUDA build to improve build time from 3.5hrs -> 2 hrs

1. Windows does NOT run by default on all PRs (we run only Linux compute_cap 90).
2. The difference between 8-core vs 16-core is `2hrs` vs `1.5hrs` . `2hrs` is sufficient speed for release taking into account main binaries build takes ~[2h 23m 36s](https://github.com/spiceai/spiceai/actions/runs/17933676623/usage) due to Windows.

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/7280

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
