### PR TITLE
Forbid `INSERT OVERWRITE` DML operations

### DIFF
--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -46,7 +46,10 @@ pub fn validate_sql_query_operations(
         }
         // Data Manipulation Language (DML): Insert / Update / Delete
         LogicalPlan::Dml(dml) => {
-            if let datafusion::logical_expr::WriteOp::Insert(_) = &dml.op {
+            if let datafusion::logical_expr::WriteOp::Insert(op) = &dml.op {
+                if op != &datafusion_expr::dml::InsertOp::Append {
+                    return plan_err!("Only Append (`INSERT INTO`) operations are permitted: '{op}' is not allowed");
+                }
 
                 if super::is_spice_internal_dataset(&dml.table_name) {
                     return plan_err!(
@@ -339,10 +342,6 @@ mod tests {
 
         let result = validate_sql_query_operations(&plan, &df);
         assert!(result.is_err(), "CREATE TABLE should be blocked");
-
-        if let Err(e) = result {
-            assert!(e.to_string().contains("Operation is not allowed"));
-        }
     }
 
     #[tokio::test]
@@ -360,10 +359,6 @@ mod tests {
 
         let result = validate_sql_query_operations(&plan, &df);
         assert!(result.is_err(), "COPY operations should be blocked");
-
-        if let Err(e) = result {
-            assert!(e.to_string().contains("COPY operations are not allowed"));
-        }
     }
 
     #[tokio::test]
@@ -381,10 +376,6 @@ mod tests {
 
         let result = validate_sql_query_operations(&plan, &df);
         assert!(result.is_err(), "SET statements should be blocked");
-
-        if let Err(e) = result {
-            assert!(e.to_string().contains("Statements are not allowed"));
-        }
     }
 
     #[tokio::test]
@@ -456,6 +447,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validate_insert_overwrite_blocked() {
+        let df = create_test_datafusion();
+
+        let sql = "INSERT OVERWRITE tbl_writable VALUES (1, 'foo', 42.0)";
+        let plan = df
+            .ctx
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .expect("plan should be created");
+
+        let result = validate_sql_query_operations(&plan, &df);
+        assert!(result.is_err(), "INSERT OVERWRITE should be blocked");
+    }
+
+    #[tokio::test]
     async fn test_validate_default_catalog_table_uses_dataset_rules() {
         let df = create_test_datafusion();
 
@@ -488,12 +495,5 @@ mod tests {
             result.is_err(),
             "INSERT should fail on read-only dataset in default catalog"
         );
-
-        if let Err(e) = result {
-            assert!(
-                e.to_string()
-                    .contains("INSERT operations are not allowed on read-only dataset")
-            );
-        }
     }
 }


### PR DESCRIPTION
## 📝 Summary

Prohibit `INSERT OVERWRITE` usage to prevent potential data loss, allowing append-only writes

Note: `InsertOp::Replace ` is SQLite DataFusion dialect only so unit tests does NOT cover this case as such sql can't be parsed with currently used by Spice Postgres dialect setting.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
