### PR TITLE
Fix integration tests by reverting the use of batch inserts w/ prepared statements

### DIFF
--- a/crates/runtime/src/dataaccelerator/sqlite.rs
+++ b/crates/runtime/src/dataaccelerator/sqlite.rs
@@ -101,7 +101,11 @@ impl SqliteAccelerator {
             sqlite3_auto_extension(Some(sqlite3_decimal_init));
         }
         Self {
-            sqlite_factory: SqliteTableProviderFactory::new().with_decimal_between(true),
+            sqlite_factory: SqliteTableProviderFactory::new()
+                .with_decimal_between(true)
+                // Prepared statements currently map timestamp values incorrectly (see spiceai#7629),
+                // so use the legacy insert path until the upstream fix lands.
+                .with_batch_insert_use_prepared_statements(false),
         }
     }
 


### PR DESCRIPTION
## 📝 Summary

- In https://github.com/datafusion-contrib/datafusion-table-providers/pull/452 support was added for batch inserts in SQLite using prepared statements - but the timestamp handling broke when integrated in Spice and run against our integration tests.

Disable the prepared statement for SQLite until #7629 is fixed

## 🔗 Related

- Opened https://github.com/spiceai/spiceai/issues/7629 to track the datafusion-table-providers issue
