### PR TITLE
Cherry Pick "Fix partition_by accelerations when a projection is applied on empty partition sets" to release 1.8

### DIFF
--- a/crates/runtime-table-partition/src/provider.rs
+++ b/crates/runtime-table-partition/src/provider.rs
@@ -20,7 +20,7 @@ use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{
     catalog::{Session, TableProvider},
-    common::{Constraints, DFSchema},
+    common::{Constraints, DFSchema, project_schema},
     datasource::TableType,
     error::DataFusionError,
     logical_expr::{TableProviderFilterPushDown, dml::InsertOp},
@@ -164,7 +164,8 @@ impl TableProvider for PartitionTableProvider {
 
         let plan = match plans {
             plans if plans.is_empty() => {
-                return Ok(Arc::new(EmptyExec::new(Arc::clone(&self.schema))));
+                let projected_schema = project_schema(&self.schema, projection)?;
+                return Ok(Arc::new(EmptyExec::new(projected_schema)));
             }
             mut plans if plans.len() == 1 => plans.pop().ok_or_else(|| {
                 DataFusionError::Execution("expected an ExecutionPlan".to_string())


### PR DESCRIPTION
## 📝 Summary

Cherry-pick "Fix partition_by accelerations when a projection is applied on empty partition sets (#7526)" to release 1.8


