### PR TITLE
Use DataFusion JoinSetTracer for async context propagation

### DIFF
--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -135,6 +135,13 @@ impl RuntimeBuilder {
 
     #[allow(clippy::too_many_lines)]
     pub async fn build(self) -> Runtime {
+        // Initialize DataFusion tracer for span context propagation across async boundaries
+        if let Err(e) = tracers::init_datafusion_tracer() {
+            tracing::warn!(
+                "Failed to initialize DataFusion tracer: {e}. Span context may not propagate correctly across async boundaries."
+            );
+        }
+
         self.accelerator_engine_registry.register_all().await;
         dataconnector::register_all().await;
         catalogconnector::register_all().await;

--- a/crates/runtime/src/tracers.rs
+++ b/crates/runtime/src/tracers.rs
@@ -147,10 +147,10 @@ macro_rules! error_spaced {
 
 /// A tracer that ensures spawned tasks and blocking closures inherit the current span context.
 ///
-/// When DataFusion spawns tasks internally (e.g., for parallel query execution), without this
+/// When `DataFusion` spawns tasks internally (e.g., for parallel query execution), without this
 /// tracer the span context is lost when crossing thread boundaries. This tracer ensures that:
 ///
-/// 1. Async futures spawned via DataFusion's `JoinSet` run with the current span as their parent
+/// 1. Async futures spawned via `DataFusion`'s `JoinSet` run with the current span as their parent
 /// 2. Blocking closures run within the current span's scope
 ///
 /// This is essential for proper trace hierarchies like:
@@ -164,14 +164,14 @@ macro_rules! error_spaced {
 ///
 /// ## Scope
 ///
-/// This tracer **only affects DataFusion's internal task spawning** via `JoinSet`. For other
+/// This tracer **only affects `DataFusion`'s internal task spawning** via `JoinSet`. For other
 /// async operations (e.g., direct `tokio::spawn` calls), use `.instrument(span)` or capture
 /// the span context manually before entering async boundaries.
 ///
 /// ## Usage
 ///
 /// This tracer is automatically initialized during runtime startup via `init_datafusion_tracer()`.
-/// No additional configuration is needed for DataFusion operations to properly propagate spans.
+/// No additional configuration is needed for `DataFusion` operations to properly propagate spans.
 ///
 /// For non-DataFusion async code emitting to `target: "task_history"`:
 /// - Use `.instrument(span)` on futures before spawning them
@@ -203,11 +203,11 @@ impl JoinSetTracer for TaskHistorySpanTracer {
     }
 }
 
-/// Initializes the global `JoinSetTracer` for DataFusion.
+/// Initializes the global `JoinSetTracer` for `DataFusion`.
 ///
-/// This should be called once during runtime initialization, before any DataFusion
+/// This should be called once during runtime initialization, before any `DataFusion`
 /// queries are executed. It sets up the `TaskHistorySpanTracer` globally so that
-/// all DataFusion operations will properly propagate span context.
+/// all `DataFusion` operations will properly propagate span context.
 ///
 /// # Errors
 ///

--- a/crates/runtime/src/tracers.rs
+++ b/crates/runtime/src/tracers.rs
@@ -14,11 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use datafusion::common::runtime::JoinSetTracer;
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use std::{
+    any::Any,
     collections::{HashMap, HashSet},
     sync::Mutex,
     time::{Duration, Instant},
 };
+use tracing::{Instrument, Span};
 
 /// Traces a log with a given parameter once, to prevent log spam.
 ///
@@ -138,4 +143,77 @@ macro_rules! error_spaced {
             tracing::error!($msg, $key);
         }
     }};
+}
+
+/// A tracer that ensures spawned tasks and blocking closures inherit the current span context.
+///
+/// When DataFusion spawns tasks internally (e.g., for parallel query execution), without this
+/// tracer the span context is lost when crossing thread boundaries. This tracer ensures that:
+///
+/// 1. Async futures spawned via DataFusion's `JoinSet` run with the current span as their parent
+/// 2. Blocking closures run within the current span's scope
+///
+/// This is essential for proper trace hierarchies like:
+/// ```text
+/// sql_query
+///   └── ai (UDF call)
+///         └── ai_completion (individual row processing)
+/// ```
+///
+/// Without this tracer, the `ai_completion` spans would not properly parent under `sql_query`.
+///
+/// ## Scope
+///
+/// This tracer **only affects DataFusion's internal task spawning** via `JoinSet`. For other
+/// async operations (e.g., direct `tokio::spawn` calls), use `.instrument(span)` or capture
+/// the span context manually before entering async boundaries.
+///
+/// ## Usage
+///
+/// This tracer is automatically initialized during runtime startup via `init_datafusion_tracer()`.
+/// No additional configuration is needed for DataFusion operations to properly propagate spans.
+///
+/// For non-DataFusion async code emitting to `target: "task_history"`:
+/// - Use `.instrument(span)` on futures before spawning them
+/// - Or capture `Span::current()` before async boundaries and use `parent: &span` in child spans
+pub struct TaskHistorySpanTracer;
+
+impl JoinSetTracer for TaskHistorySpanTracer {
+    /// Instruments a boxed future to run in the current span.
+    ///
+    /// The future's return type is erased to `Box<dyn Any + Send>`, which we
+    /// run inside the current span context using `in_current_span()`.
+    fn trace_future(
+        &self,
+        fut: BoxFuture<'static, Box<dyn Any + Send>>,
+    ) -> BoxFuture<'static, Box<dyn Any + Send>> {
+        fut.in_current_span().boxed()
+    }
+
+    /// Instruments a boxed blocking closure by running it inside the current span's scope.
+    ///
+    /// Captures the current span and returns a new closure that runs the original
+    /// closure within that span's scope.
+    fn trace_block(
+        &self,
+        f: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send>,
+    ) -> Box<dyn FnOnce() -> Box<dyn Any + Send> + Send> {
+        let span = Span::current();
+        Box::new(move || span.in_scope(f))
+    }
+}
+
+/// Initializes the global `JoinSetTracer` for DataFusion.
+///
+/// This should be called once during runtime initialization, before any DataFusion
+/// queries are executed. It sets up the `TaskHistorySpanTracer` globally so that
+/// all DataFusion operations will properly propagate span context.
+///
+/// # Errors
+///
+/// Returns an error if a tracer has already been set. This is a programming error
+/// and indicates the function was called multiple times.
+pub fn init_datafusion_tracer() -> Result<(), Box<dyn std::error::Error>> {
+    datafusion::common::runtime::set_join_set_tracer(&TaskHistorySpanTracer)
+        .map_err(|e| format!("Failed to set DataFusion JoinSet tracer: {e}").into())
 }


### PR DESCRIPTION
As per https://datafusion.apache.org/blog/2025/07/11/datafusion-47.0.0/#context-propagation-in-spawned-tasks-for-tracing-logging-etc

This pull request adds support for proper tracing context propagation across async boundaries in DataFusion operations. It introduces a custom tracer to ensure that spans (used for distributed tracing and logging) are correctly inherited by tasks spawned internally by DataFusion, resulting in more accurate and hierarchical trace logs for query execution.

The most important changes include:

**Tracing context propagation improvements:**

* Added a `TaskHistorySpanTracer` struct implementing DataFusion's `JoinSetTracer` trait, ensuring that both async futures and blocking closures spawned by DataFusion inherit the current tracing span context. This maintains correct parent-child relationships in trace logs, especially for nested operations like SQL queries and UDF calls.
* Provided detailed documentation explaining the scope, necessity, and usage of the new tracer, including instructions for non-DataFusion async code to maintain proper tracing.

**Runtime initialization:**

* Implemented an `init_datafusion_tracer()` function that initializes the global tracer for DataFusion, ensuring it is set up once during runtime startup.
* Updated the `RuntimeBuilder::build` method to initialize the DataFusion tracer at startup, with a warning if initialization fails. This guarantees that all DataFusion operations in the runtime will propagate spans as intended.

**Dependency and import updates:**

* Added necessary imports for DataFusion's `JoinSetTracer`, `futures` utilities, and `tracing` span management to support the new tracing functionality.