### PR TITLE
Fix missing winver dependency for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12153,7 +12153,6 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid 1.18.0",
- "winver",
  "workers",
  "x509-certificate",
 ]
@@ -12309,6 +12308,7 @@ dependencies = [
  "tonic",
  "tower 0.5.2",
  "tracing",
+ "winver",
 ]
 
 [[package]]

--- a/crates/runtime-request-context/Cargo.toml
+++ b/crates/runtime-request-context/Cargo.toml
@@ -25,3 +25,6 @@ http.workspace = true
 runtime-auth = { path = "../runtime-auth" }
 regex.workspace = true
 opentelemetry.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+winver = "1.0.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -265,6 +265,3 @@ sqlite = [
     "dep:rusqlite",
 ]
 xxhash = ["dep:twox-hash", "cache/xxhash"]
-
-[target.'cfg(windows)'.dependencies]
-winver = "1.0.0"


### PR DESCRIPTION
## 📝 Summary

Add missing winver dependency for Windows to `runtime-request-context`


