### PR TITLE
v1.8.3 release notes

### DIFF
--- a/docs/release_notes/v1.8.3.md
+++ b/docs/release_notes/v1.8.3.md
@@ -1,18 +1,14 @@
 # Spice v1.8.3 (Oct 27, 2025)
 
-Spice v1.8.3 is a patch release focused on performance improvements, DuckDB acceleration enhancements, and observability features, with significant optimizations for query execution and better tools for monitoring query performance.
+Spice v1.8.3 is a patch release focused on performance, reliability, and observability. This release delivers optimizations for DuckDB acceleration, parameterized queries, and query plans. A new opt-in dedicated thread pool for queries is now in preview.
 
 ## What's New in v1.8.3
 
-### Optimized Prepared Statements (Parameterized Queries)
+### DuckDB Data Accelerator Improvements
 
-Significant performance improvements for parameterized queries, enabling faster repeated query execution with different parameters. This optimization dramatically reduces overhead when executing the same query structure with different values.
+- **Connection Pool Sizing**: The DuckDB accelerator now supports a configurable `connection_pool_size` parameter, supporting fine-grained control over concurrent query execution. This enables tuning for high-concurrency workloads and improved resource utilization.
 
-### DuckDB Data Accelerator Enhancements
-
-- **Connection Pool Sizing**: New `connection_pool_size` parameter allows fine-tuning of DuckDB connection pools for better concurrency control.
-
-Example:
+Example Spicepod.yaml snippet:
 
 ```yaml
 datasets:
@@ -22,12 +18,12 @@ datasets:
       enabled: true
       engine: duckdb
       params:
-        connection_pool_size: '10'
+        connection_pool_size: 10
 ```
 
-- **Statistics Recomputation**: New `on_refresh_recompute_statistics` parameter with automatic `ANALYZE` execution for table-based partitioning. This keeps query optimizer statistics up-to-date, ensuring optimal query plans.
+- **Automatic Statistics Recomputation**: The new `on_refresh_recompute_statistics` parameter, on by default, triggers automatic `ANALYZE` execution after refreshes. This keeps DuckDB optimizer statistics up-to-date, ensuring efficient query plans and optimal performance.
 
-Example:
+Example Spicepod.yaml snippet:
 
 ```yaml
 datasets:
@@ -37,32 +33,59 @@ datasets:
       enabled: true
       engine: duckdb
       params:
-        partition_mode: tables
-        on_refresh_recompute_statistics: true
-      partition_by:
-        - region
+        on_refresh_recompute_statistics: disabled # default enabled
 ```
 
-### Task History Query Plans
+### Task History SQL Query Plan Capture & Configuration
 
-Task history now captures and stores SQL query plans, making it easier to debug and optimize queries. Combined with the new `min_sql_duration` filter support, you can now focus on analyzing slow queries and understanding their execution patterns.
+Spice now supports automated SQL query plan capture and store (via `EXPLAIN` or `EXPLAIN ANALYZE`) in the task history, enabling deeper analysis and debugging of query execution. This feature is configurable, supporting control of which queries are included based on duration thresholds and plan type.
 
-For more information, see the [Task History Documentation](https://spiceai.org/docs/reference/task_history).
+- **New Configuration Options**:
+  - `task_history.captured_plan`: Controls which plan is captured (`none`, `explain`, or `explain analyze`). Default `none`.
+  - `task_history.min_sql_duration`: Minimum query duration before a plan is captured.
+  - `task_history.min_plan_duration`: Minimum plan execution duration before a plan is captured.
+
+Example `spicepod.yaml` snippet:
+
+```yaml
+runtime:
+  task_history:
+    captured_plan: explain analyze
+    min_sql_duration: 5s
+    min_plan_duration: 10s
+```
+
+Query plans are captured asynchronously to avoid blocking query execution. The result of the plan is stored in it's standard `sql_query` output in the task history.
+
+Learn more in the [Task History Documentation](https://spiceai.org/docs/reference/task_history).
 
 ### Query Performance Optimizations
 
-- **Limit Pushdown**: New `BytesProcessedExec` physical operator enables limit pushdown optimization, improving query performance when working with large datasets by reducing the amount of data processed.
+- **Optimized Prepared Statements (Parameterized Queries):** Prepared statement caching for parameterized SQL queries has been improved, reducing planning overhead for repeated queries with different parameters. This results in faster execution and lower latency for workloads that reuse query structures.
 
-- **Empty Hash Join Optimization**: New physical optimization rule that eliminates unnecessary hash joins when one side is empty, significantly improving vector search performance.
+- **Limit Pushdown via BytesProcessedExec**: Introduces the `BytesProcessedExec` physical operator, enabling limit pushdown for large datasets. This optimization reduces the amount of data processed and improves top-k query performance.
 
-### Additional Improvements & Bugfixes
+### Dedicated Query Thread Pool (Opt-In)
 
-- **Observability**: Extended query-related metrics for better visibility into query performance and behavior.
-- **REPL**: Display execution time in Spice REPL even when queries return no results.
-- **Runtime**: New `spill_compression` configuration option for better memory management during large queries.
-- **Validation**: Enhanced validation using `#[serde(deny_unknown_fields)]` for base spicepod components to catch configuration errors early.
-- **Performance**: Only load evaluation scorers when evaluation is explicitly defined, reducing unnecessary initialization overhead.
-- **Bugfix**: Improved error reporting when full-text search (FTS) is misconfigured for datasets or views.
+Spice now supports running query execution and accelerated refreshes on a **dedicated thread pool**, separate from the HTTP server. This prevents heavy query workloads from slowing down API responses, keeping health and readiness checks fast. **Opt-In for v1.8.3**: This feature is opt-in for this release and will become enabled by default (opt-out) in v1.9.
+
+Example Spicepod.yaml snippet:
+
+```yaml
+runtime:
+  params:
+    dedicated_thread_pool: sql_engine. # Default: disabled
+```
+
+### Validation & Reliability Improvements
+
+- **Selective Evaluation Scorer Loading**: Evaluation scorers are now loaded only when evaluation is explicitly defined, reducing unnecessary initialization and improving startup performance.
+
+- **Improved Error Reporting**: Enhanced error messages for misconfigured full-text search (FTS) on datasets and views, providing actionable feedback for configuration issues.
+
+### REPL & Usability
+
+- **Execution Time Display**: The Spice REPL now displays query execution time even when queries return no results, improving user feedback and diagnostics.
 
 ## Contributors
 
@@ -73,29 +96,6 @@ For more information, see the [Task History Documentation](https://spiceai.org/d
 - [@lukekim](https://github.com/lukekim)
 - [@kczimm](https://github.com/kczimm)
 - [@sgrebnov](https://github.com/sgrebnov)
-
-## What's Changed
-
-### Changelog
-
-- Fix generate spicepod schema by [@phillipleblanc](https://github.com/phillipleblanc) in [#7464](https://github.com/spiceai/spiceai/pull/7464)
-- Only load eval scorers when eval defined by [@Jeadie](https://github.com/Jeadie) in [#7549](https://github.com/spiceai/spiceai/pull/7549)
-- BytesProcessedExec to allow optimizer to do limit pushdown by [@mach-kernel](https://github.com/mach-kernel) in [#7539](https://github.com/spiceai/spiceai/pull/7539)
-- Extend query-related metrics by [@krinart](https://github.com/krinart) in [#7571](https://github.com/spiceai/spiceai/pull/7571)
-- Enhancement: Add `spill_compression` to runtime config by [@krinart](https://github.com/krinart) in [#7505](https://github.com/spiceai/spiceai/pull/7505)
-- Task History `min_sql_duration` filter support by [@lukekim](https://github.com/lukekim) in [#7698](https://github.com/spiceai/spiceai/pull/7698)
-- Show error if FTS is misconfigured for datasets/views by [@krinart](https://github.com/krinart) in [#7458](https://github.com/spiceai/spiceai/pull/7458)
-- project_schema when using EmptyExec by [@kczimm](https://github.com/kczimm) in [#7543](https://github.com/spiceai/spiceai/pull/7543)
-- Fix score order for one test case by [@Jeadie](https://github.com/Jeadie) in [#7595](https://github.com/spiceai/spiceai/pull/7595)
-- Fix license issue in table-providers by [@phillipleblanc](https://github.com/phillipleblanc) in [#7620](https://github.com/spiceai/spiceai/pull/7620)
-- Split integration tests into 3 partitions by [@phillipleblanc](https://github.com/phillipleblanc) in [#7635](https://github.com/spiceai/spiceai/pull/7635)
-- Fix OSS docker release trigger when release marked as latest by [@phillipleblanc](https://github.com/phillipleblanc) in [#7668](https://github.com/spiceai/spiceai/pull/7668)
-- Properly set auth headers in github_release.py by [@krinart](https://github.com/krinart) in [#7560](https://github.com/spiceai/spiceai/pull/7560)
-- Run Datafusion queries on a separate Tokio runtime by [@phillipleblanc](https://github.com/phillipleblanc) in [#7586](https://github.com/spiceai/spiceai/pull/7586)
-- Update BytesProcessedExec snapshots by [@mach-kernel](https://github.com/mach-kernel) in [#7637](https://github.com/spiceai/spiceai/pull/7637)
-- Display execution time in Spice REPL for no results by [@sgrebnov](https://github.com/sgrebnov) in [#7713](https://github.com/spiceai/spiceai/pull/7713)
-- Add support for DuckDB `connection_pool_size` param by [@sgrebnov](https://github.com/sgrebnov) in [#7716](https://github.com/spiceai/spiceai/pull/7716)
-- Task History capture and store SQL query plans by [@lukekim](https://github.com/lukekim) in [#7701](https://github.com/spiceai/spiceai/pull/7701)
 
 ## Breaking Changes
 
@@ -143,3 +143,25 @@ helm upgrade spiceai spiceai/spiceai
 **AWS Marketplace**:
 
 🎉 Spice is now available in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-jmf6jskjvnq7i)!
+
+## What's Changed
+
+### Changelog
+
+- Fix generate spicepod schema by [@phillipleblanc](https://github.com/phillipleblanc) in [#7464](https://github.com/spiceai/spiceai/pull/7464)
+- Only load eval scorers when eval defined by [@Jeadie](https://github.com/Jeadie) in [#7549](https://github.com/spiceai/spiceai/pull/7549)
+- BytesProcessedExec to allow optimizer to do limit pushdown by [@mach-kernel](https://github.com/mach-kernel) in [#7539](https://github.com/spiceai/spiceai/pull/7539)
+- Enhancement: Add `spill_compression` to runtime config by [@krinart](https://github.com/krinart) in [#7505](https://github.com/spiceai/spiceai/pull/7505)
+- Task History `min_sql_duration` filter support by [@lukekim](https://github.com/lukekim) in [#7698](https://github.com/spiceai/spiceai/pull/7698)
+- Show error if FTS is misconfigured for datasets/views by [@krinart](https://github.com/krinart) in [#7458](https://github.com/spiceai/spiceai/pull/7458)
+- project_schema when using EmptyExec by [@kczimm](https://github.com/kczimm) in [#7543](https://github.com/spiceai/spiceai/pull/7543)
+- Fix score order for one test case by [@Jeadie](https://github.com/Jeadie) in [#7595](https://github.com/spiceai/spiceai/pull/7595)
+- Fix license issue in table-providers by [@phillipleblanc](https://github.com/phillipleblanc) in [#7620](https://github.com/spiceai/spiceai/pull/7620)
+- Split integration tests into 3 partitions by [@phillipleblanc](https://github.com/phillipleblanc) in [#7635](https://github.com/spiceai/spiceai/pull/7635)
+- Fix OSS docker release trigger when release marked as latest by [@phillipleblanc](https://github.com/phillipleblanc) in [#7668](https://github.com/spiceai/spiceai/pull/7668)
+- Properly set auth headers in github_release.py by [@krinart](https://github.com/krinart) in [#7560](https://github.com/spiceai/spiceai/pull/7560)
+- Run Datafusion queries on a separate Tokio runtime by [@phillipleblanc](https://github.com/phillipleblanc) in [#7586](https://github.com/spiceai/spiceai/pull/7586)
+- Update BytesProcessedExec snapshots by [@mach-kernel](https://github.com/mach-kernel) in [#7637](https://github.com/spiceai/spiceai/pull/7637)
+- Display execution time in Spice REPL for no results by [@sgrebnov](https://github.com/sgrebnov) in [#7713](https://github.com/spiceai/spiceai/pull/7713)
+- Add support for DuckDB `connection_pool_size` param by [@sgrebnov](https://github.com/sgrebnov) in [#7716](https://github.com/spiceai/spiceai/pull/7716)
+- Task History capture and store SQL query plans by [@lukekim](https://github.com/lukekim) in [#7701](https://github.com/spiceai/spiceai/pull/7701)

--- a/docs/release_notes/v1.8.3.md
+++ b/docs/release_notes/v1.8.3.md
@@ -1,0 +1,145 @@
+# Spice v1.8.3 (Oct 27, 2025)
+
+Spice v1.8.3 is a patch release focused on performance improvements, DuckDB acceleration enhancements, and observability features, with significant optimizations for query execution and better tools for monitoring query performance.
+
+## What's New in v1.8.3
+
+### Optimized Prepared Statements (Parameterized Queries)
+
+Significant performance improvements for parameterized queries, enabling faster repeated query execution with different parameters. This optimization dramatically reduces overhead when executing the same query structure with different values.
+
+### DuckDB Data Accelerator Enhancements
+
+- **Connection Pool Sizing**: New `connection_pool_size` parameter allows fine-tuning of DuckDB connection pools for better concurrency control.
+
+Example:
+
+```yaml
+datasets:
+  - from: postgres:my_table
+    name: my_table
+    acceleration:
+      enabled: true
+      engine: duckdb
+      params:
+        connection_pool_size: '10'
+```
+
+- **Statistics Recomputation**: New `on_refresh_recompute_statistics` parameter with automatic `ANALYZE` execution for table-based partitioning. This keeps query optimizer statistics up-to-date, ensuring optimal query plans.
+
+Example:
+
+```yaml
+datasets:
+  - from: postgres:my_table
+    name: my_table
+    acceleration:
+      enabled: true
+      engine: duckdb
+      params:
+        partition_mode: tables
+        on_refresh_recompute_statistics: true
+      partition_by:
+        - region
+```
+
+### Task History Query Plans
+
+Task history now captures and stores SQL query plans, making it easier to debug and optimize queries. Combined with the new `min_sql_duration` filter support, you can now focus on analyzing slow queries and understanding their execution patterns.
+
+For more information, see the [Task History Documentation](https://spiceai.org/docs/reference/task_history).
+
+### Query Performance Optimizations
+
+- **Limit Pushdown**: New `BytesProcessedExec` physical operator enables limit pushdown optimization, improving query performance when working with large datasets by reducing the amount of data processed.
+
+- **Empty Hash Join Optimization**: New physical optimization rule that eliminates unnecessary hash joins when one side is empty, significantly improving vector search performance.
+
+### Additional Improvements & Bugfixes
+
+- **Observability**: Extended query-related metrics for better visibility into query performance and behavior.
+- **REPL**: Display execution time in Spice REPL even when queries return no results.
+- **Runtime**: New `spill_compression` configuration option for better memory management during large queries.
+- **Validation**: Enhanced validation using `#[serde(deny_unknown_fields)]` for base spicepod components to catch configuration errors early.
+- **Performance**: Only load evaluation scorers when evaluation is explicitly defined, reducing unnecessary initialization overhead.
+- **Bugfix**: Improved error reporting when full-text search (FTS) is misconfigured for datasets or views.
+
+## Contributors
+
+- [@phillipleblanc](https://github.com/phillipleblanc)
+- [@Jeadie](https://github.com/Jeadie)
+- [@mach-kernel](https://github.com/mach-kernel)
+- [@krinart](https://github.com/krinart)
+- [@lukekim](https://github.com/lukekim)
+- [@kczimm](https://github.com/kczimm)
+- [@sgrebnov](https://github.com/sgrebnov)
+
+## What's Changed
+
+### Changelog
+
+- Fix generate spicepod schema by [@phillipleblanc](https://github.com/phillipleblanc) in [#7464](https://github.com/spiceai/spiceai/pull/7464)
+- Only load eval scorers when eval defined by [@Jeadie](https://github.com/Jeadie) in [#7549](https://github.com/spiceai/spiceai/pull/7549)
+- BytesProcessedExec to allow optimizer to do limit pushdown by [@mach-kernel](https://github.com/mach-kernel) in [#7539](https://github.com/spiceai/spiceai/pull/7539)
+- Extend query-related metrics by [@krinart](https://github.com/krinart) in [#7571](https://github.com/spiceai/spiceai/pull/7571)
+- Enhancement: Add `spill_compression` to runtime config by [@krinart](https://github.com/krinart) in [#7505](https://github.com/spiceai/spiceai/pull/7505)
+- Task History `min_sql_duration` filter support by [@lukekim](https://github.com/lukekim) in [#7698](https://github.com/spiceai/spiceai/pull/7698)
+- Show error if FTS is misconfigured for datasets/views by [@krinart](https://github.com/krinart) in [#7458](https://github.com/spiceai/spiceai/pull/7458)
+- project_schema when using EmptyExec by [@kczimm](https://github.com/kczimm) in [#7543](https://github.com/spiceai/spiceai/pull/7543)
+- Fix score order for one test case by [@Jeadie](https://github.com/Jeadie) in [#7595](https://github.com/spiceai/spiceai/pull/7595)
+- Fix license issue in table-providers by [@phillipleblanc](https://github.com/phillipleblanc) in [#7620](https://github.com/spiceai/spiceai/pull/7620)
+- Split integration tests into 3 partitions by [@phillipleblanc](https://github.com/phillipleblanc) in [#7635](https://github.com/spiceai/spiceai/pull/7635)
+- Fix OSS docker release trigger when release marked as latest by [@phillipleblanc](https://github.com/phillipleblanc) in [#7668](https://github.com/spiceai/spiceai/pull/7668)
+- Properly set auth headers in github_release.py by [@krinart](https://github.com/krinart) in [#7560](https://github.com/spiceai/spiceai/pull/7560)
+- Run Datafusion queries on a separate Tokio runtime by [@phillipleblanc](https://github.com/phillipleblanc) in [#7586](https://github.com/spiceai/spiceai/pull/7586)
+- Update BytesProcessedExec snapshots by [@mach-kernel](https://github.com/mach-kernel) in [#7637](https://github.com/spiceai/spiceai/pull/7637)
+- Display execution time in Spice REPL for no results by [@sgrebnov](https://github.com/sgrebnov) in [#7713](https://github.com/spiceai/spiceai/pull/7713)
+- Add support for DuckDB `connection_pool_size` param by [@sgrebnov](https://github.com/sgrebnov) in [#7716](https://github.com/spiceai/spiceai/pull/7716)
+- Task History capture and store SQL query plans by [@lukekim](https://github.com/lukekim) in [#7701](https://github.com/spiceai/spiceai/pull/7701)
+
+## Breaking Changes
+
+No breaking changes.
+
+## Cookbook Updates
+
+No major cookbook updates.
+
+The [Spice Cookbook](https://spiceai.org/cookbook) includes 81 recipes to help you get started with Spice quickly and easily.
+
+## Upgrading
+
+To upgrade to v1.8.3, use one of the following methods:
+
+**CLI**:
+
+```console
+spice upgrade
+```
+
+**Homebrew**:
+
+```console
+brew upgrade spiceai/spiceai/spice
+```
+
+**Docker**:
+
+Pull the `spiceai/spiceai:1.8.3` image:
+
+```console
+docker pull spiceai/spiceai:1.8.3
+```
+
+For available tags, see [DockerHub](https://hub.docker.com/r/spiceai/spiceai/tags).
+
+**Helm**:
+
+```console
+helm repo update
+helm upgrade spiceai spiceai/spiceai
+```
+
+**AWS Marketplace**:
+
+🎉 Spice is now available in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-jmf6jskjvnq7i)!

--- a/docs/release_notes/v1.8.3.md
+++ b/docs/release_notes/v1.8.3.md
@@ -55,7 +55,7 @@ runtime:
     min_plan_duration: 10s
 ```
 
-Query plans are captured asynchronously to avoid blocking query execution. The result of the plan is stored in it's standard `sql_query` output in the task history.
+Query plans are captured asynchronously to avoid blocking query execution. The result of the plan is stored in the standard `sql_query` output in the task history.
 
 Learn more in the [Task History Documentation](https://spiceai.org/docs/reference/task_history).
 
@@ -74,7 +74,7 @@ Example Spicepod.yaml snippet:
 ```yaml
 runtime:
   params:
-    dedicated_thread_pool: sql_engine. # Default: disabled
+    dedicated_thread_pool: sql_engine # Default: disabled
 ```
 
 ### Validation & Reliability Improvements


### PR DESCRIPTION
Moved all of the 1.8x notes to `1.8/` and added v1.8.3 release notes + changelog.