### PR TITLE
Pepper use SQLite WAL

### DIFF
--- a/crates/pepper/src/pepper_catalog.rs
+++ b/crates/pepper/src/pepper_catalog.rs
@@ -243,14 +243,27 @@ impl MetadataCatalog for PepperCatalog {
 
     #[allow(clippy::too_many_lines)]
     async fn create_table(&self, options: CreateTableOptions) -> CatalogResult<i64> {
+        /// Result of attempting to create a table in the catalog
+        enum CreateTableResult {
+            /// Table was created successfully with the given snapshot ID
+            Created {
+                table_id: i64,
+                snapshot_id: String,
+                base_path: String,
+            },
+            /// Table already existed with the given ID
+            AlreadyExists { table_id: i64 },
+        }
+
         let table_name = options.table_name.clone();
         let base_path = options.base_path.clone();
+        let db_path_owned = self.db_path().to_string();
 
         // Check if table already exists first (read-only check)
-        let db_path_owned = self.db_path().to_string();
+        let db_path_for_check = db_path_owned.clone();
         let table_name_check = table_name.clone();
         let existing_table_id: Option<i64> = tokio::task::spawn_blocking(move || {
-            let conn = Self::open_connection(&db_path_owned, true)?;
+            let conn = Self::open_connection(&db_path_for_check, true)?;
             match conn.query_row(
                 "SELECT table_id FROM pepper_table WHERE table_name = ?1",
                 [&table_name_check],
@@ -300,8 +313,7 @@ impl MetadataCatalog for PepperCatalog {
 
         let partition_column = options.partition_column.clone();
 
-        let db_path_owned = self.db_path().to_string();
-        let blocking_result = tokio::task::spawn_blocking(move || {
+        let create_result = tokio::task::spawn_blocking(move || {
             let conn = Self::open_connection(&db_path_owned, false)?;
 
             // Start transaction with IMMEDIATE to acquire write lock upfront
@@ -318,7 +330,9 @@ impl MetadataCatalog for PepperCatalog {
                 Ok(id) => {
                     // Another thread created it, return that ID
                     conn.execute("COMMIT", [])?;
-                    Ok::<(i64, String, String), CatalogError>((id, String::new(), base_path))
+                    Ok::<CreateTableResult, CatalogError>(CreateTableResult::AlreadyExists {
+                        table_id: id,
+                    })
                 }
                 Err(rusqlite::Error::QueryReturnedNoRows) => {
                     // Proceed with creation
@@ -368,34 +382,41 @@ impl MetadataCatalog for PepperCatalog {
                     // Commit transaction
                     conn.execute("COMMIT", [])?;
 
-                    Ok::<(i64, String, String), CatalogError>((
+                    Ok::<CreateTableResult, CatalogError>(CreateTableResult::Created {
                         table_id,
-                        initial_snapshot_id,
+                        snapshot_id: initial_snapshot_id,
                         base_path,
-                    ))
+                    })
                 }
                 Err(e) => Err(CatalogError::from(e)),
             }
         })
         .await??;
 
-        // Destructure the return value from spawn_blocking
-        let (table_id, initial_snapshot_id, base_path) = blocking_result;
+        // Handle the result - only create snapshot directory if table was newly created
+        match create_result {
+            CreateTableResult::Created {
+                table_id,
+                snapshot_id,
+                base_path,
+            } => {
+                // Create the initial snapshot directory
+                // Directory structure: [base_path]/[table_id]/[snapshot_id]/
+                let snapshot_dir = std::path::PathBuf::from(&base_path)
+                    .join(table_id.to_string())
+                    .join(&snapshot_id);
 
-        // Only create snapshot directory if we actually created a new table
-        if !initial_snapshot_id.is_empty() {
-            // Create the initial snapshot directory
-            // Directory structure: [base_path]/[table_id]/[snapshot_id]/
-            let snapshot_dir = std::path::PathBuf::from(&base_path)
-                .join(table_id.to_string())
-                .join(&initial_snapshot_id);
+                tokio::fs::create_dir_all(&snapshot_dir)
+                    .await
+                    .map_err(|e| CatalogError::Io { source: e })?;
 
-            tokio::fs::create_dir_all(&snapshot_dir)
-                .await
-                .map_err(|e| CatalogError::Io { source: e })?;
+                Ok(table_id)
+            }
+            CreateTableResult::AlreadyExists { table_id } => {
+                // Table already exists, no need to create snapshot directory
+                Ok(table_id)
+            }
         }
-
-        Ok(table_id)
     }
 
     async fn get_table(&self, table_name: &str) -> CatalogResult<TableMetadata> {

--- a/crates/pepper/src/pepper_catalog.rs
+++ b/crates/pepper/src/pepper_catalog.rs
@@ -36,11 +36,19 @@ use std::sync::Arc;
 ///
 /// Operations on files (read, append, delete, stats) are delegated to the
 /// corresponding Vortex `ListingTable` provider.
+///
+/// ## Concurrency Model
+///
+/// The catalog uses `SQLite` with WAL (Write-Ahead Logging) mode which allows:
+/// - Multiple concurrent readers
+/// - One writer at a time (serialized by `SQLite` itself)
+///
+/// Each async operation opens a new connection with proper configuration (WAL mode,
+/// busy timeout, etc.). `SQLite`'s internal locking with the 5-second busy timeout
+/// handles write serialization automatically, eliminating the need for application-level
+/// locks.
 pub struct PepperCatalog {
     connection_string: String,
-    // Using rusqlite with tokio requires careful handling
-    // For now, we'll use a simple approach with a mutex
-    _marker: std::marker::PhantomData<()>,
 }
 
 impl PepperCatalog {
@@ -48,7 +56,6 @@ impl PepperCatalog {
     pub fn new(connection_string: impl Into<String>) -> Self {
         Self {
             connection_string: connection_string.into(),
-            _marker: std::marker::PhantomData,
         }
     }
 
@@ -57,6 +64,46 @@ impl PepperCatalog {
         self.connection_string
             .strip_prefix("sqlite://")
             .unwrap_or(&self.connection_string)
+    }
+
+    /// Open a `SQLite` connection configured for concurrent access.
+    ///
+    /// Applies performance optimizations based on `SQLite` best practices:
+    /// - WAL mode for non-blocking reads/writes
+    /// - Busy timeout to reduce lock contention errors
+    /// - NORMAL synchronous mode (safe with WAL)
+    /// - Memory cache and temp storage for performance
+    /// - Foreign keys enabled
+    fn open_connection(db_path: &str, read_only: bool) -> CatalogResult<rusqlite::Connection> {
+        let flags = if read_only {
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+        } else {
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+        };
+
+        let conn = rusqlite::Connection::open_with_flags(db_path, flags)?;
+
+        // Enable WAL mode for better concurrent access (allows multiple readers with one writer)
+        if !read_only {
+            conn.pragma_update(None, "journal_mode", "WAL")?;
+        }
+
+        // SQLite will wait 5 seconds to obtain a lock before returning SQLITE_BUSY errors
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
+
+        // NORMAL synchronous mode is safe with WAL and more performant than FULL
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+
+        // 32MB cache size (negative number means kilobytes)
+        conn.pragma_update(None, "cache_size", -32000)?;
+
+        // Enable foreign keys (disabled by default for historical reasons)
+        conn.pragma_update(None, "foreign_keys", true)?;
+
+        // Store temporary tables in memory for better performance
+        conn.pragma_update(None, "temp_store", "memory")?;
+
+        Ok(conn)
     }
 
     /// Generate a unique directory path for a new virtual file (`ListingTable`).
@@ -182,14 +229,10 @@ impl MetadataCatalog for PepperCatalog {
             tokio::fs::create_dir_all(db_dir).await?;
         }
 
-        // Open connection and initialize schema with write permissions
-        let db_path_owned = db_path.to_string();
+        // Initialize schema using connection with WAL mode
+        let db_path_owned = self.db_path().to_string();
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-                    | rusqlite::OpenFlags::SQLITE_OPEN_CREATE,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, false)?;
             Self::initialize_schema(&conn)?;
             Ok::<(), CatalogError>(())
         })
@@ -198,10 +241,32 @@ impl MetadataCatalog for PepperCatalog {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn create_table(&self, options: CreateTableOptions) -> CatalogResult<i64> {
-        let db_path_owned = self.db_path().to_string();
         let table_name = options.table_name.clone();
         let base_path = options.base_path.clone();
+
+        // Check if table already exists first (read-only check)
+        let db_path_owned = self.db_path().to_string();
+        let table_name_check = table_name.clone();
+        let existing_table_id: Option<i64> = tokio::task::spawn_blocking(move || {
+            let conn = Self::open_connection(&db_path_owned, true)?;
+            match conn.query_row(
+                "SELECT table_id FROM pepper_table WHERE table_name = ?1",
+                [&table_name_check],
+                |row| row.get(0),
+            ) {
+                Ok(id) => Ok(Some(id)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(CatalogError::from(e)),
+            }
+        })
+        .await??;
+
+        if let Some(table_id) = existing_table_id {
+            // Table already exists, return its ID
+            return Ok(table_id);
+        }
 
         // Serialize schema using Arrow IPC format (supports all Arrow types)
         let schema_json = {
@@ -235,78 +300,100 @@ impl MetadataCatalog for PepperCatalog {
 
         let partition_column = options.partition_column.clone();
 
+        let db_path_owned = self.db_path().to_string();
         let blocking_result = tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-                    | rusqlite::OpenFlags::SQLITE_OPEN_CREATE,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, false)?;
 
-            // Start transaction
-            conn.execute("BEGIN TRANSACTION", [])?;
+            // Start transaction with IMMEDIATE to acquire write lock upfront
+            conn.execute("BEGIN IMMEDIATE TRANSACTION", [])?;
 
-            // Get next catalog ID (for table_id)
-            let next_catalog_id: i64 = conn.query_row(
-                "SELECT value FROM pepper_metadata WHERE key = 'next_catalog_id'",
-                [],
+            // Double-check if table was created by another thread while we were preparing
+            let existing: Result<i64, rusqlite::Error> = conn.query_row(
+                "SELECT table_id FROM pepper_table WHERE table_name = ?1",
+                [&table_name],
                 |row| row.get(0),
-            )?;
+            );
 
-            let table_id = next_catalog_id;
+            match existing {
+                Ok(id) => {
+                    // Another thread created it, return that ID
+                    conn.execute("COMMIT", [])?;
+                    Ok::<(i64, String, String), CatalogError>((id, String::new(), base_path))
+                }
+                Err(rusqlite::Error::QueryReturnedNoRows) => {
+                    // Proceed with creation
+                    // Get next catalog ID (for table_id)
+                    let next_catalog_id: i64 = conn.query_row(
+                        "SELECT value FROM pepper_metadata WHERE key = 'next_catalog_id'",
+                        [],
+                        |row| row.get(0),
+                    )?;
 
-            // Generate table UUID
-            let table_uuid = uuid::Uuid::now_v7().to_string();
+                    let table_id = next_catalog_id;
 
-            // Generate initial snapshot UUID
-            let initial_snapshot_id = uuid::Uuid::now_v7().to_string();
+                    // Generate table UUID
+                    let table_uuid = uuid::Uuid::now_v7().to_string();
 
-            // Insert table metadata with initial snapshot
-            conn.execute(
-                r"
-                INSERT INTO pepper_table (
-                    table_id, table_uuid,
-                    table_name, path, path_is_relative, schema_json, primary_key_json,
-                    current_snapshot_id, partition_column
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-                ",
-                rusqlite::params![
-                    table_id,
-                    table_uuid,
-                    table_name,
-                    base_path,
-                    false, // path_is_relative - using absolute paths for now
-                    schema_json,
-                    primary_key_json,
-                    initial_snapshot_id, // All tables start with an initial snapshot
-                    partition_column,
-                ],
-            )?;
+                    // Generate initial snapshot UUID
+                    let initial_snapshot_id = uuid::Uuid::now_v7().to_string();
 
-            // Update next_catalog_id in metadata
-            conn.execute(
-                "UPDATE pepper_metadata SET value = ?1 WHERE key = 'next_catalog_id'",
-                [next_catalog_id + 1],
-            )?;
+                    // Insert table metadata with initial snapshot
+                    conn.execute(
+                        r"
+                        INSERT INTO pepper_table (
+                            table_id, table_uuid,
+                            table_name, path, path_is_relative, schema_json, primary_key_json,
+                            current_snapshot_id, partition_column
+                        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                        ",
+                        rusqlite::params![
+                            table_id,
+                            table_uuid,
+                            table_name,
+                            base_path,
+                            false, // path_is_relative - using absolute paths for now
+                            schema_json,
+                            primary_key_json,
+                            initial_snapshot_id, // All tables start with an initial snapshot
+                            partition_column,
+                        ],
+                    )?;
 
-            // Commit transaction
-            conn.execute("COMMIT", [])?;
+                    // Update next_catalog_id in metadata
+                    conn.execute(
+                        "UPDATE pepper_metadata SET value = ?1 WHERE key = 'next_catalog_id'",
+                        [next_catalog_id + 1],
+                    )?;
 
-            Ok::<(i64, String, String), CatalogError>((table_id, initial_snapshot_id, base_path))
+                    // Commit transaction
+                    conn.execute("COMMIT", [])?;
+
+                    Ok::<(i64, String, String), CatalogError>((
+                        table_id,
+                        initial_snapshot_id,
+                        base_path,
+                    ))
+                }
+                Err(e) => Err(CatalogError::from(e)),
+            }
         })
         .await??;
 
         // Destructure the return value from spawn_blocking
         let (table_id, initial_snapshot_id, base_path) = blocking_result;
 
-        // Create the initial snapshot directory
-        // Directory structure: [base_path]/[table_id]/[snapshot_id]/
-        let snapshot_dir = std::path::PathBuf::from(&base_path)
-            .join(table_id.to_string())
-            .join(&initial_snapshot_id);
+        // Only create snapshot directory if we actually created a new table
+        if !initial_snapshot_id.is_empty() {
+            // Create the initial snapshot directory
+            // Directory structure: [base_path]/[table_id]/[snapshot_id]/
+            let snapshot_dir = std::path::PathBuf::from(&base_path)
+                .join(table_id.to_string())
+                .join(&initial_snapshot_id);
 
-        tokio::fs::create_dir_all(&snapshot_dir)
-            .await
-            .map_err(|e| CatalogError::Io { source: e })?;
+            tokio::fs::create_dir_all(&snapshot_dir)
+                .await
+                .map_err(|e| CatalogError::Io { source: e })?;
+        }
 
         Ok(table_id)
     }
@@ -316,10 +403,7 @@ impl MetadataCatalog for PepperCatalog {
         let table_name_owned = table_name.to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, true)?;
 
             // Query for the table
             let mut stmt = conn.prepare(
@@ -403,10 +487,7 @@ impl MetadataCatalog for PepperCatalog {
         let db_path_owned = self.db_path().to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, true)?;
 
             let snapshot_id: String = conn.query_row(
                 "SELECT current_snapshot_id FROM pepper_table WHERE table_id = ?1",
@@ -424,7 +505,7 @@ impl MetadataCatalog for PepperCatalog {
         let snapshot_id_owned = snapshot_id.to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open(&db_path_owned)?;
+            let conn = Self::open_connection(&db_path_owned, false)?;
 
             conn.execute(
                 "UPDATE pepper_table SET current_snapshot_id = ?1 WHERE table_id = ?2",
@@ -486,51 +567,70 @@ impl MetadataCatalog for PepperCatalog {
         let db_path_owned = self.db_path().to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-                    | rusqlite::OpenFlags::SQLITE_OPEN_CREATE,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, false)?;
 
-            // Start transaction
-            conn.execute("BEGIN TRANSACTION", [])?;
+            // Start transaction with IMMEDIATE to acquire write lock upfront
+            conn.execute("BEGIN IMMEDIATE TRANSACTION", [])?;
 
-            // Get next partition ID
-            let next_partition_id: i64 = conn.query_row(
-                "SELECT value FROM pepper_metadata WHERE key = 'next_partition_id'",
-                [],
+            // Check if partition already exists
+            let existing_partition: Result<i64, rusqlite::Error> = conn.query_row(
+                "SELECT partition_id FROM pepper_partition WHERE table_id = ?1 AND partition_value = ?2",
+                rusqlite::params![partition.table_id, partition.partition_value],
                 |row| row.get(0),
-            )?;
+            );
 
-            let partition_id = next_partition_id;
+            let partition_id = match existing_partition {
+                Ok(id) => {
+                    // Partition already exists, return its ID
+                    conn.execute("COMMIT", [])?;
+                    id
+                }
+                Err(rusqlite::Error::QueryReturnedNoRows) => {
+                    // Partition doesn't exist, create it
+                    // Get next partition ID
+                    let next_partition_id: i64 = conn.query_row(
+                        "SELECT value FROM pepper_metadata WHERE key = 'next_partition_id'",
+                        [],
+                        |row| row.get(0),
+                    )?;
 
-            // Insert partition metadata
-            conn.execute(
-                r"
-                INSERT INTO pepper_partition (
-                    partition_id, table_id, partition_column, partition_value, path, path_is_relative, record_count, file_size_bytes
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-                ",
-                rusqlite::params![
-                    partition_id,
-                    partition.table_id,
-                    partition.partition_column,
-                    partition.partition_value,
-                    partition.path,
-                    partition.path_is_relative,
-                    partition.record_count,
-                    partition.file_size_bytes,
-                ],
-            )?;
+                    let partition_id = next_partition_id;
 
-            // Update next_partition_id in metadata
-            conn.execute(
-                "UPDATE pepper_metadata SET value = ?1 WHERE key = 'next_partition_id'",
-                [next_partition_id + 1],
-            )?;
+                    // Insert partition metadata
+                    conn.execute(
+                        r"
+                        INSERT INTO pepper_partition (
+                            partition_id, table_id, partition_column, partition_value, path, path_is_relative, record_count, file_size_bytes
+                        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                        ",
+                        rusqlite::params![
+                            partition_id,
+                            partition.table_id,
+                            partition.partition_column,
+                            partition.partition_value,
+                            partition.path,
+                            partition.path_is_relative,
+                            partition.record_count,
+                            partition.file_size_bytes,
+                        ],
+                    )?;
 
-            // Commit transaction
-            conn.execute("COMMIT", [])?;
+                    // Update next_partition_id in metadata
+                    conn.execute(
+                        "UPDATE pepper_metadata SET value = ?1 WHERE key = 'next_partition_id'",
+                        [next_partition_id + 1],
+                    )?;
+
+                    // Commit transaction
+                    conn.execute("COMMIT", [])?;
+
+                    partition_id
+                }
+                Err(e) => {
+                    // Other error, propagate it
+                    return Err(CatalogError::from(e));
+                }
+            };
 
             Ok::<i64, CatalogError>(partition_id)
         })
@@ -541,10 +641,7 @@ impl MetadataCatalog for PepperCatalog {
         let db_path_owned = self.db_path().to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, true)?;
 
             let mut stmt = conn.prepare(
                 r"
@@ -584,10 +681,7 @@ impl MetadataCatalog for PepperCatalog {
         let partition_value_owned = partition_value.to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, true)?;
 
             let mut stmt = conn.prepare(
                 r"
@@ -627,11 +721,7 @@ impl MetadataCatalog for PepperCatalog {
         let db_path_owned = self.db_path().to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-                    | rusqlite::OpenFlags::SQLITE_OPEN_CREATE,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, false)?;
 
             conn.execute(
                 r"
@@ -651,10 +741,7 @@ impl MetadataCatalog for PepperCatalog {
         let db_path_owned = self.db_path().to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, true)?;
 
             let (record_count, file_size_bytes): (i64, i64) = conn.query_row(
                 r"
@@ -678,10 +765,7 @@ impl MetadataCatalog for PepperCatalog {
         let db_path_owned = self.db_path().to_string();
 
         tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open_with_flags(
-                &db_path_owned,
-                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-            )?;
+            let conn = Self::open_connection(&db_path_owned, true)?;
 
             let mut stmt = conn.prepare(
                 r"

--- a/crates/runtime/src/dataaccelerator/pepper.rs
+++ b/crates/runtime/src/dataaccelerator/pepper.rs
@@ -320,9 +320,7 @@ impl PepperAccelerator {
         schema: Arc<Schema>,
         source: &dyn AccelerationSource,
     ) -> Result<Arc<dyn TableProvider>> {
-        use pepper::{
-            MetadataCatalog, PepperCatalog, PepperTableProvider, metadata::CreateTableOptions,
-        };
+        use pepper::{PepperTableProvider, metadata::CreateTableOptions};
 
         // Use custom metadata directory if provided (for testing), otherwise use shared directory
         let metadata_dir = if let Some(acceleration) = source.acceleration() {
@@ -340,9 +338,10 @@ impl PepperAccelerator {
             source: Box::new(e),
         })?;
 
-        let catalog = Arc::new(PepperCatalog::new(format!(
+        // Create a new catalog - it will use WAL mode and busy timeout internally
+        let catalog = Arc::new(pepper::PepperCatalog::new(format!(
             "sqlite://{metadata_dir}/pepper.db"
-        )));
+        ))) as Arc<dyn pepper::MetadataCatalog>;
 
         // Initialize the catalog (creates tables if needed)
         catalog
@@ -597,15 +596,28 @@ impl DataAccelerator for PepperAccelerator {
                 format!("{}/metadata", crate::spice_data_base_path())
             };
 
+            // Ensure metadata directory exists
+            std::fs::create_dir_all(&metadata_dir).map_err(|e| {
+                Error::AccelerationCreationFailed {
+                    source: Box::new(e),
+                }
+            })?;
+
+            // Create a new catalog - it will use WAL mode and busy timeout internally
             let catalog = Arc::new(pepper::PepperCatalog::new(format!(
                 "sqlite://{metadata_dir}/pepper.db"
-            )));
+            ))) as Arc<dyn pepper::MetadataCatalog>;
 
-            // Cast to trait object for partition creator
-            let catalog_trait: Arc<dyn pepper::MetadataCatalog> = catalog;
+            // Initialize the catalog (creates tables if needed)
+            catalog
+                .init()
+                .await
+                .map_err(|e| Error::AccelerationInitializationFailed {
+                    source: Box::new(e),
+                })?;
 
             // Get or create table_id from catalog
-            let table_metadata = catalog_trait.get_table(&table_name).await.map_err(|e| {
+            let table_metadata = catalog.get_table(&table_name).await.map_err(|e| {
                 Error::AccelerationCreationFailed {
                     source: Box::new(e),
                 }
@@ -618,7 +630,7 @@ impl DataAccelerator for PepperAccelerator {
                 PathBuf::from(&dir_path),
                 partition_by_first,
                 Arc::clone(&arrow_schema),
-                catalog_trait,
+                catalog,
                 table_metadata.table_id,
                 unsupported_type_action,
             ));


### PR DESCRIPTION
This pull request significantly improves the concurrency, safety, and performance of the `PepperCatalog` by centralizing and optimizing SQLite connection handling. The main changes include introducing a dedicated connection-opening method that applies best-practice SQLite configurations (WAL mode, busy timeout, etc.), refactoring all catalog operations to use this method, and enhancing correctness in concurrent scenarios such as table and partition creation. Additionally, the code is updated to ensure proper trait usage and initialization in the runtime accelerator.

**SQLite connection management and concurrency improvements:**

* Added a new `open_connection` method to `PepperCatalog` that configures SQLite connections for optimal concurrent access (WAL mode, busy timeout, cache size, etc.), and updated all catalog operations to use this method instead of direct `rusqlite::Connection` calls.
* Documented the concurrency model and removed outdated comments about mutex usage, clarifying that SQLite's WAL mode and busy timeout handle write serialization.

**Correctness and robustness in catalog operations:**

* Refactored table and partition creation logic to:
  - Use `BEGIN IMMEDIATE TRANSACTION` for acquiring write locks up front.
  - Double-check existence of tables/partitions after acquiring the lock, to avoid race conditions.
  - Only perform side effects (like creating directories) when a new table or partition is actually created. [[1]](diffhunk://#diff-eda823179bd4e94591280d343e79d902936264a9297306a0d7789e2dfdd2f07cR244-R270) [[2]](diffhunk://#diff-eda823179bd4e94591280d343e79d902936264a9297306a0d7789e2dfdd2f07cR303-R324) [[3]](diffhunk://#diff-eda823179bd4e94591280d343e79d902936264a9297306a0d7789e2dfdd2f07cL294-R386) [[4]](diffhunk://#diff-eda823179bd4e94591280d343e79d902936264a9297306a0d7789e2dfdd2f07cR396) [[5]](diffhunk://#diff-eda823179bd4e94591280d343e79d902936264a9297306a0d7789e2dfdd2f07cL489-R589) [[6]](diffhunk://#diff-eda823179bd4e94591280d343e79d902936264a9297306a0d7789e2dfdd2f07cR627-R634)

**Trait usage and initialization improvements in runtime:**

* Updated the runtime accelerator to consistently use the trait object form (`Arc<dyn MetadataCatalog>`) and to call `init()` on the catalog after creation, ensuring proper initialization. [[1]](diffhunk://#diff-fcae3bba2ed45dd526e4230da2f761d22c5ff8ea2947ffb415a1e731d75227d9L343-R344) [[2]](diffhunk://#diff-fcae3bba2ed45dd526e4230da2f761d22c5ff8ea2947ffb415a1e731d75227d9R599-R620) [[3]](diffhunk://#diff-fcae3bba2ed45dd526e4230da2f761d22c5ff8ea2947ffb415a1e731d75227d9L621-R633)

**General code cleanup:**

* Removed unused imports and outdated comments, and improved error handling for directory creation and catalog operations. [[1]](diffhunk://#diff-fcae3bba2ed45dd526e4230da2f761d22c5ff8ea2947ffb415a1e731d75227d9L323-R323) [[2]](diffhunk://#diff-fcae3bba2ed45dd526e4230da2f761d22c5ff8ea2947ffb415a1e731d75227d9R599-R620)

These changes collectively make the catalog more robust under concurrent workloads, easier to reason about, and safer for both reads and writes.