### PR TITLE
fix: partition name validation

### DIFF
--- a/crates/data_components/src/s3_vectors/partition.rs
+++ b/crates/data_components/src/s3_vectors/partition.rs
@@ -55,8 +55,8 @@ pub enum Error {
     IncorrectNumPartsInName { num_parts: usize },
     #[snafu(display("The 'partition_by' expression, {expr}, is not supported"))]
     UnsupportedPartitionByExpression { expr: Box<Expr> },
-    #[snafu(display("Index names cannot contain periods when using 'partition_by'"))]
-    InvalidIndexNamePeriod,
+    #[snafu(display("Index name, '{index}', cannot contain periods when using 'partition_by'"))]
+    InvalidIndexNamePeriod { index: String },
     #[snafu(display(
         "Index names are restricted to {INDEX_NAME_MAX_LENGTH} characters when using 'partition_by', but {index} is {len} characters"
     ))]
@@ -184,7 +184,7 @@ fn validate_index(index: &str) -> Result<(), Error> {
             len
         }
     );
-    ensure!(!index.contains('.'), InvalidIndexNamePeriodSnafu);
+    ensure!(!index.contains('.'), InvalidIndexNamePeriodSnafu { index });
 
     Ok(())
 }

--- a/crates/data_components/src/s3_vectors/partition.rs
+++ b/crates/data_components/src/s3_vectors/partition.rs
@@ -55,10 +55,10 @@ pub enum Error {
     IncorrectNumPartsInName { num_parts: usize },
     #[snafu(display("The 'partition_by' expression, {expr}, is not supported"))]
     UnsupportedPartitionByExpression { expr: Box<Expr> },
-    #[snafu(display("Index names cannot contain hyphens"))]
-    InvalidIndexNameHyphen,
+    #[snafu(display("Index names cannot contain periods when using 'partition_by'"))]
+    InvalidIndexNamePeriod,
     #[snafu(display(
-        "Index names are restricted to {INDEX_NAME_MAX_LENGTH} characters, but {index} is {len} characters"
+        "Index names are restricted to {INDEX_NAME_MAX_LENGTH} characters when using 'partition_by', but {index} is {len} characters"
     ))]
     InvalidIndexNameLength { index: String, len: usize },
 }
@@ -184,7 +184,7 @@ fn validate_index(index: &str) -> Result<(), Error> {
             len
         }
     );
-    ensure!(!index.contains('-'), InvalidIndexNameHyphenSnafu);
+    ensure!(!index.contains('.'), InvalidIndexNamePeriodSnafu);
 
     Ok(())
 }


### PR DESCRIPTION
## 📝 Summary

Fix validation of S3 vector index names when using partitions. Previously disallowed hyphens but need to disallow periods, as they are used for metadata delimiter.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
