### PR TITLE
Remove Windows CUDA builds

### DIFF
--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -37,7 +37,6 @@ on:
         options:
           - 'all'
           - 'Linux x64'
-          - 'Windows x64'
         default: 'all'
       compute_cap:
         description: 'Which CUDA compute capability to build for? (Default is ALL)'
@@ -103,36 +102,6 @@ jobs:
                 runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
-              },
-              {
-                compute_cap: "80",
-                runner: "windows-latest-8core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "86",
-                runner: "windows-latest-8core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "87",
-                runner: "windows-latest-8core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "89",
-                runner: "windows-latest-8core",
-                target_os: "windows",
-                target_arch: "x86_64"
-              },
-              {
-                compute_cap: "90",
-                runner: "windows-latest-8core",
-                target_os: "windows",
-                target_arch: "x86_64"
               }
             ];
 
@@ -144,8 +113,7 @@ jobs:
 
               // Filter by platform if specified
               if (platform_option !== 'all') {
-                const target_os = platform_option === 'Linux x64' ? 'linux' : 'windows';
-                filtered = filtered.filter(m => m.target_os === target_os);
+                filtered = filtered.filter(m => m.target_os === 'linux');
               }
 
               // Filter by compute capability if specified
@@ -182,10 +150,6 @@ jobs:
 
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
-
-      - name: Install Visual Studio Build Tools
-        if: matrix.target.target_os == 'windows'
-        uses: ./.github/actions/install-vs-buildtools
 
       - name: Set up Rust
         uses: ./.github/actions/setup-rust

--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -95,7 +95,7 @@ func getRustArch() string {
 	return runtime.GOARCH
 }
 
-// GPU versions that are supported via dedicated CUDA builds
+// GPU versions that are supported via dedicated CUDA builds (Linux only)
 var supportedCudaVersionsBinaries = []string{"80", "86", "87", "89", "90"}
 
 func checkCudaVersionSupported(computeCap string) bool {
@@ -119,7 +119,7 @@ func get_ai_accelerator() (string, bool) {
 		}
 	}
 
-	if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
+	if runtime.GOOS == "linux" {
 		version, err := get_cuda_version()
 		if err != nil {
 			slog.Debug("Failed to check for CUDA device", "error", err)
@@ -157,7 +157,7 @@ func has_metal_device() (bool, error) {
 }
 
 func get_cuda_version() (*string, error) {
-	if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
+	if runtime.GOOS != "linux" {
 		return nil, nil
 	}
 

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -66,8 +66,8 @@ verifySupported() {
         if [ "$osarch" == "$current_osarch" ]; then
             # Validate CUDA variant combinations
             if [ "$VARIANT" == "cuda" ]; then
-                if [ "$OS" != "linux" ] && [ "$OS" != "windows" ]; then
-                    echo "CUDA variants are only supported on Linux and Windows"
+                if [ "$OS" != "linux" ]; then
+                    echo "CUDA variants are only supported on Linux"
                     exit 1
                 fi
                 if [ -z "$CUDA_VERSION" ]; then
@@ -225,7 +225,7 @@ downloadFile() {
     
     if [ "$asset_id" = "null" ] || [ -z "$asset_id" ]; then
         echo "ERROR: version not found $LATEST_RELEASE_TAG or artifact $SPICED_ARTIFACT not found"
-        echo "Available variants: default, models, cuda (with CUDA_VERSION), metal"
+        echo "Available variants: default, models, cuda (Linux only, requires CUDA_VERSION), metal"
         exit 1
     fi
 


### PR DESCRIPTION
- remove Windows targets from the CUDA build matrix to stop producing unused binaries