### PR TITLE
Enable DML (INSERT INTO) operations for catalogs configured as `access:read_write`

### DIFF
--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -21,7 +21,7 @@ use spicepod::{component::catalog as spicepod_catalog, param::Params};
 use std::{collections::HashMap, sync::Arc};
 
 use super::{find_first_delimiter, validate_identifier};
-use crate::Runtime;
+use crate::{Runtime, component::dataset::AccessMode};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -42,6 +42,7 @@ pub struct Catalog {
     pub catalog_id: Option<String>,
     pub from: String,
     pub name: String,
+    pub access: AccessMode,
     pub(crate) orig_include: Vec<String>,
     pub include: Option<GlobSet>,
     pub params: HashMap<String, String>,
@@ -57,6 +58,7 @@ impl std::fmt::Debug for Catalog {
             .field("catalog_id", &self.catalog_id)
             .field("from", &self.from)
             .field("name", &self.name)
+            .field("access", &self.access)
             .field("orig_include", &self.orig_include)
             .field("include", &self.include)
             .field("params", &self.params)
@@ -70,6 +72,7 @@ impl PartialEq for Catalog {
     fn eq(&self, other: &Self) -> bool {
         self.from == other.from
             && self.name == other.name
+            && self.access == other.access
             && self.orig_include == other.orig_include
             && self.params == other.params
             && self.dataset_params == other.dataset_params
@@ -148,6 +151,7 @@ pub struct CatalogBuilder {
     pub catalog_id: Option<String>,
     pub from: String,
     pub name: String,
+    pub access: AccessMode,
     orig_include: Vec<String>,
     pub include: Option<GlobSet>,
     pub params: HashMap<String, String>,
@@ -187,6 +191,7 @@ impl TryFrom<spicepod_catalog::Catalog> for CatalogBuilder {
             catalog_id,
             from: catalog.from.clone(),
             name: catalog.name,
+            access: AccessMode::from(catalog.access),
             orig_include: catalog.include.clone(),
             include: globset_opt,
             params: catalog
@@ -218,6 +223,7 @@ impl CatalogBuilder {
             catalog_id,
             from,
             name: name.to_string(),
+            access: AccessMode::default(),
             orig_include: Vec::default(),
             include: None,
             params: HashMap::default(),
@@ -254,6 +260,7 @@ impl CatalogBuilder {
             catalog_id: self.catalog_id,
             from: self.from,
             name: self.name,
+            access: self.access,
             orig_include: self.orig_include,
             include: self.include,
             params: self.params,

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -231,6 +231,7 @@ impl DataFusionBuilder {
             runtime_status: self.status,
             ctx: Arc::new(ctx),
             data_writers: RwLock::new(HashSet::new()),
+            writable_catalogs: RwLock::new(HashSet::new()),
             caching,
             pending_sink_tables: TokioRwLock::new(Vec::new()),
             deferred_tables: TokioRwLock::new(HashMap::new()),

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -225,6 +225,9 @@ pub enum Error {
     #[snafu(display("Unable to get the lock of data writers"))]
     UnableToLockDataWriters {},
 
+    #[snafu(display("Unable to acquire lock for writable catalogs"))]
+    UnableToLockWritableCatalogs {},
+
     #[snafu(display(
         "The schema returned by the data connector for 'refresh_mode: changes' does not contain a data field"
     ))]
@@ -302,6 +305,7 @@ pub struct DataFusion {
     pub ctx: Arc<SessionContext>,
     runtime_status: Arc<status::RuntimeStatus>,
     data_writers: RwLock<HashSet<TableReference>>,
+    writable_catalogs: RwLock<HashSet<String>>,
     accelerated_tables: TokioRwLock<HashSet<TableReference>>,
     caching: Arc<Caching>,
     pending_sink_tables: TokioRwLock<Vec<PendingSinkRegistration>>,
@@ -319,6 +323,7 @@ impl std::fmt::Debug for DataFusion {
         f.debug_struct("DataFusion")
             .field("runtime_status", &self.runtime_status)
             .field("data_writers", &self.data_writers)
+            .field("writable_catalogs", &self.writable_catalogs)
             .field("accelerated_tables", &self.accelerated_tables)
             .field("caching", &self.caching)
             .finish_non_exhaustive()
@@ -418,6 +423,7 @@ impl DataFusion {
     pub async fn register_catalog(
         &self,
         name: &str,
+        access: &AccessMode,
         catalog: Arc<dyn CatalogProvider>,
     ) -> Result<()> {
         if let Some(deferred_catalog) = catalog.as_any().downcast_ref::<DeferredCatalogProvider>() {
@@ -427,6 +433,10 @@ impl DataFusion {
                 .insert(name.to_string(), Arc::new(deferred_catalog.clone()));
         } else {
             self.ctx.register_catalog(name, catalog);
+
+            if matches!(access, AccessMode::ReadWrite) {
+                self.mark_catalog_writable(name)?;
+            }
         }
 
         Ok(())
@@ -526,6 +536,23 @@ impl DataFusion {
     }
 
     #[must_use]
+    pub fn is_catalog_writable(&self, catalog_name: &str) -> bool {
+        if let Ok(writable_catalogs) = self.writable_catalogs.read() {
+            writable_catalogs.contains(catalog_name)
+        } else {
+            false
+        }
+    }
+
+    pub fn mark_catalog_writable(&self, catalog_name: &str) -> Result<()> {
+        self.writable_catalogs
+            .write()
+            .map_err(|_| Error::UnableToLockWritableCatalogs {})?
+            .insert(catalog_name.to_string());
+        Ok(())
+    }
+
+    #[must_use]
     pub async fn is_accelerated(&self, table_reference: &TableReference) -> bool {
         self.accelerated_tables
             .read()
@@ -596,11 +623,14 @@ impl DataFusion {
         Ok(())
     }
 
-    pub async fn load_deferred_catalog(&self, name: &str) -> Result<()> {
+    pub async fn load_deferred_catalog(&self, name: &str, access: &AccessMode) -> Result<()> {
         let deferred_catalogs = self.deferred_catalogs.read().await;
         if let Some(catalog) = deferred_catalogs.get(name) {
             if let Ok(provider) = catalog.get_catalog_provider().await {
                 self.ctx.register_catalog(name, Arc::clone(&provider));
+                if matches!(access, AccessMode::ReadWrite) {
+                    self.mark_catalog_writable(name)?;
+                }
             }
 
             drop(deferred_catalogs);

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -55,6 +55,17 @@ pub fn validate_sql_query_operations(
                     );
                 }
 
+                // Check if attempting to write into a catalog. The default catalog name indicates writing to a table registered as a dataset, not via a catalog.
+                if let Some(catalog) = dml.table_name.catalog() && catalog != super::SPICE_DEFAULT_CATALOG {
+                    if !df.is_catalog_writable(catalog) {
+                        return plan_err!(
+                            "INSERT operations are not allowed on read-only catalog table '{}'. Verify the catalog is configured with 'access: read_write' and try again.",
+                            dml.table_name
+                        );
+                    }
+                    return Ok(TreeNodeRecursion::Continue);
+                }
+
                 if df.is_writable(&dml.table_name) {
                     Ok(TreeNodeRecursion::Continue)
                 } else {
@@ -80,14 +91,16 @@ pub fn validate_sql_query_operations(
 mod tests {
     use crate::{
         dataaccelerator::AcceleratorEngineRegistry,
-        datafusion::{SPICE_RUNTIME_SCHEMA, builder::DataFusionBuilder},
+        datafusion::{
+            SPICE_RUNTIME_SCHEMA, builder::DataFusionBuilder, schema::SpiceSchemaProvider,
+        },
         status::RuntimeStatus,
     };
 
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema};
     use data_components::arrow::write::MemTable;
-    use datafusion::sql::TableReference;
+    use datafusion::{catalog::MemoryCatalogProvider, sql::TableReference};
     use std::sync::Arc;
 
     fn create_test_schema() -> Arc<Schema> {
@@ -132,13 +145,56 @@ mod tests {
 
         let internal_table = TableReference::partial(SPICE_RUNTIME_SCHEMA, "spice_table");
         df.ctx
-            .register_table(internal_table.clone(), mem_table)
+            .register_table(
+                internal_table.clone(),
+                Arc::<data_components::arrow::write::MemTable>::clone(&mem_table),
+            )
             .expect("table should be registered");
 
         df.data_writers
             .write()
             .expect("data writers should be acquired")
             .insert(internal_table);
+
+        df.ctx.register_catalog(
+            "readonly_catalog".to_string(),
+            Arc::new(MemoryCatalogProvider::new()),
+        );
+
+        df.ctx
+            .catalog("readonly_catalog")
+            .expect("catalog should be found")
+            .register_schema("public", Arc::new(SpiceSchemaProvider::new()))
+            .expect("schema should be registered");
+
+        df.ctx
+            .register_table(
+                TableReference::full("readonly_catalog", "public", "test_table"),
+                Arc::<data_components::arrow::write::MemTable>::clone(&mem_table),
+            )
+            .expect("table should be registered");
+
+        df.ctx.register_catalog(
+            "writable_catalog".to_string(),
+            Arc::new(MemoryCatalogProvider::new()),
+        );
+
+        df.ctx
+            .catalog("writable_catalog")
+            .expect("catalog should be found")
+            .register_schema("public", Arc::new(SpiceSchemaProvider::new()))
+            .expect("schema should be registered");
+
+        df.ctx
+            .register_table(
+                TableReference::full("writable_catalog", "public", "test_table"),
+                mem_table,
+            )
+            .expect("table should be registered");
+
+        // Mark writable_catalog as writable
+        df.mark_catalog_writable("writable_catalog")
+            .expect("catalog should be marked as writable");
 
         df
     }
@@ -178,6 +234,27 @@ mod tests {
             "INSERT should be allowed on writable dataset"
         );
     }
+
+    #[tokio::test]
+    async fn test_validate_insert_on_writable_dataset_full_reference() {
+        let df = create_test_datafusion();
+
+        let sql = "INSERT INTO spice.public.tbl_writable VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        // INSERT should be allowed on writable dataset
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_ok(),
+            "INSERT should be allowed on writable dataset with full reference"
+        );
+    }
+
     #[tokio::test]
     async fn test_validate_insert_on_readonly_dataset_blocked() {
         let df = create_test_datafusion();
@@ -341,5 +418,82 @@ mod tests {
 
         let result = validate_sql_query_operations(&plan, &df);
         assert!(result.is_ok(), "Read-only subqueries should be allowed");
+    }
+
+    #[tokio::test]
+    async fn test_validate_insert_on_writable_catalog() {
+        let df = create_test_datafusion();
+
+        let sql = "INSERT INTO writable_catalog.public.test_table VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_ok(),
+            "INSERT should be allowed on writable catalog table"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_insert_on_readonly_catalog_blocked() {
+        let df = create_test_datafusion();
+
+        let sql = "INSERT INTO readonly_catalog.public.test_table VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "INSERT should fail on read-only catalog");
+    }
+
+    #[tokio::test]
+    async fn test_validate_default_catalog_table_uses_dataset_rules() {
+        let df = create_test_datafusion();
+
+        // Default catalog should follow dataset writable rules, not catalog rules
+        let sql = "INSERT INTO spice.public.tbl_writable VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_ok(),
+            "INSERT should be allowed on writable dataset in default catalog"
+        );
+
+        // Test read-only dataset in default catalog
+        let sql = "INSERT INTO spice.public.tbl_read_only VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(
+            result.is_err(),
+            "INSERT should fail on read-only dataset in default catalog"
+        );
+
+        if let Err(e) = result {
+            assert!(
+                e.to_string()
+                    .contains("INSERT operations are not allowed on read-only dataset")
+            );
+        }
     }
 }

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -181,7 +181,7 @@ impl Runtime {
             });
 
         self.df
-            .register_catalog(&catalog.name, catalog_provider)
+            .register_catalog(&catalog.name, &catalog.access, catalog_provider)
             .await
             .boxed()
             .context(UnableToLoadCatalogConnectorSnafu {

--- a/crates/runtime/src/request/databricks.rs
+++ b/crates/runtime/src/request/databricks.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::datafusion::DataFusion;
+use crate::{component::dataset::AccessMode, datafusion::DataFusion};
 
 const SPICE_DATABRICKS_HEADER: &str = "spice-databricks-auth";
 
@@ -147,8 +147,9 @@ impl DatabricksAuthExtension {
             let catalog_futures = databricks_u2m_catalogs.into_iter().map(|catalog| {
                 let df = Arc::clone(&df);
                 let name = catalog.name.clone();
+                let access = AccessMode::from(catalog.access);
                 Box::pin(async move {
-                    if let Err(err) = df.load_deferred_catalog(name.as_str()).await {
+                    if let Err(err) = df.load_deferred_catalog(name.as_str(), &access).await {
                         tracing::warn!("Failed to load catalog {}: {}", name, err);
                     }
                 }) as Pin<Box<dyn Future<Output = ()> + Send>>

--- a/crates/spicepod/src/component/catalog.rs
+++ b/crates/spicepod/src/component/catalog.rs
@@ -21,7 +21,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::WithDependsOn;
+use super::{WithDependsOn, dataset::AccessMode, is_default};
 use crate::{metric::Metrics, param::Params};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -36,6 +36,9 @@ pub struct Catalog {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
     pub metadata: HashMap<String, Value>,
+
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub access: AccessMode,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub include: Vec<String>,
@@ -62,6 +65,7 @@ impl Catalog {
             name,
             description: None,
             metadata: HashMap::default(),
+            access: AccessMode::default(),
             include: Vec::default(),
             params: None,
             dataset_params: None,
@@ -78,6 +82,7 @@ impl WithDependsOn<Catalog> for Catalog {
             name: self.name.clone(),
             description: self.description.clone(),
             metadata: self.metadata.clone(),
+            access: self.access.clone(),
             include: self.include.clone(),
             params: self.params.clone(),
             dataset_params: self.dataset_params.clone(),


### PR DESCRIPTION
## 📝 Summary

PR adds support for `access` mode for catalogs (previously supported for Datasets only) and enables `INSERT INTO` SQL for catalogs  configured with `access: read_write` mode. The mode must be supported by underlying TableProvider.

## 🔗 Related

Part of https://github.com/spiceai/spiceai/issues/7149

Implements
- https://github.com/spiceai/spiceai/issues/7321

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
