### PR TITLE
Set local timezone to UTC for DuckDB

### DIFF
--- a/crates/runtime/src/dataaccelerator/duckdb.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb.rs
@@ -109,7 +109,8 @@ impl DuckDBAccelerator {
                     DuckDBSettingsRegistry::new()
                         .with_setting(Box::new(OrderByNonIntegerLiteral))
                         .with_setting(Box::new(settings::IndexScanPercentage))
-                        .with_setting(Box::new(settings::IndexScanMaxCount)),
+                        .with_setting(Box::new(settings::IndexScanMaxCount))
+                        .with_setting(Box::new(settings::TimeZone)),
                 ),
         }
     }

--- a/crates/runtime/src/dataaccelerator/duckdb/settings.rs
+++ b/crates/runtime/src/dataaccelerator/duckdb/settings.rs
@@ -135,3 +135,24 @@ impl DuckDBSetting for IndexScanMaxCount {
         Ok(())
     }
 }
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct TimeZone;
+
+impl DuckDBSetting for TimeZone {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn setting_name(&self) -> &'static str {
+        "TimeZone"
+    }
+
+    fn get_value(&self, _options: &std::collections::HashMap<String, String>) -> Option<String> {
+        Some(String::from("UTC"))
+    }
+
+    fn scope(&self) -> DuckDBSettingScope {
+        DuckDBSettingScope::Local
+    }
+}

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -83,6 +83,7 @@ mod ready_state;
 mod refresh_retry;
 mod refresh_sql;
 mod results_cache;
+#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
 mod retention;
 mod s3;
 #[cfg(feature = "postgres")]

--- a/crates/runtime/tests/retention/mod.rs
+++ b/crates/runtime/tests/retention/mod.rs
@@ -14,41 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow::array::RecordBatch;
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
-use arrow::array::{BooleanArray, StringArray, TimestampNanosecondArray};
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use arrow::array::{BooleanArray, RecordBatch, StringArray, TimestampNanosecondArray};
 use arrow::datatypes::{DataType, TimeUnit};
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
 use datafusion::common::TableReference;
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
-use futures::StreamExt;
-use futures::TryStreamExt;
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
-use std::collections::HashMap;
-use std::{sync::Arc, time::Duration};
+use futures::{StreamExt, TryStreamExt};
+use secrecy::ExposeSecret;
+use spicepod::{
+    acceleration::{Acceleration, Mode, OnConflictBehavior, RefreshMode},
+    component::dataset::{Dataset, TimeFormat},
+    param::Params,
+};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use app::AppBuilder;
 
 use runtime::Runtime;
-use spicepod::{acceleration::Acceleration, component::dataset::Dataset};
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
-use spicepod::{
-    acceleration::{Mode, OnConflictBehavior, RefreshMode},
-    component::dataset::TimeFormat,
-    param::Params,
-};
-
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
-use secrecy::ExposeSecret;
-
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
-use crate::postgres::common::{
-    get_pg_params, get_postgres_connection_pool, get_random_port, start_postgres_docker_container,
-};
 
 use crate::{
     configure_test_datafusion, init_tracing,
+    postgres::common::{
+        get_pg_params, get_postgres_connection_pool, get_random_port,
+        start_postgres_docker_container,
+    },
     utils::{runtime_ready_check, test_request_context},
 };
 
@@ -87,7 +74,6 @@ fn make_s3_dataset(
     ds
 }
 
-#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
 fn rows_from_batches(batches: &[RecordBatch]) -> Result<Vec<(String, i64, bool)>, anyhow::Error> {
     let mut rows = Vec::new();
 
@@ -120,22 +106,20 @@ fn rows_from_batches(batches: &[RecordBatch]) -> Result<Vec<(String, i64, bool)>
     Ok(rows)
 }
 
-#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
 struct TimezoneGuard {
     original: Option<String>,
 }
 
-#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
 unsafe extern "C" {
     fn tzset();
 }
 
-#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
 impl TimezoneGuard {
     fn new(tz: &str) -> Self {
         let original = std::env::var("TZ").ok();
+        // Change the TZ environment variable; this is process-wide but scoped by the guard.
         unsafe {
-            // Safety: Changing the TZ environment variable is process-wide but acceptable in this scoped test helper.
+            // Safety: Modifying TZ is process-wide but controlled via the guard.
             std::env::set_var("TZ", tz);
         }
         unsafe {
@@ -145,16 +129,15 @@ impl TimezoneGuard {
     }
 }
 
-#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
 impl Drop for TimezoneGuard {
     fn drop(&mut self) {
         match &self.original {
             Some(value) => unsafe {
-                // Safety: Restoring the original TZ value for the process.
+                // Safety: Restoring original TZ value captured by the guard.
                 std::env::set_var("TZ", value);
             },
             None => unsafe {
-                // Safety: Clearing TZ to restore original process state.
+                // Safety: Clearing TZ resets process state to original value.
                 std::env::remove_var("TZ");
             },
         }
@@ -164,7 +147,6 @@ impl Drop for TimezoneGuard {
     }
 }
 
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
 async fn execute_rt_sql(rt: Arc<Runtime>, sql: &str) -> Result<Vec<RecordBatch>, anyhow::Error> {
     let mut result = rt.datafusion().query_builder(sql).build().run().await?;
 
@@ -176,7 +158,6 @@ async fn execute_rt_sql(rt: Arc<Runtime>, sql: &str) -> Result<Vec<RecordBatch>,
     Ok(results)
 }
 
-#[cfg(all(feature = "duckdb", feature = "postgres"))]
 async fn refresh_table(rt: Arc<Runtime>, table_name: &str) -> Result<(), anyhow::Error> {
     let notifier = rt
         .datafusion()
@@ -257,11 +238,7 @@ async fn test_retention_sql() -> Result<(), anyhow::Error> {
         .await
 }
 
-#[cfg_attr(
-    all(unix, feature = "duckdb", feature = "postgres"),
-    allow(clippy::too_many_lines)
-)]
-#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
+#[allow(clippy::too_many_lines)]
 #[tokio::test]
 async fn test_duckdb_append_refresh_preserves_timestamptz() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
@@ -373,6 +350,9 @@ SET
             }
 
             runtime_ready_check(&rt).await;
+
+            // Ensure the accelerator processes an initial refresh before validation.
+            refresh_table(Arc::clone(&rt), "widgets").await?;
 
             let initial_batches = execute_rt_sql(
                 Arc::clone(&rt),

--- a/crates/runtime/tests/retention/mod.rs
+++ b/crates/runtime/tests/retention/mod.rs
@@ -15,13 +15,37 @@ limitations under the License.
 */
 
 use arrow::array::RecordBatch;
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use arrow::array::{BooleanArray, StringArray, TimestampNanosecondArray};
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use arrow::datatypes::{DataType, TimeUnit};
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use datafusion::common::TableReference;
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use futures::StreamExt;
 use futures::TryStreamExt;
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
 
 use app::AppBuilder;
 
 use runtime::Runtime;
 use spicepod::{acceleration::Acceleration, component::dataset::Dataset};
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use spicepod::{
+    acceleration::{Mode, OnConflictBehavior, RefreshMode},
+    component::dataset::TimeFormat,
+    param::Params,
+};
+
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use secrecy::ExposeSecret;
+
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+use crate::postgres::common::{
+    get_pg_params, get_postgres_connection_pool, get_random_port, start_postgres_docker_container,
+};
 
 use crate::{
     configure_test_datafusion, init_tracing,
@@ -61,6 +85,108 @@ fn make_s3_dataset(
         ..Default::default()
     });
     ds
+}
+
+#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
+fn rows_from_batches(batches: &[RecordBatch]) -> Result<Vec<(String, i64, bool)>, anyhow::Error> {
+    let mut rows = Vec::new();
+
+    for batch in batches {
+        let names = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| anyhow::anyhow!("Expected StringArray in column 0"))?;
+        let updated_at = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .ok_or_else(|| anyhow::anyhow!("Expected TimestampNanosecondArray in column 1"))?;
+        let deleted = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .ok_or_else(|| anyhow::anyhow!("Expected BooleanArray in column 2"))?;
+
+        for row_idx in 0..batch.num_rows() {
+            rows.push((
+                names.value(row_idx).to_string(),
+                updated_at.value(row_idx),
+                deleted.value(row_idx),
+            ));
+        }
+    }
+
+    Ok(rows)
+}
+
+#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
+struct TimezoneGuard {
+    original: Option<String>,
+}
+
+#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
+unsafe extern "C" {
+    fn tzset();
+}
+
+#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
+impl TimezoneGuard {
+    fn new(tz: &str) -> Self {
+        let original = std::env::var("TZ").ok();
+        unsafe {
+            // Safety: Changing the TZ environment variable is process-wide but acceptable in this scoped test helper.
+            std::env::set_var("TZ", tz);
+        }
+        unsafe {
+            tzset();
+        }
+        Self { original }
+    }
+}
+
+#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
+impl Drop for TimezoneGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(value) => unsafe {
+                // Safety: Restoring the original TZ value for the process.
+                std::env::set_var("TZ", value);
+            },
+            None => unsafe {
+                // Safety: Clearing TZ to restore original process state.
+                std::env::remove_var("TZ");
+            },
+        }
+        unsafe {
+            tzset();
+        }
+    }
+}
+
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+async fn execute_rt_sql(rt: Arc<Runtime>, sql: &str) -> Result<Vec<RecordBatch>, anyhow::Error> {
+    let mut result = rt.datafusion().query_builder(sql).build().run().await?;
+
+    let mut results: Vec<RecordBatch> = vec![];
+    while let Some(batch) = result.data.next().await {
+        results.push(batch?);
+    }
+
+    Ok(results)
+}
+
+#[cfg(all(feature = "duckdb", feature = "postgres"))]
+async fn refresh_table(rt: Arc<Runtime>, table_name: &str) -> Result<(), anyhow::Error> {
+    let notifier = rt
+        .datafusion()
+        .refresh_table(&TableReference::from(table_name), None)
+        .await?;
+    notifier
+        .ok_or_else(|| anyhow::anyhow!("Failed to refresh table"))?
+        .notified()
+        .await;
+    Ok(())
 }
 
 #[tokio::test]
@@ -125,6 +251,224 @@ async fn test_retention_sql() -> Result<(), anyhow::Error> {
                     arrow::util::pretty::pretty_format_batches(&results).expect("pretty batches");
                 insta::assert_snapshot!(snapshot_name, results_str);
             }
+
+            Ok(())
+        })
+        .await
+}
+
+#[cfg_attr(
+    all(unix, feature = "duckdb", feature = "postgres"),
+    allow(clippy::too_many_lines)
+)]
+#[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
+#[tokio::test]
+async fn test_duckdb_append_refresh_preserves_timestamptz() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let _tz_guard = TimezoneGuard::new("Asia/Tokyo");
+
+            let port = get_random_port()?;
+            let running_container = start_postgres_docker_container(port).await?;
+
+            let pool = get_postgres_connection_pool(port, None).await?;
+            let db_conn = pool
+                .connect_direct()
+                .await
+                .expect("connection can be established");
+
+            db_conn
+                .conn
+                .batch_execute(
+                    r"
+CREATE TABLE IF NOT EXISTS widgets (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    description TEXT,
+    quantity INTEGER NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS widgets_set_updated_at ON widgets;
+CREATE TRIGGER widgets_set_updated_at
+BEFORE UPDATE ON widgets
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();
+
+INSERT INTO widgets (name, description, quantity, deleted)
+VALUES
+    ('Sample widget', 'First sample widget row', 10, FALSE),
+    ('Default widget', 'Second example row', 25, FALSE),
+    ('Legacy widget', 'Record starts soft-deleted', 0, TRUE)
+ON CONFLICT (name) DO UPDATE
+SET
+    description = EXCLUDED.description,
+    quantity = EXCLUDED.quantity,
+    deleted = EXCLUDED.deleted;
+                ",
+                )
+                .await?;
+
+            db_conn
+                .conn
+                .execute("UPDATE widgets SET deleted = FALSE;", &[])
+                .await?;
+
+            let pg_initial_ts: i64 = db_conn
+                .conn
+                .query_one(
+                    "SELECT (EXTRACT(EPOCH FROM updated_at) * 1000000000)::BIGINT FROM widgets WHERE name = 'Sample widget';",
+                    &[],
+                )
+                .await?
+                .get(0);
+
+            let mut dataset = Dataset::new("postgres:widgets", "widgets");
+            let params = get_pg_params(port)
+                .into_iter()
+                .map(|(k, v)| (k, v.expose_secret().to_string()))
+                .collect::<HashMap<String, String>>();
+            dataset.params = Some(Params::from_string_map(params));
+            dataset.time_column = Some("updated_at".to_string());
+            dataset.time_format = Some(TimeFormat::Timestamptz);
+            dataset.acceleration = Some(Acceleration {
+                enabled: true,
+                mode: Mode::File,
+                engine: Some("duckdb".to_string()),
+                refresh_mode: Some(RefreshMode::Append),
+                refresh_check_interval: Some("200ms".to_string()),
+                retention_sql: Some("DELETE FROM widgets WHERE deleted = true".to_string()),
+                retention_check_enabled: true,
+                retention_check_interval: Some("200ms".to_string()),
+                primary_key: Some("id".to_string()),
+                on_conflict: HashMap::from([("id".to_string(), OnConflictBehavior::Upsert)]),
+                ..Acceleration::default()
+            });
+
+            configure_test_datafusion();
+            let app = AppBuilder::new("duckdb_timezone_retention")
+                .with_dataset(dataset)
+                .build();
+
+            let rt = Runtime::builder().with_app(app).build().await;
+            let rt = Arc::new(rt);
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let initial_batches = execute_rt_sql(
+                Arc::clone(&rt),
+                "SELECT name, updated_at, deleted FROM widgets ORDER BY name",
+            )
+            .await?;
+
+            assert!(
+                !initial_batches.is_empty(),
+                "expected accelerated rows to load"
+            );
+
+            let schema = initial_batches[0].schema();
+            let updated_field = schema
+                .field_with_name("updated_at")
+                .expect("updated_at column present");
+            assert_eq!(
+                updated_field.data_type(),
+                &DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                "accelerator should expose updated_at as UTC"
+            );
+
+            let initial_rows = rows_from_batches(&initial_batches)?;
+            let (_, runtime_initial_ts, runtime_initial_deleted) = initial_rows
+                .into_iter()
+                .find(|(name, _, _)| name == "Sample widget")
+                .expect("sample widget present after initial load");
+
+            assert_eq!(
+                runtime_initial_ts, pg_initial_ts,
+                "initial load should keep timestamptz values aligned with source"
+            );
+            assert!(
+                !runtime_initial_deleted,
+                "sample widget should not be marked deleted initially"
+            );
+
+            db_conn
+                .conn
+                .execute(
+                    "UPDATE widgets SET deleted = TRUE WHERE name = 'Sample widget';",
+                    &[],
+                )
+                .await?;
+
+            let pg_updated_ts: i64 = db_conn
+                .conn
+                .query_one(
+                    "SELECT (EXTRACT(EPOCH FROM updated_at) * 1000000000)::BIGINT FROM widgets WHERE name = 'Sample widget';",
+                    &[],
+                )
+                .await?
+                .get(0);
+
+            refresh_table(Arc::clone(&rt), "widgets").await?;
+
+            let refreshed_batches = execute_rt_sql(
+                Arc::clone(&rt),
+                "SELECT name, updated_at, deleted FROM widgets ORDER BY name",
+            )
+            .await?;
+
+            let refreshed_rows = rows_from_batches(&refreshed_batches)?;
+            let (_, runtime_updated_ts, runtime_deleted_flag) = refreshed_rows
+                .into_iter()
+                .find(|(name, _, _)| name == "Sample widget")
+                .expect("sample widget should still be present after append refresh");
+
+            assert!(runtime_deleted_flag, "append refresh should include updated rows");
+            assert_eq!(
+                runtime_updated_ts, pg_updated_ts,
+                "append refresh should keep timestamptz values aligned even when host timezone is positive"
+            );
+
+            let mut retention_applied = false;
+            for _ in 0..15 {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                let deleted_batches = execute_rt_sql(
+                    Arc::clone(&rt),
+                    "SELECT name FROM widgets WHERE deleted = TRUE",
+                )
+                .await?;
+                let deleted_count: usize =
+                    deleted_batches.iter().map(RecordBatch::num_rows).sum();
+                if deleted_count == 0 {
+                    retention_applied = true;
+                    break;
+                }
+            }
+
+            assert!(
+                retention_applied,
+                "retention_sql should eventually remove soft-deleted rows"
+            );
+
+            running_container.remove().await?;
 
             Ok(())
         })


### PR DESCRIPTION
## 📝 Summary

Fixes a bug where we were reading timestamps with local time zones as UTC values, thus causing some incorrect calculations for the append mode refreshes.

This PR fixes it by adding a new DuckDB local setting for `SET TimeZone = UTC` which forces DuckDB to render all timestamps in UTC, which is what Spice expects.