### PR TITLE
Pepper TPC-H SF-1 benchmark

### DIFF
--- a/test/spicepods/tpch/sf1/accelerated/file[parquet]-pepper[file].yaml
+++ b/test/spicepods/tpch/sf1/accelerated/file[parquet]-pepper[file].yaml
@@ -1,0 +1,31 @@
+version: v1
+kind: Spicepod
+name: file[parquet]-pepper[file]
+datasets:
+  - from: file:data/customer.parquet
+    name: customer
+    acceleration: &acceleration
+      enabled: true
+      engine: pepper
+      mode: file
+  - from: file:data/lineitem.parquet
+    name: lineitem
+    acceleration: *acceleration
+  - from: file:data/nation.parquet
+    name: nation
+    acceleration: *acceleration
+  - from: file:data/orders.parquet
+    name: orders
+    acceleration: *acceleration
+  - from: file:data/part.parquet
+    name: part
+    acceleration: *acceleration
+  - from: file:data/partsupp.parquet
+    name: partsupp
+    acceleration: *acceleration
+  - from: file:data/region.parquet
+    name: region
+    acceleration: *acceleration
+  - from: file:data/supplier.parquet
+    name: supplier
+    acceleration: *acceleration


### PR DESCRIPTION
This pull request introduces a new `Spicepod` configuration for the TPC-H SF1 dataset using Parquet files with the Pepper acceleration engine in file mode. The configuration enables acceleration for all dataset tables in the pod.

Dataset acceleration configuration:

* Added a new `file[parquet]-pepper[file]` Spicepod YAML file that defines the TPC-H SF1 tables (`customer`, `lineitem`, `nation`, `orders`, `part`, `partsupp`, `region`, `supplier`) as Parquet files, each with Pepper acceleration enabled in file mode. ([test/spicepods/tpch/sf1/accelerated/file[parquet]-pepper[file].yamlR1-R31](diffhunk://#diff-cfa22f2244b13491c1ee4a1f462fd4857baab81a8f131ee2ee2e4c9fbbe2e449R1-R31))