### PR TITLE
DuckDB acceleration: fix memory leak in duckdb_arrow_scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4926,7 +4926,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 [[package]]
 name = "duckdb"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a5e5f8875b4bb95134817441c11978eaca7fb5d7#a5e5f8875b4bb95134817441c11978eaca7fb5d7"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a731d95e32338780a12f8ff14b5efcc79d2e8822#a731d95e32338780a12f8ff14b5efcc79d2e8822"
 dependencies = [
  "arrow",
  "cast",
@@ -7718,7 +7718,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 [[package]]
 name = "libduckdb-sys"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a5e5f8875b4bb95134817441c11978eaca7fb5d7#a5e5f8875b4bb95134817441c11978eaca7fb5d7"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a731d95e32338780a12f8ff14b5efcc79d2e8822#a731d95e32338780a12f8ff14b5efcc79d2e8822"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4926,7 +4926,7 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 [[package]]
 name = "duckdb"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=394325a8527df459f79e15f19ea5e97693339db2#394325a8527df459f79e15f19ea5e97693339db2"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a5e5f8875b4bb95134817441c11978eaca7fb5d7#a5e5f8875b4bb95134817441c11978eaca7fb5d7"
 dependencies = [
  "arrow",
  "cast",
@@ -7718,7 +7718,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 [[package]]
 name = "libduckdb-sys"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=394325a8527df459f79e15f19ea5e97693339db2#394325a8527df459f79e15f19ea5e97693339db2"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a5e5f8875b4bb95134817441c11978eaca7fb5d7#a5e5f8875b4bb95134817441c11978eaca7fb5d7"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,7 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "0e5d8bca9b6f76087b88d7554c09a6cc43e87183" } # spiceai-0.14.0
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a5e5f8875b4bb95134817441c11978eaca7fb5d7" } # spiceai-1.3.2
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a731d95e32338780a12f8ff14b5efcc79d2e8822" } # spiceai-1.3.2
 
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af725caf5d3e952e349746706e00d0ea5" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,7 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "0e5d8bca9b6f76087b88d7554c09a6cc43e87183" } # spiceai-0.14.0
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "394325a8527df459f79e15f19ea5e97693339db2" } # spiceai-1.3.2
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a5e5f8875b4bb95134817441c11978eaca7fb5d7" } # spiceai-1.3.2
 
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af725caf5d3e952e349746706e00d0ea5" }
 


### PR DESCRIPTION
## 📝 Summary

Update `duckdb-rs` to include the following improvement:
 - https://github.com/spiceai/duckdb-rs/pull/24
