### PR TITLE
For `vector_search`, use a default limit of 1000 if no limit specified

### DIFF
--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -459,7 +459,7 @@ impl VectorSearchUDTFProvider {
     fn limit_to_use(&self, limit: Option<usize>) -> Option<usize> {
         match (self.args.limit, limit) {
             (Some(l), None) | (None, Some(l)) => Some(l),
-            (None, None) => None,
+            (None, None) => Some(1000), // Default limit when none specified
 
             // Equivalent to using always using pre_limit, unless `limit` < `pre_limit`.
             (Some(a), Some(b)) => Some(min(a, b)),

--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -456,13 +456,13 @@ impl VectorSearchUDTFProvider {
     /// Determine whether and how to pick between
     ///   1. The query-provided limit (i.e. passed through in the SQL/Logical plan)
     ///   2. The limit provided in `vector_search` args
-    fn limit_to_use(&self, limit: Option<usize>) -> Option<usize> {
+    fn limit_to_use(&self, limit: Option<usize>) -> usize {
         match (self.args.limit, limit) {
-            (Some(l), None) | (None, Some(l)) => Some(l),
-            (None, None) => Some(1000), // Default limit when none specified
+            (Some(l), None) | (None, Some(l)) => l,
+            (None, None) => 1000, // Default limit when none specified
 
             // Equivalent to using always using pre_limit, unless `limit` < `pre_limit`.
-            (Some(a), Some(b)) => Some(min(a, b)),
+            (Some(a), Some(b)) => min(a, b),
         }
     }
 }
@@ -581,7 +581,7 @@ impl TableProvider for VectorSearchUDTFProvider {
                 false,
             )],
             input: Arc::new(proj),
-            fetch: self.limit_to_use(limit),
+            fetch: Some(self.limit_to_use(limit)),
         });
 
         // wrap the score calculation in a subquery before final projection, to avoid collapsing away the score calculation.


### PR DESCRIPTION
This pull request updates the logic for determining the row limit in vector search operations and ensures consistent handling of limit values. The main changes are focused on improving default behavior and type consistency for the limit parameter.

Limit handling improvements:

* The `limit_to_use` method in `VectorSearchUDTFProvider` now always returns a `usize` instead of an `Option<usize>`, and provides a default value of `1000` when no limit is specified. This ensures a sensible default and simplifies downstream usage.
* The `fetch` field assignment in the `TableProvider` implementation is updated to wrap the result of `limit_to_use` in `Some`, matching the expected type and preventing possible errors.