### PR TITLE
Move snapshot download to DataAccelerator::init()

### DIFF
--- a/crates/runtime/src/component/dataset/mod.rs
+++ b/crates/runtime/src/component/dataset/mod.rs
@@ -754,6 +754,10 @@ pub struct FullTextSearchDatasetConfig {
 }
 
 impl AccelerationSource for Dataset {
+    fn clone_arc(&self) -> Arc<dyn AccelerationSource> {
+        Arc::new(self.clone())
+    }
+
     fn is_file_accelerated(&self) -> bool {
         self.is_file_accelerated()
     }

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -33,6 +33,7 @@ use super::{
 use spicepod::semantic::Column;
 
 /// [`View`] is the internal representation of the [`spicepod_view::View`] spicepod component.
+#[derive(Clone)]
 pub struct View {
     pub name: TableReference,
     pub sql: Arc<str>,

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -212,6 +212,10 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
 }
 
 impl AccelerationSource for View {
+    fn clone_arc(&self) -> Arc<dyn AccelerationSource> {
+        Arc::new(self.clone()) as Arc<dyn AccelerationSource>
+    }
+
     fn is_file_accelerated(&self) -> bool {
         if let Some(acceleration) = &self.acceleration {
             if acceleration.engine == acceleration::Engine::PostgreSQL {

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -315,6 +315,11 @@ impl DataAccelerator for DuckDBAccelerator {
                 .into());
             }
 
+            // We don't want to eagerly create the DuckDB file if we're bootstrapping from a snapshot
+            if acceleration.snapshots.bootstrap_enabled() {
+                return Ok(());
+            }
+
             self.get_shared_pool(source).await?;
         }
 

--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -23,7 +23,7 @@ use crate::{
         },
         view::View,
     },
-    dataaccelerator::FilePathError,
+    dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed},
     datafusion::dialect::new_duckdb_dialect,
     make_spice_data_directory,
     parameters::ParameterSpec,
@@ -49,6 +49,7 @@ use std::{
     cmp::max,
     collections::HashSet,
     ffi::OsStr,
+    path::PathBuf,
     sync::{Arc, Once},
 };
 
@@ -315,10 +316,7 @@ impl DataAccelerator for DuckDBAccelerator {
                 .into());
             }
 
-            // We don't want to eagerly create the DuckDB file if we're bootstrapping from a snapshot
-            if acceleration.snapshots.bootstrap_enabled() {
-                return Ok(());
-            }
+            download_snapshot_if_needed(acceleration, source, PathBuf::from(path)).await;
 
             self.get_shared_pool(source).await?;
         }

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -60,6 +60,7 @@ pub mod postgres;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+mod snapshots;
 pub mod spice_sys;
 
 #[derive(Debug, Snafu)]
@@ -488,7 +489,10 @@ impl AcceleratorExternalTableBuilder {
 
 /// Represents acceleration source component, such as a dataset or a view.
 /// Provides additional information about the source, such as its name and associated runtime information.
-pub trait AccelerationSource: Sync {
+pub trait AccelerationSource: Send + Sync {
+    /// Returns a clone of the source as an `Arc<dyn AccelerationSource>`
+    fn clone_arc(&self) -> Arc<dyn AccelerationSource>;
+
     /// Returns true if the source uses file-based acceleration
     fn is_file_accelerated(&self) -> bool;
 

--- a/crates/runtime/src/dataaccelerator/snapshots.rs
+++ b/crates/runtime/src/dataaccelerator/snapshots.rs
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{path::PathBuf, sync::Arc};
+
+use runtime_acceleration::{
+    dataset_checkpoint::make_checkpointer_factory, snapshot::SnapshotManager,
+};
+use snafu::ResultExt;
+
+use crate::{
+    component::dataset::acceleration::Acceleration,
+    dataaccelerator::{
+        AccelerationSource,
+        spice_sys::{OpenOption, dataset_checkpoint::DatasetCheckpoint},
+    },
+};
+
+pub(super) async fn download_snapshot_if_needed(
+    acceleration: &Acceleration,
+    source: &dyn AccelerationSource,
+    path: PathBuf,
+) {
+    if !acceleration.snapshots.bootstrap_enabled() {
+        return;
+    }
+
+    let source_name = source.name().to_string();
+    let source = source.clone_arc();
+    let checkpoint_factory = make_checkpointer_factory(move || {
+        let source = Arc::clone(&source);
+        async move {
+            DatasetCheckpoint::try_new(source.as_ref(), OpenOption::OpenExisting)
+                .await
+                .boxed()
+        }
+    });
+    if let Some(manager) = SnapshotManager::try_new(
+        source_name,
+        acceleration.snapshots.clone(),
+        checkpoint_factory,
+        path,
+    )
+    .await
+    {
+        let _ = manager.download_latest_snapshot().await.ok().flatten();
+    }
+}

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -239,6 +239,11 @@ impl DataAccelerator for SqliteAccelerator {
                 .into());
             }
 
+            // We don't want to eagerly create the SQLite file if we're bootstrapping from a snapshot
+            if acceleration.snapshots.bootstrap_enabled() {
+                return Ok(());
+            }
+
             self.get_shared_pool(source).await?;
         }
 

--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -27,11 +27,11 @@ use datafusion_table_providers::{
 use runtime_table_partition::expression::PartitionBy;
 use rusqlite::ffi::{sqlite3_auto_extension, sqlite3_decimal_init};
 use snafu::prelude::*;
-use std::{any::Any, ffi::OsStr, sync::Arc, time::Duration};
+use std::{any::Any, ffi::OsStr, path::PathBuf, sync::Arc, time::Duration};
 
 use crate::{
     component::dataset::acceleration::{Engine, Mode},
-    dataaccelerator::FilePathError,
+    dataaccelerator::{FilePathError, snapshots::download_snapshot_if_needed},
     make_spice_data_directory,
     parameters::ParameterSpec,
     spice_data_base_path,
@@ -239,10 +239,7 @@ impl DataAccelerator for SqliteAccelerator {
                 .into());
             }
 
-            // We don't want to eagerly create the SQLite file if we're bootstrapping from a snapshot
-            if acceleration.snapshots.bootstrap_enabled() {
-                return Ok(());
-            }
+            download_snapshot_if_needed(acceleration, source, PathBuf::from(path)).await;
 
             self.get_shared_pool(source).await?;
         }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -26,10 +26,10 @@ use crate::component::access::AccessMode;
 use crate::component::dataset::acceleration::RefreshMode;
 use crate::component::dataset::{Dataset, ReadyState};
 use crate::component::view::View;
+use crate::dataaccelerator::AcceleratorEngineRegistry;
 use crate::dataaccelerator::spice_sys::OpenOption;
 use crate::dataaccelerator::spice_sys::dataset_checkpoint::DatasetCheckpoint;
 use crate::dataaccelerator::{self};
-use crate::dataaccelerator::{AcceleratorEngineRegistry, acceleration_file_path};
 use crate::dataconnector::deferred::DeferredConnector;
 use crate::dataconnector::localpod::LOCALPOD_DATACONNECTOR;
 use crate::dataconnector::sink::SinkConnector;
@@ -911,31 +911,6 @@ impl DataFusion {
                 .ok_or_else(|| Error::ExpectedAccelerationSettings {
                     name: dataset.name.to_string(),
                 })?;
-
-        if acceleration_settings.snapshots.bootstrap_enabled()
-            && let Ok(file_path) = acceleration_file_path(dataset).await
-        {
-            let dataset_name = dataset.name.to_string();
-            let dataset = dataset.clone();
-            let checkpoint_factory = make_checkpointer_factory(move || {
-                let dataset = dataset.clone();
-                async move {
-                    DatasetCheckpoint::try_new(&dataset, OpenOption::OpenExisting)
-                        .await
-                        .boxed()
-                }
-            });
-            if let Some(manager) = SnapshotManager::try_new(
-                dataset_name,
-                acceleration_settings.snapshots.clone(),
-                checkpoint_factory,
-                file_path,
-            )
-            .await
-            {
-                let _ = manager.download_latest_snapshot().await.ok().flatten();
-            }
-        }
 
         let refresh_sql = dataset.refresh_sql();
         let refresh_schema = if let Some(refresh_sql) = &refresh_sql {

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -70,8 +70,6 @@ use datafusion_federation::FederatedTableProviderAdaptor;
 use error::find_datafusion_root;
 use itertools::Itertools;
 use query::QueryBuilder;
-use runtime_acceleration::dataset_checkpoint::make_checkpointer_factory;
-use runtime_acceleration::snapshot::SnapshotManager;
 use schema::ensure_schema_exists;
 use snafu::prelude::*;
 use tokio::spawn;


### PR DESCRIPTION
## 📝 Summary

Moves the snapshot download to happen in the DataAccelerator::init() function. This fixes a bug where the init() function would eagerly create the acceleration file before the previous snapshot download code was invoked.

I had considered putting it here initially, but decided against it because it means that resolving snapshots would prevent other datasets from initializing - but doing it here does simplify some later code and waiting for the snapshots to resolve first is probably desirable behavior anyway.

Part of #7361