### PR TITLE
Set PostgreSQL unsupported_spice_action=string by default

### DIFF
--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -101,10 +101,10 @@ impl DataConnectorFactory for PostgresFactory {
             );
 
             match PostgresConnectionPool::new(param_map).await {
-                Ok(mut pool) => {
-                    if let Some(unsupported_type_action) = params.unsupported_type_action {
-                        pool = pool.with_unsupported_type_action(unsupported_type_action);
-                    }
+                Ok(pool) => {
+                    let unsupported_type_action = params.unsupported_type_action
+                        .unwrap_or(datafusion_table_providers::UnsupportedTypeAction::String);
+                    let pool = pool.with_unsupported_type_action(unsupported_type_action);
 
                     let postgres_factory = PostgresTableFactory::new(Arc::new(pool));
                     Ok(Arc::new(Postgres { postgres_factory }) as Arc<dyn DataConnector>)

--- a/crates/runtime/src/dataconnector/postgres.rs
+++ b/crates/runtime/src/dataconnector/postgres.rs
@@ -102,7 +102,8 @@ impl DataConnectorFactory for PostgresFactory {
 
             match PostgresConnectionPool::new(param_map).await {
                 Ok(pool) => {
-                    let unsupported_type_action = params.unsupported_type_action
+                    let unsupported_type_action = params
+                        .unsupported_type_action
                         .unwrap_or(datafusion_table_providers::UnsupportedTypeAction::String);
                     let pool = pool.with_unsupported_type_action(unsupported_type_action);
 


### PR DESCRIPTION
This pull request updates the handling of the `unsupported_type_action` parameter when creating a `PostgresConnectionPool`. Now, if the parameter is not provided, it defaults to `UnsupportedTypeAction::String`, ensuring a consistent fallback behavior.

Improvements to connection pool configuration:

* The `unsupported_type_action` for the `PostgresConnectionPool` now defaults to `UnsupportedTypeAction::String` if not explicitly set in `params`, simplifying configuration and ensuring a safe default.