### PR TITLE
fix: Add feature flag for using object store in `spicepod`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,7 +2043,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -5089,7 +5089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5280,7 +5280,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7945,7 +7945,7 @@ dependencies = [
  "reqwest",
  "reqwest-eventsource",
  "runtime-rate-control",
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "secrecy",
  "serde",
  "serde_json",
@@ -10835,7 +10835,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -10868,7 +10868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -11169,7 +11169,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12099,7 +12099,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "s3_vectors",
  "scheduler",
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "scopeguard",
  "search",
  "secrecy",
@@ -12413,7 +12413,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12426,7 +12426,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12722,13 +12722,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive 0.9.0",
+ "schemars_derive 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -12747,9 +12747,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13601,7 +13601,7 @@ dependencies = [
  "futures",
  "object_store",
  "regex",
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde-value",
  "serde_json",
@@ -13616,7 +13616,7 @@ dependencies = [
 name = "spicepodschema"
 version = "1.8.0-unstable"
 dependencies = [
- "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde_json",
  "spicepod",
 ]
@@ -13756,7 +13756,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16430,7 +16430,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7945,7 +7945,7 @@ dependencies = [
  "reqwest",
  "reqwest-eventsource",
  "runtime-rate-control",
- "schemars 1.0.4",
+ "schemars 0.9.0",
  "secrecy",
  "serde",
  "serde_json",
@@ -12099,7 +12099,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "s3_vectors",
  "scheduler",
- "schemars 1.0.4",
+ "schemars 0.9.0",
  "scopeguard",
  "search",
  "secrecy",
@@ -12722,13 +12722,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.0.4",
+ "schemars_derive 0.9.0",
  "serde",
  "serde_json",
 ]
@@ -12747,9 +12747,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.0.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13601,7 +13601,7 @@ dependencies = [
  "futures",
  "object_store",
  "regex",
- "schemars 1.0.4",
+ "schemars 0.9.0",
  "serde",
  "serde-value",
  "serde_json",
@@ -13616,7 +13616,7 @@ dependencies = [
 name = "spicepodschema"
 version = "1.8.0-unstable"
 dependencies = [
- "schemars 1.0.4",
+ "schemars 0.9.0",
  "serde_json",
  "spicepod",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ rmcp = { git = "https://github.com/spiceai/modelcontextprotocol-rust-sdk.git", r
 rusqlite = { version = "0.31.0", features = ["bundled-decimal", "chrono"] }
 rustls = "0.23"
 rustls-pemfile = "2.1.3"
-schemars = "0.9.0"
+schemars = "1.0.4"
 secrecy = "0.10.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ rmcp = { git = "https://github.com/spiceai/modelcontextprotocol-rust-sdk.git", r
 rusqlite = { version = "0.31.0", features = ["bundled-decimal", "chrono"] }
 rustls = "0.23"
 rustls-pemfile = "2.1.3"
-schemars = "1.0.4"
+schemars = "0.9.0"
 secrecy = "0.10.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"

--- a/crates/spicepod/Cargo.toml
+++ b/crates/spicepod/Cargo.toml
@@ -9,11 +9,11 @@ version.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-aws-sdk-credential-bridge = { path = "../aws-sdk-credential-bridge" }
+aws-sdk-credential-bridge = { path = "../aws-sdk-credential-bridge", optional = true }
 byte-unit.workspace = true
 fundu.workspace = true
 futures.workspace = true
-object_store.workspace = true
+object_store = { workspace = true, optional = true }
 regex.workspace = true
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
@@ -21,10 +21,13 @@ serde-value = "0.7.0"
 serde_json.workspace = true
 serde_yaml.workspace = true
 snafu.workspace = true
-tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+tokio.workspace = true
+
 [features]
-default = []
+default = ["object-store"]
 schemars = ["dep:schemars"]
+object-store = ["dep:aws-sdk-credential-bridge", "dep:object_store"]

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -290,6 +290,7 @@ pub enum InvalidTypeAction {
 }
 
 /// Helper struct for deserializing Dataset with custom logic for handling `InvalidTypeAction` migration
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct DatasetDeserializer {

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -23,7 +23,10 @@ use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use std::collections::HashMap;
 use std::path::Path;
-use std::{fmt::Debug, path::PathBuf, sync::Arc};
+use std::{fmt::Debug, path::PathBuf};
+
+#[cfg(feature = "object-store")]
+use std::sync::Arc;
 
 use component::{
     catalog::Catalog, dataset::Dataset, embeddings::Embeddings, eval::Eval, model::Model,
@@ -61,9 +64,7 @@ pub enum Error {
     #[snafu(display("Unable to load duplicate spicepod {component} component '{name}'"))]
     DuplicateComponent { component: String, name: String },
 
-    #[snafu(display("Unable to create tokio runtime: {source}"))]
-    UnableToCreateTokioRuntime { source: std::io::Error },
-
+    #[cfg(feature = "object-store")]
     #[snafu(display("Unable to parse URL {}: {source}", path))]
     UnableToParseUrl {
         source: object_store::Error,
@@ -76,6 +77,7 @@ pub enum Error {
         path: PathBuf,
     },
 
+    #[cfg(feature = "object-store")]
     #[snafu(display("Unable to parse S3 URL {}: {source}", path))]
     UnableToParseS3Url {
         source: aws_sdk_credential_bridge::Error,
@@ -154,9 +156,8 @@ fn check_for_reserved_keywords(components: &[Dataset]) -> Result<()> {
 impl Spicepod {
     pub async fn load(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
-        let path_str = path.to_string_lossy();
-
-        match url::Url::parse(&path_str) {
+        #[cfg(feature = "object-store")]
+        match url::Url::parse(&path.to_string_lossy()) {
             Ok(url)
                 if matches!(
                     url.scheme(),
@@ -167,8 +168,14 @@ impl Spicepod {
             }
             _ => Self::load_from(&reader::StdFileSystem, path).await,
         }
+
+        #[cfg(not(feature = "object-store"))]
+        {
+            Self::load_from(&reader::StdFileSystem, path).await
+        }
     }
 
+    #[cfg(feature = "object-store")]
     pub async fn load_from_object_store(url: url::Url) -> Result<Self> {
         let (store, path) = match (url.scheme(), url.path()) {
             ("s3", path) => {

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -25,6 +25,9 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::{fmt::Debug, path::PathBuf};
 
+#[cfg(feature = "schemars")]
+use schemars::JsonSchema;
+
 #[cfg(feature = "object-store")]
 use std::sync::Arc;
 
@@ -92,6 +95,7 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Spicepod {
     pub version: SpicepodVersion,

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -25,9 +25,6 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::{fmt::Debug, path::PathBuf};
 
-#[cfg(feature = "schemars")]
-use schemars::JsonSchema;
-
 #[cfg(feature = "object-store")]
 use std::sync::Arc;
 
@@ -95,7 +92,6 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Spicepod {
     pub version: SpicepodVersion,

--- a/crates/spicepod/src/reader.rs
+++ b/crates/spicepod/src/reader.rs
@@ -16,9 +16,13 @@ limitations under the License.
 
 #![allow(clippy::missing_errors_doc)]
 
-use std::{io, path::PathBuf, sync::Arc};
+use std::{io, path::PathBuf};
+
+#[cfg(feature = "object-store")]
+use std::sync::Arc;
 
 use async_trait::async_trait;
+#[cfg(feature = "object-store")]
 use object_store::{DynObjectStore, ObjectStore};
 use snafu::prelude::*;
 
@@ -30,12 +34,14 @@ pub enum Error {
         path: PathBuf,
     },
 
+    #[cfg(feature = "object-store")]
     #[snafu(display("Unable to open object store path {}: {source}", path))]
     UnableToOpenObjectStorePath {
         source: object_store::Error,
         path: String,
     },
 
+    #[cfg(feature = "object-store")]
     #[snafu(display("Unable to parse object store path {}: {source}", path))]
     UnableToParseObjectStorePath {
         source: object_store::path::Error,
@@ -89,16 +95,19 @@ pub trait ReadableYaml: ReadablePath {
 
 impl ReadableYaml for StdFileSystem {}
 
+#[cfg(feature = "object-store")]
 pub struct ObjectStoreFilesystem {
     store: Arc<DynObjectStore>,
 }
 
+#[cfg(feature = "object-store")]
 impl ObjectStoreFilesystem {
     pub fn new(store: Arc<DynObjectStore>) -> Self {
         Self { store }
     }
 }
 
+#[cfg(feature = "object-store")]
 #[async_trait]
 impl ReadablePath for ObjectStoreFilesystem {
     async fn open(&self, path: PathBuf) -> Result<Box<dyn io::Read + Send + Sync>> {
@@ -125,4 +134,5 @@ impl ReadablePath for ObjectStoreFilesystem {
     }
 }
 
+#[cfg(feature = "object-store")]
 impl ReadableYaml for ObjectStoreFilesystem {}


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Feature flags out usage of the `object-store` or AWS connection features.
  * Consumers of the `spicepod` crate may not want to use `object-store` or AWS connection features. Building these crates adds a fair number of dependencies to the graph.
