### PR TITLE
Configure macOS setup in workflow

### DIFF
--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Set up make
         uses: ./.github/actions/setup-make
+        with:
+          os: macos
 
       - name: Build Cargo project
         run: cargo build --manifest-path tools/spicepodschema/Cargo.toml


### PR DESCRIPTION
See issue with using `apt-get` when installing make since we don't specify OS: 
 - Failed run: https://github.com/spiceai/spiceai/actions/runs/18707354323/job/53347844654