### PR TITLE
Simplify `AcceleratedTable`

### DIFF
--- a/crates/runtime/src/accelerated_table/federation/mod.rs
+++ b/crates/runtime/src/accelerated_table/federation/mod.rs
@@ -21,66 +21,51 @@ use crate::component::dataset::acceleration::ZeroResultsAction;
 use data_components::poly::PolyTableProvider;
 use datafusion::datasource::TableProvider;
 use datafusion_federation::{
-    FederatedTableProviderAdaptor, FederatedTableSource, FederationProvider, sql::SQLTableSource,
+    FederatedTableProviderAdaptor, FederatedTableSource, sql::SQLTableSource,
 };
 use provider::AcceleratedTableFederationProvider;
 
 mod provider;
 
 impl AcceleratedTable {
-    fn get_federation_provider_for_accelerator(&self) -> Option<Arc<PolyTableProvider>> {
-        let poly = self
-            .accelerator
-            .as_any()
-            .downcast_ref::<PolyTableProvider>()?;
-
-        Some(Arc::new(poly.clone()))
-    }
-
     #[must_use]
     fn create_federated_table_source(&self) -> Option<Arc<dyn FederatedTableSource>> {
-        let schema = Arc::clone(&self.schema());
-        let accelerated_table_federation_provider = self.get_federation_provider_for_accelerator();
+        let accelerated_table_federation_provider = Arc::new(
+            self.accelerator
+                .as_any()
+                .downcast_ref::<PolyTableProvider>()?
+                .clone(),
+        );
+
+        let remote_table_name = accelerated_table_federation_provider
+            .get_table_source()?
+            .as_any()
+            .downcast_ref::<SQLTableSource>()
+            .map(SQLTableSource::table_reference)?;
 
         let enabled =
             self.zero_results_action != ZeroResultsAction::UseSource && !self.disable_federation;
 
-        let remote_table_name = accelerated_table_federation_provider
-            .as_ref()
-            .and_then(|provider| provider.get_table_source())
-            .and_then(|source| {
-                source
-                    .as_any()
-                    .downcast_ref::<SQLTableSource>()
-                    .map(SQLTableSource::table_reference)
-            })?;
-
         let fed_provider = Arc::new(AcceleratedTableFederationProvider::new(
             enabled,
-            accelerated_table_federation_provider.map(|x| x as Arc<dyn FederationProvider>),
+            Some(accelerated_table_federation_provider),
             self.refresher(),
         ));
 
         Some(Arc::new(SQLTableSource::new_with_schema(
             fed_provider,
             remote_table_name,
-            schema,
+            Arc::clone(&self.schema()),
         )))
     }
 
     #[must_use]
-    fn create_federated_table_provider(self: Arc<Self>) -> Option<FederatedTableProviderAdaptor> {
-        let table_source = self.create_federated_table_source()?;
-        Some(FederatedTableProviderAdaptor::new_with_provider(
-            table_source,
-            self,
-        ))
-    }
-
-    #[must_use]
     pub fn table_provider(self: Arc<Self>) -> Arc<dyn TableProvider> {
-        match Arc::clone(&self).create_federated_table_provider() {
-            Some(provider) => Arc::new(provider),
+        match Arc::clone(&self).create_federated_table_source() {
+            Some(table_source) => Arc::new(FederatedTableProviderAdaptor::new_with_provider(
+                table_source,
+                self,
+            )),
             None => self,
         }
     }


### PR DESCRIPTION
## 📝 Summary
- Whilst working on #7722, I noticed that `impl Accelerated Table` had several superflous functions (`get_federation_provider_for_accelerator` and `create_federated_table_provider`). 
