### PR TITLE
Add DuckDB file accelerator 2G and 4G dispatches

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -19,6 +19,6 @@ jobs:
         if: github.event_name == 'pull_request_target'
         with:
           require_title_min_length: '10'
-          required_labels_any: 'kind/refactor,kind/bug,kind/enhancement,kind/documentation,kind/optimization,kind/dependencies,kind/endgame,kind/task'
+          required_labels_any: 'kind/refactor,kind/bug,kind/enhancement,kind/documentation,kind/optimization,kind/dependencies,kind/endgame,kind/task,kind/performance'
           banned_labels: 'invalid,wontfix,nomerge,duplicate'
           require_assignee: 'true'

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -1,5 +1,5 @@
 name: benchmark e2e tests
-run-name: benchmark - ${{ github.event.inputs.query_set }} - ${{ github.event.inputs.spicepod_path }}
+run-name: bench - ${{ github.event.inputs.query_set }} - ${{ github.event.inputs.spicepod_path }}
 
 on:
   workflow_dispatch:

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yaml
@@ -1,15 +1,15 @@
 tests:
   bench:
-    spicepod_path: accelerated/s3[parquet]-duckdb[file].yaml
+    spicepod_path: accelerated/s3[parquet]-duckdb[file]-2gib.yaml
     query_set: tpch
     runner_type: spiceai-dev-runners
     validate_results: true
   throughput:
-    spicepod_path: accelerated/s3[parquet]-duckdb[file].yaml
+    spicepod_path: accelerated/s3[parquet]-duckdb[file]-2gib.yaml
     query_set: tpch
     runner_type: spiceai-dev-large-runners
   load:
-    spicepod_path: accelerated/s3[parquet]-duckdb[file].yaml
+    spicepod_path: accelerated/s3[parquet]-duckdb[file]-2gib.yaml
     query_set: tpch
     runner_type: spiceai-dev-large-runners
     duration: 28800

--- a/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml
+++ b/tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml
@@ -1,15 +1,15 @@
 tests:
   bench:
-    spicepod_path: accelerated/s3[parquet]-duckdb[file].yaml
+    spicepod_path: accelerated/s3[parquet]-duckdb[file]-4gib.yaml
     query_set: tpch
     runner_type: spiceai-dev-runners
     validate_results: true
   throughput:
-    spicepod_path: accelerated/s3[parquet]-duckdb[file].yaml
+    spicepod_path: accelerated/s3[parquet]-duckdb[file]-4gib.yaml
     query_set: tpch
     runner_type: spiceai-dev-large-runners
   load:
-    spicepod_path: accelerated/s3[parquet]-duckdb[file].yaml
+    spicepod_path: accelerated/s3[parquet]-duckdb[file]-4gib.yaml
     query_set: tpch
     runner_type: spiceai-dev-large-runners
     duration: 28800


### PR DESCRIPTION
This pull request introduces new benchmark test configurations for TPCH datasets with different sizes and updates the workflow naming for clarity. The main changes are the addition of new test definitions for 2 GiB and 4 GiB datasets and a minor update to the workflow run name.

**Test Configuration Additions:**

* Added a `tests` section to `tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yaml`, defining `bench`, `throughput`, and `load` test scenarios for the 2 GiB dataset. ([tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-2gib.yamlR1-R15](diffhunk://#diff-c3c22de105bbe77b16bf967fc29b150015f33ecd8284dc56b1639a851d30a034R1-R15))
* Added a `tests` section to `tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yaml`, defining `bench`, `throughput`, and `load` test scenarios for the 4 GiB dataset. ([tools/testoperator/dispatch/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-4gib.yamlR1-R15](diffhunk://#diff-b15916cb443f7b498cb711beed7bc28ac7fbaadd7777eafe4f56fc1a07de2d30R1-R15))

**Workflow Update:**

* Changed the workflow run name in `.github/workflows/testoperator_run_bench.yml` from "benchmark" to "bench" for consistency with test definitions.