### PR TITLE
Set minimum CUDA compute cap to 8.6 (Ampere) and support to Blackwell

### DIFF
--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -30,26 +30,21 @@ on:
 
   workflow_dispatch:
     inputs:
-      platform_option:
-        description: 'Which platform do you want to run on? (Default is ALL)'
-        required: false
-        type: choice
-        options:
-          - 'all'
-          - 'Linux x64'
-          - 'Windows x64'
-        default: 'all'
       compute_cap:
         description: 'Which CUDA compute capability to build for? (Default is ALL)'
         required: false
         type: choice
         options:
           - 'all'
-          - '80'
-          - '86'
-          - '87'
-          - '89'
-          - '90'
+          - '86' # Ampere: A10G, A40, A10, RTX 30 series
+          - '87' # Ampere: Jetson AGX Orin
+          - '89' # Ada Lovelace: L4, L40, RTX 40 series
+          - '90' # Hopper: H100, H200
+          - '100' # Blackwell: B200, GB200
+          - '103' # Blackwell: B300, GB300
+          - '110' # Jetson T5000, T4000
+          - '120' # Blackwell: RTX 50 series, RTX PRO
+          - '121' # Blackwell: GB10 (DGX Spark)
         default: 'all'
       profile_option:
         description: 'Which Rust build profile to use? (Default is release)'
@@ -74,79 +69,75 @@ jobs:
         with:
           script: |
             const matrix = [
-              {
-                compute_cap: "80",
-                runner: "spiceai-large-runners",
-                target_os: "linux",
-                target_arch: "x86_64"
-              },
+              // Ampere: A10G, A40, A10, A16, A2, RTX 30 series
               {
                 compute_cap: "86",
                 runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
+              // Ampere: Jetson AGX Orin, Jetson Orin NX/Nano
               {
                 compute_cap: "87",
                 runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
+              // Ada Lovelace: L4, L40, L40S, RTX 40 series
               {
                 compute_cap: "89",
                 runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
+              // Hopper: H100, H200, GH200
               {
                 compute_cap: "90",
                 runner: "spiceai-large-runners",
                 target_os: "linux",
                 target_arch: "x86_64"
               },
+              // Blackwell: B200, GB200
               {
-                compute_cap: "80",
-                runner: "windows-latest-8core",
-                target_os: "windows",
+                compute_cap: "100",
+                runner: "spiceai-large-runners",
+                target_os: "linux",
                 target_arch: "x86_64"
               },
+              // Blackwell: B300, GB300
               {
-                compute_cap: "86",
-                runner: "windows-latest-8core",
-                target_os: "windows",
+                compute_cap: "103",
+                runner: "spiceai-large-runners",
+                target_os: "linux",
                 target_arch: "x86_64"
               },
+              // Jetson T5000, T4000
               {
-                compute_cap: "87",
-                runner: "windows-latest-8core",
-                target_os: "windows",
+                compute_cap: "110",
+                runner: "spiceai-large-runners",
+                target_os: "linux",
                 target_arch: "x86_64"
               },
+              // Blackwell: RTX 50 series, RTX PRO Blackwell series
               {
-                compute_cap: "89",
-                runner: "windows-latest-8core",
-                target_os: "windows",
+                compute_cap: "120",
+                runner: "spiceai-large-runners",
+                target_os: "linux",
                 target_arch: "x86_64"
               },
+              // Blackwell: GB10 (DGX Spark)
               {
-                compute_cap: "90",
-                runner: "windows-latest-8core",
-                target_os: "windows",
+                compute_cap: "121",
+                runner: "spiceai-large-runners",
+                target_os: "linux",
                 target_arch: "x86_64"
               }
             ];
 
             // If running via workflow_dispatch, filter based on input
             if (context.eventName === 'workflow_dispatch') {
-              const platform_option = context.payload.inputs.platform_option;
               const compute_cap = context.payload.inputs.compute_cap;
               let filtered = matrix;
-
-              // Filter by platform if specified
-              if (platform_option !== 'all') {
-                const target_os = platform_option === 'Linux x64' ? 'linux' : 'windows';
-                filtered = filtered.filter(m => m.target_os === target_os);
-              }
 
               // Filter by compute capability if specified
               if (compute_cap !== 'all') {

--- a/bin/spice/pkg/github/runtime_release.go
+++ b/bin/spice/pkg/github/runtime_release.go
@@ -96,7 +96,17 @@ func getRustArch() string {
 }
 
 // GPU versions that are supported via dedicated CUDA builds
-var supportedCudaVersionsBinaries = []string{"80", "86", "87", "89", "90"}
+// Minimum: A10G (8.6 Ampere) to Maximum: DGX Spark (12.1 Blackwell)
+// 86: Ampere - A10G, A40, A10, A16, A2, RTX 30 series
+// 87: Ampere - Jetson AGX Orin, Jetson Orin NX/Nano
+// 89: Ada Lovelace - L4, L40, L40S, RTX 40 series
+// 90: Hopper - H100, H200, GH200
+// 100: Blackwell - B200, GB200
+// 103: Blackwell - B300, GB300
+// 110: Jetson T5000, T4000
+// 120: Blackwell - RTX 50 series, RTX PRO Blackwell series
+// 121: Blackwell - GB10 (DGX Spark)
+var supportedCudaVersionsBinaries = []string{"86", "87", "89", "90", "100", "103", "110", "120", "121"}
 
 func checkCudaVersionSupported(computeCap string) bool {
 	for _, version := range supportedCudaVersionsBinaries {
@@ -119,7 +129,7 @@ func get_ai_accelerator() (string, bool) {
 		}
 	}
 
-	if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
+	if runtime.GOOS == "linux" {
 		version, err := get_cuda_version()
 		if err != nil {
 			slog.Debug("Failed to check for CUDA device", "error", err)
@@ -157,7 +167,7 @@ func has_metal_device() (bool, error) {
 }
 
 func get_cuda_version() (*string, error) {
-	if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
+	if runtime.GOOS != "linux" {
 		return nil, nil
 	}
 

--- a/install/install-spiced.sh
+++ b/install/install-spiced.sh
@@ -66,12 +66,13 @@ verifySupported() {
         if [ "$osarch" == "$current_osarch" ]; then
             # Validate CUDA variant combinations
             if [ "$VARIANT" == "cuda" ]; then
-                if [ "$OS" != "linux" ] && [ "$OS" != "windows" ]; then
-                    echo "CUDA variants are only supported on Linux and Windows"
+                if [ "$OS" != "linux" ]; then
+                    echo "CUDA variants are only supported on Linux"
                     exit 1
                 fi
                 if [ -z "$CUDA_VERSION" ]; then
-                    echo "CUDA_VERSION must be set when using CUDA variant (e.g., 80, 86, 87, 89, 90)"
+                    echo "CUDA_VERSION must be set when using CUDA variant (e.g., 86, 87, 89, 90, 100, 103, 110, 120, 121)"
+                    echo "Supported range: A10G (86) to DGX Spark (121)"
                     exit 1
                 fi
             fi


### PR DESCRIPTION
This pull request updates the CUDA build and release workflow to support the latest NVIDIA GPU architectures and removes Windows support for CUDA builds. The changes expand the list of supported CUDA compute capabilities, update validation logic and error messages, and ensure the workflow only targets Linux environments for CUDA.

**CUDA architecture and platform support updates:**

* Expanded supported CUDA compute capabilities in `.github/workflows/build_and_release_cuda.yml` to include newer architectures (Blackwell, Jetson T5000, RTX 50 series, etc.), with descriptive comments for each option. [[1]](diffhunk://#diff-f6c5bf35bb6ac7ed7eafdef419821dd828e5c80446f5f1c55318ecc4b9c30163L33-R47) [[2]](diffhunk://#diff-f6c5bf35bb6ac7ed7eafdef419821dd828e5c80446f5f1c55318ecc4b9c30163L77-L150)
* Removed Windows support for CUDA builds in both the workflow matrix and the install script, restricting CUDA builds to Linux only. [[1]](diffhunk://#diff-f6c5bf35bb6ac7ed7eafdef419821dd828e5c80446f5f1c55318ecc4b9c30163L33-R47) [[2]](diffhunk://#diff-f6c5bf35bb6ac7ed7eafdef419821dd828e5c80446f5f1c55318ecc4b9c30163L77-L150) [[3]](diffhunk://#diff-0c9ec45ee7de9b848619bb89d41b9a8b54858187bcbd9e7958385f19428cfa6cL69-R75)

**Validation and messaging improvements:**

* Updated the validation logic and error messages in `install/install-spiced.sh` to reflect the new supported CUDA versions and clarify the supported range (A10G/86 to DGX Spark/121).