### PR TITLE
Add missing remote CLI feature

### DIFF
--- a/docs/release_notes/v1.8.0.md
+++ b/docs/release_notes/v1.8.0.md
@@ -168,6 +168,38 @@ LIMIT 10;
 
 Learn more in the [SQL Reference AI documentation](https://spiceai.org/docs/reference/sql/ai).
 
+### Remote Endpoint Support for Spice CLI
+
+**Run CLI Commands Remotely:** The Spice CLI now supports connecting to remote Spice instances, enabling you to run `spice sql`, `spice search`, and `spice chat` commands from your local machine against a remote `spiced` daemon or to Spice Cloud. Previously, these commands required running on the same machine as the runtime. Now, new flags allow remote execution:
+
+- `--cloud`: Connect to a Spice Cloud instance (requires `--api-key`).
+- `--endpoint <endpoint>`: Connect to a remote Spice instance via HTTP or Arrow Flight SQL (gRPC). Supports `http://`, `https://`, `grpc://`, or `grpc+tls://` schemes.
+
+**Examples:**
+
+```bash
+# Run SQL queries against a remote Spice instance
+spice sql --endpoint http://remote-host:8090
+
+# Use Spice Cloud for chat or search
+spice chat --cloud --api-key <your-api-key>
+spice search --cloud --api-key <your-api-key>
+```
+
+**Supported CLI Commands:**
+
+- `spice sql --cloud` / `spice sql --endpoint <endpoint>`
+- `spice search --cloud` / `spice search --endpoint <endpoint>`
+- `spice chat --cloud` / `spice chat --endpoint <endpoint>`
+
+**Additional Flags:**
+
+- `--headers`: Pass custom HTTP headers to the remote endpoint.
+- `--tls-root-certificate-file`: Specify a root certificate for TLS verification.
+- `--user-agent`: Set a custom user agent for requests.
+
+For more details, see the [Spice CLI Command Reference](https://spiceai.org/docs/cli/reference).
+
 ### Spice.js v3.0.3 SDK
 
 **Spice.js v3.0.3 Released:** The official [Spice.ai Node.js/JavaScript SDK](https://www.npmjs.com/package/@spiceai/spice) has been updated to v3.0.3, bringing cross-platform support, new APIs, and improved reliability for both Node.js and browser environments.
@@ -211,9 +243,11 @@ See [Spice.js SDK documentation](https://spiceai.org/docs/sdks/javascript) for f
 - [@ewgenius](https://github.com/ewgenius)
 
 ## Breaking Changes
+
 This release introduces two breaking changes associated with the search observability and tooling.
 
 Firstly, the [`document_similarity`](https://spiceai.org/docs/components/tools#available-tools) tool has been renamed to `search`. This has the equivalent change to tracing of these tool calls:
+
 ```bash
 ## Old: v1.7.1
 >> spice trace tool_use::document_similarity
@@ -233,7 +267,6 @@ Firstly, the [`document_similarity`](https://spiceai.org/docs/components/tools#a
 ```
 
 Secondly, the `vector_search` task in `runtime.task_history` has been renamed to `search`.
-
 
 ## Cookbook Updates
 


### PR DESCRIPTION
This pull request updates the `docs/release_notes/v1.8.0.md` file to announce new features and breaking changes in the release. The most significant addition is support for running Spice CLI commands against remote Spice instances, including Spice Cloud, along with documentation of new flags and usage examples. It also documents two breaking changes related to search observability and tooling.

New Features:

* Added documentation for remote endpoint support in the Spice CLI, allowing users to run `spice sql`, `spice search`, and `spice chat` commands against remote Spice instances or Spice Cloud using new flags such as `--cloud`, `--endpoint`, and additional options for headers, TLS, and user-agent customization. Usage examples and a link to the CLI reference are included.

Breaking Changes:

* Documented that the `document_similarity` tool has been renamed to `search`, affecting tracing and tool usage.
* Noted that the `vector_search` task in `runtime.task_history` has been renamed to `search`.