### PR TITLE
fix: duckdb partitioning cannot reload config

### DIFF
--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -95,9 +95,6 @@ pub enum Error {
     #[snafu(display("Partitioned DuckDB acceleration only supported for file mode."))]
     FileModeOnly,
 
-    #[snafu(display("Partitioned DuckDB acceleration only supports a single table"))]
-    SingleTable,
-
     #[snafu(display("Unable to read directory: {source}"))]
     UnableToReadDirectory { source: std::io::Error },
 
@@ -242,6 +239,8 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
         source: Option<&dyn AccelerationSource>,
         partition_by: Option<PartitionBy>,
     ) -> Result<Arc<dyn TableProvider>, Box<dyn std::error::Error + Send + Sync>> {
+        self.is_initialized.store(false, Ordering::Release);
+
         let partition_by = partition_by.context(PartitionByRequiredSnafu)?;
 
         let source = source.context(ExpectedAccelerationSourceSnafu)?;
@@ -249,7 +248,6 @@ impl DataAccelerator for PartitionedDuckDBAccelerator {
         parameter_validation(source);
 
         let mut table_provider_guard = self.table_provider.lock().await;
-        ensure!(table_provider_guard.is_none(), SingleTableSnafu);
 
         let PartitionBy {
             expressions_hash,


### PR DESCRIPTION
## 📝 Summary

Fixes an issue where you can only load a partitioned DuckDB table once which does not allow reloading configurations.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
