### PR TITLE
fix: partitioned acceleration refresh in append

### DIFF
--- a/crates/runtime-table-partition/src/creator/filename.rs
+++ b/crates/runtime-table-partition/src/creator/filename.rs
@@ -78,6 +78,7 @@ pub fn decode_pair(value: &str) -> Result<(ScalarValue, u64), Error> {
 
 #[derive(Serialize, Deserialize)]
 enum SupportedScalarValue {
+    Null,
     Boolean(Option<bool>),
     Int8(Option<i8>),
     Int16(Option<i16>),
@@ -108,6 +109,7 @@ impl TryFrom<ScalarValue> for SupportedScalarValue {
 
     fn try_from(value: ScalarValue) -> Result<Self, Self::Error> {
         Ok(match value {
+            ScalarValue::Null => Self::Null,
             ScalarValue::Boolean(maybe_value) => Self::Boolean(maybe_value),
             ScalarValue::Int8(maybe_value) => Self::Int8(maybe_value),
             ScalarValue::Int16(maybe_value) => Self::Int16(maybe_value),
@@ -154,6 +156,7 @@ impl TryFrom<SupportedScalarValue> for ScalarValue {
 
     fn try_from(value: SupportedScalarValue) -> Result<Self, Self::Error> {
         Ok(match value {
+            SupportedScalarValue::Null => Self::Null,
             SupportedScalarValue::Boolean(maybe_value) => Self::Boolean(maybe_value),
             SupportedScalarValue::Int8(maybe_value) => Self::Int8(maybe_value),
             SupportedScalarValue::Int16(maybe_value) => Self::Int16(maybe_value),

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -105,10 +105,11 @@ impl PartitionTableProvider {
 
         let partitions = Arc::new(RwLock::new(partitions));
 
+        // This was created from #7449 as a workaround to [`EmptyExec`] and federation support
         let empty = creator
             .create_partition(ScalarValue::Null)
             .await
-            .unwrap()
+            .context(CreatingPartitionSnafu)?
             .table_provider;
 
         Ok(Self {

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -85,10 +85,13 @@ impl PartitionTableProvider {
         );
         let df_schema = DFSchema::try_from(Arc::clone(&schema)).context(SchemaConversionSnafu)?;
 
-        let partitions = creator
+        let mut partitions = creator
             .infer_existing_partitions()
             .await
             .context(CreatingPartitionSnafu)?;
+
+        // Do not consider the Null partition, if it exists.
+        partitions.retain(|p| !matches!(p.partition_value, ScalarValue::Null));
 
         let partition_by = partition_by
             .pop()

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -24,8 +24,9 @@ use datafusion::{
     datasource::TableType,
     error::DataFusionError,
     logical_expr::{TableProviderFilterPushDown, dml::InsertOp},
-    physical_plan::{ExecutionPlan, empty::EmptyExec, limit::GlobalLimitExec, union::UnionExec},
+    physical_plan::{ExecutionPlan, limit::GlobalLimitExec, union::UnionExec},
     prelude::Expr,
+    scalar::ScalarValue,
 };
 use pruning::prune_partition;
 use snafu::prelude::*;
@@ -62,6 +63,7 @@ pub struct PartitionTableProvider {
     partition_by: Expr,
     partitions: Arc<RwLock<HashMap<ScalarValueString, Partition>>>,
     schema: SchemaRef,
+    empty: Arc<dyn TableProvider>,
 }
 
 impl PartitionTableProvider {
@@ -103,11 +105,18 @@ impl PartitionTableProvider {
 
         let partitions = Arc::new(RwLock::new(partitions));
 
+        let empty = creator
+            .create_partition(ScalarValue::Null)
+            .await
+            .unwrap()
+            .table_provider;
+
         Ok(Self {
             creator,
             partition_by,
             partitions,
             schema,
+            empty,
         })
     }
 }
@@ -164,7 +173,7 @@ impl TableProvider for PartitionTableProvider {
 
         let plan = match plans {
             plans if plans.is_empty() => {
-                return Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema))));
+                return Ok(self.empty.scan(state, projection, filters, limit).await?);
             }
             mut plans if plans.len() == 1 => plans.pop().ok_or_else(|| {
                 DataFusionError::Execution("expected an ExecutionPlan".to_string())

--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -174,7 +174,7 @@ impl TableProvider for PartitionTableProvider {
 
         let plan = match plans {
             plans if plans.is_empty() => {
-                return Ok(self.empty.scan(state, projection, filters, limit).await?);
+                return self.empty.scan(state, projection, filters, limit).await;
             }
             mut plans if plans.len() == 1 => plans.pop().ok_or_else(|| {
                 DataFusionError::Execution("expected an ExecutionPlan".to_string())


### PR DESCRIPTION
## 📝 Summary

This is a workaround. 

No longer use `EmptyExec` for `PartitionTableProvider::scan` when no partitions are available. Instead, initialize an empty partition file to be used when no other partitions exist.

## 🔗 Related

Closes
- #7449 

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
