### PR TITLE
Add S3vector variant to financebench. 

### DIFF
--- a/test/spicepods/financebench/embedding[s3vector].yaml
+++ b/test/spicepods/financebench/embedding[s3vector].yaml
@@ -1,0 +1,61 @@
+version: v1
+kind: Spicepod
+name: financebench
+
+runtime:
+  flight:
+    max_message_size: 1G
+
+dependencies:
+  - models
+  - evals
+
+snapshots:
+  enabled: disabled
+  location: s3://spiceai-public-datasets/financebench/indexes
+  bootstrap_on_failure_behavior: warn
+
+datasets:
+  - from: s3://spiceai-public-datasets/financebench/txt_small/
+    name: data
+    description: Financial information
+    # Use `last_modified` with append refresh and snapshots enabled will mean we will load DuckDB file and only add in new data.
+    # This also means we won't reindex into S3 vectors either.
+    time_column: last_modified
+    time_format: timestamptz
+    metadata:
+      last_modified: enabled
+    params:
+      file_format: txt
+    acceleration:
+      enabled: true
+      engine: duckdb
+      snapshots: disabled
+      mode: file
+      primary_key: location
+      refresh_mode: append
+      params:
+        duckdb_file: ./financebench_data.db
+    columns:
+      - name: content
+        embeddings:
+          - from: openai_embed
+            row_id: location
+            chunking:
+              enabled: true
+              target_chunk_size: 1000
+              overlap_size: 200
+    vectors:
+      enabled: true
+      engine: s3_vectors
+      params:
+        s3_vectors_bucket: spiceai-financebench-s3-data
+        s3_vectors_aws_region: us-east-1
+        s3_vectors_index: jeadie-test
+
+embeddings:
+  - from: model2vec:minishlab/potion-retrieval-32M
+    # - from: openai:text-embedding-3-small
+    name: openai_embed
+    params:
+      openai_api_key: ${secrets:OPENAI_API_KEY}

--- a/test/spicepods/financebench/embedding[s3vector].yaml
+++ b/test/spicepods/financebench/embedding[s3vector].yaml
@@ -19,8 +19,8 @@ datasets:
   - from: s3://spiceai-public-datasets/financebench/txt/
     name: data
     description: Financial information
-    # Use `last_modified` with append refresh and snapshots enabled will mean we will load DuckDB file and only add in new data.
-    # This also means we won't reindex into S3 vectors either.
+    # We use `refresh_mode: append` based on `last_modified` so that if we have `duckdb_file` present, we don't reindex (or rewrite into S3vectors).
+    # With snapshotting soon™, we will be able to automatically load this `duckdb_file` whether we run this spicepod.
     time_column: last_modified
     time_format: timestamptz
     metadata:

--- a/test/spicepods/financebench/embedding[s3vector].yaml
+++ b/test/spicepods/financebench/embedding[s3vector].yaml
@@ -20,7 +20,7 @@ datasets:
     name: data
     description: Financial information
     # We use `refresh_mode: append` based on `last_modified` so that if we have `duckdb_file` present, we don't reindex (or rewrite into S3vectors).
-    # With snapshotting soon™, we will be able to automatically load this `duckdb_file` whether we run this spicepod.
+    # With snapshotting soon™, we will be able to automatically load this `duckdb_file` whereever we run this spicepod.
     time_column: last_modified
     time_format: timestamptz
     metadata:

--- a/test/spicepods/financebench/embedding[s3vector].yaml
+++ b/test/spicepods/financebench/embedding[s3vector].yaml
@@ -11,12 +11,12 @@ dependencies:
   - evals
 
 snapshots:
-  enabled: disabled
+  enabled: false
   location: s3://spiceai-public-datasets/financebench/indexes
   bootstrap_on_failure_behavior: warn
 
 datasets:
-  - from: s3://spiceai-public-datasets/financebench/txt_small/
+  - from: s3://spiceai-public-datasets/financebench/txt/
     name: data
     description: Financial information
     # Use `last_modified` with append refresh and snapshots enabled will mean we will load DuckDB file and only add in new data.
@@ -51,11 +51,3 @@ datasets:
       params:
         s3_vectors_bucket: spiceai-financebench-s3-data
         s3_vectors_aws_region: us-east-1
-        s3_vectors_index: jeadie-test
-
-embeddings:
-  - from: model2vec:minishlab/potion-retrieval-32M
-    # - from: openai:text-embedding-3-small
-    name: openai_embed
-    params:
-      openai_api_key: ${secrets:OPENAI_API_KEY}

--- a/test/spicepods/financebench/embedding[s3vector].yaml
+++ b/test/spicepods/financebench/embedding[s3vector].yaml
@@ -35,7 +35,7 @@ datasets:
       primary_key: location
       refresh_mode: append
       params:
-        duckdb_file: ./financebench_data.db
+        duckdb_file: ./financebench_data_s3.db
     columns:
       - name: content
         embeddings:


### PR DESCRIPTION
## 📝 Summary
 - Until we have snapshotting, this will require significant startup time (last time it was run, without S3vectors, it was ~17 minutes). 
 - Currently, Financebench models perform search and SQL on financebench data over a Flight connection to SCP. This will use different query & planning paths to using a direct search index. 
   - i.e. `from: spice.ai/spiceai/financebench/datasets/spice.financebench.data`, see [source](https://github.com/spiceai/spiceai/blob/trunk/test/spicepods/financebench/embedding%5Bopenai%5D.yaml#L13-L14).