### PR TITLE
Enhancement: Implement before/after/lag metrics for acceleration refresh

### DIFF
--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -52,3 +52,31 @@ pub(crate) static READY_STATE_FALLBACK: LazyLock<Counter<u64>> = LazyLock::new(|
         .with_description("Number of times the federated table was queried due to the accelerated table loading the initial data.")
         .build()
 });
+
+pub(crate) static MAX_TIMESTAMP_BEFORE_REFRESH_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
+    METER
+        .i64_gauge("dataset_acceleration_max_timestamp_before_refresh_ms")
+        .with_description("Maximum value of the dataset's time_column before the refresh operation, in milliseconds.")
+        .build()
+});
+
+pub(crate) static MAX_TIMESTAMP_AFTER_REFRESH_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
+    METER
+        .i64_gauge("dataset_acceleration_max_timestamp_after_refresh_ms")
+        .with_description("Maximum value of the dataset's time_column after the refresh operation, in milliseconds.")
+        .build()
+});
+
+pub(crate) static REFRESH_LAG_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
+    METER
+        .i64_gauge("dataset_acceleration_refresh_lag_ms")
+        .with_description("Difference between the maximum time_column value after and before the refresh operation, in milliseconds.")
+        .build()
+});
+
+pub(crate) static INGESTION_LAG_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
+    METER
+        .i64_gauge("dataset_acceleration_ingestion_lag_ms")
+        .with_description("Lag between the current wall-clock time and the maximum time_column value after the refresh operation, in milliseconds.")
+        .build()
+});

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -61,6 +61,7 @@ mod refresh_task_runner;
 mod retention;
 mod sink;
 mod synchronized_table;
+mod time_utils;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -61,7 +61,7 @@ mod refresh_task_runner;
 mod retention;
 mod sink;
 mod synchronized_table;
-mod time_utils;
+mod timestamp_metrics_utils;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -342,7 +342,6 @@ impl RefreshTask {
     async fn get_max_timestamp_before_refresh(&self, refresh: &Refresh) -> Option<i64> {
         if refresh.time_column.is_some() {
             match self.timestamp_nanos_for_append_query(refresh).await {
-                #[allow(clippy::cast_possible_truncation)]
                 Ok(Some(time_nanos)) => i64::try_from(time_nanos / NANOS_TO_MILLIS).ok(),
                 Ok(None) => None,
                 Err(e) => {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -364,7 +364,7 @@ impl RefreshTask {
 
     async fn handle_metrics(
         &self,
-        dataset_metrics_label_sets: &Vec<Vec<KeyValue>>,
+        dataset_metrics_label_sets: &[Vec<KeyValue>],
         max_timestamp_before_refresh_ms: Option<i64>,
         max_timestamp_after_refresh_ms: Option<Arc<Mutex<Option<i64>>>>,
     ) {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -343,7 +343,7 @@ impl RefreshTask {
         if refresh.time_column.is_some() {
             match self.timestamp_nanos_for_append_query(refresh).await {
                 #[allow(clippy::cast_possible_truncation)]
-                Ok(Some(time_nanos)) => Some((time_nanos / NANOS_TO_MILLIS) as i64),
+                Ok(Some(time_nanos)) => i64::try_from(time_nanos / NANOS_TO_MILLIS).ok(),
                 Ok(None) => None,
                 Err(e) => {
                     tracing::warn!(

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -61,9 +61,10 @@ use super::{UnableToCreateMemTableFromUpdateSnafu, metrics};
 use crate::component::dataset::TimeFormat;
 use std::time::{Duration, UNIX_EPOCH};
 use std::{cmp::Ordering, sync::Arc, time::SystemTime};
-use tokio::sync::{RwLock, Semaphore, oneshot};
+use tokio::sync::{Mutex, RwLock, Semaphore, oneshot};
 
 use super::refresh::Refresh;
+use crate::accelerated_table::time_utils::max_timestamp_in_stream;
 use data_components::poly::PolyTableProvider;
 use datafusion::execution::context::SessionContext;
 use datafusion::{
@@ -250,6 +251,10 @@ impl RefreshTask {
         self.set_refresh_status(refresh.sql.as_deref(), status::ComponentStatus::Refreshing)
             .await;
 
+        let dataset_metrics_label_sets = self.get_dataset_label_sets(&refresh.mode).await;
+
+        let max_timestamp_before_refresh_ms = self.get_max_timestamp_before_refresh(refresh).await;
+
         let _timer = MultiTimeMeasurement::new(
             match refresh.mode {
                 RefreshMode::Disabled => {
@@ -258,7 +263,7 @@ impl RefreshTask {
                 RefreshMode::Full | RefreshMode::Append => &metrics::REFRESH_DURATION_MS,
                 RefreshMode::Changes => unreachable!("changes are handled upstream"),
             },
-            self.get_dataset_label_sets(&refresh.mode).await,
+            &dataset_metrics_label_sets,
         );
 
         let start_time = SystemTime::now();
@@ -284,6 +289,20 @@ impl RefreshTask {
             }
         };
 
+        let source_name = format!(
+            "{} {}",
+            self.component_type(),
+            include_source_to_table_name(&self.dataset_name, self.federated_source.as_deref())
+        );
+        let (streaming_data_update, max_timestamp_after_refresh_ms) = max_timestamp_in_stream(
+            streaming_data_update,
+            self.federated.schema(),
+            refresh.time_column.clone(),
+            refresh.time_format,
+            source_name,
+        )
+        .await;
+
         self.write_streaming_data_update(
             Some(start_time),
             streaming_data_update,
@@ -304,7 +323,82 @@ impl RefreshTask {
                     inner_err_from_retry_ref(e)
                 );
             }
-        })
+        })?;
+
+        // Only record metrics if a refresh was successful
+        self.handle_metrics(
+            &dataset_metrics_label_sets,
+            max_timestamp_before_refresh_ms,
+            max_timestamp_after_refresh_ms,
+        )
+        .await;
+
+        Ok(())
+    }
+
+    async fn get_max_timestamp_before_refresh(&self, refresh: &Refresh) -> Option<u64> {
+        if refresh.time_column.is_some() {
+            match self.timestamp_nanos_for_append_query(refresh).await {
+                #[allow(clippy::cast_possible_truncation)]
+                Ok(Some(time_nanos)) => Some((time_nanos / 1_000_000) as u64),
+                Ok(None) => None,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to fetch max_timestamp_before_refresh for {} {}: {}",
+                        self.component_type(),
+                        include_source_to_table_name(
+                            &self.dataset_name,
+                            self.federated_source.as_deref()
+                        ),
+                        e
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    async fn handle_metrics(
+        &self,
+        dataset_metrics_label_sets: &Vec<Vec<KeyValue>>,
+        max_timestamp_before_refresh_ms: Option<u64>,
+        max_timestamp_after_refresh_ms: Option<Arc<Mutex<Option<i64>>>>,
+    ) {
+        if let (Some(max_timestamp_before_refresh_ms), Some(max_timestamp_after_refresh_ms)) = (
+            max_timestamp_before_refresh_ms,
+            max_timestamp_after_refresh_ms,
+        ) {
+            let max_timestamp_after_refresh_ms = {
+                let guard = max_timestamp_after_refresh_ms.lock().await;
+                *guard
+            };
+
+            if let Some(max_timestamp_after_refresh_ms) = max_timestamp_after_refresh_ms {
+                #[allow(clippy::cast_possible_wrap)]
+                let max_timestamp_before_refresh_ms = max_timestamp_before_refresh_ms as i64;
+
+                #[allow(clippy::cast_possible_truncation)]
+                let current_time_ms = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as i64;
+
+                let refresh_lag_ms =
+                    max_timestamp_after_refresh_ms - max_timestamp_before_refresh_ms;
+                let ingestion_lag_ms = current_time_ms - max_timestamp_after_refresh_ms;
+
+                for label_set in dataset_metrics_label_sets {
+                    metrics::MAX_TIMESTAMP_BEFORE_REFRESH_MS
+                        .record(max_timestamp_before_refresh_ms, label_set);
+                    metrics::MAX_TIMESTAMP_AFTER_REFRESH_MS
+                        .record(max_timestamp_after_refresh_ms, label_set);
+                    metrics::REFRESH_LAG_MS.record(refresh_lag_ms, label_set);
+                    metrics::INGESTION_LAG_MS.record(ingestion_lag_ms, label_set);
+                }
+            }
+        }
     }
 
     async fn write_streaming_data_update(

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -81,6 +81,8 @@ use datafusion_federation::FederatedTableProviderAdaptor;
 mod changes;
 mod streaming_append;
 
+const NANOS_TO_MILLIS: u128 = 1_000_000;
+
 #[derive(Debug, Clone, Default)]
 struct RefreshStat {
     pub num_rows: usize,
@@ -336,11 +338,11 @@ impl RefreshTask {
         Ok(())
     }
 
-    async fn get_max_timestamp_before_refresh(&self, refresh: &Refresh) -> Option<u64> {
+    async fn get_max_timestamp_before_refresh(&self, refresh: &Refresh) -> Option<i64> {
         if refresh.time_column.is_some() {
             match self.timestamp_nanos_for_append_query(refresh).await {
                 #[allow(clippy::cast_possible_truncation)]
-                Ok(Some(time_nanos)) => Some((time_nanos / 1_000_000) as u64),
+                Ok(Some(time_nanos)) => Some((time_nanos / NANOS_TO_MILLIS) as i64),
                 Ok(None) => None,
                 Err(e) => {
                     tracing::warn!(
@@ -363,7 +365,7 @@ impl RefreshTask {
     async fn handle_metrics(
         &self,
         dataset_metrics_label_sets: &Vec<Vec<KeyValue>>,
-        max_timestamp_before_refresh_ms: Option<u64>,
+        max_timestamp_before_refresh_ms: Option<i64>,
         max_timestamp_after_refresh_ms: Option<Arc<Mutex<Option<i64>>>>,
     ) {
         if let (Some(max_timestamp_before_refresh_ms), Some(max_timestamp_after_refresh_ms)) = (
@@ -376,9 +378,6 @@ impl RefreshTask {
             };
 
             if let Some(max_timestamp_after_refresh_ms) = max_timestamp_after_refresh_ms {
-                #[allow(clippy::cast_possible_wrap)]
-                let max_timestamp_before_refresh_ms = max_timestamp_before_refresh_ms as i64;
-
                 #[allow(clippy::cast_possible_truncation)]
                 let current_time_ms = SystemTime::now()
                     .duration_since(UNIX_EPOCH)

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -64,7 +64,7 @@ use std::{cmp::Ordering, sync::Arc, time::SystemTime};
 use tokio::sync::{Mutex, RwLock, Semaphore, oneshot};
 
 use super::refresh::Refresh;
-use crate::accelerated_table::time_utils::max_timestamp_in_stream;
+use crate::accelerated_table::timestamp_metrics_utils::max_timestamp_in_stream;
 use data_components::poly::PolyTableProvider;
 use datafusion::execution::context::SessionContext;
 use datafusion::{

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -64,7 +64,7 @@ use std::{cmp::Ordering, sync::Arc, time::SystemTime};
 use tokio::sync::{Mutex, RwLock, Semaphore, oneshot};
 
 use super::refresh::Refresh;
-use crate::accelerated_table::timestamp_metrics_utils::max_timestamp_in_stream;
+use crate::accelerated_table::timestamp_metrics_utils::with_find_max_timestamp_in_stream;
 use data_components::poly::PolyTableProvider;
 use datafusion::execution::context::SessionContext;
 use datafusion::{
@@ -296,14 +296,15 @@ impl RefreshTask {
             self.component_type(),
             include_source_to_table_name(&self.dataset_name, self.federated_source.as_deref())
         );
-        let (streaming_data_update, max_timestamp_after_refresh_ms) = max_timestamp_in_stream(
-            streaming_data_update,
-            self.federated.schema(),
-            refresh.time_column.clone(),
-            refresh.time_format,
-            source_name,
-        )
-        .await;
+        let (streaming_data_update, max_timestamp_after_refresh_ms) =
+            with_find_max_timestamp_in_stream(
+                streaming_data_update,
+                self.federated.schema(),
+                refresh.time_column.clone(),
+                refresh.time_format,
+                source_name,
+            )
+            .await;
 
         self.write_streaming_data_update(
             Some(start_time),

--- a/crates/runtime/src/accelerated_table/time_utils.rs
+++ b/crates/runtime/src/accelerated_table/time_utils.rs
@@ -1,0 +1,632 @@
+use crate::component::dataset::TimeFormat;
+use crate::dataupdate::StreamingDataUpdate;
+use arrow::array::{
+    Array, Date32Array, Float16Array, Float32Array, Float64Array, Int8Array, Int16Array,
+    Int32Array, Int64Array, LargeStringArray, StringArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+    UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::datatypes::TimeUnit;
+use arrow_schema::{DataType, SchemaRef};
+use async_stream::stream;
+use chrono::DateTime;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::StreamExt;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+const MS_IN_A_DAY: i64 = 24 * 60 * 60 * 1000;
+
+macro_rules! max_ts_macro {
+    ($ty:ty, $max_ts:expr, $array:expr, $value:expr) => {{
+        match $array.as_any().downcast_ref::<$ty>() {
+            Some(arr) => {
+                let batch_max = (0..arr.len())
+                    .filter(|&i| !arr.is_null(i))
+                    .filter_map(|i| $value(arr, i))
+                    .max();
+                match batch_max {
+                    Some(bm) => Some($max_ts.map_or(bm, |cur| cur.max(bm))),
+                    None => $max_ts,
+                }
+            }
+            None => $max_ts,
+        }
+    }};
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn max_timestamp_in_stream(
+    data_update: StreamingDataUpdate,
+    schema: SchemaRef,
+    time_column: Option<String>,
+    time_format: Option<TimeFormat>,
+    source_name: String,
+) -> (StreamingDataUpdate, Option<Arc<Mutex<Option<i64>>>>) {
+    let Some(time_column_str) = time_column.as_ref() else {
+        return (data_update, None);
+    };
+
+    let time_format = time_format.unwrap_or_default();
+    let Some(field) = schema
+        .column_with_name(time_column_str)
+        .map(|(_, f)| f)
+        .cloned()
+    else {
+        return (data_update, None);
+    };
+
+    let max_ts = Arc::new(Mutex::new(None::<i64>));
+    let max_ts_clone = Arc::clone(&max_ts);
+
+    let out_stream = stream! {
+        let mut input_stream = data_update.data;
+        let mut max_ts: Option<i64> = None;
+
+        while let Some(batch_result) = input_stream.next().await {
+            if let Ok(ref batch) = batch_result
+                && let Ok(idx) = batch.schema().index_of(field.name()) {
+                    let array = batch.column(idx);
+
+                    let mut matched_supported_type = true;
+
+                    match field.data_type() {
+                        DataType::Timestamp(time_unit, _) => {
+                            match time_unit {
+                                TimeUnit::Nanosecond =>
+                                    max_ts = max_ts_macro!(TimestampNanosecondArray, max_ts, array, |arr: &TimestampNanosecondArray, i| ts_to_ms(arr.value(i), time_format, TimeUnit::Nanosecond)),
+                                TimeUnit::Microsecond =>
+                                    max_ts = max_ts_macro!(TimestampMicrosecondArray, max_ts, array, |arr: &TimestampMicrosecondArray, i| ts_to_ms(arr.value(i), time_format, TimeUnit::Microsecond)),
+                                TimeUnit::Millisecond =>
+                                    max_ts = max_ts_macro!(TimestampMillisecondArray, max_ts, array, |arr: &TimestampMillisecondArray, i| ts_to_ms(arr.value(i), time_format, TimeUnit::Millisecond)),
+                                TimeUnit::Second =>
+                                    max_ts = max_ts_macro!(TimestampSecondArray, max_ts, array, |arr: &TimestampSecondArray, i| ts_to_ms(arr.value(i), time_format, TimeUnit::Second)),
+                            }
+                        }
+
+                        // Utf8
+                        DataType::Utf8 =>
+                            max_ts = max_ts_macro!(StringArray, max_ts, array, |arr: &StringArray, i| string_to_ms(arr.value(i), time_format)),
+                        DataType::LargeUtf8 =>
+                            max_ts = max_ts_macro!(LargeStringArray, max_ts, array, |arr: &LargeStringArray, i| string_to_ms(arr.value(i), time_format)),
+
+                        // Int
+                        DataType::Int8 =>
+                            max_ts = max_ts_macro!(Int8Array, max_ts, array, |arr: &Int8Array, i| int_to_ms(i64::from(arr.value(i)), time_format)),
+                        DataType::Int16 =>
+                            max_ts = max_ts_macro!(Int16Array, max_ts, array, |arr: &Int16Array, i| int_to_ms(i64::from(arr.value(i)), time_format)),
+                        DataType::Int32 =>
+                            max_ts = max_ts_macro!(Int32Array, max_ts, array, |arr: &Int32Array, i| int_to_ms(i64::from(arr.value(i)), time_format)),
+                        DataType::Int64 =>
+                            max_ts = max_ts_macro!(Int64Array, max_ts, array, |arr: &Int64Array, i| int_to_ms(arr.value(i), time_format)),
+
+                        // UInt
+                        DataType::UInt8 =>
+                            max_ts = max_ts_macro!(UInt8Array, max_ts, array, |arr: &UInt8Array, i| int_to_ms(i64::from(arr.value(i)), time_format)),
+                        DataType::UInt16 =>
+                            max_ts = max_ts_macro!(UInt16Array, max_ts, array, |arr: &UInt16Array, i| int_to_ms(i64::from(arr.value(i)), time_format)),
+                        DataType::UInt32 =>
+                            max_ts = max_ts_macro!(UInt32Array, max_ts, array, |arr: &UInt32Array, i| int_to_ms(i64::from(arr.value(i)), time_format)),
+                        DataType::UInt64 =>
+                            max_ts = max_ts_macro!(UInt64Array, max_ts, array, |arr: &UInt64Array, i| uint64_to_ms(arr.value(i), time_format)),
+
+                        // Float
+                        DataType::Float16 =>
+                            max_ts = max_ts_macro!(Float16Array, max_ts, array, |arr: &Float16Array, i| float_to_ms(arr.value(i).to_f64(), time_format)),
+                        DataType::Float32 =>
+                            max_ts = max_ts_macro!(Float32Array, max_ts, array, |arr: &Float32Array, i| float_to_ms(f64::from(arr.value(i)), time_format)),
+                        DataType::Float64 =>
+                            max_ts = max_ts_macro!(Float64Array, max_ts, array, |arr: &Float64Array, i| float_to_ms(arr.value(i), time_format)),
+
+                        // Date32
+                        DataType::Date32 =>
+                            max_ts = max_ts_macro!(Date32Array, max_ts, array, |arr: &Date32Array, i| Some(i64::from(arr.value(i)) * MS_IN_A_DAY)),
+
+                        _ => {
+                            matched_supported_type = false;
+                        }
+                    }
+
+                    if matched_supported_type {
+                        if batch.num_rows() > 0 && max_ts.is_none() {
+                            tracing::warn!(
+                                "Failed to extract max_timestamp_after_refresh for {}: batch_size={}, time_column={:?}, field_type={:?}",
+                                source_name,
+                                batch.num_rows(),
+                                time_column,
+                                field.data_type(),
+                            );
+                        }
+                    } else {
+                        tracing::warn!(
+                            source_name,
+                            "Unsupported time column for {}: time_column={:?}, field_type={:?}",
+                            batch.num_rows(),
+                            time_column,
+                            field.data_type(),
+                        );
+                    }
+                }
+
+            yield batch_result;
+        }
+
+        // Make this update as fast as possible
+        *max_ts_clone.lock().await = max_ts;
+    };
+
+    let output_stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+        Arc::clone(&schema),
+        out_stream,
+    ));
+    let new_data_update = StreamingDataUpdate {
+        data: output_stream,
+        update_type: data_update.update_type,
+    };
+
+    (new_data_update, Some(max_ts))
+}
+
+fn ts_to_ms(ts: i64, time_format: TimeFormat, time_unit: TimeUnit) -> Option<i64> {
+    match time_format {
+        TimeFormat::Timestamp | TimeFormat::Timestamptz => match time_unit {
+            TimeUnit::Nanosecond => Some(ts / 1_000_000),
+            TimeUnit::Microsecond => Some(ts / 1_000),
+            TimeUnit::Millisecond => Some(ts),
+            TimeUnit::Second => Some(ts * 1000),
+        },
+        _ => None,
+    }
+}
+
+fn int_to_ms(ts: i64, time_format: TimeFormat) -> Option<i64> {
+    match time_format {
+        TimeFormat::UnixSeconds => Some(ts * 1000),
+        TimeFormat::UnixMillis => Some(ts),
+        _ => None,
+    }
+}
+
+#[allow(clippy::cast_possible_wrap)]
+fn uint64_to_ms(ts: u64, time_format: TimeFormat) -> Option<i64> {
+    if ts > i64::MAX as u64 {
+        None
+    } else {
+        int_to_ms(ts as i64, time_format)
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn float_to_ms(ts: f64, time_format: TimeFormat) -> Option<i64> {
+    match time_format {
+        TimeFormat::UnixSeconds => Some((ts * 1000.0) as i64),
+        TimeFormat::UnixMillis => Some(ts as i64),
+        _ => None,
+    }
+}
+
+fn string_to_ms(s: &str, time_format: TimeFormat) -> Option<i64> {
+    if time_format != TimeFormat::ISO8601 {
+        return None;
+    }
+
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.timestamp_millis())
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataupdate::UpdateType;
+    use arrow::array::*;
+    use arrow::record_batch::RecordBatch;
+    use arrow_schema::{Field, Schema};
+
+    async fn prepare_and_run(
+        batch: RecordBatch,
+        time_format: Option<TimeFormat>,
+    ) -> (StreamingDataUpdate, Option<Arc<Mutex<Option<i64>>>>) {
+        // Prepare
+        let schema = batch.schema();
+        let stream = futures::stream::iter(vec![Ok(batch)]);
+
+        let data_update = StreamingDataUpdate {
+            data: Box::pin(RecordBatchStreamAdapter::new(Arc::clone(&schema), stream)),
+            update_type: UpdateType::Append,
+        };
+
+        // Run
+        let (new_data_update, max_ts_arc_opt) = max_timestamp_in_stream(
+            data_update,
+            schema,
+            Some("ts".to_string()),
+            time_format,
+            "test_source".to_string(),
+        )
+        .await;
+        (new_data_update, max_ts_arc_opt)
+    }
+
+    async fn perform_test(batch: RecordBatch, time_format: Option<TimeFormat>) -> i64 {
+        let (new_data_update, max_ts_arc_opt) = prepare_and_run(batch, time_format).await;
+
+        // Consume stream and extract max_ts
+        let max_ts_arc = max_ts_arc_opt.expect("max_ts Arc should be returned");
+        let mut stream = new_data_update.data;
+
+        while let Some(_batch_result) = stream.next().await {}
+
+        {
+            let guard = max_ts_arc.lock().await;
+            guard.expect("max_ts should be set after consuming stream")
+        }
+    }
+
+    #[tokio::test]
+    async fn test_utf8_iso8601() {
+        let batch = record_batch!((
+            "ts",
+            Utf8,
+            [
+                Some("2010-01-01T00:00:00Z"),
+                None,
+                Some("2020-01-01T00:00:00Z")
+            ]
+        ))
+        .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::ISO8601)).await;
+
+        assert_eq!(max_ts, 1_577_836_800_000);
+    }
+
+    #[tokio::test]
+    async fn test_uint16_milli_seconds() {
+        let batch =
+            record_batch!(("ts", UInt16, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixMillis)).await;
+
+        assert_eq!(max_ts, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_uint32_milli_seconds() {
+        let batch =
+            record_batch!(("ts", UInt32, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixMillis)).await;
+
+        assert_eq!(max_ts, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_uint64_milli_seconds() {
+        let batch =
+            record_batch!(("ts", UInt64, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixMillis)).await;
+
+        assert_eq!(max_ts, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_uint16_seconds() {
+        let batch =
+            record_batch!(("ts", UInt16, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixSeconds)).await;
+
+        assert_eq!(max_ts, 2000 * 1000);
+    }
+
+    #[tokio::test]
+    async fn test_uint32_seconds() {
+        let batch =
+            record_batch!(("ts", UInt32, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixSeconds)).await;
+
+        assert_eq!(max_ts, 2000 * 1000);
+    }
+
+    #[tokio::test]
+    async fn test_uint64_seconds() {
+        let batch =
+            record_batch!(("ts", UInt64, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixSeconds)).await;
+
+        assert_eq!(max_ts, 2000 * 1000);
+    }
+
+    #[tokio::test]
+    async fn test_int16_milli_seconds() {
+        let batch =
+            record_batch!(("ts", Int16, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixMillis)).await;
+
+        assert_eq!(max_ts, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_int32_milli_seconds() {
+        let batch =
+            record_batch!(("ts", Int32, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixMillis)).await;
+
+        assert_eq!(max_ts, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_int64_milli_seconds() {
+        let batch =
+            record_batch!(("ts", Int64, [Some(1000), Some(2000), None])).expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixMillis)).await;
+
+        assert_eq!(max_ts, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_float32_unix_milli_seconds() {
+        let batch = record_batch!(("ts", Float32, [Some(1000.0), Some(2000.0), None]))
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixMillis)).await;
+
+        assert_eq!(max_ts, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_float64_unix_milli_seconds() {
+        let batch = record_batch!(("ts", Float64, [Some(1000.0), Some(2000.0), None]))
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixMillis)).await;
+
+        assert_eq!(max_ts, 2000);
+    }
+
+    #[tokio::test]
+    async fn test_float32_unix_seconds() {
+        let batch = record_batch!(("ts", Float32, [Some(1000.0), Some(2000.0), None]))
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixSeconds)).await;
+
+        assert_eq!(max_ts, 2000 * 1000);
+    }
+
+    #[tokio::test]
+    async fn test_float64_unix_seconds() {
+        let batch = record_batch!(("ts", Float64, [Some(1000.0), Some(2000.0), None]))
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::UnixSeconds)).await;
+        assert_eq!(max_ts, 2000 * 1000);
+    }
+
+    #[tokio::test]
+    async fn test_date32() {
+        let array = Date32Array::from(vec![Some(0), Some(18262), None]);
+
+        let schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Date32, true)]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Date)).await;
+        assert_eq!(max_ts, 18262 * 86_400_000);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_nanosecond() {
+        let array = TimestampNanosecondArray::from(vec![
+            Some(1_500_000_000_000_000_000),
+            None,
+            Some(1_600_000_000_000_000_000),
+        ]);
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Timestamp)).await;
+        assert_eq!(max_ts, 1_600_000_000_000_000_000 / 1_000_000);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_microsecond() {
+        let array = TimestampMicrosecondArray::from(vec![
+            Some(1_500_000_000_000_000),
+            None,
+            Some(1_600_000_000_000_000),
+        ]);
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Timestamp)).await;
+        assert_eq!(max_ts, 1_600_000_000_000_000 / 1_000);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_millisecond() {
+        let array = TimestampMillisecondArray::from(vec![
+            Some(1_500_000_000_000),
+            None,
+            Some(1_600_000_000_000),
+        ]);
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Timestamp)).await;
+        assert_eq!(max_ts, 1_600_000_000_000);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_second() {
+        let array =
+            TimestampSecondArray::from(vec![Some(1_500_000_000), None, Some(1_600_000_000)]);
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Second, None),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Timestamp)).await;
+        assert_eq!(max_ts, 1_600_000_000 * 1000);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_nanosecond_timezone() {
+        let tz = Arc::<str>::from("UTC");
+        let mut builder =
+            TimestampNanosecondBuilder::with_capacity(3).with_timezone(Arc::clone(&tz));
+        builder.append_value(1_500_000_000_000_000_000);
+        builder.append_null();
+        builder.append_value(1_600_000_000_000_000_000);
+        let array = builder.finish();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some(tz)),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Timestamp)).await;
+        assert_eq!(max_ts, 1_600_000_000_000_000_000 / 1_000_000);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_microsecond_timezone() {
+        let tz = Arc::<str>::from("America/New_York");
+        let mut builder =
+            TimestampMicrosecondBuilder::with_capacity(3).with_timezone(Arc::clone(&tz));
+        builder.append_value(1_500_000_000_000_000_000);
+        builder.append_null();
+        builder.append_value(1_600_000_000_000_000_000);
+        let array = builder.finish();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(tz)),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Timestamp)).await;
+        assert_eq!(max_ts, 1_600_000_000_000_000_000 / 1_000);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_millisecond_timezone() {
+        let tz = Arc::<str>::from("Asia/Tokyo");
+        let mut builder =
+            TimestampMillisecondBuilder::with_capacity(3).with_timezone(Arc::clone(&tz));
+        builder.append_value(1_500_000_000_000);
+        builder.append_null();
+        builder.append_value(1_600_000_000_000);
+        let array = builder.finish();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Millisecond, Some(tz)),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Timestamp)).await;
+        assert_eq!(max_ts, 1_600_000_000_000);
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_second_timezone() {
+        let tz = Arc::<str>::from("Europe/London");
+        let mut builder = TimestampSecondBuilder::with_capacity(3).with_timezone(Arc::clone(&tz));
+        builder.append_value(1_500_000_000);
+        builder.append_null();
+        builder.append_value(1_600_000_000);
+        let array = builder.finish();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Second, Some(tz)),
+            true,
+        )]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let max_ts = perform_test(batch, Some(TimeFormat::Timestamp)).await;
+        assert_eq!(max_ts, 1_600_000_000 * 1000);
+    }
+
+    #[tokio::test]
+    async fn test_missing_time_column() {
+        let batch = record_batch!(("other_column", UInt16, [Some(1000), Some(2000), None]))
+            .expect("created batch");
+
+        let (_, max_ts) = prepare_and_run(batch, Some(TimeFormat::UnixSeconds)).await;
+        assert!(max_ts.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_empty_batch() {
+        let array = UInt16Array::from(vec![] as Vec<u16>);
+
+        let schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::UInt16, true)]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let (new_data_update, max_ts_arc_opt) =
+            prepare_and_run(batch, Some(TimeFormat::UnixSeconds)).await;
+
+        let max_ts_arc = max_ts_arc_opt.expect("max_ts Arc should be returned");
+        let mut stream = new_data_update.data;
+
+        while let Some(_batch_result) = stream.next().await {}
+
+        let max_ts = {
+            let guard = max_ts_arc.lock().await;
+            *guard
+        };
+
+        assert!(max_ts.is_none());
+    }
+}

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -71,7 +71,6 @@ macro_rules! max_ts_macro {
 ///         - `Some(i64)`: The maximum timestamp found in the stream (in milliseconds)
 ///         - `None`: Attempted extraction but no valid timestamps found
 ///             - If batches were not empty, a warning is logged
-#[allow(clippy::too_many_lines)]
 pub async fn with_find_max_timestamp_in_stream(
     data_update: StreamingDataUpdate,
     schema: SchemaRef,
@@ -100,10 +99,8 @@ pub async fn with_find_max_timestamp_in_stream(
     let max_ts = Arc::new(Mutex::new(None::<i64>));
     let max_ts_clone = Arc::clone(&max_ts);
 
-    let update_type = data_update.update_type.clone();
-
     let out_stream = find_max_timestamp_in_stream_inner(
-        data_update,
+        data_update.data,
         time_column,
         time_format,
         field,
@@ -114,14 +111,14 @@ pub async fn with_find_max_timestamp_in_stream(
 
     let new_data_update = StreamingDataUpdate {
         data: out_stream,
-        update_type,
+        update_type: data_update.update_type,
     };
 
     (new_data_update, Some(max_ts))
 }
 
 fn find_max_timestamp_in_stream_inner(
-    data_update: StreamingDataUpdate,
+    mut input_stream: SendableRecordBatchStream,
     time_column: String,
     time_format: TimeFormat,
     field: Field,
@@ -130,7 +127,6 @@ fn find_max_timestamp_in_stream_inner(
     source_name: String,
 ) -> SendableRecordBatchStream {
     let output_stream = stream! {
-        let mut input_stream = data_update.data;
         let mut max_ts: Option<i64> = None;
 
         while let Some(batch_result) = input_stream.next().await {

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -170,8 +170,6 @@ pub async fn max_timestamp_in_stream(
                             );
                         }
                     }
-
-
                 }
 
             yield batch_result;

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -36,6 +36,25 @@ macro_rules! max_ts_macro {
     }};
 }
 
+/// Extracts the maximum timestamp from a stream of record batches.
+///
+/// The extraction uses `time_column` and `time_format` to interpret timestamps
+/// from various data types (timestamps, strings, integers, floats, dates).
+///
+/// # Parameters
+/// - `time_column`: Name of the column containing timestamp data
+/// - `time_format`: Format specification for interpreting the timestamp values
+/// - `source_name`: Used for logging warnings
+///
+/// # Returns
+/// - An updated data stream
+/// - An `Option<Arc<Mutex<Option<i64>>>>` with the following semantics:
+///     - `None`: Did not attempt to find a max timestamp (e.g., no `time_column`
+///       provided or column does not exist in schema)
+///     - `Some(Arc<Mutex<Option<i64>>>)`: Will be populated after the stream is consumed:
+///         - `Some(i64)`: The maximum timestamp found in the stream (in milliseconds)
+///         - `None`: Attempted extraction but no valid timestamps found
+///             - If batches were not empty, a warning is logged
 #[allow(clippy::too_many_lines)]
 pub async fn max_timestamp_in_stream(
     data_update: StreamingDataUpdate,
@@ -44,16 +63,21 @@ pub async fn max_timestamp_in_stream(
     time_format: Option<TimeFormat>,
     source_name: String,
 ) -> (StreamingDataUpdate, Option<Arc<Mutex<Option<i64>>>>) {
-    let Some(time_column_str) = time_column.as_ref() else {
+    let Some(time_column) = time_column else {
         return (data_update, None);
     };
 
     let time_format = time_format.unwrap_or_default();
     let Some(field) = schema
-        .column_with_name(time_column_str)
+        .column_with_name(&time_column)
         .map(|(_, f)| f)
         .cloned()
     else {
+        tracing::warn!(
+            "Failed to extract max_timestamp after refresh for {}: column {} not found in schema.",
+            source_name,
+            time_column,
+        );
         return (data_update, None);
     };
 
@@ -128,25 +152,26 @@ pub async fn max_timestamp_in_stream(
                         }
                     }
 
-                    if matched_supported_type {
-                        if batch.num_rows() > 0 && max_ts.is_none() {
+                    if batch.num_rows() > 0 && max_ts.is_none() {
+                        if matched_supported_type {
                             tracing::warn!(
-                                "Failed to extract max_timestamp_after_refresh for {}: batch_size={}, time_column={:?}, field_type={:?}",
+                                "Failed to extract max_timestamp after refresh for {}: batch_size={}, time_column={}, field_type={}",
                                 source_name,
                                 batch.num_rows(),
                                 time_column,
                                 field.data_type(),
                             );
+                        } else {
+                            tracing::warn!(
+                                "Failed to extract max_timestamp after refresh for {}: unsupported time column: time_column={}, field_type={}",
+                                source_name,
+                                time_column,
+                                field.data_type(),
+                            );
                         }
-                    } else {
-                        tracing::warn!(
-                            source_name,
-                            "Unsupported time column for {}: time_column={:?}, field_type={:?}",
-                            batch.num_rows(),
-                            time_column,
-                            field.data_type(),
-                        );
                     }
+
+
                 }
 
             yield batch_result;

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -663,6 +663,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_unsupported_time_column() {
+        let array = Date64Array::from(vec![Some(0), Some(18262), None]);
+
+        let schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Date64, true)]));
+
+        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(array) as ArrayRef])
+            .expect("created batch");
+
+        let (new_data_update, max_ts_arc_opt) =
+            prepare_and_run(batch, Some(TimeFormat::UnixSeconds)).await;
+
+        let max_ts_arc = max_ts_arc_opt.expect("max_ts Arc should be returned");
+        let mut stream = new_data_update.data;
+
+        while let Some(_batch_result) = stream.next().await {}
+
+        let max_ts = {
+            let guard = max_ts_arc.lock().await;
+            *guard
+        };
+
+        assert!(max_ts.is_none());
+    }
+
+    #[tokio::test]
     async fn test_empty_batch() {
         let array = UInt16Array::from(vec![] as Vec<u16>);
 

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -247,13 +247,11 @@ fn int_to_ms(ts: i64, time_format: TimeFormat) -> Option<i64> {
     }
 }
 
-#[allow(clippy::cast_possible_wrap)]
 fn uint64_to_ms(ts: u64, time_format: TimeFormat) -> Option<i64> {
-    if ts > i64::MAX as u64 {
-        None
-    } else {
-        int_to_ms(ts as i64, time_format)
-    }
+    i64::try_from(ts)
+        .map(|v| int_to_ms(v, time_format))
+        .ok()
+        .flatten()
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -1,3 +1,19 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 use crate::component::dataset::TimeFormat;
 use crate::dataupdate::StreamingDataUpdate;
 use arrow::array::{
@@ -7,7 +23,7 @@ use arrow::array::{
     UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::TimeUnit;
-use arrow_schema::{DataType, SchemaRef};
+use arrow_schema::{DataType, Field, SchemaRef};
 use async_stream::stream;
 use chrono::DateTime;
 use datafusion::execution::SendableRecordBatchStream;
@@ -56,7 +72,7 @@ macro_rules! max_ts_macro {
 ///         - `None`: Attempted extraction but no valid timestamps found
 ///             - If batches were not empty, a warning is logged
 #[allow(clippy::too_many_lines)]
-pub async fn max_timestamp_in_stream(
+pub async fn with_find_max_timestamp_in_stream(
     data_update: StreamingDataUpdate,
     schema: SchemaRef,
     time_column: Option<String>,
@@ -84,7 +100,36 @@ pub async fn max_timestamp_in_stream(
     let max_ts = Arc::new(Mutex::new(None::<i64>));
     let max_ts_clone = Arc::clone(&max_ts);
 
-    let out_stream = stream! {
+    let update_type = data_update.update_type.clone();
+
+    let out_stream = find_max_timestamp_in_stream_inner(
+        data_update,
+        time_column,
+        time_format,
+        field,
+        max_ts_clone,
+        Arc::clone(&schema),
+        source_name,
+    );
+
+    let new_data_update = StreamingDataUpdate {
+        data: out_stream,
+        update_type,
+    };
+
+    (new_data_update, Some(max_ts))
+}
+
+fn find_max_timestamp_in_stream_inner(
+    data_update: StreamingDataUpdate,
+    time_column: String,
+    time_format: TimeFormat,
+    field: Field,
+    max_ts_clone: Arc<Mutex<Option<i64>>>,
+    schema: SchemaRef,
+    source_name: String,
+) -> SendableRecordBatchStream {
+    let output_stream = stream! {
         let mut input_stream = data_update.data;
         let mut max_ts: Option<i64> = None;
 
@@ -179,16 +224,7 @@ pub async fn max_timestamp_in_stream(
         *max_ts_clone.lock().await = max_ts;
     };
 
-    let output_stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
-        Arc::clone(&schema),
-        out_stream,
-    ));
-    let new_data_update = StreamingDataUpdate {
-        data: output_stream,
-        update_type: data_update.update_type,
-    };
-
-    (new_data_update, Some(max_ts))
+    Box::pin(RecordBatchStreamAdapter::new(schema, output_stream))
 }
 
 fn ts_to_ms(ts: i64, time_format: TimeFormat, time_unit: TimeUnit) -> Option<i64> {
@@ -261,7 +297,7 @@ mod tests {
         };
 
         // Run
-        let (new_data_update, max_ts_arc_opt) = max_timestamp_in_stream(
+        let (new_data_update, max_ts_arc_opt) = with_find_max_timestamp_in_stream(
             data_update,
             schema,
             Some("ts".to_string()),

--- a/crates/runtime/src/timing.rs
+++ b/crates/runtime/src/timing.rs
@@ -55,15 +55,15 @@ impl Drop for TimeMeasurement {
 
 /// Measures the time in milliseconds it takes to execute a block of code and records it in a histogram metric
 /// with multiple independent sets of labels.
-pub struct MultiTimeMeasurement {
+pub struct MultiTimeMeasurement<'a> {
     start: Instant,
     metric: &'static Histogram<f64>,
-    label_sets: Vec<Vec<KeyValue>>,
+    label_sets: &'a Vec<Vec<KeyValue>>,
 }
 
-impl MultiTimeMeasurement {
+impl<'a> MultiTimeMeasurement<'a> {
     #[must_use]
-    pub fn new(metric: &'static Histogram<f64>, label_sets: Vec<Vec<KeyValue>>) -> Self {
+    pub fn new(metric: &'static Histogram<f64>, label_sets: &'a Vec<Vec<KeyValue>>) -> Self {
         Self {
             start: Instant::now(),
             metric,
@@ -72,10 +72,10 @@ impl MultiTimeMeasurement {
     }
 }
 
-impl Drop for MultiTimeMeasurement {
+impl Drop for MultiTimeMeasurement<'_> {
     fn drop(&mut self) {
         let elapsed = 1000_f64 * self.start.elapsed().as_secs_f64();
-        for label_set in &self.label_sets {
+        for label_set in self.label_sets {
             self.metric.record(elapsed, label_set);
         }
     }


### PR DESCRIPTION
## 📝 Summary

Expose Prometheus metrics that report:

- The maximum data timestamp present in the source Iceberg table
- The maximum data timestamp known to the Spice acceleration
- Computed refresh lag (after-before)
- Computed ingestion lag (now() - after)

Pseudo-code for `RefreshTask::run_once()`:
```python
# at the beginning of refresh (new)
max_timestamp_before_refresh_ms <- null
if time_column is defined:
    max_timestamp_before_refresh_ms <- timestamp_nanos_for_append_query()

# this is already implemented, no changes here
refresh_dataset_stream <- get_refresh_dataset_stream()

# new logic
refresh_dataset_stream, max_timestamp <- max_timestamp_in_stream(refresh_dataset_stream)

# this is already implemented, no changes here
update_acceleration(refresh_dataset)

# after refresh is done (new)
if time_column is defined:
    current_time_ms <- now()
    max_timestamp_after_refresh_ms <- *max_timestamp
    refresh_lag_ms = max_timestamp_after_refresh_ms - max_timestamp_before_refresh_ms
    ingestion_lag_ms = current_time_ms - max_timestamp_after_refresh_ms

    emit("before_refresh", max_timestamp_before_refresh_ms)
    emit("after_refresh", max_timestamp_after_refresh_ms)
    emit("refresh_lag", refresh_lag_ms)
    emit("ingestion_lag", ingestion_lag_ms)
```

## 🔗 Related
Closes https://github.com/spiceai/spiceai/issues/7184

## 📚 Docs
Should be added to https://github.com/spiceai/docs/blob/trunk/website/docs/features/observability/index.md
| Metric                                                         | Description                                                                                                            |
|---------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
| dataset_acceleration_max_timestamp_before_refresh_ms <br> (gauge)        | Maximum value of the dataset's time_column before the refresh operation, in milliseconds.                              |
| dataset_acceleration_max_timestamp_after_refresh_ms  <br> (gauge)         | Maximum value of the dataset's time_column after the refresh operation, in milliseconds.                               |
| dataset_acceleration_refresh_lag_ms  <br> (gauge)                        | Difference between the maximum time_column value after and before the refresh operation, in milliseconds.              |
| dataset_acceleration_ingestion_lag_ms  <br> (gauge)                      | Lag between the current wall-clock time and the maximum time_column value after the refresh operation, in milliseconds.|

## 👀 Notes for Reviewers

Since this code is for metrics, it is written in a way that it never returns an error and should never panic. 

In following cases a warning will be logged:
* `time_column` is defined, failed to find max timestamp before refresh
* `time_column` is defined, but no such column exists in schema (unlikely to happen since it should have been validated at this point)
* time column is found, acceleration refresh batch is non empty, time column is supported, but failed to find maximum ts
* time column is found, acceleration refresh batch is non empty, time column is not supported

Additionally, there are certain cases of of casting i128 to i64 timestamps in ms, but since timestamp values have known safe range, it is safe to do so. So these cases are marked with `#[allow(clippy::cast_possible_truncation)]`