### PR TITLE
[S3 Vectors] Filter out nulls in addition to zero vectors

### DIFF
--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -436,7 +436,7 @@ fn create_embedding_array(
     }
 
     let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dimension);
-    let field = Field::new_list_field(DataType::Float32, false);
+    let field = Field::new_list_field(DataType::Float32, true);
     builder = builder.with_field(field);
 
     for embedding_opt in embedding_vectors {
@@ -447,6 +447,7 @@ fn create_embedding_array(
             );
             builder.append(true);
         } else {
+            // Null embeddings will be filtered out before being written to the S3 index
             builder.values().append_nulls(dimension as usize);
             builder.append(false);
         }
@@ -455,7 +456,7 @@ fn create_embedding_array(
     Ok(Arc::new(builder.finish()))
 }
 
-/// Filter out zero vectors (all values in the vector are 0.0)
+/// Filter out zero vectors (all values in the vector are 0.0) and null embeddings
 #[allow(clippy::type_complexity)]
 fn filter_zero_vectors(
     mut embeddings: Vec<Option<Vec<f32>>>,
@@ -469,17 +470,31 @@ fn filter_zero_vectors(
 ) {
     // Filter in reverse order to avoid index shifting when removing elements
     for i in (0..embeddings.len()).rev() {
-        if let Some(embedding) = &embeddings[i]
-            && embedding.iter().all(|&x| x == 0.0)
-        {
-            let key_str = primary_keys
-                .get(i)
-                .and_then(|k| k.as_ref().map(String::as_str))
-                .unwrap_or("unknown");
-            tracing::warn!(
-                "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes"
-            );
+        let should_skip = match &embeddings[i] {
+            None => {
+                let key_str = primary_keys
+                    .get(i)
+                    .and_then(|k| k.as_ref().map(String::as_str))
+                    .unwrap_or("unknown");
+                tracing::debug!(
+                    "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding is null (source text was null or empty)"
+                );
+                true
+            }
+            Some(embedding) if embedding.iter().all(|&x| x == 0.0) => {
+                let key_str = primary_keys
+                    .get(i)
+                    .and_then(|k| k.as_ref().map(String::as_str))
+                    .unwrap_or("unknown");
+                tracing::warn!(
+                    "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes"
+                );
+                true
+            }
+            _ => false,
+        };
 
+        if should_skip {
             embeddings.remove(i);
             primary_keys.remove(i);
             for values in metadata.values_mut() {
@@ -508,7 +523,7 @@ mod tests {
 
         // Create embedding array
         let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dim);
-        let field = Field::new_list_field(DataType::Float32, false);
+        let field = Field::new_list_field(DataType::Float32, true);
         builder = builder.with_field(field);
         for embedding_opt in embeddings {
             if let Some(embedding) = embedding_opt {
@@ -527,10 +542,7 @@ mod tests {
             Field::new("text", DataType::Utf8, true),
             Field::new(
                 "text_embedding",
-                DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Float32, false)),
-                    dim,
-                ),
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
                 true,
             ),
         ]);
@@ -675,14 +687,16 @@ mod tests {
         let embeddings = vec![
             Some(vec![1.0, 2.0]), // Keep
             Some(vec![0.0, 0.0]), // Filter out (zero vector)
-            None,                 // Keep
+            None,                 // Filter out (null embedding)
             Some(vec![3.0, 4.0]), // Keep
+            None,                 // Filter out (null embedding)
         ];
         let keys = vec![
             Some("key1".to_string()),
             Some("key2".to_string()),
             Some("key3".to_string()),
             Some("key4".to_string()),
+            Some("key5".to_string()),
         ];
         let mut metadata = HashMap::new();
         metadata.insert(
@@ -692,19 +706,22 @@ mod tests {
                 Some(Value::String("b".to_string())),
                 Some(Value::String("c".to_string())),
                 Some(Value::String("d".to_string())),
+                Some(Value::String("e".to_string())),
             ],
         );
 
         let (filtered_embeddings, filtered_keys, filtered_metadata) =
             filter_zero_vectors(embeddings, keys, metadata, "test_index");
 
-        assert_eq!(filtered_embeddings.len(), 3);
-        assert_eq!(filtered_keys.len(), 3);
-        assert_eq!(filtered_metadata["test"].len(), 3);
+        // Should only keep records with valid non-zero embeddings
+        assert_eq!(filtered_embeddings.len(), 2);
+        assert_eq!(filtered_keys.len(), 2);
+        assert_eq!(filtered_metadata["test"].len(), 2);
 
-        // Check that zero vector was filtered out
+        // Check that only non-null, non-zero vectors remain
         assert_eq!(filtered_embeddings[0], Some(vec![1.0, 2.0]));
-        assert_eq!(filtered_embeddings[1], None);
-        assert_eq!(filtered_embeddings[2], Some(vec![3.0, 4.0]));
+        assert_eq!(filtered_keys[0], Some("key1".to_string()));
+        assert_eq!(filtered_embeddings[1], Some(vec![3.0, 4.0]));
+        assert_eq!(filtered_keys[1], Some("key4".to_string()));
     }
 }

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -456,7 +456,7 @@ fn create_embedding_array(
     Ok(Arc::new(builder.finish()))
 }
 
-/// Filter out zero vectors (all values in the vector are 0.0) and null embeddings
+/// Filter out invalid embeddings: null embeddings, empty vectors, and zero vectors (all values are 0.0)
 #[allow(clippy::type_complexity)]
 fn filter_zero_vectors(
     mut embeddings: Vec<Option<Vec<f32>>>,
@@ -478,6 +478,16 @@ fn filter_zero_vectors(
                     .unwrap_or("unknown");
                 tracing::debug!(
                     "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding is null (source text was null or empty)"
+                );
+                true
+            }
+            Some(embedding) if embedding.is_empty() => {
+                let key_str = primary_keys
+                    .get(i)
+                    .and_then(|k| k.as_ref().map(String::as_str))
+                    .unwrap_or("unknown");
+                tracing::warn!(
+                    "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is empty (zero length)"
                 );
                 true
             }
@@ -685,11 +695,15 @@ mod tests {
         use std::collections::HashMap;
 
         let embeddings = vec![
-            Some(vec![1.0, 2.0]), // Keep
-            Some(vec![0.0, 0.0]), // Filter out (zero vector)
-            None,                 // Filter out (null embedding)
-            Some(vec![3.0, 4.0]), // Keep
-            None,                 // Filter out (null embedding)
+            Some(vec![1.0, 2.0]),      // Keep - valid embedding
+            Some(vec![0.0, 0.0]),      // Filter out - zero vector
+            None,                      // Filter out - null embedding
+            Some(vec![3.0, 4.0]),      // Keep - valid embedding
+            None,                      // Filter out - null embedding
+            Some(vec![]),              // Filter out - empty vector (zero length)
+            Some(vec![0.0, 0.0, 0.0]), // Filter out - zero vector (3D)
+            Some(vec![5.0, 6.0]),      // Keep - valid embedding
+            Some(vec![0.0]),           // Filter out - single zero
         ];
         let keys = vec![
             Some("key1".to_string()),
@@ -697,6 +711,10 @@ mod tests {
             Some("key3".to_string()),
             Some("key4".to_string()),
             Some("key5".to_string()),
+            Some("key6".to_string()),
+            Some("key7".to_string()),
+            Some("key8".to_string()),
+            Some("key9".to_string()),
         ];
         let mut metadata = HashMap::new();
         metadata.insert(
@@ -707,6 +725,10 @@ mod tests {
                 Some(Value::String("c".to_string())),
                 Some(Value::String("d".to_string())),
                 Some(Value::String("e".to_string())),
+                Some(Value::String("f".to_string())),
+                Some(Value::String("g".to_string())),
+                Some(Value::String("h".to_string())),
+                Some(Value::String("i".to_string())),
             ],
         );
 
@@ -714,14 +736,30 @@ mod tests {
             filter_zero_vectors(embeddings, keys, metadata, "test_index");
 
         // Should only keep records with valid non-zero embeddings
-        assert_eq!(filtered_embeddings.len(), 2);
-        assert_eq!(filtered_keys.len(), 2);
-        assert_eq!(filtered_metadata["test"].len(), 2);
+        assert_eq!(filtered_embeddings.len(), 3);
+        assert_eq!(filtered_keys.len(), 3);
+        assert_eq!(filtered_metadata["test"].len(), 3);
 
-        // Check that only non-null, non-zero vectors remain
+        // Check that only non-null, non-zero, non-empty vectors remain
         assert_eq!(filtered_embeddings[0], Some(vec![1.0, 2.0]));
         assert_eq!(filtered_keys[0], Some("key1".to_string()));
+        assert_eq!(
+            filtered_metadata["test"][0],
+            Some(Value::String("a".to_string()))
+        );
+
         assert_eq!(filtered_embeddings[1], Some(vec![3.0, 4.0]));
         assert_eq!(filtered_keys[1], Some("key4".to_string()));
+        assert_eq!(
+            filtered_metadata["test"][1],
+            Some(Value::String("d".to_string()))
+        );
+
+        assert_eq!(filtered_embeddings[2], Some(vec![5.0, 6.0]));
+        assert_eq!(filtered_keys[2], Some("key8".to_string()));
+        assert_eq!(
+            filtered_metadata["test"][2],
+            Some(Value::String("h".to_string()))
+        );
     }
 }


### PR DESCRIPTION
This pull request improves the handling of embedding vectors in the S3 vector index pipeline by updating both the filtering logic and the Arrow schema to better support null embeddings. The main changes ensure that null embeddings are filtered out (in addition to zero vectors), and the Arrow data structures are updated to mark embedding elements as nullable. Unit tests are also updated to reflect the new filtering behavior.

**Filtering and data processing improvements:**

* The `filter_zero_vectors` function now filters out both null embeddings and zero vectors, logging debug messages for nulls and warnings for zero vectors. [[1]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23L458-R459) [[2]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23L472-R497)
* The filtering logic in tests has been updated to expect only non-null, non-zero vectors to remain after filtering. [[1]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23L678-R699) [[2]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23R709-R725)

**Schema and Arrow array updates:**

* The Arrow schema for embedding vectors (`Field::new_list_field`) and the test schema now mark elements as nullable, allowing for proper handling of nulls. [[1]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23L439-R439) [[2]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23L511-R526) [[3]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23L530-R545)
* Comments and documentation are updated to clarify that both zero vectors and null embeddings are filtered out. [[1]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23R450) [[2]](diffhunk://#diff-68f58ad7749e7535fd331901e484a8c0ae6c99d763512b1e33bfa7fbb300aa23L458-R459)