### PR TITLE
Spawn `object_store` IO tasks on the original Tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ mailparse = "0.15.0"
 moka = { version = "0.12", features = ["future"] }
 mongodb = { version = "3.3.0", features = ["openssl-tls"] }
 mysql_async = { version = "0.35.1", features = ["native-tls-tls", "chrono"] }
-object_store = { version = "0.12", features = ["aws", "gcp", "azure"] }
+object_store = { version = "0.12", features = ["aws", "gcp", "azure", "http"] }
 odbc-api = { version = "13" }
 opentelemetry = { version = "0.27", default-features = false, features = [
     "metrics",

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -235,7 +235,8 @@ pub async fn run(args: Args) -> Result<()> {
         )]))
         .with_datasets_health_monitor()
         .with_metrics_server_opt(args.metrics, prometheus_registry.clone())
-        .with_runtime_config(args.runtime.clone());
+        .with_runtime_config(args.runtime.clone())
+        .with_io_runtime(Handle::current());
 
     if args.pods_watcher_enabled && args.spicepod.is_none() {
         let pods_watcher = PodsWatcher::new(spicepod_path.clone());

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -42,6 +42,7 @@ use serde_yaml::Value;
 use snafu::prelude::*;
 use spice_cloud::SpiceExtensionFactory;
 use spiced_tracing::LogVerbosity;
+use tokio::runtime::Handle;
 #[cfg(feature = "tpc-extension")]
 use tpc_extension::TpcExtensionFactory;
 use util::in_tracing_context;
@@ -264,7 +265,7 @@ pub async fn run(args: Args) -> Result<()> {
         .boxed()
         .context(UnableToInitializeDatafusionTokioRuntimeSnafu)?;
 
-    rt.datafusion().set_tokio_runtime(tokio_runtime);
+    rt.datafusion().set_cpu_runtime(tokio_runtime);
 
     if let Some(metrics_registry) = prometheus_registry {
         init_metrics(&rt.datafusion(), metrics_registry).context(UnableToInitializeMetricsSnafu)?;

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -124,6 +124,7 @@ pub fn from_s3_url_and_config(
     url: &url::Url,
     region: Option<String>,
     sdk_config: &SdkConfig,
+    io_runtime: Handle,
 ) -> Result<Box<dyn ObjectStore>> {
     if url.scheme() != "s3" {
         return Err(Error::NotAnS3Url {
@@ -135,7 +136,7 @@ pub fn from_s3_url_and_config(
     let mut builder = AmazonS3Builder::from_env().with_bucket_name(bucket_name);
     let credential_provider = S3CredentialProvider::from_config(sdk_config)?;
 
-    builder = builder.with_http_connector(SpawnedReqwestConnector::new(Handle::current()));
+    builder = builder.with_http_connector(SpawnedReqwestConnector::new(io_runtime));
 
     if let Some(region) = region.or(sdk_config.region().map(ToString::to_string)) {
         builder = builder.with_region(region);

--- a/crates/aws-sdk-credential-bridge/src/lib.rs
+++ b/crates/aws-sdk-credential-bridge/src/lib.rs
@@ -16,13 +16,13 @@ limitations under the License.
 
 mod credential_provider;
 use std::sync::Arc;
-use tokio::sync::OnceCell;
+use tokio::{runtime::Handle, sync::OnceCell};
 
 use aws_config::{BehaviorVersion, SdkConfig};
 use aws_sdk_s3::config::ProvideCredentials;
 use aws_smithy_runtime_api::client::runtime_components::BuildError;
 pub use credential_provider::S3CredentialProvider;
-use object_store::{ObjectStore, aws::AmazonS3Builder};
+use object_store::{ObjectStore, aws::AmazonS3Builder, client::SpawnedReqwestConnector};
 use url::Url;
 
 #[derive(Debug, snafu::Snafu)]
@@ -98,7 +98,9 @@ pub async fn from_s3_url(url: &url::Url, region: Option<String>) -> Result<Box<d
     }
 
     let bucket_name = get_bucket_name(url)?;
-    let mut builder = AmazonS3Builder::from_env().with_bucket_name(bucket_name);
+    let mut builder = AmazonS3Builder::from_env()
+        .with_bucket_name(bucket_name)
+        .with_http_connector(SpawnedReqwestConnector::new(Handle::current()));
     let (credential_provider, config) = S3CredentialProvider::from_env().await?;
 
     if let Some(region) = region.or(config.region().map(ToString::to_string)) {
@@ -132,6 +134,8 @@ pub fn from_s3_url_and_config(
     let bucket_name = get_bucket_name(url)?;
     let mut builder = AmazonS3Builder::from_env().with_bucket_name(bucket_name);
     let credential_provider = S3CredentialProvider::from_config(sdk_config)?;
+
+    builder = builder.with_http_connector(SpawnedReqwestConnector::new(Handle::current()));
 
     if let Some(region) = region.or(sdk_config.region().map(ToString::to_string)) {
         builder = builder.with_region(region);

--- a/crates/data_components/src/databricks/delta.rs
+++ b/crates/data_components/src/databricks/delta.rs
@@ -24,12 +24,14 @@ use secrecy::SecretString;
 use snafu::prelude::*;
 use std::{collections::HashMap, sync::Arc};
 use token_provider::TokenProvider;
+use tokio::runtime::Handle;
 
 #[derive(Clone)]
 pub struct DatabricksDelta {
     endpoint: Endpoint,
     token_provider: Arc<dyn TokenProvider>,
     storage_options: HashMap<String, SecretString>,
+    io_runtime: Handle,
 }
 
 #[derive(Debug, Snafu)]
@@ -49,11 +51,13 @@ impl DatabricksDelta {
         endpoint: Endpoint,
         storage_options: HashMap<String, SecretString>,
         token_provider: Arc<dyn TokenProvider>,
+        io_runtime: Handle,
     ) -> Self {
         Self {
             endpoint,
             token_provider,
             storage_options,
+            io_runtime,
         }
     }
 
@@ -76,7 +80,7 @@ impl DatabricksDelta {
             }
         }
 
-        let delta_table = DeltaTable::from(table_uri, storage_options)?;
+        let delta_table = DeltaTable::from(table_uri, storage_options, self.io_runtime.clone())?;
 
         Ok(Arc::new(delta_table) as Arc<dyn TableProvider>)
     }

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -41,7 +41,7 @@ use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::TableReference;
 use delta_kernel::engine::default::DefaultEngine;
-use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
+use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
 use delta_kernel::expressions::{BinaryExpressionOp, DecimalData, Expression, Scalar};
 use delta_kernel::scan::ScanBuilder;
 use delta_kernel::scan::state::{DvInfo, Stats};
@@ -112,7 +112,7 @@ impl Read for DeltaTableFactory {
 #[derive(Debug)]
 pub struct DeltaTable {
     table_url: Url,
-    engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>,
+    engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
     arrow_schema: SchemaRef,
     delta_schema: delta_kernel::schema::SchemaRef,
 }
@@ -154,10 +154,7 @@ impl DeltaTable {
             (true, Some(sdk_config)) => {
                 let region = storage_options.get("aws_region").map(ToString::to_string);
                 aws_sdk_credential_bridge::from_s3_url_and_config(
-                    &table_url,
-                    region,
-                    sdk_config,
-                    io_runtime.clone(),
+                    &table_url, region, sdk_config, io_runtime,
                 )
                 .ok()
             }
@@ -167,13 +164,13 @@ impl DeltaTable {
         let engine = match table_object_store {
             Some(object_store) => Arc::new(DefaultEngine::new(
                 object_store.into(),
-                Arc::new(TokioMultiThreadExecutor::new(io_runtime)),
+                Arc::new(TokioBackgroundExecutor::default()),
             )),
             None => Arc::new(
                 DefaultEngine::try_new(
                     &table_url,
                     storage_options,
-                    Arc::new(TokioMultiThreadExecutor::new(io_runtime)),
+                    Arc::new(TokioBackgroundExecutor::default()),
                 )
                 .map_err(handle_delta_error)?,
             ),
@@ -557,13 +554,13 @@ impl TableProvider for DeltaTable {
 
 struct ScanContext {
     pub errs: Vec<datafusion::error::DataFusionError>,
-    engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>,
+    engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
     pub files: Vec<PartitionFileContext>,
     table_root: Url,
 }
 
 impl ScanContext {
-    fn new(engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>, table_root: Url) -> Self {
+    fn new(engine: Arc<DefaultEngine<TokioBackgroundExecutor>>, table_root: Url) -> Self {
         Self {
             engine,
             errs: Vec::new(),

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -41,7 +41,7 @@ use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
 use datafusion::scalar::ScalarValue;
 use datafusion::sql::TableReference;
 use delta_kernel::engine::default::DefaultEngine;
-use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+use delta_kernel::engine::default::executor::tokio::TokioMultiThreadExecutor;
 use delta_kernel::expressions::{BinaryExpressionOp, DecimalData, Expression, Scalar};
 use delta_kernel::scan::ScanBuilder;
 use delta_kernel::scan::state::{DvInfo, Stats};
@@ -54,6 +54,7 @@ use pruning::{can_be_evaluted_for_partition_pruning, prune_partitions};
 use secrecy::{ExposeSecret, SecretString};
 use snafu::prelude::*;
 use std::{collections::HashMap, sync::Arc};
+use tokio::runtime::Handle;
 use url::Url;
 
 use crate::Read;
@@ -77,6 +78,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct DeltaTableFactory {
     params: HashMap<String, SecretString>,
+    io_runtime: Handle,
 }
 
 impl std::fmt::Debug for DeltaTableFactory {
@@ -89,8 +91,8 @@ impl std::fmt::Debug for DeltaTableFactory {
 
 impl DeltaTableFactory {
     #[must_use]
-    pub fn new(params: HashMap<String, SecretString>) -> Self {
-        Self { params }
+    pub fn new(params: HashMap<String, SecretString>, io_runtime: Handle) -> Self {
+        Self { params, io_runtime }
     }
 }
 
@@ -101,7 +103,8 @@ impl Read for DeltaTableFactory {
         table_reference: TableReference,
     ) -> Result<Arc<dyn TableProvider + 'static>, Box<dyn std::error::Error + Send + Sync>> {
         let delta_path = table_reference.table().to_string();
-        let delta: DeltaTable = DeltaTable::from(delta_path, self.params.clone()).boxed()?;
+        let delta: DeltaTable =
+            DeltaTable::from(delta_path, self.params.clone(), self.io_runtime.clone()).boxed()?;
         Ok(Arc::new(delta))
     }
 }
@@ -109,13 +112,17 @@ impl Read for DeltaTableFactory {
 #[derive(Debug)]
 pub struct DeltaTable {
     table_url: Url,
-    engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
+    engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>,
     arrow_schema: SchemaRef,
     delta_schema: delta_kernel::schema::SchemaRef,
 }
 
 impl DeltaTable {
-    pub fn from(table_location: String, options: HashMap<String, SecretString>) -> Result<Self> {
+    pub fn from(
+        table_location: String,
+        options: HashMap<String, SecretString>,
+        io_runtime: Handle,
+    ) -> Result<Self> {
         let table_url = delta_kernel::try_parse_uri(ensure_folder_location(table_location))
             .map_err(handle_delta_error)?;
 
@@ -146,8 +153,13 @@ impl DeltaTable {
         ) {
             (true, Some(sdk_config)) => {
                 let region = storage_options.get("aws_region").map(ToString::to_string);
-                aws_sdk_credential_bridge::from_s3_url_and_config(&table_url, region, sdk_config)
-                    .ok()
+                aws_sdk_credential_bridge::from_s3_url_and_config(
+                    &table_url,
+                    region,
+                    sdk_config,
+                    io_runtime.clone(),
+                )
+                .ok()
             }
             _ => None,
         };
@@ -155,13 +167,13 @@ impl DeltaTable {
         let engine = match table_object_store {
             Some(object_store) => Arc::new(DefaultEngine::new(
                 object_store.into(),
-                Arc::new(TokioBackgroundExecutor::new()),
+                Arc::new(TokioMultiThreadExecutor::new(io_runtime)),
             )),
             None => Arc::new(
                 DefaultEngine::try_new(
                     &table_url,
                     storage_options,
-                    Arc::new(TokioBackgroundExecutor::new()),
+                    Arc::new(TokioMultiThreadExecutor::new(io_runtime)),
                 )
                 .map_err(handle_delta_error)?,
             ),
@@ -545,13 +557,13 @@ impl TableProvider for DeltaTable {
 
 struct ScanContext {
     pub errs: Vec<datafusion::error::DataFusionError>,
-    engine: Arc<DefaultEngine<TokioBackgroundExecutor>>,
+    engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>,
     pub files: Vec<PartitionFileContext>,
     table_root: Url,
 }
 
 impl ScanContext {
-    fn new(engine: Arc<DefaultEngine<TokioBackgroundExecutor>>, table_root: Url) -> Self {
+    fn new(engine: Arc<DefaultEngine<TokioMultiThreadExecutor>>, table_root: Url) -> Self {
         Self {
             engine,
             errs: Vec::new(),

--- a/crates/runtime-acceleration/src/snapshot/behavior.rs
+++ b/crates/runtime-acceleration/src/snapshot/behavior.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Weak};
 use runtime_secrets::Secrets;
 use spicepod::acceleration as spicepod_acceleration;
 use spicepod::component::snapshot::Snapshots;
+use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
 #[cfg(feature = "snapshots")]
@@ -30,22 +31,25 @@ pub enum SnapshotBehavior {
     #[default]
     Disabled,
     /// Enable both creating and bootstrapping from snapshots.
-    Enabled(Arc<Snapshots>, Weak<RwLock<Secrets>>),
+    Enabled(Arc<Snapshots>, Weak<RwLock<Secrets>>, Handle),
     /// Only bootstrap from existing snapshots, don't attempt to create new ones.
-    BootstrapOnly(Arc<Snapshots>, Weak<RwLock<Secrets>>),
+    BootstrapOnly(Arc<Snapshots>, Weak<RwLock<Secrets>>, Handle),
     /// Only create new snapshots.
-    CreateOnly(Arc<Snapshots>, Weak<RwLock<Secrets>>),
+    CreateOnly(Arc<Snapshots>, Weak<RwLock<Secrets>>, Handle),
 }
 
 impl PartialEq for SnapshotBehavior {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (SnapshotBehavior::Disabled, SnapshotBehavior::Disabled) => true,
-            (SnapshotBehavior::Enabled(snap1, _), SnapshotBehavior::Enabled(snap2, _))
-            | (SnapshotBehavior::CreateOnly(snap1, _), SnapshotBehavior::CreateOnly(snap2, _))
+            (SnapshotBehavior::Enabled(snap1, _, _), SnapshotBehavior::Enabled(snap2, _, _))
             | (
-                SnapshotBehavior::BootstrapOnly(snap1, _),
-                SnapshotBehavior::BootstrapOnly(snap2, _),
+                SnapshotBehavior::CreateOnly(snap1, _, _),
+                SnapshotBehavior::CreateOnly(snap2, _, _),
+            )
+            | (
+                SnapshotBehavior::BootstrapOnly(snap1, _, _),
+                SnapshotBehavior::BootstrapOnly(snap2, _, _),
             ) => snap1 == snap2,
             _ => false,
         }
@@ -59,7 +63,11 @@ impl SnapshotBehavior {
     }
 
     #[must_use]
-    pub fn enabled(snapshots: Arc<Snapshots>, secrets: Weak<RwLock<Secrets>>) -> Self {
+    pub fn enabled(
+        snapshots: Arc<Snapshots>,
+        secrets: Weak<RwLock<Secrets>>,
+        io_runtime: Handle,
+    ) -> Self {
         // Snapshot support must be compiled in for bootstrapping to be possible.
         if !SNAPSHOTS_ENABLED {
             tracing::trace!(
@@ -72,11 +80,15 @@ impl SnapshotBehavior {
             return SnapshotBehavior::Disabled;
         }
 
-        SnapshotBehavior::Enabled(snapshots, secrets)
+        SnapshotBehavior::Enabled(snapshots, secrets, io_runtime)
     }
 
     #[must_use]
-    pub fn bootstrap_only(snapshots: Arc<Snapshots>, secrets: Weak<RwLock<Secrets>>) -> Self {
+    pub fn bootstrap_only(
+        snapshots: Arc<Snapshots>,
+        secrets: Weak<RwLock<Secrets>>,
+        io_runtime: Handle,
+    ) -> Self {
         // Snapshot support must be compiled in for bootstrapping to be possible.
         if !SNAPSHOTS_ENABLED {
             tracing::trace!(
@@ -89,11 +101,15 @@ impl SnapshotBehavior {
             return SnapshotBehavior::Disabled;
         }
 
-        SnapshotBehavior::BootstrapOnly(snapshots, secrets)
+        SnapshotBehavior::BootstrapOnly(snapshots, secrets, io_runtime)
     }
 
     #[must_use]
-    pub fn create_only(snapshots: Arc<Snapshots>, secrets: Weak<RwLock<Secrets>>) -> Self {
+    pub fn create_only(
+        snapshots: Arc<Snapshots>,
+        secrets: Weak<RwLock<Secrets>>,
+        io_runtime: Handle,
+    ) -> Self {
         // Snapshot support must be compiled in for snapshot creation to be possible.
         if !SNAPSHOTS_ENABLED {
             tracing::trace!(
@@ -106,14 +122,14 @@ impl SnapshotBehavior {
             return SnapshotBehavior::Disabled;
         }
 
-        SnapshotBehavior::CreateOnly(snapshots, secrets)
+        SnapshotBehavior::CreateOnly(snapshots, secrets, io_runtime)
     }
 
     #[must_use]
     pub fn bootstrap_enabled(&self) -> bool {
         matches!(
             self,
-            SnapshotBehavior::Enabled(_, _) | SnapshotBehavior::BootstrapOnly(_, _)
+            SnapshotBehavior::Enabled(_, _, _) | SnapshotBehavior::BootstrapOnly(_, _, _)
         )
     }
 
@@ -121,7 +137,7 @@ impl SnapshotBehavior {
     pub fn create_enabled(&self) -> bool {
         matches!(
             self,
-            SnapshotBehavior::Enabled(_, _) | SnapshotBehavior::CreateOnly(_, _)
+            SnapshotBehavior::Enabled(_, _, _) | SnapshotBehavior::CreateOnly(_, _, _)
         )
     }
 
@@ -130,6 +146,7 @@ impl SnapshotBehavior {
         snapshots: Option<Arc<Snapshots>>,
         snapshot_behavior: spicepod_acceleration::SnapshotBehavior,
         secrets: Weak<RwLock<Secrets>>,
+        io_runtime: Handle,
     ) -> Self {
         // Snapshot support must be compiled in for snapshot creation to be possible.
         if !SNAPSHOTS_ENABLED {
@@ -153,7 +170,7 @@ impl SnapshotBehavior {
                     return SnapshotBehavior::Disabled;
                 }
 
-                SnapshotBehavior::Enabled(snapshots, secrets)
+                SnapshotBehavior::Enabled(snapshots, secrets, io_runtime)
             }
             spicepod_acceleration::SnapshotBehavior::BootstrapOnly => {
                 if !snapshots.enabled {
@@ -163,7 +180,7 @@ impl SnapshotBehavior {
                     return SnapshotBehavior::Disabled;
                 }
 
-                SnapshotBehavior::BootstrapOnly(snapshots, secrets)
+                SnapshotBehavior::BootstrapOnly(snapshots, secrets, io_runtime)
             }
             spicepod_acceleration::SnapshotBehavior::CreateOnly => {
                 if !snapshots.enabled {
@@ -173,7 +190,7 @@ impl SnapshotBehavior {
                     return SnapshotBehavior::Disabled;
                 }
 
-                SnapshotBehavior::CreateOnly(snapshots, secrets)
+                SnapshotBehavior::CreateOnly(snapshots, secrets, io_runtime)
             }
         }
     }

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -506,14 +506,16 @@ impl SnapshotManager {
         snapshots: SnapshotBehavior,
         local_path: PathBuf,
     ) -> Option<Self> {
-        let (snapshot_config, secrets) = match snapshots {
+        let (snapshot_config, secrets, io_runtime) = match snapshots {
             SnapshotBehavior::Disabled => {
                 tracing::debug!("Snapshots are disabled for {dataset_name}");
                 return None;
             }
-            SnapshotBehavior::Enabled(s, secrets)
-            | SnapshotBehavior::BootstrapOnly(s, secrets)
-            | SnapshotBehavior::CreateOnly(s, secrets) => (s, secrets.upgrade()?),
+            SnapshotBehavior::Enabled(s, secrets, io_runtime)
+            | SnapshotBehavior::BootstrapOnly(s, secrets, io_runtime)
+            | SnapshotBehavior::CreateOnly(s, secrets, io_runtime) => {
+                (s, secrets.upgrade()?, io_runtime)
+            }
         };
         tracing::debug!("Snapshots are enabled for {dataset_name}");
 
@@ -544,6 +546,7 @@ impl SnapshotManager {
                     &snapshots_location_url,
                     secrets,
                     snapshot_config.params.as_ref().map(Params::as_string_map),
+                    io_runtime,
                 )
                 .await
                 .inspect_err(|e| {
@@ -1350,6 +1353,7 @@ async fn build_s3_object_store(
     snapshots_url: &Url,
     secrets: Arc<RwLock<Secrets>>,
     params: Option<HashMap<String, String>>,
+    io_runtime: Handle,
 ) -> Result<Box<dyn ObjectStore>, S3ObjectStoreError> {
     let s3_params = build_s3_parameters(Arc::clone(&secrets), params.as_ref()).await;
 
@@ -1366,7 +1370,7 @@ async fn build_s3_object_store(
 
     let mut s3_builder = AmazonS3Builder::from_env()
         .with_bucket_name(bucket_name)
-        .with_http_connector(SpawnedReqwestConnector::new(Handle::current()))
+        .with_http_connector(SpawnedReqwestConnector::new(io_runtime))
         .with_allow_http(allow_http);
     let mut client_options = ClientOptions::default();
 

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -29,7 +29,7 @@ use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use futures::StreamExt;
 use object_store::{
     ClientOptions, ObjectStore, PutMode, PutPayload, UpdateVersion, aws::AmazonS3Builder,
-    path::Path as ObjectPath,
+    client::SpawnedReqwestConnector, path::Path as ObjectPath,
 };
 use runtime_parameters::{ParameterSpec, Parameters};
 use runtime_secrets::{Secrets, get_params_with_secrets};
@@ -41,6 +41,7 @@ use spicepod::{component::snapshot::BootstrapOnFailureBehavior, param::Params};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncWriteExt, BufReader},
+    runtime::Handle,
     sync::RwLock,
 };
 use url::Url;
@@ -1365,6 +1366,7 @@ async fn build_s3_object_store(
 
     let mut s3_builder = AmazonS3Builder::from_env()
         .with_bucket_name(bucket_name)
+        .with_http_connector(SpawnedReqwestConnector::new(Handle::current()))
         .with_allow_http(allow_http);
     let mut client_options = ClientOptions::default();
 

--- a/crates/runtime-object-store/src/registry/mod.rs
+++ b/crates/runtime-object-store/src/registry/mod.rs
@@ -26,8 +26,9 @@ use datafusion::{
 };
 use object_store::{
     ClientOptions, ObjectStore, RetryConfig, aws::AmazonS3Builder, azure::MicrosoftAzureBuilder,
-    http::HttpBuilder,
+    client::SpawnedReqwestConnector, http::HttpBuilder,
 };
+use tokio::runtime::Handle;
 use url::{Url, form_urlencoded::parse};
 
 #[cfg(feature = "ftp")]
@@ -35,18 +36,25 @@ use crate::store::ftp::FTPObjectStore;
 #[cfg(feature = "ftp")]
 use crate::store::sftp::SFTPObjectStore;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SpiceObjectStoreRegistry {
     inner: DefaultObjectStoreRegistry,
+    io_runtime: Handle,
 }
 
 impl SpiceObjectStoreRegistry {
     #[must_use]
-    pub fn new() -> Self {
-        SpiceObjectStoreRegistry::default()
+    pub fn new(io_runtime: Handle) -> Self {
+        Self {
+            inner: DefaultObjectStoreRegistry::new(),
+            io_runtime,
+        }
     }
 
-    fn prepare_s3_object_store(url: &Url) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
+    fn prepare_s3_object_store(
+        &self,
+        url: &Url,
+    ) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
         let Some(bucket_name) = url.host_str() else {
             return Err(DataFusionError::Configuration(
                 "No bucket name provided".to_string(),
@@ -55,6 +63,7 @@ impl SpiceObjectStoreRegistry {
 
         let mut s3_builder = AmazonS3Builder::from_env()
             .with_bucket_name(bucket_name)
+            .with_http_connector(SpawnedReqwestConnector::new(self.io_runtime.clone()))
             .with_allow_http(true);
         let mut client_options = ClientOptions::default();
 
@@ -143,7 +152,10 @@ impl SpiceObjectStoreRegistry {
         Ok(Arc::new(s3_builder.build()?))
     }
 
-    fn prepare_https_object_store(url: &Url) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
+    fn prepare_https_object_store(
+        &self,
+        url: &Url,
+    ) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
         let base_url = if url.scheme() == "https" {
             format!("https://{}/", url.authority())
         } else {
@@ -163,6 +175,7 @@ impl SpiceObjectStoreRegistry {
 
         let builder = HttpBuilder::new()
             .with_url(base_url)
+            .with_http_connector(SpawnedReqwestConnector::new(self.io_runtime.clone()))
             .with_client_options(client_options);
 
         Ok(Arc::new(builder.build()?))
@@ -251,7 +264,10 @@ impl SpiceObjectStoreRegistry {
 
     // Splitting up this function wouldn't make much sense as it's all used to create the ObjectStore
     #[allow(clippy::too_many_lines)]
-    fn prepare_azure_object_store(url: &Url) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
+    fn prepare_azure_object_store(
+        &self,
+        url: &Url,
+    ) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
         let mut url = url.clone();
 
         // Rewrite the URL Scheme
@@ -265,7 +281,9 @@ impl SpiceObjectStoreRegistry {
             .into_owned()
             .collect();
         url.set_fragment(None);
-        let mut builder = MicrosoftAzureBuilder::from_env();
+
+        let mut builder = MicrosoftAzureBuilder::from_env()
+            .with_http_connector(SpawnedReqwestConnector::new(self.io_runtime.clone()));
 
         if let Some(sas) = params.get("sas_string") {
             url.set_query(Some(sas));
@@ -431,16 +449,16 @@ impl SpiceObjectStoreRegistry {
         Ok(azure_store as Arc<dyn ObjectStore>)
     }
 
-    fn get_feature_store(url: &Url) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
+    fn get_feature_store(&self, url: &Url) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
         if url.as_str().starts_with("https://") || url.as_str().starts_with("http://") {
-            return Self::prepare_https_object_store(url);
+            return self.prepare_https_object_store(url);
         }
         if url.as_str().starts_with("s3://") {
-            return Self::prepare_s3_object_store(url);
+            return self.prepare_s3_object_store(url);
         }
 
         if url.as_str().starts_with("abfs://") {
-            return Self::prepare_azure_object_store(url);
+            return self.prepare_azure_object_store(url);
         }
 
         #[cfg(feature = "ftp")]
@@ -470,7 +488,7 @@ impl ObjectStoreRegistry for SpiceObjectStoreRegistry {
 
     fn get_store(&self, url: &Url) -> datafusion::error::Result<Arc<dyn ObjectStore>> {
         self.inner.get_store(url).or_else(|_| {
-            let store = Self::get_feature_store(url)?;
+            let store = self.get_feature_store(url)?;
             self.inner.register_store(url, Arc::clone(&store));
 
             Ok(store)
@@ -481,9 +499,9 @@ impl ObjectStoreRegistry for SpiceObjectStoreRegistry {
 // This method uses unwrap_or_default, however it should never fail on the initialization. See
 // RuntimeEnv::default()
 #[must_use]
-pub fn default_runtime_env() -> Arc<RuntimeEnv> {
+pub fn default_runtime_env(io_runtime: Handle) -> Arc<RuntimeEnv> {
     match RuntimeEnvBuilder::default()
-        .with_object_store_registry(Arc::new(SpiceObjectStoreRegistry::default()))
+        .with_object_store_registry(Arc::new(SpiceObjectStoreRegistry::new(io_runtime)))
         .build_arc()
     {
         Ok(runtime_env) => runtime_env,
@@ -497,8 +515,8 @@ pub fn default_runtime_env() -> Arc<RuntimeEnv> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_default_runtime_env() {
-        let _ = default_runtime_env();
+    #[tokio::test]
+    async fn test_default_runtime_env() {
+        let _ = default_runtime_env(Handle::current());
     }
 }

--- a/crates/runtime-object-store/src/store/github.rs
+++ b/crates/runtime-object-store/src/store/github.rs
@@ -81,6 +81,7 @@ impl GitHubRawObjectStore {
         repo: impl Display,
         rev: impl Display,
         token: Option<&str>,
+        io_runtime: Handle,
     ) -> Result<Self, Error> {
         let mut headers = HeaderMap::with_capacity(1);
         if let Some(token) = token {
@@ -95,7 +96,7 @@ impl GitHubRawObjectStore {
                 "https://raw.githubusercontent.com/{org}/{repo}/{rev}"
             ))
             .with_client_options(ClientOptions::default().with_default_headers(headers))
-            .with_http_connector(SpawnedReqwestConnector::new(Handle::current()))
+            .with_http_connector(SpawnedReqwestConnector::new(io_runtime))
             .build()
             .context(HttpBuilderFailedSnafu)?;
         Ok(Self {
@@ -289,8 +290,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_opts() {
-        let store = GitHubRawObjectStore::try_new("spiceai", "spiceai", "refs/heads/trunk", None)
-            .expect("failed to create store");
+        let store = GitHubRawObjectStore::try_new(
+            "spiceai",
+            "spiceai",
+            "refs/heads/trunk",
+            None,
+            Handle::current(),
+        )
+        .expect("failed to create store");
         let result = store
             .get_opts(&Path::from("README.md"), GetOptions::default())
             .await

--- a/crates/runtime-object-store/src/store/github.rs
+++ b/crates/runtime-object-store/src/store/github.rs
@@ -28,11 +28,13 @@ use http::{
 use object_store::{
     ClientOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    client::SpawnedReqwestConnector,
     http::{HttpBuilder, HttpStore},
     path::Path,
 };
 use serde::Deserialize;
 use snafu::prelude::*;
+use tokio::runtime::Handle;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -93,6 +95,7 @@ impl GitHubRawObjectStore {
                 "https://raw.githubusercontent.com/{org}/{repo}/{rev}"
             ))
             .with_client_options(ClientOptions::default().with_default_headers(headers))
+            .with_http_connector(SpawnedReqwestConnector::new(Handle::current()))
             .build()
             .context(HttpBuilderFailedSnafu)?;
         Ok(Self {

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -247,7 +247,8 @@ pub struct Builder {
     snapshot_behavior: SnapshotBehavior,
     snapshot_local_path: Option<PathBuf>,
     metrics: Option<Metrics>,
-    tokio_runtime: Option<Handle>,
+    cpu_runtime: Option<Handle>,
+    io_runtime: Handle,
 }
 
 impl Builder {
@@ -258,6 +259,7 @@ impl Builder {
         federated_source: String,
         accelerator: Arc<dyn TableProvider>,
         refresh: refresh::Refresh,
+        io_runtime: Handle,
     ) -> Self {
         Self {
             runtime_status,
@@ -281,7 +283,8 @@ impl Builder {
             snapshot_behavior: SnapshotBehavior::default(),
             snapshot_local_path: None,
             metrics: None,
-            tokio_runtime: None,
+            cpu_runtime: None,
+            io_runtime,
         }
     }
 
@@ -325,8 +328,8 @@ impl Builder {
         self
     }
 
-    pub fn tokio_runtime(&mut self, runtime: Option<Handle>) -> &mut Self {
-        self.tokio_runtime = runtime;
+    pub fn cpu_runtime(&mut self, runtime: Option<Handle>) -> &mut Self {
+        self.cpu_runtime = runtime;
         self
     }
 
@@ -469,7 +472,8 @@ impl Builder {
             Some(self.federated_source),
             Arc::clone(&refresh_params),
             Arc::clone(&self.accelerator),
-            self.tokio_runtime.clone(),
+            self.cpu_runtime.clone(),
+            self.io_runtime.clone(),
         );
         refresher.caching(&self.caching);
         refresher.checkpointer(self.checkpointer);
@@ -500,6 +504,7 @@ impl Builder {
                 Arc::clone(&self.accelerator),
                 retention,
                 self.caching.clone(),
+                self.io_runtime.clone(),
             ));
             handlers.push(retention_check_handle);
         }
@@ -534,6 +539,7 @@ impl AcceleratedTable {
         federated_source: String,
         accelerator: Arc<dyn TableProvider>,
         refresh: refresh::Refresh,
+        io_runtime: Handle,
     ) -> Builder {
         Builder::new(
             runtime_status,
@@ -542,6 +548,7 @@ impl AcceleratedTable {
             federated_source,
             accelerator,
             refresh,
+            io_runtime,
         )
     }
 

--- a/crates/runtime/src/accelerated_table/refresh.rs
+++ b/crates/runtime/src/accelerated_table/refresh.rs
@@ -438,7 +438,8 @@ pub struct Refresher {
     disable_federation: bool,
     semaphore: Option<Arc<Semaphore>>,
     on_complete_notification: Option<Arc<Notify>>,
-    tokio_runtime: Option<Handle>,
+    cpu_runtime: Option<Handle>,
+    io_runtime: Handle,
 }
 
 impl std::fmt::Debug for Refresher {
@@ -454,6 +455,7 @@ impl std::fmt::Debug for Refresher {
 }
 
 impl Refresher {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         runtime_status: Arc<status::RuntimeStatus>,
         dataset_name: TableReference,
@@ -461,7 +463,8 @@ impl Refresher {
         federated_source: Option<String>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
-        tokio_runtime: Option<Handle>,
+        cpu_runtime: Option<Handle>,
+        io_runtime: Handle,
     ) -> Self {
         Self {
             runtime_status,
@@ -482,7 +485,8 @@ impl Refresher {
             snapshot_behavior: SnapshotBehavior::default(),
             snapshot_local_path: None,
             metrics: None,
-            tokio_runtime,
+            cpu_runtime,
+            io_runtime,
         }
     }
 
@@ -625,6 +629,7 @@ impl Refresher {
             self.federated_source.clone(),
             Arc::clone(&self.refresh),
             Arc::clone(&self.accelerator),
+            self.io_runtime.clone(),
         )
         .with_disable_federation(self.disable_federation);
 
@@ -634,7 +639,7 @@ impl Refresher {
 
         refresh_task_runner = refresh_task_runner.with_metrics(self.metrics.clone());
 
-        refresh_task_runner = refresh_task_runner.with_tokio_runtime(self.tokio_runtime.clone());
+        refresh_task_runner = refresh_task_runner.with_cpu_runtime(self.cpu_runtime.clone());
 
         let mut refresh_task_runner = refresh_task_runner.build();
 
@@ -800,10 +805,11 @@ impl Refresher {
                 Arc::clone(&self.federated),
                 self.federated_source.clone(),
                 Arc::clone(&self.accelerator),
-                self.metrics.clone(),
+                self.io_runtime.clone(),
             )
             .with_disable_federation(self.disable_federation)
-            .with_tokio_runtime(self.tokio_runtime.clone())
+            .with_cpu_runtime(self.cpu_runtime.clone())
+            .with_metrics(self.metrics.clone())
             .build(),
         );
 
@@ -834,10 +840,11 @@ impl Refresher {
                 Arc::clone(&self.federated),
                 self.federated_source.clone(),
                 Arc::clone(&self.accelerator),
-                self.metrics.clone(),
+                self.io_runtime.clone(),
             )
             .with_disable_federation(self.disable_federation)
-            .with_tokio_runtime(self.tokio_runtime.clone())
+            .with_cpu_runtime(self.cpu_runtime.clone())
+            .with_metrics(self.metrics.clone())
             .build(),
         );
 
@@ -1007,6 +1014,7 @@ mod tests {
             Arc::new(RwLock::new(refresh)),
             Arc::clone(&accelerator),
             None,
+            Handle::current(),
         );
 
         refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1216,6 +1224,7 @@ mod tests {
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
                 None,
+                Handle::current(),
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1371,6 +1380,7 @@ mod tests {
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
                 None,
+                Handle::current(),
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));
@@ -1576,6 +1586,7 @@ mod tests {
                 Arc::new(RwLock::new(refresh)),
                 Arc::clone(&accelerator),
                 None,
+                Handle::current(),
             );
 
             refresher.with_completion_notifier(Arc::clone(&notifier));

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -110,7 +110,8 @@ pub struct RefreshTaskBuilder {
     // Used to control how many parallel refreshes the runtime performs.
     semaphore: Option<Arc<Semaphore>>,
     metrics: Option<Metrics>,
-    tokio_runtime: Option<Handle>,
+    cpu_runtime: Option<Handle>,
+    io_runtime: Handle,
 }
 
 impl RefreshTaskBuilder {
@@ -121,7 +122,7 @@ impl RefreshTaskBuilder {
         federated: Arc<FederatedTable>,
         federated_source: Option<String>,
         accelerator: Arc<dyn TableProvider>,
-        metrics: Option<Metrics>,
+        io_runtime: Handle,
     ) -> Self {
         Self {
             runtime_status,
@@ -132,8 +133,9 @@ impl RefreshTaskBuilder {
             sink: Arc::new(RwLock::new(AccelerationSink::new(accelerator))),
             disable_federation: false,
             semaphore: None,
-            metrics,
-            tokio_runtime: None,
+            metrics: None,
+            cpu_runtime: None,
+            io_runtime,
         }
     }
 
@@ -151,8 +153,14 @@ impl RefreshTaskBuilder {
     }
 
     #[must_use]
-    pub fn with_tokio_runtime(mut self, runtime: Option<Handle>) -> RefreshTaskBuilder {
-        self.tokio_runtime = runtime;
+    pub fn with_metrics(mut self, metrics: Option<Metrics>) -> RefreshTaskBuilder {
+        self.metrics = metrics;
+        self
+    }
+
+    #[must_use]
+    pub fn with_cpu_runtime(mut self, runtime: Option<Handle>) -> RefreshTaskBuilder {
+        self.cpu_runtime = runtime;
         self
     }
 
@@ -180,7 +188,8 @@ impl RefreshTaskBuilder {
                 .iter()
                 .cloned()
                 .collect(),
-            tokio_runtime: self.tokio_runtime,
+            cpu_runtime: self.cpu_runtime,
+            io_runtime: self.io_runtime,
         }
     }
 }
@@ -197,7 +206,8 @@ pub struct RefreshTask {
     // Used to control how many parallel refreshes the runtime performs.
     semaphore: Arc<Semaphore>,
     enabled_metrics: HashSet<String>,
-    tokio_runtime: Option<Handle>,
+    cpu_runtime: Option<Handle>,
+    io_runtime: Handle,
 }
 
 impl RefreshTask {
@@ -208,7 +218,7 @@ impl RefreshTask {
         federated: Arc<FederatedTable>,
         federated_source: Option<String>,
         accelerator: Arc<dyn TableProvider>,
-        metrics: Option<Metrics>,
+        io_runtime: Handle,
     ) -> RefreshTaskBuilder {
         RefreshTaskBuilder::new(
             runtime_status,
@@ -216,7 +226,7 @@ impl RefreshTask {
             federated,
             federated_source,
             accelerator,
-            metrics,
+            io_runtime,
         )
     }
 
@@ -731,7 +741,7 @@ impl RefreshTask {
             RefreshMode::Changes => unreachable!("changes are handled upstream"),
         };
 
-        if let Some(runtime_handle) = self.tokio_runtime.clone() {
+        if let Some(cpu_runtime_handle) = self.cpu_runtime.clone() {
             let dataset_name_for_runtime = dataset_name.clone();
             let filters_for_runtime = filters.clone();
             let update_type_for_runtime = update_type.clone();
@@ -742,12 +752,12 @@ impl RefreshTask {
 
             // Capture necessary state to create ctx inside the closure
             let dataset_name_for_ctx = self.dataset_name.clone();
-            let federated_for_ctx = Arc::clone(&self.federated);
             let accelerator_for_ctx = Arc::clone(&self.accelerator);
             let disable_federation = self.disable_federation;
+            let io_runtime = self.io_runtime.clone();
 
             let managed_stream = managed_runtime::run_record_batch_stream_on_runtime(
-                runtime_handle,
+                cpu_runtime_handle,
                 request_context,
                 span,
                 async move {
@@ -755,9 +765,9 @@ impl RefreshTask {
                     let mut ctx = Self::create_refresh_df_context(
                         Arc::clone(&provider_for_runtime),
                         &dataset_name_for_ctx,
-                        &federated_for_ctx,
                         &accelerator_for_ctx,
                         disable_federation,
+                        io_runtime,
                     )
                     .await;
 
@@ -788,9 +798,14 @@ impl RefreshTask {
         }
 
         // Create ctx only in the fallback path (no managed runtime)
-        let mut ctx = self
-            .refresh_df_context(Arc::clone(&federated_provider))
-            .await;
+        let mut ctx = Self::create_refresh_df_context(
+            Arc::clone(&federated_provider),
+            &self.dataset_name,
+            &self.accelerator,
+            self.disable_federation,
+            self.io_runtime.clone(),
+        )
+        .await;
 
         let get_data_result = get_data(
             &mut ctx,
@@ -828,33 +843,19 @@ impl RefreshTask {
         )
     }
 
-    async fn refresh_df_context(
-        &self,
-        federated_provider: Arc<dyn TableProvider>,
-    ) -> SessionContext {
-        Self::create_refresh_df_context(
-            federated_provider,
-            &self.dataset_name,
-            &self.federated,
-            &self.accelerator,
-            self.disable_federation,
-        )
-        .await
-    }
-
     /// Static helper method to create a `DataFusion` context for refresh operations.
     /// This is separated from `refresh_df_context` to allow it to be called from async closures
     /// without requiring `self`, avoiding the need to create the context twice.
     async fn create_refresh_df_context(
         federated_provider: Arc<dyn TableProvider>,
         dataset_name: &TableReference,
-        _federated: &Arc<FederatedTable>,
         accelerator: &Arc<dyn TableProvider>,
         disable_federation: bool,
+        io_runtime: Handle,
     ) -> SessionContext {
         let state_builder = SessionStateBuilder::new()
             .with_config(get_df_default_config())
-            .with_runtime_env(default_runtime_env())
+            .with_runtime_env(default_runtime_env(io_runtime))
             .with_default_features();
 
         let mut extension_planners: Vec<Arc<dyn ExtensionPlanner + Send + Sync>> = vec![
@@ -939,9 +940,14 @@ impl RefreshTask {
 
         let existing_records = accelerator_df(
             &Arc::clone(&self.accelerator),
-            &self
-                .refresh_df_context(Arc::clone(&federated_provider))
-                .await,
+            &Self::create_refresh_df_context(
+                Arc::clone(&federated_provider),
+                &self.dataset_name,
+                &self.accelerator,
+                self.disable_federation,
+                self.io_runtime.clone(),
+            )
+            .await,
         )
         .map_err(find_datafusion_root)
         .context(super::UnableToScanTableProviderSnafu)?
@@ -977,7 +983,14 @@ impl RefreshTask {
         refresh: &Refresh,
     ) -> super::Result<Option<u128>> {
         let federated = self.federated.table_provider().await;
-        let ctx = self.refresh_df_context(federated).await;
+        let ctx = Self::create_refresh_df_context(
+            federated,
+            &self.dataset_name,
+            &self.accelerator,
+            self.disable_federation,
+            self.io_runtime.clone(),
+        )
+        .await;
 
         refresh
             .validate_time_format(self.dataset_name.to_string(), &self.accelerator.schema())

--- a/crates/runtime/src/accelerated_table/refresh_task/streaming_append.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task/streaming_append.rs
@@ -91,7 +91,14 @@ impl RefreshTask {
     ) -> impl Stream<Item = crate::accelerated_table::Result<(Option<SystemTime>, DataUpdate)>>
     {
         let federated = self.federated.table_provider().await;
-        let ctx = self.refresh_df_context(Arc::clone(&federated)).await;
+        let ctx = Self::create_refresh_df_context(
+            Arc::clone(&federated),
+            &self.dataset_name,
+            &self.accelerator,
+            self.disable_federation,
+            self.io_runtime.clone(),
+        )
+        .await;
         let dataset_name = self.dataset_name.clone();
 
         stream! {

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -47,7 +47,8 @@ pub struct RefreshTaskRunnerBuilder {
     disable_federation: bool,
     semaphore: Option<Arc<Semaphore>>,
     metrics: Option<Metrics>,
-    tokio_runtime: Option<Handle>,
+    cpu_runtime: Option<Handle>,
+    io_runtime: Handle,
 }
 
 impl RefreshTaskRunnerBuilder {
@@ -59,6 +60,7 @@ impl RefreshTaskRunnerBuilder {
         federated_source: Option<String>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
+        io_runtime: Handle,
     ) -> Self {
         Self {
             runtime_status,
@@ -70,7 +72,8 @@ impl RefreshTaskRunnerBuilder {
             disable_federation: false,
             semaphore: None,
             metrics: None,
-            tokio_runtime: None,
+            cpu_runtime: None,
+            io_runtime,
         }
     }
 
@@ -94,8 +97,8 @@ impl RefreshTaskRunnerBuilder {
     }
 
     #[must_use]
-    pub fn with_tokio_runtime(mut self, runtime: Option<Handle>) -> Self {
-        self.tokio_runtime = runtime;
+    pub fn with_cpu_runtime(mut self, runtime: Option<Handle>) -> Self {
+        self.cpu_runtime = runtime;
         self
     }
 
@@ -107,15 +110,16 @@ impl RefreshTaskRunnerBuilder {
             self.federated,
             self.federated_source,
             self.accelerator,
-            self.metrics,
+            self.io_runtime,
         )
-        .with_disable_federation(self.disable_federation);
+        .with_disable_federation(self.disable_federation)
+        .with_metrics(self.metrics);
 
         if let Some(semaphore) = self.semaphore {
             refresh_task_builder = refresh_task_builder.with_semaphore(semaphore);
         }
 
-        refresh_task_builder = refresh_task_builder.with_tokio_runtime(self.tokio_runtime);
+        refresh_task_builder = refresh_task_builder.with_cpu_runtime(self.cpu_runtime);
 
         let refresh_task = Arc::new(refresh_task_builder.build());
 
@@ -148,6 +152,7 @@ impl RefreshTaskRunner {
         federated_source: Option<String>,
         refresh: Arc<RwLock<Refresh>>,
         accelerator: Arc<dyn TableProvider>,
+        io_runtime: Handle,
     ) -> RefreshTaskRunnerBuilder {
         RefreshTaskRunnerBuilder::new(
             runtime_status,
@@ -156,6 +161,7 @@ impl RefreshTaskRunner {
             federated_source,
             refresh,
             accelerator,
+            io_runtime,
         )
     }
 

--- a/crates/runtime/src/accelerated_table/retention.rs
+++ b/crates/runtime/src/accelerated_table/retention.rs
@@ -26,6 +26,7 @@ use datafusion::{
     prelude::{Expr, SessionContext},
     sql::TableReference,
 };
+use tokio::runtime::Handle;
 
 use crate::{
     accelerated_table::{DataRetentionFilter, Retention, refresh},
@@ -46,6 +47,7 @@ impl super::AcceleratedTable {
         accelerator: Arc<dyn TableProvider>,
         retention: Retention,
         caching: Option<Arc<Caching>>,
+        io_runtime: Handle,
     ) {
         let mut interval_timer = tokio::time::interval(retention.check_interval);
 
@@ -117,7 +119,7 @@ impl super::AcceleratedTable {
 
                 let ctx = SessionContext::new_with_config_rt(
                     get_df_default_config(),
-                    default_runtime_env(),
+                    default_runtime_env(io_runtime.clone()),
                 );
 
                 let plan = deleted_table_provider
@@ -323,6 +325,7 @@ mod tests {
             Arc::clone(&accelerator),
             retention,
             caching,
+            Handle::current(),
         ));
 
         // Wait for retention to run

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -34,6 +34,7 @@ use app::App;
 use spicepod::component::caching::Caching;
 use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 use token_provider::registry::TokenProviderRegistry;
+use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
 use util::in_tracing_context;
 
@@ -49,6 +50,7 @@ pub struct RuntimeBuilder {
     prometheus_registry: Option<prometheus::Registry>,
     runtime_status: Arc<status::RuntimeStatus>,
     rate_limits: Option<Arc<RateLimits>>,
+    io_runtime: Option<Handle>,
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     datafusion_configuration_fn: Option<DatafusionConfigurationCallback>,
     token_provider_registry: Arc<TokenProviderRegistry>,
@@ -67,6 +69,7 @@ impl RuntimeBuilder {
             autoload_extensions: HashMap::new(),
             runtime_status: status::RuntimeStatus::new(),
             rate_limits: None,
+            io_runtime: None,
             accelerator_engine_registry: Arc::new(AcceleratorEngineRegistry::new()),
             datafusion_configuration_fn: None,
             token_provider_registry: Arc::new(TokenProviderRegistry::new()),
@@ -135,6 +138,11 @@ impl RuntimeBuilder {
 
     pub fn with_rate_limits(mut self, rate_limits: RateLimits) -> Self {
         self.rate_limits = Some(Arc::new(rate_limits));
+        self
+    }
+
+    pub fn with_io_runtime(mut self, io_runtime: Handle) -> Self {
+        self.io_runtime = Some(io_runtime);
         self
     }
 
@@ -266,6 +274,9 @@ impl RuntimeBuilder {
             metrics_endpoint: self.metrics_endpoint,
             prometheus_registry: self.prometheus_registry,
             rate_limits: self.rate_limits.unwrap_or_default(),
+            io_runtime: self
+                .io_runtime
+                .unwrap_or_else(|| tokio::runtime::Handle::current()),
             status: self.runtime_status,
             tasks: Arc::new(RwLock::new(HashMap::new())),
             accelerator_engine_registry: self.accelerator_engine_registry,

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -204,9 +204,12 @@ impl RuntimeBuilder {
         #[cfg(feature = "cluster")]
         let cluster_config = Arc::new(self.runtime_config.cluster.clone());
 
+        let io_runtime = self.io_runtime.clone().unwrap_or_else(|| Handle::current());
+
         let mut df_builder = DataFusion::builder(
             Arc::clone(&self.runtime_status),
             Arc::clone(&self.accelerator_engine_registry),
+            io_runtime.clone(),
         )
         .memory_limit(memory_limit)
         .temp_directory(query.temp_directory)
@@ -274,9 +277,7 @@ impl RuntimeBuilder {
             metrics_endpoint: self.metrics_endpoint,
             prometheus_registry: self.prometheus_registry,
             rate_limits: self.rate_limits.unwrap_or_default(),
-            io_runtime: self
-                .io_runtime
-                .unwrap_or_else(|| tokio::runtime::Handle::current()),
+            io_runtime,
             status: self.runtime_status,
             tasks: Arc::new(RwLock::new(HashMap::new())),
             accelerator_engine_registry: self.accelerator_engine_registry,

--- a/crates/runtime/src/catalogconnector/databricks.rs
+++ b/crates/runtime/src/catalogconnector/databricks.rs
@@ -222,21 +222,27 @@ impl CatalogConnector for Databricks {
         let mode = self.params.get("mode").expose().ok();
         let (table_creator, table_reference_creator) = if let Some("delta_lake") = mode {
             (
-                Arc::new(DeltaTableFactory::new(params.to_secret_map())) as Arc<dyn Read>,
+                Arc::new(DeltaTableFactory::new(
+                    params.to_secret_map(),
+                    runtime.tokio_io_runtime(),
+                )) as Arc<dyn Read>,
                 table_reference_creator_delta_lake as fn(&UCTable) -> Option<TableReference>,
             )
         } else {
-            let dataset_databricks =
-                match DatabricksDataConnector::new(params, runtime.token_provider_registry())
-                    .await
-                    .map_err(|source| super::Error::UnableToGetCatalogProvider {
-                        connector: "databricks".to_string(),
-                        source: source.into(),
-                        connector_component: ConnectorComponent::from(catalog),
-                    }) {
-                    Ok(dataset_databricks) => dataset_databricks,
-                    Err(e) => return Err(e),
-                };
+            let dataset_databricks = match DatabricksDataConnector::new(
+                params,
+                runtime.tokio_io_runtime(),
+                runtime.token_provider_registry(),
+            )
+            .await
+            .map_err(|source| super::Error::UnableToGetCatalogProvider {
+                connector: "databricks".to_string(),
+                source: source.into(),
+                connector_component: ConnectorComponent::from(catalog),
+            }) {
+                Ok(dataset_databricks) => dataset_databricks,
+                Err(e) => return Err(e),
+            };
 
             (
                 dataset_databricks.read_provider(),

--- a/crates/runtime/src/catalogconnector/glue/provider.rs
+++ b/crates/runtime/src/catalogconnector/glue/provider.rs
@@ -177,7 +177,8 @@ impl GlueCatalogProvider {
                     parameters.insert("catalog_id".to_string(), catalog_id.to_string().into());
                 }
 
-                let connector = GlueDataConnector::new(parameters);
+                let connector =
+                    GlueDataConnector::new(parameters, self.parameters.io_runtime.clone());
                 let from = format!("{database}.{}", table.name());
                 let runtime = Arc::clone(&self.runtime);
                 let dataset = DatasetBuilder::try_new(from, table.name())

--- a/crates/runtime/src/catalogconnector/spice_cloud.rs
+++ b/crates/runtime/src/catalogconnector/spice_cloud.rs
@@ -214,7 +214,7 @@ impl SpiceCloudPlatformCatalog {
                     "spice.ai".into(),
                     ConnectorComponent::Dataset(Arc::new(template_dataset)),
                 )
-                .build(runtime.secrets())
+                .build(runtime.secrets(), runtime.tokio_io_runtime())
                 .await
                 .map_err(|e| super::Error::InvalidConfiguration {
                     connector: "spice.ai".into(),

--- a/crates/runtime/src/catalogconnector/unity_catalog.rs
+++ b/crates/runtime/src/catalogconnector/unity_catalog.rs
@@ -157,8 +157,10 @@ impl CatalogConnector for UnityCatalog {
             connector_component: ConnectorComponent::from(catalog),
         })?;
 
-        let delta_table_creator =
-            Arc::new(DeltaTableFactory::new(params.to_secret_map())) as Arc<dyn Read>;
+        let delta_table_creator = Arc::new(DeltaTableFactory::new(
+            params.to_secret_map(),
+            runtime.tokio_io_runtime(),
+        )) as Arc<dyn Read>;
 
         let catalog_provider = match UnityCatalogProvider::try_new(
             client,

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -242,6 +242,7 @@ impl DatasetBuilder {
                 app.snapshots.clone(),
                 self.acceleration_snapshot,
                 runtime.secrets_weak(),
+                runtime.tokio_io_runtime(),
             );
         }
 

--- a/crates/runtime/src/dataconnector/abfs.rs
+++ b/crates/runtime/src/dataconnector/abfs.rs
@@ -29,6 +29,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::string::String;
 use std::sync::{Arc, LazyLock};
+use tokio::runtime::Handle;
 use url::Url;
 
 #[derive(Debug, Snafu)]
@@ -60,6 +61,7 @@ pub enum Error {
 #[derive(Debug)]
 pub struct AzureBlobFS {
     params: Parameters,
+    tokio_io_runtime: Handle,
 }
 
 #[derive(Default, Clone)]
@@ -206,6 +208,7 @@ impl DataConnectorFactory for AzureBlobFSFactory {
             if use_emulator {
                 let azure = AzureBlobFS {
                     params: params.parameters,
+                    tokio_io_runtime: params.io_runtime,
                 };
                 Ok(Arc::new(azure) as Arc<dyn DataConnector>)
             } else {
@@ -221,6 +224,7 @@ impl DataConnectorFactory for AzureBlobFSFactory {
                 } else {
                     let azure = AzureBlobFS {
                         params: params.parameters,
+                        tokio_io_runtime: params.io_runtime,
                     };
                     Ok(Arc::new(azure) as Arc<dyn DataConnector>)
                 }
@@ -250,6 +254,10 @@ impl ListingTableConnector for AzureBlobFS {
 
     fn get_params(&self) -> &Parameters {
         &self.params
+    }
+
+    fn get_tokio_io_runtime(&self) -> Handle {
+        self.tokio_io_runtime.clone()
     }
 
     fn get_object_store_url(

--- a/crates/runtime/src/dataconnector/databricks.rs
+++ b/crates/runtime/src/dataconnector/databricks.rs
@@ -35,6 +35,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use token_provider::registry::TokenProviderRegistry;
 use token_provider::{StaticTokenProvider, TokenProvider};
+use tokio::runtime::Handle;
 
 use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec,
@@ -104,6 +105,7 @@ impl std::fmt::Debug for Databricks {
 impl Databricks {
     pub async fn new(
         params: Parameters,
+        io_runtime: Handle,
         token_provider_registry: Arc<TokenProviderRegistry>,
     ) -> Result<Self> {
         let mode = params.get("mode").expose().ok().unwrap_or_default();
@@ -163,6 +165,7 @@ impl Databricks {
                     Endpoint(endpoint.to_string()),
                     storage_options,
                     token_provider,
+                    io_runtime,
                 );
 
                 Ok(Self {
@@ -466,8 +469,12 @@ impl DataConnectorFactory for DatabricksFactory {
             Box::pin(async move {
                 // Initialize the AWS SDK and make it available.
                 let _ = aws_sdk_credential_bridge::initialize_sdk_config().await;
-                let databricks =
-                    Databricks::new(params.parameters, runtime.token_provider_registry()).await?;
+                let databricks = Databricks::new(
+                    params.parameters,
+                    params.io_runtime,
+                    runtime.token_provider_registry(),
+                )
+                .await?;
                 Ok(Arc::new(databricks) as Arc<dyn DataConnector>)
             })
         } else {

--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -24,6 +24,7 @@ use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use tokio::runtime::Handle;
 
 use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec,
@@ -38,9 +39,9 @@ pub struct DeltaLake {
 impl DeltaLake {
     #[must_use]
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new(params: Parameters) -> Self {
+    pub fn new(params: Parameters, io_runtime: Handle) -> Self {
         Self {
-            delta_table_factory: DeltaTableFactory::new(params.to_secret_map()),
+            delta_table_factory: DeltaTableFactory::new(params.to_secret_map(), io_runtime),
         }
     }
 }
@@ -116,7 +117,7 @@ impl DataConnectorFactory for DeltaLakeFactory {
         Box::pin(async move {
             // Initialize the AWS SDK and make it available.
             let _ = aws_sdk_credential_bridge::initialize_sdk_config().await;
-            let delta = DeltaLake::new(params.parameters);
+            let delta = DeltaLake::new(params.parameters, params.io_runtime);
             Ok(Arc::new(delta) as Arc<dyn DataConnector>)
         })
     }

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 use std::{any::Any, env};
+use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 use url::Url;
 
@@ -42,6 +43,7 @@ use super::{
 #[derive(Debug)]
 pub struct File {
     params: Parameters,
+    tokio_io_runtime: Handle,
 }
 
 impl std::fmt::Display for File {
@@ -50,14 +52,12 @@ impl std::fmt::Display for File {
     }
 }
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct FileFactory {}
 
 impl FileFactory {
     #[must_use]
-    pub fn new() -> Self {
-        Self {}
-    }
+    pub fn new() -> Self {}
 
     #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {
@@ -77,6 +77,7 @@ impl DataConnectorFactory for FileFactory {
         Box::pin(async move {
             Ok(Arc::new(File {
                 params: params.parameters,
+                tokio_io_runtime: params.io_runtime,
             }) as Arc<dyn DataConnector>)
         })
     }
@@ -98,6 +99,10 @@ impl ListingTableConnector for File {
 
     fn get_params(&self) -> &Parameters {
         &self.params
+    }
+
+    fn get_tokio_io_runtime(&self) -> Handle {
+        self.tokio_io_runtime.clone()
     }
 
     /// Creates a valid file [`url::Url`], from the dataset, supporting both
@@ -282,6 +287,7 @@ mod tests {
 
         let connector = File {
             params: Parameters::new(([]).to_vec(), "test", &[]),
+            tokio_io_runtime: Handle::current(),
         };
 
         let url = connector

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -52,12 +52,14 @@ impl std::fmt::Display for File {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Copy, Clone)]
 pub struct FileFactory {}
 
 impl FileFactory {
     #[must_use]
-    pub fn new() -> Self {}
+    pub fn new() -> Self {
+        Self {}
+    }
 
     #[must_use]
     pub fn new_arc() -> Arc<dyn DataConnectorFactory> {

--- a/crates/runtime/src/dataconnector/ftp.rs
+++ b/crates/runtime/src/dataconnector/ftp.rs
@@ -102,6 +102,10 @@ impl ListingTableConnector for FTP {
         &self.params
     }
 
+    fn get_tokio_io_runtime(&self) -> tokio::runtime::Handle {
+        tokio::runtime::Handle::current()
+    }
+
     fn get_object_store_url(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -101,12 +101,16 @@ pub enum Error {
 #[derive(Clone, Debug)]
 pub struct GlueDataConnector {
     params: Parameters,
+    tokio_io_runtime: tokio::runtime::Handle,
 }
 
 impl GlueDataConnector {
     #[must_use]
-    pub fn new(params: Parameters) -> Self {
-        Self { params }
+    pub fn new(params: Parameters, tokio_io_runtime: tokio::runtime::Handle) -> Self {
+        Self {
+            params,
+            tokio_io_runtime,
+        }
     }
 
     async fn create_table_provider(
@@ -187,7 +191,14 @@ impl GlueDataConnector {
             }
         })? {
             input_format @ (InputFormat::Parquet | InputFormat::Csv) => {
-                create_s3_provider(input_format, dataset.clone(), self.params.clone(), &table).await
+                create_s3_provider(
+                    input_format,
+                    dataset.clone(),
+                    self.params.clone(),
+                    &table,
+                    self.tokio_io_runtime.clone(),
+                )
+                .await
             }
             InputFormat::Iceberg => {
                 create_iceberg_provider(dataset, &config, database.to_string(), &table).await
@@ -240,7 +251,7 @@ impl DataConnectorFactory for GlueDataConnectorFactory {
         params: ConnectorParams,
     ) -> Pin<Box<dyn Future<Output = super::NewDataConnectorResult> + Send>> {
         Box::pin(async move {
-            let glue = GlueDataConnector::new(params.parameters);
+            let glue = GlueDataConnector::new(params.parameters, params.io_runtime);
             Ok(Arc::new(glue) as Arc<dyn DataConnector>)
         })
     }
@@ -452,6 +463,7 @@ async fn create_s3_provider(
     mut dataset: Dataset,
     mut params: Parameters,
     table: &Table,
+    tokio_io_runtime: tokio::runtime::Handle,
 ) -> super::DataConnectorResult<Arc<dyn TableProvider>> {
     let Some(storage_descriptor) = table.storage_descriptor() else {
         let e = Error::MissingStorageDescriptor {
@@ -503,6 +515,7 @@ async fn create_s3_provider(
     let s3 = S3 {
         params,
         runtime: Some(Arc::unwrap_or_clone(dataset.runtime())),
+        tokio_io_runtime,
     };
 
     dataset.from = from;

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -44,13 +44,13 @@ impl std::fmt::Display for Https {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct HttpsFactory {}
 
 impl HttpsFactory {
     #[must_use]
     pub fn new() -> Self {
-        Self {}
+        HttpsFactory::default()
     }
 
     #[must_use]

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -22,6 +22,7 @@ use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, LazyLock};
+use tokio::runtime::Handle;
 use url::Url;
 
 use super::{ConnectorComponent, ConnectorParams};
@@ -34,6 +35,7 @@ use super::{
 #[derive(Debug)]
 pub struct Https {
     params: Parameters,
+    tokio_io_runtime: Handle,
 }
 
 impl std::fmt::Display for Https {
@@ -42,7 +44,7 @@ impl std::fmt::Display for Https {
     }
 }
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct HttpsFactory {}
 
 impl HttpsFactory {
@@ -82,6 +84,7 @@ impl DataConnectorFactory for HttpsFactory {
         Box::pin(async move {
             Ok(Arc::new(Https {
                 params: params.parameters,
+                tokio_io_runtime: params.io_runtime,
             }) as Arc<dyn DataConnector>)
         })
     }
@@ -102,6 +105,10 @@ impl ListingTableConnector for Https {
 
     fn get_params(&self) -> &Parameters {
         &self.params
+    }
+
+    fn get_tokio_io_runtime(&self) -> tokio::runtime::Handle {
+        self.tokio_io_runtime.clone()
     }
 
     fn get_object_store_url(

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -989,6 +989,7 @@ mod tests {
     use std::collections::HashMap;
     use std::future::Future;
     use std::pin::Pin;
+    use tokio::runtime::Handle;
     use url::Url;
 
     use crate::component::dataset::builder::DatasetBuilder;

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -84,13 +84,13 @@ pub trait ListingTableConnector: DataConnector {
     fn get_params(&self) -> &Parameters;
 
     #[must_use]
-    fn get_session_context() -> SessionContext {
+    fn get_session_context(&self) -> SessionContext {
         SessionContext::new_with_config_rt(
             get_df_default_config().set_bool(
                 "datafusion.execution.listing_table_ignore_subdirectory",
                 false,
             ),
-            default_runtime_env(),
+            default_runtime_env(self.get_tokio_io_runtime()),
         )
     }
 
@@ -105,7 +105,7 @@ pub trait ListingTableConnector: DataConnector {
                 connector_component: ConnectorComponent::from(dataset),
             },
         )?;
-        Self::get_session_context()
+        self.get_session_context()
             .runtime_env()
             .object_store(&listing_store_url)
             .boxed()
@@ -118,6 +118,10 @@ pub trait ListingTableConnector: DataConnector {
     fn get_runtime(&self) -> Option<Runtime> {
         None
     }
+
+    /// Returns a handle to the IO runtime that this object store connector should
+    /// use for spawning IO tasks.
+    fn get_tokio_io_runtime(&self) -> tokio::runtime::Handle;
 
     async fn construct_metadata_provider(
         &self,
@@ -519,7 +523,7 @@ pub trait ListingTableConnector: DataConnector {
 
         let object_store = self.get_object_store(dataset)?;
 
-        let ctx: SessionContext = Self::get_session_context();
+        let ctx: SessionContext = self.get_session_context();
 
         let (schema_infer_url, schema_infer_meta) =
             if let Some(url) = dataset.params.get("schema_source_path") {
@@ -1039,6 +1043,10 @@ mod tests {
 
         fn get_params(&self) -> &Parameters {
             &self.params
+        }
+
+        fn get_tokio_io_runtime(&self) -> Handle {
+            Handle::current()
         }
 
         fn get_object_store_url(

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -756,7 +756,7 @@ mod tests {
             ConnectorComponent::Dataset(Arc::new(dataset)),
         );
 
-        let result = builder.build(secrets).await;
+        let result = builder.build(secrets, Handle::current()).await;
         assert!(result.is_ok());
 
         let params = result.expect("failed to build connector params");

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -682,6 +682,7 @@ fn include_computed_columns(
 #[cfg(test)]
 mod tests {
     use datafusion_table_providers::UnsupportedTypeAction;
+    use tokio::runtime::Handle;
     use tokio::sync::RwLock;
 
     use super::*;

--- a/crates/runtime/src/dataconnector/parameters.rs
+++ b/crates/runtime/src/dataconnector/parameters.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use app::App;
 use async_trait::async_trait;
 use datafusion_table_providers::UnsupportedTypeAction;
-use tokio::sync::RwLock;
+use tokio::{runtime::Handle, sync::RwLock};
 
 use crate::{
     Runtime, catalogconnector::CATALOG_CONNECTOR_FACTORY_REGISTRY, parameters::Parameters,
@@ -47,6 +47,7 @@ pub struct ConnectorParams {
     pub(crate) component: ConnectorComponent,
     pub(crate) app: Option<Arc<App>>,
     pub(crate) runtime: Option<Arc<Runtime>>,
+    pub(crate) io_runtime: Handle,
 }
 
 pub struct ConnectorParamsBuilder {
@@ -66,6 +67,7 @@ impl ConnectorParamsBuilder {
     pub async fn build(
         self,
         secrets: Arc<RwLock<Secrets>>,
+        io_runtime: Handle,
     ) -> Result<ConnectorParams, Box<dyn std::error::Error + Send + Sync>> {
         let name = self.connector.to_string();
         let mut unsupported_type_action = None;
@@ -134,6 +136,7 @@ impl ConnectorParamsBuilder {
             component: self.component,
             app,
             runtime,
+            io_runtime,
         })
     }
 }

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -102,6 +102,7 @@ pub enum Error {
 pub struct S3 {
     pub(crate) params: Parameters,
     pub(crate) runtime: Option<Runtime>,
+    pub(crate) tokio_io_runtime: tokio::runtime::Handle,
 }
 
 impl std::fmt::Debug for S3 {
@@ -181,6 +182,7 @@ impl DataConnectorFactory for S3Factory {
             let s3 = S3 {
                 params: params.parameters,
                 runtime: params.runtime.map(Arc::unwrap_or_clone),
+                tokio_io_runtime: params.io_runtime,
             };
             Ok(Arc::new(s3) as Arc<dyn DataConnector>)
         })
@@ -208,6 +210,10 @@ impl ListingTableConnector for S3 {
 
     fn get_params(&self) -> &Parameters {
         &self.params
+    }
+
+    fn get_tokio_io_runtime(&self) -> tokio::runtime::Handle {
+        self.tokio_io_runtime.clone()
     }
 
     fn get_object_store_url(

--- a/crates/runtime/src/dataconnector/sftp.rs
+++ b/crates/runtime/src/dataconnector/sftp.rs
@@ -113,6 +113,10 @@ impl ListingTableConnector for SFTP {
         &self.params
     }
 
+    fn get_tokio_io_runtime(&self) -> tokio::runtime::Handle {
+        tokio::runtime::Handle::current()
+    }
+
     fn get_object_store_url(
         &self,
         dataset: &Dataset,

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -55,7 +55,10 @@ use runtime_object_store::registry::SpiceObjectStoreRegistry;
 use spicepod::component::runtime::SpillCompression as SpiceSpillCompression;
 use spicepod::metric::Metrics;
 use std::sync::LazyLock;
-use tokio::sync::{RwLock as TokioRwLock, Semaphore};
+use tokio::{
+    runtime::Handle,
+    sync::{RwLock as TokioRwLock, Semaphore},
+};
 
 pub static DEFAULT_DATAFUSION_CONFIG: LazyLock<RwLock<SessionConfig>> = LazyLock::new(|| {
     let mut df_config = SessionConfig::new();
@@ -98,6 +101,7 @@ pub struct DataFusionBuilder {
     #[cfg(feature = "cluster")]
     cluster_config: Arc<ClusterConfig>,
     metrics: Option<Metrics>,
+    io_runtime: Handle,
 }
 
 pub(crate) fn get_df_default_config() -> SessionConfig {
@@ -117,6 +121,7 @@ impl DataFusionBuilder {
     pub fn new(
         status: Arc<status::RuntimeStatus>,
         accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
+        io_runtime: Handle,
     ) -> Self {
         let mut df_config = get_df_default_config()
             .with_information_schema(true)
@@ -138,6 +143,7 @@ impl DataFusionBuilder {
             #[cfg(feature = "cluster")]
             cluster_config: Arc::new(ClusterConfig::default()),
             metrics: None,
+            io_runtime,
         }
     }
 
@@ -219,7 +225,11 @@ impl DataFusionBuilder {
                 SpiceQueryPlanner::new()
                     .with_extension_planners(SpiceQueryPlanner::default_extension_planners()),
             ))
-            .with_runtime_env(runtime_env(self.memory_limit, self.temp_directory.clone()))
+            .with_runtime_env(runtime_env(
+                self.memory_limit,
+                self.temp_directory.clone(),
+                self.io_runtime.clone(),
+            ))
             .with_physical_optimizer_rule(Arc::new(EmptyHashJoinExecPhysicalOptimization {}))
             .with_analyzer_rules(AnalyzerRulesBuilder::default().build())
             .build();
@@ -301,7 +311,8 @@ impl DataFusionBuilder {
             acceleration_refresh_semaphore: self.accelerated_refresh_semaphore,
             task_history_enabled: self.task_history_enabled,
             temp_directory: self.temp_directory.clone(),
-            tokio_runtime: OnceLock::new(),
+            cpu_runtime: OnceLock::new(),
+            io_runtime: self.io_runtime,
             metrics: self.metrics,
             #[cfg(feature = "cluster")]
             cluster_config: self.cluster_config,
@@ -372,6 +383,7 @@ impl Default for AnalyzerRulesBuilder {
 pub(crate) fn runtime_env(
     memory_limit: Option<u64>,
     temp_directory: Option<String>,
+    io_runtime: Handle,
 ) -> Arc<RuntimeEnv> {
     let disk_manager_builder = if let Some(directory) = temp_directory {
         let mode = DiskManagerMode::Directories(vec![directory.into()]);
@@ -409,7 +421,7 @@ pub(crate) fn runtime_env(
     };
 
     match RuntimeEnvBuilder::default()
-        .with_object_store_registry(Arc::new(SpiceObjectStoreRegistry::default()))
+        .with_object_store_registry(Arc::new(SpiceObjectStoreRegistry::new(io_runtime)))
         .with_memory_pool(memory_pool)
         .with_disk_manager_builder(disk_manager_builder)
         .build_arc()

--- a/crates/runtime/src/datafusion/cluster/mod.rs
+++ b/crates/runtime/src/datafusion/cluster/mod.rs
@@ -182,6 +182,7 @@ async fn create_scheduler_server(
 
     // Bind Spice Datafusion configuration incl SpiceQueryPlanner as bound in `DataFusionBuilder`
     let current_context = Arc::clone(&rt.df.ctx);
+    let io_runtime = rt.tokio_io_runtime();
 
     let scheduler_config = SchedulerConfig {
         bind_host: bind_addr.ip().to_string(),
@@ -205,7 +206,7 @@ async fn create_scheduler_server(
             Ok(
                 SessionStateBuilder::new_from_existing(current_context.as_ref().state().clone())
                     .with_config(cfg)
-                    .with_runtime_env(default_runtime_env())
+                    .with_runtime_env(default_runtime_env(io_runtime.clone()))
                     .with_physical_optimizer_rule(DistributeFileScanOptimizer::new())
                     .with_physical_optimizer_rule(UnionProjectionPushdownOptimizer::new())
                     .build(),

--- a/crates/runtime/src/datafusion/extension/mod.rs
+++ b/crates/runtime/src/datafusion/extension/mod.rs
@@ -135,6 +135,7 @@ mod tests {
     use futures::TryStreamExt;
     use spicepod::component::caching::SQLResultsCacheConfig;
     use std::sync::Arc;
+    use tokio::runtime::Handle;
 
     fn create_test_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
@@ -148,6 +149,7 @@ mod tests {
         let mut builder = DataFusionBuilder::new(
             RuntimeStatus::new(),
             Arc::new(AcceleratorEngineRegistry::new()),
+            Handle::current(),
         );
 
         // Add cache if provided

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -82,6 +82,7 @@ use runtime_async::ManagedTokioRuntime;
 use schema::ensure_schema_exists;
 use snafu::prelude::*;
 use spicepod::metric::Metrics;
+use tokio::runtime::Handle;
 use tokio::spawn;
 use tokio::sync::Notify;
 use tokio::sync::{RwLock as TokioRwLock, Semaphore};
@@ -340,7 +341,8 @@ pub struct DataFusion {
     // Controls the parallelism of accelerated table refreshes
     acceleration_refresh_semaphore: Option<Arc<Semaphore>>,
     pub(crate) task_history_enabled: bool,
-    tokio_runtime: OnceLock<ManagedTokioRuntime>,
+    cpu_runtime: OnceLock<ManagedTokioRuntime>,
+    io_runtime: Handle,
     metrics: Option<Metrics>,
 
     pub temp_directory: Option<String>,
@@ -369,8 +371,9 @@ impl DataFusion {
     pub fn builder(
         status: Arc<status::RuntimeStatus>,
         accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
+        io_runtime: Handle,
     ) -> DataFusionBuilder {
-        DataFusionBuilder::new(status, accelerator_engine_registry)
+        DataFusionBuilder::new(status, accelerator_engine_registry, io_runtime)
     }
 
     #[must_use]
@@ -605,8 +608,8 @@ impl DataFusion {
             .contains(table_reference)
     }
 
-    pub fn set_tokio_runtime(&self, handle: ManagedTokioRuntime) {
-        if self.tokio_runtime.set(handle).is_err() {
+    pub fn set_cpu_runtime(&self, handle: ManagedTokioRuntime) {
+        if self.cpu_runtime.set(handle).is_err() {
             // Failure to set means this was already set - that shouldn't happen.
             tracing::error!(
                 "Failed to set tokio runtime on the Datafusion struct, this is an unexpected internal error"
@@ -615,8 +618,8 @@ impl DataFusion {
     }
 
     #[must_use]
-    pub fn tokio_runtime(&self) -> Option<&tokio::runtime::Handle> {
-        self.tokio_runtime.get().map(ManagedTokioRuntime::handle)
+    pub fn cpu_runtime(&self) -> Option<&tokio::runtime::Handle> {
+        self.cpu_runtime.get().map(ManagedTokioRuntime::handle)
     }
 
     async fn get_table_provider(
@@ -1067,8 +1070,9 @@ impl DataFusion {
             dataset.source().to_string(),
             accelerated_table_provider,
             refresh,
+            self.io_runtime.clone(),
         );
-        accelerated_table_builder.tokio_runtime(self.tokio_runtime().cloned());
+        accelerated_table_builder.cpu_runtime(self.cpu_runtime().cloned());
 
         let retention_delete_expr = match dataset.retention_sql() {
             Some(retention_sql) => Some(
@@ -1633,8 +1637,9 @@ impl DataFusion {
             "view".to_string(),
             accelerated_table_provider,
             refresh,
+            self.io_runtime.clone(),
         );
-        builder.tokio_runtime(self.tokio_runtime().cloned());
+        builder.cpu_runtime(self.cpu_runtime().cloned());
         builder.initial_load_complete(initial_load_complete);
         builder.caching(Some(Arc::clone(&self.caching)));
         builder.checkpointer_opt(
@@ -1962,6 +1967,7 @@ mod tests {
             DataFusion::builder(
                 status::RuntimeStatus::new(),
                 runtime.accelerator_engine_registry(),
+                Handle::current(),
             )
             .with_caching(Arc::new(
                 Caching::new().with_plans_cache(plan_cache_provider),

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -190,7 +190,7 @@ impl Query {
     /// Panics when running under test if no cache key is computed for the query.
     pub async fn run(self) -> Result<QueryResult> {
         let request_context = RequestContext::current(AsyncMarker::new().await);
-        if let Some(runtime_handle) = self.df.tokio_runtime().cloned() {
+        if let Some(runtime_handle) = self.df.cpu_runtime().cloned() {
             return self
                 .run_with_managed_runtime(request_context, runtime_handle)
                 .await;
@@ -751,6 +751,7 @@ mod tests {
             DataFusionBuilder::new(
                 RuntimeStatus::new(),
                 Arc::new(AcceleratorEngineRegistry::new()),
+                Handle::current(),
             )
             .with_caching(Arc::new(Caching::new().with_results_cache(cache_provider)))
             .build(),

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -311,6 +311,7 @@ mod tests {
         Caching, QueryResultsCacheProvider, SimpleCache, key::CacheKey, result::CacheStatus,
     };
     use spicepod::component::caching::SQLResultsCacheConfig;
+    use tokio::runtime::Handle;
 
     use crate::{
         builder::RuntimeBuilder,
@@ -356,6 +357,7 @@ mod tests {
             DataFusion::builder(
                 status::RuntimeStatus::new(),
                 runtime.accelerator_engine_registry(),
+                Handle::current(),
             )
             .with_caching(Arc::new(
                 Caching::new()

--- a/crates/runtime/src/datafusion/retention_sql.rs
+++ b/crates/runtime/src/datafusion/retention_sql.rs
@@ -207,8 +207,8 @@ mod tests {
         ]))
     }
 
-    #[test]
-    fn test_valid_delete_statement() -> Result<()> {
+    #[tokio::test]
+    async fn test_valid_delete_statement() -> Result<()> {
         let schema = create_test_schema();
         let table = TableReference::parse_str("test_table");
         let sql = "DELETE FROM test_table WHERE deleted = true";
@@ -219,8 +219,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_missing_where_clause() {
+    #[tokio::test]
+    async fn test_missing_where_clause() {
         let schema = create_test_schema();
         let table = TableReference::parse_str("test_table");
         let sql = "DELETE FROM test_table";
@@ -229,8 +229,8 @@ mod tests {
         assert!(matches!(result, Err(Error::MissingWhereClause { .. })));
     }
 
-    #[test]
-    fn test_wrong_table_name() {
+    #[tokio::test]
+    async fn test_wrong_table_name() {
         let schema = create_test_schema();
         let table = TableReference::parse_str("test_table");
         let sql = "DELETE FROM wrong_table WHERE deleted = true";
@@ -239,8 +239,8 @@ mod tests {
         assert!(matches!(result, Err(Error::TableMismatch { .. })));
     }
 
-    #[test]
-    fn test_select_statement_not_allowed() {
+    #[tokio::test]
+    async fn test_select_statement_not_allowed() {
         let schema = create_test_schema();
         let table = TableReference::parse_str("test_table");
         let sql = "SELECT * FROM test_table WHERE deleted = true";
@@ -249,8 +249,8 @@ mod tests {
         assert!(matches!(result, Err(Error::OnlyDeleteStatements { .. })));
     }
 
-    #[test]
-    fn test_multiple_statements() {
+    #[tokio::test]
+    async fn test_multiple_statements() {
         let schema = create_test_schema();
         let table = TableReference::parse_str("test_table");
         let sql =
@@ -263,8 +263,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_complex_where_clause() -> Result<()> {
+    #[tokio::test]
+    async fn test_complex_where_clause() -> Result<()> {
         let schema = create_test_schema();
         let table = TableReference::parse_str("test_table");
         let sql = "DELETE FROM test_table WHERE deleted = true OR created_at < NOW() - INTERVAL '10 days'";
@@ -274,8 +274,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_qualified_table_name() -> Result<()> {
+    #[tokio::test]
+    async fn test_qualified_table_name() -> Result<()> {
         let schema = create_test_schema();
         let table = TableReference::parse_str("schema.test_table");
         let sql = "DELETE FROM schema.test_table WHERE deleted = true";
@@ -285,8 +285,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_case_sensitive_table_and_column_names() -> Result<()> {
+    #[tokio::test]
+    async fn test_case_sensitive_table_and_column_names() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("ID", DataType::Int64, false),
             Field::new("Deleted", DataType::Boolean, true),
@@ -300,8 +300,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_quoted_table_and_column_names() -> Result<()> {
+    #[tokio::test]
+    async fn test_quoted_table_and_column_names() -> Result<()> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("is deleted", DataType::Boolean, true),
@@ -315,8 +315,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_nonexistent_column() {
+    #[tokio::test]
+    async fn test_nonexistent_column() {
         let schema = create_test_schema();
         let table = TableReference::parse_str("test_table");
         let sql = "DELETE FROM test_table WHERE nonexistent_column = true";

--- a/crates/runtime/src/datafusion/retention_sql.rs
+++ b/crates/runtime/src/datafusion/retention_sql.rs
@@ -26,6 +26,7 @@ use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::{TableReference, sqlparser};
 use snafu::prelude::*;
 use sqlparser::ast::Statement as SQLStatement;
+use tokio::runtime::Handle;
 
 use crate::datafusion::builder::get_df_default_config;
 use runtime_object_store::registry::default_runtime_env;
@@ -176,7 +177,10 @@ fn validate_table_name(
 fn to_df_logical_expr(sql_expr: &SQLExpr, schema: Arc<Schema>) -> Result<Expr> {
     let df_schema = DFSchema::try_from(schema).context(SchemaConversionSnafu)?;
 
-    let ctx = SessionContext::new_with_config_rt(get_df_default_config(), default_runtime_env());
+    let ctx = SessionContext::new_with_config_rt(
+        get_df_default_config(),
+        default_runtime_env(Handle::current()),
+    );
 
     // To convert SQLExpr to DataFusion Expr, we need SqlToRel, which requires a ContextProvider.
     // SessionContextProvider used by DataFusion is not exposed publicly, so we provide the filter as a string

--- a/crates/runtime/src/datafusion/sql_validator.rs
+++ b/crates/runtime/src/datafusion/sql_validator.rs
@@ -105,6 +105,7 @@ mod tests {
     use data_components::arrow::write::MemTable;
     use datafusion::{catalog::MemoryCatalogProvider, sql::TableReference};
     use std::sync::Arc;
+    use tokio::runtime::Handle;
 
     fn create_test_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
@@ -119,6 +120,7 @@ mod tests {
             DataFusionBuilder::new(
                 RuntimeStatus::new(),
                 Arc::new(AcceleratorEngineRegistry::new()),
+                Handle::current(),
             )
             .build(),
         );

--- a/crates/runtime/src/datasets_health_monitor.rs
+++ b/crates/runtime/src/datasets_health_monitor.rs
@@ -413,6 +413,7 @@ mod test {
         catalog::MemorySchemaProvider, catalog::SchemaProvider, datasource::MemTable,
     };
     use std::sync::Arc;
+    use tokio::runtime::Handle;
 
     #[tokio::test]
     async fn test_register_dataset_with_schema() {
@@ -445,7 +446,12 @@ mod test {
         accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     ) -> Arc<DataFusion> {
         let df = Arc::new(
-            DataFusion::builder(RuntimeStatus::new(), accelerator_engine_registry).build(),
+            DataFusion::builder(
+                RuntimeStatus::new(),
+                accelerator_engine_registry,
+                Handle::current(),
+            )
+            .build(),
         );
 
         let catalog = df.ctx.catalog("spice").expect("default catalog is spice");

--- a/crates/runtime/src/http/v1/packages.rs
+++ b/crates/runtime/src/http/v1/packages.rs
@@ -23,6 +23,7 @@ use object_store::{ObjectStore, path::Path};
 use runtime_object_store::store::github::GitHubRawObjectStore;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
+use tokio::runtime::Handle;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -99,7 +100,8 @@ pub(crate) async fn generate(Json(payload): Json<GeneratePackageRequest>) -> Res
 
     let github_token = payload.params.get("github_token").map(String::as_str);
 
-    let store = match GitHubRawObjectStore::try_new(org, repo, sha, github_token) {
+    let store = match GitHubRawObjectStore::try_new(org, repo, sha, github_token, Handle::current())
+    {
         Ok(store) => Arc::new(store) as Arc<dyn ObjectStore>,
         Err(e) => {
             return (StatusCode::BAD_REQUEST, e.to_string()).into_response();

--- a/crates/runtime/src/init/catalog.rs
+++ b/crates/runtime/src/init/catalog.rs
@@ -85,7 +85,7 @@ impl Runtime {
 
         let source = catalog.provider.clone();
         let params = ConnectorParamsBuilder::new(source.clone().into(), (&catalog).into())
-            .build(self.secrets())
+            .build(self.secrets(), self.tokio_io_runtime())
             .await
             .context(UnableToInitializeCatalogConnectorSnafu)?;
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -605,7 +605,7 @@ impl Runtime {
         let source = ds.source();
 
         let params = ConnectorParamsBuilder::new(source.into(), (&ds).into())
-            .build(self.secrets())
+            .build(self.secrets(), self.tokio_io_runtime())
             .await
             .context(UnableToInitializeDataConnectorSnafu)?;
 

--- a/crates/runtime/src/internal_table.rs
+++ b/crates/runtime/src/internal_table.rs
@@ -153,8 +153,9 @@ pub async fn create_internal_accelerated_table(
         "internal".to_string(),
         accelerated_table_provider,
         refresh,
+        runtime.tokio_io_runtime(),
     );
-    builder.tokio_runtime(runtime.datafusion().tokio_runtime().cloned());
+    builder.cpu_runtime(runtime.datafusion().cpu_runtime().cloned());
 
     builder.retention(retention);
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -28,6 +28,7 @@ use std::sync::Weak;
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 use token_provider::registry::TokenProviderRegistry;
+use tokio::runtime::Handle;
 use tokio::{sync::Mutex, task::JoinHandle, time::Instant};
 use tools::factory::{ToolFactory, default_catalog_names};
 use util::force_shutdown_signal;
@@ -467,6 +468,7 @@ pub struct Runtime {
     metrics_endpoint: Option<SocketAddr>,
     prometheus_registry: Option<prometheus::Registry>,
     rate_limits: Arc<RateLimits>,
+    io_runtime: Handle,
 
     autoload_extensions: Arc<HashMap<String, Box<dyn ExtensionFactory>>>,
     extensions: Arc<RwLock<HashMap<String, Arc<dyn Extension>>>>,
@@ -491,6 +493,12 @@ impl Runtime {
     #[must_use]
     pub fn builder() -> RuntimeBuilder {
         RuntimeBuilder::new()
+    }
+
+    /// Returns a handle to the Tokio runtime that should be used to spawn IO tasks.
+    #[must_use]
+    pub fn tokio_io_runtime(&self) -> Handle {
+        self.io_runtime.clone()
     }
 
     #[must_use]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -449,6 +449,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct LogErrors(pub bool);
 
 #[derive(Clone)]
+#[allow(clippy::struct_field_names)]
 pub struct Runtime {
     app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,

--- a/crates/runtime/src/management/mod.rs
+++ b/crates/runtime/src/management/mod.rs
@@ -275,6 +275,7 @@ async fn get_spiceai_table_provider(
     };
 
     let secrets = runtime.secrets();
+    let tokio_io_runtime = runtime.tokio_io_runtime();
 
     let mut dataset = DatasetBuilder::try_new(format!("spice.ai/{cloud_dataset_path}"), name)
         .boxed()
@@ -289,7 +290,7 @@ async fn get_spiceai_table_provider(
     dataset.access = AccessMode::ReadWrite;
 
     let params = ConnectorParamsBuilder::new("spice.ai".into(), (&dataset).into())
-        .build(secrets)
+        .build(secrets, tokio_io_runtime)
         .await
         .context(UnableToCreateDataConnectorSnafu)?;
 

--- a/crates/runtime/tests/aws_sdk/mod.rs
+++ b/crates/runtime/tests/aws_sdk/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use arrow::record_batch::RecordBatch;
 use runtime::Runtime;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_aws_sdk_environment_resolution() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
 

--- a/crates/runtime/tests/refresh_retry/mysql.rs
+++ b/crates/runtime/tests/refresh_retry/mysql.rs
@@ -39,6 +39,7 @@ use runtime::{
     accelerated_table::{AcceleratedTable, refresh::Refresh, refresh_task::RefreshTask},
 };
 use spicepod::acceleration::Acceleration;
+use tokio::runtime::Handle;
 use tokio::time;
 use tracing::instrument;
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
@@ -118,9 +119,9 @@ async fn create_refresh_task(
             Arc::clone(&accelerated_table.get_federated_table()),
             None,
             accelerated_table.get_accelerator(),
-            None,
+            Handle::current(),
         )
-        .with_tokio_runtime(rt.datafusion().tokio_runtime().cloned())
+        .with_cpu_runtime(rt.datafusion().cpu_runtime().cloned())
         .build(),
         accelerated_table.refresh_params().read().await.clone(),
     ))

--- a/crates/runtime/tests/refresh_sql/refresh_max_timestamp_df.rs
+++ b/crates/runtime/tests/refresh_sql/refresh_max_timestamp_df.rs
@@ -35,6 +35,7 @@ use runtime_datafusion_index::analyzer::{
 use runtime_object_store::registry::default_runtime_env;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::runtime::Handle;
 
 /// This test verifies:
 ///   *  `DataAccelerator::create_external_table` returns `PolyTableProvider`
@@ -99,7 +100,7 @@ async fn test_refresh_max_timestamp_df() -> anyhow::Result<()> {
                 .expect("Expected PolyTableProvider");
 
             let mut state = SessionStateBuilder::new()
-                .with_runtime_env(default_runtime_env())
+                .with_runtime_env(default_runtime_env(Handle::current()))
                 .with_default_features()
                 .with_query_planner(Arc::new(SpiceQueryPlanner::new().with_extension_planners(
                     vec![

--- a/crates/runtime/tests/snapshot_integration/mod.rs
+++ b/crates/runtime/tests/snapshot_integration/mod.rs
@@ -944,8 +944,11 @@ async fn snapshot_int_test6_concurrent_snapshot_writes_retry() -> Result<()> {
                 .and_then(|app| app.snapshots.clone())
                 .ok_or_else(|| anyhow!("Runtime snapshots configuration unavailable"))?;
 
-            let snapshot_behavior =
-                RuntimeSnapshotBehavior::enabled(runtime_snapshots, runtime.secrets_weak());
+            let snapshot_behavior = RuntimeSnapshotBehavior::enabled(
+                runtime_snapshots,
+                runtime.secrets_weak(),
+                runtime.tokio_io_runtime(),
+            );
 
             let manager = SnapshotManager::try_new(
                 TAXI_TRIPS_DATASET_NAME.to_string(),
@@ -1027,7 +1030,7 @@ async fn snapshot_int_test7_respects_current_snapshot_metadata_selection() -> Re
                 .and_then(|app| app.snapshots.clone())
                 .ok_or_else(|| anyhow!("Runtime snapshots configuration unavailable"))?;
             let snapshot_behavior =
-                RuntimeSnapshotBehavior::enabled(runtime_snapshots, runtime.secrets_weak());
+                RuntimeSnapshotBehavior::enabled(runtime_snapshots, runtime.secrets_weak(), runtime.tokio_io_runtime());
             let manager = SnapshotManager::try_new(
                 TAXI_TRIPS_DATASET_NAME.to_string(),
                 snapshot_behavior,

--- a/crates/spice_cloud/src/lib.rs
+++ b/crates/spice_cloud/src/lib.rs
@@ -302,6 +302,8 @@ async fn get_spiceai_table_provider(
         });
     };
 
+    let io_runtime = runtime.tokio_io_runtime();
+
     let mut dataset = DatasetBuilder::try_new(cloud_dataset_path.to_string(), name)
         .boxed()
         .context(UnableToCreateDataConnectorSnafu)?
@@ -315,7 +317,7 @@ async fn get_spiceai_table_provider(
     dataset.replication = Some(Replication { enabled: true });
 
     let params = ConnectorParamsBuilder::new(name.into(), (&dataset).into())
-        .build(secrets)
+        .build(secrets, io_runtime)
         .await
         .context(UnableToCreateDataConnectorSnafu)?;
 
@@ -380,8 +382,9 @@ pub async fn create_synced_internal_accelerated_table(
         "spice.ai".to_string(),
         accelerated_table_provider,
         refresh,
+        runtime.tokio_io_runtime(),
     );
-    builder.tokio_runtime(runtime.datafusion().tokio_runtime().cloned());
+    builder.cpu_runtime(runtime.datafusion().cpu_runtime().cloned());
 
     builder.retention(retention);
 


### PR DESCRIPTION
## 📝 Summary

When using a separate CPU runtime for DataFusion execution, we still want IO-bound tasks to be executed on the main Tokio runtime with all other IO.

This PR wires that up using the `SpawnedReqwestConnector` in the `object_store` crate that was designed for that purpose. There is a bunch of associated wiring to pipe the IO runtime everywhere it needs to be.

## 🔗 Related

- Closes #7677
