### PR TITLE
Handle async queries for Databricks SQL Warehouse API

### DIFF
--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -493,7 +493,7 @@ impl SqlWarehouseApi {
             ResponseStatus::Running => Err(Error::QueryStillRunning),
             ResponseStatus::Canceled => Err(Error::QueryCanceled),
             ResponseStatus::Closed => Err(Error::QueryFailure {
-                message: format!("Query failed with state CLOSED"),
+                message: "Query failed with state CLOSED".to_string(),
             }),
         }
     }

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -39,8 +39,16 @@ use reqwest::{Client, ClientBuilder};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use snafu::{Snafu, prelude::*};
-use std::{io::Cursor, pin::Pin, sync::Arc};
+use std::{
+    fmt::{Display, Formatter},
+    io::Cursor,
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 use token_provider::TokenProvider;
+use util::fibonacci_backoff::{Backoff, FibonacciBackoffBuilder};
 
 mod datatypes;
 
@@ -154,6 +162,49 @@ impl DbConnectionPool<Arc<SqlWarehouseApi>, &'static dyn Sync> for SqlWarehouseC
     }
 }
 
+// https://docs.databricks.com/api/workspace/statementexecution/executestatement#status-error
+// states: Enum: PENDING | RUNNING | SUCCEEDED | FAILED | CANCELED | CLOSED
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ResponseStatus {
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Canceled,
+    Closed,
+}
+
+impl Display for ResponseStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResponseStatus::Pending => write!(f, "PENDING"),
+            ResponseStatus::Running => write!(f, "RUNNING"),
+            ResponseStatus::Succeeded => write!(f, "SUCCEEDED"),
+            ResponseStatus::Failed => write!(f, "FAILED"),
+            ResponseStatus::Canceled => write!(f, "CANCELED"),
+            ResponseStatus::Closed => write!(f, "CLOSED"),
+        }
+    }
+}
+
+impl FromStr for ResponseStatus {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "SUCCEEDED" => Ok(Self::Succeeded),
+            "FAILED" => Ok(Self::Failed),
+            // waiting for warehouse or async query
+            "PENDING" => Ok(Self::Pending),
+            "RUNNING" => Ok(Self::Running),
+            "CANCELED" => Ok(Self::Canceled),
+            "CLOSED" => Ok(Self::Closed),
+            other => Err(Error::UnexpectedStatementState {
+                state: other.to_string(),
+            }),
+        }
+    }
+}
+
 struct SqlWarehouseApi {
     client: Client,
     host: String,
@@ -183,7 +234,7 @@ impl SqlWarehouseApi {
     async fn get_schema(&self, table: &TableReference) -> Result<SchemaRef, Error> {
         let token = self.token_provider.get_token();
         let payload = self.create_schema_payload(table)?;
-        let response = self.execute_request(&token, &payload).await?;
+        let response = self.execute_sql_statement(&token, &payload).await?;
         schema_from_json(&response)
     }
 
@@ -208,12 +259,34 @@ impl SqlWarehouseApi {
         }))
     }
 
-    async fn execute_request(&self, token: &str, payload: &Value) -> Result<Value, Error> {
+    async fn execute_sql_statement(&self, token: &str, payload: &Value) -> Result<Value, Error> {
         let url = format!("https://{}/api/2.0/sql/statements/", self.host);
         self.client
             .post(&url)
             .bearer_auth(token)
             .json(payload)
+            .send()
+            .await
+            .context(HttpRequestFailedSnafu)?
+            .error_for_status()
+            .context(HttpRequestFailedSnafu)?
+            .json()
+            .await
+            .context(JsonParsingFailedSnafu)
+    }
+
+    async fn get_sql_statement_status(
+        &self,
+        token: &str,
+        statement_id: &str,
+    ) -> Result<Value, Error> {
+        let url = format!(
+            "https://{}/api/2.0/sql/statements/{statement_id}",
+            self.host
+        );
+        self.client
+            .get(&url)
+            .bearer_auth(token)
             .send()
             .await
             .context(HttpRequestFailedSnafu)?
@@ -374,7 +447,7 @@ impl SqlWarehouseApi {
             .collect())
     }
 
-    fn verify_response_status(response: &Value) -> Result<(), Error> {
+    fn extract_response_status(response: &Value) -> Result<ResponseStatus, Error> {
         let state = response
             .get("status")
             .and_then(|s| s.get("state"))
@@ -382,12 +455,30 @@ impl SqlWarehouseApi {
             .ok_or_else(|| Error::MissingJsonField {
                 field: "status.state".to_string(),
             })?;
+        ResponseStatus::from_str(state)
+    }
 
-        // https://docs.databricks.com/api/workspace/statementexecution/executestatement#status-error
-        // states: Enum: PENDING | RUNNING | SUCCEEDED | FAILED | CANCELED | CLOSED
-        match state.to_uppercase().as_str() {
-            "SUCCEEDED" => Ok(()),
-            "FAILED" => {
+    fn extract_statement_id(response: &Value) -> Result<String, Error> {
+        response
+            .get("statement_id")
+            .and_then(|v| v.as_str())
+            .map(ToString::to_string)
+            .ok_or_else(|| Error::MissingJsonField {
+                field: "statement_id".to_string(),
+            })
+    }
+
+    /// This is an async query running on the Databricks SQL Warehouse
+    fn is_async_query(state: ResponseStatus) -> bool {
+        matches!(state, ResponseStatus::Pending | ResponseStatus::Running)
+    }
+
+    fn verify_response_status(response: &Value) -> Result<(), Error> {
+        let state = Self::extract_response_status(response)?;
+
+        match state {
+            ResponseStatus::Succeeded => Ok(()),
+            ResponseStatus::Failed => {
                 let message = Self::extract_error_message(response)
                     .unwrap_or_else(|| "Unknown error".to_string());
                 Err(Error::QueryFailure {
@@ -395,14 +486,14 @@ impl SqlWarehouseApi {
                 })
             }
             // waiting for warehouse
-            "PENDING" => Err(Error::InvalidWarehouseState {
+            ResponseStatus::Pending => Err(Error::InvalidWarehouseState {
                 state: state.to_string(),
             }),
             // long-running queries are not currently supported
-            "RUNNING" => Err(Error::QueryStillRunning),
-            "CANCELED" => Err(Error::QueryCanceled),
-            other => Err(Error::UnexpectedStatementState {
-                state: other.to_string(),
+            ResponseStatus::Running => Err(Error::QueryStillRunning),
+            ResponseStatus::Canceled => Err(Error::QueryCanceled),
+            ResponseStatus::Closed => Err(Error::QueryFailure {
+                message: format!("Query failed with state CLOSED"),
             }),
         }
     }
@@ -539,10 +630,33 @@ impl<'a> AsyncDbConnection<Arc<SqlWarehouseApi>, &'a dyn Sync> for SqlWarehouseC
             "warehouse_id": self.api.sql_warehouse_id,
             "format": "ARROW_STREAM",
             "disposition": "EXTERNAL_LINKS",
+            "wait_timeout": "30s",
+            "on_wait_timeout": "CONTINUE",
             "statement": sql,
         });
 
-        let mut response = self.api.execute_request(&token, &payload).await?;
+        let mut response = self.api.execute_sql_statement(&token, &payload).await?;
+
+        tracing::trace!("Parsing Databricks JSON response: {response}");
+
+        let mut state = SqlWarehouseApi::extract_response_status(&response)?;
+        let statement_id = SqlWarehouseApi::extract_statement_id(&response)?;
+
+        let mut backoff = FibonacciBackoffBuilder::new()
+            .max_duration(Some(Duration::from_secs(5)))
+            .build();
+        while SqlWarehouseApi::is_async_query(state) {
+            tracing::trace!("Query is still running (state: '{state}')");
+            let Some(backoff_duration) = backoff.next_backoff() else {
+                break;
+            };
+            tokio::time::sleep(backoff_duration).await;
+            response = self
+                .api
+                .get_sql_statement_status(&token, &statement_id)
+                .await?;
+            state = SqlWarehouseApi::extract_response_status(&response)?;
+        }
 
         SqlWarehouseApi::verify_response_status(&response)?;
 

--- a/crates/util/src/fibonacci_backoff.rs
+++ b/crates/util/src/fibonacci_backoff.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::time::Duration;
 
-use backoff::backoff::Backoff;
+pub use backoff::backoff::Backoff;
 
 // Fibonacci-based backoff delay intervals capped at 5 mins
 const BACKOFF_INTERVALS_MS: [u64; 14] = [


### PR DESCRIPTION
## 📝 Summary

The Databricks SQL Warehouse API will default to returning an async query identifier instead of returning the results inline if the query takes longer than 10 seconds (https://docs.databricks.com/api/workspace/statementexecution/executestatement#wait_timeout). We were not properly handling this, resulting in the error linked in the bug.

With this change we will now wait up to 30 seconds for the query to complete, after which Spice will poll the results endpoint using a fibonacci backoff up to 5 seconds. This allows us to more reliably handler longer running queries that use the Databricks SQL Warehouse API.

## 🔗 Related

- Fixes #7112

## 👀 Notes for Reviewers

The SQL Statement API always returns `state: PENDING` when the async query has started, regardless of whether the SQL warehouse is already running.

```bash
2025-09-29T07:14:33.596410Z TRACE data_components::databricks::sql_warehouse: Parsing Databricks JSON response: {"statement_id":"01f09d03-e125-1f72-af66-42eae0b386db","status":{"state":"PENDING"}}
2025-09-29T07:14:33.596567Z TRACE data_components::databricks::sql_warehouse: Query is still running (state: 'PENDING')
2025-09-29T07:14:39.679707Z TRACE data_components::databricks::sql_warehouse: Query is still running (state: 'RUNNING')
2025-09-29T07:14:47.104453Z TRACE data_components::databricks::sql_warehouse: Query is still running (state: 'RUNNING')
2025-09-29T07:14:55.882565Z TRACE data_components::databricks::sql_warehouse: Query is still running (state: 'RUNNING')
2025-09-29T07:15:04.880563Z TRACE data_components::databricks::sql_warehouse: Query is still running (state: 'RUNNING')
2025-09-29T07:15:15.059252Z TRACE data_components::databricks::sql_warehouse: Query is still running (state: 'RUNNING')
```
