### PR TITLE
Rename `duckdb_partition_mode` to `partition_mode` param

### DIFF
--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -266,7 +266,7 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("preserve_insertion_order"),
     ParameterSpec::component("index_scan_percentage"),
     ParameterSpec::component("index_scan_max_count"),
-    ParameterSpec::component("partition_mode"),
+    ParameterSpec::runtime("partition_mode"),
 ];
 
 #[async_trait]

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb.rs
@@ -75,7 +75,7 @@ impl DuckDBPartitionMode {
             "files" => DuckDBPartitionMode::Files,
             other => {
                 tracing::warn!(
-                    "Unknown `duckdb_partition_mode` '{}', defaulting to 'files' mode.",
+                    "Unknown `partition_mode` '{}', defaulting to 'files' mode.",
                     other
                 );
                 DuckDBPartitionMode::Files
@@ -88,7 +88,7 @@ impl DuckDBPartitionMode {
 pub fn get_duckdb_partition_mode(params: &Option<spicepod::param::Params>) -> DuckDBPartitionMode {
     params
         .as_ref()
-        .and_then(|p| p.as_string_map().get("duckdb_partition_mode").cloned())
+        .and_then(|p| p.as_string_map().get("partition_mode").cloned())
         .map_or(DuckDBPartitionMode::Files, |v| {
             DuckDBPartitionMode::parse_str(&v)
         })

--- a/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
+++ b/crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs
@@ -184,8 +184,6 @@ impl DataAccelerator for TablesModePartitionedDuckDBAccelerator {
 
         let source = source.context(ExpectedAccelerationSourceSnafu)?;
 
-        super::parameter_validation(source);
-
         if !cmd.options.contains_key("open") {
             let duckdb_file = duckdb_file_path(&self.duckdb_factory, source)?;
             cmd.options.insert("open".to_string(), duckdb_file);


### PR DESCRIPTION
## 📝 Summary

1. Make `partition_mode ` runtime  (not component) level so it can be re-used across other acceleration engines.

1. Remove misleading validation  (warnings that `duckdb_file` is not supported) for tables based partitioning. This was incorrectly re-used from files-based duckdb partitioning.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
