### PR TITLE
RRF: Fix decay for disjoint result sets

### DIFF
--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -300,12 +300,8 @@ impl ReciprocalRankFusion {
             let (_, qname) = recency_col.qualified_name();
             let cols = subquery_dfs
                 .iter()
-                .map(|df| Self::first_qualified_field(df, &qname))
-                .collect::<Result<Vec<_>>>()?
-                .into_iter()
-                .map(col)
-                .collect::<Vec<_>>();
-
+                .map(|df| Self::first_qualified_field(df, &qname).map(col))
+                .collect::<Result<Vec<_>>>()?;
             coalesce(cols)
         } else {
             return Ok(score_expr);

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -298,7 +298,15 @@ impl ReciprocalRankFusion {
         // If user specifies a recency column, we enable recency boosting
         let qualified_recency_col = if let Some(recency_col) = args.time_column.clone() {
             let (_, qname) = recency_col.qualified_name();
-            Self::first_qualified_field(&subquery_dfs[0], &qname)?
+            let cols = subquery_dfs
+                .iter()
+                .map(|df| Self::first_qualified_field(df, &qname))
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .map(col)
+                .collect::<Vec<_>>();
+
+            coalesce(cols)
         } else {
             return Ok(score_expr);
         };
@@ -312,7 +320,7 @@ impl ReciprocalRankFusion {
 
         // Lots of casting annoyances are avoided by treating everything as `long`
         let today_epoch = to_unixtime(vec![now()]);
-        let recency_col_epoch = to_unixtime(vec![col(qualified_recency_col)]);
+        let recency_col_epoch = to_unixtime(vec![qualified_recency_col]);
         let age_in_units = (today_epoch - recency_col_epoch) / lit(decay_scale_secs);
 
         let recency_expr = match recency_decay {
@@ -588,13 +596,13 @@ mod tests {
     use crate::embeddings::table::EmbeddingTable;
     use crate::request::{Protocol, RequestContext};
     use crate::search::rrf::ReciprocalRankFusionArgs;
-    use arrow::array::{StringArray, as_string_array};
+    use arrow::array::as_string_array;
     use arrow::record_batch::RecordBatch;
     use async_graphql::futures_util::TryStreamExt;
     use datafusion::arrow::datatypes::DataType;
     use datafusion::catalog::TableProvider;
     use datafusion::common::Result;
-    use datafusion::common::cast::as_float64_array;
+    use datafusion::common::cast::{as_float64_array, as_uint64_array};
     use datafusion::functions_window::expr_fn::row_number;
     use datafusion::logical_expr::Expr;
     use datafusion::logical_expr::col;
@@ -640,7 +648,6 @@ mod tests {
 
     macro_rules! test_query {
         ($runtime:ident, $query:expr) => {{
-            let query = "select * from rrf(vector_search(foo, 'red crispy'), vector_search(foo, 'fruit'), time_column => 'picked_at', decay_constant => 0.1)";
             let query = QueryBuilder::new($query, $runtime.datafusion()).build();
             query
                 .run()
@@ -649,7 +656,7 @@ mod tests {
                 .data
                 .try_collect::<Vec<RecordBatch>>()
                 .await?
-        }}
+        }};
     }
 
     // Assumes column "content" is embedded
@@ -769,7 +776,6 @@ mod tests {
 
         // decay_constant is made more aggressive in this query to further deprioritize
         // old results. The test will/should fail if you use the default of 0.01.
-
         let results = test_query!(
             runtime,
             "select * from rrf(vector_search(foo, 'red crispy'), vector_search(foo, 'fruit'), time_column => 'picked_at', decay_constant => 0.1)"
@@ -782,6 +788,71 @@ mod tests {
 
         // fruit_df.show() to debug me
         assert_eq!(content.value(0), fruit_df_recent.value(0));
+
+        Ok(ExitCode::SUCCESS)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_recency_unboosting_disjoint() -> Result<ExitCode> {
+        let runtime = make_test_runtime().await?;
+
+        let fruit_df = make_fruit_dataframe(&runtime)
+            .await?
+            .with_column("picked_at", now())?
+            .with_column(
+                "picked_at",
+                to_unixtime(vec![col("picked_at")]) - (lit(86400) * col("id")),
+            )?;
+
+        let picked_at_expr = fruit_df.parse_sql_expr("to_timestamp(cast(picked_at as bigint))")?;
+
+        // Rows ordered picked_at DESC
+        let fruit_df = fruit_df
+            .with_column("picked_at", picked_at_expr)?
+            .sort(vec![col("picked_at").sort(false, false)])?;
+
+        // left_fruit: id (2, 3) with (now() - 1 day, now() - 2 day) respectively
+        let left_fruit = df_as_embedding_table(&runtime, fruit_df.clone().limit(1, Some(2))?);
+        // right_fruit: id (1) with timestamp 1970-01-01
+        let right_fruit = df_as_embedding_table(
+            &runtime,
+            fruit_df.clone().limit(0, Some(1))?.with_column(
+                "picked_at",
+                fruit_df.parse_sql_expr("to_timestamp(cast(0 as timestamp))")?,
+            )?,
+        );
+
+        runtime.df.ctx.register_table("left_fruit", left_fruit)?;
+
+        runtime.df.ctx.register_table("right_fruit", right_fruit)?;
+
+        // Baseline: query against self to obtain fused score with recency decay
+        let results = test_query!(
+            runtime,
+            "select * from rrf(vector_search(left_fruit, 'red crispy'), vector_search(right_fruit, 'red crispy'), k => 0, time_column => 'picked_at', decay_constant => 0.25)"
+        );
+
+        /*
+        Prior to fix:
+
+        Base RRF score for id=1, k=0 = 1/(k + rank) = 1/(0+1) = 1/1
+        But should be unboosted!
+        | fused_score        | content                      | id | picked_at           |
+        +--------------------+------------------------------+----+---------------------+
+        | 1.0                | orange citrus round juicy    | 1  | 1970-01-01T00:00:00 |
+        | 0.4723665527410147 | apple fruit sweet red crispy | 3  | 2025-09-23T14:26:15 |
+        | 0.3032653298563167 | banana yellow curved fruit   | 2  | 2025-09-24T14:26:15 |
+        +--------------------+------------------------------+----+---------------------+
+
+        After:
+        | fused_score        | content                      | id | picked_at           |
+        +--------------------+------------------------------+----+---------------------+
+        | 0.4723665527410147 | apple fruit sweet red crispy | 3  | 2025-09-23T14:32:53 |
+        | 0.3032653298563167 | banana yellow curved fruit   | 2  | 2025-09-24T14:32:53 |
+        | 0.0                | orange citrus round juicy    | 1  | 1970-01-01T00:00:00 |
+        +--------------------+------------------------------+----+---------------------+
+         */
+        assert_ne!(extract_column!(results, "id", as_uint64_array)?.value(0), 1);
 
         Ok(ExitCode::SUCCESS)
     }
@@ -859,8 +930,7 @@ mod tests {
             "select * from rrf(vector_search(bar, 'empty'), vector_search(foo, 'red')) order by fused_score desc"
         );
         let query_empty_red_content =
-            extract_column!(query_empty_red_results, "fused_score", as_float64_array)
-                .expect("Must be f64[]");
+            extract_column!(query_empty_red_results, "fused_score", as_float64_array)?;
         let query_empty_red_score = query_empty_red_content.value(0);
 
         let query_red_empty_results = test_query!(
@@ -868,8 +938,7 @@ mod tests {
             "select * from rrf(vector_search(foo, 'red'), vector_search(bar, 'empty'))"
         );
         let query_red_empty_content =
-            extract_column!(query_red_empty_results, "fused_score", as_float64_array)
-                .expect("Must be f64[]");
+            extract_column!(query_red_empty_results, "fused_score", as_float64_array)?;
         let query_red_empty_score = query_red_empty_content.value(0);
 
         // Compare permutation of RRF invocations to ensure score is consistent regardless of order
@@ -885,8 +954,7 @@ mod tests {
             query_empty_red_recency_results,
             "fused_score",
             as_float64_array
-        )
-        .expect("Must be f64[]");
+        )?;
 
         assert!(
             query_empty_red_recency_scores

--- a/crates/runtime/src/search/rrf.rs
+++ b/crates/runtime/src/search/rrf.rs
@@ -588,7 +588,7 @@ mod tests {
     use crate::embeddings::table::EmbeddingTable;
     use crate::request::{Protocol, RequestContext};
     use crate::search::rrf::ReciprocalRankFusionArgs;
-    use arrow::array::as_string_array;
+    use arrow::array::{StringArray, as_string_array};
     use arrow::record_batch::RecordBatch;
     use async_graphql::futures_util::TryStreamExt;
     use datafusion::arrow::datatypes::DataType;
@@ -622,6 +622,34 @@ mod tests {
             )]));
             Expr::Literal(scalar_value, Some(spice_metadata))
         }};
+    }
+
+    macro_rules! extract_column {
+        ($batches:expr, $column_name:expr, $array_cast_fn:ident, $nth:expr) => {
+            $array_cast_fn(
+                $batches[$nth]
+                    .column_by_name($column_name)
+                    .expect(format!("Must have {}", $column_name).as_str()),
+            )
+        };
+
+        ($batches:expr, $column_name:expr, $array_cast_fn:ident) => {
+            extract_column!($batches, $column_name, $array_cast_fn, 0)
+        };
+    }
+
+    macro_rules! test_query {
+        ($runtime:ident, $query:expr) => {{
+            let query = "select * from rrf(vector_search(foo, 'red crispy'), vector_search(foo, 'fruit'), time_column => 'picked_at', decay_constant => 0.1)";
+            let query = QueryBuilder::new($query, $runtime.datafusion()).build();
+            query
+                .run()
+                .await
+                .expect("Must run query")
+                .data
+                .try_collect::<Vec<RecordBatch>>()
+                .await?
+        }}
     }
 
     // Assumes column "content" is embedded
@@ -741,28 +769,16 @@ mod tests {
 
         // decay_constant is made more aggressive in this query to further deprioritize
         // old results. The test will/should fail if you use the default of 0.01.
-        let query = "select * from rrf(vector_search(foo, 'red crispy'), vector_search(foo, 'fruit'), time_column => 'picked_at', decay_constant => 0.1)";
-        let query = QueryBuilder::new(query, runtime.datafusion()).build();
-        let results = query
-            .run()
-            .await
-            .expect("Must run query")
-            .data
-            .try_collect::<Vec<RecordBatch>>()
-            .await?;
 
-        let content = as_string_array(
-            results[0]
-                .column_by_name("content")
-                .expect("Must have content column"),
+        let results = test_query!(
+            runtime,
+            "select * from rrf(vector_search(foo, 'red crispy'), vector_search(foo, 'fruit'), time_column => 'picked_at', decay_constant => 0.1)"
         );
+
+        let content = extract_column!(results, "content", as_string_array);
 
         let fruit_df_batches = fruit_df.collect().await?;
-        let fruit_df_recent = as_string_array(
-            fruit_df_batches[0]
-                .column_by_name("content")
-                .expect("Must have content column"),
-        );
+        let fruit_df_recent = extract_column!(fruit_df_batches, "content", as_string_array);
 
         // fruit_df.show() to debug me
         assert_eq!(content.value(0), fruit_df_recent.value(0));
@@ -782,22 +798,15 @@ mod tests {
             .ctx
             .register_table("foo", fruit_embedding_table)?;
 
-        let query = "select * from rrf(vector_search(foo, 'yellow', rank_weight => 100), vector_search(foo, 'red', rank_weight => 10))";
-        let query = QueryBuilder::new(query, runtime.datafusion()).build();
-        let results = query
-            .run()
-            .await
-            .expect("Must run query")
-            .data
-            .try_collect::<Vec<RecordBatch>>()
-            .await?;
-
-        let content = as_string_array(
-            results[0]
-                .column_by_name("content")
-                .expect("Must have content column"),
+        let results = test_query!(
+            runtime,
+            "select * from rrf(vector_search(foo, 'yellow', rank_weight => 100), vector_search(foo, 'red', rank_weight => 10))"
         );
-        assert_eq!(content.value(0), "banana yellow curved fruit");
+
+        assert_eq!(
+            extract_column!(results, "content", as_string_array).value(0),
+            "banana yellow curved fruit"
+        );
 
         Ok(ExitCode::SUCCESS)
     }
@@ -814,22 +823,15 @@ mod tests {
             .ctx
             .register_table("foo", fruit_embedding_table)?;
 
-        let query = "select * from rrf(vector_search(foo, 'crispy'), vector_search(foo, 'red'), join_key => 'id', k => 600.0)";
-        let query = QueryBuilder::new(query, runtime.datafusion()).build();
-        let results = query
-            .run()
-            .await
-            .expect("Must run query")
-            .data
-            .try_collect::<Vec<RecordBatch>>()
-            .await?;
-
-        let content = as_string_array(
-            results[0]
-                .column_by_name("content")
-                .expect("Must have content column"),
+        let results = test_query!(
+            runtime,
+            "select * from rrf(vector_search(foo, 'crispy'), vector_search(foo, 'red'), join_key => 'id', k => 600.0)"
         );
-        assert_eq!(content.value(0), "apple fruit sweet red crispy");
+
+        assert_eq!(
+            extract_column!(results, "content", as_string_array).value(0),
+            "apple fruit sweet red crispy"
+        );
 
         Ok(ExitCode::SUCCESS)
     }
@@ -850,46 +852,24 @@ mod tests {
         let no_fruit_table = df_as_embedding_table(&runtime, no_fruit_df);
 
         runtime.df.ctx.register_table("foo", fruit_table)?;
-
         runtime.df.ctx.register_table("bar", no_fruit_table)?;
 
-        let query_empty_red = "select * from rrf(vector_search(bar, 'empty'), vector_search(foo, 'red')) order by fused_score desc";
-        let query_empty_red = QueryBuilder::new(query_empty_red, runtime.datafusion()).build();
-        let query_empty_red_results = query_empty_red
-            .run()
-            .await
-            .expect("Must run query")
-            .data
-            .try_collect::<Vec<RecordBatch>>()
-            .await?;
-
-        let query_empty_red_content = as_float64_array(
-            query_empty_red_results[0]
-                .column_by_name("fused_score")
-                .expect("Must have score column"),
-        )
-        .expect("Must be f64[]");
-
+        let query_empty_red_results = test_query!(
+            runtime,
+            "select * from rrf(vector_search(bar, 'empty'), vector_search(foo, 'red')) order by fused_score desc"
+        );
+        let query_empty_red_content =
+            extract_column!(query_empty_red_results, "fused_score", as_float64_array)
+                .expect("Must be f64[]");
         let query_empty_red_score = query_empty_red_content.value(0);
 
-        let query_red_empty =
-            "select * from rrf(vector_search(foo, 'red'), vector_search(bar, 'empty'))";
-        let query_red_empty = QueryBuilder::new(query_red_empty, runtime.datafusion()).build();
-        let query_red_empty_results = query_red_empty
-            .run()
-            .await
-            .expect("Must run query")
-            .data
-            .try_collect::<Vec<RecordBatch>>()
-            .await?;
-
-        let query_red_empty_content = as_float64_array(
-            query_red_empty_results[0]
-                .column_by_name("fused_score")
-                .expect("Must have score column"),
-        )
-        .expect("Must be f64[]");
-
+        let query_red_empty_results = test_query!(
+            runtime,
+            "select * from rrf(vector_search(foo, 'red'), vector_search(bar, 'empty'))"
+        );
+        let query_red_empty_content =
+            extract_column!(query_red_empty_results, "fused_score", as_float64_array)
+                .expect("Must be f64[]");
         let query_red_empty_score = query_red_empty_content.value(0);
 
         // Compare permutation of RRF invocations to ensure score is consistent regardless of order
@@ -897,21 +877,14 @@ mod tests {
         assert!(score_diff < 0.0001f64);
 
         // If timestamp column is missing due to FULL OUTER JOIN, ensure a score is still output
-        let query_empty_red_recency = "select * from rrf(vector_search(bar, 'empty'), vector_search(foo, 'red'), time_column => 'timestamp')";
-        let query_empty_red_recency =
-            QueryBuilder::new(query_empty_red_recency, runtime.datafusion()).build();
-        let query_empty_red_recency_results = query_empty_red_recency
-            .run()
-            .await
-            .expect("Must run query")
-            .data
-            .try_collect::<Vec<RecordBatch>>()
-            .await?;
-
-        let query_empty_red_recency_scores = as_float64_array(
-            query_empty_red_recency_results[0]
-                .column_by_name("fused_score")
-                .expect("Must have score column"),
+        let query_empty_red_recency_results = test_query!(
+            runtime,
+            "select * from rrf(vector_search(bar, 'empty'), vector_search(foo, 'red'), time_column => 'timestamp')"
+        );
+        let query_empty_red_recency_scores = extract_column!(
+            query_empty_red_recency_results,
+            "fused_score",
+            as_float64_array
         )
         .expect("Must be f64[]");
 


### PR DESCRIPTION
## 📝 Summary

- If the resultset JOIN is disjoint, recency decay isn't applied correctly depending on subquery ordering
- Adds test, fixes bug
- Adds a macro to DRY up some test stuff
