### PR TITLE
Delta Lake Connector: Support `AWS_SESSION_TOKEN` parameter

### DIFF
--- a/crates/runtime/src/dataconnector/delta_lake.rs
+++ b/crates/runtime/src/dataconnector/delta_lake.rs
@@ -74,6 +74,9 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("aws_secret_access_key")
         .description("The AWS secret access key to use for S3 storage.")
         .secret(),
+    ParameterSpec::component("aws_session_token")
+        .description("The AWS session token to use for S3 storage.")
+        .secret(),
     ParameterSpec::component("aws_endpoint")
         .description("The AWS endpoint to use for S3 storage.")
         .secret(),


### PR DESCRIPTION
## 📝 Summary

```yaml
datasets:
  - from: delta_lake:s3://foo/bar
    name: region_delta
    params:
      delta_lake_aws_region: us-west-2
      delta_lake_aws_access_key_id: ${env:AWS_ACCESS_KEY_ID}
      delta_lake_aws_secret_access_key: ${env:AWS_SECRET_ACCESS_KEY}
      # pass this through
      delta_lake_aws_session_token: ${env:AWS_SESSION_TOKEN}
```
