### PR TITLE
Handle refresh worker panics and add recovery test

### DIFF
--- a/crates/runtime/src/accelerated_table/metrics.rs
+++ b/crates/runtime/src/accelerated_table/metrics.rs
@@ -27,6 +27,7 @@ pub const METRIC_MAX_TIMESTAMP_AFTER_REFRESH_MS: &str =
     "dataset_acceleration_max_timestamp_after_refresh_ms";
 pub const METRIC_REFRESH_LAG_MS: &str = "dataset_acceleration_refresh_lag_ms";
 pub const METRIC_INGESTION_LAG_MS: &str = "dataset_acceleration_ingestion_lag_ms";
+pub const METRIC_REFRESH_WORKER_PANICS: &str = "dataset_acceleration_refresh_worker_panics";
 
 static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("dataset_acceleration"));
 
@@ -50,6 +51,13 @@ pub(crate) static REFRESH_DURATION_MS: LazyLock<Histogram<f64>> = LazyLock::new(
         .f64_histogram("dataset_acceleration_refresh_duration_ms")
         .with_description("Duration in milliseconds to load a full or appended refresh data.")
         .with_unit("ms")
+        .build()
+});
+
+pub(crate) static REFRESH_WORKER_PANICS: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    METER
+        .u64_counter(METRIC_REFRESH_WORKER_PANICS)
+        .with_description("Number of times a refresh worker panicked while refreshing a dataset.")
         .build()
 });
 

--- a/crates/runtime/src/accelerated_table/mod.rs
+++ b/crates/runtime/src/accelerated_table/mod.rs
@@ -67,6 +67,8 @@ mod sink;
 mod synchronized_table;
 mod timestamp_metrics_utils;
 
+pub use refresh_task_runner::RefreshTaskRunner;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display(
@@ -88,6 +90,14 @@ pub enum Error {
         "Failed to get data from the connector. {source} Ensure the dataset configuration is valid, and try again."
     ))]
     UnableToCreateMemTableFromUpdate { source: DataFusionError },
+
+    #[snafu(display(
+        "Failed to refresh dataset {dataset_name}: refresh worker panicked. {message}"
+    ))]
+    RefreshWorkerPanicked {
+        dataset_name: String,
+        message: String,
+    },
 
     #[snafu(display("Failed to refresh the dataset. {source}"))]
     FailedToTriggerRefresh {

--- a/crates/runtime/src/accelerated_table/refresh_task_runner.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task_runner.rs
@@ -17,9 +17,10 @@ limitations under the License.
 use crate::{federated_table::FederatedTable, status};
 
 use super::{
-    refresh::RefreshOverrides, refresh_task::RefreshTask, synchronized_table::SynchronizedTable,
+    metrics, refresh::RefreshOverrides, refresh_task::RefreshTask,
+    synchronized_table::SynchronizedTable,
 };
-use futures::future::BoxFuture;
+use futures::{FutureExt, future::BoxFuture};
 use tokio::{
     runtime::Handle,
     select,
@@ -30,11 +31,12 @@ use tokio::{
     task::JoinHandle,
 };
 
-use std::sync::Arc;
+use std::{any::Any, panic::AssertUnwindSafe, sync::Arc};
 use tokio::sync::RwLock;
 
 use super::refresh::Refresh;
 use datafusion::{datasource::TableProvider, sql::TableReference};
+use opentelemetry::KeyValue;
 use spicepod::metric::Metrics;
 
 pub struct RefreshTaskRunnerBuilder {
@@ -143,6 +145,9 @@ pub struct RefreshTaskRunner {
     task: Option<JoinHandle<()>>,
 }
 
+type RefreshRunFuture =
+    BoxFuture<'static, std::result::Result<super::Result<()>, Box<dyn Any + Send>>>;
+
 impl RefreshTaskRunner {
     #[must_use]
     pub fn builder(
@@ -165,6 +170,9 @@ impl RefreshTaskRunner {
         )
     }
 
+    /// # Panics
+    ///
+    /// Panics if `start` is called more than once for the same runner instance.
     pub fn start(
         &mut self,
     ) -> (
@@ -185,22 +193,41 @@ impl RefreshTaskRunner {
         let refresh_task = Arc::clone(&self.refresh_task);
 
         self.task = Some(tokio::spawn(async move {
-            let mut task_completion: Option<BoxFuture<super::Result<()>>> = None;
+            let mut task_completion: Option<RefreshRunFuture> = None;
 
             loop {
                 if let Some(task) = task_completion.take() {
                     select! {
                         res = task => {
                             match res {
-                                Ok(()) => {
+                                Ok(Ok(())) => {
                                     tracing::debug!("Dataset {dataset_name} refreshed successfully");
                                     if let Err(err) = notify_refresh_complete.send(Ok(())).await {
                                         tracing::debug!("Failed to send refresh task completion for dataset {dataset_name}: {err}");
                                     }
                                 },
-                                Err(err) => {
+                                Ok(Err(err)) => {
                                     tracing::debug!("Dataset {dataset_name} failed to refresh with error: {err}");
                                     if let Err(err) = notify_refresh_complete.send(Err(err)).await {
+                                        tracing::debug!("Failed to send refresh task completion for dataset {dataset_name}: {err}");
+                                    }
+                                },
+                                Err(panic_payload) => {
+                                    let dataset_label = dataset_name.to_string();
+                                    let panic_message = Self::panic_to_message(panic_payload);
+                                    tracing::error!(
+                                        dataset = %dataset_label,
+                                        %panic_message,
+                                        "Refresh worker panicked; continuing refresh loop"
+                                    );
+                                    metrics::REFRESH_WORKER_PANICS.add(1, &[KeyValue::new("dataset", dataset_label.clone())]);
+
+                                    let panic_error = super::Error::RefreshWorkerPanicked {
+                                        dataset_name: dataset_label,
+                                        message: panic_message.clone(),
+                                    };
+
+                                    if let Err(err) = notify_refresh_complete.send(Err(panic_error)).await {
                                         tracing::debug!("Failed to send refresh task completion for dataset {dataset_name}: {err}");
                                     }
                                 }
@@ -208,14 +235,14 @@ impl RefreshTaskRunner {
                         },
                         Some(overrides_opt) = on_start_refresh.recv() => {
                             let request = Self::create_refresh_from_overrides(Arc::clone(&base_refresh), overrides_opt).await;
-                            task_completion = Some(Box::pin(refresh_task.run(request)));
+                            task_completion = Some(Self::wrap_refresh_future(Arc::clone(&refresh_task), request));
                         }
                     }
                 } else {
                     select! {
                         Some(overrides_opt) = on_start_refresh.recv() => {
                             let request = Self::create_refresh_from_overrides(Arc::clone(&base_refresh), overrides_opt).await;
-                            task_completion = Some(Box::pin(refresh_task.run(request)));
+                            task_completion = Some(Self::wrap_refresh_future(Arc::clone(&refresh_task), request));
                         }
                         else => {
                             // The parent refresher is shutting down, we should too
@@ -246,6 +273,20 @@ impl RefreshTaskRunner {
             r = r.with_overrides(&overrides);
         }
         r
+    }
+
+    fn wrap_refresh_future(refresh_task: Arc<RefreshTask>, request: Refresh) -> RefreshRunFuture {
+        Box::pin(AssertUnwindSafe(async move { refresh_task.run(request).await }).catch_unwind())
+    }
+
+    fn panic_to_message(panic: Box<dyn Any + Send>) -> String {
+        match panic.downcast::<String>() {
+            Ok(message) => *message,
+            Err(panic) => match panic.downcast::<&'static str>() {
+                Ok(message) => (*message).to_string(),
+                Err(_) => "refresh worker panicked with a non-string payload".to_string(),
+            },
+        }
     }
 
     pub fn abort(&mut self) {

--- a/crates/runtime/tests/integration.rs
+++ b/crates/runtime/tests/integration.rs
@@ -82,6 +82,7 @@ mod postgres;
 mod ready_state;
 mod refresh_retry;
 mod refresh_sql;
+mod refresh_worker_panic;
 mod results_cache;
 #[cfg(all(unix, feature = "duckdb", feature = "postgres"))]
 mod retention;

--- a/crates/runtime/tests/refresh_worker_panic.rs
+++ b/crates/runtime/tests/refresh_worker_panic.rs
@@ -1,0 +1,200 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::any::Any;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use arrow::array::{ArrayRef, Int32Array};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use datafusion::catalog::Session;
+use datafusion::datasource::TableProvider;
+use datafusion::datasource::memory::MemTable;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::sql::TableReference;
+use runtime::accelerated_table::refresh::Refresh;
+use runtime::accelerated_table::{Error as AcceleratedError, RefreshTaskRunner};
+use runtime::component::dataset::acceleration::RefreshMode;
+use runtime::federated_table::FederatedTable;
+use runtime::status;
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+use tokio::time::{Duration, timeout};
+
+#[derive(Debug)]
+struct PanickingOnceTableProvider {
+    inner: Arc<MemTable>,
+    should_panic: AtomicBool,
+}
+
+impl PanickingOnceTableProvider {
+    fn new(inner: Arc<MemTable>) -> Self {
+        Self {
+            inner,
+            should_panic: AtomicBool::new(true),
+        }
+    }
+}
+
+#[async_trait]
+impl TableProvider for PanickingOnceTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+
+    fn constraints(&self) -> Option<&datafusion::common::Constraints> {
+        self.inner.constraints()
+    }
+
+    fn table_type(&self) -> datafusion::logical_expr::TableType {
+        self.inner.table_type()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion::common::Result<Vec<TableProviderFilterPushDown>> {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    fn statistics(&self) -> Option<datafusion::physical_plan::Statistics> {
+        self.inner.statistics()
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        assert!(
+            !self.should_panic.swap(false, Ordering::SeqCst),
+            "intentional panic for refresh worker test"
+        );
+
+        self.inner.scan(state, projection, filters, limit).await
+    }
+
+    async fn insert_into(
+        &self,
+        state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        insert_op: datafusion::logical_expr::dml::InsertOp,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        self.inner.insert_into(state, input, insert_op).await
+    }
+
+    fn get_column_default(&self, column: &str) -> Option<&Expr> {
+        self.inner.get_column_default(column)
+    }
+}
+
+#[tokio::test]
+async fn refresh_worker_recovers_from_panic() -> Result<(), String> {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Int32,
+        false,
+    )]));
+
+    let values: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let batch =
+        RecordBatch::try_new(Arc::clone(&schema), vec![values]).map_err(|e| e.to_string())?;
+
+    let federated_mem_table = Arc::new(
+        MemTable::try_new(Arc::clone(&schema), vec![vec![batch.clone()]])
+            .map_err(|e| e.to_string())?,
+    );
+
+    let accelerator_mem_table = Arc::new(
+        MemTable::try_new(Arc::clone(&schema), vec![Vec::new()]).map_err(|e| e.to_string())?,
+    );
+
+    let dataset_name = TableReference::bare("panic_dataset");
+
+    let refresh_defaults = Refresh::new(RefreshMode::Append)
+        .sql(format!("SELECT value FROM {}", dataset_name.table()));
+    let refresh_state = Arc::new(RwLock::new(refresh_defaults));
+
+    let runtime_status = status::RuntimeStatus::new();
+
+    let panicking_provider: Arc<dyn TableProvider> = Arc::new(PanickingOnceTableProvider::new(
+        Arc::clone(&federated_mem_table),
+    ));
+    let federated_table = Arc::new(FederatedTable::new_unchecked(Arc::clone(
+        &panicking_provider,
+    )));
+
+    let accelerator_provider: Arc<dyn TableProvider> = accelerator_mem_table;
+
+    let mut runner = RefreshTaskRunner::builder(
+        runtime_status,
+        dataset_name.clone(),
+        federated_table,
+        None,
+        refresh_state,
+        accelerator_provider,
+        Handle::current(),
+    )
+    .build();
+
+    let (start_refresh, mut on_refresh_complete) = runner.start();
+
+    start_refresh.send(None).await.map_err(|e| e.to_string())?;
+
+    let first_result = timeout(Duration::from_secs(10), on_refresh_complete.recv())
+        .await
+        .map_err(|_| "timed out waiting for panic result".to_string())?
+        .ok_or_else(|| "refresh worker channel closed unexpectedly".to_string())?;
+
+    match first_result {
+        Ok(()) => return Err("expected panic error from first refresh".to_string()),
+        Err(AcceleratedError::RefreshWorkerPanicked {
+            dataset_name,
+            message,
+        }) => {
+            assert_eq!(dataset_name, "panic_dataset");
+            assert!(
+                message.contains("intentional panic"),
+                "unexpected panic message: {message}"
+            );
+        }
+        Err(other) => return Err(format!("unexpected error from first refresh: {other}")),
+    }
+
+    start_refresh.send(None).await.map_err(|e| e.to_string())?;
+
+    let second_result = timeout(Duration::from_secs(10), on_refresh_complete.recv())
+        .await
+        .map_err(|_| "timed out waiting for successful refresh".to_string())?
+        .ok_or_else(|| "refresh worker channel closed unexpectedly".to_string())?;
+
+    second_result.map_err(|e| format!("second refresh returned error: {e}"))?;
+
+    runner.abort();
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes an issue where a panic in a refresh worker would prevent the accelerated dataset from further refreshes until the Spice runtime has restarted.

Now we catch any panics that occur during a refresh and treat them as we do for any other error - log it and retry on the next refresh attempt.

Adds a new metric: `dataset_acceleration_refresh_worker_panics` that can be used to monitor for these panics happening.