### PR TITLE
Add `RequestTimeoutException` to S3 client

### DIFF
--- a/crates/runtime/src/embeddings/index/s3/retry_client.rs
+++ b/crates/runtime/src/embeddings/index/s3/retry_client.rs
@@ -211,6 +211,7 @@ impl S3Vectors for S3VectorRetryClient {
             {
                 Ok(result) => Ok(result),
                 Err(e) => match &e {
+                    SdkError::TimeoutError(_) => Err(RetryError::transient(e)),
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         DeleteIndexError::ServiceUnavailableException(_)
                         | DeleteIndexError::TooManyRequestsException(_) => {

--- a/crates/runtime/src/embeddings/index/s3/retry_client.rs
+++ b/crates/runtime/src/embeddings/index/s3/retry_client.rs
@@ -110,6 +110,9 @@ impl S3Vectors for S3VectorRetryClient {
                         | CreateIndexError::TooManyRequestsException(_) => {
                             Err(RetryError::transient(e))
                         }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
+                            Err(RetryError::transient(e))
+                        }
                         CreateIndexError::AccessDeniedException(_)
                         | CreateIndexError::ConflictException(_)
                         | CreateIndexError::InternalServerException(_)
@@ -158,6 +161,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         CreateVectorBucketError::ServiceUnavailableException(_)
                         | CreateVectorBucketError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         CreateVectorBucketError::AccessDeniedException(_)
@@ -210,6 +216,9 @@ impl S3Vectors for S3VectorRetryClient {
                         | DeleteIndexError::TooManyRequestsException(_) => {
                             Err(RetryError::transient(e))
                         }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
+                            Err(RetryError::transient(e))
+                        }
                         DeleteIndexError::AccessDeniedException(_)
                         | DeleteIndexError::InternalServerException(_)
                         | DeleteIndexError::ServiceQuotaExceededException(_)
@@ -256,6 +265,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         DeleteVectorBucketError::ServiceUnavailableException(_)
                         | DeleteVectorBucketError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         DeleteVectorBucketError::AccessDeniedException(_)
@@ -307,6 +319,9 @@ impl S3Vectors for S3VectorRetryClient {
                         | DeleteVectorBucketPolicyError::TooManyRequestsException(_) => {
                             Err(RetryError::transient(e))
                         }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
+                            Err(RetryError::transient(e))
+                        }
                         DeleteVectorBucketPolicyError::AccessDeniedException(_)
                         | DeleteVectorBucketPolicyError::InternalServerException(_)
                         | DeleteVectorBucketPolicyError::NotFoundException(_)
@@ -356,6 +371,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         DeleteVectorsError::ServiceUnavailableException(_)
                         | DeleteVectorsError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         DeleteVectorsError::AccessDeniedException(_)
@@ -411,6 +429,9 @@ impl S3Vectors for S3VectorRetryClient {
                         | GetIndexError::TooManyRequestsException(_) => {
                             Err(RetryError::transient(e))
                         }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
+                            Err(RetryError::transient(e))
+                        }
                         GetIndexError::AccessDeniedException(_)
                         | GetIndexError::InternalServerException(_)
                         | GetIndexError::NotFoundException(_)
@@ -460,6 +481,9 @@ impl S3Vectors for S3VectorRetryClient {
                         | GetVectorBucketError::TooManyRequestsException(_) => {
                             Err(RetryError::transient(e))
                         }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
+                            Err(RetryError::transient(e))
+                        }
                         GetVectorBucketError::AccessDeniedException(_)
                         | GetVectorBucketError::InternalServerException(_)
                         | GetVectorBucketError::NotFoundException(_)
@@ -507,6 +531,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         GetVectorBucketPolicyError::ServiceUnavailableException(_)
                         | GetVectorBucketPolicyError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         GetVectorBucketPolicyError::AccessDeniedException(_)
@@ -560,6 +587,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         GetVectorsError::ServiceUnavailableException(_)
                         | GetVectorsError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         GetVectorsError::AccessDeniedException(_)
@@ -619,6 +649,9 @@ impl S3Vectors for S3VectorRetryClient {
                         | ListIndexesError::TooManyRequestsException(_) => {
                             Err(RetryError::transient(e))
                         }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
+                            Err(RetryError::transient(e))
+                        }
                         ListIndexesError::AccessDeniedException(_)
                         | ListIndexesError::InternalServerException(_)
                         | ListIndexesError::NotFoundException(_)
@@ -667,6 +700,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         ListVectorBucketsError::ServiceUnavailableException(_)
                         | ListVectorBucketsError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         ListVectorBucketsError::AccessDeniedException(_)
@@ -724,6 +760,9 @@ impl S3Vectors for S3VectorRetryClient {
                         | ListVectorsError::TooManyRequestsException(_) => {
                             Err(RetryError::transient(e))
                         }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
+                            Err(RetryError::transient(e))
+                        }
                         ListVectorsError::AccessDeniedException(_)
                         | ListVectorsError::InternalServerException(_)
                         | ListVectorsError::NotFoundException(_)
@@ -772,6 +811,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         PutVectorBucketPolicyError::ServiceUnavailableException(_)
                         | PutVectorBucketPolicyError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         PutVectorBucketPolicyError::AccessDeniedException(_)
@@ -823,6 +865,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         PutVectorsError::ServiceUnavailableException(_)
                         | PutVectorsError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         PutVectorsError::AccessDeniedException(_)
@@ -882,6 +927,9 @@ impl S3Vectors for S3VectorRetryClient {
                     SdkError::ServiceError(service_error) => match service_error.err() {
                         QueryVectorsError::ServiceUnavailableException(_)
                         | QueryVectorsError::TooManyRequestsException(_) => {
+                            Err(RetryError::transient(e))
+                        }
+                        err if err.meta().code() == Some("RequestTimeoutException") => {
                             Err(RetryError::transient(e))
                         }
                         QueryVectorsError::AccessDeniedException(_)


### PR DESCRIPTION
## 📝 Summary
 - `RequestTimeoutException` does not appear to be in [AWS SDK](https://docs.rs/aws-sdk-s3vectors). It appears to be a `SdkError::ServiceError` and not a `SdkError::TimeoutError`. 
 - Added both as transient.