### PR TITLE
Configurable DuckDB duckdb_index_scan_percentage  & duckdb_index_scan_max_count

### DIFF
--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -106,7 +106,10 @@ impl DuckDBAccelerator {
             duckdb_factory: DuckDBTableProviderFactory::new(AccessMode::ReadWrite)
                 .with_dialect(new_duckdb_dialect())
                 .with_settings_registry(
-                    DuckDBSettingsRegistry::new().with_setting(Box::new(OrderByNonIntegerLiteral)),
+                    DuckDBSettingsRegistry::new()
+                        .with_setting(Box::new(OrderByNonIntegerLiteral))
+                        .with_setting(Box::new(settings::IndexScanPercentage))
+                        .with_setting(Box::new(settings::IndexScanMaxCount)),
                 ),
         }
     }
@@ -169,7 +172,8 @@ impl DuckDBAccelerator {
                 let max_size = Self::get_max_size(num_accelerating_datasets);
                 let pool_builder = DuckDbConnectionPoolBuilder::file(&duckdb_file)
                     .with_max_size(Some(max_size))
-                    .with_min_idle(Some(DEFAULT_MIN_IDLE_CONNECTIONS));
+                    .with_min_idle(Some(DEFAULT_MIN_IDLE_CONNECTIONS))
+                    .with_connection_setup_query("PRAGMA enable_checkpoint_on_shutdown");
                 self.duckdb_factory
                     .get_or_init_instance_with_builder(pool_builder)
                     .await
@@ -182,7 +186,8 @@ impl DuckDBAccelerator {
                 let max_size = Self::get_max_size(num_accelerating_datasets);
                 let pool_builder = DuckDbConnectionPoolBuilder::memory()
                     .with_max_size(Some(max_size))
-                    .with_min_idle(Some(DEFAULT_MIN_IDLE_CONNECTIONS));
+                    .with_min_idle(Some(DEFAULT_MIN_IDLE_CONNECTIONS))
+                    .with_connection_setup_query("PRAGMA enable_checkpoint_on_shutdown");
                 self.duckdb_factory
                     .get_or_init_instance_with_builder(pool_builder)
                     .await
@@ -251,6 +256,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::runtime("file_watcher"),
     ParameterSpec::component("memory_limit"),
     ParameterSpec::component("preserve_insertion_order"),
+    ParameterSpec::component("index_scan_percentage"),
+    ParameterSpec::component("index_scan_max_count"),
 ];
 
 #[async_trait]

--- a/crates/runtime/src/dataaccelerator/duckdb/settings.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb/settings.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use datafusion_table_providers::duckdb::{DuckDBSetting, DuckDBSettingScope};
+use datafusion_table_providers::duckdb::{DuckDBSetting, DuckDBSettingScope, Error};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct OrderByNonIntegerLiteral;
@@ -34,5 +34,107 @@ impl DuckDBSetting for OrderByNonIntegerLiteral {
 
     fn scope(&self) -> DuckDBSettingScope {
         DuckDBSettingScope::Local
+    }
+}
+
+/// DuckDB setting for configuring the percentage of rows that trigger an index scan.
+///
+/// The index scan percentage sets a threshold for index scans. If fewer than
+/// MAX(index_scan_max_count, index_scan_percentage * total_row_count) rows match,
+/// an index scan is performed instead of a table scan.
+///
+/// Type: DOUBLE, Default: 0.001
+///
+/// See: https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct IndexScanPercentage;
+
+impl DuckDBSetting for IndexScanPercentage {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn setting_name(&self) -> &'static str {
+        "index_scan_percentage"
+    }
+
+    fn get_value(&self, options: &std::collections::HashMap<String, String>) -> Option<String> {
+        options.get("index_scan_percentage").cloned()
+    }
+
+    fn scope(&self) -> DuckDBSettingScope {
+        DuckDBSettingScope::Global
+    }
+
+    fn validate(&self, value: &str) -> Result<(), Error> {
+        // Validate that the value is a valid percentage (0.0-1.0)
+        let percentage = value.parse::<f64>().map_err(|e| Error::DbConnectionError {
+            source: Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid index_scan_percentage value '{}'. Must be a number between 0.0 and 1.0. Error: {}",
+                    value, e
+                ),
+            )),
+        })?;
+
+        if !(0.0..=1.0).contains(&percentage) {
+            return Err(Error::DbConnectionError {
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!(
+                        "Invalid index_scan_percentage value '{}'. Must be between 0.0 and 1.0.",
+                        percentage
+                    ),
+                )),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// DuckDB setting for configuring the maximum number of rows that trigger an index scan.
+///
+/// The maximum index scan count sets a threshold for index scans. If fewer than
+/// MAX(index_scan_max_count, index_scan_percentage * total_row_count) rows match,
+/// an index scan is performed instead of a table scan.
+///
+/// Type: UBIGINT, Default: 2048
+///
+/// See: https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct IndexScanMaxCount;
+
+impl DuckDBSetting for IndexScanMaxCount {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn setting_name(&self) -> &'static str {
+        "index_scan_max_count"
+    }
+
+    fn get_value(&self, options: &std::collections::HashMap<String, String>) -> Option<String> {
+        options.get("index_scan_max_count").cloned()
+    }
+
+    fn scope(&self) -> DuckDBSettingScope {
+        DuckDBSettingScope::Global
+    }
+
+    fn validate(&self, value: &str) -> Result<(), Error> {
+        // Validate that the value is a valid non-negative integer
+        value.parse::<u64>().map_err(|e| Error::DbConnectionError {
+            source: Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid index_scan_max_count value '{}'. Must be a non-negative integer. Error: {}",
+                    value, e
+                ),
+            )),
+        })?;
+
+        Ok(())
     }
 }

--- a/crates/runtime/src/dataaccelerator/duckdb/settings.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb/settings.rs
@@ -59,7 +59,7 @@ impl DuckDBSetting for IndexScanPercentage {
     }
 
     fn get_value(&self, options: &std::collections::HashMap<String, String>) -> Option<String> {
-        options.get("index_scan_percentage").cloned()
+        options.get(self.setting_name()).cloned()
     }
 
     fn scope(&self) -> DuckDBSettingScope {

--- a/crates/runtime/src/dataaccelerator/duckdb/settings.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb/settings.rs
@@ -39,9 +39,9 @@ impl DuckDBSetting for OrderByNonIntegerLiteral {
 
 /// `DuckDB` setting for configuring the percentage of rows that trigger an index scan.
 ///
-/// The index scan percentage sets a threshold for index scans. If fewer than
-/// `MAX(index_scan_max_count, index_scan_percentage * total_row_count)` rows match,
-/// an index scan is performed instead of a table scan.
+/// The index scan percentage sets a threshold for index scans. An index scan is performed
+/// instead of a table scan when the number of matching rows is less than the maximum of
+/// `index_scan_max_count` and `index_scan_percentage × total_row_count`.
 ///
 /// Type: DOUBLE, Default: 0.001
 ///
@@ -94,9 +94,9 @@ impl DuckDBSetting for IndexScanPercentage {
 
 /// `DuckDB` setting for configuring the maximum number of rows that trigger an index scan.
 ///
-/// The maximum index scan count sets a threshold for index scans. If fewer than
-/// `MAX(index_scan_max_count, index_scan_percentage * total_row_count)` rows match,
-/// an index scan is performed instead of a table scan.
+/// The maximum index scan count sets a threshold for index scans. An index scan is performed
+/// instead of a table scan when the number of matching rows is less than the maximum of
+/// `index_scan_max_count` and `index_scan_percentage × total_row_count`.
 ///
 /// Type: UBIGINT, Default: 2048
 ///

--- a/crates/runtime/src/dataaccelerator/duckdb/settings.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb/settings.rs
@@ -37,15 +37,15 @@ impl DuckDBSetting for OrderByNonIntegerLiteral {
     }
 }
 
-/// DuckDB setting for configuring the percentage of rows that trigger an index scan.
+/// `DuckDB` setting for configuring the percentage of rows that trigger an index scan.
 ///
 /// The index scan percentage sets a threshold for index scans. If fewer than
-/// MAX(index_scan_max_count, index_scan_percentage * total_row_count) rows match,
+/// `MAX(index_scan_max_count, index_scan_percentage * total_row_count)` rows match,
 /// an index scan is performed instead of a table scan.
 ///
 /// Type: DOUBLE, Default: 0.001
 ///
-/// See: https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans
+/// See: <https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans>
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct IndexScanPercentage;
 
@@ -72,8 +72,7 @@ impl DuckDBSetting for IndexScanPercentage {
             source: Box::new(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!(
-                    "Invalid index_scan_percentage value '{}'. Must be a number between 0.0 and 1.0. Error: {}",
-                    value, e
+                    "Invalid index_scan_percentage value '{value}'. Must be a number between 0.0 and 1.0. Error: {e}"
                 ),
             )),
         })?;
@@ -83,8 +82,7 @@ impl DuckDBSetting for IndexScanPercentage {
                 source: Box::new(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
                     format!(
-                        "Invalid index_scan_percentage value '{}'. Must be between 0.0 and 1.0.",
-                        percentage
+                        "Invalid index_scan_percentage value '{percentage}'. Must be between 0.0 and 1.0."
                     ),
                 )),
             });
@@ -94,15 +92,15 @@ impl DuckDBSetting for IndexScanPercentage {
     }
 }
 
-/// DuckDB setting for configuring the maximum number of rows that trigger an index scan.
+/// `DuckDB` setting for configuring the maximum number of rows that trigger an index scan.
 ///
 /// The maximum index scan count sets a threshold for index scans. If fewer than
-/// MAX(index_scan_max_count, index_scan_percentage * total_row_count) rows match,
+/// `MAX(index_scan_max_count, index_scan_percentage * total_row_count)` rows match,
 /// an index scan is performed instead of a table scan.
 ///
 /// Type: UBIGINT, Default: 2048
 ///
-/// See: https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans
+/// See: <https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans>
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct IndexScanMaxCount;
 
@@ -129,8 +127,7 @@ impl DuckDBSetting for IndexScanMaxCount {
             source: Box::new(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!(
-                    "Invalid index_scan_max_count value '{}'. Must be a non-negative integer. Error: {}",
-                    value, e
+                    "Invalid index_scan_max_count value '{value}'. Must be a non-negative integer. Error: {e}"
                 ),
             )),
         })?;

--- a/crates/runtime/src/dataaccelerator/duckdb/settings.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb/settings.rs
@@ -116,7 +116,7 @@ impl DuckDBSetting for IndexScanMaxCount {
     }
 
     fn get_value(&self, options: &std::collections::HashMap<String, String>) -> Option<String> {
-        options.get("index_scan_max_count").cloned()
+        options.get(self.setting_name()).cloned()
     }
 
     fn scope(&self) -> DuckDBSettingScope {

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -360,3 +360,448 @@ async fn duckdb_regexp() -> Result<(), String> {
         })
         .await
 }
+
+#[tokio::test]
+async fn test_duckdb_settings_persist() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            // Create a temporary DuckDB file
+            let temp_dir = std::env::temp_dir().join("spiced_duckdb_settings_test");
+            std::fs::create_dir_all(&temp_dir).expect("failed to create temp dir");
+            let duckdb_file = temp_dir.join("test_settings.db");
+
+            defer! {
+                std::fs::remove_dir_all(&temp_dir).expect("failed to remove temp dir");
+            }
+
+            // Create a dataset with DuckDB acceleration and custom settings
+            use spicepod::param::Params;
+            use std::collections::HashMap;
+
+            let mut accel_params = HashMap::new();
+            accel_params.insert(
+                "duckdb_file".to_string(),
+                duckdb_file.to_str().unwrap().to_string(),
+            );
+            accel_params.insert(
+                "duckdb_index_scan_percentage".to_string(),
+                "0.05".to_string(),
+            ); // 5% as decimal
+            accel_params.insert(
+                "duckdb_index_scan_max_count".to_string(),
+                "5000".to_string(),
+            );
+
+            // Create a simple CSV file for testing
+            let csv_file = temp_dir.join("test.csv");
+            std::fs::write(&csv_file, "id,name\n1,test\n2,test2\n").expect("failed to write csv");
+
+            let mut dataset = Dataset::new(
+                format!("file:{}", csv_file.display()),
+                "test_settings".to_string(),
+            );
+            dataset.name = "test_settings".to_string();
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                engine: Some("duckdb".to_string()),
+                mode: Mode::File,
+                refresh_mode: Some(RefreshMode::Full),
+                params: Some(Params::from_string_map(accel_params)),
+                ..Acceleration::default()
+            });
+
+            let app = AppBuilder::new("duckdb_settings_test")
+                .with_dataset(dataset)
+                .build();
+
+            configure_test_datafusion();
+
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            // Set a timeout for the test
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                    return Err("Timed out waiting for datasets to load".to_string());
+                }
+                () = Arc::clone(&cloned_rt).load_components() => {}
+            }
+
+            runtime_ready_check(&cloned_rt).await;
+
+            // Verify the accelerated dataset loaded successfully
+            println!("✅ DuckDB accelerator initialized successfully with custom settings:");
+            println!("   - duckdb_index_scan_percentage: 0.05 (5%)");
+            println!("   - duckdb_index_scan_max_count: 5000");
+            println!("   - PRAGMA enable_checkpoint_on_shutdown (automatic)");
+
+            // Query the accelerated table to ensure it's working
+            let df = cloned_rt.datafusion();
+            let result = df
+                .query_builder("SELECT COUNT(*) as row_count FROM test_settings")
+                .build()
+                .run()
+                .await
+                .map_err(|e| format!("Failed to query test_settings: {e}"))?;
+
+            let batches: Vec<RecordBatch> = result
+                .data
+                .try_collect()
+                .await
+                .map_err(|e| format!("Failed to collect results: {e}"))?;
+
+            // Verify we got data
+            if batches.is_empty() || batches[0].num_rows() == 0 {
+                return Err("No rows returned from query".to_string());
+            }
+
+            let count_col = batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::Int64Array>()
+                .ok_or_else(|| "Failed to downcast count column".to_string())?;
+            let count = count_col.value(0);
+
+            println!(
+                "✅ Query successful: test_settings table has {} rows",
+                count
+            );
+
+            if count != 2 {
+                return Err(format!("Expected 2 rows, got {}", count));
+            }
+
+            // Shutdown the runtime
+            cloned_rt.shutdown().await;
+            drop(cloned_rt);
+            drop(rt);
+
+            // Give time for shutdown and checkpoint
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+            // Verify the file was checkpointed (file should exist and be non-zero)
+            if !duckdb_file.exists() {
+                return Err("DuckDB file does not exist after shutdown".to_string());
+            }
+
+            let metadata = std::fs::metadata(&duckdb_file)
+                .map_err(|e| format!("Failed to get file metadata: {e}"))?;
+
+            println!(
+                "✓ DuckDB file size after shutdown: {} bytes",
+                metadata.len()
+            );
+
+            if metadata.len() == 0 {
+                return Err(
+                    "DuckDB file is empty after shutdown - checkpoint may have failed".to_string(),
+                );
+            }
+
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_duckdb_all_settings() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            use spicepod::param::Params;
+            use std::collections::HashMap;
+
+            // Test 1: Index scan settings with custom file
+            println!("\n=== Test 1: Index Scan Settings with Custom File ===");
+            {
+                let temp_dir = std::env::temp_dir().join("spiced_duckdb_test_1");
+                std::fs::create_dir_all(&temp_dir).expect("failed to create temp dir");
+                let duckdb_file = temp_dir.join("test_index_scan.db");
+
+                defer! {
+                    std::fs::remove_dir_all(&temp_dir).expect("failed to remove temp dir");
+                }
+
+                let mut accel_params = HashMap::new();
+                accel_params.insert("duckdb_file".to_string(), duckdb_file.to_str().unwrap().to_string());
+                accel_params.insert("duckdb_index_scan_percentage".to_string(), "0.05".to_string());
+                accel_params.insert("duckdb_index_scan_max_count".to_string(), "5000".to_string());
+
+                let csv_file = temp_dir.join("test.csv");
+                std::fs::write(&csv_file, "id,name\n1,test\n2,test2\n").expect("failed to write csv");
+
+                let mut dataset = Dataset::new(format!("file:{}", csv_file.display()), "test_index_scan".to_string());
+                dataset.name = "test_index_scan".to_string();
+                dataset.acceleration = Some(Acceleration {
+                    enabled: true,
+                    engine: Some("duckdb".to_string()),
+                    mode: Mode::File,
+                    refresh_mode: Some(RefreshMode::Full),
+                    params: Some(Params::from_string_map(accel_params)),
+                    ..Acceleration::default()
+                });
+
+                let app = AppBuilder::new("duckdb_test_index_scan").with_dataset(dataset).build();
+                configure_test_datafusion();
+                let rt = Runtime::builder().with_app(app).build().await;
+                let cloned_rt = Arc::new(rt.clone());
+
+                tokio::select! {
+                    () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                        return Err("Test 1: Timed out waiting for datasets to load".to_string());
+                    }
+                    () = Arc::clone(&cloned_rt).load_components() => {}
+                }
+
+                runtime_ready_check(&cloned_rt).await;
+
+                // Verify query works
+                let df = cloned_rt.datafusion();
+                let result = df
+                    .query_builder("SELECT COUNT(*) FROM test_index_scan")
+                    .build()
+                    .run()
+                    .await
+                    .map_err(|e| format!("Test 1: Query failed: {e}"))?;
+                let batches: Vec<RecordBatch> = result.data.try_collect().await
+                    .map_err(|e| format!("Test 1: Failed to collect: {e}"))?;
+                
+                let count_col = batches[0].column(0).as_any().downcast_ref::<arrow::array::Int64Array>()
+                    .ok_or_else(|| "Test 1: Failed to downcast".to_string())?;
+                assert_eq!(count_col.value(0), 2, "Test 1: Expected 2 rows");
+
+                println!("✅ Index scan settings applied successfully");
+                println!("   - duckdb_file: custom path");
+                println!("   - index_scan_percentage: 0.05");
+                println!("   - index_scan_max_count: 5000");
+
+                cloned_rt.shutdown().await;
+                drop(cloned_rt);
+                drop(rt);
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+                // Verify checkpoint occurred
+                assert!(duckdb_file.exists(), "Test 1: DuckDB file should exist");
+                let metadata = std::fs::metadata(&duckdb_file)
+                    .map_err(|e| format!("Test 1: Failed to get metadata: {e}"))?;
+                assert!(metadata.len() > 0, "Test 1: File should be non-zero");
+                println!("✅ Checkpoint verified: {} bytes", metadata.len());
+            }
+
+            // Test 2: Memory limit setting
+            println!("\n=== Test 2: Memory Limit Setting ===");
+            {
+                let temp_dir = std::env::temp_dir().join("spiced_duckdb_test_2");
+                std::fs::create_dir_all(&temp_dir).expect("failed to create temp dir");
+
+                defer! {
+                    std::fs::remove_dir_all(&temp_dir).expect("failed to remove temp dir");
+                }
+
+                let mut accel_params = HashMap::new();
+                accel_params.insert("duckdb_memory_limit".to_string(), "512MB".to_string());
+
+                let csv_file = temp_dir.join("test.csv");
+                std::fs::write(&csv_file, "id,value\n1,100\n2,200\n3,300\n").expect("failed to write csv");
+
+                let mut dataset = Dataset::new(format!("file:{}", csv_file.display()), "test_memory".to_string());
+                dataset.name = "test_memory".to_string();
+                dataset.acceleration = Some(Acceleration {
+                    enabled: true,
+                    engine: Some("duckdb".to_string()),
+                    mode: Mode::Memory,
+                    refresh_mode: Some(RefreshMode::Full),
+                    params: Some(Params::from_string_map(accel_params)),
+                    ..Acceleration::default()
+                });
+
+                let app = AppBuilder::new("duckdb_test_memory").with_dataset(dataset).build();
+                configure_test_datafusion();
+                let rt = Runtime::builder().with_app(app).build().await;
+                let cloned_rt = Arc::new(rt.clone());
+
+                tokio::select! {
+                    () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                        return Err("Test 2: Timed out waiting for datasets to load".to_string());
+                    }
+                    () = Arc::clone(&cloned_rt).load_components() => {}
+                }
+
+                runtime_ready_check(&cloned_rt).await;
+
+                let df = cloned_rt.datafusion();
+                let result = df
+                    .query_builder("SELECT SUM(value) as total FROM test_memory")
+                    .build()
+                    .run()
+                    .await
+                    .map_err(|e| format!("Test 2: Query failed: {e}"))?;
+                let batches: Vec<RecordBatch> = result.data.try_collect().await
+                    .map_err(|e| format!("Test 2: Failed to collect: {e}"))?;
+
+                let sum_col = batches[0].column(0).as_any().downcast_ref::<arrow::array::Int64Array>()
+                    .ok_or_else(|| "Test 2: Failed to downcast".to_string())?;
+                assert_eq!(sum_col.value(0), 600, "Test 2: Expected sum of 600");
+
+                println!("✅ Memory limit setting applied successfully");
+                println!("   - memory_limit: 512MB");
+                println!("   - mode: Memory");
+
+                cloned_rt.shutdown().await;
+                drop(cloned_rt);
+                drop(rt);
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            }
+
+            // Test 3: Preserve insertion order
+            println!("\n=== Test 3: Preserve Insertion Order ===");
+            {
+                let temp_dir = std::env::temp_dir().join("spiced_duckdb_test_3");
+                std::fs::create_dir_all(&temp_dir).expect("failed to create temp dir");
+
+                defer! {
+                    std::fs::remove_dir_all(&temp_dir).expect("failed to remove temp dir");
+                }
+
+                let mut accel_params = HashMap::new();
+                accel_params.insert("duckdb_preserve_insertion_order".to_string(), "true".to_string());
+
+                let csv_file = temp_dir.join("test.csv");
+                std::fs::write(&csv_file, "id,name\n3,charlie\n1,alice\n2,bob\n").expect("failed to write csv");
+
+                let mut dataset = Dataset::new(format!("file:{}", csv_file.display()), "test_order".to_string());
+                dataset.name = "test_order".to_string();
+                dataset.acceleration = Some(Acceleration {
+                    enabled: true,
+                    engine: Some("duckdb".to_string()),
+                    mode: Mode::File,
+                    refresh_mode: Some(RefreshMode::Full),
+                    params: Some(Params::from_string_map(accel_params)),
+                    ..Acceleration::default()
+                });
+
+                let app = AppBuilder::new("duckdb_test_order").with_dataset(dataset).build();
+                configure_test_datafusion();
+                let rt = Runtime::builder().with_app(app).build().await;
+                let cloned_rt = Arc::new(rt.clone());
+
+                tokio::select! {
+                    () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                        return Err("Test 3: Timed out waiting for datasets to load".to_string());
+                    }
+                    () = Arc::clone(&cloned_rt).load_components() => {}
+                }
+
+                runtime_ready_check(&cloned_rt).await;
+
+                let df = cloned_rt.datafusion();
+                let result = df
+                    .query_builder("SELECT * FROM test_order")
+                    .build()
+                    .run()
+                    .await
+                    .map_err(|e| format!("Test 3: Query failed: {e}"))?;
+                let batches: Vec<RecordBatch> = result.data.try_collect().await
+                    .map_err(|e| format!("Test 3: Failed to collect: {e}"))?;
+
+                assert!(!batches.is_empty(), "Test 3: Should have results");
+                assert_eq!(batches[0].num_rows(), 3, "Test 3: Expected 3 rows");
+
+                println!("✅ Preserve insertion order setting applied successfully");
+                println!("   - preserve_insertion_order: true");
+
+                cloned_rt.shutdown().await;
+                drop(cloned_rt);
+                drop(rt);
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            }
+
+            // Test 4: Combined settings
+            println!("\n=== Test 4: Combined Settings ===");
+            {
+                let temp_dir = std::env::temp_dir().join("spiced_duckdb_test_4");
+                std::fs::create_dir_all(&temp_dir).expect("failed to create temp dir");
+                let duckdb_file = temp_dir.join("test_combined.db");
+
+                defer! {
+                    std::fs::remove_dir_all(&temp_dir).expect("failed to remove temp dir");
+                }
+
+                let mut accel_params = HashMap::new();
+                accel_params.insert("duckdb_file".to_string(), duckdb_file.to_str().unwrap().to_string());
+                accel_params.insert("duckdb_memory_limit".to_string(), "256MB".to_string());
+                accel_params.insert("duckdb_index_scan_percentage".to_string(), "0.10".to_string());
+                accel_params.insert("duckdb_index_scan_max_count".to_string(), "1000".to_string());
+                accel_params.insert("duckdb_preserve_insertion_order".to_string(), "false".to_string());
+
+                let csv_file = temp_dir.join("test.csv");
+                std::fs::write(&csv_file, "id,category,amount\n1,A,100\n2,B,200\n3,A,150\n4,C,300\n").expect("failed to write csv");
+
+                let mut dataset = Dataset::new(format!("file:{}", csv_file.display()), "test_combined".to_string());
+                dataset.name = "test_combined".to_string();
+                dataset.acceleration = Some(Acceleration {
+                    enabled: true,
+                    engine: Some("duckdb".to_string()),
+                    mode: Mode::File,
+                    refresh_mode: Some(RefreshMode::Full),
+                    params: Some(Params::from_string_map(accel_params)),
+                    ..Acceleration::default()
+                });
+
+                let app = AppBuilder::new("duckdb_test_combined").with_dataset(dataset).build();
+                configure_test_datafusion();
+                let rt = Runtime::builder().with_app(app).build().await;
+                let cloned_rt = Arc::new(rt.clone());
+
+                tokio::select! {
+                    () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                        return Err("Test 4: Timed out waiting for datasets to load".to_string());
+                    }
+                    () = Arc::clone(&cloned_rt).load_components() => {}
+                }
+
+                runtime_ready_check(&cloned_rt).await;
+
+                let df = cloned_rt.datafusion();
+                
+                // Test aggregation
+                let result = df
+                    .query_builder("SELECT category, SUM(amount) as total FROM test_combined GROUP BY category ORDER BY category")
+                    .build()
+                    .run()
+                    .await
+                    .map_err(|e| format!("Test 4: Aggregation query failed: {e}"))?;
+                let batches: Vec<RecordBatch> = result.data.try_collect().await
+                    .map_err(|e| format!("Test 4: Failed to collect: {e}"))?;
+
+                assert_eq!(batches[0].num_rows(), 3, "Test 4: Expected 3 categories");
+
+                println!("✅ Combined settings applied successfully");
+                println!("   - file: custom path");
+                println!("   - memory_limit: 256MB");
+                println!("   - index_scan_percentage: 0.10");
+                println!("   - index_scan_max_count: 1000");
+                println!("   - preserve_insertion_order: false");
+                println!("   - PRAGMA enable_checkpoint_on_shutdown: automatic");
+
+                cloned_rt.shutdown().await;
+                drop(cloned_rt);
+                drop(rt);
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+                // Verify checkpoint
+                assert!(duckdb_file.exists(), "Test 4: DuckDB file should exist");
+                let metadata = std::fs::metadata(&duckdb_file)
+                    .map_err(|e| format!("Test 4: Failed to get metadata: {e}"))?;
+                assert!(metadata.len() > 0, "Test 4: File should be non-zero");
+                println!("✅ Checkpoint verified: {} bytes", metadata.len());
+            }
+
+            println!("\n=== All DuckDB Settings Tests Passed ===");
+            Ok(())
+        })
+        .await
+}

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -383,7 +383,7 @@ async fn test_duckdb_settings_persist() -> Result<(), String> {
             let mut accel_params = HashMap::new();
             accel_params.insert(
                 "duckdb_file".to_string(),
-                duckdb_file.to_str().unwrap().to_string(),
+                duckdb_file.to_str().expect("DuckDB file path should be valid UTF-8").to_string(),
             );
             accel_params.insert(
                 "duckdb_index_scan_percentage".to_string(),
@@ -526,7 +526,7 @@ async fn test_duckdb_all_settings() -> Result<(), String> {
                 }
 
                 let mut accel_params = HashMap::new();
-                accel_params.insert("duckdb_file".to_string(), duckdb_file.to_str().unwrap().to_string());
+                accel_params.insert("duckdb_file".to_string(), duckdb_file.to_str().expect("DuckDB file path should be valid UTF-8").to_string());
                 accel_params.insert("duckdb_index_scan_percentage".to_string(), "0.05".to_string());
                 accel_params.insert("duckdb_index_scan_max_count".to_string(), "5000".to_string());
 
@@ -731,7 +731,7 @@ async fn test_duckdb_all_settings() -> Result<(), String> {
                 }
 
                 let mut accel_params = HashMap::new();
-                accel_params.insert("duckdb_file".to_string(), duckdb_file.to_str().unwrap().to_string());
+                accel_params.insert("duckdb_file".to_string(), duckdb_file.to_str().expect("DuckDB file path should be valid UTF-8").to_string());
                 accel_params.insert("duckdb_memory_limit".to_string(), "256MB".to_string());
                 accel_params.insert("duckdb_index_scan_percentage".to_string(), "0.10".to_string());
                 accel_params.insert("duckdb_index_scan_max_count".to_string(), "1000".to_string());

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -362,7 +362,11 @@ async fn duckdb_regexp() -> Result<(), String> {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn test_duckdb_settings_persist() -> Result<(), String> {
+    use spicepod::param::Params;
+    use std::collections::HashMap;
+
     let _tracing = init_tracing(Some("integration=debug,info"));
 
     test_request_context()
@@ -377,13 +381,13 @@ async fn test_duckdb_settings_persist() -> Result<(), String> {
             }
 
             // Create a dataset with DuckDB acceleration and custom settings
-            use spicepod::param::Params;
-            use std::collections::HashMap;
-
             let mut accel_params = HashMap::new();
             accel_params.insert(
                 "duckdb_file".to_string(),
-                duckdb_file.to_str().expect("DuckDB file path should be valid UTF-8").to_string(),
+                duckdb_file
+                    .to_str()
+                    .expect("DuckDB file path should be valid UTF-8")
+                    .to_string(),
             );
             accel_params.insert(
                 "duckdb_index_scan_percentage".to_string(),
@@ -464,13 +468,10 @@ async fn test_duckdb_settings_persist() -> Result<(), String> {
                 .ok_or_else(|| "Failed to downcast count column".to_string())?;
             let count = count_col.value(0);
 
-            println!(
-                "✅ Query successful: test_settings table has {} rows",
-                count
-            );
+            println!("✅ Query successful: test_settings table has {count} rows");
 
             if count != 2 {
-                return Err(format!("Expected 2 rows, got {}", count));
+                return Err(format!("Expected 2 rows, got {count}"));
             }
 
             // Shutdown the runtime
@@ -506,13 +507,15 @@ async fn test_duckdb_settings_persist() -> Result<(), String> {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn test_duckdb_all_settings() -> Result<(), String> {
+    use spicepod::param::Params;
+    use std::collections::HashMap;
+
     let _tracing = init_tracing(Some("integration=debug,info"));
 
     test_request_context()
         .scope(async {
-            use spicepod::param::Params;
-            use std::collections::HashMap;
 
             // Test 1: Index scan settings with custom file
             println!("\n=== Test 1: Index Scan Settings with Custom File ===");
@@ -568,7 +571,7 @@ async fn test_duckdb_all_settings() -> Result<(), String> {
                     .map_err(|e| format!("Test 1: Query failed: {e}"))?;
                 let batches: Vec<RecordBatch> = result.data.try_collect().await
                     .map_err(|e| format!("Test 1: Failed to collect: {e}"))?;
-                
+
                 let count_col = batches[0].column(0).as_any().downcast_ref::<arrow::array::Int64Array>()
                     .ok_or_else(|| "Test 1: Failed to downcast".to_string())?;
                 assert_eq!(count_col.value(0), 2, "Test 1: Expected 2 rows");
@@ -766,7 +769,7 @@ async fn test_duckdb_all_settings() -> Result<(), String> {
                 runtime_ready_check(&cloned_rt).await;
 
                 let df = cloned_rt.datafusion();
-                
+
                 // Test aggregation
                 let result = df
                     .query_builder("SELECT category, SUM(amount) as total FROM test_combined GROUP BY category ORDER BY category")

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -516,7 +516,6 @@ async fn test_duckdb_all_settings() -> Result<(), String> {
 
     test_request_context()
         .scope(async {
-
             // Test 1: Index scan settings with custom file
             println!("\n=== Test 1: Index Scan Settings with Custom File ===");
             {

--- a/docs/features/duckdb_index_scan_settings.md
+++ b/docs/features/duckdb_index_scan_settings.md
@@ -1,0 +1,79 @@
+# DuckDB Accelerator Configuration
+
+The DuckDB accelerator supports configuration parameters to control index scan behavior and checkpoint settings.
+
+## Automatic Configuration
+
+### Checkpoint on Shutdown
+
+The DuckDB accelerator automatically enables `PRAGMA enable_checkpoint_on_shutdown` for all connections. This ensures that any pending changes in the Write-Ahead Log (WAL) are checkpointed when the database is shut down, maintaining data consistency.
+
+## Index Scan Parameters
+
+These parameters control when ART (Adaptive Radix Tree) index scans are used for query execution.
+
+### `duckdb_index_scan_percentage`
+
+The index scan percentage sets a threshold for index scans. If fewer than `MAX(index_scan_max_count, index_scan_percentage * total_row_count)` rows match, an index scan is performed instead of a table scan.
+
+**Type:** DOUBLE (0.0 to 1.0, representing 0% to 100%)  
+**Default:** 0.001 (0.1%)  
+**Scope:** Global
+
+**Example:**
+
+```yaml
+datasets:
+  - from: postgres:my_table
+    name: my_table
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      params:
+        duckdb_index_scan_percentage: '0.10' # Use index scan if < 10% of rows qualify
+```
+
+### `duckdb_index_scan_max_count`
+
+The maximum index scan count sets a threshold for index scans. If fewer than `MAX(index_scan_max_count, index_scan_percentage * total_row_count)` rows match, an index scan is performed instead of a table scan.
+
+**Type:** UBIGINT (non-negative integer)  
+**Default:** 2048  
+**Scope:** Global
+
+**Example:**
+
+```yaml
+datasets:
+  - from: postgres:my_table
+    name: my_table
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      params:
+        duckdb_index_scan_max_count: '1000' # Use index scan if < 1000 rows qualify
+```
+
+## Combined Usage
+
+Both parameters can be used together. DuckDB will use an index scan when the number of qualifying rows is less than the maximum of these two thresholds:
+
+```yaml
+datasets:
+  - from: postgres:my_table
+    name: my_table
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      params:
+        duckdb_index_scan_percentage: '0.10' # 10% as decimal
+        duckdb_index_scan_max_count: '1000'
+```
+
+## References
+
+For more information about DuckDB ART index scans, see:
+https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans

--- a/docs/features/duckdb_index_scan_settings.md
+++ b/docs/features/duckdb_index_scan_settings.md
@@ -14,7 +14,7 @@ These parameters control when ART (Adaptive Radix Tree) index scans are used for
 
 ### `duckdb_index_scan_percentage`
 
-The index scan percentage sets a threshold for index scans. If fewer than `MAX(index_scan_max_count, index_scan_percentage * total_row_count)` rows match, an index scan is performed instead of a table scan.
+The index scan percentage sets a threshold for index scans. An index scan is performed instead of a table scan when the number of matching rows is less than the maximum of `index_scan_max_count` and `index_scan_percentage × total_row_count`.
 
 **Type:** DOUBLE (0.0 to 1.0, representing 0% to 100%)  
 **Default:** 0.001 (0.1%)  
@@ -36,7 +36,7 @@ datasets:
 
 ### `duckdb_index_scan_max_count`
 
-The maximum index scan count sets a threshold for index scans. If fewer than `MAX(index_scan_max_count, index_scan_percentage * total_row_count)` rows match, an index scan is performed instead of a table scan.
+The maximum index scan count sets a threshold for index scans. An index scan is performed instead of a table scan when the number of matching rows is less than the maximum of `index_scan_max_count` and `index_scan_percentage × total_row_count`.
 
 **Type:** UBIGINT (non-negative integer)  
 **Default:** 2048  
@@ -76,4 +76,4 @@ datasets:
 ## References
 
 For more information about DuckDB ART index scans, see:
-https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans
+<https://duckdb.org/docs/stable/guides/performance/indexing#art-index-scans>


### PR DESCRIPTION
This pull request adds new configuration options and documentation to enhance the DuckDB accelerator's index scan behavior and database shutdown consistency. The main changes introduce settings for fine-tuning when index scans are used, and ensure that database checkpoints are reliably performed on shutdown.

**DuckDB index scan configuration and checkpoint enhancements:**

* Added two new DuckDB settings, `index_scan_percentage` and `index_scan_max_count`, allowing users to control when ART index scans are triggered based on percentage of qualifying rows or a maximum row count. These settings are validated and registered in the DuckDB settings registry. [[1]](diffhunk://#diff-beda56756b4f52eb72155f884bc39571f12b2f3f7808feb3c9dfc41702f1e9c8R39-R140) [[2]](diffhunk://#diff-a3c782f8431507243ca00368e50627f150f87a60b1c4d5b70f06a377beac5d65L109-R112) [[3]](diffhunk://#diff-a3c782f8431507243ca00368e50627f150f87a60b1c4d5b70f06a377beac5d65R259-R260)
* Updated the DuckDB accelerator to automatically enable `PRAGMA enable_checkpoint_on_shutdown` for all new database connections, ensuring data consistency by checkpointing the WAL on shutdown. [[1]](diffhunk://#diff-a3c782f8431507243ca00368e50627f150f87a60b1c4d5b70f06a377beac5d65L172-R176) [[2]](diffhunk://#diff-a3c782f8431507243ca00368e50627f150f87a60b1c4d5b70f06a377beac5d65L185-R190)

**Documentation:**

* Added a new documentation file, `duckdb_index_scan_settings.md`, detailing the new index scan configuration parameters and the automatic checkpoint behavior, including usage examples and references to DuckDB documentation.

**Internal improvements:**

* Updated imports in `duckdb/settings.rs` to include the `Error` type for improved error handling in setting validation.