### PR TITLE
Fix minor lint warnings

### DIFF
--- a/crates/db_connection_pool/src/dbconnection/odbcconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/odbcconn.rs
@@ -66,7 +66,7 @@ impl<T: InputParameter + Sync + Send + DynClone> ODBCSyncParameter for T {
 dyn_clone::clone_trait_object!(ODBCSyncParameter);
 
 pub type ODBCParameter = Box<dyn ODBCSyncParameter>;
-pub type ODBCDbConnection<'a> = (dyn DbConnection<Connection<'a>, ODBCParameter>);
+pub type ODBCDbConnection<'a> = dyn DbConnection<Connection<'a>, ODBCParameter>;
 pub type ODBCDbConnectionPool<'a> =
     dyn DbConnectionPool<Connection<'a>, ODBCParameter> + Sync + Send;
 

--- a/crates/scheduler/src/channel/cron.rs
+++ b/crates/scheduler/src/channel/cron.rs
@@ -188,7 +188,7 @@ mod tests {
         let request = rx.recv().await.expect("Should receive a task request");
         let now = Local::now();
         assert!(
-            now.second() % 5 == 0,
+            now.second().is_multiple_of(5),
             "The request should be sent at a 5-second interval"
         );
         assert!(!request.cancel_running);
@@ -207,7 +207,7 @@ mod tests {
             "The next request should be sent after 5 seconds"
         );
         assert!(
-            next_now.second() % 5 == 0,
+            next_now.second().is_multiple_of(5),
             "The request should be sent at a 5-second interval"
         );
         assert!(!request.cancel_running);
@@ -252,7 +252,7 @@ mod tests {
         let request = rx.recv().await.expect("Should receive a task request");
         let last_now = Local::now();
         assert!(
-            last_now.second() % 5 == 0,
+            last_now.second().is_multiple_of(5),
             "The request should be sent at a 5-second interval"
         );
         assert!(!request.cancel_running);
@@ -289,7 +289,7 @@ mod tests {
             "The next request should be sent after 5 seconds"
         );
         assert!(
-            next_now.second() % 5 == 0,
+            next_now.second().is_multiple_of(5),
             "The request should be sent at a 5-second interval"
         );
         assert!(!request.cancel_running);

--- a/crates/test-framework/src/metrics/mod.rs
+++ b/crates/test-framework/src/metrics/mod.rs
@@ -175,7 +175,7 @@ impl StatisticsCollector<Duration, Vec<Duration>> for Vec<Duration> {
         sorted_durations.sort();
 
         let half = sorted_durations.len() / 2;
-        if sorted_durations.len() % 2 == 0 {
+        if sorted_durations.len().is_multiple_of(2) {
             Ok((sorted_durations[half - 1] + sorted_durations[half]) / 2)
         } else {
             Ok(sorted_durations[half])

--- a/crates/test-framework/src/utils/mod.rs
+++ b/crates/test-framework/src/utils/mod.rs
@@ -121,7 +121,7 @@ pub fn median_observed_memory(readings: &[MemoryReading]) -> anyhow::Result<f64>
     memory_usages.sort_by(f64::total_cmp);
 
     let len = memory_usages.len();
-    if len % 2 == 0 {
+    if len.is_multiple_of(2) {
         Ok(f64::midpoint(
             memory_usages[len / 2],
             memory_usages[len / 2 - 1],


### PR DESCRIPTION
This pull request makes several improvements to the codebase by replacing manual modulus checks with the more expressive `is_multiple_of` method, enhancing code readability and intent. It also includes a minor type alias adjustment for ODBC database connections. The most important changes are grouped below:

### Consistency and Readability Improvements

* Replaced manual modulus checks (e.g., `x % 2 == 0` and `x % 5 == 0`) with the more idiomatic `.is_multiple_of()` method in test assertions and statistics calculations, improving code clarity in `crates/scheduler/src/channel/cron.rs`, `crates/test-framework/src/metrics/mod.rs`, and `crates/test-framework/src/utils/mod.rs`. [[1]](diffhunk://#diff-ceeac7919c37aafdf88ebf8888d07eea9badec294fd9426d7e5862283d149a7dL191-R191) [[2]](diffhunk://#diff-ceeac7919c37aafdf88ebf8888d07eea9badec294fd9426d7e5862283d149a7dL210-R210) [[3]](diffhunk://#diff-ceeac7919c37aafdf88ebf8888d07eea9badec294fd9426d7e5862283d149a7dL255-R255) [[4]](diffhunk://#diff-ceeac7919c37aafdf88ebf8888d07eea9badec294fd9426d7e5862283d149a7dL292-R292) [[5]](diffhunk://#diff-7452d9b090f35ddc56f522c86f23bf967dfd0b1f7272f522f1b54f68dfd9f77eL178-R178) [[6]](diffhunk://#diff-65ec3988570beea1efaeb5e2d672f23ca5113bc63195e104030a84009e16f132L124-R124)

### Type Alias Simplification

* Updated the `ODBCDbConnection` type alias in `crates/db_connection_pool/src/dbconnection/odbcconn.rs` to remove unnecessary parentheses, simplifying the type definition.