### PR TITLE
Fix E2E Test sporadic failures on the macOS runners

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -106,6 +106,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1 # Shallow clone for faster checkout
 
+      - name: Configure Cargo directories (self-hosted macOS)
+        if: matrix.target.builder == 'spiceai-macos'
+        run: |
+          set -euo pipefail
+          cargo_home="${{ runner.temp }}/cargo-${{ github.run_id }}-${{ github.job }}"
+          mkdir -p "$cargo_home/bin"
+          echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
+
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 
@@ -149,27 +157,6 @@ jobs:
 
       - name: Build spiced
         run: make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="tpc-extension"
-
-      - name: Update build cache (macOS)
-        if: matrix.target.target_os == 'darwin'
-        run: |
-          if [ -d /Users/spiceai/build/target ]; then
-            rsync -av target/ /Users/spiceai/build/target/
-          fi
-
-      - name: Update build cache (Linux)
-        if: matrix.target.target_os == 'linux'
-        run: |
-          if [ -d /home/spiceai/build/target ]; then
-            rsync -av target/ /home/spiceai/build/target/
-          fi
-
-      - name: Update build cache (Windows)
-        if: matrix.target.target_os == 'windows'
-        run: |
-          if (Test-Path C:/spiceai/build/target) {
-            Copy-Item -Recurse -Force target/* C:/spiceai/build/target
-          }
 
       - name: Build spice
         run: make -C bin/spice

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -86,6 +86,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Configure Cargo directories (self-hosted macOS)
+        if: matrix.target.builder == 'spiceai-macos'
+        run: |
+          set -euo pipefail
+          cargo_home="${{ runner.temp }}/cargo-${{ github.run_id }}-${{ github.job }}"
+          mkdir -p "$cargo_home/bin"
+          echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
+
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 
@@ -129,27 +137,6 @@ jobs:
           MISTRALRS_METAL_PRECOMPILE: 0
         run: |
           make -C bin/spiced SPICED_NON_DEFAULT_FEATURES="models,metal"
-
-      - name: Update build cache (macOS)
-        if: matrix.target.target_os == 'darwin'
-        run: |
-          if [ -d /Users/spiceai/build/target ]; then
-            rsync -av target/ /Users/spiceai/build/target/
-          fi
-
-      - name: Update build cache (Linux)
-        if: matrix.target.target_os == 'linux'
-        run: |
-          if [ -d /home/spiceai/build/target ]; then
-            rsync -av target/ /home/spiceai/build/target/
-          fi
-
-      - name: Update build cache (Windows)
-        if: matrix.target.target_os == 'windows'
-        run: |
-          if (Test-Path C:/spiceai/build/target) {
-            Copy-Item -Recurse -Force target/* C:/spiceai/build/target
-          }
 
       - name: Build spice
         run: make -C bin/spice


### PR DESCRIPTION
## 📝 Summary

Fix for a sporadic failure of the E2E Tests when building Spice on the macOS runners. The error would be something like:

```
error: could not compile sqlparser_derive (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not parse/generate dep info at: /opt/github-runner-01/_work/spiceai/spiceai/bin/spiced/../../target/release/deps/brotli-eeeaf28edd9b2e3c.d

Caused by:
  No such file or directory (os error 2)
error: could not parse/generate dep info at: /opt/github-runner-01/_work/spiceai/spiceai/bin/spiced/../../target/release/deps/backtrace-ccc65af41be3053f.d

Caused by:
  No such file or directory (os error 2)
make: *** [all] Error 101
```

This was caused by multiple concurrent builds overwriting each other's cargo registry cache. Fix this by giving each runner instance their own cache using CARGO_HOME

Successful run: https://github.com/spiceai/spiceai/actions/runs/18674219188/job/53240838750