### PR TITLE
`ObjectMeta` filter pushdown for `ObjectStoreTextTable`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,3 @@
 allow-expect-in-tests = true
-future-size-threshold = 44593
+# Large futures are in tests. 
+future-size-threshold = 44784

--- a/crates/data_components/src/object/filter.rs
+++ b/crates/data_components/src/object/filter.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024-2025 The Spice.ai OSS Authors
+Copyright 2025 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,77 +15,92 @@ limitations under the License.
 */
 
 use arrow::array::{ArrayRef, RecordBatch, StringArray, TimestampMillisecondArray, UInt64Array};
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::compute::filter_record_batch;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use arrow::error::ArrowError;
-use std::sync::Arc;
+use arrow_array::BooleanArray;
+use datafusion::common::DFSchema;
+use datafusion::logical_expr::ColumnarValue;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, LazyLock};
 
 use datafusion::{
     error::DataFusionError,
     prelude::{Expr, SessionContext},
 };
-use futures::StreamExt;
 use object_store::ObjectMeta;
 
+static OBJECT_META_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new("location", DataType::Utf8, false),
+        Field::new(
+            "last_modified",
+            DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+            false,
+        ),
+        Field::new("size", DataType::UInt64, false),
+        Field::new("e_tag", DataType::Utf8, true),
+        Field::new("version", DataType::Utf8, true),
+    ]))
+});
+
 /// Filters [`ObjectMeta`]s that satisfy all provided `filter`s.
+///
+/// If `filters` contains any [`Expr`] that is not parseable by [`SessionContext::default`], all [`ObjectMeta`] are returned.
 pub async fn filter_object_meta(
-    filter: &[Expr],
+    filters: &[Expr],
     metas: &[ObjectMeta],
 ) -> Result<Vec<ObjectMeta>, DataFusionError> {
-    let Some(combined_filter) = filter.iter().cloned().reduce(Expr::and) else {
+    let Some(combined_filter) = filters.iter().cloned().reduce(Expr::and) else {
         return Ok(metas.to_vec());
     };
 
-    let ctx = SessionContext::new();
-    ctx.register_batch(
-        "tmp",
-        to_record_batch(metas).map_err(|e| {
-            DataFusionError::ArrowError(
-                Box::new(e),
-                Some("Failed to convert 'ObjectMeta' to arrow".to_string()),
-            )
-        })?,
-    )?;
+    let rb = to_record_batch(metas).map_err(|e| {
+        DataFusionError::ArrowError(
+            Box::new(e),
+            Some("Failed to convert 'ObjectMeta' to arrow".to_string()),
+        )
+    })?;
+    let ctx = SessionContext::default();
 
-    let mut stream = ctx
-        .table("tmp")
-        .await?
-        .filter(combined_filter)?
-        .execute_stream()
-        .await?;
+    let df_schema =
+        DFSchema::from_unqualified_fields(OBJECT_META_SCHEMA.fields().clone(), HashMap::default())?;
 
-    let mut valid_locations = std::collections::HashSet::new();
+    // First evaluate filters as physical expression.
+    let ColumnarValue::Array(arr) = ctx
+        .create_physical_expr(combined_filter, &df_schema)?
+        .evaluate(&rb)?
+    else {
+        return Err(DataFusionError::Internal(
+            "Unexpectedly recieved scalar value for 'location' column".to_string(),
+        ));
+    };
 
-    while let Some(batch_result) = stream.next().await {
-        let rb = batch_result?;
-        if let Some(location_array) = rb.column(0).as_any().downcast_ref::<StringArray>() {
-            for loc_opt in location_array {
-                if let Some(loc) = loc_opt {
-                    valid_locations.insert(loc.to_string());
-                }
-            }
-        };
-    }
+    let Some(bool_arr) = arr.as_any().downcast_ref::<BooleanArray>() else {
+        return Err(DataFusionError::Internal(
+            "Unexpectedly recieved scalar value for 'location' column".to_string(),
+        ));
+    };
+
+    let filtered_rb = filter_record_batch(&rb, bool_arr)?;
+    let valid_locations = filtered_rb
+        .column_by_name("location")
+        .ok_or_else(|| DataFusionError::Internal("location column not found".to_string()))?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .map(|s| s.iter().filter_map(|s| s).collect::<HashSet<_>>())
+        .unwrap_or_default();
 
     Ok(metas
         .into_iter()
-        .filter(|m| valid_locations.contains(&m.location.to_string()))
+        .filter(|m| valid_locations.contains(m.location.as_ref()))
         .cloned()
         .collect())
 }
 
 fn to_record_batch(metas: &[ObjectMeta]) -> Result<RecordBatch, ArrowError> {
     RecordBatch::try_new(
-        Arc::new(Schema::new(vec![
-            Field::new("location", DataType::Utf8, false),
-            Field::new(
-                "last_modified",
-                DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
-                false,
-            ),
-            Field::new("size", DataType::UInt64, false),
-            Field::new("e_tag", DataType::Utf8, true),
-            Field::new("version", DataType::Utf8, true),
-        ])),
+        Arc::clone(&OBJECT_META_SCHEMA),
         vec![
             // location
             Arc::new(StringArray::from(

--- a/crates/data_components/src/object/filter.rs
+++ b/crates/data_components/src/object/filter.rs
@@ -72,13 +72,14 @@ pub async fn filter_object_meta(
         .evaluate(&rb)?
     else {
         return Err(DataFusionError::Internal(
-            "Unexpectedly recieved scalar value for 'location' column".to_string(),
+            "Unexpectedly received scalar value when evaluating object store metadata filters."
+                .to_string(),
         ));
     };
 
     let Some(bool_arr) = arr.as_any().downcast_ref::<BooleanArray>() else {
         return Err(DataFusionError::Internal(
-            "Unexpectedly recieved scalar value for 'location' column".to_string(),
+            "Unexpectedly received non-boolean value when evaluating object store metadata filters.".to_string(),
         ));
     };
 
@@ -88,11 +89,11 @@ pub async fn filter_object_meta(
         .ok_or_else(|| DataFusionError::Internal("location column not found".to_string()))?
         .as_any()
         .downcast_ref::<StringArray>()
-        .map(|s| s.iter().filter_map(|s| s).collect::<HashSet<_>>())
+        .map(|s| s.iter().flatten().collect::<HashSet<_>>())
         .unwrap_or_default();
 
     Ok(metas
-        .into_iter()
+        .iter()
         .filter(|m| valid_locations.contains(m.location.as_ref()))
         .cloned()
         .collect())
@@ -174,7 +175,9 @@ mod tests {
             create_test_meta("file2.txt", Utc::now(), 200, None, None),
         ];
 
-        let result = filter_object_meta(&[], &metas).await.unwrap();
+        let result = filter_object_meta(&[], &metas)
+            .await
+            .expect("could not filter ObjectMeta");
         assert_eq!(result.len(), 2);
     }
 
@@ -183,7 +186,9 @@ mod tests {
         let filters = vec![col("size").gt(lit(100u64))];
         let metas: Vec<ObjectMeta> = vec![];
 
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
         assert_eq!(result.len(), 0);
     }
 
@@ -196,7 +201,9 @@ mod tests {
         ];
 
         let filters = vec![col("size").gt(lit(150u64))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file2.txt");
@@ -212,7 +219,9 @@ mod tests {
         ];
 
         let filters = vec![col("location").like(lit("data%"))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert!(result[0].location.as_ref().starts_with("data"));
@@ -229,7 +238,9 @@ mod tests {
         ];
 
         let filters = vec![col("size").gt(lit(150u64)), col("size").lt(lit(350u64))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file2.txt");
@@ -252,7 +263,9 @@ mod tests {
             ScalarValue::TimestampMillisecond(Some(now.timestamp_millis()), Some("UTC".into())),
             None,
         ))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].location.as_ref(), "file3.txt");
@@ -266,7 +279,9 @@ mod tests {
         ];
 
         let filters = vec![col("size").gt(lit(1000u64))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 0);
     }
@@ -280,7 +295,9 @@ mod tests {
         ];
 
         let filters = vec![col("size").gt(lit(50u64))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 3);
     }
@@ -306,7 +323,9 @@ mod tests {
         ];
 
         let filters = vec![col("e_tag").is_not_null()];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file1.txt");
@@ -322,7 +341,9 @@ mod tests {
         ];
 
         let filters = vec![col("version").is_not_null()];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file1.txt");
@@ -338,7 +359,9 @@ mod tests {
         ];
 
         let filters = vec![col("size").eq(lit(200u64))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file2.txt");
@@ -354,7 +377,9 @@ mod tests {
         ];
 
         let filters = vec![col("size").lt(lit(250u64))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file1.txt");
@@ -374,7 +399,9 @@ mod tests {
             col("location").like(lit("data%")),
             col("size").gt(lit(150u64)),
         ];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "data/file2.txt");
@@ -390,7 +417,9 @@ mod tests {
         ];
 
         let filters = vec![col("size").not_eq(lit(200u64))];
-        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        let result = filter_object_meta(&filters, &metas)
+            .await
+            .expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file1.txt");

--- a/crates/data_components/src/object/filter.rs
+++ b/crates/data_components/src/object/filter.rs
@@ -1,0 +1,30 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use datafusion::prelude::Expr;
+use object_store::ObjectMeta;
+
+/// Checks if then `Expr` filter is valid to apply on a `ObjectMeta`.
+pub fn valid_object_meta_filter(filter: &Expr) -> bool {
+    false
+}
+
+/// Returns true if the [`ObjectMeta`] satisfies the provided `filter`.
+///
+/// If the filter is not valid (i.e. `valid_object_meta_filter` is false), returns true.
+pub fn filter_object_meta(filter: &Expr, meta: &ObjectMeta) -> bool {
+    true
+}

--- a/crates/data_components/src/object/filter.rs
+++ b/crates/data_components/src/object/filter.rs
@@ -14,17 +14,110 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use datafusion::prelude::Expr;
+use arrow_array::RecordBatch;
+use datafusion::error::DataFusionError;
+use datafusion::prelude::{Expr, SessionContext};
+use futures::StreamExt;
 use object_store::ObjectMeta;
 
-/// Checks if then `Expr` filter is valid to apply on a `ObjectMeta`.
-pub fn valid_object_meta_filter(filter: &Expr) -> bool {
-    false
+/// Filters [`ObjectMeta`]s that satisfy all provided `filter`s.
+pub async fn filter_object_meta(
+    filter: &[Expr],
+    metas: &[ObjectMeta],
+) -> Result<Vec<ObjectMeta>, DataFusionError> {
+    let Some(combined_filter) = filter.iter().cloned().reduce(Expr::and) else {
+        return Ok(metas.to_vec());
+    };
+
+    let ctx = SessionContext::new();
+    ctx.register_batch("tmp", to_record_batch(metas))?;
+
+    let mut stream = ctx
+        .table("tmp")
+        .await?
+        .filter(combined_filter)?
+        .execute_stream()
+        .await?;
+
+    let mut valid_locations = std::collections::HashSet::new();
+
+    while let Some(batch_result) = stream.next().await {
+        let rb = batch_result?;
+        if let Some(location_array) = rb.column(0).as_any().downcast_ref::<StringArray>() {
+            for loc_opt in location_array {
+                if let Some(loc) = loc_opt {
+                    valid_locations.insert(loc.to_string());
+                }
+            }
+        };
+    }
+
+    Ok(metas
+        .into_iter()
+        .filter(|m| valid_locations.contains(&m.location.to_string()))
+        .cloned()
+        .collect())
 }
 
-/// Returns true if the [`ObjectMeta`] satisfies the provided `filter`.
-///
-/// If the filter is not valid (i.e. `valid_object_meta_filter` is false), returns true.
-pub fn filter_object_meta(filter: &Expr, meta: &ObjectMeta) -> bool {
-    true
+use arrow::array::{ArrayRef, StringArray, TimestampMillisecondArray, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use std::sync::Arc;
+
+fn to_record_batch(metas: &[ObjectMeta]) -> RecordBatch {
+    // Define the schema
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("location", DataType::Utf8, false),
+        Field::new(
+            "last_modified",
+            DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+            false,
+        ),
+        Field::new("size", DataType::UInt64, false),
+        Field::new("e_tag", DataType::Utf8, true),
+        Field::new("version", DataType::Utf8, true),
+    ]));
+
+    // Build arrays from the metadata
+    let location_array = StringArray::from(
+        metas
+            .iter()
+            .map(|meta| meta.location.as_ref())
+            .collect::<Vec<_>>(),
+    );
+
+    let last_modified_array = TimestampMillisecondArray::from(
+        metas
+            .iter()
+            .map(|meta| meta.last_modified.timestamp_millis())
+            .collect::<Vec<_>>(),
+    )
+    .with_timezone("UTC");
+
+    let size_array = UInt64Array::from(metas.iter().map(|meta| meta.size).collect::<Vec<_>>());
+
+    let e_tag_array = StringArray::from(
+        metas
+            .iter()
+            .map(|meta| meta.e_tag.as_deref())
+            .collect::<Vec<_>>(),
+    );
+
+    let version_array = StringArray::from(
+        metas
+            .iter()
+            .map(|meta| meta.version.as_deref())
+            .collect::<Vec<_>>(),
+    );
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(location_array) as ArrayRef,
+            Arc::new(last_modified_array) as ArrayRef,
+            Arc::new(size_array) as ArrayRef,
+            Arc::new(e_tag_array) as ArrayRef,
+            Arc::new(version_array) as ArrayRef,
+        ],
+    )
+    .expect("Failed to create RecordBatch")
 }

--- a/crates/data_components/src/object/filter.rs
+++ b/crates/data_components/src/object/filter.rs
@@ -47,7 +47,7 @@ static OBJECT_META_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 /// Filters [`ObjectMeta`]s that satisfy all provided `filter`s.
 ///
 /// If `filters` contains any [`Expr`] that is not parseable by [`SessionContext::default`], all [`ObjectMeta`] are returned.
-pub async fn filter_object_meta(
+pub fn filter_object_meta(
     filters: &[Expr],
     metas: &[ObjectMeta],
 ) -> Result<Vec<ObjectMeta>, DataFusionError> {
@@ -175,9 +175,7 @@ mod tests {
             create_test_meta("file2.txt", Utc::now(), 200, None, None),
         ];
 
-        let result = filter_object_meta(&[], &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&[], &metas).expect("could not filter ObjectMeta");
         assert_eq!(result.len(), 2);
     }
 
@@ -186,9 +184,7 @@ mod tests {
         let filters = vec![col("size").gt(lit(100u64))];
         let metas: Vec<ObjectMeta> = vec![];
 
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
         assert_eq!(result.len(), 0);
     }
 
@@ -201,9 +197,7 @@ mod tests {
         ];
 
         let filters = vec![col("size").gt(lit(150u64))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file2.txt");
@@ -219,9 +213,7 @@ mod tests {
         ];
 
         let filters = vec![col("location").like(lit("data%"))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert!(result[0].location.as_ref().starts_with("data"));
@@ -238,9 +230,7 @@ mod tests {
         ];
 
         let filters = vec![col("size").gt(lit(150u64)), col("size").lt(lit(350u64))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file2.txt");
@@ -263,9 +253,7 @@ mod tests {
             ScalarValue::TimestampMillisecond(Some(now.timestamp_millis()), Some("UTC".into())),
             None,
         ))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].location.as_ref(), "file3.txt");
@@ -279,9 +267,7 @@ mod tests {
         ];
 
         let filters = vec![col("size").gt(lit(1000u64))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 0);
     }
@@ -295,9 +281,7 @@ mod tests {
         ];
 
         let filters = vec![col("size").gt(lit(50u64))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 3);
     }
@@ -323,9 +307,7 @@ mod tests {
         ];
 
         let filters = vec![col("e_tag").is_not_null()];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file1.txt");
@@ -341,9 +323,7 @@ mod tests {
         ];
 
         let filters = vec![col("version").is_not_null()];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file1.txt");
@@ -359,9 +339,7 @@ mod tests {
         ];
 
         let filters = vec![col("size").eq(lit(200u64))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file2.txt");
@@ -377,9 +355,7 @@ mod tests {
         ];
 
         let filters = vec![col("size").lt(lit(250u64))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file1.txt");
@@ -399,9 +375,7 @@ mod tests {
             col("location").like(lit("data%")),
             col("size").gt(lit(150u64)),
         ];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "data/file2.txt");
@@ -417,9 +391,7 @@ mod tests {
         ];
 
         let filters = vec![col("size").not_eq(lit(200u64))];
-        let result = filter_object_meta(&filters, &metas)
-            .await
-            .expect("could not filter ObjectMeta");
+        let result = filter_object_meta(&filters, &metas).expect("could not filter ObjectMeta");
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].location.as_ref(), "file1.txt");

--- a/crates/data_components/src/object/filter.rs
+++ b/crates/data_components/src/object/filter.rs
@@ -140,3 +140,260 @@ fn to_record_batch(metas: &[ObjectMeta]) -> Result<RecordBatch, ArrowError> {
         ],
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use datafusion::{
+        prelude::{col, lit},
+        scalar::ScalarValue,
+    };
+    use object_store::path::Path;
+
+    fn create_test_meta(
+        location: &str,
+        last_modified: DateTime<Utc>,
+        size: u64,
+        e_tag: Option<String>,
+        version: Option<String>,
+    ) -> ObjectMeta {
+        ObjectMeta {
+            location: Path::from(location),
+            last_modified,
+            size,
+            e_tag,
+            version,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_empty_filters() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+        ];
+
+        let result = filter_object_meta(&[], &metas).await.unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_empty_metas() {
+        let filters = vec![col("size").gt(lit(100u64))];
+        let metas: Vec<ObjectMeta> = vec![];
+
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+        assert_eq!(result.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_by_size() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("file3.txt", Utc::now(), 300, None, None),
+        ];
+
+        let filters = vec![col("size").gt(lit(150u64))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].location.as_ref(), "file2.txt");
+        assert_eq!(result[1].location.as_ref(), "file3.txt");
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_by_location() {
+        let metas = vec![
+            create_test_meta("data/file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("logs/file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("data/file3.txt", Utc::now(), 300, None, None),
+        ];
+
+        let filters = vec![col("location").like(lit("data%"))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(result[0].location.as_ref().starts_with("data"));
+        assert!(result[1].location.as_ref().starts_with("data"));
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_combined_filters() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("file3.txt", Utc::now(), 300, None, None),
+            create_test_meta("file4.txt", Utc::now(), 400, None, None),
+        ];
+
+        let filters = vec![col("size").gt(lit(150u64)), col("size").lt(lit(350u64))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].location.as_ref(), "file2.txt");
+        assert_eq!(result[1].location.as_ref(), "file3.txt");
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_by_last_modified() {
+        let now = Utc::now();
+        let past = now - chrono::Duration::hours(2);
+        let future = now + chrono::Duration::hours(2);
+
+        let metas = vec![
+            create_test_meta("file1.txt", past, 100, None, None),
+            create_test_meta("file2.txt", now, 200, None, None),
+            create_test_meta("file3.txt", future, 300, None, None),
+        ];
+
+        let filters = vec![col("last_modified").gt(Expr::Literal(
+            ScalarValue::TimestampMillisecond(Some(now.timestamp_millis()), Some("UTC".into())),
+            None,
+        ))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].location.as_ref(), "file3.txt");
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_no_matches() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+        ];
+
+        let filters = vec![col("size").gt(lit(1000u64))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_all_match() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("file3.txt", Utc::now(), 300, None, None),
+        ];
+
+        let filters = vec![col("size").gt(lit(50u64))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_with_etag() {
+        let metas = vec![
+            create_test_meta(
+                "file1.txt",
+                Utc::now(),
+                100,
+                Some("etag1".to_string()),
+                None,
+            ),
+            create_test_meta(
+                "file2.txt",
+                Utc::now(),
+                200,
+                Some("etag2".to_string()),
+                None,
+            ),
+            create_test_meta("file3.txt", Utc::now(), 300, None, None),
+        ];
+
+        let filters = vec![col("e_tag").is_not_null()];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].location.as_ref(), "file1.txt");
+        assert_eq!(result[1].location.as_ref(), "file2.txt");
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_with_version() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, Some("v1".to_string())),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("file3.txt", Utc::now(), 300, None, Some("v2".to_string())),
+        ];
+
+        let filters = vec![col("version").is_not_null()];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].location.as_ref(), "file1.txt");
+        assert_eq!(result[1].location.as_ref(), "file3.txt");
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_equality() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("file3.txt", Utc::now(), 200, None, None),
+        ];
+
+        let filters = vec![col("size").eq(lit(200u64))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].location.as_ref(), "file2.txt");
+        assert_eq!(result[1].location.as_ref(), "file3.txt");
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_size_less_than() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("file3.txt", Utc::now(), 300, None, None),
+        ];
+
+        let filters = vec![col("size").lt(lit(250u64))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].location.as_ref(), "file1.txt");
+        assert_eq!(result[1].location.as_ref(), "file2.txt");
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_multiple_and_filters() {
+        let metas = vec![
+            create_test_meta("data/file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("data/file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("logs/file3.txt", Utc::now(), 300, None, None),
+            create_test_meta("data/file4.txt", Utc::now(), 400, None, None),
+        ];
+
+        let filters = vec![
+            col("location").like(lit("data%")),
+            col("size").gt(lit(150u64)),
+        ];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].location.as_ref(), "data/file2.txt");
+        assert_eq!(result[1].location.as_ref(), "data/file4.txt");
+    }
+
+    #[tokio::test]
+    async fn test_filter_object_meta_not_equal() {
+        let metas = vec![
+            create_test_meta("file1.txt", Utc::now(), 100, None, None),
+            create_test_meta("file2.txt", Utc::now(), 200, None, None),
+            create_test_meta("file3.txt", Utc::now(), 300, None, None),
+        ];
+
+        let filters = vec![col("size").not_eq(lit(200u64))];
+        let result = filter_object_meta(&filters, &metas).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].location.as_ref(), "file1.txt");
+        assert_eq!(result[1].location.as_ref(), "file3.txt");
+    }
+}

--- a/crates/data_components/src/object/filter.rs
+++ b/crates/data_components/src/object/filter.rs
@@ -14,9 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow_array::RecordBatch;
-use datafusion::error::DataFusionError;
-use datafusion::prelude::{Expr, SessionContext};
+use arrow::array::{ArrayRef, RecordBatch, StringArray, TimestampMillisecondArray, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::error::ArrowError;
+use std::sync::Arc;
+
+use datafusion::{
+    error::DataFusionError,
+    prelude::{Expr, SessionContext},
+};
 use futures::StreamExt;
 use object_store::ObjectMeta;
 
@@ -30,7 +36,15 @@ pub async fn filter_object_meta(
     };
 
     let ctx = SessionContext::new();
-    ctx.register_batch("tmp", to_record_batch(metas))?;
+    ctx.register_batch(
+        "tmp",
+        to_record_batch(metas).map_err(|e| {
+            DataFusionError::ArrowError(
+                Box::new(e),
+                Some("Failed to convert 'ObjectMeta' to arrow".to_string()),
+            )
+        })?,
+    )?;
 
     let mut stream = ctx
         .table("tmp")
@@ -59,65 +73,55 @@ pub async fn filter_object_meta(
         .collect())
 }
 
-use arrow::array::{ArrayRef, StringArray, TimestampMillisecondArray, UInt64Array};
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
-use std::sync::Arc;
-
-fn to_record_batch(metas: &[ObjectMeta]) -> RecordBatch {
-    // Define the schema
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("location", DataType::Utf8, false),
-        Field::new(
-            "last_modified",
-            DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
-            false,
-        ),
-        Field::new("size", DataType::UInt64, false),
-        Field::new("e_tag", DataType::Utf8, true),
-        Field::new("version", DataType::Utf8, true),
-    ]));
-
-    // Build arrays from the metadata
-    let location_array = StringArray::from(
-        metas
-            .iter()
-            .map(|meta| meta.location.as_ref())
-            .collect::<Vec<_>>(),
-    );
-
-    let last_modified_array = TimestampMillisecondArray::from(
-        metas
-            .iter()
-            .map(|meta| meta.last_modified.timestamp_millis())
-            .collect::<Vec<_>>(),
-    )
-    .with_timezone("UTC");
-
-    let size_array = UInt64Array::from(metas.iter().map(|meta| meta.size).collect::<Vec<_>>());
-
-    let e_tag_array = StringArray::from(
-        metas
-            .iter()
-            .map(|meta| meta.e_tag.as_deref())
-            .collect::<Vec<_>>(),
-    );
-
-    let version_array = StringArray::from(
-        metas
-            .iter()
-            .map(|meta| meta.version.as_deref())
-            .collect::<Vec<_>>(),
-    );
-
+fn to_record_batch(metas: &[ObjectMeta]) -> Result<RecordBatch, ArrowError> {
     RecordBatch::try_new(
-        schema,
+        Arc::new(Schema::new(vec![
+            Field::new("location", DataType::Utf8, false),
+            Field::new(
+                "last_modified",
+                DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+                false,
+            ),
+            Field::new("size", DataType::UInt64, false),
+            Field::new("e_tag", DataType::Utf8, true),
+            Field::new("version", DataType::Utf8, true),
+        ])),
         vec![
-            Arc::new(location_array) as ArrayRef,
-            Arc::new(last_modified_array) as ArrayRef,
-            Arc::new(size_array) as ArrayRef,
-            Arc::new(e_tag_array) as ArrayRef,
-            Arc::new(version_array) as ArrayRef,
+            // location
+            Arc::new(StringArray::from(
+                metas
+                    .iter()
+                    .map(|meta| meta.location.as_ref())
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef,
+            // last_modified
+            Arc::new(
+                TimestampMillisecondArray::from(
+                    metas
+                        .iter()
+                        .map(|meta| meta.last_modified.timestamp_millis())
+                        .collect::<Vec<_>>(),
+                )
+                .with_timezone("UTC"),
+            ) as ArrayRef,
+            // size
+            Arc::new(UInt64Array::from(
+                metas.iter().map(|meta| meta.size).collect::<Vec<_>>(),
+            )) as ArrayRef,
+            // etag
+            Arc::new(StringArray::from(
+                metas
+                    .iter()
+                    .map(|meta| meta.e_tag.as_deref())
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef,
+            // version
+            Arc::new(StringArray::from(
+                metas
+                    .iter()
+                    .map(|meta| meta.version.as_deref())
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef,
         ],
     )
-    .expect("Failed to create RecordBatch")
 }

--- a/crates/data_components/src/object/mod.rs
+++ b/crates/data_components/src/object/mod.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 use std::{path::PathBuf, sync::Arc};
 
+pub mod filter;
 pub mod metadata;
 pub mod text;
 

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::{
     catalog::Session,
-    common::{Column, Constraints, Statistics, project_schema, stats::Precision},
+    common::{Column, Constraint, Constraints, Statistics, project_schema, stats::Precision},
     datasource::{TableProvider, TableType},
     error::{DataFusionError, Result as DataFusionResult},
     execution::{SendableRecordBatchStream, TaskContext},

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -36,6 +36,7 @@ use datafusion::{
         execution_plan::{Boundedness, EmissionType},
         stream::RecordBatchStreamAdapter,
     },
+    prelude::col,
 };
 use datafusion_datasource::metadata::MetadataColumn;
 use document_parse::DocumentParser;
@@ -45,7 +46,7 @@ use object_store::{GetResult, ObjectMeta, ObjectStore, path::Path};
 use snafu::ResultExt;
 use std::{any::Any, fmt, sync::Arc};
 
-use crate::object::filter::{filter_object_meta, valid_object_meta_filter};
+use crate::object::filter::filter_object_meta;
 
 use super::ObjectStoreContext;
 use url::Url;
@@ -212,7 +213,6 @@ impl TableProvider for ObjectStoreTextTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        tracing::warn!("filters={:?}, limit={:?}", filters, limit);
         let projected_schema = project_schema(&self.schema(), projection)?;
         Ok(Arc::new(ObjectStoreTextExec::new(
             projected_schema,
@@ -230,10 +230,10 @@ impl TableProvider for ObjectStoreTextTable {
         Ok(filters
             .iter()
             .map(|f| {
-                if valid_object_meta_filter(f) {
-                    TableProviderFilterPushDown::Exact
-                } else {
+                if f.column_refs().contains(&col("content")) {
                     TableProviderFilterPushDown::Unsupported
+                } else {
+                    TableProviderFilterPushDown::Exact
                 }
             })
             .collect())
@@ -345,38 +345,38 @@ pub(crate) fn to_sendable_stream(
     schema: SchemaRef,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> + 'static {
     stream! {
-        let mut object_stream = ctx.store.list(ctx.prefix.clone().map(Path::from).as_ref());
+        let mut object_stream = ctx.store.list(ctx.prefix.clone().map(Path::from).as_ref()).chunks(128);
         let mut count = 0;
 
-        while let Some(item) = object_stream.next().await {
-            match item {
-                Ok(object_meta) => {
-                    if !filters.iter().all(|f| filter_object_meta(f, &object_meta)) {
+        while let Some(items) = object_stream.next().await {
+
+            match items.into_iter().collect::<Result<Vec<_>, _>>() {
+                Ok(object_metas) => {
+
+                    for object_meta in filter_object_meta(&filters, &object_metas).await? {
+                        if !ctx.filename_in_scan(&object_meta) {
                         continue;
-                    }
-                    if !ctx.filename_in_scan(&object_meta) {
-                    continue;
-                    }
+                        }
 
-                    let result: GetResult = ctx.store.get(&object_meta.location).await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
-                    let bytz = result.bytes().await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
+                        let result: GetResult = ctx.store.get(&object_meta.location).await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
+                        let bytz = result.bytes().await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
 
-                    match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz], formatter.as_ref(), Arc::clone(&schema)) {
-                        Ok(batch) => {
-                            let n = batch.num_rows();
-                            yield Ok(batch);
-                            count += n;
-                        },
-                        Err(e) => yield Err(DataFusionError::Execution(format!("{e}"))),
+                        match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz], formatter.as_ref(), Arc::clone(&schema)) {
+                            Ok(batch) => {
+                                let n = batch.num_rows();
+                                yield Ok(batch);
+                                count += n;
+                            },
+                            Err(e) => yield Err(DataFusionError::Execution(format!("{e}"))),
+                        }
+                        // Early exit on LIMIT clause
+                        if let Some(limit) = limit && count >= limit {
+                                break;
+                        }
                     }
                 },
                 Err(e) => yield Err(DataFusionError::Execution(format!("{e}"))),
             }
-
-            // Early exit on LIMIT clause
-            if let Some(limit) = limit && count >= limit {
-                    break;
-                }
         }
     }
 }

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -43,7 +43,7 @@ use futures::Stream;
 use futures::StreamExt;
 use object_store::{GetResult, ObjectMeta, ObjectStore, path::Path};
 use snafu::ResultExt;
-use std::{any::Any, cmp::min, fmt, sync::Arc};
+use std::{any::Any, fmt, sync::Arc};
 
 use crate::object::filter::filter_object_meta;
 
@@ -95,17 +95,17 @@ impl ObjectStoreTextTable {
     }
 
     fn get_content_value(
-        raw: Bytes,
+        raw: &Bytes,
         formatter: Option<&Arc<dyn DocumentParser>>,
         location: &Path,
     ) -> Result<ArrayRef, ArrowError> {
         let utf8 = match formatter {
             Some(f) => f
-                .parse(&raw)
+                .parse(raw)
                 .and_then(|doc| doc.as_flat_utf8())
                 .boxed()
                 .map_err(|e| format!("Error parsing document {location}: {e}").into()),
-            None => std::str::from_utf8(&raw).boxed().map(ToString::to_string),
+            None => std::str::from_utf8(raw).boxed().map(ToString::to_string),
         }
         .map_err(ArrowError::from_external_error)?;
 
@@ -148,11 +148,10 @@ impl ObjectStoreTextTable {
 
     fn to_record_batch(
         meta: &ObjectMeta,
-        raw: Bytes,
+        raw: &Bytes,
         formatter: Option<&Arc<dyn DocumentParser>>,
         schema: SchemaRef,
     ) -> Result<RecordBatch, ArrowError> {
-        let mut raw_opt = Some(raw);
         let columns = schema
             .fields()
             .iter()
@@ -160,11 +159,7 @@ impl ObjectStoreTextTable {
                 "location" => {
                     Ok(Arc::new(StringArray::from(vec![meta.location.to_string()])) as ArrayRef)
                 }
-                "content" => Self::get_content_value(
-                    raw_opt.take().unwrap_or_default(),
-                    formatter,
-                    &meta.location,
-                ),
+                "content" => Self::get_content_value(raw, formatter, &meta.location),
                 "last_modified" => Ok(Arc::new(
                     TimestampMicrosecondArray::from(vec![meta.last_modified.timestamp_micros()])
                         .with_timezone("UTC"),
@@ -215,7 +210,9 @@ impl TableProvider for ObjectStoreTextTable {
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let mut object_metas = self.list_and_filter_objects(filters, limit).await?;
-        object_metas.truncate(min(object_metas.len(), limit.unwrap_or(object_metas.len())));
+        if let Some(l) = limit {
+            object_metas.truncate(l);
+        }
 
         let projected_schema = project_schema(&self.schema(), projection)?;
 
@@ -304,16 +301,21 @@ impl ExecutionPlan for ObjectStoreTextExec {
         &self,
         _partition: Option<usize>,
     ) -> Result<Statistics, DataFusionError> {
+        let size = usize::try_from(
+            self.object_metas
+                .iter()
+                .map(|obj| obj.size)
+                .reduce(|a, b| a + b)
+                .unwrap_or_default(),
+        );
+
         // Only one partition.
         Ok(Statistics::new_unknown(&self.schema())
             .with_num_rows(Precision::Exact(self.object_metas.len()))
-            .with_total_byte_size(Precision::Exact(
-                self.object_metas
-                    .iter()
-                    .map(|obj| obj.size as usize)
-                    .reduce(|a, b| a + b)
-                    .unwrap_or_default(),
-            )))
+            .with_total_byte_size(match size {
+                Ok(s) => Precision::Exact(s),
+                Err(_) => Precision::Absent,
+            }))
     }
 
     fn execute(
@@ -372,7 +374,7 @@ pub(crate) fn to_sendable_stream(
                 Bytes::new()
             };
 
-            match ObjectStoreTextTable::to_record_batch(&object_meta, bytz, formatter.as_ref(), Arc::clone(&schema)) {
+            match ObjectStoreTextTable::to_record_batch(object_meta, &bytz, formatter.as_ref(), Arc::clone(&schema)) {
                 Ok(batch) => {
                     yield Ok(batch);
                 },

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -235,7 +235,7 @@ impl TableProvider for ObjectStoreTextTable {
                 {
                     TableProviderFilterPushDown::Unsupported
                 } else {
-                    TableProviderFilterPushDown::Exact
+                    TableProviderFilterPushDown::Inexact
                 }
             })
             .collect())

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -135,8 +135,7 @@ impl ObjectStoreTextTable {
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
 
-            let filtered = filter_object_meta(filters, &metas)
-                .await?
+            let filtered = filter_object_meta(filters, &metas)?
                 .into_iter()
                 .filter(|meta| self.ctx.filename_in_scan(meta))
                 .collect::<Vec<_>>();

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::{
     catalog::Session,
-    common::{Constraints, project_schema},
+    common::{Column, Constraints, project_schema},
     datasource::{TableProvider, TableType},
     error::{DataFusionError, Result as DataFusionResult},
     execution::{SendableRecordBatchStream, TaskContext},
@@ -230,7 +230,9 @@ impl TableProvider for ObjectStoreTextTable {
         Ok(filters
             .iter()
             .map(|f| {
-                if f.column_refs().contains(&col("content")) {
+                if f.column_refs()
+                    .contains(&Column::from_qualified_name("content"))
+                {
                     TableProviderFilterPushDown::Unsupported
                 } else {
                     TableProviderFilterPushDown::Exact

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::{
     catalog::Session,
-    common::{Column, Constraints, project_schema},
+    common::{Column, Constraints, Statistics, project_schema, stats::Precision},
     datasource::{TableProvider, TableType},
     error::{DataFusionError, Result as DataFusionResult},
     execution::{SendableRecordBatchStream, TaskContext},
@@ -36,7 +36,6 @@ use datafusion::{
         execution_plan::{Boundedness, EmissionType},
         stream::RecordBatchStreamAdapter,
     },
-    prelude::col,
 };
 use datafusion_datasource::metadata::MetadataColumn;
 use document_parse::DocumentParser;
@@ -44,7 +43,7 @@ use futures::Stream;
 use futures::StreamExt;
 use object_store::{GetResult, ObjectMeta, ObjectStore, path::Path};
 use snafu::ResultExt;
-use std::{any::Any, fmt, sync::Arc};
+use std::{any::Any, cmp::min, fmt, sync::Arc};
 
 use crate::object::filter::filter_object_meta;
 
@@ -92,89 +91,87 @@ impl ObjectStoreTextTable {
     }
 
     fn get_content_value(
-        raw: &[Bytes],
+        raw: Bytes,
         formatter: Option<&Arc<dyn DocumentParser>>,
-        meta_list: &[ObjectMeta],
+        location: &Path,
     ) -> Result<ArrayRef, ArrowError> {
-        let utf8_strings: Result<Vec<_>, ArrowError> = raw
-            .iter()
-            .enumerate()
-            .map(|(idx, bytes)| {
-                let utf8 = match formatter {
-                    Some(f) => f
-                        .parse(bytes)
-                        .and_then(|doc| doc.as_flat_utf8())
-                        .boxed()
-                        .map_err(|e| {
-                            if let Some(meta) = meta_list.get(idx) {
-                                format!("Error parsing document {}: {e}", meta.location).into()
-                            } else {
-                                e
-                            }
-                        }),
-                    None => std::str::from_utf8(bytes).boxed().map(ToString::to_string),
-                };
-                utf8.map_err(ArrowError::from_external_error)
-            })
-            .collect();
+        let utf8 = match formatter {
+            Some(f) => f
+                .parse(&raw)
+                .and_then(|doc| doc.as_flat_utf8())
+                .boxed()
+                .map_err(|e| format!("Error parsing document {location}: {e}").into()),
+            None => std::str::from_utf8(&raw).boxed().map(ToString::to_string),
+        }
+        .map_err(ArrowError::from_external_error)?;
 
-        Ok(Arc::new(StringArray::from(
-            utf8_strings?.into_iter().collect::<Vec<_>>(),
-        )))
+        Ok(Arc::new(StringArray::from(vec![utf8])))
     }
 
-    fn get_field_value(
-        meta_list: &[ObjectMeta],
-        raw: &[Bytes],
-        field_name: &str,
-        formatter: Option<&Arc<dyn DocumentParser>>,
-    ) -> Result<ArrayRef, ArrowError> {
-        match field_name {
-            "location" => Ok(Arc::new(StringArray::from(
-                meta_list
-                    .iter()
-                    .map(|meta| meta.location.to_string())
-                    .collect::<Vec<_>>(),
-            ))),
-            "content" => Self::get_content_value(raw, formatter, meta_list),
-            "last_modified" => Ok(Arc::new(
-                TimestampMicrosecondArray::from(
-                    meta_list
-                        .iter()
-                        .map(|meta| meta.last_modified.timestamp_micros())
-                        .collect::<Vec<_>>(),
-                )
-                .with_timezone("UTC"),
-            )),
-            "size" => Ok(Arc::new(UInt64Array::from(
-                meta_list.iter().map(|meta| meta.size).collect::<Vec<_>>(),
-            ))),
-            _ => Err(ArrowError::SchemaError(format!(
-                "Unsupported field name: {field_name}",
-            ))),
+    async fn list_and_filter_objects(
+        &self,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Vec<ObjectMeta>> {
+        let mut object_stream = self
+            .ctx
+            .store
+            .list(self.ctx.prefix.clone().map(Path::from).as_ref())
+            .chunks(128);
+
+        let mut all_metas = Vec::new();
+
+        while let Some(items) = object_stream.next().await {
+            if limit.is_some_and(|l| all_metas.len() >= l) {
+                break;
+            }
+
+            let metas = items
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| DataFusionError::Execution(format!("{e}")))?;
+
+            let filtered = filter_object_meta(filters, &metas)
+                .await?
+                .into_iter()
+                .filter(|meta| self.ctx.filename_in_scan(meta))
+                .collect::<Vec<_>>();
+            all_metas.extend(filtered);
         }
+
+        Ok(all_metas)
     }
 
     fn to_record_batch(
-        meta_list: &[ObjectMeta],
-        raw: &[Bytes],
+        meta: &ObjectMeta,
+        raw: Bytes,
         formatter: Option<&Arc<dyn DocumentParser>>,
         schema: SchemaRef,
     ) -> Result<RecordBatch, ArrowError> {
-        if meta_list.len() != raw.len() {
-            return Err(ArrowError::ParseError("Length mismatch".to_string()));
-        }
-
+        let mut raw_opt = Some(raw);
         let columns = schema
             .fields()
             .iter()
-            .map(|field| {
-                let field_name = field.name();
-                Self::get_field_value(meta_list, raw, field_name, formatter).map_err(|e| {
-                    ArrowError::SchemaError(format!("Error getting field {field_name}: {e}"))
-                })
+            .map(|field| match field.name().as_str() {
+                "location" => {
+                    Ok(Arc::new(StringArray::from(vec![meta.location.to_string()])) as ArrayRef)
+                }
+                "content" => Self::get_content_value(
+                    raw_opt.take().unwrap_or_default(),
+                    formatter,
+                    &meta.location,
+                ),
+                "last_modified" => Ok(Arc::new(
+                    TimestampMicrosecondArray::from(vec![meta.last_modified.timestamp_micros()])
+                        .with_timezone("UTC"),
+                ) as ArrayRef),
+                "size" => Ok(Arc::new(UInt64Array::from(vec![meta.size])) as ArrayRef),
+                _ => Err(ArrowError::SchemaError(format!(
+                    "Unsupported field name: {}",
+                    field.name()
+                ))),
             })
-            .collect::<Result<Vec<_>, ArrowError>>()?;
+            .collect::<Result<Vec<ArrayRef>, ArrowError>>()?;
 
         RecordBatch::try_new(schema, columns)
     }
@@ -213,11 +210,14 @@ impl TableProvider for ObjectStoreTextTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let mut object_metas = self.list_and_filter_objects(filters, limit).await?;
+        object_metas.truncate(min(object_metas.len(), limit.unwrap_or(object_metas.len())));
+
         let projected_schema = project_schema(&self.schema(), projection)?;
+
         Ok(Arc::new(ObjectStoreTextExec::new(
             projected_schema,
-            filters,
-            limit,
+            object_metas,
             self.ctx.clone(),
             self.document_formatter.clone(),
         )))
@@ -244,8 +244,7 @@ impl TableProvider for ObjectStoreTextTable {
 
 pub struct ObjectStoreTextExec {
     projected_schema: SchemaRef,
-    filters: Vec<Expr>,
-    limit: Option<usize>,
+    object_metas: Arc<Vec<ObjectMeta>>,
     properties: PlanProperties,
 
     ctx: ObjectStoreContext,
@@ -297,6 +296,22 @@ impl ExecutionPlan for ObjectStoreTextExec {
         Ok(self)
     }
 
+    fn partition_statistics(
+        &self,
+        _partition: Option<usize>,
+    ) -> Result<Statistics, DataFusionError> {
+        // Only one partition.
+        Ok(Statistics::new_unknown(&self.schema())
+            .with_num_rows(Precision::Exact(self.object_metas.len()))
+            .with_total_byte_size(Precision::Exact(
+                self.object_metas
+                    .iter()
+                    .map(|obj| obj.size as usize)
+                    .reduce(|a, b| a + b)
+                    .unwrap_or_default(),
+            )))
+    }
+
     fn execute(
         &self,
         _partition: usize,
@@ -307,8 +322,7 @@ impl ExecutionPlan for ObjectStoreTextExec {
             to_sendable_stream(
                 self.ctx.clone(),
                 self.formatter.clone(),
-                self.filters.clone(),
-                self.limit,
+                Arc::clone(&self.object_metas),
                 self.schema(),
             ),
         )))
@@ -318,15 +332,13 @@ impl ExecutionPlan for ObjectStoreTextExec {
 impl ObjectStoreTextExec {
     pub(crate) fn new(
         projected_schema: SchemaRef,
-        filters: &[Expr],
-        limit: Option<usize>,
+        object_metas: Vec<ObjectMeta>,
         ctx: ObjectStoreContext,
         formatter: Option<Arc<dyn DocumentParser>>,
     ) -> Self {
         Self {
             projected_schema: Arc::clone(&projected_schema),
-            filters: filters.to_vec(),
-            limit,
+            object_metas: Arc::new(object_metas),
             properties: PlanProperties::new(
                 EquivalenceProperties::new(projected_schema),
                 Partitioning::UnknownPartitioning(1),
@@ -342,40 +354,23 @@ impl ObjectStoreTextExec {
 pub(crate) fn to_sendable_stream(
     ctx: ObjectStoreContext,
     formatter: Option<Arc<dyn DocumentParser>>,
-    filters: Vec<Expr>,
-    limit: Option<usize>,
+    object_metas: Arc<Vec<ObjectMeta>>,
     schema: SchemaRef,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> + 'static {
     stream! {
-        let mut object_stream = ctx.store.list(ctx.prefix.clone().map(Path::from).as_ref()).chunks(128);
-        let mut count = 0;
+        for object_meta in object_metas.iter() {
 
-        while let Some(items) = object_stream.next().await {
+            // Avoid object-store GET if not in projection
+            let bytz = if schema.column_with_name("content").is_some() {
+            let result: GetResult = ctx.store.get(&object_meta.location).await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
+              result.bytes().await.map_err(|e| DataFusionError::Execution(format!("{e}")))?
+            } else {
+                Bytes::new()
+            };
 
-            match items.into_iter().collect::<Result<Vec<_>, _>>() {
-                Ok(object_metas) => {
-
-                    for object_meta in filter_object_meta(&filters, &object_metas).await? {
-                        if !ctx.filename_in_scan(&object_meta) {
-                        continue;
-                        }
-
-                        let result: GetResult = ctx.store.get(&object_meta.location).await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
-                        let bytz = result.bytes().await.map_err(|e| DataFusionError::Execution(format!("{e}")))?;
-
-                        match ObjectStoreTextTable::to_record_batch(&[object_meta], &[bytz], formatter.as_ref(), Arc::clone(&schema)) {
-                            Ok(batch) => {
-                                let n = batch.num_rows();
-                                yield Ok(batch);
-                                count += n;
-                            },
-                            Err(e) => yield Err(DataFusionError::Execution(format!("{e}"))),
-                        }
-                        // Early exit on LIMIT clause
-                        if let Some(limit) = limit && count >= limit {
-                                break;
-                        }
-                    }
+            match ObjectStoreTextTable::to_record_batch(&object_meta, bytz, formatter.as_ref(), Arc::clone(&schema)) {
+                Ok(batch) => {
+                    yield Ok(batch);
                 },
                 Err(e) => yield Err(DataFusionError::Execution(format!("{e}"))),
             }

--- a/crates/data_components/src/object/text.rs
+++ b/crates/data_components/src/object/text.rs
@@ -45,6 +45,8 @@ use object_store::{GetResult, ObjectMeta, ObjectStore, path::Path};
 use snafu::ResultExt;
 use std::{any::Any, fmt, sync::Arc};
 
+use crate::object::filter::{filter_object_meta, valid_object_meta_filter};
+
 use super::ObjectStoreContext;
 use url::Url;
 
@@ -210,6 +212,7 @@ impl TableProvider for ObjectStoreTextTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        tracing::warn!("filters={:?}, limit={:?}", filters, limit);
         let projected_schema = project_schema(&self.schema(), projection)?;
         Ok(Arc::new(ObjectStoreTextExec::new(
             projected_schema,
@@ -224,16 +227,22 @@ impl TableProvider for ObjectStoreTextTable {
         &self,
         filters: &[&Expr],
     ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
-        Ok(vec![
-            TableProviderFilterPushDown::Unsupported;
-            filters.len()
-        ])
+        Ok(filters
+            .iter()
+            .map(|f| {
+                if valid_object_meta_filter(f) {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
     }
 }
 
 pub struct ObjectStoreTextExec {
     projected_schema: SchemaRef,
-    _filters: Vec<Expr>,
+    filters: Vec<Expr>,
     limit: Option<usize>,
     properties: PlanProperties,
 
@@ -296,6 +305,7 @@ impl ExecutionPlan for ObjectStoreTextExec {
             to_sendable_stream(
                 self.ctx.clone(),
                 self.formatter.clone(),
+                self.filters.clone(),
                 self.limit,
                 self.schema(),
             ),
@@ -313,7 +323,7 @@ impl ObjectStoreTextExec {
     ) -> Self {
         Self {
             projected_schema: Arc::clone(&projected_schema),
-            _filters: filters.to_vec(),
+            filters: filters.to_vec(),
             limit,
             properties: PlanProperties::new(
                 EquivalenceProperties::new(projected_schema),
@@ -330,6 +340,7 @@ impl ObjectStoreTextExec {
 pub(crate) fn to_sendable_stream(
     ctx: ObjectStoreContext,
     formatter: Option<Arc<dyn DocumentParser>>,
+    filters: Vec<Expr>,
     limit: Option<usize>,
     schema: SchemaRef,
 ) -> impl Stream<Item = DataFusionResult<RecordBatch>> + 'static {
@@ -340,7 +351,9 @@ pub(crate) fn to_sendable_stream(
         while let Some(item) = object_stream.next().await {
             match item {
                 Ok(object_meta) => {
-
+                    if !filters.iter().all(|f| filter_object_meta(f, &object_meta)) {
+                        continue;
+                    }
                     if !ctx.filename_in_scan(&object_meta) {
                     continue;
                     }


### PR DESCRIPTION
## 📝 Summary
 - Enable filter pushdown for all `ObjectMeta` filters in `ObjectStoreTextTable`
 - Important for `refresh_mode: append` since the refresh_sql will have filter `WHERE last_modified > 'some_time'`
 
 ### Example 
**Before**
 ```
 sql> explain select location, length(content) from docx where log(size) > 6 ;
 +---------------+-----------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                            |
+---------------+-----------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: docx.location, character_length(docx.content)                                                       |
|               |   BytesProcessedNode                                                                                            |
|               |     TableScan: docx projection=[location, content], full_filters=[log(CAST(docx.size AS Float32)) > Float32(6)] |
+---------------+-----------------------------------------------------------------------------------------------------------------+
```

**Now**
```
sql> explain select location, length(content) from docx where log(size) > 6 ;
+---------------+--------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                         |
+---------------+--------------------------------------------------------------------------------------------------------------+
| logical_plan  | Projection: docx.location, character_length(docx.content)                                                    |
|               |   BytesProcessedNode                                                                                         |
|               |     Filter: log(CAST(docx.size AS Float32)) > Float32(6)                                                     |
|               |       TableScan: docx projection=[location, content, size]                                                   |
+---------------+-----------------------------------------------------------------------------------------------------------------+
```