### PR TITLE
Fix JOIN level filters not having columns in schema

### DIFF
--- a/crates/runtime/src/search/full_text/mod.rs
+++ b/crates/runtime/src/search/full_text/mod.rs
@@ -24,7 +24,6 @@ use search::generation::{
     CandidateGeneration, post_apply::PostApplyCandidateGeneration,
     text_search::index::FullTextDatabaseIndex,
 };
-use snafu::ResultExt;
 
 use runtime_object_store::registry::SpiceObjectStoreRegistry;
 

--- a/crates/runtime/src/search/full_text/mod.rs
+++ b/crates/runtime/src/search/full_text/mod.rs
@@ -26,6 +26,7 @@ use search::generation::{
 };
 
 use runtime_object_store::registry::SpiceObjectStoreRegistry;
+use snafu::ResultExt;
 
 use crate::{datafusion::DataFusion, search::candidate::text::TextSearchCandidate};
 

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -243,12 +243,11 @@ impl SearchQueryProvider {
                 .iter()
                 .map(|f| f.name().as_str())
                 .collect::<HashSet<_>>();
-
             // These columns may be needed to handle filters in the JOIN.
             // Don't add any that will be in search index.
             let filter_cols = filters
                 .iter()
-                .map(|f| {
+                .flat_map(|f| {
                     let filter_cols = f
                         .column_refs()
                         .iter()
@@ -256,13 +255,11 @@ impl SearchQueryProvider {
                         .collect::<HashSet<_>>();
                     filter_cols
                         .difference(&search_index_cols)
-                        .cloned()
+                        .copied()
                         .collect::<Vec<_>>()
                 })
-                .flatten()
                 .filter_map(|c| self.schema().index_of(c).ok())
                 .collect::<Vec<_>>();
-
             p.extend(filter_cols);
             p.into_iter().collect()
         });

--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -232,11 +232,38 @@ impl SearchQueryProvider {
             .collect();
 
         // Ensure primary keys are retrieved from underlying table.
+        // Ensure all columns needed for filters are here (or in index).
         let table_proj: Option<Vec<_>> = projection.map(|proj| {
             let mut p = proj.clone().into_iter().collect::<HashSet<_>>();
-            for pp in primary_key_projection {
-                p.insert(pp);
-            }
+            p.extend(primary_key_projection);
+
+            let search_index_cols = search_index_proj
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect::<HashSet<_>>();
+
+            // These columns may be needed to handle filters in the JOIN.
+            // Don't add any that will be in search index.
+            let filter_cols = filters
+                .iter()
+                .map(|f| {
+                    let filter_cols = f
+                        .column_refs()
+                        .iter()
+                        .map(|c| c.name())
+                        .collect::<HashSet<_>>();
+                    filter_cols
+                        .difference(&search_index_cols)
+                        .cloned()
+                        .collect::<Vec<_>>()
+                })
+                .flatten()
+                .filter_map(|c| self.schema().index_of(c).ok())
+                .collect::<Vec<_>>();
+
+            p.extend(filter_cols);
             p.into_iter().collect()
         });
 


### PR DESCRIPTION
## 📝 Summary
- If a `TableProvider` supports a filter pushdown exactly, DataFusion will not provide the column in the projection. When it is not support, DataFusion will have this column in the projection, and add a `Filter` node above.
```sql
-- Without filter pushdown
Projection: text_search(...).id, text_search(...).question1, text_search(...).score
    Filter: text_search(...).is_duplicate = Int64(0)
        TableScan: text_search(...) projection=[id, question1, is_duplicate, score]

-- With
TableScan: text_search(...) projection=[id, question1, score], full_filters=[text_search(...).is_duplicate = Int64(0)]
```

- When `SearchQueryProvider` requires to join on a base table, and has a filter that cannot be pushed into the search index, but can be pushed into the base table, and the column is not in the search index (i.e. primary key or metadata) the filters atop the associated `JOIN` node expect these columns in the `JOIN`'s schema. If they are not, an error like this occurs 
```
type_coercion: caused by: Schema error: No field named is_duplicate. Valid fields are search_index.id, search_index.score, base_table.id.
```