### PR TITLE
Fix Windows builds by excluding pepper/vortex

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -178,11 +178,8 @@ utoipa-swagger-ui = { version = ">=8.1.1", features = [
 ], optional = true }
 
 uuid = { workspace = true, features = ["v7"] }
-vortex-datafusion = { path = "../vortex-datafusion", optional = true }
-vortex = { workspace = true, optional = true }
 workers = { path = "../workers" }
 x509-certificate.workspace = true
-pepper = { path = "../pepper" }
 
 [dev-dependencies]
 anyhow = "1.0.99"
@@ -278,8 +275,13 @@ sqlite = [
     "dep:rusqlite",
 ]
 turso = []
-pepper = ["dep:vortex-datafusion", "dep:vortex"]
+pepper = ["dep:pepper", "dep:vortex-datafusion", "dep:vortex"]
 xxhash = ["dep:twox-hash", "cache/xxhash"]
+
+[target.'cfg(not(windows))'.dependencies]
+pepper = { path = "../pepper", optional = true }
+vortex-datafusion = { path = "../vortex-datafusion", optional = true }
+vortex = { workspace = true, optional = true }
 
 [[bench]]
 name = "prepared_statement"

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -47,7 +47,7 @@ use self::duckdb::DuckDBAccelerator;
 use self::partitioned_duckdb::PartitionedDuckDBAccelerator;
 #[cfg(feature = "duckdb")]
 use self::partitioned_duckdb::tables_mode::TablesModePartitionedDuckDBAccelerator;
-#[cfg(feature = "pepper")]
+#[cfg(all(feature = "pepper", not(windows)))]
 use self::pepper::PepperAccelerator;
 #[cfg(feature = "postgres")]
 use self::postgres::PostgresAccelerator;
@@ -59,7 +59,7 @@ pub mod arrow;
 pub mod duckdb;
 #[cfg(feature = "duckdb")]
 pub mod partitioned_duckdb;
-#[cfg(feature = "pepper")]
+#[cfg(all(feature = "pepper", not(windows)))]
 pub mod pepper;
 #[cfg(feature = "postgres")]
 pub mod postgres;
@@ -160,7 +160,7 @@ impl AcceleratorEngineRegistry {
         #[cfg(feature = "sqlite")]
         self.register_accelerator_engine(Engine::Sqlite, Arc::new(SqliteAccelerator::new()))
             .await;
-        #[cfg(feature = "pepper")]
+        #[cfg(all(feature = "pepper", not(windows)))]
         self.register_accelerator_engine(Engine::Pepper, Arc::new(PepperAccelerator::new()))
             .await;
     }
@@ -783,7 +783,7 @@ mod accelerator_compat_tests {
             #[cfg(feature = "duckdb")]
             (Engine::DuckDB, "file", None),
             (Engine::Arrow, "memory", None),
-            #[cfg(feature = "pepper")]
+            #[cfg(all(feature = "pepper", not(windows)))]
             (Engine::Pepper, "file", None), // Pepper only supports file mode
         ];
 
@@ -904,7 +904,7 @@ mod accelerator_compat_tests {
                         }
                     }
                 }
-                #[cfg(feature = "pepper")]
+                #[cfg(all(feature = "pepper", not(windows)))]
                 Engine::Pepper => {
                     use crate::component::dataset::builder::DatasetBuilder;
                     use crate::dataaccelerator::pepper::PepperAccelerator;
@@ -2125,7 +2125,7 @@ mod accelerator_compat_tests {
                             .await
                             .expect("Arrow table should be created")
                     }
-                    #[cfg(feature = "pepper")]
+                    #[cfg(all(feature = "pepper", not(windows)))]
                     Engine::Pepper => {
                         use crate::component::dataset::builder::DatasetBuilder;
                         use crate::dataaccelerator::pepper::PepperAccelerator; // Clean up any existing files and metadata

--- a/crates/runtime/tests/acceleration/refresh/refresh_modes.rs
+++ b/crates/runtime/tests/acceleration/refresh/refresh_modes.rs
@@ -225,7 +225,7 @@ async fn test_acceleration_refresh_postgres_full_variant() -> Result<(), anyhow:
 // Pepper (feature-gated)
 // Note: Pepper requires mode: file in addition to refresh_mode: append/full.
 // These tests need custom helpers that set both mode and refresh_mode.
-#[cfg(feature = "pepper")]
+#[cfg(all(feature = "pepper", not(windows)))]
 #[tokio::test]
 #[ignore = "Pepper requires mode: file which is not set by the generic test helpers"]
 async fn test_acceleration_refresh_pepper_append_variant() {
@@ -235,7 +235,7 @@ async fn test_acceleration_refresh_pepper_append_variant() {
         .expect("Test should pass when mode: file is properly configured");
 }
 
-#[cfg(feature = "pepper")]
+#[cfg(all(feature = "pepper", not(windows)))]
 #[tokio::test]
 #[ignore = "Pepper requires mode: file which is not set by the generic test helpers"]
 async fn test_acceleration_refresh_pepper_full_variant() {


### PR DESCRIPTION
## 📝 Summary

Fixes the `build_and_release` workflow that has been failing in trunk for a while due to the Windows build failing: https://github.com/spiceai/spiceai/actions/workflows/build_and_release.yml

`vortex` is linux-only

Workflow run: https://github.com/spiceai/spiceai/actions/runs/18829236567