### PR TITLE
Use '#[serde(deny_unknown_fields)]' for base spicepod components

### DIFF
--- a/crates/spicepod/src/component/catalog.rs
+++ b/crates/spicepod/src/component/catalog.rs
@@ -26,6 +26,7 @@ use crate::{metric::Metrics, param::Params};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Catalog {
     pub from: String,
 

--- a/crates/spicepod/src/component/embeddings.rs
+++ b/crates/spicepod/src/component/embeddings.rs
@@ -29,6 +29,7 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Embeddings {
     pub from: String,
     pub name: String,

--- a/crates/spicepod/src/component/eval.rs
+++ b/crates/spicepod/src/component/eval.rs
@@ -24,6 +24,7 @@ use super::{Nameable, WithDependsOn};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Eval {
     pub name: String,
 

--- a/crates/spicepod/src/component/management.rs
+++ b/crates/spicepod/src/component/management.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Management {
     #[serde(default = "default_true")]
     pub enabled: bool,

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -27,6 +27,7 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Model {
     pub from: String,
     pub name: String,

--- a/crates/spicepod/src/component/secret.rs
+++ b/crates/spicepod/src/component/secret.rs
@@ -33,6 +33,7 @@ use crate::param::Params;
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Secret {
     pub from: String,
 

--- a/crates/spicepod/src/component/tool.rs
+++ b/crates/spicepod/src/component/tool.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Tool {
     pub from: String,
     pub name: String,

--- a/crates/spicepod/src/component/view.rs
+++ b/crates/spicepod/src/component/view.rs
@@ -26,6 +26,7 @@ use crate::{acceleration::Acceleration, semantic::Column};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct View {
     pub name: String,
 

--- a/crates/spicepod/src/component/worker.rs
+++ b/crates/spicepod/src/component/worker.rs
@@ -25,6 +25,7 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(deny_unknown_fields)]
 pub struct Worker {
     pub name: String,
 


### PR DESCRIPTION
## 📝 Summary
- Instead of silently ignoring fields, show warning if any spicepod component has unexpected extra fields.

```
>>>  spice run
2025-10-23T03:29:20.650995Z  INFO spiced: Starting runtime v1.9.0-unstable-build.1d62d9cd4-dev+models.metal
2025-10-23T03:29:20.656240Z  WARN spiced: Unable to load spicepod /Users/jeadie/Github/spiceai: Unable to parse spicepod.yaml: models[0]: Unknown field system_prompt. Expected one of from, name, description, metadata, files, params, datasets, dependsOn, metrics at line 170 column 5
```

##  Breaking Change
 - This PR introduces more strict parsing of spicepod.yaml. This is a breaking change: previous spicepods that had superfluous fields will be invalid instead of ignored. 