### PR TITLE
Validate spicepod file exists before running tests

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -102,6 +102,14 @@ jobs:
           SPICEPOD_PATH="./test/spicepods/${query_set}/sf${{ github.event.inputs.scale_factor }}/${{ github.event.inputs.spicepod_path }}"
           echo "SPICEPOD_PATH=${SPICEPOD_PATH}" >> $GITHUB_OUTPUT
 
+      - name: Validate spicepod file exists
+        run: |
+          if [ ! -f "${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}" ]; then
+            echo "Error: Spicepod file not found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:

--- a/.github/workflows/testoperator_run_data_consistency.yml
+++ b/.github/workflows/testoperator_run_data_consistency.yml
@@ -66,6 +66,20 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Validate spicepod files exist
+        run: |
+          if [ ! -f "${{ github.event.inputs.spicepod_path }}" ]; then
+            echo "Error: Spicepod file not found at ${{ github.event.inputs.spicepod_path }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ github.event.inputs.spicepod_path }}"
+
+          if [ ! -f "${{ github.event.inputs.compare_spicepod_path }}" ]; then
+            echo "Error: Compare spicepod file not found at ${{ github.event.inputs.compare_spicepod_path }}"
+            exit 1
+          fi
+          echo "Compare spicepod file found at ${{ github.event.inputs.compare_spicepod_path }}"
+
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:

--- a/.github/workflows/testoperator_run_http_consistency.yml
+++ b/.github/workflows/testoperator_run_http_consistency.yml
@@ -72,6 +72,14 @@ jobs:
 
       - uses: actions/checkout@v5
 
+      - name: Validate spicepod file exists
+        run: |
+          if [ ! -f "${{ github.event.inputs.spicepod_path }}" ]; then
+            echo "Error: Spicepod file not found at ${{ github.event.inputs.spicepod_path }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ github.event.inputs.spicepod_path }}"
+
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:

--- a/.github/workflows/testoperator_run_http_overhead.yml
+++ b/.github/workflows/testoperator_run_http_overhead.yml
@@ -72,6 +72,14 @@ jobs:
 
       - uses: actions/checkout@v5
 
+      - name: Validate spicepod file exists
+        run: |
+          if [ ! -f "${{ github.event.inputs.spicepod_path }}" ]; then
+            echo "Error: Spicepod file not found at ${{ github.event.inputs.spicepod_path }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ github.event.inputs.spicepod_path }}"
+
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:

--- a/.github/workflows/testoperator_run_load.yml
+++ b/.github/workflows/testoperator_run_load.yml
@@ -88,6 +88,14 @@ jobs:
           SPICEPOD_PATH="./test/spicepods/${query_set}/sf${{ github.event.inputs.scale_factor }}/${{ github.event.inputs.spicepod_path }}"
           echo "SPICEPOD_PATH=${SPICEPOD_PATH}" >> $GITHUB_OUTPUT
 
+      - name: Validate spicepod file exists
+        run: |
+          if [ ! -f "${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}" ]; then
+            echo "Error: Spicepod file not found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:

--- a/.github/workflows/testoperator_run_search.yml
+++ b/.github/workflows/testoperator_run_search.yml
@@ -28,6 +28,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Validate spicepod file exists
+        run: |
+          if [ ! -f "${{ github.event.inputs.spicepod_path }}" ]; then
+            echo "Error: Spicepod file not found at ${{ github.event.inputs.spicepod_path }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ github.event.inputs.spicepod_path }}"
+
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:

--- a/.github/workflows/testoperator_run_throughput.yml
+++ b/.github/workflows/testoperator_run_throughput.yml
@@ -84,6 +84,14 @@ jobs:
           SPICEPOD_PATH="./test/spicepods/${query_set}/sf${{ github.event.inputs.scale_factor }}/${{ github.event.inputs.spicepod_path }}"
           echo "SPICEPOD_PATH=${SPICEPOD_PATH}" >> $GITHUB_OUTPUT
 
+      - name: Validate spicepod file exists
+        run: |
+          if [ ! -f "${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}" ]; then
+            echo "Error: Spicepod file not found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+            exit 1
+          fi
+          echo "Spicepod file found at ${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+
       - name: Install MinIO
         uses: ./.github/actions/setup-minio
         with:


### PR DESCRIPTION
This pull request adds validation steps to several GitHub Actions workflows to ensure that required `spicepod` files exist before proceeding with the jobs. This helps catch missing or misconfigured input files early, preventing downstream errors and making failures easier to diagnose.

Key changes by workflow:

**Validation of spicepod file existence:**

* Added a step to check for the existence of the `spicepod` file in the following workflows: `testoperator_run_bench.yml`, `testoperator_run_load.yml`, and `testoperator_run_throughput.yml`. The workflow will now fail early with a clear error message if the file is missing. [[1]](diffhunk://#diff-777ba109da7373f098735283ee97b805d1733e1c9bc769ef3dac2f0c698e0de6R105-R112) [[2]](diffhunk://#diff-cd2f41ee25acfc24181474e8d3968a875472285df4bb2c395ea2de820c94d79fR91-R98) [[3]](diffhunk://#diff-0d3d23d059c6e1185140f294fb43988ca120e3b991bbb60262781217f7d1f48bR87-R94)
* Added similar validation steps to the `testoperator_run_http_consistency.yml`, `testoperator_run_http_overhead.yml`, and `testoperator_run_search.yml` workflows, ensuring the specified `spicepod` file exists before proceeding. [[1]](diffhunk://#diff-940f119d19068fbab15e0c1ed236fe7f8d3efcd884f9348e405010067f0e22f5R75-R82) [[2]](diffhunk://#diff-712efbd22234ea693ceb8d39381ec0e139f8560cdf2935d24a0c1e5229df008bR75-R82) [[3]](diffhunk://#diff-91a3bec2debda33b8822f9aa16a535a26ab3b7682168b0883e822baf3abe69e7R31-R38)
* In the `testoperator_run_data_consistency.yml` workflow, added validation for both the main `spicepod` file and the `compare_spicepod` file, with clear error messages for each.