### PR TITLE
fix: Disable go cache in actions

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -139,6 +139,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GOVER }}
+          cache: false
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -121,17 +121,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GOVER }}
-
-      # Cache Go modules
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: false
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/e2e_test_ci_models.yml
+++ b/.github/workflows/e2e_test_ci_models.yml
@@ -101,6 +101,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GOVER }}
+          cache: false
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GOVER }}
+          cache: false
 
       - name: Set up make
         if: matrix.target.target_os == 'linux' && github.event.inputs.build_cli == 'true'

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GOVER }}
+          cache: false
 
       - name: Install go-licences
         run: go get github.com/google/go-licenses

--- a/.github/workflows/types_check.yml
+++ b/.github/workflows/types_check.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GOVER }}
+          cache: false
 
       - run: rustup toolchain install stable --profile minimal
 


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Disables the Go module cache as it takes 30+ minutes to restore
* Disables the Go cache for `setup-go` as it is slower than installing without cache

These are currently accounting for 35+ minutes in some workflows:

<img width="1528" height="290" alt="image" src="https://github.com/user-attachments/assets/d87ff071-936c-4267-a800-cac724665ce0" />

