### PR TITLE
Refresh request context bindings / fix trunk integration tests

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -80,7 +80,7 @@ use datafusion::{
 };
 use datafusion_expr::{LogicalPlanBuilder, UNNAMED_TABLE, ident};
 use datafusion_federation::{FederatedPlanner, FederatedTableProviderAdaptor};
-use runtime_request_context::{AsyncMarker, Protocol, RequestContext};
+use runtime_request_context::{AsyncMarker, RequestContext};
 use spicepod::metric::Metrics;
 use std::collections::HashSet;
 

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -80,6 +80,7 @@ use datafusion::{
 };
 use datafusion_expr::{LogicalPlanBuilder, UNNAMED_TABLE, ident};
 use datafusion_federation::{FederatedPlanner, FederatedTableProviderAdaptor};
+use runtime_request_context::{AsyncMarker, Protocol, RequestContext};
 use spicepod::metric::Metrics;
 use std::collections::HashSet;
 
@@ -706,7 +707,9 @@ impl RefreshTask {
     ) -> Result<StreamingDataUpdate, RetryError<super::Error>> {
         let federated_provider = self.federated.table_provider().await;
 
-        let mut ctx = self.refresh_df_context(Arc::clone(&federated_provider));
+        let mut ctx = self
+            .refresh_df_context(Arc::clone(&federated_provider))
+            .await;
         let dataset_name = self.dataset_name.clone();
 
         let update_type = match refresh.mode {
@@ -754,7 +757,10 @@ impl RefreshTask {
         )
     }
 
-    fn refresh_df_context(&self, federated_provider: Arc<dyn TableProvider>) -> SessionContext {
+    async fn refresh_df_context(
+        &self,
+        federated_provider: Arc<dyn TableProvider>,
+    ) -> SessionContext {
         let state_builder = SessionStateBuilder::new()
             .with_config(get_df_default_config())
             .with_runtime_env(default_runtime_env())
@@ -782,6 +788,10 @@ impl RefreshTask {
             .with_optimizer_rule(Arc::new(IndexTableScanOptimizerRule::new()))
             .with_analyzer_rules(analyzer_rules_builder.build())
             .build();
+
+        state
+            .config_mut()
+            .set_extension(RequestContext::current(AsyncMarker::new().await));
 
         if let Err(e) = datafusion_functions_json::register_all(&mut state) {
             tracing::error!("Unable to register JSON functions: {e}");
@@ -838,7 +848,9 @@ impl RefreshTask {
 
         let existing_records = accelerator_df(
             &Arc::clone(&self.accelerator),
-            &self.refresh_df_context(Arc::clone(&federated_provider)),
+            &self
+                .refresh_df_context(Arc::clone(&federated_provider))
+                .await,
         )
         .map_err(find_datafusion_root)
         .context(super::UnableToScanTableProviderSnafu)?
@@ -874,7 +886,7 @@ impl RefreshTask {
         refresh: &Refresh,
     ) -> super::Result<Option<u128>> {
         let federated = self.federated.table_provider().await;
-        let ctx = self.refresh_df_context(federated);
+        let ctx = self.refresh_df_context(federated).await;
 
         refresh
             .validate_time_format(self.dataset_name.to_string(), &self.accelerator.schema())

--- a/crates/runtime/src/accelerated_table/refresh_task/streaming_append.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/streaming_append.rs
@@ -91,7 +91,7 @@ impl RefreshTask {
     ) -> impl Stream<Item = crate::accelerated_table::Result<(Option<SystemTime>, DataUpdate)>>
     {
         let federated = self.federated.table_provider().await;
-        let ctx = self.refresh_df_context(Arc::clone(&federated));
+        let ctx = self.refresh_df_context(Arc::clone(&federated)).await;
         let dataset_name = self.dataset_name.clone();
 
         stream! {

--- a/crates/runtime/tests/acceleration/refresh/common.rs
+++ b/crates/runtime/tests/acceleration/refresh/common.rs
@@ -1,7 +1,7 @@
-use crate::configure_test_datafusion;
 use crate::postgres::common;
 use crate::postgres::common::get_pg_params;
 use crate::utils::runtime_ready_check;
+use crate::{configure_test_datafusion, configure_test_datafusion_request_context};
 use app::AppBuilder;
 use arrow::array::RecordBatch;
 use datafusion::common::TableReference;
@@ -119,6 +119,7 @@ pub(crate) async fn start_test_runtime(
         .build();
 
     configure_test_datafusion();
+    configure_test_datafusion_request_context();
 
     let rt = Arc::new(Runtime::builder().with_app(app).build().await);
     let cloned_rt = Arc::clone(&rt);

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -13,13 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 use arrow::{array::RecordBatch, util::display::FormatOptions};
 use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use futures::TryStreamExt;
+use std::sync::Arc;
 
+use crate::utils::TEST_REQUEST_CONTEXT;
 use runtime::Runtime;
 use runtime::datafusion::builder::DEFAULT_DATAFUSION_CONFIG;
+use runtime_request_context::RequestContext;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::EnvFilter;
 
@@ -119,6 +121,13 @@ fn configure_test_datafusion() {
 
             config.options_mut().optimizer.repartition_joins = false;
         }
+        _ => panic!("Must obtain write lock to defaults"),
+    }
+}
+
+fn configure_test_datafusion_request_context() {
+    match DEFAULT_DATAFUSION_CONFIG.write() {
+        Ok(mut config) => config.set_extension(Arc::clone(&TEST_REQUEST_CONTEXT)),
         _ => panic!("Must obtain write lock to defaults"),
     }
 }

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use crate::utils::TEST_REQUEST_CONTEXT;
 use runtime::Runtime;
 use runtime::datafusion::builder::DEFAULT_DATAFUSION_CONFIG;
-use runtime_request_context::RequestContext;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::EnvFilter;
 


### PR DESCRIPTION
## 📝 Summary

- `RefreshTask::refresh_df_context()` -> async, bind the request context
- Await on usages

