### PR TITLE
add Timestamp support for partition expressions

### DIFF
--- a/crates/runtime-table-partition/src/creator/filename.rs
+++ b/crates/runtime-table-partition/src/creator/filename.rs
@@ -36,7 +36,7 @@ pub enum Error {
     #[snafu(display("Unsupported scalar value type: {data_type}"))]
     UnsupportedType { data_type: DataType },
 
-    #[snafu(display("Unsupported partition key: {value}"))]
+    #[snafu(display("Unsupported partition key: {value:?}"))]
     UnsupportedPartitionKey { value: ScalarValue },
 
     #[snafu(display("Failed to parse partition key: {source}"))]
@@ -77,6 +77,10 @@ fn encode_key(key: &ScalarValue) -> Result<String, Error> {
         ScalarValue::UInt16(v) => v.map(|v| format!("{v}")),
         ScalarValue::UInt32(v) => v.map(|v| format!("{v}")),
         ScalarValue::UInt64(v) => v.map(|v| format!("{v}")),
+        ScalarValue::TimestampSecond(v, _) => v.map(|v| format!("{v}")),
+        ScalarValue::TimestampMillisecond(v, _) => v.map(|v| format!("{v}")),
+        ScalarValue::TimestampMicrosecond(v, _) => v.map(|v| format!("{v}")),
+        ScalarValue::TimestampNanosecond(v, _) => v.map(|v| format!("{v}")),
         ScalarValue::Utf8(v) => v.clone(),
         value => {
             return Err(Error::UnsupportedPartitionKey {


### PR DESCRIPTION
## 📝 Summary

Adds missing timestamp support for partition naming. Allows partition expressions like:

```yaml
      partition_by:
        - day: "date_trunc('day', CAST(created_at AS TIMESTAMP))"
```


## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
