### PR TITLE
fix: Use median cached response duration for test search cache

### DIFF
--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -1237,7 +1237,7 @@ async fn test_search_with_cache() -> Result<(), anyhow::Error> {
                 let duration_cached = start.elapsed();
                 measured_cache_times.push(duration_cached);
             }
-            
+
             // take the median time from the cached responses
             measured_cache_times.sort();
             let duration_cached = measured_cache_times[measured_cache_times.len() / 2];

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -1195,15 +1195,15 @@ async fn test_search_with_cache() -> Result<(), anyhow::Error> {
 
     let cache_config = CacheConfig {
         enabled: true,
-        item_ttl: Some("10s".to_string()),
+        item_ttl: Some("30s".to_string()),
+        max_size: Some("512mb".to_string()),
         ..Default::default()
     };
 
-    // get_model_to_vec_embeddings("minishlab/potion-base-2M", "hf_minilm")
     let app = AppBuilder::new("cached_search")
         .with_dataset(chunked)
         .with_embedding(get_model_to_vec_embeddings(
-            "minishlab/potion-base-2M",
+            "minishlab/potion-base-32M",
             "hf_minilm",
         ))
         .with_search_cache(cache_config)
@@ -1220,20 +1220,29 @@ async fn test_search_with_cache() -> Result<(), anyhow::Error> {
                 "with_cache_pre_cache",
                 SearchTestType::Http(json!({
                     "text": "new patient",
-                    "limit": 2,
+                    "limit": 50,
                 })),
             ), None, false).await?;
             let duration = start.elapsed();
-            let start = Instant::now();
-            run_search_test(http_base_url.as_str(), &SearchTestCase::new(
-                "with_cache_post_cache",
-                SearchTestType::Http(json!({
-                    "text": "new patient",
-                    "limit": 2,
-                })),
-            ), None, false).await?;
-            let duration_cached = start.elapsed();
-            assert!(duration_cached * 5 < duration, "Cache did not improve performance by an order of magnitude. First: {duration:?}, Second: {duration_cached:?}");
+            let mut measured_cache_times = Vec::new();
+            for _ in 0..10 {
+                let start = Instant::now();
+                run_search_test(http_base_url.as_str(), &SearchTestCase::new(
+                    "with_cache_post_cache",
+                    SearchTestType::Http(json!({
+                        "text": "new patient",
+                        "limit": 50,
+                    })),
+                ), None, false).await?;
+                let duration_cached = start.elapsed();
+                measured_cache_times.push(duration_cached);
+            }
+            
+            // take the median time from the cached responses
+            measured_cache_times.sort();
+            let duration_cached = measured_cache_times[measured_cache_times.len() / 2];
+
+            assert!(duration_cached * 10 < duration, "Cache did not improve performance by an order of magnitude. First: {duration:?}, Second: {duration_cached:?}");
             Ok(())
         })
         .await

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_post_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_post_cache_response.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
 expression: normalize_search_response(resp)
-snapshot_kind: text
 ---
 {
   "duration_ms": "duration_ms_val",
@@ -9,12 +8,32 @@ snapshot_kind: text
     {
       "dataset": "spice.public.cached_search",
       "matches": {
-        "cp_description": "Programmes receive just likely, key homes. Relevant"
+        "cp_description": "Members comfort major horses. All good vehicles must perform ago wrong new conditions. P"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 11
+        "cp_catalog_page_sk": 20
       },
-      "score": 0.61
+      "score": 0.52
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Close customers might struggle away different mem"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 15
+      },
+      "score": 0.51
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Human, successive tears highlight also as radical prod"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 10
+      },
+      "score": 0.51
     },
     {
       "dataset": "spice.public.cached_search",
@@ -24,7 +43,157 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 8
       },
-      "score": 0.59
+      "score": 0.51
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Times could not address disabled indians. Effectively public ports "
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 12
+      },
+      "score": 0.5
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Earlier different differences get just to a methods; masses inclu"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 3
+      },
+      "score": 0.49
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "So appropriate hopes cannot constitute with a shapes. Investors know therefo"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 9
+      },
+      "score": 0.49
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Social pictures welcome almost british teams. Awful preparations leave g"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 16
+      },
+      "score": 0.49
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "In general basic characters welcome. Clearly lively friends con"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
+      },
+      "score": 0.48
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Necessary, major terms give still now joint thoughts. Only considerable wome"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 14
+      },
+      "score": 0.48
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Respects might appear early, long metres. Cases would understan"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 13
+      },
+      "score": 0.47
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Even democratic stairs would know happy investigations. Hist"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 2
+      },
+      "score": 0.46
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Good questions borrow only base children. Remarkably present "
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 19
+      },
+      "score": 0.46
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Legislative origins precede bold stations. Tiny sports should resume all pupils. Forces launch t"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 6
+      },
+      "score": 0.46
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Years must understand. Well fat thousands take. Good police "
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 7
+      },
+      "score": 0.45
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Programmes receive just likely, key homes. Relevant"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 11
+      },
+      "score": 0.44
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Practical schools might put twice interested, strong organizations. Regulatory"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 17
+      },
+      "score": 0.43
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Absolute, early papers spare. Independent services need. About extreme women "
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 18
+      },
+      "score": 0.42
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Narrowly great dogs carry only by the events. Successful, able legs would no"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 5
+      },
+      "score": 0.42
     }
   ]
 }

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_pre_cache_response.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__with_cache_pre_cache_response.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/runtime/tests/models/search.rs
 expression: normalize_search_response(resp)
-snapshot_kind: text
 ---
 {
   "duration_ms": "duration_ms_val",
@@ -9,12 +8,32 @@ snapshot_kind: text
     {
       "dataset": "spice.public.cached_search",
       "matches": {
-        "cp_description": "Programmes receive just likely, key homes. Relevant"
+        "cp_description": "Members comfort major horses. All good vehicles must perform ago wrong new conditions. P"
       },
       "primary_key": {
-        "cp_catalog_page_sk": 11
+        "cp_catalog_page_sk": 20
       },
-      "score": 0.61
+      "score": 0.52
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Close customers might struggle away different mem"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 15
+      },
+      "score": 0.51
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Human, successive tears highlight also as radical prod"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 10
+      },
+      "score": 0.51
     },
     {
       "dataset": "spice.public.cached_search",
@@ -24,7 +43,157 @@ snapshot_kind: text
       "primary_key": {
         "cp_catalog_page_sk": 8
       },
-      "score": 0.59
+      "score": 0.51
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Times could not address disabled indians. Effectively public ports "
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 12
+      },
+      "score": 0.5
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Earlier different differences get just to a methods; masses inclu"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 3
+      },
+      "score": 0.49
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "So appropriate hopes cannot constitute with a shapes. Investors know therefo"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 9
+      },
+      "score": 0.49
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Social pictures welcome almost british teams. Awful preparations leave g"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 16
+      },
+      "score": 0.49
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "In general basic characters welcome. Clearly lively friends con"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 1
+      },
+      "score": 0.48
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Necessary, major terms give still now joint thoughts. Only considerable wome"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 14
+      },
+      "score": 0.48
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Respects might appear early, long metres. Cases would understan"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 13
+      },
+      "score": 0.47
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Even democratic stairs would know happy investigations. Hist"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 2
+      },
+      "score": 0.46
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Good questions borrow only base children. Remarkably present "
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 19
+      },
+      "score": 0.46
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Legislative origins precede bold stations. Tiny sports should resume all pupils. Forces launch t"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 6
+      },
+      "score": 0.46
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Years must understand. Well fat thousands take. Good police "
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 7
+      },
+      "score": 0.45
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Programmes receive just likely, key homes. Relevant"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 11
+      },
+      "score": 0.44
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Practical schools might put twice interested, strong organizations. Regulatory"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 17
+      },
+      "score": 0.43
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Absolute, early papers spare. Independent services need. About extreme women "
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 18
+      },
+      "score": 0.42
+    },
+    {
+      "dataset": "spice.public.cached_search",
+      "matches": {
+        "cp_description": "Narrowly great dogs carry only by the events. Successful, able legs would no"
+      },
+      "primary_key": {
+        "cp_catalog_page_sk": 5
+      },
+      "score": 0.42
     }
   ]
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Uses `potion-base-32M` and increases results limit to 50 to induce a longer uncached search duration
* Calculates cached search duration based on the median from 10 requests to avoid environmental conditions

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #7285
