### PR TITLE
fix: Don't nullify DuckDB release callbacks for schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4963,7 +4963,7 @@ checksum = "d3a5ccdfd6c5e7e2fea9c5cf256f2a08216047fab19c621c3da64e9ae4a1462d"
 [[package]]
 name = "duckdb"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a731d95e32338780a12f8ff14b5efcc79d2e8822#a731d95e32338780a12f8ff14b5efcc79d2e8822"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f#68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f"
 dependencies = [
  "arrow",
  "cast",
@@ -7911,7 +7911,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 [[package]]
 name = "libduckdb-sys"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=a731d95e32338780a12f8ff14b5efcc79d2e8822#a731d95e32338780a12f8ff14b5efcc79d2e8822"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f#68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4963,7 +4963,7 @@ checksum = "d3a5ccdfd6c5e7e2fea9c5cf256f2a08216047fab19c621c3da64e9ae4a1462d"
 [[package]]
 name = "duckdb"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f#68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=43c12908261bd818510d7520950d2a049d9d2aed#43c12908261bd818510d7520950d2a049d9d2aed"
 dependencies = [
  "arrow",
  "cast",
@@ -7911,7 +7911,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 [[package]]
 name = "libduckdb-sys"
 version = "1.3.2"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f#68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=43c12908261bd818510d7520950d2a049d9d2aed#43c12908261bd818510d7520950d2a049d9d2aed"
 dependencies = [
  "cc",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "0e5d8bca9b6f76087b88d7554c09a6cc43e87183" } # spiceai-0.14.0
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f" } # spiceai-1.3.2
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "43c12908261bd818510d7520950d2a049d9d2aed" } # spiceai-1.3.2
 
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af725caf5d3e952e349746706e00d0ea5" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ datafusion-table-providers = { git = "https://github.com/datafusion-contrib/data
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "0e5d8bca9b6f76087b88d7554c09a6cc43e87183" } # spiceai-0.14.0
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "a731d95e32338780a12f8ff14b5efcc79d2e8822" } # spiceai-1.3.2
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "68ec7c64d603cdde8dbfbb0f00f443ec77c58d5f" } # spiceai-1.3.2
 
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "97054b6af725caf5d3e952e349746706e00d0ea5" }
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates duckdb and duckdb-rs to include this change: https://github.com/spiceai/duckdb-rs/pull/25

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes #7594
