### PR TITLE
Remove Cache Rust builds step

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,16 +77,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      # Cache Rust build artifacts
-      - name: Cache Rust build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-rust-integration-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-rust-integration-
-            ${{ runner.os }}-rust-
-
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -90,16 +90,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      # Cache Rust build artifacts
-      - name: Cache Rust build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-rust-llms-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-rust-llms-
-            ${{ runner.os }}-rust-
-
       - name: Set up Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,17 +100,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      # Cache Rust build artifacts
-      - name: Cache Rust build
-        if: needs.check_changes.outputs.relevant_changes == 'true'
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-rust-lint-${{ env.RUST_PROFILE }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-rust-lint-${{ env.RUST_PROFILE }}-
-            ${{ runner.os }}-rust-lint-
-
       - name: Set up Go
         if: needs.check_changes.outputs.relevant_changes == 'true'
         uses: actions/setup-go@v6


### PR DESCRIPTION
## 📝 Summary

Downloading and zipping/uploading the Rust caches takes longer than just building from scratch.

<img width="1483" height="657" alt="Screenshot 2025-10-21 at 12 02 54 PM" src="https://github.com/user-attachments/assets/5f3f4eeb-2910-48e8-b086-a01b21a8aecb" />
