### PR TITLE
RRF: Rank and recency boosting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "futures",
  "log",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4029,12 +4029,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 
 [[package]]
 name = "datafusion-execution"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "dashmap",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4169,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "chrono",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,7 +2043,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "futures",
  "log",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4029,12 +4029,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 
 [[package]]
 name = "datafusion-execution"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "dashmap",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4169,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "chrono",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=912eebec159e037c7c233aae35c090071675d5a9#912eebec159e037c7c233aae35c090071675d5a9"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8116e1a17b8df438c4ff145a4671ec05cdbe9b3d#8116e1a17b8df438c4ff145a4671ec05cdbe9b3d"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -5089,7 +5089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5280,7 +5280,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10835,7 +10835,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -10868,7 +10868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -11169,7 +11169,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12413,7 +12413,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12426,7 +12426,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13756,7 +13756,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "futures",
  "log",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4029,12 +4029,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 
 [[package]]
 name = "datafusion-execution"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "dashmap",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4169,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "chrono",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -4359,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "49.0.2"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1d9c68089a3a4ed41988492b33357069c6bf0713#1d9c68089a3a4ed41988492b33357069c6bf0713"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b687ce48fdbdb77c055b0a011d746ff3f1167471#b687ce48fdbdb77c055b0a011d746ff3f1167471"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,11 +226,11 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" }            # spiceai/spiceai-49
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" }     # spiceai/spiceai-49
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" } # spiceai/spiceai-49
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" }  # spiceai/spiceai-49
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" }       # spiceai/spiceai-49
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" }            # spiceai/spiceai-49
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" }     # spiceai/spiceai-49
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" } # spiceai/spiceai-49
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" }  # spiceai/spiceai-49
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" }       # spiceai/spiceai-49
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5ad2f52b9bafc6eaa50851f2e1fcf0585fb5184d" }                      # spiceai-49
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4cf111b947dc42efa945aa4d0250b02ee615273e" } # spiceai

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ datafusion-datasource = "49.0.2"
 datafusion-execution= "49.0.2"
 datafusion-expr = "49.0.2"
 datafusion-federation = { version = "0.4.2", features = ["sql"] }
+datafusion-functions = "49.0.2"
 datafusion-functions-json = "0.49"
 datafusion-table-providers = "0.1"
 delta_kernel = { version = "0.14", features = [
@@ -226,11 +227,12 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" }            # spiceai/spiceai-49
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" }     # spiceai/spiceai-49
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" } # spiceai/spiceai-49
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" }  # spiceai/spiceai-49
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1d9c68089a3a4ed41988492b33357069c6bf0713" }       # spiceai/spiceai-49
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b687ce48fdbdb77c055b0a011d746ff3f1167471" }            # spiceai/spiceai-49
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b687ce48fdbdb77c055b0a011d746ff3f1167471" }     # spiceai/spiceai-49
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b687ce48fdbdb77c055b0a011d746ff3f1167471" } # spiceai/spiceai-49
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b687ce48fdbdb77c055b0a011d746ff3f1167471" }  # spiceai/spiceai-49
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b687ce48fdbdb77c055b0a011d746ff3f1167471" }       # spiceai/spiceai-49
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b687ce48fdbdb77c055b0a011d746ff3f1167471" }       # spiceai/spiceai-49
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5ad2f52b9bafc6eaa50851f2e1fcf0585fb5184d" }                      # spiceai-49
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4cf111b947dc42efa945aa4d0250b02ee615273e" } # spiceai

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,11 +226,11 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "912eebec159e037c7c233aae35c090071675d5a9" }            # spiceai/spiceai-49
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "912eebec159e037c7c233aae35c090071675d5a9" }     # spiceai/spiceai-49
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "912eebec159e037c7c233aae35c090071675d5a9" } # spiceai/spiceai-49
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "912eebec159e037c7c233aae35c090071675d5a9" }  # spiceai/spiceai-49
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "912eebec159e037c7c233aae35c090071675d5a9" }       # spiceai/spiceai-49
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" }            # spiceai/spiceai-49
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" }     # spiceai/spiceai-49
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" } # spiceai/spiceai-49
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" }  # spiceai/spiceai-49
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "8116e1a17b8df438c4ff145a4671ec05cdbe9b3d" }       # spiceai/spiceai-49
 
 datafusion-federation = { git = "https://github.com/spiceai/datafusion-federation.git", rev = "5ad2f52b9bafc6eaa50851f2e1fcf0585fb5184d" }                      # spiceai-49
 datafusion-table-providers = { git = "https://github.com/datafusion-contrib/datafusion-table-providers.git", rev = "4cf111b947dc42efa945aa4d0250b02ee615273e" } # spiceai

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -25,12 +25,13 @@ use datafusion::logical_expr::{
 };
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::{DataFrame, SessionContext, coalesce, make_array, md5};
+use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ExprFunctionExt, ExprSchemable, col, lit};
 use itertools::Itertools;
 use std::any::Any;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::{Arc, LazyLock};
-use datafusion_expr::expr::ScalarFunction;
 use tract_core::ops::math::Recip;
 
 pub static RRF_UDF_NAME: &str = "rrf";
@@ -57,20 +58,41 @@ pub static SIGNATURE: LazyLock<Signature> =
 
 #[derive(Debug, Default)]
 struct ReciprocalRankFusionSubqueryArgs {
-    pub rank_boost: Option<f64>,
+    pub rank_boost: Option<i64>,
 }
 
 impl ReciprocalRankFusionSubqueryArgs {
-    pub fn from_scalar_function_expr(expr: &Expr) -> Result<ReciprocalRankFusionSubqueryArgs> {
-        if let Expr::ScalarFunction(ScalarFunction { args, .. })  = expr {
-            println!("{args:?}");
-            Ok(ReciprocalRankFusionSubqueryArgs::default())
-        } else {
-            Err(DataFusionError::NotImplemented(
-                format!(
-                    "{RRF_UDF_NAME} subquery arguments require a scalar function invocation."
-                )
+    pub fn from_scalar_function_expr(
+        expr: &Expr,
+    ) -> Result<(Expr, ReciprocalRankFusionSubqueryArgs)> {
+        if let Expr::ScalarFunction(ScalarFunction { args, func }) = expr {
+            let mut args = args.clone();
+            let rrf_args = args
+                .extract_if(.., |arg| {
+                    matches!(arg, Expr::Literal(ScalarValue::Int64(Some(_)), Some(_)))
+                })
+                .filter_map(|arg| match arg {
+                    Expr::Literal(ScalarValue::Int64(Some(value)), Some(meta)) => meta
+                        .inner()
+                        .get("spice.parameter_name")
+                        .map(|name| (name.clone(), value)),
+                    _ => None,
+                })
+                .collect::<HashMap<String, i64>>();
+
+            Ok((
+                Expr::ScalarFunction(ScalarFunction {
+                    args,
+                    func: func.clone(),
+                }),
+                ReciprocalRankFusionSubqueryArgs {
+                    rank_boost: rrf_args.get("rank_boost").copied(),
+                },
             ))
+        } else {
+            Err(DataFusionError::NotImplemented(format!(
+                "{RRF_UDF_NAME} subquery arguments require a scalar function invocation."
+            )))
         }
     }
 }
@@ -106,9 +128,12 @@ impl ReciprocalRankFusionArgs {
         for expr in args {
             match expr {
                 e @ Expr::ScalarFunction(_) => {
-                    subquery_args.push(ReciprocalRankFusionSubqueryArgs::from_scalar_function_expr(e)?);
-                    search_udtfs.push(e.clone())
-                },
+                    let (subquery_expr, rrf_subquery_args) =
+                        ReciprocalRankFusionSubqueryArgs::from_scalar_function_expr(e)?;
+
+                    subquery_args.push(rrf_subquery_args);
+                    search_udtfs.push(subquery_expr)
+                }
                 Expr::Literal(ScalarValue::Float64(Some(k)), ..) if k_argument.is_none() => {
                     k_argument = Some(*k);
                 }
@@ -184,7 +209,15 @@ impl ReciprocalRankFusion {
 
         let score_expr = (0..subquery_dfs.len())
             .map(|i| {
-                lit(1.0f64)
+                // Either use 1 as dividend or user provided boost
+                let dividend = args
+                    .rrf_subquery_arguments
+                    .get(i)
+                    .and_then(|args| args.rank_boost)
+                    .map(|rb| rb as f64)
+                    .unwrap_or(1.0f64);
+
+                lit(dividend)
                     / (lit(args.k)
                         + coalesce(vec![col(format!("search_{i}.rank")), lit(f64::INFINITY)]))
             })

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -24,7 +24,9 @@ use datafusion::logical_expr::{
     Volatility,
 };
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::prelude::{DataFrame, SessionContext, coalesce, make_array, md5};
+use datafusion::prelude::{
+    DataFrame, SessionContext, coalesce, exp, greatest, make_array, md5, now, to_unixtime,
+};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{ExprFunctionExt, ExprSchemable, col, lit};
 use itertools::Itertools;
@@ -33,7 +35,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
-use tract_core::ops::math::Recip;
 
 pub static RRF_UDF_NAME: &str = "rrf";
 pub static DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
@@ -90,7 +91,7 @@ macro_rules! extract_string {
       };
   }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum RecencyDecay {
     Linear,
     Exponential,
@@ -111,7 +112,6 @@ impl FromStr for RecencyDecay {
 #[derive(Debug, Default)]
 struct ReciprocalRankFusionSubqueryArgs {
     pub rank_boost: Option<f64>,
-    pub recency_decay: Option<RecencyDecay>,
 }
 
 impl ReciprocalRankFusionSubqueryArgs {
@@ -140,7 +140,6 @@ impl ReciprocalRankFusionSubqueryArgs {
                 }),
                 ReciprocalRankFusionSubqueryArgs {
                     rank_boost: extract_f64!(rrf_args, "rank_boost"),
-                    recency_decay: None,
                 },
             ))
         } else {
@@ -155,7 +154,11 @@ struct ReciprocalRankFusionArgs {
     pub rrf_subquery_arguments: Vec<ReciprocalRankFusionSubqueryArgs>,
     pub k: f64,
     pub join_key: Option<Expr>,
+    pub recency_column: Option<Expr>,
     pub recency_decay: Option<RecencyDecay>,
+    pub recency_decay_alpha: Option<f64>,
+    pub recency_time_unit_seconds: Option<f64>,
+    pub recency_window_seconds: Option<f64>,
 }
 
 impl ReciprocalRankFusionArgs {
@@ -167,7 +170,7 @@ impl ReciprocalRankFusionArgs {
     /// ...into a neat struct of subquery expressions and an optional user-provided smoothing parameter.
     ///
     /// # Arguments
-    /// * `args` - A slice of `Expr` containing search UDTF invocations and an optional `k` parameter
+    /// * `args` - A slice of `Expr` containing search UDTF invocations and optional named arguments
     ///
     /// # Returns
     /// * `Ok(ReciprocalRankFusionArgs)` - Successfully parsed arguments
@@ -213,7 +216,12 @@ impl ReciprocalRankFusionArgs {
             rrf_subquery_arguments: subquery_args,
             k: extract_f64!(rrf_args, "k").unwrap_or(60.0),
             join_key: extract_string!(rrf_args, "join_key").map(col),
-            recency_decay: extract_string!(rrf_args, "recency_decay").and_then(|rd| RecencyDecay::from_str(&rd).ok()),
+            recency_column: extract_string!(rrf_args, "recency_column").map(col),
+            recency_decay: extract_string!(rrf_args, "recency_decay")
+                .and_then(|rd| RecencyDecay::from_str(&rd).ok()),
+            recency_decay_alpha: extract_f64!(rrf_args, "recency_decay_alpha"),
+            recency_time_unit_seconds: extract_f64!(rrf_args, "recency_time_unit_seconds"),
+            recency_window_seconds: extract_f64!(rrf_args, "recency_window_seconds"),
         })
     }
 }
@@ -256,11 +264,12 @@ impl ReciprocalRankFusion {
         )
     }
 
-    // Given arguments to n search calls: execute searches, generate row IDs, rank by score, JOIN,
-    // then finally re-rank and sort fused results
-    fn rerank_and_fuse_df(&self, args: &ReciprocalRankFusionArgs) -> Result<DataFrame> {
-        let subquery_dfs = self.prepare_and_execute_subqueries(args)?;
-
+    fn compute_score_expr(
+        &self,
+        args: &ReciprocalRankFusionArgs,
+        subquery_dfs: &Vec<DataFrame>,
+    ) -> Result<Expr> {
+        // Compute base score expression with boost
         let score_expr = (0..subquery_dfs.len())
             .map(|i| {
                 // Either use 1 as dividend or user provided boost
@@ -281,6 +290,50 @@ impl ReciprocalRankFusion {
         } else {
             return exec_err!("{RRF_UDF_NAME} unable to compute fused_score");
         };
+
+        if args.recency_column.is_none() {
+            return Ok(score_expr);
+        }
+
+        // If user specifies a recency column, we enable recency boosting
+        let recency_col = args.recency_column.as_ref().unwrap().clone();
+        let (_, recency_col) = recency_col.qualified_name();
+        let qualified_recency_col = Self::first_qualified_field(&subquery_dfs[0], &recency_col)?;
+
+        // Defaults: exponential decay over days (86400s)
+        let recency_decay = args
+            .recency_decay
+            .clone()
+            .unwrap_or(RecencyDecay::Exponential);
+        let recency_time_unit_seconds = args.recency_time_unit_seconds.unwrap_or(86400.0);
+
+        // Lots of casting annoyances are avoided by treating everything as `long`
+        let today_epoch = to_unixtime(vec![now()]);
+        let recency_col_epoch = to_unixtime(vec![col(qualified_recency_col)]);
+        let age_in_units = (today_epoch - recency_col_epoch) / lit(recency_time_unit_seconds);
+
+        let recency_expr = match recency_decay {
+            // e^(-alpha * age units)
+            RecencyDecay::Exponential => {
+                let recency_decay_alpha = args.recency_decay_alpha.unwrap_or(0.01);
+                exp(lit(-1.0f64 * recency_decay_alpha) * age_in_units)
+            }
+            // 1 - (age units / boost window)
+            RecencyDecay::Linear => {
+                let recency_window_seconds = args.recency_window_seconds.unwrap_or(86400.0);
+                let boost = lit(1) - (age_in_units / lit(recency_window_seconds));
+                greatest(vec![lit(0), boost])
+            }
+        };
+
+        Ok((score_expr * recency_expr).alias("fused_score"))
+    }
+
+    // Given arguments to n search calls: execute searches, generate row IDs, rank by score, JOIN,
+    // then finally re-rank and sort fused results
+    fn rerank_and_fuse_df(&self, args: &ReciprocalRankFusionArgs) -> Result<DataFrame> {
+        let subquery_dfs = self.prepare_and_execute_subqueries(args)?;
+        let score_expr = self.compute_score_expr(args, &subquery_dfs)?;
 
         // Create column expressions for final projection
         let mut columns: Vec<Expr> = vec![score_expr];

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -30,6 +30,8 @@ use itertools::Itertools;
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::{Arc, LazyLock};
+use datafusion_expr::expr::ScalarFunction;
+use tract_core::ops::math::Recip;
 
 pub static RRF_UDF_NAME: &str = "rrf";
 pub static DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
@@ -54,8 +56,29 @@ pub static SIGNATURE: LazyLock<Signature> =
     LazyLock::new(|| Signature::variadic_any(Volatility::Stable));
 
 #[derive(Debug, Default)]
+struct ReciprocalRankFusionSubqueryArgs {
+    pub rank_boost: Option<f64>,
+}
+
+impl ReciprocalRankFusionSubqueryArgs {
+    pub fn from_scalar_function_expr(expr: &Expr) -> Result<ReciprocalRankFusionSubqueryArgs> {
+        if let Expr::ScalarFunction(ScalarFunction { args, .. })  = expr {
+            println!("{args:?}");
+            Ok(ReciprocalRankFusionSubqueryArgs::default())
+        } else {
+            Err(DataFusionError::NotImplemented(
+                format!(
+                    "{RRF_UDF_NAME} subquery arguments require a scalar function invocation."
+                )
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Default)]
 struct ReciprocalRankFusionArgs {
     pub search_udtf_exprs: Vec<Expr>,
+    pub rrf_subquery_arguments: Vec<ReciprocalRankFusionSubqueryArgs>,
     pub k: f64,
     pub join_key: Option<Expr>,
 }
@@ -76,12 +99,16 @@ impl ReciprocalRankFusionArgs {
     /// * `Err` - If fewer than 2 search queries are provided or if unparsing fails
     pub fn from_udtf_exprs(args: &[Expr]) -> Result<ReciprocalRankFusionArgs> {
         let mut search_udtfs: Vec<Expr> = vec![];
+        let mut subquery_args: Vec<ReciprocalRankFusionSubqueryArgs> = vec![];
         let mut k_argument: Option<f64> = None;
         let mut join_pk_argument: Option<Expr> = None;
 
         for expr in args {
             match expr {
-                e @ Expr::ScalarFunction(_) => search_udtfs.push(e.clone()),
+                e @ Expr::ScalarFunction(_) => {
+                    subquery_args.push(ReciprocalRankFusionSubqueryArgs::from_scalar_function_expr(e)?);
+                    search_udtfs.push(e.clone())
+                },
                 Expr::Literal(ScalarValue::Float64(Some(k)), ..) if k_argument.is_none() => {
                     k_argument = Some(*k);
                 }
@@ -105,6 +132,7 @@ impl ReciprocalRankFusionArgs {
 
         Ok(Self {
             search_udtf_exprs: search_udtfs,
+            rrf_subquery_arguments: subquery_args,
             k: k_argument.unwrap_or(60.0),
             join_key: join_pk_argument,
         })

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -91,6 +91,17 @@ macro_rules! extract_string {
       };
   }
 
+macro_rules! spice_named_lit {
+    ($name:literal, $value:expr) => {{
+        let scalar_value = ScalarValue::from($value);
+        let spice_metadata = FieldMetadata::new(BTreeMap::from([(
+            "spice.parameter_name".to_string(),
+            $name.to_string(),
+        )]));
+        Expr::Literal(scalar_value, Some(spice_metadata))
+    }};
+}
+
 #[derive(Debug, Clone)]
 enum RecencyDecay {
     Linear,
@@ -111,7 +122,7 @@ impl FromStr for RecencyDecay {
 
 #[derive(Debug, Default)]
 struct ReciprocalRankFusionSubqueryArgs {
-    pub rank_boost: Option<f64>,
+    pub rank_weight: Option<f64>,
 }
 
 impl ReciprocalRankFusionSubqueryArgs {
@@ -139,7 +150,7 @@ impl ReciprocalRankFusionSubqueryArgs {
                     func: func.clone(),
                 }),
                 ReciprocalRankFusionSubqueryArgs {
-                    rank_boost: extract_f64!(rrf_args, "rank_boost"),
+                    rank_weight: extract_f64!(rrf_args, "rank_weight"),
                 },
             ))
         } else {
@@ -154,11 +165,11 @@ struct ReciprocalRankFusionArgs {
     pub rrf_subquery_arguments: Vec<ReciprocalRankFusionSubqueryArgs>,
     pub k: f64,
     pub join_key: Option<Expr>,
-    pub recency_column: Option<Expr>,
+    pub time_column: Option<Expr>,
     pub recency_decay: Option<RecencyDecay>,
-    pub recency_decay_alpha: Option<f64>,
-    pub recency_time_unit_seconds: Option<f64>,
-    pub recency_window_seconds: Option<f64>,
+    pub decay_constant: Option<f64>,
+    pub decay_scale_seconds: Option<f64>,
+    pub decay_window: Option<f64>,
 }
 
 impl ReciprocalRankFusionArgs {
@@ -216,12 +227,12 @@ impl ReciprocalRankFusionArgs {
             rrf_subquery_arguments: subquery_args,
             k: extract_f64!(rrf_args, "k").unwrap_or(60.0),
             join_key: extract_string!(rrf_args, "join_key").map(col),
-            recency_column: extract_string!(rrf_args, "recency_column").map(col),
+            time_column: extract_string!(rrf_args, "time_column").map(col),
             recency_decay: extract_string!(rrf_args, "recency_decay")
                 .and_then(|rd| RecencyDecay::from_str(&rd).ok()),
-            recency_decay_alpha: extract_f64!(rrf_args, "recency_decay_alpha"),
-            recency_time_unit_seconds: extract_f64!(rrf_args, "recency_time_unit_seconds"),
-            recency_window_seconds: extract_f64!(rrf_args, "recency_window_seconds"),
+            decay_constant: extract_f64!(rrf_args, "decay_constant"),
+            decay_scale_seconds: extract_f64!(rrf_args, "decay_scale_seconds"),
+            decay_window: extract_f64!(rrf_args, "decay_window"),
         })
     }
 }
@@ -276,7 +287,7 @@ impl ReciprocalRankFusion {
                 let dividend: f64 = args
                     .rrf_subquery_arguments
                     .get(i)
-                    .and_then(|args| args.rank_boost)
+                    .and_then(|args| args.rank_weight)
                     .unwrap_or(1.0f64);
 
                 lit(dividend)
@@ -291,12 +302,12 @@ impl ReciprocalRankFusion {
             return exec_err!("{RRF_UDF_NAME} unable to compute fused_score");
         };
 
-        if args.recency_column.is_none() {
+        if args.time_column.is_none() {
             return Ok(score_expr);
         }
 
         // If user specifies a recency column, we enable recency boosting
-        let recency_col = args.recency_column.as_ref().unwrap().clone();
+        let recency_col = args.time_column.as_ref().unwrap().clone();
         let (_, recency_col) = recency_col.qualified_name();
         let qualified_recency_col = Self::first_qualified_field(&subquery_dfs[0], &recency_col)?;
 
@@ -305,23 +316,23 @@ impl ReciprocalRankFusion {
             .recency_decay
             .clone()
             .unwrap_or(RecencyDecay::Exponential);
-        let recency_time_unit_seconds = args.recency_time_unit_seconds.unwrap_or(86400.0);
+        let decay_scale_seconds = args.decay_scale_seconds.unwrap_or(86400.0);
 
         // Lots of casting annoyances are avoided by treating everything as `long`
         let today_epoch = to_unixtime(vec![now()]);
         let recency_col_epoch = to_unixtime(vec![col(qualified_recency_col)]);
-        let age_in_units = (today_epoch - recency_col_epoch) / lit(recency_time_unit_seconds);
+        let age_in_units = (today_epoch - recency_col_epoch) / lit(decay_scale_seconds);
 
         let recency_expr = match recency_decay {
             // e^(-alpha * age units)
             RecencyDecay::Exponential => {
-                let recency_decay_alpha = args.recency_decay_alpha.unwrap_or(0.01);
-                exp(lit(-1.0f64 * recency_decay_alpha) * age_in_units)
+                let decay_constant = args.decay_constant.unwrap_or(0.01);
+                exp(lit(-1.0f64 * decay_constant) * age_in_units)
             }
             // 1 - (age units / boost window)
             RecencyDecay::Linear => {
-                let recency_window_seconds = args.recency_window_seconds.unwrap_or(86400.0);
-                let boost = lit(1) - (age_in_units / lit(recency_window_seconds));
+                let decay_window = args.decay_window.unwrap_or(86400.0);
+                let boost = lit(1) - (age_in_units / lit(decay_window));
                 greatest(vec![lit(0), boost])
             }
         };
@@ -596,12 +607,13 @@ mod tests {
     use datafusion::common::cast::as_float64_array;
     use datafusion::logical_expr::Expr;
     use datafusion::logical_expr::col;
-    use datafusion::logical_expr::lit;
+    use datafusion::logical_expr::expr::FieldMetadata;
     use datafusion::logical_expr::{ColumnarValue, Volatility, create_udf};
     use datafusion::scalar::ScalarValue;
     use datafusion_expr::expr::ScalarFunction;
     use llms::embeddings::Embed;
     use llms::model2vec::Model2Vec;
+    use std::collections::BTreeMap;
     use std::collections::HashMap;
     use std::sync::{Arc, LazyLock};
     use tokio::sync::RwLock;
@@ -706,8 +718,7 @@ mod tests {
             .await
             .expect("Failed to create test runtime");
 
-        let query =
-            "select * from rrf(vector_search(foo, 'crispy'), vector_search(foo, 'red'), id, 600.0)";
+        let query = "select * from rrf(vector_search(foo, 'crispy'), vector_search(foo, 'red'), join_key => 'id', k => 600.0)";
         let query = QueryBuilder::new(query, runtime.datafusion()).build();
         let results = query
             .run()
@@ -740,7 +751,7 @@ mod tests {
             .expect("Failed to register bar table");
 
         let query_empty_red =
-            "select * from rrf(vector_search(bar, 'empty'), vector_search(foo, 'red'), id, 600.0)";
+            "select * from rrf(vector_search(bar, 'empty'), vector_search(foo, 'red'))";
         let query_empty_red = QueryBuilder::new(query_empty_red, runtime.datafusion()).build();
         let query_empty_red_results = query_empty_red
             .run()
@@ -761,7 +772,7 @@ mod tests {
         let query_empty_red_score = query_empty_red_content.value(0);
 
         let query_red_empty =
-            "select * from rrf(vector_search(foo, 'red'), vector_search(bar, 'empty'), id, 600.0)";
+            "select * from rrf(vector_search(foo, 'red'), vector_search(bar, 'empty'))";
         let query_red_empty = QueryBuilder::new(query_red_empty, runtime.datafusion()).build();
         let query_red_empty_results = query_red_empty
             .run()
@@ -802,7 +813,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_argument_exprs() {
+    fn test_parse_argument_exprs() -> Result<()> {
         // Empty call
         let empty_args = ReciprocalRankFusionArgs::from_udtf_exprs(&[]);
         assert!(empty_args.is_err());
@@ -817,7 +828,7 @@ mod tests {
         // Call with at least 2 arguments, but one of them overrides k only
         let one_search_with_k = ReciprocalRankFusionArgs::from_udtf_exprs(&[
             stub_scalar_function("one_search_with_k"),
-            lit(1337.0f64),
+            spice_named_lit!("k", 42.0),
         ]);
         assert!(one_search_with_k.is_err());
         assert_eq!(
@@ -844,7 +855,7 @@ mod tests {
         );
 
         // Call with many searches + k override
-        many_search_exprs.push(lit(1337.0f64));
+        many_search_exprs.push(spice_named_lit!("k", 1337.0f64));
         let many_with_k = ReciprocalRankFusionArgs::from_udtf_exprs(&many_search_exprs);
         assert!(many_with_k.is_ok());
 
@@ -853,7 +864,7 @@ mod tests {
         // assert_eq!(many_with_k.k, 1337.0f64);
 
         // Call with many searches + k override + join key specified
-        many_search_exprs.push(col("hello"));
+        many_search_exprs.push(spice_named_lit!("join_key", "hello"));
         let many_with_k_and_column = ReciprocalRankFusionArgs::from_udtf_exprs(&many_search_exprs);
         assert!(many_with_k_and_column.is_ok());
 
@@ -861,5 +872,7 @@ mod tests {
         assert_eq!(many_with_k_and_column.search_udtf_exprs.len(), 100);
         // assert_eq!(many_with_k_and_column.k, 1337.0f64);
         assert_eq!(many_with_k_and_column.join_key, Some(col("hello")));
+
+        Ok(())
     }
 }

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -40,8 +40,8 @@ pub static RRF_UDF_NAME: &str = "rrf";
 pub static DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
     Documentation {
     doc_section: DocSection::default(),
-    description: "Merge and rank several search queries into a single result set solely considering the order and not score of the input search queries".to_string(),
-    syntax_example: "rrf(query_1, query_2, ..., k)".to_string(),
+    description: "Merge several search queries by re-ranking them into a single result set considering each result set's orders, rank weights (if requested), and recency (if requested).".to_string(),
+    syntax_example: "rrf(query_1, query_2, ..., [named_arguments])".to_string(),
     sql_example: None,
     arguments: Some(vec![
         (
@@ -91,17 +91,6 @@ macro_rules! extract_string {
       };
   }
 
-macro_rules! spice_named_lit {
-    ($name:literal, $value:expr) => {{
-        let scalar_value = ScalarValue::from($value);
-        let spice_metadata = FieldMetadata::new(BTreeMap::from([(
-            "spice.parameter_name".to_string(),
-            $name.to_string(),
-        )]));
-        Expr::Literal(scalar_value, Some(spice_metadata))
-    }};
-}
-
 #[derive(Debug, Clone)]
 enum RecencyDecay {
     Linear,
@@ -147,7 +136,7 @@ impl ReciprocalRankFusionSubqueryArgs {
             Ok((
                 Expr::ScalarFunction(ScalarFunction {
                     args,
-                    func: func.clone(),
+                    func: Arc::clone(func),
                 }),
                 ReciprocalRankFusionSubqueryArgs {
                     rank_weight: extract_f64!(rrf_args, "rank_weight"),
@@ -203,9 +192,7 @@ impl ReciprocalRankFusionArgs {
                     match meta.inner().get("spice.parameter_name") {
                         Some(name) => Ok((name.clone(), value.clone())),
                         None => {
-                            return not_impl_err!(
-                                "{RRF_UDF_NAME} does not yet support {arg} arguments."
-                            );
+                            not_impl_err!("{RRF_UDF_NAME} does not yet support {arg} arguments.")
                         }
                     }
                 }
@@ -276,9 +263,8 @@ impl ReciprocalRankFusion {
     }
 
     fn compute_score_expr(
-        &self,
         args: &ReciprocalRankFusionArgs,
-        subquery_dfs: &Vec<DataFrame>,
+        subquery_dfs: &[DataFrame],
     ) -> Result<Expr> {
         // Compute base score expression with boost
         let score_expr = (0..subquery_dfs.len())
@@ -302,14 +288,13 @@ impl ReciprocalRankFusion {
             return exec_err!("{RRF_UDF_NAME} unable to compute fused_score");
         };
 
-        if args.time_column.is_none() {
-            return Ok(score_expr);
-        }
-
         // If user specifies a recency column, we enable recency boosting
-        let recency_col = args.time_column.as_ref().unwrap().clone();
-        let (_, recency_col) = recency_col.qualified_name();
-        let qualified_recency_col = Self::first_qualified_field(&subquery_dfs[0], &recency_col)?;
+        let qualified_recency_col = if let Some(recency_col) = args.time_column.clone() {
+            let (_, qname) = recency_col.qualified_name();
+            Self::first_qualified_field(&subquery_dfs[0], &qname)?
+        } else {
+            return Ok(score_expr);
+        };
 
         // Defaults: exponential decay over days (86400s)
         let recency_decay = args
@@ -327,6 +312,7 @@ impl ReciprocalRankFusion {
             // e^(-alpha * age units)
             RecencyDecay::Exponential => {
                 let decay_constant = args.decay_constant.unwrap_or(0.01);
+                #[allow(clippy::neg_multiply)]
                 exp(lit(-1.0f64 * decay_constant) * age_in_units)
             }
             // 1 - (age units / boost window)
@@ -344,7 +330,7 @@ impl ReciprocalRankFusion {
     // then finally re-rank and sort fused results
     fn rerank_and_fuse_df(&self, args: &ReciprocalRankFusionArgs) -> Result<DataFrame> {
         let subquery_dfs = self.prepare_and_execute_subqueries(args)?;
-        let score_expr = self.compute_score_expr(args, &subquery_dfs)?;
+        let score_expr = Self::compute_score_expr(args, &subquery_dfs)?;
 
         // Create column expressions for final projection
         let mut columns: Vec<Expr> = vec![score_expr];
@@ -594,44 +580,44 @@ mod tests {
     use crate::embeddings::table::EmbeddingTable;
     use crate::request::{Protocol, RequestContext};
     use crate::search::rrf::ReciprocalRankFusionArgs;
-    use arrow::array::Int64Array;
-    use arrow::array::StringArray;
-    use arrow::array::{FixedSizeListArray, as_string_array};
+    use arrow::array::as_string_array;
     use arrow::record_batch::RecordBatch;
     use async_graphql::futures_util::TryStreamExt;
-    use async_openai::types::EmbeddingInput;
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::catalog::MemTable;
+    use datafusion::arrow::datatypes::DataType;
     use datafusion::catalog::TableProvider;
     use datafusion::common::Result;
     use datafusion::common::cast::as_float64_array;
+    use datafusion::functions_window::expr_fn::row_number;
     use datafusion::logical_expr::Expr;
     use datafusion::logical_expr::col;
     use datafusion::logical_expr::expr::FieldMetadata;
     use datafusion::logical_expr::{ColumnarValue, Volatility, create_udf};
+    use datafusion::prelude::{DataFrame, now, to_unixtime};
     use datafusion::scalar::ScalarValue;
     use datafusion_expr::expr::ScalarFunction;
-    use llms::embeddings::Embed;
+    use datafusion_expr::{ExprFunctionExt, lit};
     use llms::model2vec::Model2Vec;
     use std::collections::BTreeMap;
     use std::collections::HashMap;
+    use std::process::ExitCode;
     use std::sync::{Arc, LazyLock};
-    use tokio::sync::RwLock;
 
     pub static TEST_REQUEST_CONTEXT: LazyLock<Arc<RequestContext>> =
         LazyLock::new(|| Arc::new(RequestContext::builder(Protocol::Internal).build()));
 
-    fn make_test_table(test_data: &[&str]) -> Result<Arc<dyn TableProvider>> {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int64, false),
-            Field::new("content", DataType::Utf8, false),
-            Field::new(
-                "content_embedding",
-                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 64),
-                true,
-            ),
-        ]));
+    macro_rules! spice_named_lit {
+        ($name:literal, $value:expr) => {{
+            let scalar_value = ScalarValue::from($value);
+            let spice_metadata = FieldMetadata::new(BTreeMap::from([(
+                "spice.parameter_name".to_string(),
+                $name.to_string(),
+            )]));
+            Expr::Literal(scalar_value, Some(spice_metadata))
+        }};
+    }
 
+    // Assumes column "content" is embedded
+    fn df_as_embedding_table(runtime: &Runtime, df: DataFrame) -> Result<Arc<dyn TableProvider>> {
         let mut embedded_columns = HashMap::new();
         embedded_columns.insert(
             "content".to_string(),
@@ -642,6 +628,21 @@ mod tests {
                 chunker: None,
             },
         );
+
+        Ok(Arc::new(EmbeddingTable {
+            base_table: df.into_view(),
+            embedded_columns,
+            embedding_models: runtime.embeds.clone(),
+        }))
+    }
+
+    async fn make_test_runtime() -> Result<Runtime> {
+        let rt = RuntimeBuilder::new().build().await;
+        rt.df
+            .ctx
+            .state()
+            .config_mut()
+            .set_extension(Arc::clone(&TEST_REQUEST_CONTEXT));
 
         let embedding_model = Arc::new(
             Model2Vec::from_params(
@@ -655,68 +656,155 @@ mod tests {
             )
             .expect("Must make embedding model"),
         );
-
-        let batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![
-                Arc::new(Int64Array::from_iter_values(
-                    0i64..i64::try_from(test_data.len()).expect("Must cast"),
-                )),
-                Arc::new(StringArray::from_iter_values(test_data.iter())),
-                Arc::new(FixedSizeListArray::from_iter_primitive::<
-                    arrow::datatypes::Float32Type,
-                    _,
-                    _,
-                >(
-                    test_data.iter().map(|s| {
-                        embedding_model
-                            .embed_sync(EmbeddingInput::String((*s).to_string()))
-                            .map(|e| e[0].iter().map(|f| Some(*f)).collect::<Vec<Option<_>>>())
-                            .ok()
-                    }),
-                    64,
-                )),
-            ],
-        )?;
-
-        let mem_table = Arc::new(MemTable::try_new(schema, vec![vec![batch]])?);
-        let mut embedding_model_store: HashMap<String, Arc<dyn Embed>> = HashMap::new();
-        embedding_model_store.insert("test_model".to_string(), embedding_model);
-
-        Ok(Arc::new(EmbeddingTable {
-            base_table: mem_table,
-            embedded_columns,
-            embedding_models: Arc::new(RwLock::new(embedding_model_store)),
-        }))
-    }
-
-    async fn make_test_runtime() -> Result<Runtime> {
-        let rt = RuntimeBuilder::new().build().await;
-        rt.df
-            .ctx
-            .state()
-            .config_mut()
-            .set_extension(Arc::clone(&TEST_REQUEST_CONTEXT));
-
-        let test_table = make_test_table(&[
-            "banana yellow curved fruit",
-            "orange citrus round juicy",
-            "apple fruit sweet red crispy",
-        ])?;
-        rt.df
-            .ctx
-            .register_table("foo", test_table)
-            .expect("Failed to register foo table");
+        rt.embeds
+            .write()
+            .await
+            .insert("test_model".to_string(), embedding_model);
 
         register_udfs(&rt);
         Ok(rt)
     }
 
+    async fn make_fruit_dataframe(runtime: &Runtime) -> Result<DataFrame> {
+        let rowid_expr = row_number()
+            .order_by(vec![col("content").sort(false, false)])
+            .build()?
+            .alias("id");
+
+        let df = runtime
+            .df
+            .ctx
+            .sql(
+                "SELECT
+              unnest([
+                  'banana yellow curved fruit',
+                  'orange citrus round juicy',
+                  'apple fruit sweet red crispy'
+              ]) as content",
+            )
+            .await?;
+
+        let embed_expr = df.parse_sql_expr("embed(content, 'test_model')")?;
+
+        df.window(vec![rowid_expr])?
+            .with_column("content_embedding", embed_expr)
+    }
+
+    fn stub_scalar_function(name: &str) -> Expr {
+        let stub_udf = create_udf(
+            name,
+            vec![DataType::Utf8; 0],
+            DataType::Utf8,
+            Volatility::Stable,
+            Arc::new(|_| {
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
+                    "stub".to_string(),
+                ))))
+            }),
+        );
+
+        Expr::ScalarFunction(ScalarFunction::new_udf(Arc::new(stub_udf), vec![]))
+    }
+
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_fuse_queries() {
-        let runtime = make_test_runtime()
+    async fn test_recency_scoring() -> Result<ExitCode> {
+        let runtime = make_test_runtime().await?;
+
+        let fruit_df = make_fruit_dataframe(&runtime)
+            .await?
+            .with_column("picked_at", now())?
+            .with_column(
+                "picked_at",
+                to_unixtime(vec![col("picked_at")]) - (lit(43200) * col("id")),
+            )?;
+
+        let picked_at_expr = fruit_df.parse_sql_expr("to_timestamp(cast(picked_at as bigint))")?;
+
+        let fruit_df = fruit_df
+            .with_column("picked_at", picked_at_expr)?
+            .sort(vec![col("picked_at").sort(false, false)])?;
+
+        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df.clone())?;
+
+        runtime
+            .df
+            .ctx
+            .register_table("foo", fruit_embedding_table)?;
+
+        // decay_constant is made more aggressive in this query to further deprioritize
+        // old results. The test will/should fail if you use the default of 0.01.
+        let query = "select * from rrf(vector_search(foo, 'red crispy'), vector_search(foo, 'fruit'), time_column => 'picked_at', decay_constant => 0.1)";
+        let query = QueryBuilder::new(query, runtime.datafusion()).build();
+        let results = query
+            .run()
             .await
-            .expect("Failed to create test runtime");
+            .expect("Must run query")
+            .data
+            .try_collect::<Vec<RecordBatch>>()
+            .await?;
+
+        let content = as_string_array(
+            results[0]
+                .column_by_name("content")
+                .expect("Must have content column"),
+        );
+
+        let fruit_df_batches = fruit_df.collect().await?;
+        let fruit_df_recent = as_string_array(
+            fruit_df_batches[0]
+                .column_by_name("content")
+                .expect("Must have content column"),
+        );
+
+        // fruit_df.show() to debug me
+        assert_eq!(content.value(0), fruit_df_recent.value(0));
+
+        Ok(ExitCode::SUCCESS)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rank_weighting() -> Result<ExitCode> {
+        let runtime = make_test_runtime().await?;
+
+        let fruit_df = make_fruit_dataframe(&runtime).await?;
+        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df)?;
+
+        runtime
+            .df
+            .ctx
+            .register_table("foo", fruit_embedding_table)?;
+
+        let query = "select * from rrf(vector_search(foo, 'yellow', rank_weight => 100), vector_search(foo, 'red', rank_weight => 10))";
+        let query = QueryBuilder::new(query, runtime.datafusion()).build();
+        let results = query
+            .run()
+            .await
+            .expect("Must run query")
+            .data
+            .try_collect::<Vec<RecordBatch>>()
+            .await?;
+
+        let content = as_string_array(
+            results[0]
+                .column_by_name("content")
+                .expect("Must have content column"),
+        );
+        assert_eq!(content.value(0), "banana yellow curved fruit");
+
+        Ok(ExitCode::SUCCESS)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_fuse_queries() -> Result<ExitCode> {
+        let runtime = make_test_runtime().await?;
+
+        let fruit_df = make_fruit_dataframe(&runtime).await?;
+        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df)?;
+
+        runtime
+            .df
+            .ctx
+            .register_table("foo", fruit_embedding_table)?;
 
         let query = "select * from rrf(vector_search(foo, 'crispy'), vector_search(foo, 'red'), join_key => 'id', k => 600.0)";
         let query = QueryBuilder::new(query, runtime.datafusion()).build();
@@ -726,8 +814,7 @@ mod tests {
             .expect("Must run query")
             .data
             .try_collect::<Vec<RecordBatch>>()
-            .await
-            .expect("Must collect results");
+            .await?;
 
         let content = as_string_array(
             results[0]
@@ -735,20 +822,26 @@ mod tests {
                 .expect("Must have content column"),
         );
         assert_eq!(content.value(0), "apple fruit sweet red crispy");
+
+        Ok(ExitCode::SUCCESS)
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_score_computation() {
-        let runtime = make_test_runtime()
-            .await
-            .expect("Failed to create test runtime");
+    async fn test_score_computation() -> Result<ExitCode> {
+        let runtime = make_test_runtime().await?;
 
-        let empty_table = make_test_table(&[]).expect("Failed to create empty table");
-        runtime
-            .df
-            .ctx
-            .register_table("bar", empty_table)
-            .expect("Failed to register bar table");
+        let fruit_df = make_fruit_dataframe(&runtime).await?;
+        let fruit_table = df_as_embedding_table(&runtime, fruit_df.clone())?;
+
+        let no_fruit_df = fruit_df
+            .clone()
+            .limit(0, Some(0))
+            .expect("Must have fruit DF");
+        let no_fruit_table = df_as_embedding_table(&runtime, no_fruit_df)?;
+
+        runtime.df.ctx.register_table("foo", fruit_table)?;
+
+        runtime.df.ctx.register_table("bar", no_fruit_table)?;
 
         let query_empty_red =
             "select * from rrf(vector_search(bar, 'empty'), vector_search(foo, 'red'))";
@@ -759,8 +852,7 @@ mod tests {
             .expect("Must run query")
             .data
             .try_collect::<Vec<RecordBatch>>()
-            .await
-            .expect("Must collect results");
+            .await?;
 
         let query_empty_red_content = as_float64_array(
             query_empty_red_results[0]
@@ -780,8 +872,7 @@ mod tests {
             .expect("Must run query")
             .data
             .try_collect::<Vec<RecordBatch>>()
-            .await
-            .expect("Must collect results");
+            .await?;
 
         let query_red_empty_content = as_float64_array(
             query_red_empty_results[0]
@@ -794,22 +885,8 @@ mod tests {
 
         let score_diff = (query_red_empty_score - query_empty_red_score).abs();
         assert!(score_diff < 0.0001f64);
-    }
 
-    fn stub_scalar_function(name: &str) -> Expr {
-        let stub_udf = create_udf(
-            name,
-            vec![DataType::Utf8; 0],
-            DataType::Utf8,
-            Volatility::Stable,
-            Arc::new(|_| {
-                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-                    "stub".to_string(),
-                ))))
-            }),
-        );
-
-        Expr::ScalarFunction(ScalarFunction::new_udf(Arc::new(stub_udf), vec![]))
+        Ok(ExitCode::SUCCESS)
     }
 
     #[test]

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -48,7 +48,14 @@ pub static DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
             "query...".to_string(),
             "Inline text_search or vector_search UDTF invocations".to_string(),
         ),
-        ("k".to_string(), "RRF smoothing parameter".to_string()),
+        ("k".to_string(), "RRF smoothing parameter (default: 60.0)".to_string()),
+        ("join_key".to_string(), "Column name to use for joining results instead of auto-generated row ID".to_string()),
+        ("time_column".to_string(), "Column name containing timestamps for recency boosting".to_string()),
+        ("recency_decay".to_string(), "Type of decay function: 'linear' or 'exponential' (default: 'exponential')".to_string()),
+        ("decay_constant".to_string(), "Decay rate constant for exponential decay (default: 0.01)".to_string()),
+        ("decay_scale_secs".to_string(), "Time scale in seconds for decay calculation (default: 86400)".to_string()),
+        ("decay_window".to_string(), "Window size for linear decay function (default: 86400)".to_string()),
+        ("rank_weight".to_string(), "Per-query rank weighting factor (used within individual search queries)".to_string()),
     ]),
     alternative_syntax: None,
     related_udfs: Some(vec!["text_search".to_string(), "vector_search".to_string()]),
@@ -157,7 +164,7 @@ struct ReciprocalRankFusionArgs {
     pub time_column: Option<Expr>,
     pub recency_decay: Option<RecencyDecay>,
     pub decay_constant: Option<f64>,
-    pub decay_scale_seconds: Option<f64>,
+    pub decay_scale_secs: Option<f64>,
     pub decay_window: Option<f64>,
 }
 
@@ -218,7 +225,7 @@ impl ReciprocalRankFusionArgs {
             recency_decay: extract_string!(rrf_args, "recency_decay")
                 .and_then(|rd| RecencyDecay::from_str(&rd).ok()),
             decay_constant: extract_f64!(rrf_args, "decay_constant"),
-            decay_scale_seconds: extract_f64!(rrf_args, "decay_scale_seconds"),
+            decay_scale_secs: extract_f64!(rrf_args, "decay_scale_secs"),
             decay_window: extract_f64!(rrf_args, "decay_window"),
         })
     }
@@ -301,12 +308,12 @@ impl ReciprocalRankFusion {
             .recency_decay
             .clone()
             .unwrap_or(RecencyDecay::Exponential);
-        let decay_scale_seconds = args.decay_scale_seconds.unwrap_or(86400.0);
+        let decay_scale_secs = args.decay_scale_secs.unwrap_or(86400.0);
 
         // Lots of casting annoyances are avoided by treating everything as `long`
         let today_epoch = to_unixtime(vec![now()]);
         let recency_col_epoch = to_unixtime(vec![col(qualified_recency_col)]);
-        let age_in_units = (today_epoch - recency_col_epoch) / lit(decay_scale_seconds);
+        let age_in_units = (today_epoch - recency_col_epoch) / lit(decay_scale_secs);
 
         let recency_expr = match recency_decay {
             // e^(-alpha * age units)
@@ -890,7 +897,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_argument_exprs() -> Result<()> {
+    fn test_parse_argument_exprs() {
         // Empty call
         let empty_args = ReciprocalRankFusionArgs::from_udtf_exprs(&[]);
         assert!(empty_args.is_err());
@@ -949,7 +956,5 @@ mod tests {
         assert_eq!(many_with_k_and_column.search_udtf_exprs.len(), 100);
         // assert_eq!(many_with_k_and_column.k, 1337.0f64);
         assert_eq!(many_with_k_and_column.join_key, Some(col("hello")));
-
-        Ok(())
     }
 }

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -16,7 +16,7 @@ limitations under the License.
 use arrow_schema::{DataType, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::{Session, TableFunctionImpl, TableProvider};
-use datafusion::common::{DataFusionError, JoinType, Result, ScalarValue, exec_err};
+use datafusion::common::{DataFusionError, JoinType, Result, ScalarValue, exec_err, not_impl_err};
 use datafusion::datasource::TableType;
 use datafusion::functions_window::expr_fn::row_number;
 use datafusion::logical_expr::{
@@ -31,6 +31,7 @@ use itertools::Itertools;
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 use tract_core::ops::math::Recip;
 
@@ -56,9 +57,61 @@ pub static DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
 pub static SIGNATURE: LazyLock<Signature> =
     LazyLock::new(|| Signature::variadic_any(Volatility::Stable));
 
+macro_rules! extract_scalar_base {
+    ($map:expr, $key:literal, $datatype:expr, $pattern:pat => $value:expr) => {
+        $map.get($key)
+            .and_then(|sv| sv.cast_to(&$datatype).ok())
+            .and_then(|sv| match sv {
+                $pattern => Some($value),
+                _ => None,
+            })
+    };
+}
+
+macro_rules! extract_f64 {
+      ($map:expr, $key:literal) => {
+          extract_scalar_base!(
+              $map,
+              $key,
+              DataType::Float64,
+              ScalarValue::Float64(Some(val), ..) => val
+          )
+      };
+  }
+
+macro_rules! extract_string {
+      ($map:expr, $key:literal) => {
+          extract_scalar_base!(
+              $map,
+              $key,
+              DataType::Utf8,
+              ScalarValue::Utf8(Some(val), ..) => val
+          )
+      };
+  }
+
+#[derive(Debug)]
+enum RecencyDecay {
+    Linear,
+    Exponential,
+}
+
+impl FromStr for RecencyDecay {
+    type Err = DataFusionError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "linear" => Ok(RecencyDecay::Linear),
+            "exponential" => Ok(RecencyDecay::Exponential),
+            other => not_impl_err!("{RRF_UDF_NAME} does not implement decay function {other}"),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 struct ReciprocalRankFusionSubqueryArgs {
-    pub rank_boost: Option<i64>,
+    pub rank_boost: Option<f64>,
+    pub recency_decay: Option<RecencyDecay>,
 }
 
 impl ReciprocalRankFusionSubqueryArgs {
@@ -69,16 +122,16 @@ impl ReciprocalRankFusionSubqueryArgs {
             let mut args = args.clone();
             let rrf_args = args
                 .extract_if(.., |arg| {
-                    matches!(arg, Expr::Literal(ScalarValue::Int64(Some(_)), Some(_)))
+                    matches!(arg, Expr::Literal(_, Some(meta)) if meta.inner().contains_key("spice.parameter_name"))
                 })
                 .filter_map(|arg| match arg {
-                    Expr::Literal(ScalarValue::Int64(Some(value)), Some(meta)) => meta
+                    Expr::Literal(value, Some(meta)) => meta
                         .inner()
                         .get("spice.parameter_name")
                         .map(|name| (name.clone(), value)),
                     _ => None,
                 })
-                .collect::<HashMap<String, i64>>();
+                .collect::<HashMap<String, ScalarValue>>();
 
             Ok((
                 Expr::ScalarFunction(ScalarFunction {
@@ -86,13 +139,12 @@ impl ReciprocalRankFusionSubqueryArgs {
                     func: func.clone(),
                 }),
                 ReciprocalRankFusionSubqueryArgs {
-                    rank_boost: rrf_args.get("rank_boost").copied(),
+                    rank_boost: extract_f64!(rrf_args, "rank_boost"),
+                    recency_decay: None,
                 },
             ))
         } else {
-            Err(DataFusionError::NotImplemented(format!(
-                "{RRF_UDF_NAME} subquery arguments require a scalar function invocation."
-            )))
+            not_impl_err!("{RRF_UDF_NAME} subquery arguments require a scalar function invocation.")
         }
     }
 }
@@ -103,6 +155,7 @@ struct ReciprocalRankFusionArgs {
     pub rrf_subquery_arguments: Vec<ReciprocalRankFusionSubqueryArgs>,
     pub k: f64,
     pub join_key: Option<Expr>,
+    pub recency_decay: Option<RecencyDecay>,
 }
 
 impl ReciprocalRankFusionArgs {
@@ -120,34 +173,34 @@ impl ReciprocalRankFusionArgs {
     /// * `Ok(ReciprocalRankFusionArgs)` - Successfully parsed arguments
     /// * `Err` - If fewer than 2 search queries are provided or if unparsing fails
     pub fn from_udtf_exprs(args: &[Expr]) -> Result<ReciprocalRankFusionArgs> {
-        let mut search_udtfs: Vec<Expr> = vec![];
-        let mut subquery_args: Vec<ReciprocalRankFusionSubqueryArgs> = vec![];
-        let mut k_argument: Option<f64> = None;
-        let mut join_pk_argument: Option<Expr> = None;
+        let mut rrf_args = args.to_vec();
 
-        for expr in args {
-            match expr {
-                e @ Expr::ScalarFunction(_) => {
-                    let (subquery_expr, rrf_subquery_args) =
-                        ReciprocalRankFusionSubqueryArgs::from_scalar_function_expr(e)?;
+        let (search_udtfs, subquery_args): (Vec<_>, Vec<_>) = rrf_args
+            .extract_if(.., |arg| matches!(arg, Expr::ScalarFunction(_)))
+            .map(|e| ReciprocalRankFusionSubqueryArgs::from_scalar_function_expr(&e))
+            .collect::<Result<Vec<(Expr, ReciprocalRankFusionSubqueryArgs)>>>()?
+            .into_iter()
+            .unzip();
 
-                    subquery_args.push(rrf_subquery_args);
-                    search_udtfs.push(subquery_expr)
-                }
-                Expr::Literal(ScalarValue::Float64(Some(k)), ..) if k_argument.is_none() => {
-                    k_argument = Some(*k);
-                }
-                Expr::Column(c) if join_pk_argument.is_none() => {
-                    join_pk_argument = Some(col(c.name.clone()));
+        let rrf_args = rrf_args
+            .iter()
+            .map(|arg| match arg {
+                Expr::Literal(value, Some(meta)) => {
+                    match meta.inner().get("spice.parameter_name") {
+                        Some(name) => Ok((name.clone(), value.clone())),
+                        None => {
+                            return not_impl_err!(
+                                "{RRF_UDF_NAME} does not yet support {arg} arguments."
+                            );
+                        }
+                    }
                 }
                 // Show a useful error for the rest
                 other_expr => {
-                    return Err(DataFusionError::NotImplemented(format!(
-                        "{RRF_UDF_NAME} does not yet support {other_expr} arguments."
-                    )));
+                    not_impl_err!("{RRF_UDF_NAME} does not yet support {other_expr} arguments.")
                 }
-            }
-        }
+            })
+            .collect::<Result<HashMap<String, ScalarValue>>>()?;
 
         if search_udtfs.len() < 2 {
             return Err(DataFusionError::Plan(format!(
@@ -158,8 +211,9 @@ impl ReciprocalRankFusionArgs {
         Ok(Self {
             search_udtf_exprs: search_udtfs,
             rrf_subquery_arguments: subquery_args,
-            k: k_argument.unwrap_or(60.0),
-            join_key: join_pk_argument,
+            k: extract_f64!(rrf_args, "k").unwrap_or(60.0),
+            join_key: extract_string!(rrf_args, "join_key").map(col),
+            recency_decay: extract_string!(rrf_args, "recency_decay").and_then(|rd| RecencyDecay::from_str(&rd).ok()),
         })
     }
 }
@@ -210,11 +264,10 @@ impl ReciprocalRankFusion {
         let score_expr = (0..subquery_dfs.len())
             .map(|i| {
                 // Either use 1 as dividend or user provided boost
-                let dividend = args
+                let dividend: f64 = args
                     .rrf_subquery_arguments
                     .get(i)
                     .and_then(|args| args.rank_boost)
-                    .map(|rb| rb as f64)
                     .unwrap_or(1.0f64);
 
                 lit(dividend)

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -624,7 +624,7 @@ mod tests {
     }
 
     // Assumes column "content" is embedded
-    fn df_as_embedding_table(runtime: &Runtime, df: DataFrame) -> Result<Arc<dyn TableProvider>> {
+    fn df_as_embedding_table(runtime: &Runtime, df: DataFrame) -> Arc<dyn TableProvider> {
         let mut embedded_columns = HashMap::new();
         embedded_columns.insert(
             "content".to_string(),
@@ -636,11 +636,11 @@ mod tests {
             },
         );
 
-        Ok(Arc::new(EmbeddingTable {
+        Arc::new(EmbeddingTable {
             base_table: df.into_view(),
             embedded_columns,
-            embedding_models: runtime.embeds.clone(),
-        }))
+            embedding_models: Arc::clone(&runtime.embeds),
+        })
     }
 
     async fn make_test_runtime() -> Result<Runtime> {
@@ -731,7 +731,7 @@ mod tests {
             .with_column("picked_at", picked_at_expr)?
             .sort(vec![col("picked_at").sort(false, false)])?;
 
-        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df.clone())?;
+        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df.clone());
 
         runtime
             .df
@@ -774,7 +774,7 @@ mod tests {
         let runtime = make_test_runtime().await?;
 
         let fruit_df = make_fruit_dataframe(&runtime).await?;
-        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df)?;
+        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df);
 
         runtime
             .df
@@ -806,7 +806,7 @@ mod tests {
         let runtime = make_test_runtime().await?;
 
         let fruit_df = make_fruit_dataframe(&runtime).await?;
-        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df)?;
+        let fruit_embedding_table = df_as_embedding_table(&runtime, fruit_df);
 
         runtime
             .df
@@ -838,13 +838,13 @@ mod tests {
         let runtime = make_test_runtime().await?;
 
         let fruit_df = make_fruit_dataframe(&runtime).await?;
-        let fruit_table = df_as_embedding_table(&runtime, fruit_df.clone())?;
+        let fruit_table = df_as_embedding_table(&runtime, fruit_df.clone());
 
         let no_fruit_df = fruit_df
             .clone()
             .limit(0, Some(0))
             .expect("Must have fruit DF");
-        let no_fruit_table = df_as_embedding_table(&runtime, no_fruit_df)?;
+        let no_fruit_table = df_as_embedding_table(&runtime, no_fruit_df);
 
         runtime.df.ctx.register_table("foo", fruit_table)?;
 

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -54,7 +54,7 @@ pub static DOCUMENTATION: LazyLock<Documentation> = LazyLock::new(|| {
         ("recency_decay".to_string(), "Type of decay function: 'linear' or 'exponential' (default: 'exponential')".to_string()),
         ("decay_constant".to_string(), "Decay rate constant for exponential decay (default: 0.01)".to_string()),
         ("decay_scale_secs".to_string(), "Time scale in seconds for decay calculation (default: 86400)".to_string()),
-        ("decay_window".to_string(), "Window size for linear decay function (default: 86400)".to_string()),
+        ("decay_window_secs".to_string(), "Window size for linear decay function (default: 86400)".to_string()),
         ("rank_weight".to_string(), "Per-query rank weighting factor (used within individual search queries)".to_string()),
     ]),
     alternative_syntax: None,
@@ -165,7 +165,7 @@ struct ReciprocalRankFusionArgs {
     pub recency_decay: Option<RecencyDecay>,
     pub decay_constant: Option<f64>,
     pub decay_scale_secs: Option<f64>,
-    pub decay_window: Option<f64>,
+    pub decay_window_secs: Option<f64>,
 }
 
 impl ReciprocalRankFusionArgs {
@@ -226,7 +226,7 @@ impl ReciprocalRankFusionArgs {
                 .and_then(|rd| RecencyDecay::from_str(&rd).ok()),
             decay_constant: extract_f64!(rrf_args, "decay_constant"),
             decay_scale_secs: extract_f64!(rrf_args, "decay_scale_secs"),
-            decay_window: extract_f64!(rrf_args, "decay_window"),
+            decay_window_secs: extract_f64!(rrf_args, "decay_window_secs"),
         })
     }
 }
@@ -324,8 +324,8 @@ impl ReciprocalRankFusion {
             }
             // 1 - (age units / boost window)
             RecencyDecay::Linear => {
-                let decay_window = args.decay_window.unwrap_or(86400.0);
-                let boost = lit(1) - (age_in_units / lit(decay_window));
+                let decay_window_secs = args.decay_window_secs.unwrap_or(86400.0);
+                let boost = lit(1) - (age_in_units / lit(decay_window_secs));
                 greatest(vec![lit(0), boost])
             }
         };

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -761,13 +761,13 @@ async fn test_rrf_search() -> Result<(), anyhow::Error> {
             SearchTestCase::new(
                 "hybrid_multiple_column_sql_rrf_explicit_join",
                 SearchTestType::Sql(
-                    "SELECT id, question, trunc(fused_score, 3) FROM rrf(vector_search(qs, 'second'), text_search(qs, 'second'), id) order by fused_score desc LIMIT 4",
+                    "SELECT id, question, trunc(fused_score, 3) FROM rrf(vector_search(qs, 'second'), text_search(qs, 'second'), join_key => 'id') order by fused_score desc LIMIT 4",
                 ),
             ),
             SearchTestCase::new(
                 "hybrid_multiple_column_sql_rrf_explicit_join_wrong_column",
                 SearchTestType::Sql(
-                    "SELECT id, question, trunc(fused_score, 3) FROM rrf(vector_search(qs, 'second'), text_search(qs, 'second'), foobar) order by fused_score desc LIMIT 4",
+                    "SELECT id, question, trunc(fused_score, 3) FROM rrf(vector_search(qs, 'second'), text_search(qs, 'second'), join_key => 'foobar') order by fused_score desc LIMIT 4",
                 ),
             ).should_fail(),
             SearchTestCase::new(

--- a/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_explicit_join.snap
+++ b/crates/runtime/tests/models/snapshots/integration_models__models__search__hybrid_multiple_column_sql_rrf_explicit_join.snap
@@ -6,21 +6,21 @@ expression: resp?
   {
     "id": 525,
     "question": "In a group of 3 machines where 2 are faulty, what is the probability that the first two machines tested are both faulty?",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), id).fused_score,Int64(3))": 0.02
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} }).fused_score,Int64(3))": 0.02
   },
   {
     "id": 772,
     "question": "State the degree of the differential equation:\n$$\ny^{\\prime \\prime} = 6x + \\sin x\n$$",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), id).fused_score,Int64(3))": 0.017
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} }).fused_score,Int64(3))": 0.017
   },
   {
     "id": 361,
     "question": "Find the number of ways a judge can award first, second, and third places in a contest with 18 contestants.",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), id).fused_score,Int64(3))": 0.016
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} }).fused_score,Int64(3))": 0.016
   },
   {
     "id": 462,
     "question": "How many groups of 2 are in 14?",
-    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), id).fused_score,Int64(3))": 0.016
+    "trunc(rrf(vector_search(qs, Utf8(\"second\")), text_search(qs, Utf8(\"second\")), Utf8(\"id\") FieldMetadata { inner: {\"spice.parameter_name\": \"join_key\"} }).fused_score,Int64(3))": 0.016
   }
 ]


### PR DESCRIPTION
## 📝 Summary

Let's do a quick tour of the new functionality:

#### Named arguments only

With our recent DataFusion patch, we can now rely on named arguments instead of positional ones:

```sql
SELECT id, title, fused_score
FROM rrf(
    vector_search(wiki_a_potion, 'fire'),
    text_search(wiki_a_potion, 'noise'),
    k => 10.0,
    join_key => 'id'
);
```

Unfortunately, we have to express columns as strings because column references do not have metadata like literals do. Well, there's a table reference facility, but it would not make much sense to use to bind parameters. In both the existing and new implementation we lift the name out of the Column expr to obtain a qualified reference, so there is no loss of functionality or correctness -- just cosmetic.

#### Rank weighting

This can now be expressed as a named argument in your `vector_search` and `text_search` calls!

```sql
SELECT id, title, fused_score
FROM rrf(
    vector_search(wiki_a_potion, 'fire', rank_weight => 100),
    text_search(wiki_a_potion, 'noise', rank_weight => 10)
 );
```

#### Recency boosting

This one is fun, and very configurable! Out of the box, recency is configured with an exponential decay function to be sensitive to _days_ with a correspondingly appropriate alpha constant. Users opt in to recency boosting by specifying a `time_column`.

##### Math

I haven't written LaTeX since school.

$\text{decay}(t) = e^{-\alpha \cdot t}$
| Age (t) in Days | Decay Multiplier |
|------------------|------------------|
| 0                | 1.000            |
| 10               | 0.905            |
| 20               | 0.819            |

Linear decay is also available:

$\text{decay}(t) = \max\left(0,\ 1 - \frac{t}{T} \right)$


##### With defaults

```sql
SELECT id, name, city, fused_score
FROM rrf(
    vector_search(people, 'northeast'),
    text_search(people, 'california'),
    join_key => 'id',
    time_column => 'ts'
);
```

##### With overrides (exponential)

```sql
SELECT id, name, city, fused_score
FROM rrf(
    vector_search(people, 'northeast', rank_weight => 10),
    text_search(people, 'california'),
    join_key => 'id',
    time_column => 'ts',
    decay_constant => 0.01, -- less decay
    decay_scale_secs => 31536000 -- 1 year
 );
```

##### With overrides (linear, 48 hour window)

```sql
SELECT id, name, city, fused_score
FROM rrf(
    vector_search(people, 'northeast', rank_weight => 10),
    text_search(people, 'california'),
    time_column => 'ts',
    recency_decay => 'linear',
    decay_window_secs => 172800 -- 2 days
 );
```

## 🔗 Related

https://github.com/spiceai/datafusion/pull/104
https://github.com/apache/datafusion/issues/17379

Resolves https://github.com/spiceai/spiceai/issues/7058

## 🚨 Breaking Changes

n/a

## 📚 Docs

TODO with a nice dataset. Will circle back.

## 👀 Notes for Reviewers

See PR comments
