### PR TITLE
Fix OSS docker release trigger when release marked as latest

### DIFF
--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   setup:
-    if: ${{ github.event_name != 'release' || (github.event.action == 'edited' && github.event.changes.make_latest && github.event.changes.make_latest.to == true) }}
+    if: ${{ github.event_name != 'release' || (github.event.action == 'edited' && github.event.changes.make_latest && github.event.changes.make_latest.to == 'true') }}
     runs-on: ubuntu-latest
     outputs:
       rel_version: ${{ steps.resolve.outputs.rel_version }}


### PR DESCRIPTION
## 📝 Summary

Fixes a bug with the new docker release that didn't properly trigger when the GitHub release with the binary assets are marked latest
