### PR TITLE
Use self-hosted and spiceai-macos runners for workflows where possible

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,7 @@
 name: 'CodeQL'
 
 on:
+  workflow_dispatch:
   push:
     branches: [trunk, release-*]
     paths-ignore:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['go']
+        language: ['go', 'rust']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed

--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   enforce-pull-with-spice:
-    runs-on: spiceai-macos
+    runs-on: self-hosted
     steps:
       - uses: spiceai/pulls-with-spice-action@v1.0.7
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   enforce-pull-with-spice:
-    runs-on: spiceai-dev-runners
+    runs-on: spiceai-macos
     steps:
       - uses: spiceai/pulls-with-spice-action@v1.0.6
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -15,7 +15,7 @@ jobs:
   enforce-pull-with-spice:
     runs-on: spiceai-macos
     steps:
-      - uses: spiceai/pulls-with-spice-action@v1.0.6
+      - uses: spiceai/pulls-with-spice-action@v1.0.7
         if: github.event_name == 'pull_request_target'
         with:
           require_title_min_length: '10'

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   generate_openapi:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Check out repository

--- a/.github/workflows/generate_acknowledgements.yml
+++ b/.github/workflows/generate_acknowledgements.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   generate:
     name: Generate Acknowledgements
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   generate:
     name: Generate Changelog
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   generate_schema:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -43,13 +43,13 @@ jobs:
               {
                 name: 'self-hosted',
                 needs_env: false,
-                runner: 'macOS',
+                runner: 'spiceai-macos',
                 model_allowlist: 'local_phi3,hf_phi3'
               },
               {
                 name: 'hosted',
                 needs_env: true,
-                runner: 'macOS',
+                runner: 'spiceai-macos',
                 model_allowlist: 'anthropic,bedrock,openai,xai,perplexity'
               }
             ];
@@ -67,7 +67,7 @@ jobs:
 
   build:
     name: Build Test Binary
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, spiceai-macos]
     steps:
       - uses: actions/checkout@v5
 
@@ -93,7 +93,7 @@ jobs:
           retention-days: 1
 
   test:
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, spiceai-macos]
     needs: [build, setup-matrix]
     strategy:
       matrix:

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -140,7 +140,7 @@ jobs:
             exit 1
           fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture openai_embeddings_beta_requirements
-      
+
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always'
         uses: ./.github/actions/push-snap-changes
@@ -152,7 +152,7 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.run_all_tests == 'true' }}
     permissions: read-all
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, spiceai-macos]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -190,7 +190,7 @@ jobs:
             exit 1
           fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture hf_embeddings_beta_requirements
-      
+
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always'
         uses: ./.github/actions/push-snap-changes
@@ -201,7 +201,7 @@ jobs:
     name: Test Local Models
     needs: build
     permissions: read-all
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, spiceai-macos]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -223,7 +223,7 @@ jobs:
           INSTA_UPDATE: ${{ github.event.inputs.update_snapshots }}
         run: |
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture local_embeddings_beta_requirements
-      
+
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always'
         uses: ./.github/actions/push-snap-changes
@@ -235,7 +235,7 @@ jobs:
     needs: build
     if: ${{ github.event.inputs.run_all_tests == 'true' }}
     permissions: read-all
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, spiceai-macos]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -259,7 +259,7 @@ jobs:
           AWS_BEDROCK_SECRET: ${{ secrets.AWS_BEDROCK_SECRET }}
         run: |
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture bedrock_test
-      
+
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always'
         uses: ./.github/actions/push-snap-changes
@@ -270,7 +270,7 @@ jobs:
     name: Test Workers
     needs: build
     permissions: read-all
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, spiceai-macos]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -301,7 +301,7 @@ jobs:
             exit 1
           fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture workers
-      
+
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always'
         uses: ./.github/actions/push-snap-changes
@@ -312,7 +312,7 @@ jobs:
     name: Test Search
     needs: build
     permissions: read-all
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, spiceai-macos]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -345,7 +345,7 @@ jobs:
             exit 1
           fi
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/ai_integration_test --nocapture search
-      
+
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always'
         uses: ./.github/actions/push-snap-changes

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -39,7 +39,7 @@ env:
 jobs:
   license-check-rust:
     name: Check Rust Licenses
-    runs-on: spiceai-macos
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
 
@@ -57,7 +57,7 @@ jobs:
 
   license-check-go:
     name: Check Golang Licenses
-    runs-on: spiceai-dev-runners
+    runs-on: self-hosted
     env:
       GOVER: 1.24.2
 


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve CI/CD infrastructure flexibility and coverage. The main changes include switching runner environments from specific hosted runners to the more generic `self-hosted` or `spiceai-macos` runners, expanding language support for CodeQL analysis, and updating action versions for better reliability.

**Runner environment updates:**

* Changed workflow runner environments from `ubuntu-latest`, `macOS`, and `spiceai-dev-runners` to `self-hosted` or `spiceai-macos` across multiple workflow files, including `codeql-analysis.yml`, `enforce-pulls-with-spice.yml`, `generate-openapi.yml`, `generate_changelog.yml`, `generate_json_schema.yml`, `integration_llms.yml`, `integration_models.yml`, and `license_check.yml`. This allows for more control and consistency over the CI/CD infrastructure. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L15-R16) [[2]](diffhunk://#diff-3e62b019e0514248eff0affeb1347a357594f6075470ad271b52edeaa5e973a6L16-R18) [[3]](diffhunk://#diff-ba3450a751f3a74e6af2e04486f74790e0a0536c34f0da45ba28b93056cc3fd0L13-R13) [[4]](diffhunk://#diff-bb7b16d83114a17d47bfb9e3c86528c0afb65607ebd4398c32186379e956e8b6L18-R18) [[5]](diffhunk://#diff-39878ff52be1ad87d4bd525cf2f51b7f906da50ef249ce5798fd0556aa56bef9L13-R13) [[6]](diffhunk://#diff-29306580888afce747aae89a524b29aad08258003a80bca1c5113b183e97f621L46-R52) [[7]](diffhunk://#diff-29306580888afce747aae89a524b29aad08258003a80bca1c5113b183e97f621L70-R70) [[8]](diffhunk://#diff-29306580888afce747aae89a524b29aad08258003a80bca1c5113b183e97f621L96-R96) [[9]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L155-R155) [[10]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L204-R204) [[11]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L238-R238) [[12]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L273-R273) [[13]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L315-R315) [[14]](diffhunk://#diff-f720c7c88099c1833198924651795ee4dde030fced213a99fcdb701a6b410b42L42-R42) [[15]](diffhunk://#diff-f720c7c88099c1833198924651795ee4dde030fced213a99fcdb701a6b410b42L60-R60)

**CodeQL and language support:**

* Added `workflow_dispatch` trigger to the `codeql-analysis.yml` workflow, allowing manual runs in addition to automatic triggers.
* Expanded CodeQL language matrix to include both `go` and `rust`, increasing code scanning coverage.

**Action and runner configuration updates:**

* Updated `spiceai/pulls-with-spice-action` from version `v1.0.6` to `v1.0.7` for improved pull request enforcement.
* Standardized runner names in `integration_llms.yml` and `integration_models.yml` from `macOS` to `spiceai-macos` for clarity and consistency. [[1]](diffhunk://#diff-29306580888afce747aae89a524b29aad08258003a80bca1c5113b183e97f621L46-R52) [[2]](diffhunk://#diff-29306580888afce747aae89a524b29aad08258003a80bca1c5113b183e97f621L70-R70) [[3]](diffhunk://#diff-29306580888afce747aae89a524b29aad08258003a80bca1c5113b183e97f621L96-R96) [[4]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L155-R155) [[5]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L204-R204) [[6]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L238-R238) [[7]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L273-R273) [[8]](diffhunk://#diff-b068e6ca09dd62e8817489d3b08201795ebbe3fb13568f6dfe90e7d7c0e707b3L315-R315)