### PR TITLE
Make cleanup disk GH action; use in integration tests

### DIFF
--- a/.github/actions/cleanup-disk/action.yml
+++ b/.github/actions/cleanup-disk/action.yml
@@ -1,0 +1,36 @@
+name: 'Free Disk Space'
+description: 'Frees disk space on GitHub Actions Linux runners by removing unnecessary packages and files'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Free Disk Space
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
+        sudo rm -rf \
+          /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+          /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+          /usr/lib/jvm || true
+        echo "some directories deleted"
+        sudo apt install aptitude -y >/dev/null 2>&1
+        sudo aptitude purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
+          esl-erlang firefox gfortran-8 gfortran-9 google-chrome-stable \
+          google-cloud-sdk imagemagick \
+          libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
+          mercurial apt-transport-https mono-complete libmysqlclient \
+          yarn chrpath libssl-dev libxft-dev \
+          libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
+          snmp pollinate libpq-dev postgresql-client powershell ruby-full \
+          sphinxsearch subversion mongodb-org azure-cli microsoft-edge-stable \
+          -y -f >/dev/null 2>&1
+        sudo aptitude purge google-cloud-sdk -f -y >/dev/null 2>&1
+        sudo aptitude purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
+        sudo apt purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
+        sudo aptitude purge '~n ^php' -f -y >/dev/null 2>&1
+        sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+        sudo apt-get autoremove -y >/dev/null 2>&1
+        sudo apt-get autoclean -y >/dev/null 2>&1
+        echo "some packages purged"
+        df -h

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -141,7 +141,7 @@ jobs:
           os: 'linux'
 
       - name: Clean up Disk
-        uses: ./.github/action/cleanup-disk
+        uses: ./.github/actions/cleanup-disk
 
       - name: Install Oracle ODPI-C
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,6 +140,9 @@ jobs:
         with:
           os: 'linux'
 
+      - name: Clean up Disk
+        uses: ./.github/action/cleanup-disk
+
       - name: Install Oracle ODPI-C
         run: |
           curl -Lo basic.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip


### PR DESCRIPTION
## 📝 Summary
- Failing to run integration tests on Github hosted CI runners because of an out of disk issue. 
- Example CI [run](https://github.com/spiceai/spiceai/actions/runs/18242712517/job/51948035597?pr=7373).  
- This PR makes a useable Github Action step to free common uses of disk. Copied from: https://github.com/datafusion-contrib/datafusion-table-providers/pull/179
- Example annotated error
  ```Shell
  System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251004-104348-utc.log'
     at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
     at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
     at System.Diagnostics.TextWriterTraceListener.Flush()
     at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
     at GitHub.Runner.Common.HostTraceListener.TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, Int32 id, String message)
     at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
     at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
     at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
  System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251004-104348-utc.log'
     at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
     at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
     at System.Diagnostics.TextWriterTraceListener.Flush()
     at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
     at GitHub.Runner.Common.HostTraceListener.TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, Int32 id, String message)
     at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
     at GitHub.Runner.Common.Tracing.Error(Exception exception)
     at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
  Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251004-104348-utc.log'
     at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
     at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
     at System.Diagnostics.TextWriterTraceListener.Flush()
     at System.Diagnostics.TraceSource.Flush()
     at GitHub.Runner.Common.Tracing.Dispose(Boolean disposing)
     at GitHub.Runner.Common.Tracing.Dispose()
     at GitHub.Runner.Common.TraceManager.Dispose(Boolean disposing)
     at GitHub.Runner.Common.TraceManager.Dispose()
     at GitHub.Runner.Common.HostContext.Dispose(Boolean disposing)
     at GitHub.Runner.Common.HostContext.Dispose()
     at GitHub.Runner.Worker.Program.Main(String[] args)
  ```
