### PR TITLE
Fix Anthropic model regex and add validation tests

### DIFF
--- a/crates/llms/src/anthropic/types.rs
+++ b/crates/llms/src/anthropic/types.rs
@@ -297,15 +297,17 @@ pub struct MetadataParam {
 }
 
 // Combined pattern that matches all three formats:
-// 1. Anthropic API: claude-3-5-sonnet-20241022 or claude-3-5-sonnet-latest
+// 1. Anthropic API: claude-3-5-sonnet-20241022, claude-3-5-sonnet-latest or claude-opus-4-1
 // 2. AWS Bedrock: anthropic.claude-3-5-sonnet-20241022-v2:0
 // 3. GCP Vertex AI: claude-3-5-sonnet-v2@20241022
+// Based on available models from https://docs.claude.com/en/docs/about-claude/models/overview, as of 2025-09-28.
 pub(crate) static ANTHROPIC_REGEX: &str = r"(?x) # Enable verbose mode
     (?:anthropic\.)?                              # Optional 'anthropic.' prefix for AWS
     claude-                                       # Required 'claude-' prefix
     (?:instant-)?                                 # Optional 'instant-' for legacy
-    (?:\d+(?:\.\d+)?)-?                           # Version number (e.g., 3 or 3.5)
+    (?:\d+(?:[-.]\d+)*-)?                         # Optional leading version segment (e.g. 3-, 3-5-, 3.5-)
     (?:opus|sonnet|haiku)?                        # Optional model type
+    (?:-\d+(?:[-.]\d+)*)?                         # Optional trailing version segment (e.g. -4, -4-1)
     (?:
         -(?:latest|\d{8})                         # Anthropic format: -latest or -YYYYMMDD
         |
@@ -373,4 +375,55 @@ pub struct Usage {
     pub input_tokens: u32,
     #[serde(default)]
     pub output_tokens: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_model_variant;
+
+    // Current Anthropic model names to validate.
+    // Based on the models list from https://docs.claude.com/en/docs/about-claude/models/overview, as of 2025-09-28.
+    const VALID_MODELS: &[&str] = &[
+        "claude-opus-4-1",
+        "claude-opus-4-1-latest",
+        "claude-opus-4-1-20250805",
+        "claude-opus-4-20250514",
+        "claude-opus-4-0",
+        "claude-sonnet-4-0",
+        "claude-3-7-sonnet-latest",
+        "claude-3-5-haiku-latest",
+        "claude-sonnet-4-20250514",
+        "claude-3-7-sonnet-20250219",
+        "claude-3-5-haiku-20241022",
+        "anthropic.claude-opus-4-1-20250805-v1:0",
+        "anthropic.claude-opus-4-20250514-v1:0",
+        "anthropic.claude-sonnet-4-20250514-v1:0",
+        "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "anthropic.claude-3-5-haiku-20241022-v1:0",
+        "anthropic.claude-3-haiku-20240307-v1:0",
+        "claude-opus-4-1@20250805",
+        "claude-opus-4@20250514",
+        "claude-sonnet-4@20250514",
+        "claude-3-7-sonnet@20250219",
+        "claude-3-5-haiku@20241022",
+        "claude-3-haiku@20240307",
+    ];
+
+    #[test]
+    fn validates_known_models() {
+        for m in VALID_MODELS {
+            let res = validate_model_variant(m);
+            assert!(res.is_ok(), "model {m} should be valid: {:?}", res.err());
+        }
+    }
+
+    const INVALID_MODELS: &[&str] = &["anthropic.claude", "gpt-4o"];
+
+    #[test]
+    fn invalid_models_rejected() {
+        for m in INVALID_MODELS {
+            let res = validate_model_variant(m);
+            assert!(res.is_err(), "model {m} should be invalid");
+        }
+    }
 }


### PR DESCRIPTION
## 📝 Summary

Add support for new model formats (e.g. claude-opus-4-1) and comprehensive tests for known valid and invalid model names.

**Before**:

v4 anthropic models were failing to load:

<details><summary>[Details](spicepod.yaml)</summary>
<p>

```yaml
version: v1
kind: Spicepod
name: anthopic

models:
  - from: anthropic:claude-opus-4-1
    name: claude-opus-4-1
    params:
      tools: auto
      anthropic_api_key: ${secrets:ANTHROPIC_API_KEY}

  - from: anthropic:claude-opus-4-0
    name: claude-opus-4-0
    params:
      tools: auto
      anthropic_api_key: ${secrets:ANTHROPIC_API_KEY}

  - from: anthropic:claude-sonnet-4-0
    name: claude-sonnet-4-0
    params:
      tools: auto
      anthropic_api_key: ${secrets:ANTHROPIC_API_KEY}

  - from: anthropic:claude-3-7-sonnet-latest
    name: claude-3-7-sonnet-latest
    params:
      tools: auto
      anthropic_api_key: ${secrets:ANTHROPIC_API_KEY}

  - from: anthropic:claude-3-5-haiku-latest
    name: claude-3-5-haiku-latest
    params:
      tools: auto
      anthropic_api_key: ${secrets:ANTHROPIC_API_KEY}
```

</p>
</details> 

```console
➜ spice run
Spice.ai OSS CLI v1.8.0-unstable-build.f29ad7318
2025/09/28 21:35:11 INFO Checking for latest Spice runtime release...
2025/09/28 21:35:11 INFO Spice.ai runtime starting...
2025-09-28T12:35:11.486306Z  INFO spiced: Starting runtime v1.8.0-unstable-build.f29ad7318+models
2025-09-28T12:35:11.486779Z  INFO runtime::init::caching: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
2025-09-28T12:35:11.486813Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s
2025-09-28T12:35:11.486829Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s
2025-09-28T12:35:12.659195Z  INFO runtime::init::model: Loading model [claude-opus-4-1] from anthropic:claude-opus-4-1...
2025-09-28T12:35:12.661253Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
2025-09-28T12:35:12.661314Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
2025-09-28T12:35:12.661738Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
2025-09-28T12:35:12.662425Z  WARN runtime::init::model: Failed to load LLM: claude-opus-4-1. Failed to load the model. An error occurred: Unknown anthropic model: Some("claude-opus-4-1") Report a bug on GitHub: https://github.com/spiceai/spiceai/issues
2025-09-28T12:35:12.662452Z  INFO runtime::init::model: Loading model [claude-opus-4-0] from anthropic:claude-opus-4-0...
2025-09-28T12:35:12.663394Z  WARN runtime::init::model: Failed to load LLM: claude-opus-4-0. Failed to load the model. An error occurred: Unknown anthropic model: Some("claude-opus-4-0") Report a bug on GitHub: https://github.com/spiceai/spiceai/issues
2025-09-28T12:35:12.663405Z  INFO runtime::init::model: Loading model [claude-sonnet-4-0] from anthropic:claude-sonnet-4-0...
2025-09-28T12:35:12.664751Z  WARN runtime::init::model: Failed to load LLM: claude-sonnet-4-0. Failed to load the model. An error occurred: Unknown anthropic model: Some("claude-sonnet-4-0") Report a bug on GitHub: https://github.com/spiceai/spiceai/issues
2025-09-28T12:35:12.664767Z  INFO runtime::init::model: Loading model [claude-3-7-sonnet-latest] from anthropic:claude-3-7-sonnet-latest...
2025-09-28T12:35:15.061433Z  INFO runtime::init::model: Model [claude-3-7-sonnet-latest] deployed, ready for inferencing
2025-09-28T12:35:15.061655Z  INFO runtime::init::model: Loading model [claude-3-5-haiku-latest] from anthropic:claude-3-5-haiku-latest...
2025-09-28T12:35:16.074829Z  INFO runtime::init::model: Model [claude-3-5-haiku-latest] deployed, ready for inferencing
^C2025-09-28T12:35:16.736885Z  INFO runtime: Shutdown initiated; waiting up to 30s for connections to drain
2025-09-28T12:35:16.737995Z  INFO spiced: Goodbye!
```

**After**:

```console
➜ spice run
Spice.ai OSS CLI v1.8.0-unstable-build.f29ad7318
2025/09/28 21:53:50 INFO Checking for latest Spice runtime release...
2025/09/28 21:53:52 INFO Spice.ai runtime starting...
2025-09-28T12:53:52.656191Z  INFO spiced: Starting runtime v1.8.0-unstable-build.f29ad7318+models
2025-09-28T12:53:52.659929Z  INFO runtime::init::caching: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
2025-09-28T12:53:52.660099Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s
2025-09-28T12:53:52.660132Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s
2025-09-28T12:53:53.954018Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
2025-09-28T12:53:53.955001Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
2025-09-28T12:53:53.959354Z  INFO runtime::init::model: Loading model [claude-opus-4-1] from anthropic:claude-opus-4-1...
2025-09-28T12:53:53.962337Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
2025-09-28T12:53:55.861944Z  INFO runtime::init::model: Model [claude-opus-4-1] deployed, ready for inferencing
2025-09-28T12:53:55.862106Z  INFO runtime::init::model: Loading model [claude-opus-4-0] from anthropic:claude-opus-4-0...
2025-09-28T12:53:57.600244Z  INFO runtime::init::model: Model [claude-opus-4-0] deployed, ready for inferencing
2025-09-28T12:53:57.600344Z  INFO runtime::init::model: Loading model [claude-sonnet-4-0] from anthropic:claude-sonnet-4-0...
2025-09-28T12:53:59.236447Z  INFO runtime::init::model: Model [claude-sonnet-4-0] deployed, ready for inferencing
2025-09-28T12:53:59.236595Z  INFO runtime::init::model: Loading model [claude-3-7-sonnet-latest] from anthropic:claude-3-7-sonnet-latest...
2025-09-28T12:54:01.475127Z  INFO runtime::init::model: Model [claude-3-7-sonnet-latest] deployed, ready for inferencing
2025-09-28T12:54:01.475271Z  INFO runtime::init::model: Loading model [claude-3-5-haiku-latest] from anthropic:claude-3-5-haiku-latest...
2025-09-28T12:54:02.621043Z  INFO runtime::init::model: Model [claude-3-5-haiku-latest] deployed, ready for inferencing
2025-09-28T12:54:02.722824Z  INFO runtime: No datasets or catalogs were configured. If this is unexpected, check the Spicepod configuration.
2025-09-28T12:54:02.722905Z  INFO runtime: All components are loaded. Spice runtime is ready!
```

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
