### PR TITLE
Add Type to GitHub Data Connector issues and fix double aliasing for project author

### DIFF
--- a/crates/runtime/src/dataconnector/github/issues.rs
+++ b/crates/runtime/src/dataconnector/github/issues.rs
@@ -106,6 +106,7 @@ impl GitHubTableArgs for IssuesTableArgs {
                             milestone_title: milestone {{ milestone_title: title }}
                             comments(first: 100) {{ comments_count: totalCount, comments: nodes {{ body, author {{ login }} }} }}
                             assignees(first: 100) {{ assignees: nodes {{ login }} }}
+                            type: issueType {{ id, name, description, color }}
                         }}
                     }}
                 }}
@@ -138,6 +139,7 @@ impl GitHubTableArgs for IssuesTableArgs {
                             milestone_title: milestone {{ milestone_title: title }}
                             comments(first: 100) {{ comments_count: totalCount, comments: nodes {{ body, author {{ login }} }} }}
                             assignees(first: 100) {{ assignees: nodes {{ login }} }}
+                            type: issueType {{ id, name, description, color }}
                         }}
                     }}
                 }}

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -327,34 +327,38 @@ fn github_gql_raw_schema_cast(
         }
 
         // Handle top-level structs with a single field (e.g., creator: { creator: "value" })
-        // Extract the inner field value and flatten it
+        // Extract the inner field value and flatten it if the inner and outer fields are the same
         if let DataType::Struct(struct_fields) = field.data_type()
             && struct_fields.len() == 1
         {
-            let struct_array = column
-                .as_any()
-                .downcast_ref::<arrow::array::StructArray>()
-                .ok_or_else(|| {
-                    format!(
-                        "Expected StructArray for field {}, but got different type",
-                        field.name()
-                    )
-                })?;
-
-            // Get the single inner column
-            let inner_column = struct_array.column(0);
             let inner_field = &struct_fields[0];
 
-            // Create a new field with the outer name but inner type
-            let new_field = Arc::new(Field::new(
-                field.name(),
-                inner_field.data_type().clone(),
-                field.is_nullable(),
-            ));
+            // Only flatten if the inner field name matches the outer field name
+            if inner_field.name() == field.name() {
+                let struct_array = column
+                    .as_any()
+                    .downcast_ref::<arrow::array::StructArray>()
+                    .ok_or_else(|| {
+                        format!(
+                            "Expected StructArray for field {}, but got different type",
+                            field.name()
+                        )
+                    })?;
 
-            fields.push(new_field);
-            columns.push(Arc::clone(inner_column));
-            continue;
+                // Get the single inner column
+                let inner_column = struct_array.column(0);
+
+                // Create a new field with the outer name but inner type
+                let new_field = Arc::new(Field::new(
+                    field.name(),
+                    inner_field.data_type().clone(),
+                    field.is_nullable(),
+                ));
+
+                fields.push(new_field);
+                columns.push(Arc::clone(inner_column));
+                continue;
+            }
         }
 
         fields.push(Arc::clone(field));

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -313,6 +313,8 @@ fn github_gql_raw_schema_cast(
 
     for (idx, field) in record_batch.schema().fields().iter().enumerate() {
         let column = record_batch.column(idx);
+
+        // Handle lists with single-field structs
         if let DataType::List(inner_field) = field.data_type()
             && let DataType::Struct(struct_fields) = inner_field.data_type()
             && struct_fields.len() == 1
@@ -321,6 +323,37 @@ fn github_gql_raw_schema_cast(
                 arrow_tools::record_batch::to_primitive_type_list(column, field)?;
             fields.push(new_field);
             columns.push(new_column);
+            continue;
+        }
+
+        // Handle top-level structs with a single field (e.g., creator: { creator: "value" })
+        // Extract the inner field value and flatten it
+        if let DataType::Struct(struct_fields) = field.data_type()
+            && struct_fields.len() == 1
+        {
+            let struct_array = column
+                .as_any()
+                .downcast_ref::<arrow::array::StructArray>()
+                .ok_or_else(|| {
+                    format!(
+                        "Expected StructArray for field {}, but got different type",
+                        field.name()
+                    )
+                })?;
+
+            // Get the single inner column
+            let inner_column = struct_array.column(0);
+            let inner_field = &struct_fields[0];
+
+            // Create a new field with the outer name but inner type
+            let new_field = Arc::new(Field::new(
+                field.name(),
+                inner_field.data_type().clone(),
+                field.is_nullable(),
+            ));
+
+            fields.push(new_field);
+            columns.push(Arc::clone(inner_column));
             continue;
         }
 

--- a/crates/runtime/src/dataconnector/github/projects.rs
+++ b/crates/runtime/src/dataconnector/github/projects.rs
@@ -53,8 +53,8 @@ impl GitHubTableArgs for ProjectsTableArgs {
                                     created_at: createdAt
                                     updated_at: updatedAt
                                     closed_at: closedAt
-                                    creator: creator {{
-                                        creator: login
+                                    creator {{
+                                        login
                                     }}
                                 }}
                             }}
@@ -88,8 +88,8 @@ impl GitHubTableArgs for ProjectsTableArgs {
                                         created_at: createdAt
                                         updated_at: updatedAt
                                         closed_at: closedAt
-                                        creator: creator {{
-                                            creator: login
+                                        creator {{
+                                            login
                                         }}
                                     }}
                                 }}
@@ -114,8 +114,8 @@ impl GitHubTableArgs for ProjectsTableArgs {
                                         created_at: createdAt
                                         updated_at: updatedAt
                                         closed_at: closedAt
-                                        creator: creator {{
-                                            creator: login
+                                        creator {{
+                                            login
                                         }}
                                     }}
                                 }}

--- a/crates/runtime/src/dataconnector/github/projects.rs
+++ b/crates/runtime/src/dataconnector/github/projects.rs
@@ -53,8 +53,8 @@ impl GitHubTableArgs for ProjectsTableArgs {
                                     created_at: createdAt
                                     updated_at: updatedAt
                                     closed_at: closedAt
-                                    creator {{
-                                        login
+                                    creator: creator {{
+                                        creator: login
                                     }}
                                 }}
                             }}
@@ -88,8 +88,8 @@ impl GitHubTableArgs for ProjectsTableArgs {
                                         created_at: createdAt
                                         updated_at: updatedAt
                                         closed_at: closedAt
-                                        creator {{
-                                            login
+                                        creator: creator {{
+                                            creator: login
                                         }}
                                     }}
                                 }}
@@ -114,8 +114,8 @@ impl GitHubTableArgs for ProjectsTableArgs {
                                         created_at: createdAt
                                         updated_at: updatedAt
                                         closed_at: closedAt
-                                        creator {{
-                                            login
+                                        creator: creator {{
+                                            creator: login
                                         }}
                                     }}
                                 }}
@@ -252,6 +252,8 @@ mod tests {
         assert!(query.contains("updated_at: updatedAt"));
         assert!(query.contains("closed_at: closedAt"));
         assert!(query.contains("short_description: shortDescription"));
+        assert!(query.contains("creator: creator"));
+        assert!(query.contains("creator: login"));
 
         // Should NOT contain repositoryOwner or fragments
         assert!(!query.contains("repositoryOwner"));
@@ -279,6 +281,8 @@ mod tests {
         assert!(query.contains("updated_at: updatedAt"));
         assert!(query.contains("closed_at: closedAt"));
         assert!(query.contains("short_description: shortDescription"));
+        assert!(query.contains("creator: creator"));
+        assert!(query.contains("creator: login"));
 
         // Should NOT contain repository-specific structure
         assert!(!query.contains("repository(owner:"));


### PR DESCRIPTION
This pull request updates the GitHub data connector queries to improve the structure and completeness of the data returned for issues and projects. The main changes involve adding additional fields to the issues query and simplifying the structure of the creator field in the projects query.

**Enhancements to Issues Query:**

- Added the `type` field to the issues query, which retrieves the issue type's `id`, `name`, `description`, and `color`. [[1]](diffhunk://#diff-4ba5097cb03bd86f59f04fa36cf9641fa9df40abec4325fc51e9818f18249c1dR109) [[2]](diffhunk://#diff-4ba5097cb03bd86f59f04fa36cf9641fa9df40abec4325fc51e9818f18249c1dR142)

**Simplification of Projects Query Structure:**

- Simplified the structure of the `creator` field in the projects query by removing the extra nesting, so that only the `login` is returned directly under `creator`. This change was applied in three places in the projects query. [[1]](diffhunk://#diff-44c8e3b9587063fe201a6b70116b60f9939011bdb1a47e19fe28e63003e02d81L56-R57) [[2]](diffhunk://#diff-44c8e3b9587063fe201a6b70116b60f9939011bdb1a47e19fe28e63003e02d81L91-R92) [[3]](diffhunk://#diff-44c8e3b9587063fe201a6b70116b60f9939011bdb1a47e19fe28e63003e02d81L117-R118)