### PR TITLE
Add health probing to testoperator runs

### DIFF
--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -4,6 +4,8 @@
 
 `testoperator` is a command-line tool for running and exporting Spicepod environments for testing purposes.
 
+While a test is executing, `testoperator` continuously probes the `/health` and `/v1/ready` endpoints on the running `spiced` instance. Responses that fail or take longer than 5 ms are recorded and surfaced after the test run; any such issues will cause the test to fail with a summary that includes the number of failures and the worst latency observed.
+
 ## Common Options
 
 - `-p, --spicepod-path <SPICEPOD_PATH>`: Path to the `spicepod.yaml` file.

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use super::get_app_and_start_request;
-use crate::{args::DatasetTestArgs, wait_test_and_memory};
+use crate::{args::DatasetTestArgs, health::HealthMonitor, wait_test_and_memory};
 use std::time::Duration;
 use test_framework::{
     TestType,
@@ -61,6 +61,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+    let health_monitor = HealthMonitor::spawn()?;
 
     let append_test = append_test
         .with_spiced_instance(spiced_instance)
@@ -71,17 +72,24 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     let mut spiced_instance = test.end()?;
     let (max_memory, _) = observe_memory(memory_token, memory_readings).await?;
 
-    check_table_counts(
+    let table_count_result = check_table_counts(
         &spiced_instance,
         query_set,
         args.scale_factor.unwrap_or(1.0),
     )
-    .await?;
+    .await;
 
     let records = metrics.with_memory_usage(max_memory).build_records()?;
     print_batches(&records)?;
 
+    let health_report = health_monitor.stop().await;
     spiced_instance.stop()?;
+    let health_report = health_report?;
+
+    table_count_result?;
+    if let Some(message) = health_report.failure_message() {
+        return Err(anyhow::anyhow!(message));
+    }
     Ok(())
 }
 

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use super::{RowCounts, get_app_and_start_request};
-use crate::{args::DatasetTestArgs, wait_test_and_memory};
+use crate::{args::DatasetTestArgs, health::HealthMonitor, wait_test_and_memory};
 use std::time::Duration;
 use test_framework::{
     TestType, anyhow,
@@ -47,6 +47,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+    let health_monitor = HealthMonitor::spawn()?;
 
     // baseline run
     println!("Running benchmark test");
@@ -133,13 +134,24 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
 
     let records = metrics.with_memory_usage(max_memory).build_records()?;
     print_batches(&records)?;
+    let health_report = health_monitor.stop().await;
     spiced_instance.stop()?;
+    let health_report = health_report?;
+    let mut error_messages = Vec::new();
 
     if !test_succeeded {
-        return Err(anyhow::anyhow!(
+        error_messages.push(format!(
             "Benchmark test failed due to failed queries:\n{}",
             failures.join("\n")
         ));
+    }
+
+    if let Some(message) = health_report.failure_message() {
+        error_messages.push(message);
+    }
+
+    if !error_messages.is_empty() {
+        return Err(anyhow::anyhow!(error_messages.join("\n")));
     }
 
     Ok(row_counts)

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -34,6 +34,7 @@ use test_framework::{
     utils::observe_memory,
 };
 
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<RowCounts> {
     let query_set = QuerySet::from(args.query_set.clone());
     let query_overrides = args.query_overrides.clone().map(QueryOverrides::from);

--- a/tools/testoperator/src/commands/evals/mod.rs
+++ b/tools/testoperator/src/commands/evals/mod.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use crate::args::EvalsTestArgs;
 
 use super::get_app_and_start_request;
+use crate::health::HealthMonitor;
 use serde_json::json;
 use spiceai::Client as SpiceClient;
 use std::time::{Duration, SystemTime};
@@ -110,6 +111,7 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+    let health_monitor = HealthMonitor::spawn()?;
 
     println!("Executing {eval} eval benchmark for model {model}. It might take several minutes...");
 
@@ -133,7 +135,16 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
     let response_msq = response.text().await?;
 
     if !response_status.is_success() {
-        return Err(anyhow::anyhow!("Failed to execute evals: {response_msq}"));
+        let health_report = health_monitor.stop().await;
+        spiced_instance.stop()?;
+        let health_report = health_report?;
+
+        let mut failure_messages = vec![format!("Failed to execute evals: {response_msq}")];
+        if let Some(message) = health_report.failure_message() {
+            failure_messages.push(message);
+        }
+
+        return Err(anyhow::anyhow!(failure_messages.join("\n")));
     }
 
     println!("Evals completed:\n{response_msq}");
@@ -188,11 +199,21 @@ pub(crate) async fn run(args: &EvalsTestArgs) -> anyhow::Result<()> {
 
     telemetry.emit().await?;
 
+    let health_report = health_monitor.stop().await;
     spiced_instance.stop()?;
+    let health_report = health_report?;
 
     // Report unsuccessful evaluation run as an error
+    let mut failure_messages = Vec::new();
     if matches!(metrics.status, EvalStatus::Failed) {
-        return Err(anyhow::anyhow!("Evaluation run failed"));
+        failure_messages.push("Evaluation run failed".to_string());
+    }
+    if let Some(message) = health_report.failure_message() {
+        failure_messages.push(message);
+    }
+
+    if !failure_messages.is_empty() {
+        return Err(anyhow::anyhow!(failure_messages.join("\n")));
     }
 
     println!("Benchmark completed successfully!");

--- a/tools/testoperator/src/commands/http/consistency.rs
+++ b/tools/testoperator/src/commands/http/consistency.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use crate::{
     args::HttpConsistencyTestArgs,
     commands::{get_app_and_start_request, util::Color},
+    health::HealthMonitor,
     with_color,
 };
 use std::{sync::Arc, time::Duration};
@@ -50,6 +51,7 @@ pub async fn consistency_run(args: &HttpConsistencyTestArgs) -> anyhow::Result<(
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+    let health_monitor = HealthMonitor::spawn()?;
 
     let test = SpiceTest::new(
         app.name.clone(),
@@ -79,35 +81,46 @@ pub async fn consistency_run(args: &HttpConsistencyTestArgs) -> anyhow::Result<(
         .iter()
         .map(|minute| (minute.median_duration_ms, minute.percentile_95_duration_ms))
         .unzip();
+    let mut failure_messages = Vec::new();
     if p50.len() >= 2 {
         let increase = *p50.last().ok_or(anyhow!("no p50 data"))? as f64 / p50[0] as f64;
 
         if increase > args.increase_threshold {
-            return Err(anyhow::anyhow!(with_color!(
+            failure_messages.push(with_color!(
                 Color::RedBold,
                 "p50 increase threshold exceeded: {} > {}",
                 increase,
                 args.increase_threshold
-            )));
+            ));
         }
     }
 
     if p95.len() >= 2 {
         let increase = *p95.last().ok_or(anyhow!("no p95 data"))? as f64 / p95[0] as f64;
         if increase > args.increase_threshold {
-            return Err(anyhow::anyhow!(with_color!(
+            failure_messages.push(with_color!(
                 Color::RedBold,
                 "p95 increase threshold exceeded: {} > {}",
                 increase,
                 args.increase_threshold
-            )));
+            ));
         }
+    }
+
+    let health_report = health_monitor.stop().await;
+    spiced_instance.stop()?;
+    let health_report = health_report?;
+
+    if let Some(message) = health_report.failure_message() {
+        failure_messages.push(message);
+    }
+    if !failure_messages.is_empty() {
+        return Err(anyhow::anyhow!(failure_messages.join("\n")));
     }
 
     println!(
         "{}",
         with_color!(Color::Green, "Consistency test completed!")
     );
-    spiced_instance.stop()?;
     Ok(())
 }

--- a/tools/testoperator/src/commands/http/overhead.rs
+++ b/tools/testoperator/src/commands/http/overhead.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use crate::{
     args::HttpOverheadTestArgs,
     commands::{get_app_and_start_request, util::Color},
+    health::HealthMonitor,
     with_color,
 };
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
@@ -53,6 +54,7 @@ pub(crate) async fn overhead_run(args: &HttpOverheadTestArgs) -> anyhow::Result<
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+    let health_monitor = HealthMonitor::spawn()?;
 
     let baseline_cfg = construct_baseline_cfg(args, &component, &payloads)?;
 
@@ -79,7 +81,9 @@ pub(crate) async fn overhead_run(args: &HttpOverheadTestArgs) -> anyhow::Result<
     print_batches(&records)?;
 
     let mut spiced_instance = test.end()?;
+    let health_report = health_monitor.stop().await;
     spiced_instance.stop()?;
+    let health_report = health_report?;
 
     let Some(baseline) = results
         .metrics
@@ -96,24 +100,39 @@ pub(crate) async fn overhead_run(args: &HttpOverheadTestArgs) -> anyhow::Result<
         return Err(anyhow::anyhow!("Spice results not found"));
     };
 
-    check_threshold(
+    let mut failure_messages = Vec::new();
+    if let Err(err) = check_threshold(
         spice.median_duration_ms,
         baseline.median_duration_ms,
         args.increase_threshold,
         "median",
-    )?;
-    check_threshold(
+    ) {
+        failure_messages.push(err.to_string());
+    }
+    if let Err(err) = check_threshold(
         spice.percentile_90_duration_ms,
         baseline.percentile_90_duration_ms,
         args.increase_threshold,
         "p90",
-    )?;
-    check_threshold(
+    ) {
+        failure_messages.push(err.to_string());
+    }
+    if let Err(err) = check_threshold(
         spice.percentile_95_duration_ms,
         baseline.percentile_95_duration_ms,
         args.increase_threshold,
         "p95",
-    )?;
+    ) {
+        failure_messages.push(err.to_string());
+    }
+
+    if let Some(message) = health_report.failure_message() {
+        failure_messages.push(message);
+    }
+
+    if !failure_messages.is_empty() {
+        return Err(anyhow::anyhow!(failure_messages.join("\n")));
+    }
 
     Ok(())
 }

--- a/tools/testoperator/src/commands/load/mod.rs
+++ b/tools/testoperator/src/commands/load/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use super::get_app_and_start_request;
-use crate::{args::LoadTestArgs, wait_test_and_memory};
+use crate::{args::LoadTestArgs, health::HealthMonitor, wait_test_and_memory};
 use std::time::Duration;
 use test_framework::{
     TestType, anyhow,
@@ -53,6 +53,7 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.test_args.common.ready_wait))
         .await?;
+    let health_monitor = HealthMonitor::spawn()?;
 
     let test_duration = Duration::from_secs(args.test_args.common.duration);
     let test_hours = (test_duration.as_secs() / 60 / 60).max(1);
@@ -119,7 +120,9 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
     let records = metrics.with_memory_usage(max_memory).build_records()?;
     print_batches(&records)?;
 
+    let health_report = health_monitor.stop().await;
     spiced_instance.stop()?;
+    let health_report = health_report?;
 
     let mut test_passed = true;
     let mut yellow_measurements = 0;
@@ -166,12 +169,19 @@ pub(crate) async fn run(args: &LoadTestArgs) -> anyhow::Result<()> {
         }
     }
 
+    let mut failure_messages = Vec::new();
     if !args.no_error && yellow_measurements >= 3 {
-        return Err(anyhow::anyhow!(
-            "Load test failed due to too many yellow measurements"
-        ));
-    } else if !args.no_error && !test_passed {
-        return Err(anyhow::anyhow!("Load test failed."));
+        failure_messages.push("Load test failed due to too many yellow measurements".to_string());
+    }
+    if !args.no_error && !test_passed {
+        failure_messages.push("Load test failed.".to_string());
+    }
+    if let Some(message) = health_report.failure_message() {
+        failure_messages.push(message);
+    }
+
+    if !failure_messages.is_empty() {
+        return Err(anyhow::anyhow!(failure_messages.join("\n")));
     }
 
     println!("Load test completed");

--- a/tools/testoperator/src/commands/search/mod.rs
+++ b/tools/testoperator/src/commands/search/mod.rs
@@ -17,7 +17,7 @@ limitations under the License.
 mod mteb_quora;
 
 use super::get_app_and_start_request;
-use crate::{args::SearchTestArgs, wait_test_and_memory};
+use crate::{args::SearchTestArgs, health::HealthMonitor, wait_test_and_memory};
 use std::time::{Duration, SystemTime};
 use test_framework::{
     TestType, anyhow, git,
@@ -70,6 +70,7 @@ pub(crate) async fn run(args: &SearchTestArgs) -> anyhow::Result<()> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+    let health_monitor = HealthMonitor::spawn()?;
 
     let index_finished_at = SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
 
@@ -154,7 +155,13 @@ pub(crate) async fn run(args: &SearchTestArgs) -> anyhow::Result<()> {
 
     telemetry.emit().await?;
 
+    let health_report = health_monitor.stop().await;
     spiced_instance.stop()?;
+    let health_report = health_report?;
+
+    if let Some(message) = health_report.failure_message() {
+        return Err(anyhow::anyhow!(message));
+    }
 
     println!("Benchmark completed successfully!");
 

--- a/tools/testoperator/src/commands/throughput/mod.rs
+++ b/tools/testoperator/src/commands/throughput/mod.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use super::get_app_and_start_request;
-use crate::{args::DatasetTestArgs, wait_test_and_memory};
+use crate::{args::DatasetTestArgs, health::HealthMonitor, wait_test_and_memory};
 use std::time::Duration;
 use test_framework::{
     TestType, anyhow,
@@ -48,6 +48,7 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     spiced_instance
         .wait_for_ready(Duration::from_secs(args.common.ready_wait))
         .await?;
+    let health_monitor = HealthMonitor::spawn()?;
 
     // baseline run
     println!("Running baseline test");
@@ -97,7 +98,13 @@ pub(crate) async fn run(args: &DatasetTestArgs) -> anyhow::Result<()> {
     let records = metrics.build_records()?;
     print_batches(&records)?;
     metrics.with_memory_usage(max_memory).show_run(None)?; // no additional test pass logic applies
+    let health_report = health_monitor.stop().await;
     spiced_instance.stop()?;
+    let health_report = health_report?;
+
+    if let Some(message) = health_report.failure_message() {
+        return Err(anyhow::anyhow!(message));
+    }
 
     println!(
         "Throughput test completed with throughput: {} Queries per hour * Scale Factor",

--- a/tools/testoperator/src/health.rs
+++ b/tools/testoperator/src/health.rs
@@ -140,10 +140,10 @@ impl HealthMonitor {
                 }
 
                 tokio::select! {
-                    _ = task_token.cancelled() => {
+                    () = task_token.cancelled() => {
                         return HealthCheckReport { endpoints: stats };
                     }
-                    _ = tokio::time::sleep(SAMPLE_INTERVAL) => {}
+                    () = tokio::time::sleep(SAMPLE_INTERVAL) => {}
                 }
             }
         });

--- a/tools/testoperator/src/health.rs
+++ b/tools/testoperator/src/health.rs
@@ -1,0 +1,180 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
+
+use test_framework::{
+    anyhow::{self, Context},
+    tokio_util::sync::CancellationToken,
+};
+
+const BASE_URL: &str = "http://localhost:8090";
+const ENDPOINTS: [&str; 2] = ["/health", "/v1/ready"];
+const SAMPLE_INTERVAL: Duration = Duration::from_millis(100);
+const LATENCY_THRESHOLD: Duration = Duration::from_millis(5);
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct EndpointStats {
+    pub(crate) failure_count: u64,
+    pub(crate) max_latency: Duration,
+    pub(crate) last_error: Option<String>,
+}
+
+impl EndpointStats {
+    fn record_sample(&mut self, latency: Duration, failure: Option<String>) {
+        if latency > self.max_latency {
+            self.max_latency = latency;
+        }
+
+        if let Some(reason) = failure {
+            self.failure_count = self.failure_count.saturating_add(1);
+            self.last_error = Some(reason);
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct HealthCheckReport {
+    endpoints: BTreeMap<&'static str, EndpointStats>,
+}
+
+impl HealthCheckReport {
+    pub(crate) fn failure_message(&self) -> Option<String> {
+        let mut parts = Vec::new();
+
+        for (endpoint, stats) in &self.endpoints {
+            if stats.failure_count == 0 {
+                continue;
+            }
+
+            let max_latency_ms = stats.max_latency.as_secs_f64() * 1000.0;
+            let reason = stats
+                .last_error
+                .as_deref()
+                .unwrap_or("latency threshold exceeded");
+            parts.push(format!(
+                "{endpoint} failed {count} time(s); max latency {max_latency_ms:.2} ms; last error: {reason}",
+                count = stats.failure_count
+            ));
+        }
+
+        if parts.is_empty() {
+            None
+        } else {
+            Some(format!(
+                "Health checks detected issues: {}",
+                parts.join(" | ")
+            ))
+        }
+    }
+}
+
+pub(crate) struct HealthMonitor {
+    cancel_token: CancellationToken,
+    task: Option<tokio::task::JoinHandle<HealthCheckReport>>,
+}
+
+impl HealthMonitor {
+    pub(crate) fn spawn() -> anyhow::Result<Self> {
+        let cancel_token = CancellationToken::new();
+        let task_token = cancel_token.clone();
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .context("Failed to create health monitor HTTP client")?;
+
+        let task = tokio::spawn(async move {
+            let mut stats: BTreeMap<&'static str, EndpointStats> = ENDPOINTS
+                .into_iter()
+                .map(|ep| (ep, EndpointStats::default()))
+                .collect();
+
+            loop {
+                for endpoint in ENDPOINTS {
+                    if task_token.is_cancelled() {
+                        return HealthCheckReport { endpoints: stats };
+                    }
+
+                    let url = format!("{BASE_URL}{endpoint}");
+                    let start = Instant::now();
+                    let response = client.get(url).send().await;
+                    let latency = start.elapsed();
+
+                    let failure_reason = match response {
+                        Ok(response) => {
+                            if !response.status().is_success() {
+                                Some(format!("status {}", response.status()))
+                            } else if latency > LATENCY_THRESHOLD {
+                                Some(format!(
+                                    "latency {}ms exceeded {}ms budget",
+                                    latency.as_secs_f64() * 1_000.0,
+                                    LATENCY_THRESHOLD.as_secs_f64() * 1_000.0
+                                ))
+                            } else {
+                                None
+                            }
+                        }
+                        Err(error) => Some(error.to_string()),
+                    };
+
+                    if let Some(entry) = stats.get_mut(endpoint) {
+                        entry.record_sample(latency, failure_reason);
+                    }
+                }
+
+                tokio::select! {
+                    _ = task_token.cancelled() => {
+                        return HealthCheckReport { endpoints: stats };
+                    }
+                    _ = tokio::time::sleep(SAMPLE_INTERVAL) => {}
+                }
+            }
+        });
+
+        Ok(Self {
+            cancel_token,
+            task: Some(task),
+        })
+    }
+
+    pub(crate) async fn stop(mut self) -> anyhow::Result<HealthCheckReport> {
+        self.cancel_token.cancel();
+        let Some(task) = self.task.take() else {
+            return Ok(HealthCheckReport::default());
+        };
+
+        match task.await {
+            Ok(report) => Ok(report),
+            Err(err) => {
+                Err(anyhow::anyhow!(err)
+                    .context("Health monitor task did not complete successfully"))
+            }
+        }
+    }
+}
+
+impl Drop for HealthMonitor {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -19,6 +19,7 @@ use test_framework::{anyhow, rustls};
 
 mod args;
 mod commands;
+mod health;
 mod metrics;
 
 use args::{


### PR DESCRIPTION
## Summary
- add a reusable health monitor that polls /health and /v1/ready during test runs
- fail tests when health checks fail or exceed 5ms latency budget
- document the new behaviour in the testoperator README

## Testing
- cargo check -p testoperator
