### PR TITLE
Use rust:1.89-slim-bookworm for build, more places to bump rust version

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -36,12 +36,12 @@ runs:
       if: inputs.os != 'windows'
       shell: bash
       run: |
-        rustup toolchain install 1.88
-        rustup default 1.88
+        rustup toolchain install 1.89
+        rustup default 1.89
 
     - name: Install latest Rust stable toolchain (Windows)
       if: inputs.os == 'windows'
       shell: pwsh
       run: |
-        rustup toolchain install 1.88
-        rustup default 1.88
+        rustup toolchain install 1.89
+        rustup default 1.89

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ exclude = [".github/"]
 homepage = "https://spice.ai"
 license = "Apache-2.0"
 repository = "https://github.com/spiceai/spiceai"
-rust-version = "1.88"
+rust-version = "1.89"
 version = "1.8.0-unstable"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.88
+ARG RUST_VERSION=1.89
 FROM rust:${RUST_VERSION}-slim-bookworm as build
 
 # cache mounts below may already exist and owned by root

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.88
+ARG RUST_VERSION=1.89
 
 FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04 AS build
 


### PR DESCRIPTION
## 📝 Summary

This does not affect Rust version we use for build as it is controlled by toolchain, this is just an optimization to be consistent and fix rust version initially installed (so we don't need to install 1.88 and then automatically do 1.89)

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
