### PR TITLE
Remove duplicate line from 1.8.1 release notes

### DIFF
--- a/docs/release_notes/v1.8.1.md
+++ b/docs/release_notes/v1.8.1.md
@@ -55,8 +55,6 @@ No breaking changes.
 
 ## Cookbook Updates
 
-## Cookbook Updates
-
 - New [Accelerated Snapshots](https://github.com/spiceai/cookbook/blob/trunk/acceleration/snapshots/README.md) Recipe - The recipe shows how to bootstrap DuckDB accelerations from object storage to skip cold starts.
 
 The [Spice Cookbook](https://spiceai.org/cookbook) includes 81 recipes to help you get started with Spice quickly and easily.


### PR DESCRIPTION
## 📝 Summary

Remove duplicate `Cookbook Updates` from 1.8.1 release notes

