### PR TITLE
Add metrics for DB snapshot feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12171,6 +12171,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "object_store",
+ "opentelemetry 0.27.1",
  "runtime-parameters",
  "runtime-secrets",
  "serde",

--- a/crates/runtime-acceleration/Cargo.toml
+++ b/crates/runtime-acceleration/Cargo.toml
@@ -31,6 +31,7 @@ url.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
+opentelemetry.workspace = true
 
 [features]
 default = []

--- a/crates/runtime-acceleration/src/snapshot/metrics.rs
+++ b/crates/runtime-acceleration/src/snapshot/metrics.rs
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::LazyLock;
+
+use opentelemetry::{
+    KeyValue, global,
+    metrics::{Counter, Gauge, Histogram, Meter},
+};
+
+static METER: LazyLock<Meter> =
+    LazyLock::new(|| global::meter("dataset_acceleration_snapshot_metrics"));
+
+static SNAPSHOT_BOOTSTRAP_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("dataset_acceleration_snapshot_bootstrap_duration_ms")
+        .with_description(
+            "Time in milliseconds taken to download the snapshot used to bootstrap acceleration.",
+        )
+        .with_unit("ms")
+        .build()
+});
+
+static SNAPSHOT_BOOTSTRAP_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    METER
+        .u64_gauge("dataset_acceleration_snapshot_bootstrap_bytes")
+        .with_description(
+            "Number of bytes downloaded when bootstrapping the acceleration from a snapshot.",
+        )
+        .build()
+});
+
+static SNAPSHOT_BOOTSTRAP_CHECKSUM: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    METER
+        .f64_gauge("dataset_acceleration_snapshot_bootstrap_checksum")
+        .with_description("Checksum of the snapshot downloaded during bootstrap. Emitted with dataset and checksum attributes.")
+        .build()
+});
+
+static SNAPSHOT_FAILURE_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter("dataset_acceleration_snapshot_failure_count")
+        .with_description("Number of failures encountered while writing snapshots.")
+        .build()
+});
+
+static SNAPSHOT_WRITE_TIMESTAMP: LazyLock<Gauge<i64>> = LazyLock::new(|| {
+    METER
+        .i64_gauge("dataset_acceleration_snapshot_write_timestamp")
+        .with_description("Unix timestamp (seconds) when the most recent snapshot write completed.")
+        .build()
+});
+
+static SNAPSHOT_WRITE_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    METER
+        .f64_histogram("dataset_acceleration_snapshot_write_duration_ms")
+        .with_description(
+            "Time in milliseconds taken to write the latest snapshot to object storage.",
+        )
+        .with_unit("ms")
+        .build()
+});
+
+static SNAPSHOT_WRITE_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    METER
+        .u64_gauge("dataset_acceleration_snapshot_write_bytes")
+        .with_description("Number of bytes written for the most recent snapshot.")
+        .build()
+});
+
+static SNAPSHOT_WRITE_CHECKSUM: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    METER
+        .f64_gauge("dataset_acceleration_snapshot_write_checksum")
+        .with_description("Checksum of the most recent snapshot write. Emitted with dataset and checksum attributes.")
+        .build()
+});
+
+fn dataset_label(dataset: &str) -> KeyValue {
+    KeyValue::new("dataset", dataset.to_string())
+}
+
+pub fn record_bootstrap_metrics(dataset: &str, duration_ms: f64, bytes: u64, checksum: &str) {
+    let dataset_attr = dataset_label(dataset);
+    let duration_labels = [dataset_attr.clone()];
+    SNAPSHOT_BOOTSTRAP_DURATION_MS.record(duration_ms, &duration_labels);
+
+    let bytes_labels = [dataset_attr.clone()];
+    SNAPSHOT_BOOTSTRAP_BYTES.record(bytes, &bytes_labels);
+
+    let checksum_labels = [
+        dataset_attr,
+        KeyValue::new("checksum", checksum.to_string()),
+    ];
+    SNAPSHOT_BOOTSTRAP_CHECKSUM.record(1.0, &checksum_labels);
+}
+
+pub fn record_snapshot_failure(dataset: &str) {
+    let labels = [dataset_label(dataset)];
+    SNAPSHOT_FAILURE_COUNT.add(1, &labels);
+}
+
+pub fn record_write_metrics(
+    dataset: &str,
+    timestamp_secs: i64,
+    duration_ms: f64,
+    bytes: u64,
+    checksum: &str,
+) {
+    let dataset_attr = dataset_label(dataset);
+
+    let timestamp_labels = [dataset_attr.clone()];
+    SNAPSHOT_WRITE_TIMESTAMP.record(timestamp_secs, &timestamp_labels);
+
+    let duration_labels = [dataset_attr.clone()];
+    SNAPSHOT_WRITE_DURATION_MS.record(duration_ms, &duration_labels);
+
+    let byte_labels = [dataset_attr.clone()];
+    SNAPSHOT_WRITE_BYTES.record(bytes, &byte_labels);
+
+    let checksum_labels = [
+        dataset_attr,
+        KeyValue::new("checksum", checksum.to_string()),
+    ];
+    SNAPSHOT_WRITE_CHECKSUM.record(1.0, &checksum_labels);
+}

--- a/crates/runtime-acceleration/src/snapshot/metrics.rs
+++ b/crates/runtime-acceleration/src/snapshot/metrics.rs
@@ -21,13 +21,12 @@ use opentelemetry::{
 static METER: LazyLock<Meter> =
     LazyLock::new(|| global::meter("dataset_acceleration_snapshot_metrics"));
 
-static SNAPSHOT_BOOTSTRAP_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+static SNAPSHOT_BOOTSTRAP_DURATION_MS: LazyLock<Counter<f64>> = LazyLock::new(|| {
     METER
-        .f64_histogram("dataset_acceleration_snapshot_bootstrap_duration_ms")
+        .f64_counter("dataset_acceleration_snapshot_bootstrap_duration_ms")
         .with_description(
             "Time in milliseconds taken to download the snapshot used to bootstrap acceleration.",
         )
-        .with_unit("ms")
         .build()
 });
 
@@ -92,7 +91,7 @@ fn dataset_label(dataset: &str) -> KeyValue {
 pub fn record_bootstrap_metrics(dataset: &str, duration_ms: f64, bytes: u64, checksum: &str) {
     let dataset_attr = dataset_label(dataset);
     let duration_labels = [dataset_attr.clone()];
-    SNAPSHOT_BOOTSTRAP_DURATION_MS.record(duration_ms, &duration_labels);
+    SNAPSHOT_BOOTSTRAP_DURATION_MS.add(duration_ms, &duration_labels);
 
     let bytes_labels = [dataset_attr.clone()];
     SNAPSHOT_BOOTSTRAP_BYTES.record(bytes, &bytes_labels);

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -19,6 +19,7 @@ use std::{
     path::PathBuf,
     str::FromStr,
     sync::{Arc, LazyLock},
+    time::Instant,
 };
 
 use aws_sdk_credential_bridge::{S3CredentialProvider, get_bucket_name};
@@ -48,6 +49,7 @@ use util::{RetryError, fibonacci_backoff::FibonacciBackoff, retry};
 use crate::dataset_checkpoint::DatasetCheckpointerFactory;
 
 mod behavior;
+pub mod metrics;
 pub use behavior::SnapshotBehavior;
 
 const SNAPSHOT_TIMESTAMP_FORMAT: &str = "%Y%m%dT%H%M%SZ";
@@ -129,6 +131,13 @@ impl DatasetMetadata {
             .iter()
             .find(|schema| schema.schema_id == self.current_schema_id)
     }
+}
+
+/// Details captured when downloading a snapshot for bootstrapping.
+pub struct SnapshotDownloadInfo {
+    pub schema: SchemaRef,
+    pub bytes_downloaded: u64,
+    pub checksum: String,
 }
 
 #[derive(Debug, Clone)]
@@ -575,6 +584,7 @@ impl SnapshotManager {
         &self,
         schema: &SchemaRef,
     ) -> Result<ObjectPath, SnapshotUploadError> {
+        let start_time = Instant::now();
         let now = Utc::now();
         let layout = SnapshotPathLayout::new(&self.dataset_name);
         let location = layout.build_location(&self.snapshots_location, now);
@@ -677,12 +687,21 @@ impl SnapshotManager {
 
                 self.update_metadata_after_upload(
                     &location,
-                    checksum,
+                    checksum.clone(),
                     total_bytes,
                     timestamp_ms,
                     schema,
                 )
                 .await?;
+
+                let duration_ms = start_time.elapsed().as_secs_f64() * 1000.0;
+                metrics::record_write_metrics(
+                    &self.dataset_name,
+                    timestamp_ms / 1000,
+                    duration_ms,
+                    total_bytes,
+                    &checksum,
+                );
 
                 tracing::info!(
                     "Snapshot uploaded. dataset={} snapshot={location} size={total_bytes}",
@@ -713,7 +732,7 @@ impl SnapshotManager {
         }
     }
 
-    /// Attempts to download the latest snapshot, returning the schema if successful.
+    /// Attempts to download the latest snapshot, returning details if successful.
     ///
     /// # Errors
     ///
@@ -723,7 +742,7 @@ impl SnapshotManager {
     /// - If there is an error fetching the schema from the dataset checkpointer.
     pub async fn download_latest_snapshot(
         &self,
-    ) -> Result<Option<SchemaRef>, SnapshotDownloadError> {
+    ) -> Result<Option<SnapshotDownloadInfo>, SnapshotDownloadError> {
         let checkpointer_factory = Arc::clone(
             self.checkpointer_factory
                 .as_ref()
@@ -786,7 +805,7 @@ impl SnapshotManager {
     async fn download_latest_once(
         &self,
         checkpointer_factory: DatasetCheckpointerFactory,
-    ) -> Result<Option<SchemaRef>, SnapshotDownloadError> {
+    ) -> Result<Option<SnapshotDownloadInfo>, SnapshotDownloadError> {
         let metadata_handle = match self.load_metadata().await {
             Ok(Some(handle)) => handle,
             Ok(None) => {
@@ -835,7 +854,7 @@ impl SnapshotManager {
     async fn download_with_fallback(
         &self,
         checkpointer_factory: DatasetCheckpointerFactory,
-    ) -> Result<Option<SchemaRef>, SnapshotDownloadError> {
+    ) -> Result<Option<SnapshotDownloadInfo>, SnapshotDownloadError> {
         let metadata_handle = match self.load_metadata().await {
             Ok(Some(handle)) => handle,
             Ok(None) => return Ok(None),
@@ -965,7 +984,7 @@ impl SnapshotManager {
         entry: &SnapshotEntry,
         dataset_metadata: &DatasetMetadata,
         checkpointer_factory: DatasetCheckpointerFactory,
-    ) -> Result<SchemaRef, SnapshotDownloadError> {
+    ) -> Result<SnapshotDownloadInfo, SnapshotDownloadError> {
         let object_path = self.snapshot_uri_to_object_path(&entry.snapshot)?;
         let path_display = object_path.to_string();
 
@@ -1102,7 +1121,11 @@ impl SnapshotManager {
                 self.dataset_name,
                 entry.snapshot
             );
-            Ok(schema)
+            Ok(SnapshotDownloadInfo {
+                schema,
+                bytes_downloaded: actual_size,
+                checksum: actual_checksum,
+            })
         } else {
             tracing::warn!(
                 "Snapshot schema not found. dataset={} snapshot={}",
@@ -1563,7 +1586,7 @@ mod tests {
             snapshot_id: 0,
             timestamp_ms: instant.timestamp_millis(),
             snapshot: snapshot_uri(&location),
-            snapshot_checksum: checksum,
+            snapshot_checksum: checksum.clone(),
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: contents.len() as u64,
         };
@@ -1592,13 +1615,15 @@ mod tests {
             &schema,
         );
 
-        let result = manager
+        let info = manager
             .download_latest_snapshot()
             .await
             .expect("download should succeed")
-            .expect("expected schema");
+            .expect("expected snapshot");
 
-        assert_eq!(result.as_ref(), schema.as_ref());
+        assert_eq!(info.schema.as_ref(), schema.as_ref());
+        assert_eq!(info.bytes_downloaded, contents.len() as u64);
+        assert_eq!(info.checksum, checksum);
         let downloaded = fs::read(&local_path)
             .await
             .expect("read downloaded snapshot");
@@ -1642,11 +1667,12 @@ mod tests {
             snapshot_size: first_contents.len() as u64,
         };
 
+        let valid_checksum = compute_sha256_hex(second_contents.as_ref());
         let valid_snapshot = SnapshotEntry {
             snapshot_id: 0,
             timestamp_ms: second_instant.timestamp_millis(),
             snapshot: snapshot_uri(&second_location),
-            snapshot_checksum: compute_sha256_hex(second_contents.as_ref()),
+            snapshot_checksum: valid_checksum.clone(),
             snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
             snapshot_size: second_contents.len() as u64,
         };
@@ -1675,13 +1701,15 @@ mod tests {
             &schema,
         );
 
-        let result = manager
+        let info = manager
             .download_latest_snapshot()
             .await
             .expect("download should succeed")
-            .expect("expected schema");
+            .expect("expected snapshot");
 
-        assert_eq!(result.as_ref(), schema.as_ref());
+        assert_eq!(info.schema.as_ref(), schema.as_ref());
+        assert_eq!(info.bytes_downloaded, second_contents.len() as u64);
+        assert_eq!(info.checksum, valid_checksum);
         let downloaded = fs::read(&local_path)
             .await
             .expect("read downloaded snapshot");

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -1510,16 +1510,16 @@ mod tests {
 
     fn snapshot_uri(location: &ObjectPath) -> String {
         let base = Path::from(SNAPSHOT_BASE_PATH);
-        let relative = location
-            .prefix_match(&base)
-            .map(|parts| {
+        let relative = location.prefix_match(&base).map_or_else(
+            || location.to_string(),
+            |parts| {
                 parts
                     .map(|p| p.as_ref().to_owned())
                     .collect::<Vec<_>>()
                     .join("/")
-            })
-            .unwrap_or_else(|| location.to_string());
-        format!("{}/{}", SNAPSHOT_URI_PREFIX, relative)
+            },
+        );
+        format!("{SNAPSHOT_URI_PREFIX}/{relative}")
     }
 
     fn dataset_metadata(

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -34,7 +34,9 @@ use futures::future::BoxFuture;
 use opentelemetry::KeyValue;
 use rand::Rng;
 use runtime_acceleration::dataset_checkpoint::DatasetCheckpointer;
-use runtime_acceleration::snapshot::{SnapshotBehavior, SnapshotManager};
+use runtime_acceleration::snapshot::{
+    SnapshotBehavior, SnapshotManager, metrics as snapshot_metrics,
+};
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use tokio::select;
@@ -717,6 +719,8 @@ impl Refresher {
                                             .create_snapshot(&federated_schema)
                                             .await
                                         {
+                                            let dataset_label = dataset_name.to_string();
+                                            snapshot_metrics::record_snapshot_failure(&dataset_label);
                                             tracing::warn!("Failed to create snapshot for dataset {dataset_name}: {e}");
                                         }
                                     }

--- a/crates/runtime/src/dataaccelerator/snapshots.rs
+++ b/crates/runtime/src/dataaccelerator/snapshots.rs
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc, time::Instant};
 
 use runtime_acceleration::{
-    dataset_checkpoint::make_checkpointer_factory, snapshot::SnapshotManager,
+    dataset_checkpoint::make_checkpointer_factory,
+    snapshot::{SnapshotDownloadInfo, SnapshotManager, metrics},
 };
 use snafu::ResultExt;
 
@@ -46,7 +47,7 @@ pub(super) async fn download_snapshot_if_needed(
         return;
     }
 
-    let source_name = source.name().to_string();
+    let dataset_name = source.name().to_string();
     let source = source.clone_arc();
     let snapshot_behavior = acceleration.snapshots.clone();
     let checkpoint_factory = make_checkpointer_factory(move || {
@@ -64,11 +65,28 @@ pub(super) async fn download_snapshot_if_needed(
         }
     });
     if let Some(manager) =
-        SnapshotManager::try_new(source_name, acceleration.snapshots.clone(), path).await
+        SnapshotManager::try_new(dataset_name.clone(), acceleration.snapshots.clone(), path).await
     {
         let manager = manager.with_checkpointer_factory(checkpoint_factory);
-        let _ = manager.download_latest_snapshot().await.inspect_err(|e| {
-            tracing::error!("Failed to download snapshot: {}", e);
-        });
+        let start_time = Instant::now();
+        match manager.download_latest_snapshot().await {
+            Ok(Some(SnapshotDownloadInfo {
+                schema: _,
+                bytes_downloaded,
+                checksum,
+            })) => {
+                let duration_ms = start_time.elapsed().as_secs_f64() * 1000.0;
+                metrics::record_bootstrap_metrics(
+                    &dataset_name,
+                    duration_ms,
+                    bytes_downloaded,
+                    &checksum,
+                );
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::error!("Failed to download snapshot: {}", e);
+            }
+        }
     }
 }


### PR DESCRIPTION
## 📝 Summary

Adds in the metrics for the acceleration DB snapshotting feature. Builds on https://github.com/spiceai/spiceai/pull/7486

- `dataset_acceleration_snapshot_bootstrap_duration_ms`: The time it took the runtime to download the snapshot - only emitted when it initially downloads the snapshot. 
- `dataset_acceleration_snapshot_bootstrap_bytes`: The number of bytes downloaded to bootstrap the acceleration from the snapshot.
- `dataset_acceleration_snapshot_bootstrap_checksum`: The checksum of the snapshot used to bootstrap the acceleration.
- `dataset_acceleration_snapshot_failure_count`: Number of failures encountered when writing a new snapshot at the end of the refresh cycle. A snapshot failure does not prevent the refresh from completing.
- `dataset_acceleration_snapshot_write_timestamp`: Unix timestamp in seconds when the last snapshot was completed.
- `dataset_acceleration_snapshot_write_duration_ms`: The time it took to write the snapshot to object storage.
- `dataset_acceleration_snapshot_write_bytes`: The number of bytes written on the last snapshot write.
- `dataset_acceleration_snapshot_write_checksum`: The SHA256 checksum of the last snapshot write.

## 🔗 Related

- Closes #7367

## 📚 Docs

https://github.com/spiceai/docs/pull/1189
