### PR TITLE
Upgrade Go from v1.24.2 to v1.25.3

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     needs: setup-matrix
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
       GOOS: ${{ matrix.target.target_os }}
       GOARCH: ${{ matrix.target.target_arch_go }}
       RUST_PROFILE: ${{ github.event.inputs.profile_option || 'release' }}

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ matrix.target.builder }}
     needs: setup-matrix
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
       GOOS: ${{ matrix.target.target_os }}
       GOARCH: ${{ matrix.target.target_arch_go }}
 

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 90
     runs-on: ${{ matrix.target.builder }}
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
       GOOS: ${{ matrix.target.target_os }}
       GOARCH: ${{ matrix.target.target_arch_go }}
     strategy:

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     needs: setup-matrix
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
       GOOS: ${{ matrix.target.target_os }}
       GOARCH: ${{ matrix.target.target_arch_go }}
       REL_VERSION: ${{ github.event.inputs.rel_version || '1.0.2' }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -59,7 +59,7 @@ jobs:
     name: Check Golang Licenses
     runs-on: self-hosted
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/makefile_targets.yml
+++ b/.github/workflows/makefile_targets.yml
@@ -38,7 +38,7 @@ jobs:
     name: make install*
     runs-on: spiceai-dev-runners
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,7 +69,7 @@ jobs:
     name: Run Go & Rust Linters
     runs-on: spiceai-dev-runners
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
     needs: check_changes
 
     steps:
@@ -152,7 +152,7 @@ jobs:
     name: Build Go & Rust
     runs-on: spiceai-dev-runners
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
     needs: check_changes
 
     steps:

--- a/.github/workflows/types_check.yml
+++ b/.github/workflows/types_check.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build ${{ matrix.name }} binaries
     runs-on: ${{ matrix.runner }}
     env:
-      GOVER: 1.24.2
+      GOVER: 1.25.3
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch_go }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spiceai/spiceai
 
-go 1.24.2
+go 1.25.3
 
 require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.5.0


### PR DESCRIPTION
This pull request updates the Go version used throughout the project from 1.24.2 to 1.25.3. The change is applied consistently across all CI/CD workflow files and the `go.mod` file to ensure the project builds and tests against the latest Go release.

Go version upgrade:

* Updated the `GOVER` environment variable from `1.24.2` to `1.25.3` in all GitHub Actions workflow files, including `build_and_release.yml`, `e2e_test_ci.yml`, `e2e_test_ci_models.yml`, `e2e_test_spice_cli.yml`, `license_check.yml`, `makefile_targets.yml`, `pr.yml`, and `types_check.yml` to standardize the Go version used in CI/CD processes. [[1]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L114-R114) [[2]](diffhunk://#diff-0e9c401bad87327aa812051a27cd35662f709629b0b806e2d83353bf2e814949L95-R95) [[3]](diffhunk://#diff-9dac53aec195e605c2c78a786af4e4d34f844eca458a3b15966513f34d563c1eL65-R65) [[4]](diffhunk://#diff-7c4299cfdb897873308b6abde5ca95eb1b37915c8e3f510e8b36cf3592b8cfc8L55-R55) [[5]](diffhunk://#diff-f720c7c88099c1833198924651795ee4dde030fced213a99fcdb701a6b410b42L62-R62) [[6]](diffhunk://#diff-ec92851a1f39d4db85b03f21b0c8abff9cdeba1a0280f89ae279f690d3627009L41-R41) [[7]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L72-R72) [[8]](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L155-R155) [[9]](diffhunk://#diff-2b43fdbd55f6766f91a4ed5f96de410e7fab147228ee7dad1c5078daa02d8bf3L11-R11)
* Updated the Go version declaration in `go.mod` from `1.24.2` to `1.25.3` to match the new standard and ensure local development uses the same version.