### PR TITLE
Don't download the snapshot if the acceleration is present

### DIFF
--- a/crates/runtime/src/dataaccelerator/snapshots.rs
+++ b/crates/runtime/src/dataaccelerator/snapshots.rs
@@ -38,6 +38,14 @@ pub(super) async fn download_snapshot_if_needed(
         return;
     }
 
+    if path.exists() {
+        tracing::debug!(
+            "Acceleration already exists at {}, skipping snapshot download",
+            path.display()
+        );
+        return;
+    }
+
     let source_name = source.name().to_string();
     let source = source.clone_arc();
     let snapshot_behavior = acceleration.snapshots.clone();


### PR DESCRIPTION
We could potentially do something smarter here like check if the local acceleration is busted and fallback to downloading a snapshot to recover.