### PR TITLE
Fix integration tests for refresh append

### DIFF
--- a/crates/runtime/tests/acceleration/refresh/common.rs
+++ b/crates/runtime/tests/acceleration/refresh/common.rs
@@ -19,7 +19,7 @@ pub(crate) fn get_acceleration_config_append(
     engine: &str,
     acceleration_params: Option<Params>,
 ) -> Acceleration {
-    Acceleration {
+    let mut acceleration = Acceleration {
         enabled: true,
         params: acceleration_params,
         engine: Some(engine.to_string()),
@@ -28,17 +28,24 @@ pub(crate) fn get_acceleration_config_append(
             "select * from test_table where created_at > now() - INTERVAL '10 years'".to_string(),
         ),
         refresh_check_interval: Some("5h".to_string()),
-        primary_key: Some("id".to_string()),
-        on_conflict: [("id".to_string(), OnConflictBehavior::Upsert)]
-            .iter()
-            .cloned()
-            .collect::<HashMap<String, OnConflictBehavior>>(),
-        indexes: [("id".to_string(), IndexType::Unique)]
-            .iter()
-            .cloned()
-            .collect::<HashMap<String, IndexType>>(),
         ..Acceleration::default()
+    };
+
+    // Arrow engine doesn't support indexes, primary_key, or on_conflict
+    // Only add these for engines that support them (duckdb, sqlite, postgres)
+    if engine != "arrow" {
+        acceleration.primary_key = Some("id".to_string());
+        acceleration.on_conflict = [("id".to_string(), OnConflictBehavior::Upsert)]
+            .iter()
+            .cloned()
+            .collect::<HashMap<String, OnConflictBehavior>>();
+        acceleration.indexes = [("id".to_string(), IndexType::Unique)]
+            .iter()
+            .cloned()
+            .collect::<HashMap<String, IndexType>>();
     }
+
+    acceleration
 }
 
 pub(crate) fn get_acceleration_config_full(

--- a/crates/runtime/tests/acceleration/refresh/refresh_modes.rs
+++ b/crates/runtime/tests/acceleration/refresh/refresh_modes.rs
@@ -24,9 +24,27 @@ use crate::acceleration::refresh::common::{
     initialize_postgres, refresh_table, start_test_runtime,
 };
 use crate::postgres::common;
-use crate::postgres::common::get_random_port;
+use crate::postgres::common::{PG_PASSWORD, get_random_port};
 use crate::{init_tracing, utils::test_request_context};
+use spicepod::param::Params;
+use std::collections::HashMap;
 use std::sync::Arc;
+
+/// Get acceleration parameters for postgres engine
+fn get_postgres_acceleration_params(port: usize) -> Params {
+    let acceleration_params: HashMap<String, String> = [
+        ("pg_host".to_string(), "localhost".to_string()),
+        ("pg_user".to_string(), "postgres".to_string()),
+        ("pg_pass".to_string(), PG_PASSWORD.to_string()),
+        ("pg_db".to_string(), "acceleration".to_string()),
+        ("pg_sslmode".to_string(), "disable".to_string()),
+        ("pg_port".to_string(), port.to_string()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+    Params::from_string_map(acceleration_params)
+}
 
 /// Helper function to test append mode for a given engine
 async fn test_refresh_append_for_engine(engine: &str) -> Result<(), anyhow::Error> {
@@ -36,7 +54,15 @@ async fn test_refresh_append_for_engine(engine: &str) -> Result<(), anyhow::Erro
             let running_container = common::start_postgres_docker_container(port).await?;
 
             let db_conn = initialize_postgres(port).await?;
-            let acceleration_config = get_acceleration_config_append(engine, None);
+
+            // Postgres acceleration requires connection parameters
+            let acceleration_params = if engine == "postgres" {
+                Some(get_postgres_acceleration_params(port))
+            } else {
+                None
+            };
+
+            let acceleration_config = get_acceleration_config_append(engine, acceleration_params);
             let rt = start_test_runtime(port, acceleration_config).await?;
 
             // Initial state: 1 row
@@ -85,7 +111,15 @@ async fn test_refresh_full_for_engine(engine: &str) -> Result<(), anyhow::Error>
             let running_container = common::start_postgres_docker_container(port).await?;
 
             let db_conn = initialize_postgres(port).await?;
-            let acceleration_config = get_acceleration_config_full(engine, None);
+
+            // Postgres acceleration requires connection parameters
+            let acceleration_params = if engine == "postgres" {
+                Some(get_postgres_acceleration_params(port))
+            } else {
+                None
+            };
+
+            let acceleration_config = get_acceleration_config_full(engine, acceleration_params);
             let rt = start_test_runtime(port, acceleration_config).await?;
 
             // Initial state: 1 row

--- a/crates/runtime/tests/acceleration/refresh/refresh_modes.rs
+++ b/crates/runtime/tests/acceleration/refresh/refresh_modes.rs
@@ -20,7 +20,7 @@ limitations under the License.
 //! refresh modes using a helper function with variants for each engine.
 
 use crate::acceleration::refresh::common::{
-    execute_ps_sql, get_acceleration_config_append, get_acceleration_config_full,
+    execute_ps_sql, execute_rt_sql, get_acceleration_config_append, get_acceleration_config_full,
     initialize_postgres, refresh_table, start_test_runtime,
 };
 use crate::postgres::common;
@@ -40,8 +40,7 @@ async fn test_refresh_append_for_engine(engine: &str) -> Result<(), anyhow::Erro
             let rt = start_test_runtime(port, acceleration_config).await?;
 
             // Initial state: 1 row
-            let df = rt.datafusion().ctx.table("test_table").await?;
-            let results = df.collect().await?;
+            let results = execute_rt_sql(Arc::clone(&rt), "SELECT * FROM test_table").await?;
             let initial_count: usize = results
                 .iter()
                 .map(arrow::array::RecordBatch::num_rows)
@@ -62,8 +61,7 @@ async fn test_refresh_append_for_engine(engine: &str) -> Result<(), anyhow::Erro
             refresh_table(Arc::clone(&rt), "test_table").await?;
 
             // After refresh: 2 rows (append mode keeps old + adds new)
-            let df = rt.datafusion().ctx.table("test_table").await?;
-            let results = df.collect().await?;
+            let results = execute_rt_sql(Arc::clone(&rt), "SELECT * FROM test_table").await?;
             let final_count: usize = results
                 .iter()
                 .map(arrow::array::RecordBatch::num_rows)
@@ -91,8 +89,7 @@ async fn test_refresh_full_for_engine(engine: &str) -> Result<(), anyhow::Error>
             let rt = start_test_runtime(port, acceleration_config).await?;
 
             // Initial state: 1 row
-            let df = rt.datafusion().ctx.table("test_table").await?;
-            let results = df.collect().await?;
+            let results = execute_rt_sql(Arc::clone(&rt), "SELECT * FROM test_table").await?;
             let initial_count: usize = results
                 .iter()
                 .map(arrow::array::RecordBatch::num_rows)
@@ -113,8 +110,7 @@ async fn test_refresh_full_for_engine(engine: &str) -> Result<(), anyhow::Error>
             refresh_table(Arc::clone(&rt), "test_table").await?;
 
             // After refresh: 2 rows (full mode replaces with current source)
-            let df = rt.datafusion().ctx.table("test_table").await?;
-            let results = df.collect().await?;
+            let results = execute_rt_sql(Arc::clone(&rt), "SELECT * FROM test_table").await?;
             let final_count: usize = results
                 .iter()
                 .map(arrow::array::RecordBatch::num_rows)

--- a/crates/runtime/tests/acceleration/refresh/refresh_postgres.rs
+++ b/crates/runtime/tests/acceleration/refresh/refresh_postgres.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 #[tokio::test]
-async fn test_acceleration_refresh_duckdb_append() -> Result<(), anyhow::Error> {
+async fn test_acceleration_refresh_postgres_append() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
     test_request_context()
@@ -83,7 +83,7 @@ async fn test_acceleration_refresh_duckdb_append() -> Result<(), anyhow::Error> 
 }
 
 #[tokio::test]
-async fn test_acceleration_refresh_duckdb_full() -> Result<(), anyhow::Error> {
+async fn test_acceleration_refresh_postgres_full() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
     test_request_context()

--- a/crates/runtime/tests/acceleration/refresh/refresh_sqlite.rs
+++ b/crates/runtime/tests/acceleration/refresh/refresh_sqlite.rs
@@ -23,7 +23,7 @@ use crate::{init_tracing, utils::test_request_context};
 use std::sync::Arc;
 
 #[tokio::test]
-async fn test_acceleration_refresh_duckdb_append() -> Result<(), anyhow::Error> {
+async fn test_acceleration_refresh_sqlite_append() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
     test_request_context()
@@ -67,7 +67,7 @@ async fn test_acceleration_refresh_duckdb_append() -> Result<(), anyhow::Error> 
 }
 
 #[tokio::test]
-async fn test_acceleration_refresh_duckdb_full() -> Result<(), anyhow::Error> {
+async fn test_acceleration_refresh_sqlite_full() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 
     test_request_context()


### PR DESCRIPTION
This pull request refactors the test utilities and test cases for acceleration refresh logic across different database engines. The main focus is on improving engine-specific configuration handling, especially for Postgres, and on clarifying test coverage by renaming test functions to match their respective engines. Additionally, the code for executing SQL in tests is simplified for consistency.

**Engine-specific configuration and test improvements:**

* Added a helper function `get_postgres_acceleration_params` to generate connection parameters for the Postgres engine, ensuring proper configuration for Postgres acceleration tests.
* Updated `get_acceleration_config_append` to only set index-related fields for engines that support them (DuckDB, SQLite, Postgres), avoiding unsupported configuration for the Arrow engine. [[1]](diffhunk://#diff-a13ea544ce88e0b694e571743b6b313b0db2132ad1269c558acdfcf2e6a45385L22-R22) [[2]](diffhunk://#diff-a13ea544ce88e0b694e571743b6b313b0db2132ad1269c558acdfcf2e6a45385L31-R48)

**Test logic and naming consistency:**

* Renamed test functions in `refresh_postgres.rs` and `refresh_sqlite.rs` to correctly reflect the engine being tested (e.g., `test_acceleration_refresh_postgres_append` and `test_acceleration_refresh_sqlite_append`). [[1]](diffhunk://#diff-e7a2ae7875f2ed4e92277b7788bea418562de9c7c34954c4669d330f5b0ab92cL28-R28) [[2]](diffhunk://#diff-e7a2ae7875f2ed4e92277b7788bea418562de9c7c34954c4669d330f5b0ab92cL86-R86) [[3]](diffhunk://#diff-ca9a0fa7b48f152b4783ab1c4581e97dd269fb3f7561904952469236f9333205L26-R26) [[4]](diffhunk://#diff-ca9a0fa7b48f152b4783ab1c4581e97dd269fb3f7561904952469236f9333205L70-R70)

**Test execution simplification:**

* Replaced direct DataFusion table access and manual result collection in refresh tests with the unified `execute_rt_sql` helper for executing SQL queries, streamlining test code and improving readability. [[1]](diffhunk://#diff-2a54a088392a9ebdc063d294b77fcef563d89d74bfb3e726781382901f9994edL39-R69) [[2]](diffhunk://#diff-2a54a088392a9ebdc063d294b77fcef563d89d74bfb3e726781382901f9994edL65-R90) [[3]](diffhunk://#diff-2a54a088392a9ebdc063d294b77fcef563d89d74bfb3e726781382901f9994edL90-R126) [[4]](diffhunk://#diff-2a54a088392a9ebdc063d294b77fcef563d89d74bfb3e726781382901f9994edL116-R147)