### PR TITLE
Disable acceleration refresh metrics

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -342,9 +342,10 @@ impl RefreshTask {
         Ok(())
     }
 
-    async fn get_max_timestamp_before_refresh(&self, refresh: &Refresh) -> Option<i64> {
-        if refresh.time_column.is_some() {
-            match self.timestamp_nanos_for_append_query(refresh).await {
+    async fn get_max_timestamp_before_refresh(&self, _refresh: &Refresh) -> Option<i64> {
+        return None;
+        if _refresh.time_column.is_some() {
+            match self.timestamp_nanos_for_append_query(_refresh).await {
                 Ok(Some(time_nanos)) => i64::try_from(time_nanos / NANOS_TO_MILLIS).ok(),
                 Ok(None) => None,
                 Err(e) => {

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -342,10 +342,11 @@ impl RefreshTask {
         Ok(())
     }
 
-    async fn get_max_timestamp_before_refresh(&self, _refresh: &Refresh) -> Option<i64> {
+    #[allow(unreachable_code, unused_variables)]
+    async fn get_max_timestamp_before_refresh(&self, refresh: &Refresh) -> Option<i64> {
         return None;
-        if _refresh.time_column.is_some() {
-            match self.timestamp_nanos_for_append_query(_refresh).await {
+        if refresh.time_column.is_some() {
+            match self.timestamp_nanos_for_append_query(refresh).await {
                 Ok(Some(time_nanos)) => i64::try_from(time_nanos / NANOS_TO_MILLIS).ok(),
                 Ok(None) => None,
                 Err(e) => {

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -52,6 +52,7 @@ macro_rules! max_ts_macro {
     }};
 }
 
+#[allow(unreachable_code, unused_variables)]
 /// Extracts the maximum timestamp from a stream of record batches.
 ///
 /// The extraction uses `time_column` and `time_format` to interpret timestamps
@@ -73,26 +74,26 @@ macro_rules! max_ts_macro {
 ///             - If batches were not empty, a warning is logged
 pub async fn with_find_max_timestamp_in_stream(
     data_update: StreamingDataUpdate,
-    _schema: SchemaRef,
-    _time_column: Option<String>,
-    _time_format: Option<TimeFormat>,
-    _source_name: String,
+    schema: SchemaRef,
+    time_column: Option<String>,
+    time_format: Option<TimeFormat>,
+    source_name: String,
 ) -> (StreamingDataUpdate, Option<Arc<Mutex<Option<i64>>>>) {
     return (data_update, None);
 
-    let Some(time_column) = _time_column else {
+    let Some(time_column) = time_column else {
         return (data_update, None);
     };
 
-    let time_format = _time_format.unwrap_or_default();
-    let Some(field) = _schema
+    let time_format = time_format.unwrap_or_default();
+    let Some(field) = schema
         .column_with_name(&time_column)
         .map(|(_, f)| f)
         .cloned()
     else {
         tracing::warn!(
             "Failed to extract max_timestamp after refresh for {}: column {} not found in schema.",
-            _source_name,
+            source_name,
             time_column,
         );
         return (data_update, None);
@@ -107,8 +108,8 @@ pub async fn with_find_max_timestamp_in_stream(
         time_format,
         field,
         max_ts_clone,
-        Arc::clone(&_schema),
-        _source_name,
+        Arc::clone(&schema),
+        source_name,
     );
 
     let new_data_update = StreamingDataUpdate {

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -73,24 +73,26 @@ macro_rules! max_ts_macro {
 ///             - If batches were not empty, a warning is logged
 pub async fn with_find_max_timestamp_in_stream(
     data_update: StreamingDataUpdate,
-    schema: SchemaRef,
-    time_column: Option<String>,
-    time_format: Option<TimeFormat>,
-    source_name: String,
+    _schema: SchemaRef,
+    _time_column: Option<String>,
+    _time_format: Option<TimeFormat>,
+    _source_name: String,
 ) -> (StreamingDataUpdate, Option<Arc<Mutex<Option<i64>>>>) {
-    let Some(time_column) = time_column else {
+    return (data_update, None);
+
+    let Some(time_column) = _time_column else {
         return (data_update, None);
     };
 
-    let time_format = time_format.unwrap_or_default();
-    let Some(field) = schema
+    let time_format = _time_format.unwrap_or_default();
+    let Some(field) = _schema
         .column_with_name(&time_column)
         .map(|(_, f)| f)
         .cloned()
     else {
         tracing::warn!(
             "Failed to extract max_timestamp after refresh for {}: column {} not found in schema.",
-            source_name,
+            _source_name,
             time_column,
         );
         return (data_update, None);
@@ -105,8 +107,8 @@ pub async fn with_find_max_timestamp_in_stream(
         time_format,
         field,
         max_ts_clone,
-        Arc::clone(&schema),
-        source_name,
+        Arc::clone(&_schema),
+        _source_name,
     );
 
     let new_data_update = StreamingDataUpdate {

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -272,6 +272,7 @@ fn string_to_ms(s: &str, time_format: TimeFormat) -> Option<i64> {
         .ok()
 }
 
+#[ignore]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
+++ b/crates/runtime/src/accelerated_table/timestamp_metrics_utils.rs
@@ -272,7 +272,6 @@ fn string_to_ms(s: &str, time_format: TimeFormat) -> Option<i64> {
         .ok()
 }
 
-#[ignore]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -321,6 +320,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_utf8_iso8601() {
         let batch = record_batch!((
@@ -339,6 +339,7 @@ mod tests {
         assert_eq!(max_ts, 1_577_836_800_000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_uint16_milli_seconds() {
         let batch =
@@ -349,6 +350,7 @@ mod tests {
         assert_eq!(max_ts, 2000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_uint32_milli_seconds() {
         let batch =
@@ -359,6 +361,7 @@ mod tests {
         assert_eq!(max_ts, 2000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_uint64_milli_seconds() {
         let batch =
@@ -369,6 +372,7 @@ mod tests {
         assert_eq!(max_ts, 2000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_uint16_seconds() {
         let batch =
@@ -379,6 +383,7 @@ mod tests {
         assert_eq!(max_ts, 2000 * 1000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_uint32_seconds() {
         let batch =
@@ -389,6 +394,7 @@ mod tests {
         assert_eq!(max_ts, 2000 * 1000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_uint64_seconds() {
         let batch =
@@ -399,6 +405,7 @@ mod tests {
         assert_eq!(max_ts, 2000 * 1000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_int16_milli_seconds() {
         let batch =
@@ -409,6 +416,7 @@ mod tests {
         assert_eq!(max_ts, 2000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_int32_milli_seconds() {
         let batch =
@@ -419,6 +427,7 @@ mod tests {
         assert_eq!(max_ts, 2000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_int64_milli_seconds() {
         let batch =
@@ -429,6 +438,7 @@ mod tests {
         assert_eq!(max_ts, 2000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_float32_unix_milli_seconds() {
         let batch = record_batch!(("ts", Float32, [Some(1000.0), Some(2000.0), None]))
@@ -439,6 +449,7 @@ mod tests {
         assert_eq!(max_ts, 2000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_float64_unix_milli_seconds() {
         let batch = record_batch!(("ts", Float64, [Some(1000.0), Some(2000.0), None]))
@@ -449,6 +460,7 @@ mod tests {
         assert_eq!(max_ts, 2000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_float32_unix_seconds() {
         let batch = record_batch!(("ts", Float32, [Some(1000.0), Some(2000.0), None]))
@@ -459,6 +471,7 @@ mod tests {
         assert_eq!(max_ts, 2000 * 1000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_float64_unix_seconds() {
         let batch = record_batch!(("ts", Float64, [Some(1000.0), Some(2000.0), None]))
@@ -468,6 +481,7 @@ mod tests {
         assert_eq!(max_ts, 2000 * 1000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_date32() {
         let array = Date32Array::from(vec![Some(0), Some(18262), None]);
@@ -481,6 +495,7 @@ mod tests {
         assert_eq!(max_ts, 18262 * 86_400_000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_timestamp_nanosecond() {
         let array = TimestampNanosecondArray::from(vec![
@@ -502,6 +517,7 @@ mod tests {
         assert_eq!(max_ts, 1_600_000_000_000_000_000 / 1_000_000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_timestamp_microsecond() {
         let array = TimestampMicrosecondArray::from(vec![
@@ -523,6 +539,7 @@ mod tests {
         assert_eq!(max_ts, 1_600_000_000_000_000 / 1_000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_timestamp_millisecond() {
         let array = TimestampMillisecondArray::from(vec![
@@ -544,6 +561,7 @@ mod tests {
         assert_eq!(max_ts, 1_600_000_000_000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_timestamp_second() {
         let array =
@@ -562,6 +580,7 @@ mod tests {
         assert_eq!(max_ts, 1_600_000_000 * 1000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_timestamp_nanosecond_timezone() {
         let tz = Arc::<str>::from("UTC");
@@ -585,6 +604,7 @@ mod tests {
         assert_eq!(max_ts, 1_600_000_000_000_000_000 / 1_000_000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_timestamp_microsecond_timezone() {
         let tz = Arc::<str>::from("America/New_York");
@@ -608,6 +628,7 @@ mod tests {
         assert_eq!(max_ts, 1_600_000_000_000_000_000 / 1_000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_timestamp_millisecond_timezone() {
         let tz = Arc::<str>::from("Asia/Tokyo");
@@ -631,6 +652,7 @@ mod tests {
         assert_eq!(max_ts, 1_600_000_000_000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_timestamp_second_timezone() {
         let tz = Arc::<str>::from("Europe/London");
@@ -653,6 +675,7 @@ mod tests {
         assert_eq!(max_ts, 1_600_000_000 * 1000);
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_missing_time_column() {
         let batch = record_batch!(("other_column", UInt16, [Some(1000), Some(2000), None]))
@@ -662,6 +685,7 @@ mod tests {
         assert!(max_ts.is_none());
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_unsupported_time_column() {
         let array = Date64Array::from(vec![Some(0), Some(18262), None]);
@@ -687,6 +711,7 @@ mod tests {
         assert!(max_ts.is_none());
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_empty_batch() {
         let array = UInt16Array::from(vec![] as Vec<u16>);


### PR DESCRIPTION
## 📝 Summary

Disable acceleration refresh metrics until we finalize the UX.

Two functions fetching before/after max timestamps return `None` which will result in skipping metrics.

## 🔗 Related

https://github.com/spiceai/spiceai/issues/7184