### PR TITLE
Task History `min_sql_duration` filter support

### DIFF
--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -177,8 +177,18 @@ where
         .transpose()?
         .unwrap_or_default();
 
+    let min_sql_duration_ms = app
+        .as_ref()
+        .map(|app| app.runtime.task_history.min_sql_duration_as_millis())
+        .transpose()?
+        .flatten();
+
     let mut exporters: Vec<Box<dyn SpanExporter>> = vec![Box::new(
-        task_history::otel_exporter::TaskHistoryExporter::new(df, captured_output),
+        task_history::otel_exporter::TaskHistoryExporter::new(
+            df,
+            captured_output,
+            min_sql_duration_ms,
+        ),
     )];
 
     if let Ok(Some(zipkin_exporter)) = zipkin_task_history_otel_exporter(app_name, config).await {

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -189,7 +189,7 @@ impl SpanExporter for TaskHistoryExporter {
     fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
         let min_sql_duration_ms = self.min_sql_duration_ms;
         let should_include = |task_span: &TaskSpan| {
-            min_sql_duration_ms.map_or(true, |min| task_span.execution_duration_ms >= min)
+            min_sql_duration_ms.is_none_or(|min| task_span.execution_duration_ms >= min)
         };
         let spans: Vec<TaskSpan> = batch
             .into_iter()

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -191,14 +191,7 @@ impl SpanExporter for TaskHistoryExporter {
         let spans: Vec<TaskSpan> = batch
             .into_iter()
             .map(|span| self.span_to_task_span(span))
-            .filter(|task_span| {
-                // If min_sql_duration is set, filter out spans with shorter execution times
-                if let Some(min_duration) = min_sql_duration_ms {
-                    task_span.execution_duration_ms >= min_duration
-                } else {
-                    true
-                }
-            })
+            .filter(|task_span| min_sql_duration_ms.map_or(true, |min| task_span.execution_duration_ms >= min))
             .collect();
 
         let df = Arc::clone(&self.df);

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -44,6 +44,7 @@ macro_rules! extract_attr {
 pub struct TaskHistoryExporter {
     df: Arc<DataFusion>,
     captured_output: TaskHistoryCapturedOutput,
+    min_sql_duration_ms: Option<f64>,
 }
 
 impl Debug for TaskHistoryExporter {
@@ -53,10 +54,15 @@ impl Debug for TaskHistoryExporter {
 }
 
 impl TaskHistoryExporter {
-    pub fn new(df: Arc<DataFusion>, captured_output: TaskHistoryCapturedOutput) -> Self {
+    pub fn new(
+        df: Arc<DataFusion>,
+        captured_output: TaskHistoryCapturedOutput,
+        min_sql_duration_ms: Option<f64>,
+    ) -> Self {
         Self {
             df,
             captured_output,
+            min_sql_duration_ms,
         }
     }
 
@@ -181,9 +187,18 @@ impl TaskHistoryExporter {
 
 impl SpanExporter for TaskHistoryExporter {
     fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        let min_sql_duration_ms = self.min_sql_duration_ms;
         let spans: Vec<TaskSpan> = batch
             .into_iter()
             .map(|span| self.span_to_task_span(span))
+            .filter(|task_span| {
+                // If min_sql_duration is set, filter out spans with shorter execution times
+                if let Some(min_duration) = min_sql_duration_ms {
+                    task_span.execution_duration_ms >= min_duration
+                } else {
+                    true
+                }
+            })
             .collect();
 
         let df = Arc::clone(&self.df);

--- a/crates/runtime/src/task_history/otel_exporter.rs
+++ b/crates/runtime/src/task_history/otel_exporter.rs
@@ -188,10 +188,13 @@ impl TaskHistoryExporter {
 impl SpanExporter for TaskHistoryExporter {
     fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
         let min_sql_duration_ms = self.min_sql_duration_ms;
+        let should_include = |task_span: &TaskSpan| {
+            min_sql_duration_ms.map_or(true, |min| task_span.execution_duration_ms >= min)
+        };
         let spans: Vec<TaskSpan> = batch
             .into_iter()
             .map(|span| self.span_to_task_span(span))
-            .filter(|task_span| min_sql_duration_ms.map_or(true, |min| task_span.execution_duration_ms >= min))
+            .filter(should_include)
             .collect();
 
         let df = Arc::clone(&self.df);

--- a/crates/runtime/tests/utils/mod.rs
+++ b/crates/runtime/tests/utils/mod.rs
@@ -160,7 +160,7 @@ pub(crate) fn init_tracing_with_task_history(
     let fmt_layer = fmt::layer().with_ansi(true).with_filter(filter);
 
     let task_history_exporter =
-        TaskHistoryExporter::new(rt.datafusion(), TaskHistoryCapturedOutput::Truncated);
+        TaskHistoryExporter::new(rt.datafusion(), TaskHistoryCapturedOutput::Truncated, None);
 
     // Tests hang if we don't use TokioCurrentThread here (similar to https://github.com/open-telemetry/opentelemetry-rust/issues/868)
     let provider = TracerProvider::builder()

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -198,6 +198,8 @@ pub struct TaskHistory {
     pub retention_period: Arc<str>,
     #[serde(default = "default_retention_check_interval")]
     pub retention_check_interval: Arc<str>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_sql_duration: Option<Arc<str>>,
 }
 
 fn default_none() -> Arc<str> {
@@ -219,6 +221,7 @@ impl Default for TaskHistory {
             captured_output: default_none(),
             retention_period: default_retention_period(),
             retention_check_interval: default_retention_check_interval(),
+            min_sql_duration: None,
         }
     }
 }
@@ -268,6 +271,22 @@ impl TaskHistory {
 
     pub fn retention_check_interval_as_secs(&self) -> Result<u64, Box<dyn Error + Send + Sync>> {
         Self::retention_value_as_secs(&self.retention_check_interval, "check interval")
+    }
+
+    /// Parses the `min_sql_duration` field into milliseconds as f64. Returns `Ok(None)` if not set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the duration string cannot be parsed.
+    pub fn min_sql_duration_as_millis(&self) -> Result<Option<f64>, Box<dyn Error + Send + Sync>> {
+        let Some(min_sql_duration) = &self.min_sql_duration else {
+            return Ok(None);
+        };
+
+        let duration =
+            fundu::parse_duration(min_sql_duration.as_ref()).map_err(|e| e.to_string())?;
+
+        Ok(Some(duration.as_secs_f64() * 1000.0))
     }
 }
 
@@ -702,5 +721,90 @@ mod tests {
         ";
         let runtime: Runtime = serde_yaml::from_str(yaml).expect("Failed to parse Runtime");
         assert_eq!(runtime.query, None);
+    }
+
+    #[test]
+    fn test_task_history_min_duration() {
+        // Test default (no min_sql_duration)
+        let task_history = TaskHistory::default();
+        assert_eq!(task_history.min_sql_duration, None);
+        assert_eq!(
+            task_history
+                .min_sql_duration_as_millis()
+                .expect("should parse successfully"),
+            None
+        );
+
+        // Test with various duration formats
+        let test_cases = vec![
+            ("5ms", 5.0),
+            ("100ms", 100.0),
+            ("1s", 1000.0),
+            ("2.5s", 2500.0),
+            ("1m", 60_000.0),
+            ("1h", 3_600_000.0),
+        ];
+
+        for (duration_str, expected_ms) in test_cases {
+            let task_history = TaskHistory {
+                enabled: true,
+                captured_output: "none".into(),
+                retention_period: "8h".into(),
+                retention_check_interval: "15m".into(),
+                min_sql_duration: Some(duration_str.into()),
+            };
+
+            let result = task_history
+                .min_sql_duration_as_millis()
+                .expect("should parse successfully");
+            assert_eq!(
+                result,
+                Some(expected_ms),
+                "Failed for duration: {duration_str}"
+            );
+        }
+
+        // Test invalid duration
+        let task_history = TaskHistory {
+            enabled: true,
+            captured_output: "none".into(),
+            retention_period: "8h".into(),
+            retention_check_interval: "15m".into(),
+            min_sql_duration: Some("invalid".into()),
+        };
+        assert!(
+            task_history.min_sql_duration_as_millis().is_err(),
+            "should fail for invalid duration"
+        );
+    }
+
+    #[test]
+    fn test_task_history_yaml_parsing() {
+        // Test with min_sql_duration
+        let yaml = r"
+            task_history:
+                enabled: true
+                captured_output: truncated
+                retention_period: 8h
+                retention_check_interval: 15m
+                min_sql_duration: 10ms
+        ";
+        let runtime: Runtime = serde_yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.task_history.min_sql_duration, Some("10ms".into()));
+        assert_eq!(
+            runtime
+                .task_history
+                .min_sql_duration_as_millis()
+                .expect("should parse"),
+            Some(10.0)
+        );
+
+        // Test without min_sql_duration (should use default None)
+        let yaml = r"
+            task_history:
+                enabled: true
+        ";
+        let runtime: Runtime = serde_yaml::from_str(yaml).expect("Failed to parse Runtime");
+        assert_eq!(runtime.task_history.min_sql_duration, None);
     }
 }


### PR DESCRIPTION
This pull request introduces support for an optional minimum SQL duration threshold in task history tracking, allowing users to filter out short-lived SQL spans. The main changes add a new configuration field, parsing logic, and filtering behavior, along with comprehensive tests to ensure correct functionality.

**Task History Minimum SQL Duration Support**

* Added an optional `min_sql_duration` field to the `TaskHistory` struct, including serde configuration for YAML parsing and defaulting behavior. [[1]](diffhunk://#diff-bc5207e04273f7f21ac3dbb78f6c93c701f3e933a095f042c3b8ac69e0cdba43R201-R202) [[2]](diffhunk://#diff-bc5207e04273f7f21ac3dbb78f6c93c701f3e933a095f042c3b8ac69e0cdba43R224)
* Implemented the `min_sql_duration_as_millis` method to parse the duration string into milliseconds, with error handling for invalid formats.

**Exporter Filtering Logic**

* Updated the `TaskHistoryExporter` struct and constructor to accept and store an optional minimum SQL duration in milliseconds. [[1]](diffhunk://#diff-3790b41081669ba504cf329964ed685d05c84761b941cee3bab8bca64132c8c9R47) [[2]](diffhunk://#diff-3790b41081669ba504cf329964ed685d05c84761b941cee3bab8bca64132c8c9L56-R65)
* Modified the `export` method in `TaskHistoryExporter` to filter out SQL spans whose execution duration is below the configured threshold, if set.

**Testing and Validation**

* Added unit tests to verify parsing, YAML deserialization, and error cases for the new `min_sql_duration` field, ensuring robustness and correct integration.