### PR TITLE
Display execution time in Spice REPL for no results

### DIFF
--- a/crates/flightrepl/src/lib.rs
+++ b/crates/flightrepl/src/lib.rs
@@ -388,9 +388,6 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
         )
         .await
         {
-            Ok((_, 0, from_cache)) => {
-                println!("No results{}.", if from_cache { " (cached)" } else { "" });
-            }
             Ok((records, total_rows, from_cache)) => {
                 display_records(&records, start_time, total_rows, from_cache)?;
             }
@@ -519,6 +516,8 @@ fn display_records(
     let mut limited_records = Vec::new();
     let mut rows_collected = 0;
 
+    let elapsed = start_time.elapsed();
+
     for batch in records {
         if rows_collected >= 500 {
             break;
@@ -542,15 +541,26 @@ fn display_records(
         }
     };
 
-    println!("{pretty_batches}");
+    if total_rows > 0 {
+        println!("{pretty_batches}");
+    } else {
+        println!("No results.");
+    }
 
-    let elapsed = start_time.elapsed();
     if rows_collected == total_rows {
-        println!(
-            "\nTime: {} seconds. {rows_collected} rows{}.",
-            elapsed.as_secs_f64(),
-            if from_cache { " (cached)" } else { "" }
-        );
+        if total_rows == 0 {
+            println!(
+                "\nTime: {} seconds{}.",
+                elapsed.as_secs_f64(),
+                if from_cache { " (cached)" } else { "" }
+            );
+        } else {
+            println!(
+                "\nTime: {} seconds. {rows_collected} rows{}.",
+                elapsed.as_secs_f64(),
+                if from_cache { " (cached)" } else { "" }
+            );
+        }
     } else {
         println!(
             "\nTime: {} seconds. {rows_collected}/{total_rows} rows displayed{}.",


### PR DESCRIPTION
## 📝 Summary

Show execution time for queries with no results in REPL

```
sql> some-query
No results.

Time: 0.00561975 seconds.
```

## 🔗 Related

Closes https://github.com/spiceai/spiceai/issues/7427

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
