### PR TITLE
Update example datadog config to include Refresh/Ingestion Lag

### DIFF
--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -206,7 +206,7 @@
     {
       "id": 5713842188321988,
       "definition": {
-        "title": "Ingestion/Refresh Lag",
+        "title": "Ingestion + Refresh Lag",
         "title_size": "16",
         "title_align": "left",
         "show_legend": true,
@@ -243,6 +243,7 @@
                     "unit_name": "second"
                   }
                 },
+                "alias": "Ingestion Lag",
                 "formula": "query1 / 1000"
               },
               {
@@ -252,6 +253,7 @@
                     "unit_name": "second"
                   }
                 },
+                "alias": "Refresh Lag",
                 "formula": "query4 / 1000"
               }
             ],

--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -202,6 +202,78 @@
         "width": 5,
         "height": 3
       }
+    },
+    {
+      "id": 5713842188321988,
+      "definition": {
+        "title": "Ingestion/Refresh Lag",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": [
+          "avg",
+          "min",
+          "max",
+          "value",
+          "sum"
+        ],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{*}"
+              },
+              {
+                "name": "query4",
+                "data_source": "metrics",
+                "query": "avg:spice.dataset_acceleration_refresh_lag_ms{*}"
+              }
+            ],
+            "formulas": [
+              {
+                "number_format": {
+                  "unit": {
+                    "type": "canonical_unit",
+                    "unit_name": "second"
+                  }
+                },
+                "formula": "query1 / 1000"
+              },
+              {
+                "number_format": {
+                  "unit": {
+                    "type": "canonical_unit",
+                    "unit_name": "second"
+                  }
+                },
+                "formula": "query4 / 1000"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "order_by": "values",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "anomaly_detection": {
+          "detection_sensitivity": "never_detect"
+        }
+      },
+      "layout": {
+        "x": 0,
+        "y": 6,
+        "width": 5,
+        "height": 3
+      }
     }
   ],
   "template_variables": [


### PR DESCRIPTION
## 📝 Summary

Update example datadog config to include Refresh/Ingestion Lag

<img width="1431" height="1034" alt="spice_datadog_dashboard" src="https://github.com/user-attachments/assets/14753846-7875-4734-86f2-82d518f1590c" />




## 🔗 Related

https://github.com/spiceai/spiceai/issues/7184


