### PR TITLE
Enable  DML `Update` SQL operations for datasets configured as  `access: read_write`

### DIFF
--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -17,8 +17,8 @@ limitations under the License.
 use std::{collections::HashMap, sync::Arc};
 
 use super::{
-    CheckAvailability, Dataset, Error, Mode, ReadyState, Result, TimeFormat, UnsupportedTypeAction,
-    acceleration, replication, validate_identifier,
+    AccessMode, CheckAvailability, Dataset, Error, ReadyState, Result, TimeFormat,
+    UnsupportedTypeAction, acceleration, replication, validate_identifier,
 };
 use crate::Runtime;
 use app::App;
@@ -39,7 +39,7 @@ use spicepod::{
 pub struct DatasetBuilder {
     pub from: String,
     pub name: TableReference,
-    pub mode: Mode,
+    pub access: AccessMode,
     pub params: HashMap<String, String>,
     pub metadata: HashMap<String, String>,
     pub columns: Vec<Column>,
@@ -99,7 +99,7 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
         Ok(DatasetBuilder {
             from: dataset.from,
             name: table_reference,
-            mode: Mode::from(dataset.mode),
+            access: AccessMode::from(dataset.access),
             params: dataset
                 .params
                 .as_ref()
@@ -140,7 +140,7 @@ impl DatasetBuilder {
         Ok(DatasetBuilder {
             from,
             name: Self::parse_table_reference(name)?,
-            mode: Mode::default(),
+            access: AccessMode::default(),
             params: HashMap::default(),
             metadata: HashMap::default(),
             columns: Vec::default(),
@@ -227,7 +227,7 @@ impl DatasetBuilder {
         let dataset = Dataset {
             from: self.from,
             name: self.name,
-            mode: self.mode,
+            access: self.access,
             params: self.params,
             metadata: self.metadata,
             columns: self.columns,

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -551,7 +551,7 @@ impl Dataset {
     }
 
     #[must_use]
-    pub fn mode(&self) -> AccessMode {
+    pub fn access(&self) -> AccessMode {
         self.access
     }
 

--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -117,17 +117,17 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub enum Mode {
+pub enum AccessMode {
     #[default]
     Read,
     ReadWrite,
 }
 
-impl From<spicepod_dataset::Mode> for Mode {
-    fn from(mode: spicepod_dataset::Mode) -> Self {
+impl From<spicepod_dataset::AccessMode> for AccessMode {
+    fn from(mode: spicepod_dataset::AccessMode) -> Self {
         match mode {
-            spicepod_dataset::Mode::Read => Mode::Read,
-            spicepod_dataset::Mode::ReadWrite => Mode::ReadWrite,
+            spicepod_dataset::AccessMode::Read => AccessMode::Read,
+            spicepod_dataset::AccessMode::ReadWrite => AccessMode::ReadWrite,
         }
     }
 }
@@ -258,7 +258,7 @@ impl Display for CheckAvailability {
 pub struct Dataset {
     pub from: String,
     pub name: TableReference,
-    pub mode: Mode,
+    pub access: AccessMode,
     pub params: HashMap<String, String>,
     pub metadata: HashMap<String, String>,
     pub columns: Vec<Column>,
@@ -285,7 +285,7 @@ impl std::fmt::Debug for Dataset {
         f.debug_struct("Dataset")
             .field("from", &self.from)
             .field("name", &self.name)
-            .field("mode", &self.mode)
+            .field("access", &self.access)
             .field("params", &self.params)
             .field("metadata", &self.metadata)
             .field("columns", &self.columns)
@@ -315,7 +315,7 @@ impl PartialEq for Dataset {
     fn eq(&self, other: &Self) -> bool {
         self.from == other.from
             && self.name == other.name
-            && self.mode == other.mode
+            && self.access == other.access
             && self.params == other.params
             && self.has_metadata_table == other.has_metadata_table
             && self.replication == other.replication
@@ -566,8 +566,8 @@ impl Dataset {
     }
 
     #[must_use]
-    pub fn mode(&self) -> Mode {
-        self.mode
+    pub fn mode(&self) -> AccessMode {
+        self.access
     }
 
     #[must_use]

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -90,6 +90,7 @@ pub mod refresh_sql;
 pub mod request_context_extension;
 pub mod retention_sql;
 pub mod schema;
+mod sql_validator;
 pub mod udf;
 
 pub const SPICE_DEFAULT_CATALOG: &str = "spice";

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -440,7 +440,7 @@ impl DataFusion {
     ) -> Result<Option<Arc<Notify>>> {
         schema::ensure_schema_exists(&self.ctx, SPICE_DEFAULT_CATALOG, &dataset.name)?;
 
-        let dataset_mode = dataset.mode();
+        let dataset_access_mode = dataset.access();
         let dataset_table_ref = dataset.name.clone();
 
         let is_ready = match table {
@@ -506,7 +506,7 @@ impl DataFusion {
             }
         };
 
-        if matches!(dataset_mode, AccessMode::ReadWrite) {
+        if matches!(dataset_access_mode, AccessMode::ReadWrite) {
             self.data_writers
                 .write()
                 .map_err(|_| Error::UnableToLockDataWriters {})?
@@ -851,7 +851,7 @@ impl DataFusion {
         secrets: Arc<TokioRwLock<Secrets>>,
     ) -> Result<AcceleratedTable> {
         tracing::debug!("Creating accelerated table {dataset:?}");
-        let source_table_provider = match dataset.mode() {
+        let source_table_provider = match dataset.access() {
             AccessMode::Read => Arc::new(federated_read_table),
             AccessMode::ReadWrite => {
                 let read_write_provider = source
@@ -1272,7 +1272,7 @@ impl DataFusion {
 
         let federated_table_provider = federated_read_table.table_provider().await;
 
-        let source_table_provider = match dataset.mode() {
+        let source_table_provider = match dataset.access() {
             AccessMode::Read => federated_table_provider,
             AccessMode::ReadWrite => source
                 .read_write_provider(dataset)

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -23,7 +23,7 @@ use crate::accelerated_table::{self, AcceleratedTableBuilderError};
 use crate::accelerated_table::{AcceleratedTable, Retention, refresh::Refresh};
 use crate::catalogconnector::deferred::DeferredCatalogProvider;
 use crate::component::dataset::acceleration::RefreshMode;
-use crate::component::dataset::{Dataset, Mode, ReadyState};
+use crate::component::dataset::{AccessMode, Dataset, ReadyState};
 use crate::component::view::View;
 use crate::dataaccelerator::AcceleratorEngineRegistry;
 use crate::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
@@ -505,7 +505,7 @@ impl DataFusion {
             }
         };
 
-        if matches!(dataset_mode, Mode::ReadWrite) {
+        if matches!(dataset_mode, AccessMode::ReadWrite) {
             self.data_writers
                 .write()
                 .map_err(|_| Error::UnableToLockDataWriters {})?
@@ -851,8 +851,8 @@ impl DataFusion {
     ) -> Result<AcceleratedTable> {
         tracing::debug!("Creating accelerated table {dataset:?}");
         let source_table_provider = match dataset.mode() {
-            Mode::Read => Arc::new(federated_read_table),
-            Mode::ReadWrite => {
+            AccessMode::Read => Arc::new(federated_read_table),
+            AccessMode::ReadWrite => {
                 let read_write_provider = source
                     .read_write_provider(dataset)
                     .await
@@ -1272,8 +1272,8 @@ impl DataFusion {
         let federated_table_provider = federated_read_table.table_provider().await;
 
         let source_table_provider = match dataset.mode() {
-            Mode::Read => federated_table_provider,
-            Mode::ReadWrite => source
+            AccessMode::Read => federated_table_provider,
+            AccessMode::ReadWrite => source
                 .read_write_provider(dataset)
                 .await
                 .ok_or_else(|| {

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{cell::LazyCell, fmt::Display, sync::Arc};
+use std::{fmt::Display, sync::Arc};
 
 use ::cache::{
     get_logical_plan_input_tables,
@@ -29,12 +29,8 @@ use arrow_schema::{Field, SchemaBuilder};
 use arrow_tools::schema::verify_schema;
 use cache::PlanOrCached;
 use datafusion::{
-    common::ParamValues,
-    error::DataFusionError,
-    execution::{SendableRecordBatchStream, context::SQLOptions},
-    logical_expr::LogicalPlan,
-    physical_plan::stream::RecordBatchStreamAdapter,
-    prelude::DataFrame,
+    common::ParamValues, error::DataFusionError, execution::SendableRecordBatchStream,
+    logical_expr::LogicalPlan, physical_plan::stream::RecordBatchStreamAdapter, prelude::DataFrame,
 };
 use error_code::ErrorCode;
 use snafu::{ResultExt, Snafu};
@@ -54,7 +50,9 @@ use async_stream::stream;
 use futures::StreamExt;
 
 use crate::{
-    datafusion::{DataFusion, query::cache::RequestCacheManager},
+    datafusion::{
+        DataFusion, query::cache::RequestCacheManager, sql_validator::validate_sql_query_operations,
+    },
     request::{AsyncMarker, RequestContext},
 };
 
@@ -81,16 +79,6 @@ pub enum Error {
 
     #[snafu(display("Failed to set parameters in logical plan: {source}"))]
     BindingParameters { source: DataFusionError },
-}
-
-// There is no need to have a synchronized SQLOptions across all threads, each thread can have its own instance.
-thread_local! {
-    static RESTRICTED_SQL_OPTIONS: LazyCell<SQLOptions> = LazyCell::new(|| {
-        SQLOptions::new()
-            .with_allow_ddl(false)
-            .with_allow_dml(false)
-            .with_allow_statements(false)
-    });
 }
 
 pub enum QueryMethod {
@@ -182,9 +170,7 @@ impl Query {
                 }
             };
 
-            if let Err(e) =
-                RESTRICTED_SQL_OPTIONS.with(|sql_options| sql_options.verify_plan(&plan))
-            {
+            if let Err(e) = validate_sql_query_operations(&plan, &ctx.df) {
                 let e = find_datafusion_root(e);
                 handle_error!(
                     tracker,
@@ -332,7 +318,7 @@ impl Query {
         };
 
         // Verify the plan against the restricted options
-        if let Err(e) = RESTRICTED_SQL_OPTIONS.with(|sql_options| sql_options.verify_plan(&plan)) {
+        if let Err(e) = validate_sql_query_operations(&plan, &self.df) {
             let e = find_datafusion_root(e);
             self.handle_schema_error(&request_context, &e);
             return Err(e);

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -58,10 +58,10 @@ pub fn validate_sql_query_operations(
                 if df.is_writable(&dml.table_name) {
                     Ok(TreeNodeRecursion::Continue)
                 } else {
-                plan_err!(
-                    "INSERT operations are not allowed on read-only dataset '{}'. Verify the dataset is configured as writable and try again.",
-                    dml.table_name
-                )
+                    plan_err!(
+                        "INSERT operations are not allowed on read-only dataset '{}'. Verify the dataset is configured with 'access: read_write' and try again.",
+                        dml.table_name
+                    )
                 }
             } else { plan_err!("Operation is not allowed: {}", dml.name()) }
         }

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -1,0 +1,345 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use datafusion::{
+    common::{plan_err, tree_node::TreeNodeRecursion},
+    error::DataFusionError,
+    logical_expr::LogicalPlan,
+};
+
+use crate::datafusion::DataFusion;
+
+/// Validates that a logical plan only performs allowed operations on datasets.
+///
+/// Reads (SELECT queries) are allowed on all tables.
+/// INSERT operations are only allowed on datasets that are configured as writable,
+/// and are not allowed on internal Spice tables.
+/// DDL, DML (other than allowed INSERT), COPY, and Statement operations are not permitted.
+///
+/// # Returns
+/// * `Ok(())` if the plan is valid
+/// * `Err(DataFusionError)` if the plan contains invalid operations, such as DDL, DML on read-only datasets,
+///   or INSERT on internal datasets
+pub fn validate_sql_query_operations(
+    plan: &LogicalPlan,
+    df: &Arc<DataFusion>,
+) -> Result<(), DataFusionError> {
+    plan.apply_with_subqueries(|node| match node {
+        // Data Definition Language (DDL): CREATE / DROP TABLES / VIEWS / SCHEMAS
+        LogicalPlan::Ddl(ddl) => {
+            plan_err!("Operation is not allowed: {}", ddl.name())
+        }
+        // Data Manipulation Language (DML): Insert / Update / Delete
+        LogicalPlan::Dml(dml) => {
+            if let datafusion::logical_expr::WriteOp::Insert(_) = &dml.op {
+
+                if super::is_spice_internal_dataset(&dml.table_name) {
+                    return plan_err!(
+                        "INSERT operations are not allowed on Spice system dataset '{}'.",
+                        dml.table_name
+                    );
+                }
+
+                if df.is_writable(&dml.table_name) {
+                    Ok(TreeNodeRecursion::Continue)
+                } else {
+                plan_err!(
+                    "INSERT operations are not allowed on read-only dataset '{}'. Verify the dataset is configured as writable and try again.",
+                    dml.table_name
+                )
+                }
+            } else { plan_err!("Operation is not allowed: {}", dml.name()) }
+        }
+        LogicalPlan::Copy(_) => {
+            plan_err!("COPY operations are not allowed")
+        }
+        LogicalPlan::Statement(stmt) => {
+            plan_err!("Statements are not allowed: {}", stmt.name())
+        }
+        _ => Ok(TreeNodeRecursion::Continue),
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        dataaccelerator::AcceleratorEngineRegistry,
+        datafusion::{SPICE_RUNTIME_SCHEMA, builder::DataFusionBuilder},
+        status::RuntimeStatus,
+    };
+
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use data_components::arrow::write::MemTable;
+    use datafusion::sql::TableReference;
+    use std::sync::Arc;
+
+    fn create_test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, true),
+        ]))
+    }
+
+    fn create_test_datafusion() -> Arc<DataFusion> {
+        let df = Arc::new(
+            DataFusionBuilder::new(
+                RuntimeStatus::new(),
+                Arc::new(AcceleratorEngineRegistry::new()),
+            )
+            .build(),
+        );
+
+        let mem_table = Arc::new(
+            MemTable::try_new(create_test_schema(), vec![]).expect("mem table should be created"),
+        );
+
+        df.ctx
+            .register_table(
+                "tbl_read_only",
+                Arc::<data_components::arrow::write::MemTable>::clone(&mem_table),
+            )
+            .expect("table should be registered");
+
+        df.ctx
+            .register_table(
+                "tbl_writable",
+                Arc::<data_components::arrow::write::MemTable>::clone(&mem_table),
+            )
+            .expect("table should be registered");
+
+        df.data_writers
+            .write()
+            .expect("data writers should be acquired")
+            .insert("tbl_writable".into());
+
+        let internal_table = TableReference::partial(SPICE_RUNTIME_SCHEMA, "spice_table");
+        df.ctx
+            .register_table(internal_table.clone(), mem_table)
+            .expect("table should be registered");
+
+        df.data_writers
+            .write()
+            .expect("data writers should be acquired")
+            .insert(internal_table);
+
+        df
+    }
+
+    #[tokio::test]
+    async fn test_validate_read_only_query_allowed() {
+        let df = create_test_datafusion();
+
+        let sql = "SELECT * FROM tbl_read_only";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_ok(), "Read-only queries should be allowed");
+    }
+
+    #[tokio::test]
+    async fn test_validate_insert_on_writable_dataset() {
+        let df = create_test_datafusion();
+
+        let sql = "INSERT INTO tbl_writable VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        // INSERT should be allowed on writable dataset
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_ok(),
+            "INSERT should be allowed on writable dataset"
+        );
+    }
+    #[tokio::test]
+    async fn test_validate_insert_on_readonly_dataset_blocked() {
+        let df = create_test_datafusion();
+
+        let sql = "INSERT INTO tbl_read_only VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "INSERT should fail on read-only dataset");
+    }
+
+    #[tokio::test]
+    async fn test_validate_insert_on_internal_table_blocked() {
+        let df = create_test_datafusion();
+
+        let sql = "INSERT INTO runtime.spice_table VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_err(),
+            "INSERT should fail on Spice internal dataset"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_update_operation_blocked() {
+        let df = create_test_datafusion();
+
+        let sql = "UPDATE tbl_writable SET name = 'updated' WHERE id = 1";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        // UPDATE operations should be blocked
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "UPDATE operations should be blocked");
+    }
+
+    #[tokio::test]
+    async fn test_validate_delete_operation_blocked() {
+        let df = create_test_datafusion();
+
+        let sql = "DELETE FROM tbl_writable WHERE id = 1";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        // DELETE operations should be blocked
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "DELETE operations should be blocked");
+    }
+
+    #[tokio::test]
+    async fn test_validate_ddl_operations_blocked() {
+        let df = create_test_datafusion();
+
+        // Test CREATE TABLE
+        let sql = "CREATE TABLE test_table (id INT, name VARCHAR(50))";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "CREATE TABLE should be blocked");
+
+        if let Err(e) = result {
+            assert!(e.to_string().contains("Operation is not allowed"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validate_copy_operations_blocked() {
+        let df = create_test_datafusion();
+
+        // Test COPY TO using the registered table
+        let sql = "COPY tbl_read_only TO 'output.csv'";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "COPY operations should be blocked");
+
+        if let Err(e) = result {
+            assert!(e.to_string().contains("COPY operations are not allowed"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validate_statement_operations_blocked() {
+        let df = create_test_datafusion();
+
+        // Test SET statement
+        let sql = "SET datafusion.execution.batch_size = 1000";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "SET statements should be blocked");
+
+        if let Err(e) = result {
+            assert!(e.to_string().contains("Statements are not allowed"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validate_complex_read_query_allowed() {
+        let df = create_test_datafusion();
+
+        let sql = "SELECT name, SUM(value) as total FROM tbl_read_only WHERE value > 0.0 GROUP BY name ORDER BY total DESC LIMIT 10";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_ok(), "Complex read queries should be allowed");
+    }
+
+    #[tokio::test]
+    async fn test_validate_subquery_operations() {
+        let df = create_test_datafusion();
+
+        let sql =
+            "SELECT * FROM tbl_writable WHERE id IN (SELECT id FROM tbl_read_only WHERE id > 5)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_ok(), "Read-only subqueries should be allowed");
+    }
+}

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -680,7 +680,7 @@ impl Runtime {
                 })?;
         let accelerator_engine = acceleration_settings.engine;
 
-        if ds.mode() == dataset::Mode::ReadWrite && !replicate {
+        if ds.mode() == dataset::AccessMode::ReadWrite && !replicate {
             AcceleratedReadWriteTableWithoutReplicationSnafu.fail()?;
         }
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -680,7 +680,7 @@ impl Runtime {
                 })?;
         let accelerator_engine = acceleration_settings.engine;
 
-        if ds.mode() == dataset::AccessMode::ReadWrite && !replicate {
+        if ds.access() == dataset::AccessMode::ReadWrite && !replicate {
             AcceleratedReadWriteTableWithoutReplicationSnafu.fail()?;
         }
 

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -24,7 +24,7 @@ use tokio::sync::RwLock;
 
 use crate::Runtime;
 use crate::accelerated_table::{AcceleratedTableBuilderError, Retention};
-use crate::component::dataset::{Mode, acceleration::Acceleration, builder::DatasetBuilder};
+use crate::component::dataset::{AccessMode, acceleration::Acceleration, builder::DatasetBuilder};
 use crate::federated_table::FederatedTable;
 use crate::secrets::Secrets;
 use crate::status;
@@ -95,7 +95,7 @@ async fn get_local_table_provider(
             code: "IT-GLTP-BD-B".to_string(), // InternalTable - GetLocalTableProvider - DatasetBuilder - Build
         })?;
 
-    dataset.mode = Mode::ReadWrite;
+    dataset.access = AccessMode::ReadWrite;
 
     let mut sink = SinkConnector::new(Arc::clone(schema));
     if let Some(pk) = primary_key {

--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -48,7 +48,7 @@ use util::{
 
 use crate::{
     Runtime,
-    component::dataset::{Mode, builder::DatasetBuilder},
+    component::dataset::{AccessMode, builder::DatasetBuilder},
     dataconnector::{DataConnectorError, create_new_connector, parameters::ConnectorParamsBuilder},
     datafusion::{
         DataFusion, SPICE_RUNTIME_SCHEMA, builder::get_df_default_config, error::SpiceExternalError,
@@ -286,7 +286,7 @@ async fn get_spiceai_table_provider(
         .context(UnableToCreateDataConnectorSnafu)?
         .with_params(params);
 
-    dataset.mode = Mode::ReadWrite;
+    dataset.access = AccessMode::ReadWrite;
 
     let params = ConnectorParamsBuilder::new("spice.ai".into(), (&dataset).into())
         .build(secrets)

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -28,7 +28,7 @@ use runtime::{
         AcceleratedTable, AcceleratedTableBuilderError, Retention, refresh::Refresh,
     },
     component::dataset::{
-        Mode, TimeFormat,
+        AccessMode, TimeFormat,
         acceleration::{Acceleration, RefreshMode},
         builder::DatasetBuilder,
         replication::Replication,
@@ -308,7 +308,7 @@ async fn get_spiceai_table_provider(
         .boxed()
         .context(UnableToCreateDataConnectorSnafu)?;
 
-    dataset.mode = Mode::ReadWrite;
+    dataset.access = AccessMode::ReadWrite;
     dataset.replication = Some(Replication { enabled: true });
 
     let params = ConnectorParamsBuilder::new(name.into(), (&dataset).into())

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -302,7 +302,7 @@ struct DatasetDeserializer {
     metadata: HashMap<String, Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     columns: Vec<Column>,
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "is_default", alias = "mode")]
     access: AccessMode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     params: Option<Params>,

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -31,7 +31,7 @@ use crate::vector::VectorStore;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
-pub enum Mode {
+pub enum AccessMode {
     #[default]
     Read,
     ReadWrite,
@@ -111,8 +111,8 @@ pub struct Dataset {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub columns: Vec<Column>,
 
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub mode: Mode,
+    #[serde(default, skip_serializing_if = "is_default", alias = "mode")]
+    pub access: AccessMode,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<Params>,
@@ -178,7 +178,7 @@ impl Dataset {
             description: None,
             metadata: HashMap::default(),
             columns: Vec::default(),
-            mode: Mode::default(),
+            access: AccessMode::default(),
             params: None,
             has_metadata_table: None,
             replication: None,
@@ -246,7 +246,7 @@ impl WithDependsOn<Dataset> for Dataset {
             description: self.description.clone(),
             metadata: self.metadata.clone(),
             columns: self.columns.clone(),
-            mode: self.mode.clone(),
+            access: self.access.clone(),
             params: self.params.clone(),
             has_metadata_table: self.has_metadata_table,
             replication: self.replication.clone(),
@@ -303,7 +303,7 @@ struct DatasetDeserializer {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     columns: Vec<Column>,
     #[serde(default, skip_serializing_if = "is_default")]
-    mode: Mode,
+    access: AccessMode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     params: Option<Params>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -373,7 +373,7 @@ impl TryFrom<DatasetDeserializer> for Dataset {
             description: deserializer.description,
             metadata: deserializer.metadata,
             columns: deserializer.columns,
-            mode: deserializer.mode,
+            access: deserializer.access,
             params: deserializer.params,
             has_metadata_table: deserializer.has_metadata_table,
             replication: deserializer.replication,


### PR DESCRIPTION
## 📝 Summary

1. Rename `dataset.mode` to `dataset.access` (with mode still supported for backward compatibility) 
2. Enable SQL `INSERT INTO` SQL for datasets configured with `access: read_write` mode. This mode must be supported by underlying TableProvider, otherwise `Failed to setup the dataset  ... Table <table-name> was marked as read_write, but the underlying provider only supports reads.` error will be returned. 
3. Only `INSERT` is allowed, other DML and DDL operations are still prohibited, inserting into Spice internal tables via SQL is prohibited as well.

## 🔗 Related

Part of 
- https://github.com/spiceai/spiceai/issues/7149

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
