### PR TITLE
Run acceleration refreshes on separate Tokio runtime

### DIFF
--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -52,6 +52,7 @@ use runtime_acceleration::snapshot::SnapshotBehavior;
 use snafu::prelude::*;
 use spicepod::metric::Metrics;
 use synchronized_table::SynchronizedTable;
+use tokio::runtime::Handle;
 use tokio::sync::{Notify, RwLock, Semaphore, mpsc};
 use tokio::task::JoinHandle;
 
@@ -246,6 +247,7 @@ pub struct Builder {
     snapshot_behavior: SnapshotBehavior,
     snapshot_local_path: Option<PathBuf>,
     metrics: Option<Metrics>,
+    tokio_runtime: Option<Handle>,
 }
 
 impl Builder {
@@ -279,6 +281,7 @@ impl Builder {
             snapshot_behavior: SnapshotBehavior::default(),
             snapshot_local_path: None,
             metrics: None,
+            tokio_runtime: None,
         }
     }
 
@@ -319,6 +322,11 @@ impl Builder {
 
     pub fn metrics(&mut self, metrics: Metrics) -> &mut Self {
         self.metrics = Some(metrics);
+        self
+    }
+
+    pub fn tokio_runtime(&mut self, runtime: Option<Handle>) -> &mut Self {
+        self.tokio_runtime = runtime;
         self
     }
 
@@ -461,6 +469,7 @@ impl Builder {
             Some(self.federated_source),
             Arc::clone(&refresh_params),
             Arc::clone(&self.accelerator),
+            self.tokio_runtime.clone(),
         );
         refresher.caching(&self.caching);
         refresher.checkpointer(self.checkpointer);

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -43,6 +43,7 @@ use runtime_acceleration::snapshot::{
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
 use spicepod::metric::Metrics;
+use tokio::runtime::Handle;
 use tokio::select;
 use tokio::sync::Notify;
 use tokio::sync::mpsc::Receiver;
@@ -437,6 +438,7 @@ pub struct Refresher {
     disable_federation: bool,
     semaphore: Option<Arc<Semaphore>>,
     on_complete_notification: Option<Arc<Notify>>,
+    tokio_runtime: Option<Handle>,
 }
 
 impl std::fmt::Debug for Refresher {
@@ -459,6 +461,7 @@ impl Refresher {
         federated_source: Option<String>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
+        tokio_runtime: Option<Handle>,
     ) -> Self {
         Self {
             runtime_status,
@@ -479,6 +482,7 @@ impl Refresher {
             snapshot_behavior: SnapshotBehavior::default(),
             snapshot_local_path: None,
             metrics: None,
+            tokio_runtime,
         }
     }
 
@@ -629,6 +633,8 @@ impl Refresher {
         }
 
         refresh_task_runner = refresh_task_runner.with_metrics(self.metrics.clone());
+
+        refresh_task_runner = refresh_task_runner.with_tokio_runtime(self.tokio_runtime.clone());
 
         let mut refresh_task_runner = refresh_task_runner.build();
 
@@ -797,6 +803,7 @@ impl Refresher {
                 self.metrics.clone(),
             )
             .with_disable_federation(self.disable_federation)
+            .with_tokio_runtime(self.tokio_runtime.clone())
             .build(),
         );
 
@@ -830,6 +837,7 @@ impl Refresher {
                 self.metrics.clone(),
             )
             .with_disable_federation(self.disable_federation)
+            .with_tokio_runtime(self.tokio_runtime.clone())
             .build(),
         );
 
@@ -998,6 +1006,7 @@ mod tests {
             Some("mem_table".to_string()),
             Arc::new(RwLock::new(refresh)),
             Arc::clone(&accelerator),
+            None,
         );
 
         refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1206,6 +1215,7 @@ mod tests {
                 Some("mem_table".to_string()),
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
+                None,
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1360,6 +1370,7 @@ mod tests {
                 Some("mem_table".to_string()),
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
+                None,
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1564,6 +1575,7 @@ mod tests {
                 Some("mem_table".to_string()),
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
+                None,
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -720,10 +720,7 @@ impl RefreshTask {
         refresh: &Refresh,
     ) -> Result<StreamingDataUpdate, RetryError<super::Error>> {
         let federated_provider = self.federated.table_provider().await;
-        let mut ctx = self
-            .refresh_df_context(Arc::clone(&federated_provider))
-            .await;
-            
+
         let dataset_name = self.dataset_name.clone();
         let update_type = match refresh.mode {
             RefreshMode::Disabled => {
@@ -743,11 +740,27 @@ impl RefreshTask {
             let request_context = RequestContext::current(AsyncMarker::new().await);
             let span = Span::current();
 
+            // Capture necessary state to create ctx inside the closure
+            let dataset_name_for_ctx = self.dataset_name.clone();
+            let federated_for_ctx = Arc::clone(&self.federated);
+            let accelerator_for_ctx = Arc::clone(&self.accelerator);
+            let disable_federation = self.disable_federation;
+
             let managed_stream = managed_runtime::run_record_batch_stream_on_runtime(
                 runtime_handle,
                 request_context,
                 span,
                 async move {
+                    // Create ctx inside the managed runtime to avoid creating it twice
+                    let mut ctx = Self::create_refresh_df_context(
+                        Arc::clone(&provider_for_runtime),
+                        &dataset_name_for_ctx,
+                        &federated_for_ctx,
+                        &accelerator_for_ctx,
+                        disable_federation,
+                    )
+                    .await;
+
                     let data = get_data(
                         &mut ctx,
                         dataset_name_for_runtime,
@@ -773,6 +786,11 @@ impl RefreshTask {
             let (update_type, stream) = managed_stream.into_parts();
             return Ok(StreamingDataUpdate::new(stream, update_type));
         }
+
+        // Create ctx only in the fallback path (no managed runtime)
+        let mut ctx = self
+            .refresh_df_context(Arc::clone(&federated_provider))
+            .await;
 
         let get_data_result = get_data(
             &mut ctx,
@@ -814,6 +832,26 @@ impl RefreshTask {
         &self,
         federated_provider: Arc<dyn TableProvider>,
     ) -> SessionContext {
+        Self::create_refresh_df_context(
+            federated_provider,
+            &self.dataset_name,
+            &self.federated,
+            &self.accelerator,
+            self.disable_federation,
+        )
+        .await
+    }
+
+    /// Static helper method to create a `DataFusion` context for refresh operations.
+    /// This is separated from `refresh_df_context` to allow it to be called from async closures
+    /// without requiring `self`, avoiding the need to create the context twice.
+    async fn create_refresh_df_context(
+        federated_provider: Arc<dyn TableProvider>,
+        dataset_name: &TableReference,
+        _federated: &Arc<FederatedTable>,
+        accelerator: &Arc<dyn TableProvider>,
+        disable_federation: bool,
+    ) -> SessionContext {
         let state_builder = SessionStateBuilder::new()
             .with_config(get_df_default_config())
             .with_runtime_env(default_runtime_env())
@@ -827,7 +865,7 @@ impl RefreshTask {
         let mut analyzer_rules_builder = AnalyzerRulesBuilder::default();
 
         // If federation is disabled, disable the federation analyzer rule and don't include the federated planner.
-        if self.disable_federation {
+        if disable_federation {
             analyzer_rules_builder = analyzer_rules_builder.include_federation(false);
         } else {
             analyzer_rules_builder = analyzer_rules_builder.include_federation(true);
@@ -853,31 +891,31 @@ impl RefreshTask {
         let default_catalog = state.config_options().catalog.default_catalog.clone();
         let ctx = SessionContext::new_with_state(state);
 
-        match schema::ensure_schema_exists(&ctx, &default_catalog, &self.dataset_name) {
+        match schema::ensure_schema_exists(&ctx, &default_catalog, dataset_name) {
             Ok(()) => (),
             Err(_) => {
                 unreachable!("The default catalog should always exist");
             }
         }
 
-        if let Err(e) = ctx.register_table(self.dataset_name.clone(), federated_provider) {
+        if let Err(e) = ctx.register_table(dataset_name.clone(), federated_provider) {
             tracing::error!("Unable to register federated table: {e}");
         }
 
         let mut acc_dataset_name = String::with_capacity(
-            self.dataset_name.table().len() + self.dataset_name.schema().map_or(0, str::len),
+            dataset_name.table().len() + dataset_name.schema().map_or(0, str::len),
         );
 
-        if let Some(schema) = self.dataset_name.schema() {
+        if let Some(schema) = dataset_name.schema() {
             acc_dataset_name.push_str(schema);
         }
 
         acc_dataset_name.push_str("accelerated_");
-        acc_dataset_name.push_str(self.dataset_name.table());
+        acc_dataset_name.push_str(dataset_name.table());
 
         if let Err(e) = ctx.register_table(
             TableReference::parse_str(&acc_dataset_name),
-            Arc::new(EnsureSchema::new(Arc::clone(&self.accelerator))),
+            Arc::new(EnsureSchema::new(Arc::clone(accelerator))),
         ) {
             tracing::error!("Unable to register accelerator table: {e}");
         }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -720,6 +720,10 @@ impl RefreshTask {
         refresh: &Refresh,
     ) -> Result<StreamingDataUpdate, RetryError<super::Error>> {
         let federated_provider = self.federated.table_provider().await;
+        let mut ctx = self
+            .refresh_df_context(Arc::clone(&federated_provider))
+            .await;
+            
         let dataset_name = self.dataset_name.clone();
         let update_type = match refresh.mode {
             RefreshMode::Disabled => {
@@ -731,7 +735,6 @@ impl RefreshTask {
         };
 
         if let Some(runtime_handle) = self.tokio_runtime.clone() {
-            let mut ctx = self.refresh_df_context(Arc::clone(&federated_provider));
             let dataset_name_for_runtime = dataset_name.clone();
             let filters_for_runtime = filters.clone();
             let update_type_for_runtime = update_type.clone();

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -774,7 +774,6 @@ impl RefreshTask {
             return Ok(StreamingDataUpdate::new(stream, update_type));
         }
 
-        let mut ctx = self.refresh_df_context(Arc::clone(&federated_provider));
         let get_data_result = get_data(
             &mut ctx,
             dataset_name,

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -34,7 +34,11 @@ use runtime_datafusion_index::analyzer::{
     IndexTableScanExtensionPlanner, IndexTableScanOptimizerRule,
 };
 use snafu::{OptionExt, ResultExt};
-use tokio::time::Instant;
+use tokio::{
+    runtime::Handle,
+    sync::{Mutex, RwLock, Semaphore, oneshot},
+    time::Instant,
+};
 use tracing::{Instrument, Span};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
 use util::{RetryError, retry};
@@ -43,6 +47,7 @@ use crate::datafusion::builder::{AnalyzerRulesBuilder, get_df_default_config};
 use crate::datafusion::error::{SpiceExternalError, find_datafusion_root, get_spice_df_error};
 use crate::datafusion::extension::{SpiceExtensionPlanner, SpiceQueryPlanner};
 use crate::datafusion::is_spice_internal_dataset;
+use crate::datafusion::managed_runtime::{self, ManagedRuntimeError};
 use crate::datafusion::schema::BaseSchema;
 use crate::federated_table::FederatedTable;
 use crate::timing::MultiTimeMeasurement;
@@ -64,7 +69,6 @@ use super::{UnableToCreateMemTableFromUpdateSnafu, metrics};
 use crate::component::dataset::TimeFormat;
 use std::time::{Duration, UNIX_EPOCH};
 use std::{cmp::Ordering, sync::Arc, time::SystemTime};
-use tokio::sync::{Mutex, RwLock, Semaphore, oneshot};
 
 use super::refresh::Refresh;
 use crate::accelerated_table::timestamp_metrics_utils::with_find_max_timestamp_in_stream;
@@ -80,6 +84,7 @@ use datafusion::{
 };
 use datafusion_expr::{LogicalPlanBuilder, UNNAMED_TABLE, ident};
 use datafusion_federation::{FederatedPlanner, FederatedTableProviderAdaptor};
+use runtime_request_context::{AsyncMarker, RequestContext};
 use spicepod::metric::Metrics;
 use std::collections::HashSet;
 
@@ -105,6 +110,7 @@ pub struct RefreshTaskBuilder {
     // Used to control how many parallel refreshes the runtime performs.
     semaphore: Option<Arc<Semaphore>>,
     metrics: Option<Metrics>,
+    tokio_runtime: Option<Handle>,
 }
 
 impl RefreshTaskBuilder {
@@ -127,6 +133,7 @@ impl RefreshTaskBuilder {
             disable_federation: false,
             semaphore: None,
             metrics,
+            tokio_runtime: None,
         }
     }
 
@@ -140,6 +147,12 @@ impl RefreshTaskBuilder {
     #[must_use]
     pub fn with_semaphore(mut self, semaphore: Arc<Semaphore>) -> RefreshTaskBuilder {
         self.semaphore = Some(semaphore);
+        self
+    }
+
+    #[must_use]
+    pub fn with_tokio_runtime(mut self, runtime: Option<Handle>) -> RefreshTaskBuilder {
+        self.tokio_runtime = runtime;
         self
     }
 
@@ -167,6 +180,7 @@ impl RefreshTaskBuilder {
                 .iter()
                 .cloned()
                 .collect(),
+            tokio_runtime: self.tokio_runtime,
         }
     }
 }
@@ -183,6 +197,7 @@ pub struct RefreshTask {
     // Used to control how many parallel refreshes the runtime performs.
     semaphore: Arc<Semaphore>,
     enabled_metrics: HashSet<String>,
+    tokio_runtime: Option<Handle>,
 }
 
 impl RefreshTask {
@@ -705,10 +720,7 @@ impl RefreshTask {
         refresh: &Refresh,
     ) -> Result<StreamingDataUpdate, RetryError<super::Error>> {
         let federated_provider = self.federated.table_provider().await;
-
-        let mut ctx = self.refresh_df_context(Arc::clone(&federated_provider));
         let dataset_name = self.dataset_name.clone();
-
         let update_type = match refresh.mode {
             RefreshMode::Disabled => {
                 unreachable!("Refresh cannot be called when acceleration is disabled")
@@ -718,12 +730,54 @@ impl RefreshTask {
             RefreshMode::Changes => unreachable!("changes are handled upstream"),
         };
 
+        if let Some(runtime_handle) = self.tokio_runtime.clone() {
+            let mut ctx = self.refresh_df_context(Arc::clone(&federated_provider));
+            let dataset_name_for_runtime = dataset_name.clone();
+            let filters_for_runtime = filters.clone();
+            let update_type_for_runtime = update_type.clone();
+            let provider_for_runtime = Arc::clone(&federated_provider);
+            let sql_for_runtime = refresh.sql.clone();
+            let request_context = RequestContext::current(AsyncMarker::new().await);
+            let span = Span::current();
+
+            let managed_stream = managed_runtime::run_record_batch_stream_on_runtime(
+                runtime_handle,
+                request_context,
+                span,
+                async move {
+                    let data = get_data(
+                        &mut ctx,
+                        dataset_name_for_runtime,
+                        provider_for_runtime,
+                        sql_for_runtime,
+                        filters_for_runtime,
+                    )
+                    .await
+                    .map_err(check_and_mark_retriable_error)?;
+                    Ok((update_type_for_runtime, data))
+                },
+            )
+            .await
+            .map_err(|err| match err {
+                ManagedRuntimeError::Future(df_err) => retry_from_df_error(df_err),
+                ManagedRuntimeError::DriverTaskEnded => {
+                    retry_from_df_error(DataFusionError::Execution(
+                        "Refresh driver task ended unexpectedly".to_string(),
+                    ))
+                }
+            })?;
+
+            let (update_type, stream) = managed_stream.into_parts();
+            return Ok(StreamingDataUpdate::new(stream, update_type));
+        }
+
+        let mut ctx = self.refresh_df_context(Arc::clone(&federated_provider));
         let get_data_result = get_data(
             &mut ctx,
-            dataset_name.clone(),
+            dataset_name,
             federated_provider,
             refresh.sql.clone(),
-            filters.clone(),
+            filters,
         )
         .await
         .map_err(check_and_mark_retriable_error);

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -21,6 +21,7 @@ use super::{
 };
 use futures::future::BoxFuture;
 use tokio::{
+    runtime::Handle,
     select,
     sync::{
         Semaphore,
@@ -46,6 +47,7 @@ pub struct RefreshTaskRunnerBuilder {
     disable_federation: bool,
     semaphore: Option<Arc<Semaphore>>,
     metrics: Option<Metrics>,
+    tokio_runtime: Option<Handle>,
 }
 
 impl RefreshTaskRunnerBuilder {
@@ -68,6 +70,7 @@ impl RefreshTaskRunnerBuilder {
             disable_federation: false,
             semaphore: None,
             metrics: None,
+            tokio_runtime: None,
         }
     }
 
@@ -91,6 +94,12 @@ impl RefreshTaskRunnerBuilder {
     }
 
     #[must_use]
+    pub fn with_tokio_runtime(mut self, runtime: Option<Handle>) -> Self {
+        self.tokio_runtime = runtime;
+        self
+    }
+
+    #[must_use]
     pub fn build(self) -> RefreshTaskRunner {
         let mut refresh_task_builder = RefreshTask::builder(
             self.runtime_status,
@@ -105,6 +114,8 @@ impl RefreshTaskRunnerBuilder {
         if let Some(semaphore) = self.semaphore {
             refresh_task_builder = refresh_task_builder.with_semaphore(semaphore);
         }
+
+        refresh_task_builder = refresh_task_builder.with_tokio_runtime(self.tokio_runtime);
 
         let refresh_task = Arc::new(refresh_task_builder.build());
 

--- a/crates/runtime/src/datafusion/managed_runtime.rs
+++ b/crates/runtime/src/datafusion/managed_runtime.rs
@@ -172,3 +172,129 @@ impl Drop for RuntimeDriverStream {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, Int64Array};
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::error::DataFusionError;
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use futures::StreamExt;
+    use runtime_request_context::Protocol;
+    use tokio::runtime::Builder;
+
+    fn test_request_context() -> Arc<RequestContext> {
+        Arc::new(RequestContext::builder(Protocol::Internal).build())
+    }
+
+    fn test_runtime() -> tokio::runtime::Runtime {
+        Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("test runtime")
+    }
+
+    #[tokio::test]
+    async fn run_record_batch_stream_on_runtime_streams_batches() {
+        let runtime = test_runtime();
+        let handle = runtime.handle().clone();
+        let request_context = test_request_context();
+
+        let managed = run_record_batch_stream_on_runtime(
+            handle,
+            Arc::clone(&request_context),
+            Span::current(),
+            async move {
+                let schema = Arc::new(Schema::new(vec![Field::new(
+                    "value",
+                    DataType::Int64,
+                    false,
+                )]));
+
+                let columns: Vec<ArrayRef> =
+                    vec![Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef];
+                let batch = RecordBatch::try_new(Arc::clone(&schema), columns)
+                    .expect("create record batch");
+
+                let batches = vec![
+                    Ok::<_, DataFusionError>(batch.clone()),
+                    Ok::<_, DataFusionError>(batch),
+                ];
+
+                let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+                    Arc::clone(&schema),
+                    futures::stream::iter(batches).boxed(),
+                ));
+
+                Ok::<_, DataFusionError>((42_u8, stream))
+            },
+        )
+        .await
+        .expect("managed stream");
+
+        let (metadata, stream) = managed.into_parts();
+        assert_eq!(metadata, 42_u8);
+
+        let results: Vec<_> = stream.collect().await;
+        assert_eq!(results.len(), 2);
+        let first_batch = results
+            .first()
+            .expect("first batch result")
+            .as_ref()
+            .expect("batch ok");
+        assert_eq!(first_batch.num_rows(), 3);
+        runtime.shutdown_background();
+    }
+
+    #[tokio::test]
+    async fn run_record_batch_stream_on_runtime_propagates_future_errors() {
+        let runtime = test_runtime();
+        let handle = runtime.handle().clone();
+        let request_context = test_request_context();
+
+        let result = run_record_batch_stream_on_runtime(
+            handle,
+            Arc::clone(&request_context),
+            Span::current(),
+            async move { Err::<(u8, SendableRecordBatchStream), &'static str>("boom") },
+        )
+        .await;
+
+        match result {
+            Err(ManagedRuntimeError::Future(message)) => assert_eq!(message, "boom"),
+            Ok(_) => panic!("expected managed runtime error"),
+            Err(ManagedRuntimeError::DriverTaskEnded) => {
+                panic!("expected future error, got driver termination")
+            }
+        }
+        runtime.shutdown_background();
+    }
+
+    #[tokio::test]
+    async fn run_record_batch_stream_on_runtime_handles_driver_task_end() {
+        let runtime = test_runtime();
+        let handle = runtime.handle().clone();
+        let request_context = test_request_context();
+
+        let result = run_record_batch_stream_on_runtime::<_, u8, &'static str>(
+            handle,
+            request_context,
+            Span::current(),
+            async move {
+                panic!("driver task panic");
+            },
+        )
+        .await;
+
+        match result {
+            Err(ManagedRuntimeError::DriverTaskEnded) => (),
+            Ok(_) => panic!("expected driver termination error"),
+            Err(ManagedRuntimeError::Future(_)) => {
+                panic!("expected driver termination error, got future error")
+            }
+        }
+        runtime.shutdown_background();
+    }
+}

--- a/crates/runtime/src/datafusion/managed_runtime.rs
+++ b/crates/runtime/src/datafusion/managed_runtime.rs
@@ -1,0 +1,174 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use arrow::array::RecordBatch;
+use arrow_schema::SchemaRef;
+use datafusion::{
+    error::DataFusionError, execution::SendableRecordBatchStream,
+    physical_plan::stream::RecordBatchStreamAdapter,
+};
+use futures::{Stream, StreamExt};
+use runtime_request_context::RequestContext;
+use tokio::{
+    runtime::Handle,
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::Span;
+use tracing_futures::Instrument;
+
+#[derive(Debug)]
+pub enum ManagedRuntimeError<E> {
+    Future(E),
+    DriverTaskEnded,
+}
+
+pub struct ManagedRecordBatchStream<M> {
+    metadata: M,
+    stream: SendableRecordBatchStream,
+}
+
+impl<M> ManagedRecordBatchStream<M> {
+    fn new(metadata: M, stream: SendableRecordBatchStream) -> Self {
+        Self { metadata, stream }
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (M, SendableRecordBatchStream) {
+        (self.metadata, self.stream)
+    }
+}
+
+/// Executes a future that produces a [`SendableRecordBatchStream`] on the provided Tokio runtime.
+///
+/// The future and the resulting stream are both driven by the supplied runtime handle. The resulting
+/// stream can be consumed from the caller's runtime without blocking the managed runtime.
+pub async fn run_record_batch_stream_on_runtime<Fut, M, E>(
+    runtime_handle: Handle,
+    request_context: Arc<RequestContext>,
+    span: Span,
+    future: Fut,
+) -> Result<ManagedRecordBatchStream<M>, ManagedRuntimeError<E>>
+where
+    Fut: Future<Output = Result<(M, SendableRecordBatchStream), E>> + Send + 'static,
+    M: Send + 'static,
+    E: Send + 'static,
+{
+    let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
+    let (meta_tx, meta_rx) = oneshot::channel::<Result<(M, SchemaRef), E>>();
+
+    let driver_request_context = Arc::clone(&request_context);
+    let driver_span = span.clone();
+
+    let driver_task = async move {
+        match future.instrument(driver_span.clone()).await {
+            Ok((metadata, mut stream)) => {
+                let schema = stream.schema();
+
+                if meta_tx.send(Ok((metadata, schema))).is_err() {
+                    return;
+                }
+
+                let stream_span = driver_span.clone();
+                while let Some(batch) = Arc::clone(&driver_request_context)
+                    .scope(stream.next().instrument(stream_span.clone()))
+                    .await
+                {
+                    if batch_tx.send(batch).await.is_err() {
+                        break;
+                    }
+                }
+            }
+            Err(err) => {
+                let _ = meta_tx.send(Err(err));
+            }
+        }
+    };
+
+    let driver_handle = runtime_handle.spawn(driver_task.instrument(span.clone()));
+
+    let (metadata, schema) = match meta_rx.await {
+        Ok(Ok((metadata, schema))) => (metadata, schema),
+        Ok(Err(err)) => return Err(ManagedRuntimeError::Future(err)),
+        Err(_) => return Err(ManagedRuntimeError::DriverTaskEnded),
+    };
+
+    let driver_stream = RuntimeDriverStream::new(batch_rx, driver_handle);
+    let adapter = RecordBatchStreamAdapter::new(schema, Box::pin(driver_stream));
+    let stream: SendableRecordBatchStream = Box::pin(adapter);
+
+    Ok(ManagedRecordBatchStream::new(metadata, stream))
+}
+
+struct RuntimeDriverStream {
+    receiver: ReceiverStream<Result<RecordBatch, DataFusionError>>,
+    driver_handle: Option<JoinHandle<()>>,
+    driver_error: Option<DataFusionError>,
+}
+
+impl RuntimeDriverStream {
+    fn new(
+        receiver: tokio::sync::mpsc::Receiver<Result<RecordBatch, DataFusionError>>,
+        driver_handle: JoinHandle<()>,
+    ) -> Self {
+        Self {
+            receiver: ReceiverStream::new(receiver),
+            driver_handle: Some(driver_handle),
+            driver_error: None,
+        }
+    }
+}
+
+impl Stream for RuntimeDriverStream {
+    type Item = Result<RecordBatch, DataFusionError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if let Some(handle) = this.driver_handle.as_mut() {
+            match Future::poll(Pin::new(handle), cx) {
+                Poll::Ready(Ok(())) => {
+                    this.driver_handle = None;
+                }
+                Poll::Ready(Err(err)) => {
+                    this.driver_handle = None;
+                    if err.is_panic() {
+                        this.driver_error = Some(DataFusionError::Execution(format!(
+                            "Query driver task panicked: {err}"
+                        )));
+                    } else if !err.is_cancelled() {
+                        this.driver_error = Some(DataFusionError::Execution(format!(
+                            "Query driver task failed: {err}"
+                        )));
+                    }
+                }
+                Poll::Pending => {}
+            }
+        }
+
+        if let Some(err) = this.driver_error.take() {
+            return Poll::Ready(Some(Err(err)));
+        }
+
+        Pin::new(&mut this.receiver).poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.receiver.size_hint()
+    }
+}
+
+impl Drop for RuntimeDriverStream {
+    fn drop(&mut self) {
+        if let Some(handle) = self.driver_handle.take()
+            && !handle.is_finished()
+        {
+            handle.abort();
+        }
+    }
+}

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1042,6 +1042,7 @@ impl DataFusion {
             accelerated_table_provider,
             refresh,
         );
+        accelerated_table_builder.tokio_runtime(self.tokio_runtime().cloned());
 
         let retention_delete_expr = match dataset.retention_sql() {
             Some(retention_sql) => Some(
@@ -1607,6 +1608,7 @@ impl DataFusion {
             accelerated_table_provider,
             refresh,
         );
+        builder.tokio_runtime(self.tokio_runtime().cloned());
         builder.initial_load_complete(initial_load_complete);
         builder.caching(Some(Arc::clone(&self.caching)));
         builder.checkpointer_opt(

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -89,6 +89,7 @@ pub mod dialect;
 pub mod error;
 pub mod extension;
 pub mod filter_converter;
+pub mod managed_runtime;
 pub mod param_utils;
 pub mod refresh_sql;
 pub mod request_context_extension;

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -14,13 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{
-    fmt::Display,
-    future::Future,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::{fmt::Display, sync::Arc};
 
 use ::cache::{
     get_logical_plan_input_tables,
@@ -28,7 +22,7 @@ use ::cache::{
     result::{CacheStatus, query::QueryResult},
 };
 use arrow::{array::RecordBatch, datatypes::Schema};
-use arrow_schema::{Field, SchemaBuilder, SchemaRef};
+use arrow_schema::{Field, SchemaBuilder};
 use arrow_tools::schema::verify_schema;
 use cache::PlanOrCached;
 use datafusion::{
@@ -57,15 +51,13 @@ use crate::datafusion::{
     DataFusion, query::cache::RequestCacheManager, sql_validator::validate_sql_query_operations,
 };
 use async_stream::stream;
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use opentelemetry::KeyValue;
 use runtime_request_context::{AsyncMarker, RequestContext};
 use tokio::runtime::Handle;
-use tokio::sync::{mpsc, oneshot};
-use tokio::task::JoinHandle;
-use tokio_stream::wrappers::ReceiverStream;
 
-use super::{SPICE_RUNTIME_SCHEMA, error::find_datafusion_root};
+use super::{SPICE_RUNTIME_SCHEMA, error::find_datafusion_root, managed_runtime};
+use managed_runtime::ManagedRuntimeError;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -158,62 +150,30 @@ impl Query {
     ) -> Result<QueryResult> {
         let span = Span::current();
 
-        let (batch_tx, batch_rx) = mpsc::channel::<Result<RecordBatch, DataFusionError>>(2);
-        let (result_tx, result_rx) = oneshot::channel::<Result<(CacheStatus, SchemaRef), Error>>();
+        let runtime_request_context = Arc::clone(&request_context);
+        let future_request_context = request_context;
 
-        let request_context_clone = Arc::clone(&request_context);
-        let inner_span = span.clone();
-        let driver_task = async move {
-            let stream_span = inner_span.clone();
-            match self
-                .run_internal(request_context_clone)
-                .instrument(inner_span)
-                .await
-            {
-                Ok(query_result) => {
-                    let schema = query_result.data.schema();
-                    let cache_status = query_result.cache_status;
+        let managed_stream = managed_runtime::run_record_batch_stream_on_runtime(
+            runtime_handle,
+            runtime_request_context,
+            span,
+            async move {
+                self.run_internal(future_request_context)
+                    .await
+                    .map(|query_result| (query_result.cache_status, query_result.data))
+            },
+        )
+        .await
+        .map_err(|err| match err {
+            ManagedRuntimeError::Future(err) => err,
+            ManagedRuntimeError::DriverTaskEnded => Error::UnableToExecuteQuery {
+                source: DataFusionError::Execution(
+                    "Query driver task ended unexpectedly".to_string(),
+                ),
+            },
+        })?;
 
-                    if result_tx.send(Ok((cache_status, schema))).is_err() {
-                        return;
-                    }
-
-                    let mut stream = query_result.data;
-                    while let Some(batch) = Arc::clone(&request_context)
-                        .scope(stream.next().instrument(stream_span.clone()))
-                        .await
-                    {
-                        if batch_tx.send(batch).await.is_err() {
-                            break;
-                        }
-                    }
-                }
-                Err(err) => {
-                    if result_tx.send(Err(err)).is_err() {
-                        tracing::debug!("Failed to send query result; receiver dropped");
-                    }
-                }
-            }
-        };
-
-        let driver_handle = runtime_handle.spawn(driver_task.instrument(span));
-
-        let (cache_status, schema) = match result_rx.await {
-            Ok(Ok((cache_status, schema))) => (cache_status, schema),
-            Ok(Err(err)) => return Err(err),
-            Err(_) => {
-                return Err(Error::UnableToExecuteQuery {
-                    source: DataFusionError::Execution(
-                        "Query driver task ended unexpectedly".to_string(),
-                    ),
-                });
-            }
-        };
-
-        let driver_stream = DriverStream::new(batch_rx, driver_handle);
-        let adapter = RecordBatchStreamAdapter::new(schema, Box::pin(driver_stream));
-
-        let stream: SendableRecordBatchStream = Box::pin(adapter);
+        let (cache_status, stream) = managed_stream.into_parts();
 
         Ok(QueryResult::new(stream, cache_status))
     }
@@ -508,74 +468,6 @@ fn parameter_schema_for_plan(plan: &LogicalPlan) -> Result<Option<Schema>, DataF
     };
 
     Ok(maybe_schema)
-}
-
-struct DriverStream {
-    receiver: ReceiverStream<Result<RecordBatch, DataFusionError>>,
-    driver_handle: Option<JoinHandle<()>>,
-    driver_error: Option<DataFusionError>,
-}
-
-impl DriverStream {
-    fn new(
-        receiver: tokio::sync::mpsc::Receiver<Result<RecordBatch, DataFusionError>>,
-        driver_handle: JoinHandle<()>,
-    ) -> Self {
-        Self {
-            receiver: ReceiverStream::new(receiver),
-            driver_handle: Some(driver_handle),
-            driver_error: None,
-        }
-    }
-}
-
-impl Stream for DriverStream {
-    type Item = Result<RecordBatch, DataFusionError>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        if let Some(handle) = this.driver_handle.as_mut() {
-            match Future::poll(Pin::new(handle), cx) {
-                Poll::Ready(Ok(())) => {
-                    this.driver_handle = None;
-                }
-                Poll::Ready(Err(err)) => {
-                    this.driver_handle = None;
-                    if err.is_panic() {
-                        this.driver_error = Some(DataFusionError::Execution(format!(
-                            "Query driver task panicked: {err}"
-                        )));
-                    } else if !err.is_cancelled() {
-                        this.driver_error = Some(DataFusionError::Execution(format!(
-                            "Query driver task failed: {err}"
-                        )));
-                    }
-                }
-                Poll::Pending => {}
-            }
-        }
-
-        if let Some(err) = this.driver_error.take() {
-            return Poll::Ready(Some(Err(err)));
-        }
-
-        Pin::new(&mut this.receiver).poll_next(cx)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.receiver.size_hint()
-    }
-}
-
-impl Drop for DriverStream {
-    fn drop(&mut self) {
-        if let Some(handle) = self.driver_handle.take()
-            && !handle.is_finished()
-        {
-            handle.abort();
-        }
-    }
 }
 
 #[must_use]

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -63,7 +63,7 @@ use {
 use datafusion::execution::SessionState;
 
 use async_stream::stream;
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 
 use super::{SPICE_RUNTIME_SCHEMA, error::find_datafusion_root};
 
@@ -74,7 +74,7 @@ use opentelemetry::KeyValue;
 use runtime_request_context::{AsyncMarker, RequestContext};
 use tokio::runtime::Handle;
 
-use super::{SPICE_RUNTIME_SCHEMA, error::find_datafusion_root, managed_runtime};
+use super::managed_runtime;
 use managed_runtime::ManagedRuntimeError;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -154,6 +154,7 @@ pub async fn create_internal_accelerated_table(
         accelerated_table_provider,
         refresh,
     );
+    builder.tokio_runtime(runtime.datafusion().tokio_runtime().cloned());
 
     builder.retention(retention);
 

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -120,6 +120,7 @@ async fn create_refresh_task(
             accelerated_table.get_accelerator(),
             None,
         )
+        .with_tokio_runtime(rt.datafusion().tokio_runtime().cloned())
         .build(),
         accelerated_table.refresh_params().read().await.clone(),
     ))

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -351,9 +351,13 @@ pub async fn create_synced_internal_accelerated_table(
     runtime: Arc<Runtime>,
 ) -> Result<Arc<AcceleratedTable>, Error> {
     let ctx = Arc::clone(&runtime.datafusion().ctx);
-    let source_table_provider =
-        get_spiceai_table_provider(table_reference.table(), from, Arc::clone(&secrets), runtime)
-            .await?;
+    let source_table_provider = get_spiceai_table_provider(
+        table_reference.table(),
+        from,
+        Arc::clone(&secrets),
+        Arc::clone(&runtime),
+    )
+    .await?;
     let federated_table = Arc::new(FederatedTable::new_unchecked(source_table_provider));
 
     let accelerated_table_provider = accelerator_engine_registry
@@ -377,6 +381,7 @@ pub async fn create_synced_internal_accelerated_table(
         accelerated_table_provider,
         refresh,
     );
+    builder.tokio_runtime(runtime.datafusion().tokio_runtime().cloned());
 
     builder.retention(retention);
 


### PR DESCRIPTION
## 📝 Summary

Acceleration refreshes are now run on the same separate Tokio runtime that queries run on.

- Refactored the core logic for spawning work on the separate runtime and driving it to completion via the logic in `crates/runtime/src/datafusion/managed_runtime.rs`
- Plumb through the new runtime handle in the accelerated table struct and use the new managed runtime machinery to execute the refresh if available.

## 🔗 Related

- Part of #7089
