### PR TITLE
Add models and CUDA support to spiced install script

### DIFF
--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -255,7 +255,7 @@ installFile() {
         exit 1
     fi
 
-    chmod o+x "$tmp_root_spiced"
+    chmod a+x "$tmp_root_spiced"
     
     # Copy to install directory (use runAsRoot if needed)
     if [ "$USE_SUDO" = "true" ]; then

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # colors
 blue="\033[0;94m"
 white="\033[0;97m"
@@ -22,6 +24,17 @@ GITHUB_REPO=spiceai
 # Spice Runtime filename
 SPICED_FILENAME=spiced
 
+# Variant options: "" (no variant), "models", "cuda", "metal"
+: ${VARIANT:="models"}
+
+# CUDA version: "80", "86", "87", "89", "90"
+# Only used when VARIANT is "cuda"
+: ${CUDA_VERSION:=""}
+
+# Retry configuration
+MAX_RETRIES=3
+RETRY_DELAY=2
+
 SPICED_FILE="${SPICED_INSTALL_DIR}/${SPICED_FILENAME}"
 
 getSystemInfo() {
@@ -32,7 +45,12 @@ getSystemInfo() {
         amd64) ARCH="x86_64";;
     esac
 
-    OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+    OS=$(echo $(uname)|tr '[:upper:]' '[:lower:]')
+    
+    # Handle MINGW/MSYS/Cygwin on Windows
+    case "$OS" in
+        mingw*|msys*|cygwin*) OS="windows";;
+    esac
 
     # Most linux distro needs root permission to copy the file to /usr/local/bin
     if [[ "$OS" == "linux" || "$OS" == "darwin" ]] && [ "$SPICED_INSTALL_DIR" == "/usr/local/bin" ]; then
@@ -41,11 +59,29 @@ getSystemInfo() {
 }
 
 verifySupported() {
-    local supported=(linux-x86_64 linux-aarch64 darwin-aarch64)
+    local supported=(linux-x86_64 linux-aarch64 darwin-aarch64 windows-x86_64)
     local current_osarch="${OS}-${ARCH}"
 
     for osarch in "${supported[@]}"; do
         if [ "$osarch" == "$current_osarch" ]; then
+            # Validate CUDA variant combinations
+            if [ "$VARIANT" == "cuda" ]; then
+                if [ "$OS" != "linux" ] && [ "$OS" != "windows" ]; then
+                    echo "CUDA variants are only supported on Linux and Windows"
+                    exit 1
+                fi
+                if [ -z "$CUDA_VERSION" ]; then
+                    echo "CUDA_VERSION must be set when using CUDA variant (e.g., 80, 86, 87, 89, 90)"
+                    exit 1
+                fi
+            fi
+            
+            # Validate Metal variant
+            if [ "$VARIANT" == "metal" ] && [ "$OS" != "darwin" ]; then
+                echo "Metal variants are only supported on macOS"
+                exit 1
+            fi
+            
             return
         fi
     done
@@ -57,7 +93,7 @@ verifySupported() {
 runAsRoot() {
     local CMD="$*"
 
-    if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
+    if [ $EUID -ne 0 ] && [ "$USE_SUDO" = "true" ]; then
         CMD="sudo $CMD"
     fi
 
@@ -95,18 +131,77 @@ getLatestRelease() {
     local latest_release=""
 
     if [ "$SPICE_HTTP_REQUEST_CLI" == "curl" ]; then
-        latest_release=$(curl -s $spiceReleaseUrl | grep \"tag_name\" | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
+        latest_release=$(curl -s "$spiceReleaseUrl" | grep \"tag_name\" | awk 'NR==1{print $2}' |  sed -n 's/"\(.*\)",/\1/p')
     else
-        latest_release=$(wget -q --header="Accept: application/json" -O - $spiceReleaseUrl | grep \"tag_name\" | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
+        latest_release=$(wget -q --header="Accept: application/json" -O - "$spiceReleaseUrl" | grep \"tag_name\" | awk 'NR==1{print $2}' |  sed -n 's/"\(.*\)",/\1/p')
+    fi
+
+    if [ -z "$latest_release" ]; then
+        echo "Failed to get latest release information"
+        exit 1
     fi
 
     ret_val=$latest_release
 }
 
+downloadWithRetry() {
+    local url="$1"
+    local output="$2"
+    local attempt=1
+    
+    while [ $attempt -le $MAX_RETRIES ]; do
+        echo "Download attempt $attempt of $MAX_RETRIES..."
+        
+        if [ "$SPICE_HTTP_REQUEST_CLI" == "curl" ]; then
+            if curl -H "Accept:application/octet-stream" -SsL "$url" -o "$output" 2>/dev/null; then
+                if [ -f "$output" ]; then
+                    return 0
+                fi
+            fi
+        else
+            if wget -q --auth-no-challenge --header='Accept:application/octet-stream' "$url" -O "$output" 2>/dev/null; then
+                if [ -f "$output" ]; then
+                    return 0
+                fi
+            fi
+        fi
+        
+        if [ $attempt -lt $MAX_RETRIES ]; then
+            echo "Download failed, retrying in ${RETRY_DELAY} seconds..."
+            sleep $RETRY_DELAY
+            RETRY_DELAY=$((RETRY_DELAY * 2))
+        fi
+        
+        attempt=$((attempt + 1))
+    done
+    
+    return 1
+}
+
 downloadFile() {
     LATEST_RELEASE_TAG=$1
 
-    SPICED_ARTIFACT="${SPICED_FILENAME}_${OS}_${ARCH}.tar.gz"
+    # Build artifact name based on variant
+    local artifact_name="${SPICED_FILENAME}"
+    
+    # Note: Windows artifacts don't include .exe in the archive name
+    # The .exe extension is only for the extracted binary
+    
+    # Add variant suffix
+    if [ -n "$VARIANT" ]; then
+        if [ "$VARIANT" == "cuda" ]; then
+            artifact_name="${artifact_name}_models_cuda_${CUDA_VERSION}"
+        else
+            artifact_name="${artifact_name}_${VARIANT}"
+        fi
+    fi
+    
+    # Add .exe suffix for Windows in the artifact name only
+    if [ "$OS" == "windows" ]; then
+        artifact_name="${artifact_name}.exe"
+    fi
+    
+    SPICED_ARTIFACT="${artifact_name}_${OS}_${ARCH}.tar.gz"
     DOWNLOAD_BASE="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download"
     DOWNLOAD_URL="${DOWNLOAD_BASE}/${LATEST_RELEASE_TAG}/${SPICED_ARTIFACT}"
 
@@ -116,49 +211,74 @@ downloadFile() {
 
     echo "Downloading $DOWNLOAD_URL ..."
 
-    function gh_curl() {
-      curl -H "Accept: application/vnd.github.v3.raw" \
-          $@
-    }
-
-    parser=". | map(select(.tag_name == \"$LATEST_RELEASE_TAG\"))[0].assets | map(select(.name == \"$SPICED_ARTIFACT\"))[0].id"
-
-    asset_id=`gh_curl -s https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases | jq "$parser"`
-    if [ "$asset_id" = "null" ]; then
-      echo "ERROR: version not found $VERSION"
-      exit 1
-    fi;
-
+    # Get asset ID
+    local parser=". | map(select(.tag_name == \"$LATEST_RELEASE_TAG\"))[0].assets | map(select(.name == \"$SPICED_ARTIFACT\"))[0].id"
+    
+    local releases_url="https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases"
+    local asset_id
+    
     if [ "$SPICE_HTTP_REQUEST_CLI" == "curl" ]; then
-        curl -H "Accept:application/octet-stream" -SsL \
-            https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/assets/$asset_id \
-            -o "$ARTIFACT_TMP_FILE"
+        asset_id=$(curl -H "Accept: application/vnd.github.v3.raw" -s "$releases_url" | jq "$parser")
     else
-        wget -q --auth-no-challenge --header='Accept:application/octet-stream' \
-            https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/assets/$asset_id \
-            -O "$ARTIFACT_TMP_FILE"
+        asset_id=$(wget -q -O - "$releases_url" | jq "$parser")
     fi
-
-    if [ ! -f "$ARTIFACT_TMP_FILE" ]; then
-        echo "failed to download $DOWNLOAD_URL ..."
+    
+    if [ "$asset_id" = "null" ] || [ -z "$asset_id" ]; then
+        echo "ERROR: version not found $LATEST_RELEASE_TAG or artifact $SPICED_ARTIFACT not found"
+        echo "Available variants: default, models, cuda (with CUDA_VERSION), metal"
         exit 1
     fi
+
+    local download_url="https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/assets/$asset_id"
+    
+    if ! downloadWithRetry "$download_url" "$ARTIFACT_TMP_FILE"; then
+        echo "Failed to download $DOWNLOAD_URL after $MAX_RETRIES attempts"
+        exit 1
+    fi
+    
+    echo "Download completed successfully"
 }
 
 installFile() {
     tar xf "$ARTIFACT_TMP_FILE" -C "$SPICE_TMP_ROOT"
-    local tmp_root_spiced="$SPICE_TMP_ROOT/$SPICED_FILENAME"
+    
+    # Determine the extracted filename (Windows binaries extract with .exe)
+    local extracted_filename="${SPICED_FILENAME}"
+    if [ "$OS" == "windows" ]; then
+        extracted_filename="${SPICED_FILENAME}.exe"
+    fi
+    
+    local tmp_root_spiced="$SPICE_TMP_ROOT/$extracted_filename"
 
     if [ ! -f "$tmp_root_spiced" ]; then
         echo "Failed to unpack Spice Runtime executable."
         exit 1
     fi
 
-    chmod o+x $tmp_root_spiced
-    cp "$tmp_root_spiced" "$SPICED_INSTALL_DIR"
+    chmod o+x "$tmp_root_spiced"
+    
+    # Copy to install directory (use runAsRoot if needed)
+    if [ "$USE_SUDO" = "true" ]; then
+        runAsRoot cp "$tmp_root_spiced" "$SPICED_INSTALL_DIR"
+    else
+        cp "$tmp_root_spiced" "$SPICED_INSTALL_DIR"
+    fi
 
-    if [ -f "$SPICED_FILE" ]; then
+    local installed_file="$SPICED_FILE"
+    if [ "$OS" == "windows" ]; then
+        installed_file="${SPICED_FILE}.exe"
+    fi
+
+    if [ -f "$installed_file" ]; then
         echo "$SPICED_FILENAME installed into $SPICED_INSTALL_DIR successfully."
+        
+        # Print variant information
+        if [ -n "$VARIANT" ]; then
+            echo "Variant: $VARIANT"
+            if [ "$VARIANT" == "cuda" ]; then
+                echo "CUDA Version: $CUDA_VERSION"
+            fi
+        fi
     else
         echo "Failed to install $SPICED_FILENAME"
         exit 1
@@ -190,7 +310,7 @@ installCompleted() {
 # -----------------------------------------------------------------------------
 trap "fail_trap" EXIT
 
-mkdir -p $SPICED_INSTALL_DIR
+mkdir -p "$SPICED_INSTALL_DIR"
 
 getSystemInfo
 verifySupported
@@ -206,7 +326,7 @@ fi
 
 echo "Installing Spice Runtime $ret_val ..."
 
-downloadFile $ret_val
+downloadFile "$ret_val"
 installFile
 cleanup
 


### PR DESCRIPTION
This pull request significantly improves the `install/install-spiced.sh` script by adding support for multiple runtime variants, improving platform compatibility (especially Windows), introducing robust error handling and retries, and refactoring the artifact download and installation process for clarity and reliability.

**Major improvements include:**

**Variant and Platform Support**
- Added support for runtime variants (`models`, `cuda`, `metal`, or default) via the `VARIANT` environment variable, with validation for CUDA and Metal variants and their supported platforms. Also added support for Windows installations and proper handling of `.exe` files. [[1]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cR27-R37) [[2]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL35-R53) [[3]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL44-R84) [[4]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL119-R281)

**Download Robustness and Error Handling**
- Introduced a `downloadWithRetry` function to retry downloads up to three times with exponential backoff, improving reliability in case of transient network failures. [[1]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL98-R204) [[2]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL119-R281)
- Added checks to ensure the latest release information and artifact downloads succeed, with clear error messages if they fail. [[1]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL98-R204) [[2]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL119-R281)

**Artifact Naming and Extraction Logic**
- Refactored artifact naming to dynamically include variant and platform information, and adjusted extraction logic for `.exe` binaries on Windows. [[1]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL98-R204) [[2]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL119-R281)

**Installation Process Improvements**
- Improved installation logic to use `sudo` only when necessary, ensure correct permissions, and print detailed success messages including variant and CUDA version info if applicable. [[1]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL60-R96) [[2]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL119-R281)

**General Code Quality**
- Added `set -e` for safer script execution, improved quoting and variable handling throughout, and clarified platform detection for better cross-platform compatibility. [[1]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cR3-R4) [[2]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL35-R53) [[3]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL193-R313) [[4]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL209-R329)