### PR TITLE
fix: regexp_match for DuckDB datasets

### DIFF
--- a/crates/runtime/src/datafusion/dialect/duckdb.rs
+++ b/crates/runtime/src/datafusion/dialect/duckdb.rs
@@ -19,7 +19,7 @@ use datafusion::prelude::Expr;
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::sqlparser::ast::{self, Function, FunctionArgExpr, Ident, ObjectName};
 use datafusion_expr::sqlparser;
-use datafusion_expr::sqlparser::ast::{FunctionArg, ValueWithSpan};
+use datafusion_expr::sqlparser::ast::{Array, FunctionArg, ValueWithSpan};
 use itertools::Itertools;
 
 pub(crate) const REGEXP_LIKE_NAME: &str = "regexp_matches";
@@ -250,9 +250,13 @@ impl DuckDBRegexpFunction {
             DuckDBRegexpFunction::Match => {
                 // DuckDB ``regexp_extract`` returns a plain string
                 // DataFusion ``regexp_match`` returns an array with a single string value
-                // wrap the output of the DuckDB function with ``array_value(arg1, ...)``
-                // https://github.com/spiceai/spiceai/issues/6964
-                ast_fn = Self::wrap_function(ast_fn, "array_value");
+                ast_fn = ast::Expr::Named {
+                    expr: Box::new(ast::Expr::Array(Array {
+                        elem: vec![ast_fn],
+                        named: true,
+                    })),
+                    name: Ident::new("item"),
+                }
             }
             DuckDBRegexpFunction::Count => {
                 // Wrap the extract array in a ``len()``

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -293,11 +293,10 @@ async fn duckdb_regexp() -> Result<(), String> {
                     "test_regexp_like_with_case_insensitive_flag",
                     "SELECT * FROM csv_test WHERE regexp_like(region, 'america', 'i')",
                 ),
-                // disabled until github.com/spiceai/spiceai/issues/6964 is addressed
-                // (
-                //     "test_regexp_match",
-                //     "SELECT regexp_match(region, 'AMERICA') FROM csv_test",
-                // ),
+                (
+                    "test_regexp_match",
+                    "SELECT regexp_match(region, 'AMERICA') FROM csv_test",
+                ),
                 (
                     "test_regexp_count",
                     "SELECT regexp_count(region, 'AMERICA') FROM csv_test",

--- a/crates/runtime/tests/duckdb/snapshots/integration__duckdb__test_regexp_match_results.snap
+++ b/crates/runtime/tests/duckdb/snapshots/integration__duckdb__test_regexp_match_results.snap
@@ -1,0 +1,14 @@
+---
+source: crates/runtime/tests/duckdb/mod.rs
+expression: pretty
+---
++-----------------------------------------------+
+| regexp_match(csv_test.region,Utf8("AMERICA")) |
++-----------------------------------------------+
+| []                                            |
+| [AMERICA]                                     |
+| [AMERICA]                                     |
+| []                                            |
+| []                                            |
+| []                                            |
++-----------------------------------------------+


### PR DESCRIPTION
## 📝 Summary

Fixes a bug related to using `regexp_match` with DuckDB datasets. The DataFusion and DuckDB equivalents were made to match schemas.

## 🔗 Related

Closes:
- #6964 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
