### PR TITLE
Revert "Add Type to GitHub Data Connector issues and fix double aliasing for project author (#7519)"

### DIFF
--- a/crates/runtime/src/dataconnector/github/issues.rs
+++ b/crates/runtime/src/dataconnector/github/issues.rs
@@ -106,7 +106,6 @@ impl GitHubTableArgs for IssuesTableArgs {
                             milestone_title: milestone {{ milestone_title: title }}
                             comments(first: 100) {{ comments_count: totalCount, comments: nodes {{ body, author {{ login }} }} }}
                             assignees(first: 100) {{ assignees: nodes {{ login }} }}
-                            type: issueType {{ id, name, description, color }}
                         }}
                     }}
                 }}
@@ -139,7 +138,6 @@ impl GitHubTableArgs for IssuesTableArgs {
                             milestone_title: milestone {{ milestone_title: title }}
                             comments(first: 100) {{ comments_count: totalCount, comments: nodes {{ body, author {{ login }} }} }}
                             assignees(first: 100) {{ assignees: nodes {{ login }} }}
-                            type: issueType {{ id, name, description, color }}
                         }}
                     }}
                 }}

--- a/crates/runtime/src/dataconnector/github/mod.rs
+++ b/crates/runtime/src/dataconnector/github/mod.rs
@@ -313,8 +313,6 @@ fn github_gql_raw_schema_cast(
 
     for (idx, field) in record_batch.schema().fields().iter().enumerate() {
         let column = record_batch.column(idx);
-
-        // Handle lists with single-field structs
         if let DataType::List(inner_field) = field.data_type()
             && let DataType::Struct(struct_fields) = inner_field.data_type()
             && struct_fields.len() == 1
@@ -324,41 +322,6 @@ fn github_gql_raw_schema_cast(
             fields.push(new_field);
             columns.push(new_column);
             continue;
-        }
-
-        // Handle top-level structs with a single field (e.g., creator: { creator: "value" })
-        // Extract the inner field value and flatten it if the inner and outer fields are the same
-        if let DataType::Struct(struct_fields) = field.data_type()
-            && struct_fields.len() == 1
-        {
-            let inner_field = &struct_fields[0];
-
-            // Only flatten if the inner field name matches the outer field name
-            if inner_field.name() == field.name() {
-                let struct_array = column
-                    .as_any()
-                    .downcast_ref::<arrow::array::StructArray>()
-                    .ok_or_else(|| {
-                        format!(
-                            "Expected StructArray for field {}, but got different type",
-                            field.name()
-                        )
-                    })?;
-
-                // Get the single inner column
-                let inner_column = struct_array.column(0);
-
-                // Create a new field with the outer name but inner type
-                let new_field = Arc::new(Field::new(
-                    field.name(),
-                    inner_field.data_type().clone(),
-                    field.is_nullable(),
-                ));
-
-                fields.push(new_field);
-                columns.push(Arc::clone(inner_column));
-                continue;
-            }
         }
 
         fields.push(Arc::clone(field));

--- a/crates/runtime/src/dataconnector/github/projects.rs
+++ b/crates/runtime/src/dataconnector/github/projects.rs
@@ -252,8 +252,6 @@ mod tests {
         assert!(query.contains("updated_at: updatedAt"));
         assert!(query.contains("closed_at: closedAt"));
         assert!(query.contains("short_description: shortDescription"));
-        assert!(query.contains("creator: creator"));
-        assert!(query.contains("creator: login"));
 
         // Should NOT contain repositoryOwner or fragments
         assert!(!query.contains("repositoryOwner"));
@@ -281,8 +279,6 @@ mod tests {
         assert!(query.contains("updated_at: updatedAt"));
         assert!(query.contains("closed_at: closedAt"));
         assert!(query.contains("short_description: shortDescription"));
-        assert!(query.contains("creator: creator"));
-        assert!(query.contains("creator: login"));
 
         // Should NOT contain repository-specific structure
         assert!(!query.contains("repository(owner:"));


### PR DESCRIPTION
This reverts commit 253b67179904289833d87332c01dd6d419d64d58.

It was causing the integration tests to fail in trunk