### PR TITLE
Allow to enable/disable acceleration refresh metrics

### DIFF
--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -21,6 +21,13 @@ use opentelemetry::{
     metrics::{Counter, Gauge, Histogram, Meter},
 };
 
+pub const METRIC_MAX_TIMESTAMP_BEFORE_REFRESH_MS: &str =
+    "dataset_acceleration_max_timestamp_before_refresh_ms";
+pub const METRIC_MAX_TIMESTAMP_AFTER_REFRESH_MS: &str =
+    "dataset_acceleration_max_timestamp_after_refresh_ms";
+pub const METRIC_REFRESH_LAG_MS: &str = "dataset_acceleration_refresh_lag_ms";
+pub const METRIC_INGESTION_LAG_MS: &str = "dataset_acceleration_ingestion_lag_ms";
+
 static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("dataset_acceleration"));
 
 pub(crate) static REFRESH_ERRORS: LazyLock<Counter<u64>> = LazyLock::new(|| {
@@ -55,28 +62,28 @@ pub(crate) static READY_STATE_FALLBACK: LazyLock<Counter<u64>> = LazyLock::new(|
 
 pub(crate) static MAX_TIMESTAMP_BEFORE_REFRESH_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
     METER
-        .i64_gauge("dataset_acceleration_max_timestamp_before_refresh_ms")
+        .i64_gauge(METRIC_MAX_TIMESTAMP_BEFORE_REFRESH_MS)
         .with_description("Maximum value of the dataset's time_column before the refresh operation, in milliseconds.")
         .build()
 });
 
 pub(crate) static MAX_TIMESTAMP_AFTER_REFRESH_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
     METER
-        .i64_gauge("dataset_acceleration_max_timestamp_after_refresh_ms")
+        .i64_gauge(METRIC_MAX_TIMESTAMP_AFTER_REFRESH_MS)
         .with_description("Maximum value of the dataset's time_column after the refresh operation, in milliseconds.")
         .build()
 });
 
 pub(crate) static REFRESH_LAG_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
     METER
-        .i64_gauge("dataset_acceleration_refresh_lag_ms")
+        .i64_gauge(METRIC_REFRESH_LAG_MS)
         .with_description("Difference between the maximum time_column value after and before the refresh operation, in milliseconds.")
         .build()
 });
 
 pub(crate) static INGESTION_LAG_MS: LazyLock<Gauge<i64>> = LazyLock::new(|| {
     METER
-        .i64_gauge("dataset_acceleration_ingestion_lag_ms")
+        .i64_gauge(METRIC_INGESTION_LAG_MS)
         .with_description("Lag between the current wall-clock time and the maximum time_column value after the refresh operation, in milliseconds.")
         .build()
 });

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -555,7 +555,6 @@ impl AcceleratedTable {
     }
 
     pub async fn trigger_refresh(&self, overrides: Option<RefreshOverrides>) -> Result<()> {
-        println!("trigger_refresh");
         if let Some(refresh_trigger) = self.refresh_trigger() {
             refresh_trigger
                 .send(overrides)

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -21,6 +21,11 @@ use crate::component::dataset::acceleration::{RefreshMode, RefreshOnStartup, Zer
 use crate::component::dataset::{ReadyState, TimeFormat};
 use crate::datafusion::error::SpiceExternalError;
 use crate::datafusion::is_spice_internal_dataset;
+use crate::execution_plan::TableScanParams;
+use crate::execution_plan::fallback_on_zero_results::FallbackOnZeroResultsScanExec;
+use crate::execution_plan::schema_cast::SchemaCastScanExec;
+use crate::execution_plan::slice::SliceExec;
+use crate::execution_plan::tee::TeeExec;
 use crate::federated_table::FederatedTable;
 use crate::status;
 use arrow::datatypes::SchemaRef;
@@ -45,15 +50,10 @@ use refresh::RefreshOverrides;
 use runtime_acceleration::dataset_checkpoint::DatasetCheckpointer;
 use runtime_acceleration::snapshot::SnapshotBehavior;
 use snafu::prelude::*;
+use spicepod::metric::Metrics;
 use synchronized_table::SynchronizedTable;
 use tokio::sync::{Notify, RwLock, Semaphore, mpsc};
 use tokio::task::JoinHandle;
-
-use crate::execution_plan::TableScanParams;
-use crate::execution_plan::fallback_on_zero_results::FallbackOnZeroResultsScanExec;
-use crate::execution_plan::schema_cast::SchemaCastScanExec;
-use crate::execution_plan::slice::SliceExec;
-use crate::execution_plan::tee::TeeExec;
 
 pub mod federation;
 mod metrics;
@@ -103,7 +103,7 @@ pub enum Error {
     RefreshNotSupportedForChildTable { parent_dataset: TableReference },
 
     #[snafu(display(
-        "Failed to find latest timestamp in accelerated table. Is the 'time_column' parameter correct?"
+        "Failed to find latest timestamp in accelerated table. Is the 'time_column' parameter correct? {source}"
     ))]
     FailedToQueryLatestTimestamp { source: DataFusionError },
 
@@ -245,6 +245,7 @@ pub struct Builder {
     initial_load_complete: bool,
     snapshot_behavior: SnapshotBehavior,
     snapshot_local_path: Option<PathBuf>,
+    dataset_metrics: Option<Metrics>,
 }
 
 impl Builder {
@@ -277,6 +278,7 @@ impl Builder {
             refresh_semaphore: None,
             snapshot_behavior: SnapshotBehavior::default(),
             snapshot_local_path: None,
+            dataset_metrics: None,
         }
     }
 
@@ -312,6 +314,11 @@ impl Builder {
 
     pub fn refresh_semaphore(&mut self, refresh_semaphore: Arc<Semaphore>) -> &mut Self {
         self.refresh_semaphore = Some(refresh_semaphore);
+        self
+    }
+
+    pub fn dataset_metrics(&mut self, dataset_metrics: Metrics) -> &mut Self {
+        self.dataset_metrics = Some(dataset_metrics);
         self
     }
 
@@ -461,6 +468,7 @@ impl Builder {
         refresher.set_initial_load_completed(self.initial_load_complete);
         refresher.disable_federation(self.disable_federation);
         refresher.with_completion_notifier(Arc::clone(&on_complete_notification));
+        refresher.with_dataset_metrics(self.dataset_metrics);
         if let Some(synchronize_with) = &self.synchronize_with {
             refresher.synchronize_with(synchronize_with.clone());
         }
@@ -547,6 +555,7 @@ impl AcceleratedTable {
     }
 
     pub async fn trigger_refresh(&self, overrides: Option<RefreshOverrides>) -> Result<()> {
+        println!("trigger_refresh");
         if let Some(refresh_trigger) = self.refresh_trigger() {
             refresh_trigger
                 .send(overrides)

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -20,6 +20,9 @@ use std::sync::{Arc, Weak};
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use super::metrics;
+use super::refresh_task_runner::RefreshTaskRunner;
+use super::synchronized_table::SynchronizedTable;
 use crate::accelerated_table::refresh_task::RefreshTask;
 use crate::component::dataset::TimeFormat;
 use crate::component::dataset::acceleration::{RefreshMode, RefreshOnStartup};
@@ -37,15 +40,12 @@ use runtime_acceleration::dataset_checkpoint::DatasetCheckpointer;
 use runtime_acceleration::snapshot::{SnapshotBehavior, SnapshotManager};
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
+use spicepod::metric::Metrics;
 use tokio::select;
 use tokio::sync::Notify;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::{RwLock, Semaphore};
 use tokio::time::sleep;
-
-use super::metrics;
-use super::refresh_task_runner::RefreshTaskRunner;
-use super::synchronized_table::SynchronizedTable;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -417,6 +417,7 @@ pub(crate) enum AccelerationRefreshMode {
 pub struct Refresher {
     runtime_status: Arc<status::RuntimeStatus>,
     dataset_name: TableReference,
+    dataset_metrics: Option<Metrics>,
     federated: Arc<FederatedTable>,
     federated_source: Option<String>,
     refresh: Arc<RwLock<Refresh>>,
@@ -475,6 +476,7 @@ impl Refresher {
             on_complete_notification: None,
             snapshot_behavior: SnapshotBehavior::default(),
             snapshot_local_path: None,
+            dataset_metrics: None,
         }
     }
 
@@ -515,6 +517,11 @@ impl Refresher {
 
     pub fn with_completion_notifier(&mut self, on_complete_notification: Arc<Notify>) -> &mut Self {
         self.on_complete_notification = Some(on_complete_notification);
+        self
+    }
+
+    pub fn with_dataset_metrics(&mut self, dataset_metrics: Option<Metrics>) -> &mut Self {
+        self.dataset_metrics = dataset_metrics;
         self
     }
 
@@ -618,6 +625,9 @@ impl Refresher {
         if let Some(semaphore) = &self.semaphore {
             refresh_task_runner = refresh_task_runner.with_semaphore(Arc::clone(semaphore));
         }
+
+        refresh_task_runner =
+            refresh_task_runner.with_dataset_metrics(self.dataset_metrics.clone());
 
         let mut refresh_task_runner = refresh_task_runner.build();
 
@@ -778,6 +788,7 @@ impl Refresher {
                 Arc::clone(&self.federated),
                 self.federated_source.clone(),
                 Arc::clone(&self.accelerator),
+                self.dataset_metrics.clone(),
             )
             .with_disable_federation(self.disable_federation)
             .build(),
@@ -810,6 +821,7 @@ impl Refresher {
                 Arc::clone(&self.federated),
                 self.federated_source.clone(),
                 Arc::clone(&self.accelerator),
+                self.dataset_metrics.clone(),
             )
             .with_disable_federation(self.disable_federation)
             .build(),

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -419,6 +419,7 @@ impl RefreshTask {
             None => None,
         };
 
+        #[allow(clippy::cast_possible_truncation)]
         let current_time_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -452,44 +453,6 @@ impl RefreshTask {
             {
                 let ingestion_lag_ms = current_time_ms - after;
                 metrics::INGESTION_LAG_MS.record(ingestion_lag_ms, label_set);
-            }
-        }
-    }
-
-    async fn handle_metrics_old(
-        &self,
-        dataset_metrics_label_sets: &[Vec<KeyValue>],
-        max_timestamp_before_refresh_ms: Option<i64>,
-        max_timestamp_after_refresh_ms: Option<Arc<Mutex<Option<i64>>>>,
-    ) {
-        if let (Some(max_timestamp_before_refresh_ms), Some(max_timestamp_after_refresh_ms)) = (
-            max_timestamp_before_refresh_ms,
-            max_timestamp_after_refresh_ms,
-        ) {
-            let max_timestamp_after_refresh_ms = {
-                let guard = max_timestamp_after_refresh_ms.lock().await;
-                *guard
-            };
-
-            if let Some(max_timestamp_after_refresh_ms) = max_timestamp_after_refresh_ms {
-                #[allow(clippy::cast_possible_truncation)]
-                let current_time_ms = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as i64;
-
-                let refresh_lag_ms =
-                    max_timestamp_after_refresh_ms - max_timestamp_before_refresh_ms;
-                let ingestion_lag_ms = current_time_ms - max_timestamp_after_refresh_ms;
-
-                for label_set in dataset_metrics_label_sets {
-                    metrics::MAX_TIMESTAMP_BEFORE_REFRESH_MS
-                        .record(max_timestamp_before_refresh_ms, label_set);
-                    metrics::MAX_TIMESTAMP_AFTER_REFRESH_MS
-                        .record(max_timestamp_after_refresh_ms, label_set);
-                    metrics::REFRESH_LAG_MS.record(refresh_lag_ms, label_set);
-                    metrics::INGESTION_LAG_MS.record(ingestion_lag_ms, label_set);
-                }
             }
         }
     }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -270,8 +270,6 @@ impl RefreshTask {
     }
 
     async fn run_once(&self, refresh: &Refresh) -> Result<(), RetryError<super::Error>> {
-        println!("run_once");
-
         self.set_refresh_status(refresh.sql.as_deref(), status::ComponentStatus::Refreshing)
             .await;
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -160,7 +160,7 @@ impl RefreshTaskBuilder {
             enabled_dataset_metrics: self
                 .dataset_metrics
                 .as_ref()
-                .map(|m| m.enabled_metrics())
+                .map(spicepod::metric::Metrics::enabled_metrics)
                 .as_deref()
                 .unwrap_or(&[])
                 .iter()
@@ -425,33 +425,33 @@ impl RefreshTask {
             .as_millis() as i64;
 
         for label_set in dataset_metrics_label_sets {
-            if self.is_metric_enabled(metrics::METRIC_MAX_TIMESTAMP_BEFORE_REFRESH_MS) {
-                if let Some(val) = max_timestamp_before_refresh_ms {
-                    metrics::MAX_TIMESTAMP_BEFORE_REFRESH_MS.record(val, label_set);
-                }
+            if self.is_metric_enabled(metrics::METRIC_MAX_TIMESTAMP_BEFORE_REFRESH_MS)
+                && let Some(val) = max_timestamp_before_refresh_ms
+            {
+                metrics::MAX_TIMESTAMP_BEFORE_REFRESH_MS.record(val, label_set);
             }
 
-            if self.is_metric_enabled(metrics::METRIC_MAX_TIMESTAMP_AFTER_REFRESH_MS) {
-                if let Some(val) = max_timestamp_after_refresh_ms_value {
-                    metrics::MAX_TIMESTAMP_AFTER_REFRESH_MS.record(val, label_set);
-                }
+            if self.is_metric_enabled(metrics::METRIC_MAX_TIMESTAMP_AFTER_REFRESH_MS)
+                && let Some(val) = max_timestamp_after_refresh_ms_value
+            {
+                metrics::MAX_TIMESTAMP_AFTER_REFRESH_MS.record(val, label_set);
             }
 
-            if self.is_metric_enabled(metrics::METRIC_REFRESH_LAG_MS) {
-                if let (Some(before), Some(after)) = (
+            if self.is_metric_enabled(metrics::METRIC_REFRESH_LAG_MS)
+                && let (Some(before), Some(after)) = (
                     max_timestamp_before_refresh_ms,
                     max_timestamp_after_refresh_ms_value,
-                ) {
-                    let refresh_lag_ms = after - before;
-                    metrics::REFRESH_LAG_MS.record(refresh_lag_ms, label_set);
-                }
+                )
+            {
+                let refresh_lag_ms = after - before;
+                metrics::REFRESH_LAG_MS.record(refresh_lag_ms, label_set);
             }
 
-            if self.is_metric_enabled(metrics::METRIC_INGESTION_LAG_MS) {
-                if let Some(after) = max_timestamp_after_refresh_ms_value {
-                    let ingestion_lag_ms = current_time_ms - after;
-                    metrics::INGESTION_LAG_MS.record(ingestion_lag_ms, label_set);
-                }
+            if self.is_metric_enabled(metrics::METRIC_INGESTION_LAG_MS)
+                && let Some(after) = max_timestamp_after_refresh_ms_value
+            {
+                let ingestion_lag_ms = current_time_ms - after;
+                metrics::INGESTION_LAG_MS.record(ingestion_lag_ms, label_set);
             }
         }
     }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -80,6 +80,8 @@ use datafusion::{
 };
 use datafusion_expr::{LogicalPlanBuilder, UNNAMED_TABLE, ident};
 use datafusion_federation::{FederatedPlanner, FederatedTableProviderAdaptor};
+use spicepod::metric::Metrics;
+use std::collections::HashSet;
 
 mod changes;
 mod streaming_append;
@@ -102,6 +104,7 @@ pub struct RefreshTaskBuilder {
     disable_federation: bool,
     // Used to control how many parallel refreshes the runtime performs.
     semaphore: Option<Arc<Semaphore>>,
+    dataset_metrics: Option<Metrics>,
 }
 
 impl RefreshTaskBuilder {
@@ -112,6 +115,7 @@ impl RefreshTaskBuilder {
         federated: Arc<FederatedTable>,
         federated_source: Option<String>,
         accelerator: Arc<dyn TableProvider>,
+        dataset_metrics: Option<Metrics>,
     ) -> Self {
         Self {
             runtime_status,
@@ -122,6 +126,7 @@ impl RefreshTaskBuilder {
             sink: Arc::new(RwLock::new(AccelerationSink::new(accelerator))),
             disable_federation: false,
             semaphore: None,
+            dataset_metrics,
         }
     }
 
@@ -152,6 +157,15 @@ impl RefreshTaskBuilder {
             sink: self.sink,
             disable_federation: self.disable_federation,
             semaphore,
+            enabled_dataset_metrics: self
+                .dataset_metrics
+                .as_ref()
+                .map(|m| m.enabled_metrics())
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .cloned()
+                .collect(),
         }
     }
 }
@@ -167,6 +181,7 @@ pub struct RefreshTask {
     disable_federation: bool,
     // Used to control how many parallel refreshes the runtime performs.
     semaphore: Arc<Semaphore>,
+    enabled_dataset_metrics: HashSet<String>,
 }
 
 impl RefreshTask {
@@ -177,6 +192,7 @@ impl RefreshTask {
         federated: Arc<FederatedTable>,
         federated_source: Option<String>,
         accelerator: Arc<dyn TableProvider>,
+        dataset_metrics: Option<Metrics>,
     ) -> RefreshTaskBuilder {
         RefreshTaskBuilder::new(
             runtime_status,
@@ -184,6 +200,7 @@ impl RefreshTask {
             federated,
             federated_source,
             accelerator,
+            dataset_metrics,
         )
     }
 
@@ -253,12 +270,26 @@ impl RefreshTask {
     }
 
     async fn run_once(&self, refresh: &Refresh) -> Result<(), RetryError<super::Error>> {
+        println!("run_once");
+
         self.set_refresh_status(refresh.sql.as_deref(), status::ComponentStatus::Refreshing)
             .await;
 
         let dataset_metrics_label_sets = self.get_dataset_label_sets(&refresh.mode).await;
 
-        let max_timestamp_before_refresh_ms = self.get_max_timestamp_before_refresh(refresh).await;
+        let (need_max_timestamp_before_refresh, need_max_timestamp_after_refresh) = (
+            self.is_metric_enabled(metrics::METRIC_MAX_TIMESTAMP_BEFORE_REFRESH_MS)
+                || self.is_metric_enabled(metrics::METRIC_REFRESH_LAG_MS),
+            self.is_metric_enabled(metrics::METRIC_MAX_TIMESTAMP_AFTER_REFRESH_MS)
+                || self.is_metric_enabled(metrics::METRIC_REFRESH_LAG_MS)
+                || self.is_metric_enabled(metrics::METRIC_INGESTION_LAG_MS),
+        );
+
+        let max_timestamp_before_refresh_ms = if need_max_timestamp_before_refresh {
+            self.get_max_timestamp_before_refresh(refresh).await
+        } else {
+            None
+        };
 
         let _timer = MultiTimeMeasurement::new(
             match refresh.mode {
@@ -294,20 +325,27 @@ impl RefreshTask {
             }
         };
 
-        let source_name = format!(
-            "{} {}",
-            self.component_type(),
-            include_source_to_table_name(&self.dataset_name, self.federated_source.as_deref())
-        );
         let (streaming_data_update, max_timestamp_after_refresh_ms) =
-            with_find_max_timestamp_in_stream(
-                streaming_data_update,
-                self.federated.schema(),
-                refresh.time_column.clone(),
-                refresh.time_format,
-                source_name,
-            )
-            .await;
+            if need_max_timestamp_after_refresh {
+                let source_name = format!(
+                    "{} {}",
+                    self.component_type(),
+                    include_source_to_table_name(
+                        &self.dataset_name,
+                        self.federated_source.as_deref()
+                    )
+                );
+                with_find_max_timestamp_in_stream(
+                    streaming_data_update,
+                    self.federated.schema(),
+                    refresh.time_column.clone(),
+                    refresh.time_format,
+                    source_name,
+                )
+                .await
+            } else {
+                (streaming_data_update, None)
+            };
 
         self.write_streaming_data_update(
             Some(start_time),
@@ -342,6 +380,10 @@ impl RefreshTask {
         Ok(())
     }
 
+    fn is_metric_enabled(&self, metric_name: &str) -> bool {
+        self.enabled_dataset_metrics.contains(metric_name)
+    }
+
     async fn get_max_timestamp_before_refresh(&self, refresh: &Refresh) -> Option<i64> {
         if refresh.time_column.is_some() {
             match self.timestamp_nanos_for_append_query(refresh).await {
@@ -366,6 +408,57 @@ impl RefreshTask {
     }
 
     async fn handle_metrics(
+        &self,
+        dataset_metrics_label_sets: &[Vec<KeyValue>],
+        max_timestamp_before_refresh_ms: Option<i64>,
+        max_timestamp_after_refresh_ms: Option<Arc<Mutex<Option<i64>>>>,
+    ) {
+        let max_timestamp_after_refresh_ms_value = match &max_timestamp_after_refresh_ms {
+            Some(arc_mutex) => {
+                let guard = arc_mutex.lock().await;
+                *guard
+            }
+            None => None,
+        };
+
+        let current_time_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        for label_set in dataset_metrics_label_sets {
+            if self.is_metric_enabled(metrics::METRIC_MAX_TIMESTAMP_BEFORE_REFRESH_MS) {
+                if let Some(val) = max_timestamp_before_refresh_ms {
+                    metrics::MAX_TIMESTAMP_BEFORE_REFRESH_MS.record(val, label_set);
+                }
+            }
+
+            if self.is_metric_enabled(metrics::METRIC_MAX_TIMESTAMP_AFTER_REFRESH_MS) {
+                if let Some(val) = max_timestamp_after_refresh_ms_value {
+                    metrics::MAX_TIMESTAMP_AFTER_REFRESH_MS.record(val, label_set);
+                }
+            }
+
+            if self.is_metric_enabled(metrics::METRIC_REFRESH_LAG_MS) {
+                if let (Some(before), Some(after)) = (
+                    max_timestamp_before_refresh_ms,
+                    max_timestamp_after_refresh_ms_value,
+                ) {
+                    let refresh_lag_ms = after - before;
+                    metrics::REFRESH_LAG_MS.record(refresh_lag_ms, label_set);
+                }
+            }
+
+            if self.is_metric_enabled(metrics::METRIC_INGESTION_LAG_MS) {
+                if let Some(after) = max_timestamp_after_refresh_ms_value {
+                    let ingestion_lag_ms = current_time_ms - after;
+                    metrics::INGESTION_LAG_MS.record(ingestion_lag_ms, label_set);
+                }
+            }
+        }
+    }
+
+    async fn handle_metrics_old(
         &self,
         dataset_metrics_label_sets: &[Vec<KeyValue>],
         max_timestamp_before_refresh_ms: Option<i64>,

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -32,9 +32,9 @@ use tokio::{
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use datafusion::{datasource::TableProvider, sql::TableReference};
-
 use super::refresh::Refresh;
+use datafusion::{datasource::TableProvider, sql::TableReference};
+use spicepod::metric::Metrics;
 
 pub struct RefreshTaskRunnerBuilder {
     runtime_status: Arc<status::RuntimeStatus>,
@@ -45,6 +45,7 @@ pub struct RefreshTaskRunnerBuilder {
     accelerator: Arc<dyn TableProvider>,
     disable_federation: bool,
     semaphore: Option<Arc<Semaphore>>,
+    dataset_metrics: Option<Metrics>,
 }
 
 impl RefreshTaskRunnerBuilder {
@@ -66,6 +67,7 @@ impl RefreshTaskRunnerBuilder {
             accelerator,
             disable_federation: false,
             semaphore: None,
+            dataset_metrics: None,
         }
     }
 
@@ -83,6 +85,12 @@ impl RefreshTaskRunnerBuilder {
     }
 
     #[must_use]
+    pub fn with_dataset_metrics(mut self, metrics: Option<Metrics>) -> Self {
+        self.dataset_metrics = metrics;
+        self
+    }
+
+    #[must_use]
     pub fn build(self) -> RefreshTaskRunner {
         let mut refresh_task_builder = RefreshTask::builder(
             self.runtime_status,
@@ -90,6 +98,7 @@ impl RefreshTaskRunnerBuilder {
             self.federated,
             self.federated_source,
             self.accelerator,
+            self.dataset_metrics,
         )
         .with_disable_federation(self.disable_federation);
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1084,6 +1084,8 @@ impl DataFusion {
             accelerated_table_builder.refresh_semaphore(Arc::clone(semaphore));
         }
 
+        accelerated_table_builder.dataset_metrics(dataset.metrics.clone());
+
         if refresh_mode == RefreshMode::Changes {
             let changes_stream = source.changes_stream(Arc::clone(&source_table_provider));
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -742,7 +742,7 @@ impl Runtime {
         for ds in initialized_datasets {
             if let Some(current_ds) = existing_datasets.iter().find(|d| d.name == ds.name) {
                 if ds != *current_ds {
-                    Arc::clone(&self).update_dataset(ds).await;
+                    Box::pin(Arc::clone(&self).update_dataset(ds)).await;
                 }
             } else {
                 self.status

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -118,6 +118,7 @@ async fn create_refresh_task(
             Arc::clone(&accelerated_table.get_federated_table()),
             None,
             accelerated_table.get_accelerator(),
+            None,
         )
         .build(),
         accelerated_table.refresh_params().read().await.clone(),


### PR DESCRIPTION
## 📝 Summary

Now acceleration refresh metrics are disabled by default, but can be enabled.

Example configuration:
```yaml
datasets:
  - from: postgres:numbers
    name: numbers
    acceleration:
      ...
    metrics:
      - name: dataset_acceleration_max_timestamp_before_refresh_ms
      - name: dataset_acceleration_max_timestamp_after_refresh_ms
      - name: dataset_acceleration_refresh_lag_ms
      - name: dataset_acceleration_ingestion_lag_ms
```

## 🔗 Related

https://github.com/spiceai/spiceai/issues/7184

## 🚨 Breaking Changes

## 📚 Docs
