### PR TITLE
Use 'location' as primary key for document tables

### DIFF
--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::{
     catalog::Session,
-    common::{Constraints, project_schema},
+    common::{Constraint, Constraints, project_schema},
     datasource::{TableProvider, TableType},
     error::{DataFusionError, Result as DataFusionResult},
     execution::{SendableRecordBatchStream, TaskContext},
@@ -55,6 +55,7 @@ pub struct ObjectStoreTextTable {
     document_formatter: Option<Arc<dyn DocumentParser>>,
 
     metadata_columns: Vec<MetadataColumn>,
+    constraints: Constraints,
 }
 
 impl std::fmt::Debug for ObjectStoreTextTable {
@@ -77,11 +78,14 @@ impl ObjectStoreTextTable {
             ctx: ObjectStoreContext::try_new(store, url, extension)?,
             document_formatter,
             metadata_columns: metadata_columns.unwrap_or_default(),
+
+            constraints: Constraints::new_unverified(vec![Constraint::PrimaryKey(vec![0])]),
         })
     }
 
     #[must_use]
     pub fn base_table_schema() -> Schema {
+        // Order is important. [`ObjectStoreTextTable`].constraints expects `location` first.
         Schema::new(vec![
             Field::new("location", DataType::Utf8, false),
             Field::new("content", DataType::Utf8, false),
@@ -183,6 +187,10 @@ impl TableProvider for ObjectStoreTextTable {
         self
     }
 
+    fn constraints(&self) -> Option<&Constraints> {
+        Some(&self.constraints)
+    }
+
     fn schema(&self) -> SchemaRef {
         let mut base_field = Self::base_table_schema()
             .fields()
@@ -193,10 +201,6 @@ impl TableProvider for ObjectStoreTextTable {
         base_field.extend(self.metadata_columns.iter().map(|c| Arc::new(c.field())));
 
         Arc::new(Schema::new(base_field))
-    }
-
-    fn constraints(&self) -> Option<&Constraints> {
-        None
     }
 
     fn table_type(&self) -> TableType {

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -16,7 +16,10 @@ limitations under the License.
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use datafusion::datasource::TableProvider;
+use moka::future::FutureExt;
 use runtime_datafusion_index::{Index, IndexedTableProvider};
+use search::generation::util::get_primary_keys;
+use search::index::SearchIndex;
 use snafu::ResultExt;
 use spicepod::semantic::{IndexStore, MetadataType};
 use std::any::Any;

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -16,10 +16,7 @@ limitations under the License.
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use datafusion::datasource::TableProvider;
-use moka::future::FutureExt;
 use runtime_datafusion_index::{Index, IndexedTableProvider};
-use search::generation::util::get_primary_keys;
-use search::index::SearchIndex;
 use snafu::ResultExt;
 use spicepod::semantic::{IndexStore, MetadataType};
 use std::any::Any;

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -342,7 +342,7 @@ mod tests {
             FullTextDatabaseIndex::try_new(
                 Arc::clone(&base_table),
                 vec!["search_field".to_string()],
-                vec![].into(),
+                Some(vec!["search_field".to_string()]),
                 None,
                 &[],
             )

--- a/crates/runtime/tests/models/s3_vectors.rs
+++ b/crates/runtime/tests/models/s3_vectors.rs
@@ -38,7 +38,9 @@ mod search {
                 basic_vector_search_tests, delete_index, vectors_filterable_col,
                 vectors_nonfilterable_col,
             },
-            search::{SearchTestCase, SearchTestType, run_search_w_explain},
+            search::{
+                SearchTestCase, SearchTestType, run_search_w_explain, vectors_nonfilterable_col,
+            },
         },
         utils::verify_env_secret_exists,
     };
@@ -840,16 +842,6 @@ fn vectors_filterable_col(col: impl Into<Column>) -> Column {
         [(
             "vectors".to_string(),
             serde_json::Value::String("filterable".to_string()),
-        )]
-        .into(),
-    )
-}
-
-pub(crate) fn vectors_nonfilterable_col(col: impl Into<Column>) -> Column {
-    col.into().with_metadata(
-        [(
-            "vectors".to_string(),
-            serde_json::Value::String("non-filterable".to_string()),
         )]
         .into(),
     )

--- a/crates/runtime/tests/models/s3_vectors.rs
+++ b/crates/runtime/tests/models/s3_vectors.rs
@@ -26,7 +26,7 @@ use spicepod::{
     semantic::{Column, ColumnLevelEmbeddingConfig},
 };
 
-use crate::models::search::{SearchTestCase, SearchTestType};
+use crate::models::search::{SearchTestCase, SearchTestType, vectors_nonfilterable_col};
 
 mod search {
     use crate::{
@@ -34,10 +34,7 @@ mod search {
         models::{
             get_mega_science_dataset,
             hf::{get_huggingface_embeddings, get_model_to_vec_embeddings},
-            s3_vectors::{
-                basic_vector_search_tests, delete_index, vectors_filterable_col,
-                vectors_nonfilterable_col,
-            },
+            s3_vectors::{basic_vector_search_tests, delete_index, vectors_filterable_col},
             search::{
                 SearchTestCase, SearchTestType, run_search_w_explain, vectors_nonfilterable_col,
             },

--- a/crates/runtime/tests/models/search.rs
+++ b/crates/runtime/tests/models/search.rs
@@ -16,7 +16,6 @@ limitations under the License.
 
 use crate::models::hf::{get_huggingface_embeddings, get_model_to_vec_embeddings};
 use crate::models::openai::get_openai_embeddings;
-use crate::models::s3_vectors::vectors_nonfilterable_col;
 use crate::models::{create_api_bindings_config, get_mega_science_dataset, http_post};
 use crate::utils::{runtime_ready_check, test_request_context};
 use crate::{DEFAULT_TRACING_MODELS, configure_test_datafusion};
@@ -366,6 +365,16 @@ pub(crate) async fn run_search_w_explain(
             Ok(())
         })
         .await
+}
+
+pub(crate) fn vectors_nonfilterable_col(col: impl Into<Column>) -> Column {
+    col.into().with_metadata(
+        [(
+            "vectors".to_string(),
+            serde_json::Value::String("non-filterable".to_string()),
+        )]
+        .into(),
+    )
 }
 
 #[tokio::test]

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -134,9 +134,9 @@ impl FullTextDatabaseIndex {
     ) -> Result<Vec<String>, super::Error> {
         // Use 'primary_key_override', fallback to underlying in table.
         let pks = match (primary_key_override, get_primary_keys(inner).await) {
-            (Some(pks), _) if !pks.is_empty() => pks,
-            (_, Ok(pks)) if !pks.is_empty() => pks,
-            (None, Err(e)) => {
+            // LHS takes precedence.
+            (Some(pks), _) | (_, Ok(pks)) if !pks.is_empty() => pks,
+            (_, Err(e)) => {
                 return Err(super::Error::FailedToRetrievePrimaryKey { source: e });
             }
             _ => return Err(super::Error::NoPrimaryKey),

--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -134,17 +134,12 @@ impl FullTextDatabaseIndex {
     ) -> Result<Vec<String>, super::Error> {
         // Use 'primary_key_override', fallback to underlying in table.
         let pks = match (primary_key_override, get_primary_keys(inner).await) {
-            (Some(pks), _) => pks,
-            (None, Ok(pks)) => {
-                if pks.is_empty() {
-                    return Err(super::Error::NoPrimaryKey);
-                }
-
-                pks
-            }
+            (Some(pks), _) if !pks.is_empty() => pks,
+            (_, Ok(pks)) if !pks.is_empty() => pks,
             (None, Err(e)) => {
                 return Err(super::Error::FailedToRetrievePrimaryKey { source: e });
             }
+            _ => return Err(super::Error::NoPrimaryKey),
         };
 
         // INDEX_UNIQUE_FIELD_NAME is a reserved field name.


### PR DESCRIPTION
## 📝 Summary
 - All document tables have the following schema  (plus possible metadata columns), but `location` was not being registered as a primary key.
 https://github.com/spiceai/spiceai/blob/8f6982a30d494027fd9b635f6febf189e915efb8/crates/data_components/src/object/text.rs#L83-L89
- This change means that the `row_id` spicepod.yaml field for full text search or embeddings is now unnecessary for document tables.
- This PR also has a bug about how FTS indexes register primary key from table constraints. 