### PR TITLE
Limit results from `SearchIndex::query_table_provider`

### DIFF
--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -453,8 +453,8 @@ impl TableProvider for SearchQueryProvider {
             filters,
         )?;
         search_lp = match (just_use_index, filters.iter().cloned().reduce(Expr::and)) {
-            (true, None) => search_lp,
-            (true, Some(filter)) => search_lp.filter(filter)?,
+            (true, None) => search_lp.limit(0, limit)?,
+            (true, Some(filter)) => search_lp.filter(filter)?.limit(0, limit)?,
             (false, _) => {
                 // Pushdown indexes to search index
                 let search_index = if let Some(filter) =


### PR DESCRIPTION
## 📝 Summary
- Because `SearchIndex` provides `query_table_provider` in desc score order, in `SearchQueryProvider`, we can perform a  limit operator before the final `Sort`. 

## 🔗 Related
 - https://github.com/spiceai/spiceai/issues/6551
   - Does not resolve limit pushdown entirely, but helps in simple cases. 
